### PR TITLE
Adding user_id to cli telemetry

### DIFF
--- a/cli/pkg/telemetry/telemetry.go
+++ b/cli/pkg/telemetry/telemetry.go
@@ -113,6 +113,7 @@ func (t *Telemetry) emitBehaviourEvent(action, medium, space, screenName string)
 		InstallID:     t.InstallID,
 		BuildID:       t.Version.Commit,
 		Version:       t.Version.Number,
+		UserID:        t.UserID,
 		IsDev:         t.Version.IsDev(),
 		Mode:          "edit",
 		Action:        action,


### PR DESCRIPTION
When we added the user id telemetry we didnt add send it with the actual event.