### PR TITLE
Fix error handling in the http client

### DIFF
--- a/web-local/src/lib/util/fetchWrapper.ts
+++ b/web-local/src/lib/util/fetchWrapper.ts
@@ -29,6 +29,19 @@ export async function fetchWrapper({
     signal,
   });
   if (!resp.ok) {
+    const data = await resp.json();
+
+    // Return runtime errors in the same form as the Axios client had previously
+    if (data.code && data.message) {
+      return Promise.reject({
+        response: {
+          status: resp.status,
+          data,
+        },
+      });
+    }
+
+    // Fallback error handling
     const err = new Error();
     (err as any).response = await resp.json();
     return Promise.reject(err);


### PR DESCRIPTION
This PR modifies the `fetchWrapper` to return errors in the form of the (now-deleted) Axios client. There are several places in our code that relies on this error structure, including all of the `+page.ts` files.