### PR TITLE
Moving to db.prepare() for quick query validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,11 @@ src/server/scratch/
 server/venv/
 tsc-tmp/
 export/
+.idea
+*.parquet
 
 # generated content
+log
 saved-state.json
 last-query-output.json
 staging-databases

--- a/src/server/duckdb.ts
+++ b/src/server/duckdb.ts
@@ -71,7 +71,7 @@ export function dbRun(query:string) {
 
 export async function validQuery(db:DB, query:string): Promise<{value: boolean, message?: string}> {
 	return new Promise((resolve) => {
-		db.run(query, (err) => {
+		db.prepare(query, (err) => {
 			if (err !== null) {
 				resolve({
 					value: false,


### PR DESCRIPTION
Moving to db.prepare from db.run for query validation.