### PR TITLE
Fix DM-135 - Renamed models append the .sql extension twice

### DIFF
--- a/src/routes/_surfaces/workspace/Header.svelte
+++ b/src/routes/_surfaces/workspace/Header.svelte
@@ -22,7 +22,10 @@ const store = getContext('rill:app:store') as ApplicationStore;
 const persistentModelStore = getContext('rill:app:persistent-model-store') as PersistentModelStore;
 
 function formatModelName(str) {
-    let output = str.trim().replaceAll(' ', '_');
+    let output = str
+        .trim()
+        .replaceAll(' ', '_')
+        .replace(/\.sql/, '');
     return output;
 }
 


### PR DESCRIPTION
`updateModelName` in the server expects the model name to not include the .sql filename extension, make formatModelName() remove it if present.