### PR TITLE
Add UX support for globs

### DIFF
--- a/runtime/connectors/gcs/gcs.go
+++ b/runtime/connectors/gcs/gcs.go
@@ -30,7 +30,7 @@ var spec = connectors.Spec{
 			Placeholder: "gs://bucket-name/path/to/file.csv",
 			Type:        connectors.StringPropertyType,
 			Required:    true,
-			Hint:        "Note that glob patterns aren't yet supported",
+			Hint:        "Note that you can also use glob patterns",
 		},
 		{
 			Key:         "gcp.credentials",

--- a/runtime/connectors/s3/s3.go
+++ b/runtime/connectors/s3/s3.go
@@ -30,7 +30,7 @@ var spec = connectors.Spec{
 			Placeholder: "s3://bucket-name/path/to/file.csv",
 			Type:        connectors.StringPropertyType,
 			Required:    true,
-			Hint:        "Note that glob patterns aren't yet supported",
+			Hint:        "Note that you can also use glob patterns",
 		},
 		{
 			Key:         "region",

--- a/web-common/src/features/sources/add-source/AddSourceModal.svelte
+++ b/web-common/src/features/sources/add-source/AddSourceModal.svelte
@@ -7,12 +7,10 @@
     V1Connector,
   } from "@rilldata/web-common/runtime-client";
   import { createEventDispatcher } from "svelte";
-  import LocalSource from "./LocalSource.svelte";
   import RemoteSource from "./RemoteSource.svelte";
 
   const dispatch = createEventDispatcher();
 
-  let showLocalFileDetailedOptions;
   let selectedConnector: V1Connector;
 
   const TAB_ORDER = ["gcs", "s3", "https", "local_file"];
@@ -67,13 +65,7 @@
     </TabGroup>
   </div>
   <div class="flex-grow overflow-y-auto">
-    {#if selectedConnector?.name === "local_file" && !showLocalFileDetailedOptions}
-      <LocalSource
-        bind:showDetailedOptions={showLocalFileDetailedOptions}
-        on:close
-      />
-    {/if}
-    {#if selectedConnector?.name === "gcs" || selectedConnector?.name === "s3" || selectedConnector?.name === "https" || showLocalFileDetailedOptions}
+    {#if selectedConnector?.name === "gcs" || selectedConnector?.name === "s3" || selectedConnector?.name === "https" || selectedConnector?.name === "local_file"}
       {#key selectedConnector}
         <RemoteSource connector={selectedConnector} on:close />
       {/key}

--- a/web-common/src/features/sources/add-source/AddSourceModal.svelte
+++ b/web-common/src/features/sources/add-source/AddSourceModal.svelte
@@ -12,6 +12,7 @@
 
   const dispatch = createEventDispatcher();
 
+  let showLocalFileDetailedOptions;
   let selectedConnector: V1Connector;
 
   const TAB_ORDER = ["gcs", "s3", "https", "local_file"];
@@ -66,13 +67,16 @@
     </TabGroup>
   </div>
   <div class="flex-grow overflow-y-auto">
-    {#if selectedConnector?.name === "gcs" || selectedConnector?.name === "s3" || selectedConnector?.name === "https"}
+    {#if selectedConnector?.name === "local_file" && !showLocalFileDetailedOptions}
+      <LocalSource
+        bind:showDetailedOptions={showLocalFileDetailedOptions}
+        on:close
+      />
+    {/if}
+    {#if selectedConnector?.name === "gcs" || selectedConnector?.name === "s3" || selectedConnector?.name === "https" || showLocalFileDetailedOptions}
       {#key selectedConnector}
         <RemoteSource connector={selectedConnector} on:close />
       {/key}
-    {/if}
-    {#if selectedConnector?.name === "local_file"}
-      <LocalSource on:close />
     {/if}
   </div>
 </Dialog>

--- a/web-common/src/features/sources/add-source/LocalSource.svelte
+++ b/web-common/src/features/sources/add-source/LocalSource.svelte
@@ -24,6 +24,8 @@
   import { createSource } from "./createSource";
   import { hasDuckDBUnicodeError, niceDuckdbUnicodeError } from "./errors";
 
+  export let showDetailedOptions = false;
+
   const dispatch = createEventDispatcher();
 
   const queryClient = useQueryClient();
@@ -93,9 +95,13 @@
   }
 </script>
 
-<div class="grid place-items-center h-full">
+<div class="flex flex-col justify-center gap-y-3 place-items-center h-full">
   <Button on:click={handleOpenFileDialog} type="primary"
     >Upload a CSV or Parquet file
+  </Button>
+  <div class="text-sm ui-copy-disabled">or</div>
+  <Button on:click={() => (showDetailedOptions = true)} type="primary"
+    >Add files using path
   </Button>
   {#if errors?.length}
     <div transition:slide={{ duration: LIST_SLIDE_DURATION * 2 }}>

--- a/web-common/src/features/sources/add-source/LocalSource.svelte
+++ b/web-common/src/features/sources/add-source/LocalSource.svelte
@@ -24,8 +24,6 @@
   import { createSource } from "./createSource";
   import { hasDuckDBUnicodeError, niceDuckdbUnicodeError } from "./errors";
 
-  export let showDetailedOptions = false;
-
   const dispatch = createEventDispatcher();
 
   const queryClient = useQueryClient();
@@ -95,13 +93,9 @@
   }
 </script>
 
-<div class="flex flex-col justify-center gap-y-3 place-items-center h-full">
+<div class="flex justify-center place-items-center mt-3">
   <Button on:click={handleOpenFileDialog} type="primary"
     >Upload a CSV or Parquet file
-  </Button>
-  <div class="text-sm ui-copy-disabled">or</div>
-  <Button on:click={() => (showDetailedOptions = true)} type="primary"
-    >Add files using path
   </Button>
   {#if errors?.length}
     <div transition:slide={{ duration: LIST_SLIDE_DURATION * 2 }}>

--- a/web-common/src/features/sources/add-source/RemoteSource.svelte
+++ b/web-common/src/features/sources/add-source/RemoteSource.svelte
@@ -26,6 +26,7 @@
   import { compileCreateSourceYAML, inferSourceName } from "../sourceUtils";
   import { createSource } from "./createSource";
   import { humanReadableErrorMessage } from "./errors";
+  import LocalSource from "./LocalSource.svelte";
   import {
     fromYupFriendlyKey,
     getYupSchema,
@@ -139,16 +140,24 @@
 </script>
 
 <div class="h-full w-full flex flex-col">
+  {#if connector?.name === "local_file"}
+    <LocalSource on:close />
+  {/if}
   <form
     on:submit|preventDefault={handleSubmit}
     id="remote-source-{connector.name}-form"
     class="px-4 pb-2 flex-grow overflow-y-auto"
   >
     <div class="pt-4 pb-2">
-      Need help? Refer to our
-      <a href="https://docs.rilldata.com/using-rill/import-data" target="_blank"
-        >docs</a
-      > for more information.
+      {#if connector?.name === "local_file"}
+        Alternatively mention the path to file (globs supported)
+      {:else}
+        Need help? Refer to our
+        <a
+          href="https://docs.rilldata.com/using-rill/import-data"
+          target="_blank">docs</a
+        > for more information.
+      {/if}
     </div>
     {#if $createSourceMutation.isError || error}
       <SubmissionError

--- a/web-common/src/features/sources/add-source/yupSchemas.ts
+++ b/web-common/src/features/sources/add-source/yupSchemas.ts
@@ -46,6 +46,17 @@ export function getYupSchema(connector: V1Connector) {
           )
           .required("Source name is required"),
       });
+    case "local_file":
+      return yup.object().shape({
+        path: yup.string().required("Path is required"),
+        sourceName: yup
+          .string()
+          .matches(
+            /^[a-zA-Z_][a-zA-Z0-9_]*$/,
+            "Source name must start with a letter or underscore and contain only letters, numbers, and underscores"
+          )
+          .required("Source name is required"),
+      });
     default:
       throw new Error(`Unknown connector: ${connector.name}`);
   }

--- a/web-common/src/features/sources/embedded/ConnectorLabel.svelte
+++ b/web-common/src/features/sources/embedded/ConnectorLabel.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   export let connector: string;
+
+  $: connector = connector == "local_file" ? "local" : connector;
 </script>
 
 <div

--- a/web-common/src/features/sources/sourceUtils.ts
+++ b/web-common/src/features/sources/sourceUtils.ts
@@ -39,10 +39,9 @@ export function inferSourceName(connector: V1Connector, path: string) {
 
   if (!slug) return;
 
-  let fileName = slug.split(".").shift();
+  const fileName = slug.split(".").shift();
 
   if (!fileName) return;
 
-  fileName = fileName.replace(/\*/g, "");
   return sanitizeEntityName(fileName);
 }

--- a/web-common/src/features/sources/sourceUtils.ts
+++ b/web-common/src/features/sources/sourceUtils.ts
@@ -39,9 +39,10 @@ export function inferSourceName(connector: V1Connector, path: string) {
 
   if (!slug) return;
 
-  const fileName = slug.split(".").shift();
+  let fileName = slug.split(".").shift();
 
   if (!fileName) return;
 
+  fileName = fileName.replace(/\*/g, "");
   return sanitizeEntityName(fileName);
 }


### PR DESCRIPTION
 #1618

- [x] Sanitize the * in the source name inferred from path
- [x]  The info tool tip needs to say we DO support glob patterns
- [x]  Add UI support for local file globs (setting a path instead of uploading a file)

cc @magorlick 
We might need to think more on how to handle UX for Local files glob support here. The current implementation adds a secondary button to show the detailed options.