### PR TITLE
PRQL support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15840,6 +15840,11 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
     },
+    "node_modules/prql-js": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/prql-js/-/prql-js-0.2.11.tgz",
+      "integrity": "sha512-9+4bjNqGjgIdor9jSrImex/t+cP1FYytl55Kf1WlIa+mbtp4nBLic0bbDSNQIZJi4plFAHl9FHhXxEcb02Yc0A=="
+    },
     "node_modules/ps-tree": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
@@ -19496,6 +19501,7 @@
         "isomorphic-unfetch": "^3.1.0",
         "module-alias": "^2.2.2",
         "pgsql-ast-parser": "^10.3.1",
+        "prql-js": "^0.2.9",
         "socket.io": "^4.4.1",
         "socket.io-client": "^4.4.1",
         "svelte": "^3.48.0",
@@ -21768,6 +21774,7 @@
         "postcss-load-config": "^3.1.3",
         "prettier": "^2.6.1",
         "prettier-plugin-svelte": "^2.6.0",
+        "prql-js": "^0.2.9",
         "semver": "^7.3.7",
         "should": "^13.2.3",
         "sinon": "^13.0.1",
@@ -31102,6 +31109,11 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
+    },
+    "prql-js": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/prql-js/-/prql-js-0.2.11.tgz",
+      "integrity": "sha512-9+4bjNqGjgIdor9jSrImex/t+cP1FYytl55Kf1WlIa+mbtp4nBLic0bbDSNQIZJi4plFAHl9FHhXxEcb02Yc0A=="
     },
     "ps-tree": {
       "version": "1.2.0",

--- a/web-local/package.json
+++ b/web-local/package.json
@@ -120,6 +120,7 @@
     "isomorphic-unfetch": "^3.1.0",
     "module-alias": "^2.2.2",
     "pgsql-ast-parser": "^10.3.1",
+    "prql-js": "^0.2.9",
     "socket.io": "^4.4.1",
     "socket.io-client": "^4.4.1",
     "svelte": "^3.48.0",

--- a/web-local/src/common/data-modeler-service/ModelActions.ts
+++ b/web-local/src/common/data-modeler-service/ModelActions.ts
@@ -139,8 +139,10 @@ export class ModelActions extends DataModelerActions {
     let sanitizedQuery;
     try {
       sanitizedQuery = preprocessQuery(query);
-    } catch(error) {
-      const modelError = ActionResponseFactory.getModelQueryError(error.message)
+    } catch (error) {
+      const modelError = ActionResponseFactory.getModelQueryError(
+        error.message
+      );
       return this.setModelError(modelId, modelError);
     }
 
@@ -165,7 +167,10 @@ export class ModelActions extends DataModelerActions {
     ]);
 
     // validate query with the original query first.
-    const validationResponse = await this.validateModelQuery(model, sanitizedQuery);
+    const validationResponse = await this.validateModelQuery(
+      model,
+      sanitizedQuery
+    );
     if (validationResponse) {
       return this.setModelError(modelId, validationResponse);
     }

--- a/web-local/src/common/database-service/preprocess.ts
+++ b/web-local/src/common/database-service/preprocess.ts
@@ -4,26 +4,26 @@ import { sanitizeQuery } from "@rilldata/web-local/lib/util/sanitize-query";
  * @returns true iff @param query is likely to be a PRQL query
  */
 function isPRQL(query: string) {
-    return query.trim().toLowerCase().startsWith('from');
+  return query.trim().toLowerCase().startsWith("from");
 }
 
 /**
  * Compile PRQL and correctly throw errors.
  */
 function compilePRQL(prqlQuery: string) {
-    const prql = require("prql-js/dist/node");;
+  const prql = require("prql-js/dist/node");
 
-    const result = prql.compile(prqlQuery);
+  const result = prql.compile(prqlQuery);
 
-    if (result.error) {
-        throw new Error(result.error.message)
-    } else {
-        return result.sql;
-    }
+  if (result.error) {
+    throw new Error(result.error.message);
+  } else {
+    return result.sql;
+  }
 }
 
 export function preprocessQuery(query: string) {
-    const sqlQuery = isPRQL(query) ? compilePRQL(query) : query;
+  const sqlQuery = isPRQL(query) ? compilePRQL(query) : query;
 
-    return sanitizeQuery(sqlQuery, false);
+  return sanitizeQuery(sqlQuery, false);
 }

--- a/web-local/src/common/database-service/preprocess.ts
+++ b/web-local/src/common/database-service/preprocess.ts
@@ -1,0 +1,29 @@
+import { sanitizeQuery } from "@rilldata/web-local/lib/util/sanitize-query";
+
+/**
+ * @returns true iff @param query is likely to be a PRQL query
+ */
+function isPRQL(query: string) {
+    return query.trim().toLowerCase().startsWith('from');
+}
+
+/**
+ * Compile PRQL and correctly throw errors.
+ */
+function compilePRQL(prqlQuery: string) {
+    const prql = require("prql-js/dist/node");;
+
+    const result = prql.compile(prqlQuery);
+
+    if (result.error) {
+        throw new Error(result.error.message)
+    } else {
+        return result.sql;
+    }
+}
+
+export function preprocessQuery(query: string) {
+    const sqlQuery = isPRQL(query) ? compilePRQL(query) : query;
+
+    return sanitizeQuery(sqlQuery, false);
+}

--- a/web-local/src/lib/components/workspace/model/ModelBody.svelte
+++ b/web-local/src/lib/components/workspace/model/ModelBody.svelte
@@ -170,7 +170,7 @@
       {#if currentDerivedModel?.error}
         <div
           transition:slide={{ duration: 200 }}
-          class="error break-words overflow-auto p-6 border-2 border-gray-300 font-bold text-gray-700 w-full shrink-0 max-h-[60%] z-10 bg-gray-100"
+          class="error break-words overflow-auto p-6 border-2 border-gray-300 font-bold text-gray-700 whitespace-pre w-full shrink-0 max-h-[60%] z-10 bg-gray-100"
         >
           {currentDerivedModel.error}
         </div>


### PR DESCRIPTION
This PR adds support for [PRQL](https://prql-lang.org/).

It does this by replacing `sanitizeQuery` with `preprocessQuery`. Preprocess first compiles PRQL (with prql-compiler as WASM module) and also sanitizes the SQL. The only practical difference is that `preprocessQuery` may throw errors that need to be passed to the model.

I tried to make this PR as encapsulated as possible so it is easier to maintain.