### PR TITLE
fix: add wait for process to exit between e2e tests

### DIFF
--- a/web-local/test/ui/utils/useTestServer.ts
+++ b/web-local/test/ui/utils/useTestServer.ts
@@ -57,8 +57,12 @@ export function useTestServer(port: number, dir: string) {
   });
 
   afterEach(async () => {
+    const processExit = new Promise((resolve) => {
+      childProcess.on("exit", resolve);
+    });
     if (childProcess.pid) treeKill(childProcess.pid);
     await asyncWaitUntil(async () => !(await isPortOpen(port)));
+    await processExit;
   });
 }
 


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [x] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
Occasionally e2e test failures due to locking


#### Details:
Occasionally we see e2e tests fail because a stage db file is still locked. @AdityaHegde has already put in one PR to fix this by using different stage files for each test run. This PR adds to that by making sure we are waiting for processes to exit properly while running the test serially. While this code is probably unnecessary at this point, I think its important that while we are running our tests in serial, we should make sure that they are exiting properly to avoid any other bugs in the future.

## Steps to Verify
Run the e2e tests