### PR TITLE
Don't show overlay for non file drags

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -62,6 +62,11 @@
   $: persistentExportedModel = $persistentModelStore?.entities?.find(
     (model) => model.id === derivedExportedModel?.id
   );
+
+  function isEventWithFiles(event: DragEvent) {
+    let types = event.dataTransfer.types;
+    return types && types.indexOf("Files") != -1;
+  }
 </script>
 
 {#if derivedExportedModel && persistentExportedModel}
@@ -82,8 +87,8 @@
   on:drop|preventDefault|stopPropagation
   on:drag|preventDefault|stopPropagation
   on:dragenter|preventDefault|stopPropagation
-  on:dragover|preventDefault|stopPropagation={() => {
-    showDropOverlay = true;
+  on:dragover|preventDefault|stopPropagation={(e) => {
+    if (isEventWithFiles(e)) showDropOverlay = true;
   }}
   on:dragleave|preventDefault|stopPropagation
 >


### PR DESCRIPTION
Previously dragging any element would show the dropzone. This PR fixes the issue and only shows the dropzone if a file is dragged into the application view.