### PR TITLE
Reduce excessive calls to `/totals`

### DIFF
--- a/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
@@ -142,7 +142,9 @@
     },
     {
       query: {
-        enabled: hasTimeSeries ? !!metricsExplorer.selectedTimeRange : true,
+        enabled:
+          (hasTimeSeries ? !!metricsExplorer.selectedTimeRange : true) &&
+          !!metricsExplorer?.filters,
       },
     }
   );

--- a/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
@@ -136,8 +136,12 @@
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: metricsExplorer.selectedTimeRange?.start.toISOString(),
-      timeEnd: metricsExplorer.selectedTimeRange?.end.toISOString(),
+      timeStart: metricsExplorer.selectedTimeRange?.start
+        ? metricsExplorer.selectedTimeRange.start.toISOString()
+        : undefined,
+      timeEnd: metricsExplorer.selectedTimeRange?.end
+        ? metricsExplorer.selectedTimeRange.end.toISOString()
+        : undefined,
       filter: metricsExplorer?.filters,
     },
     {

--- a/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
@@ -131,19 +131,21 @@
 
   $: metricTimeSeries = useModelHasTimeSeries(instanceId, metricViewName);
   $: hasTimeSeries = $metricTimeSeries.data;
+  $: timeStart = metricsExplorer.selectedTimeRange?.start?.toISOString();
+  $: timeEnd = metricsExplorer.selectedTimeRange?.end?.toISOString();
   $: totalsQuery = createQueryServiceMetricsViewTotals(
     instanceId,
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: metricsExplorer.selectedTimeRange?.start?.toISOString(),
-      timeEnd: metricsExplorer.selectedTimeRange?.end?.toISOString(),
+      timeStart: timeStart,
+      timeEnd: timeEnd,
       filter: metricsExplorer?.filters,
     },
     {
       query: {
         enabled:
-          (hasTimeSeries ? !!metricsExplorer.selectedTimeRange : true) &&
+          (hasTimeSeries ? !!timeStart && !!timeEnd : true) &&
           !!metricsExplorer?.filters,
       },
     }

--- a/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
@@ -136,12 +136,8 @@
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: metricsExplorer.selectedTimeRange?.start
-        ? metricsExplorer.selectedTimeRange.start.toISOString()
-        : undefined,
-      timeEnd: metricsExplorer.selectedTimeRange?.end
-        ? metricsExplorer.selectedTimeRange.end.toISOString()
-        : undefined,
+      timeStart: metricsExplorer.selectedTimeRange?.start?.toISOString(),
+      timeEnd: metricsExplorer.selectedTimeRange?.end?.toISOString(),
       filter: metricsExplorer?.filters,
     },
     {

--- a/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
@@ -10,10 +10,7 @@
   import { createQueryServiceMetricsViewTotals } from "@rilldata/web-common/runtime-client";
   import { runtime } from "../../../runtime-client/runtime-store";
   import { MEASURE_CONFIG } from "../config";
-  import {
-    MetricsExplorerEntity,
-    metricsExplorerStore,
-  } from "../dashboard-stores";
+  import { metricsExplorerStore, useDashboardStore } from "../dashboard-stores";
   import MeasureBigNumber from "./MeasureBigNumber.svelte";
 
   import SeachableFilterButton from "@rilldata/web-common/components/searchable-filter-menu/SeachableFilterButton.svelte";
@@ -39,15 +36,14 @@
     MEASURES_PADDING_LEFT -
     LEADERBOARD_PADDING_RIGHT;
 
-  let metricsExplorer: MetricsExplorerEntity;
-  $: metricsExplorer = $metricsExplorerStore.entities[metricViewName];
+  $: dashboardStore = useDashboardStore(metricViewName);
 
   $: instanceId = $runtime.instanceId;
 
   // query the `/meta` endpoint to get the measures and the default time grain
   $: metaQuery = useMetaQuery(instanceId, metricViewName);
 
-  $: selectedMeasureNames = metricsExplorer?.selectedMeasureNames;
+  $: selectedMeasureNames = $dashboardStore?.selectedMeasureNames;
 
   const { observedNode, listenToNodeResize } =
     createResizeListenerActionFactory();
@@ -131,8 +127,8 @@
 
   $: metricTimeSeries = useModelHasTimeSeries(instanceId, metricViewName);
   $: hasTimeSeries = $metricTimeSeries.data;
-  $: timeStart = metricsExplorer.selectedTimeRange?.start?.toISOString();
-  $: timeEnd = metricsExplorer.selectedTimeRange?.end?.toISOString();
+  $: timeStart = $dashboardStore.selectedTimeRange?.start?.toISOString();
+  $: timeEnd = $dashboardStore.selectedTimeRange?.end?.toISOString();
   $: totalsQuery = createQueryServiceMetricsViewTotals(
     instanceId,
     metricViewName,
@@ -140,13 +136,13 @@
       measureNames: selectedMeasureNames,
       timeStart: timeStart,
       timeEnd: timeEnd,
-      filter: metricsExplorer?.filters,
+      filter: $dashboardStore?.filters,
     },
     {
       query: {
         enabled:
           (hasTimeSeries ? !!timeStart && !!timeEnd : true) &&
-          !!metricsExplorer?.filters,
+          !!$dashboardStore?.filters,
       },
     }
   );
@@ -159,7 +155,7 @@
 
   $: availableMeasureLabels = selectBestMeasureStrings($metaQuery);
   $: availableMeasureKeys = selectMeasureKeys($metaQuery);
-  $: visibleMeasureKeys = metricsExplorer?.visibleMeasureKeys;
+  $: visibleMeasureKeys = $dashboardStore?.visibleMeasureKeys;
   $: visibleMeasuresBitmask = availableMeasureKeys.map((k) =>
     visibleMeasureKeys.has(k)
   );

--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -233,17 +233,19 @@
     displayComparison = false;
   }
 
+  $: timeStart = metricsExplorer.selectedTimeRange?.start?.toISOString();
+  $: timeEnd = metricsExplorer.selectedTimeRange?.end?.toISOString();
   $: totalsQuery = createQueryServiceMetricsViewTotals(
     instanceId,
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: metricsExplorer.selectedTimeRange?.start?.toISOString(),
-      timeEnd: metricsExplorer.selectedTimeRange?.end?.toISOString(),
+      timeStart: timeStart,
+      timeEnd: timeEnd,
     },
     {
       query: {
-        enabled: hasTimeSeries ? !!metricsExplorer.selectedTimeRange : true,
+        enabled: hasTimeSeries ? !!timeStart && !!timeEnd : true,
       },
     }
   );

--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -238,8 +238,12 @@
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: metricsExplorer.selectedTimeRange?.start.toISOString(),
-      timeEnd: metricsExplorer.selectedTimeRange?.end.toISOString(),
+      timeStart: metricsExplorer.selectedTimeRange?.start
+        ? metricsExplorer.selectedTimeRange.start.toISOString()
+        : undefined,
+      timeEnd: metricsExplorer.selectedTimeRange?.end
+        ? metricsExplorer.selectedTimeRange.end.toISOString()
+        : undefined,
     },
     {
       query: {

--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -26,10 +26,7 @@
   import { DEFAULT_TIME_RANGES } from "../../../lib/time/config";
   import type { TimeComparisonOption } from "../../../lib/time/types";
   import { runtime } from "../../../runtime-client/runtime-store";
-  import {
-    MetricsExplorerEntity,
-    metricsExplorerStore,
-  } from "../dashboard-stores";
+  import { metricsExplorerStore, useDashboardStore } from "../dashboard-stores";
   import {
     humanizeGroupByColumns,
     NicelyFormattedTypes,
@@ -62,10 +59,9 @@
   let dimension: MetricsViewDimension;
   $: dimension = $dimensionQuery?.data;
 
-  let metricsExplorer: MetricsExplorerEntity;
-  $: metricsExplorer = $metricsExplorerStore.entities[metricViewName];
+  $: dashboardStore = useDashboardStore(metricViewName);
 
-  $: leaderboardMeasureName = metricsExplorer?.leaderboardMeasureName;
+  $: leaderboardMeasureName = $dashboardStore?.leaderboardMeasureName;
   $: leaderboardMeasureQuery = useMetaMeasure(
     instanceId,
     metricViewName,
@@ -73,24 +69,24 @@
   );
 
   let excludeValues: Array<MetricsViewFilterCond>;
-  $: excludeValues = metricsExplorer?.filters.exclude;
+  $: excludeValues = $dashboardStore?.filters.exclude;
 
   $: excludeMode =
-    metricsExplorer?.dimensionFilterExcludeMode.get(dimensionName) ?? false;
+    $dashboardStore?.dimensionFilterExcludeMode.get(dimensionName) ?? false;
 
   $: filterForDimension = getFilterForDimension(
-    metricsExplorer?.filters,
+    $dashboardStore?.filters,
     dimensionName
   );
 
-  $: selectedMeasureNames = metricsExplorer?.selectedMeasureNames;
+  $: selectedMeasureNames = $dashboardStore?.selectedMeasureNames;
 
   let selectedValues: Array<unknown>;
   $: selectedValues =
     (excludeMode
-      ? metricsExplorer?.filters.exclude.find((d) => d.name === dimension?.name)
+      ? $dashboardStore?.filters.exclude.find((d) => d.name === dimension?.name)
           ?.in
-      : metricsExplorer?.filters.include.find((d) => d.name === dimension?.name)
+      : $dashboardStore?.filters.include.find((d) => d.name === dimension?.name)
           ?.in) ?? [];
 
   $: allMeasures = $metaQuery.data?.measures;
@@ -136,8 +132,8 @@
       topListParams = {
         ...topListParams,
         ...{
-          timeStart: metricsExplorer.selectedTimeRange?.start,
-          timeEnd: metricsExplorer.selectedTimeRange?.end,
+          timeStart: $dashboardStore.selectedTimeRange?.start,
+          timeEnd: $dashboardStore.selectedTimeRange?.end,
         },
       };
     }
@@ -161,7 +157,7 @@
   }
 
   // the timeRangeName is the key to a selected time range's associated presets.
-  $: timeRangeName = metricsExplorer?.selectedTimeRange?.name;
+  $: timeRangeName = $dashboardStore?.selectedTimeRange?.name;
 
   $: allTimeRange = $allTimeRangeQuery?.data;
 
@@ -178,20 +174,20 @@
     const values: V1MetricsViewToplistResponse = $topListQuery?.data?.data;
 
     const comparisonTimeRange = getTimeComparisonParametersForComponent(
-      (metricsExplorer?.selectedComparisonTimeRange
+      ($dashboardStore?.selectedComparisonTimeRange
         ?.name as TimeComparisonOption) ||
         (DEFAULT_TIME_RANGES[timeRangeName]
           .defaultComparison as TimeComparisonOption),
       allTimeRange?.start,
       allTimeRange?.end,
-      metricsExplorer.selectedTimeRange.start,
-      metricsExplorer.selectedTimeRange.end
+      $dashboardStore.selectedTimeRange.start,
+      $dashboardStore.selectedTimeRange.end
     );
 
     const { start, end } = comparisonTimeRange;
     isComparisonRangeAvailable = comparisonTimeRange.isComparisonRangeAvailable;
     displayComparison =
-      metricsExplorer?.showComparison && isComparisonRangeAvailable;
+      $dashboardStore?.showComparison && isComparisonRangeAvailable;
 
     let comparisonFilterSet = getFilterForComparisonTable(
       filterForDimension,
@@ -233,8 +229,8 @@
     displayComparison = false;
   }
 
-  $: timeStart = metricsExplorer.selectedTimeRange?.start?.toISOString();
-  $: timeEnd = metricsExplorer.selectedTimeRange?.end?.toISOString();
+  $: timeStart = $dashboardStore.selectedTimeRange?.start?.toISOString();
+  $: timeEnd = $dashboardStore.selectedTimeRange?.end?.toISOString();
   $: totalsQuery = createQueryServiceMetricsViewTotals(
     instanceId,
     metricViewName,

--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -238,12 +238,8 @@
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: metricsExplorer.selectedTimeRange?.start
-        ? metricsExplorer.selectedTimeRange.start.toISOString()
-        : undefined,
-      timeEnd: metricsExplorer.selectedTimeRange?.end
-        ? metricsExplorer.selectedTimeRange.end.toISOString()
-        : undefined,
+      timeStart: metricsExplorer.selectedTimeRange?.start?.toISOString(),
+      timeEnd: metricsExplorer.selectedTimeRange?.end?.toISOString(),
     },
     {
       query: {

--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -233,29 +233,20 @@
     displayComparison = false;
   }
 
-  let totalsQuery;
-  $: if (
-    metricsExplorer &&
-    metaQuery &&
-    $metaQuery.isSuccess &&
-    !$metaQuery.isRefetching
-  ) {
-    let totalsQueryParams = { measureNames: selectedMeasureNames };
-    if (hasTimeSeries) {
-      totalsQueryParams = {
-        ...totalsQueryParams,
-        ...{
-          timeStart: metricsExplorer.selectedTimeRange?.start,
-          timeEnd: metricsExplorer.selectedTimeRange?.end,
-        },
-      };
+  $: totalsQuery = createQueryServiceMetricsViewTotals(
+    instanceId,
+    metricViewName,
+    {
+      measureNames: selectedMeasureNames,
+      timeStart: metricsExplorer.selectedTimeRange?.start.toISOString(),
+      timeEnd: metricsExplorer.selectedTimeRange?.end.toISOString(),
+    },
+    {
+      query: {
+        enabled: hasTimeSeries ? !!metricsExplorer.selectedTimeRange : true,
+      },
     }
-    totalsQuery = createQueryServiceMetricsViewTotals(
-      instanceId,
-      metricViewName,
-      totalsQueryParams
-    );
-  }
+  );
 
   let referenceValues = {};
   $: if ($totalsQuery?.data?.data) {

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -54,10 +54,13 @@
       measureNames: selectedMeasureNames,
       timeStart: metricsExplorer.selectedTimeRange?.start.toISOString(),
       timeEnd: metricsExplorer.selectedTimeRange?.end.toISOString(),
+      filter: metricsExplorer?.filters,
     },
     {
       query: {
-        enabled: hasTimeSeries ? !!metricsExplorer.selectedTimeRange : true,
+        enabled:
+          (hasTimeSeries ? !!metricsExplorer.selectedTimeRange : true) &&
+          !!metricsExplorer?.filters,
       },
     }
   );

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -43,19 +43,21 @@
   );
   $: hasTimeSeries = $metricTimeSeries.data;
 
+  $: timeStart = $dashboardStore?.selectedTimeRange?.start?.toISOString();
+  $: timeEnd = $dashboardStore?.selectedTimeRange?.end?.toISOString();
   $: totalsQuery = createQueryServiceMetricsViewTotals(
     $runtime.instanceId,
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: $dashboardStore?.selectedTimeRange?.start?.toISOString(),
-      timeEnd: $dashboardStore?.selectedTimeRange?.end?.toISOString(),
+      timeStart: timeStart,
+      timeEnd: timeEnd,
       filter: $dashboardStore?.filters,
     },
     {
       query: {
         enabled:
-          (hasTimeSeries ? !!$dashboardStore?.selectedTimeRange : true) &&
+          (hasTimeSeries ? !!timeStart && !!timeEnd : true) &&
           !!$dashboardStore?.filters,
       },
     }

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -52,8 +52,12 @@
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: metricsExplorer.selectedTimeRange?.start.toISOString(),
-      timeEnd: metricsExplorer.selectedTimeRange?.end.toISOString(),
+      timeStart: metricsExplorer.selectedTimeRange?.start
+        ? metricsExplorer.selectedTimeRange.start.toISOString()
+        : undefined,
+      timeEnd: metricsExplorer.selectedTimeRange?.end
+        ? metricsExplorer.selectedTimeRange.end.toISOString()
+        : undefined,
       filter: metricsExplorer?.filters,
     },
     {

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -47,23 +47,25 @@
   );
   $: hasTimeSeries = $metricTimeSeries.data;
 
+  $: timeStart = metricsExplorer?.selectedTimeRange?.start
+    ? metricsExplorer.selectedTimeRange.start.toISOString()
+    : undefined;
+  $: timeEnd = metricsExplorer?.selectedTimeRange?.end
+    ? metricsExplorer.selectedTimeRange.end.toISOString()
+    : undefined;
   $: totalsQuery = createQueryServiceMetricsViewTotals(
     $runtime.instanceId,
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: metricsExplorer.selectedTimeRange?.start
-        ? metricsExplorer.selectedTimeRange.start.toISOString()
-        : undefined,
-      timeEnd: metricsExplorer.selectedTimeRange?.end
-        ? metricsExplorer.selectedTimeRange.end.toISOString()
-        : undefined,
+      timeStart: timeStart,
+      timeEnd: timeEnd,
       filter: metricsExplorer?.filters,
     },
     {
       query: {
         enabled:
-          (hasTimeSeries ? !!metricsExplorer.selectedTimeRange : true) &&
+          (hasTimeSeries ? !!timeStart && !!timeEnd : true) &&
           !!metricsExplorer?.filters,
       },
     }

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -6,11 +6,10 @@
     useModelHasTimeSeries,
   } from "@rilldata/web-common/features/dashboards/selectors";
   import {
-    MetricsViewDimension,
-    V1MetricsViewTotalsResponse,
     createQueryServiceMetricsViewTotals,
+    MetricsViewDimension,
   } from "@rilldata/web-common/runtime-client";
-  import { CreateQueryResult, useQueryClient } from "@tanstack/svelte-query";
+  import { useQueryClient } from "@tanstack/svelte-query";
   import { onDestroy, onMount } from "svelte";
   import { runtime } from "../../../runtime-client/runtime-store";
   import {
@@ -48,33 +47,24 @@
   );
   $: hasTimeSeries = $metricTimeSeries.data;
 
+  $: totalsQuery = createQueryServiceMetricsViewTotals(
+    $runtime.instanceId,
+    metricViewName,
+    {
+      measureNames: selectedMeasureNames,
+      timeStart: metricsExplorer.selectedTimeRange?.start.toISOString(),
+      timeEnd: metricsExplorer.selectedTimeRange?.end.toISOString(),
+    },
+    {
+      query: {
+        enabled: hasTimeSeries ? !!metricsExplorer.selectedTimeRange : true,
+      },
+    }
+  );
+
   $: formatPreset =
     (activeMeasure?.format as NicelyFormattedTypes) ??
     NicelyFormattedTypes.HUMANIZE;
-
-  let totalsQuery: CreateQueryResult<V1MetricsViewTotalsResponse, Error>;
-  $: if (
-    metricsExplorer &&
-    metaQuery &&
-    $metaQuery.isSuccess &&
-    !$metaQuery.isRefetching
-  ) {
-    let totalsQueryParams = { measureNames: selectedMeasureNames };
-    if (hasTimeSeries) {
-      totalsQueryParams = {
-        ...totalsQueryParams,
-        ...{
-          timeStart: metricsExplorer.selectedTimeRange?.start,
-          timeEnd: metricsExplorer.selectedTimeRange?.end,
-        },
-      };
-    }
-    totalsQuery = createQueryServiceMetricsViewTotals(
-      $runtime.instanceId,
-      metricViewName,
-      totalsQueryParams
-    );
-  }
 
   let referenceValue: number;
   $: if (activeMeasure?.name && $totalsQuery?.data?.data) {

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -43,25 +43,19 @@
   );
   $: hasTimeSeries = $metricTimeSeries.data;
 
-  $: timeStart = $dashboardStore?.selectedTimeRange?.start
-    ? $dashboardStore.selectedTimeRange.start.toISOString()
-    : undefined;
-  $: timeEnd = $dashboardStore?.selectedTimeRange?.end
-    ? $dashboardStore.selectedTimeRange.end.toISOString()
-    : undefined;
   $: totalsQuery = createQueryServiceMetricsViewTotals(
     $runtime.instanceId,
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: timeStart,
-      timeEnd: timeEnd,
+      timeStart: $dashboardStore?.selectedTimeRange?.start?.toISOString(),
+      timeEnd: $dashboardStore?.selectedTimeRange?.end?.toISOString(),
       filter: $dashboardStore?.filters,
     },
     {
       query: {
         enabled:
-          (hasTimeSeries ? !!timeStart && !!timeEnd : true) &&
+          (hasTimeSeries ? !!$dashboardStore?.selectedTimeRange : true) &&
           !!$dashboardStore?.filters,
       },
     }

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -67,8 +67,12 @@
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: $dashboardStore?.selectedTimeRange?.start.toISOString(),
-      timeEnd: $dashboardStore?.selectedTimeRange?.end.toISOString(),
+      timeStart: $dashboardStore?.selectedTimeRange?.start
+        ? $dashboardStore.selectedTimeRange.start.toISOString()
+        : undefined,
+      timeEnd: $dashboardStore?.selectedTimeRange?.end
+        ? $dashboardStore.selectedTimeRange.end.toISOString()
+        : undefined,
       filter: $dashboardStore?.filters,
     },
     {
@@ -92,9 +96,12 @@
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart:
-        $dashboardStore?.selectedComparisonTimeRange?.start.toISOString(),
-      timeEnd: $dashboardStore?.selectedComparisonTimeRange?.end.toISOString(),
+      timeStart: $dashboardStore?.selectedComparisonTimeRange?.start
+        ? $dashboardStore.selectedComparisonTimeRange.start.toISOString()
+        : undefined,
+      timeEnd: $dashboardStore?.selectedComparisonTimeRange?.end
+        ? $dashboardStore.selectedComparisonTimeRange.end.toISOString()
+        : undefined,
       filter: $dashboardStore?.filters,
     },
     {

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -67,13 +67,14 @@
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      filter: $dashboardStore?.filters,
       timeStart: $dashboardStore?.selectedTimeRange?.start.toISOString(),
       timeEnd: $dashboardStore?.selectedTimeRange?.end.toISOString(),
+      filter: $dashboardStore?.filters,
     },
     {
       query: {
-        enabled: !!$dashboardStore?.selectedTimeRange,
+        enabled:
+          !!$dashboardStore?.selectedTimeRange && !!$dashboardStore?.filters,
       },
     }
   );
@@ -91,15 +92,17 @@
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      filter: $dashboardStore?.filters,
       timeStart:
         $dashboardStore?.selectedComparisonTimeRange?.start.toISOString(),
       timeEnd: $dashboardStore?.selectedComparisonTimeRange?.end.toISOString(),
+      filter: $dashboardStore?.filters,
     },
     {
       query: {
         enabled: Boolean(
-          displayComparison && !!$dashboardStore?.selectedComparisonTimeRange
+          displayComparison &&
+            !!$dashboardStore?.selectedComparisonTimeRange &&
+            !!$dashboardStore?.filters
         ),
       },
     }

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -62,23 +62,24 @@
     name = $dashboardStore.selectedTimeRange.name;
   }
 
+  $: timeStart = $dashboardStore?.selectedTimeRange?.start
+    ? $dashboardStore.selectedTimeRange.start.toISOString()
+    : undefined;
+  $: timeEnd = $dashboardStore?.selectedTimeRange?.end
+    ? $dashboardStore.selectedTimeRange.end.toISOString()
+    : undefined;
   $: totalsQuery = createQueryServiceMetricsViewTotals(
     instanceId,
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: $dashboardStore?.selectedTimeRange?.start
-        ? $dashboardStore.selectedTimeRange.start.toISOString()
-        : undefined,
-      timeEnd: $dashboardStore?.selectedTimeRange?.end
-        ? $dashboardStore.selectedTimeRange.end.toISOString()
-        : undefined,
+      timeStart: timeStart,
+      timeEnd: timeEnd,
       filter: $dashboardStore?.filters,
     },
     {
       query: {
-        enabled:
-          !!$dashboardStore?.selectedTimeRange && !!$dashboardStore?.filters,
+        enabled: !!timeStart && !!timeEnd && !!$dashboardStore?.filters,
       },
     }
   );

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -62,19 +62,20 @@
     name = $dashboardStore.selectedTimeRange.name;
   }
 
+  $: timeStart = $dashboardStore?.selectedTimeRange?.start?.toISOString();
+  $: timeEnd = $dashboardStore?.selectedTimeRange?.end?.toISOString();
   $: totalsQuery = createQueryServiceMetricsViewTotals(
     instanceId,
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: $dashboardStore?.selectedTimeRange?.start?.toISOString(),
-      timeEnd: $dashboardStore?.selectedTimeRange?.end?.toISOString(),
+      timeStart: timeStart,
+      timeEnd: timeEnd,
       filter: $dashboardStore?.filters,
     },
     {
       query: {
-        enabled:
-          !!$dashboardStore?.selectedTimeRange && !!$dashboardStore?.filters,
+        enabled: !!timeStart && !!timeEnd && !!$dashboardStore?.filters,
       },
     }
   );
@@ -87,21 +88,26 @@
     $dashboardStore?.selectedComparisonTimeRange?.end
   );
   $: displayComparison = showComparison && isComparisonRangeAvailable;
+
+  $: comparisonTimeStart =
+    $dashboardStore?.selectedComparisonTimeRange?.start?.toISOString();
+  $: comparisonTimeEnd =
+    $dashboardStore?.selectedComparisonTimeRange?.end?.toISOString();
   $: totalsComparisonQuery = createQueryServiceMetricsViewTotals(
     instanceId,
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart:
-        $dashboardStore?.selectedComparisonTimeRange?.start?.toISOString(),
-      timeEnd: $dashboardStore?.selectedComparisonTimeRange?.end?.toISOString(),
+      timeStart: comparisonTimeStart,
+      timeEnd: comparisonTimeEnd,
       filter: $dashboardStore?.filters,
     },
     {
       query: {
         enabled: Boolean(
           displayComparison &&
-            !!$dashboardStore?.selectedComparisonTimeRange &&
+            !!comparisonTimeStart &&
+            !!comparisonTimeEnd &&
             !!$dashboardStore?.filters
         ),
       },

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -62,24 +62,19 @@
     name = $dashboardStore.selectedTimeRange.name;
   }
 
-  $: timeStart = $dashboardStore?.selectedTimeRange?.start
-    ? $dashboardStore.selectedTimeRange.start.toISOString()
-    : undefined;
-  $: timeEnd = $dashboardStore?.selectedTimeRange?.end
-    ? $dashboardStore.selectedTimeRange.end.toISOString()
-    : undefined;
   $: totalsQuery = createQueryServiceMetricsViewTotals(
     instanceId,
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: timeStart,
-      timeEnd: timeEnd,
+      timeStart: $dashboardStore?.selectedTimeRange?.start?.toISOString(),
+      timeEnd: $dashboardStore?.selectedTimeRange?.end?.toISOString(),
       filter: $dashboardStore?.filters,
     },
     {
       query: {
-        enabled: !!timeStart && !!timeEnd && !!$dashboardStore?.filters,
+        enabled:
+          !!$dashboardStore?.selectedTimeRange && !!$dashboardStore?.filters,
       },
     }
   );
@@ -97,12 +92,9 @@
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: $dashboardStore?.selectedComparisonTimeRange?.start
-        ? $dashboardStore.selectedComparisonTimeRange.start.toISOString()
-        : undefined,
-      timeEnd: $dashboardStore?.selectedComparisonTimeRange?.end
-        ? $dashboardStore.selectedComparisonTimeRange.end.toISOString()
-        : undefined,
+      timeStart:
+        $dashboardStore?.selectedComparisonTimeRange?.start?.toISOString(),
+      timeEnd: $dashboardStore?.selectedComparisonTimeRange?.end?.toISOString(),
       filter: $dashboardStore?.filters,
     },
     {

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -4,8 +4,8 @@
   import CrossIcon from "@rilldata/web-common/components/icons/CrossIcon.svelte";
   import { useDashboardStore } from "@rilldata/web-common/features/dashboards/dashboard-stores";
   import {
-    NicelyFormattedTypes,
     humanizeDataType,
+    NicelyFormattedTypes,
     nicelyFormattedTypesToNumberKind,
   } from "@rilldata/web-common/features/dashboards/humanize-numbers";
   import {
@@ -18,10 +18,9 @@
   import { getOffset } from "@rilldata/web-common/lib/time/transforms";
   import { TimeOffsetType } from "@rilldata/web-common/lib/time/types";
   import {
-    V1MetricsViewTimeSeriesResponse,
-    V1MetricsViewTotalsResponse,
     createQueryServiceMetricsViewTimeSeries,
     createQueryServiceMetricsViewTotals,
+    V1MetricsViewTimeSeriesResponse,
   } from "@rilldata/web-common/runtime-client";
   import type { CreateQueryResult } from "@tanstack/svelte-query";
   import { isRangeInsideOther } from "../../../lib/time/ranges";
@@ -44,8 +43,6 @@
   $: selectedMeasureNames = $dashboardStore?.selectedMeasureNames;
   $: showComparison = $dashboardStore?.showComparison;
 
-  let totalsQuery: CreateQueryResult<V1MetricsViewTotalsResponse, Error>;
-
   $: allTimeRangeQuery = useModelAllTimeRange(
     $runtime.instanceId,
     $metaQuery.data.model,
@@ -65,59 +62,48 @@
     name = $dashboardStore.selectedTimeRange.name;
   }
 
-  let totalsComparisonQuery: CreateQueryResult<
-    V1MetricsViewTotalsResponse,
-    Error
-  >;
-
-  let isComparisonRangeAvailable = false;
-  let displayComparison = false;
-
-  /** Generate the totals & big number comparison query */
-  $: if (
-    name &&
-    $dashboardStore &&
-    metaQuery &&
-    $metaQuery.isSuccess &&
-    !$metaQuery.isRefetching &&
-    allTimeRange?.start &&
-    $dashboardStore?.selectedTimeRange?.start
-  ) {
-    isComparisonRangeAvailable = isRangeInsideOther(
-      allTimeRange?.start,
-      allTimeRange?.end,
-      $dashboardStore?.selectedComparisonTimeRange?.start,
-      $dashboardStore?.selectedComparisonTimeRange?.end
-    );
-    displayComparison = showComparison && isComparisonRangeAvailable;
-
-    const totalsQueryParams = {
+  $: totalsQuery = createQueryServiceMetricsViewTotals(
+    instanceId,
+    metricViewName,
+    {
       measureNames: selectedMeasureNames,
       filter: $dashboardStore?.filters,
-      timeStart: $dashboardStore.selectedTimeRange?.start.toISOString(),
-      timeEnd: $dashboardStore.selectedTimeRange?.end.toISOString(),
-    };
+      timeStart: $dashboardStore?.selectedTimeRange?.start.toISOString(),
+      timeEnd: $dashboardStore?.selectedTimeRange?.end.toISOString(),
+    },
+    {
+      query: {
+        enabled: !!$dashboardStore?.selectedTimeRange,
+      },
+    }
+  );
 
-    totalsQuery = createQueryServiceMetricsViewTotals(
-      instanceId,
-      metricViewName,
-      totalsQueryParams
-    );
-
-    totalsComparisonQuery = createQueryServiceMetricsViewTotals(
-      instanceId,
-      metricViewName,
-      {
-        ...totalsQueryParams,
-        timeStart: displayComparison
-          ? $dashboardStore?.selectedComparisonTimeRange?.start.toISOString()
-          : undefined,
-        timeEnd: displayComparison
-          ? $dashboardStore?.selectedComparisonTimeRange?.end.toISOString()
-          : undefined,
-      }
-    );
-  }
+  /** Generate the big number comparison query */
+  $: isComparisonRangeAvailable = isRangeInsideOther(
+    allTimeRange?.start,
+    allTimeRange?.end,
+    $dashboardStore?.selectedComparisonTimeRange?.start,
+    $dashboardStore?.selectedComparisonTimeRange?.end
+  );
+  $: displayComparison = showComparison && isComparisonRangeAvailable;
+  $: totalsComparisonQuery = createQueryServiceMetricsViewTotals(
+    instanceId,
+    metricViewName,
+    {
+      measureNames: selectedMeasureNames,
+      filter: $dashboardStore?.filters,
+      timeStart:
+        $dashboardStore?.selectedComparisonTimeRange?.start.toISOString(),
+      timeEnd: $dashboardStore?.selectedComparisonTimeRange?.end.toISOString(),
+    },
+    {
+      query: {
+        enabled: Boolean(
+          displayComparison && !!$dashboardStore?.selectedComparisonTimeRange
+        ),
+      },
+    }
+  );
 
   // get the totalsComparisons.
   $: totalsComparisons = $totalsComparisonQuery?.data?.data;


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
[Notion page](https://www.notion.so/rilldata/Only-run-queries-once-dashboard-state-is-initialized-451de063dba34117a4cccfdc189e17ae?d=ac03ba48ef4d45ac865bc46068a7164e)

#### Details:
This PR applies TanStack Query's `enabled` flag to each `/totals` request. We ensure that we only submit a request once the dashboard's time range and filters have been set.

Most significantly, if we issue the request without a time range, the backend will assume the query applies to the all time range. Querying the all time range locks up a Druid cluster.

## Steps to Verify
1. Open a dashboard
2. Open your browser devtools
3. Go to the Network tab
4. Filter for `/totals`
5. Refresh the dashboard page and observe 1 request to `/totals` and that request has a specified time range. Previously, there were 4 requests to `/totals`, some of which did not have a specified time range.