### PR TITLE
DM-98 fixes the title renaming bug

### DIFF
--- a/src/routes/_surfaces/header/index.svelte
+++ b/src/routes/_surfaces/header/index.svelte
@@ -9,9 +9,6 @@ const store = getContext('rill:app:store') as AppStore;
 
 function formatModelName(str) {
     let output = str.trim().replaceAll(' ', '_');
-    if (!output.endsWith('.sql')) {
-        output += '.sql';
-    }
     return output;
 }
 


### PR DESCRIPTION
There's a bug where if you rename the title of a model, it gets very angry and adds an additional `.sql`. This fixes it.