### PR TITLE
Ensure graceful shutdown of admin and runtime servers

### DIFF
--- a/cli/cmd/admin/start.go
+++ b/cli/cmd/admin/start.go
@@ -216,7 +216,8 @@ func StartCmd(cliCfg *config.Config) *cobra.Command {
 			// Run tasks
 			err = group.Wait()
 			if err != nil {
-				logger.Fatal("crashed", zap.Error(err))
+				logger.Error("crashed", zap.Error(err))
+				return
 			}
 
 			logger.Info("shutdown gracefully")

--- a/cli/cmd/runtime/start.go
+++ b/cli/cmd/runtime/start.go
@@ -137,7 +137,8 @@ func StartCmd(cliCfg *config.Config) *cobra.Command {
 			group.Go(func() error { return s.ServeHTTP(cctx, nil) })
 			err = group.Wait()
 			if err != nil {
-				logger.Fatal("server crashed", zap.Error(err))
+				logger.Error("server crashed", zap.Error(err))
+				return
 			}
 
 			logger.Info("server shutdown gracefully")


### PR DESCRIPTION
Using `logger.Fatal` causes `defer` calls not to get called. This could leave things in a weird state if a reconcile is running in the background.