### PR TITLE
Caching node_modules in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
   directories:
   - "$HOME/.npm"
   - "$TRAVIS_BUILD_DIR/data"
+  - "node_modules"
 
 jobs:
   include:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 
 If you are a developer helping us build the application, please visit our [DEVELOPER-GUIDE.md](https://github.com/gorillio/data-modeler-prototype/blob/main/DEVELOPER-GUIDE.md).
+


### PR DESCRIPTION
This takes the time for a build from ~13 down to ~2 minutes, by caching the `node_modules` directory. This will jump whenever a build is unlucky to run whenever a large/slow import like duckdb updates, but it should be an improvement in the general case (where there are few-to-no large package updates)