### PR TITLE
A Sample script to import data from existing druid cluster into data modeler

### DIFF
--- a/scripts/druid-import.sh
+++ b/scripts/druid-import.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+## Usage Sample
+# scripts/druid-import.sh --druid=<druid_url> --user=<username> --pass=<password> --datasource=chalice_sample --project=<project>
+rows=100000
+project='.'
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --druid=*)
+      druid="${1#*=}"
+      ;;
+    --user=*)
+      user="${1#*=}"
+      ;;
+    --pass=*)
+      pass="${1#*=}"
+      ;;
+    --datasource=*)
+      datasource="${1#*=}"
+      ;;
+    --rows=*)
+      rows="${1#*=}"
+      ;;
+    --project=*)
+      project="${1#*=}"
+      ;;
+
+    *)
+      printf "***************************\n"
+      printf "* Error: Invalid argument.*\n$1"
+      printf "***************************\n"
+      exit 1
+  esac
+  shift
+done
+
+
+query="{\"query\" : \"SELECT * FROM $datasource limit $rows\",\"resultFormat\" : \"csv\", \"header\" : true}"
+echo "$query" > "/tmp/$datasource-query.json"
+printf "Downloading data using query :  $query \n"
+
+curl -XPOST -H'Content-Type: application/json' -u "$user:$pass" https://$druid/druid/v2/sql/ -d @/tmp/$datasource-query.json > /tmp/$datasource.csv
+printf "Importing to data modeler project: $project \n"
+npm run cli --silent -- import-table /tmp/$datasource.csv --project $project --delimiter ","
+


### PR DESCRIPTION
A sample poc script for importing data from a Druid cluster to data modeler. 

Sample Usage - 

```scripts/druid-import.sh --druid=druid.master.in.rilldata.io --user=nishant.bangarwa@rilldata.com --pass=<password> --datasource=chalice_sample --project=/Users/nishant/dev/data-modeler```

Notes - 

1. It uses CSV as intermediate export format and imports from that, which works fine for most of the cases, but would break 
2. Just a random shell script, building this in current cli with typescript code would be more ideal
3. No error handling and tests written