### PR TITLE
Reconfig allowed grains

### DIFF
--- a/web-common/src/features/dashboards/time-controls/time-range-utils.spec.disabled.ts
+++ b/web-common/src/features/dashboards/time-controls/time-range-utils.spec.disabled.ts
@@ -1,40 +1,5 @@
 import { V1TimeGrain } from "../../../runtime-client";
-import { getDefaultTimeGrain, getTimeGrainOptions } from "./time-range-utils";
-
-describe("getTimeGrainOptions", () => {
-  it("should return an array of available time grains", () => {
-    const timeGrains = getTimeGrainOptions(
-      new Date("2020-03-01"),
-      new Date("2020-03-31")
-    );
-    expect(timeGrains).toEqual([
-      {
-        enabled: false,
-        timeGrain: V1TimeGrain.TIME_GRAIN_MINUTE,
-      },
-      {
-        enabled: true,
-        timeGrain: V1TimeGrain.TIME_GRAIN_HOUR,
-      },
-      {
-        enabled: true,
-        timeGrain: V1TimeGrain.TIME_GRAIN_DAY,
-      },
-      {
-        enabled: true,
-        timeGrain: V1TimeGrain.TIME_GRAIN_WEEK,
-      },
-      {
-        enabled: false,
-        timeGrain: V1TimeGrain.TIME_GRAIN_MONTH,
-      },
-      {
-        enabled: false,
-        timeGrain: V1TimeGrain.TIME_GRAIN_YEAR,
-      },
-    ]);
-  });
-});
+import { getDefaultTimeGrain } from "./time-range-utils";
 
 describe("getDefaultTimeGrain", () => {
   it("should return the default time grain (for a 5 day time range)", () => {

--- a/web-common/src/features/metrics-views/workspace/config-parameters/SmallestTimeGrainSelector.svelte
+++ b/web-common/src/features/metrics-views/workspace/config-parameters/SmallestTimeGrainSelector.svelte
@@ -3,8 +3,8 @@
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { TIME_GRAIN } from "@rilldata/web-common/lib/time/config";
-  import { getTimeGrainOptions } from "@rilldata/web-common/lib/time/grains";
-  import type { TimeGrainOption } from "@rilldata/web-common/lib/time/types";
+  import { getAllowedTimeGrains } from "@rilldata/web-common/lib/time/grains";
+  import type { TimeGrain } from "@rilldata/web-common/lib/time/types";
   import {
     createQueryServiceColumnTimeRange,
     V1Model,
@@ -54,29 +54,27 @@
     };
   }
 
-  let selectableTimeGrains: TimeGrainOption[] = [];
+  let allowedTimeGrains: TimeGrain[] = [];
   let maxTimeGrainPossibleIndex = 0;
+
+  const timeGrains = Object.values(TIME_GRAIN);
+
   $: if (allTimeRange) {
-    // FIXME: we should be deprecating this getTimeGrainOptions in favor of getAllowedTimeGrains.
-    selectableTimeGrains = getTimeGrainOptions(
+    allowedTimeGrains = getAllowedTimeGrains(
       allTimeRange.start,
       allTimeRange.end
     );
 
-    maxTimeGrainPossibleIndex =
-      selectableTimeGrains.length -
-      1 -
-      selectableTimeGrains
-        .slice()
-        .reverse()
-        .findIndex((grain) => grain.enabled);
+    const maxTimeGrainPossible =
+      allowedTimeGrains[allowedTimeGrains.length - 1];
+    maxTimeGrainPossibleIndex = timeGrains
+      .map((grain) => grain.label)
+      .indexOf(maxTimeGrainPossible.label);
   }
 
   $: isValidTimeGrain =
     defaultTimeGrainValue === "__DEFAULT_VALUE__" ||
-    Object.values(TIME_GRAIN).some(
-      (timeGrain) => timeGrain.label === defaultTimeGrainValue
-    );
+    timeGrains.some((timeGrain) => timeGrain.label === defaultTimeGrainValue);
 
   $: level = isValidTimeGrain ? "" : "error";
 
@@ -102,7 +100,7 @@
           },
         ]
       : []),
-    ...(selectableTimeGrains.map((grain, i) => {
+    ...(timeGrains.map((grain, i) => {
       const isGrainPossible = i <= maxTimeGrainPossibleIndex;
       return {
         divider: false,

--- a/web-common/src/lib/time/grains/index.spec.ts
+++ b/web-common/src/lib/time/grains/index.spec.ts
@@ -11,11 +11,9 @@ import { Period, TimeGrain } from "../types";
 
 const allowedGrainTests = [
   {
-    test: "should return TIME_GRAIN_MINUTE for < 2 hours",
+    test: "should return TIME_GRAIN_MINUTE for < 1 hour",
     start: new Date(0),
-    end: new Date(
-      2 * durationToMillis(TIME_GRAIN.TIME_GRAIN_HOUR.duration) - 1
-    ),
+    end: new Date(durationToMillis(TIME_GRAIN.TIME_GRAIN_HOUR.duration) - 1),
     expected: [TIME_GRAIN.TIME_GRAIN_MINUTE],
   },
   {
@@ -32,18 +30,11 @@ const allowedGrainTests = [
     end: new Date(durationToMillis(TIME_GRAIN.TIME_GRAIN_DAY.duration) - 1),
     expected: [TIME_GRAIN.TIME_GRAIN_HOUR],
   },
+
   {
-    test: "should return TIME_GRAIN_HOUR for 24 hours",
+    test: "should return TIME_GRAIN_HOUR and TIME_GRAIN_DAY if otherwise < 7 days",
     start: new Date(0),
-    end: new Date(durationToMillis(TIME_GRAIN.TIME_GRAIN_DAY.duration)),
-    expected: [TIME_GRAIN.TIME_GRAIN_HOUR],
-  },
-  {
-    test: "should return TIME_GRAIN_HOUR and TIME_GRAIN_DAY if otherwise < 14 days",
-    start: new Date(0),
-    end: new Date(
-      durationToMillis(TIME_GRAIN.TIME_GRAIN_DAY.duration) * 14 - 1
-    ),
+    end: new Date(durationToMillis(TIME_GRAIN.TIME_GRAIN_DAY.duration) * 7 - 1),
     expected: [TIME_GRAIN.TIME_GRAIN_HOUR, TIME_GRAIN.TIME_GRAIN_DAY],
   },
   {
@@ -59,19 +50,9 @@ const allowedGrainTests = [
     ],
   },
   {
-    test: "should return TIME_GRAIN_DAY, TIME_GRAIN_WEEK, and TIME_GRAIN_MONTH if otherwise < 90 days",
+    test: "should return TIME_GRAIN_WEEK, TIME_GRAIN_MONTH, and TIME_GRAIN_YEAR if otherwise < 1 year",
     start: new Date(0),
-    end: new Date(
-      3 * durationToMillis(TIME_GRAIN.TIME_GRAIN_DAY.duration) * 30 - 1
-    ),
-    expected: [TIME_GRAIN.TIME_GRAIN_DAY, TIME_GRAIN.TIME_GRAIN_WEEK],
-  },
-  {
-    test: "should return TIME_GRAIN_WEEK, TIME_GRAIN_MONTH, and TIME_GRAIN_YEAR if otherwise < 3 years",
-    start: new Date(0),
-    end: new Date(
-      3 * durationToMillis(TIME_GRAIN.TIME_GRAIN_YEAR.duration) - 1
-    ),
+    end: new Date(durationToMillis(TIME_GRAIN.TIME_GRAIN_YEAR.duration) - 1),
     expected: [
       TIME_GRAIN.TIME_GRAIN_DAY,
       TIME_GRAIN.TIME_GRAIN_WEEK,
@@ -79,7 +60,7 @@ const allowedGrainTests = [
     ],
   },
   {
-    test: "should return TIME_GRAIN_MONTH, TIME_GRAIN_YEAR, and TIME_GRAIN_QUARTER if otherwise < 10 years",
+    test: "should return TIME_GRAIN_WEEK, TIME_GRAIN_MONTH and TIME_GRAIN_YEAR if otherwise < 10 years",
     start: new Date(0),
     end: new Date(
       10 * durationToMillis(TIME_GRAIN.TIME_GRAIN_YEAR.duration) - 1

--- a/web-common/src/lib/time/grains/index.ts
+++ b/web-common/src/lib/time/grains/index.ts
@@ -78,8 +78,7 @@ export function getDefaultTimeGrain(start: Date, end: Date): TimeGrain {
 export function getAllowedTimeGrains(start: Date, end: Date): TimeGrain[] {
   const timeRangeDurationMs = getTimeWidth(start, end);
   if (
-    timeRangeDurationMs <
-    2 * durationToMillis(TIME_GRAIN.TIME_GRAIN_HOUR.duration)
+    timeRangeDurationMs < durationToMillis(TIME_GRAIN.TIME_GRAIN_HOUR.duration)
   ) {
     return [TIME_GRAIN.TIME_GRAIN_MINUTE];
   } else if (
@@ -88,12 +87,12 @@ export function getAllowedTimeGrains(start: Date, end: Date): TimeGrain[] {
   ) {
     return [TIME_GRAIN.TIME_GRAIN_MINUTE, TIME_GRAIN.TIME_GRAIN_HOUR];
   } else if (
-    timeRangeDurationMs <= durationToMillis(TIME_GRAIN.TIME_GRAIN_DAY.duration)
+    timeRangeDurationMs < durationToMillis(TIME_GRAIN.TIME_GRAIN_DAY.duration)
   ) {
     return [TIME_GRAIN.TIME_GRAIN_HOUR];
   } else if (
-    timeRangeDurationMs <=
-    14 * durationToMillis(TIME_GRAIN.TIME_GRAIN_DAY.duration)
+    timeRangeDurationMs <
+    7 * durationToMillis(TIME_GRAIN.TIME_GRAIN_DAY.duration)
   ) {
     return [TIME_GRAIN.TIME_GRAIN_HOUR, TIME_GRAIN.TIME_GRAIN_DAY];
   } else if (
@@ -106,13 +105,7 @@ export function getAllowedTimeGrains(start: Date, end: Date): TimeGrain[] {
       TIME_GRAIN.TIME_GRAIN_WEEK,
     ];
   } else if (
-    timeRangeDurationMs <
-    3 * durationToMillis(TIME_GRAIN.TIME_GRAIN_DAY.duration) * 30
-  ) {
-    return [TIME_GRAIN.TIME_GRAIN_DAY, TIME_GRAIN.TIME_GRAIN_WEEK];
-  } else if (
-    timeRangeDurationMs <
-    3 * durationToMillis(TIME_GRAIN.TIME_GRAIN_YEAR.duration)
+    timeRangeDurationMs < durationToMillis(TIME_GRAIN.TIME_GRAIN_YEAR.duration)
   ) {
     return [
       TIME_GRAIN.TIME_GRAIN_DAY,

--- a/web-common/src/lib/time/grains/index.ts
+++ b/web-common/src/lib/time/grains/index.ts
@@ -7,7 +7,7 @@ import { V1TimeGrain } from "@rilldata/web-common/runtime-client";
 import { Duration } from "luxon";
 import { TIME_GRAIN } from "../config";
 import { getTimeWidth } from "../transforms";
-import type { TimeGrain, TimeGrainOption } from "../types";
+import type { TimeGrain } from "../types";
 
 export function unitToTimeGrain(unit: string): V1TimeGrain {
   return (
@@ -18,30 +18,6 @@ export function unitToTimeGrain(unit: string): V1TimeGrain {
 
 export function durationToMillis(duration: string): number {
   return Duration.fromISO(duration).toMillis();
-}
-
-// FIXME: what is the difference between this and getAllowedTimeGrains?
-// It appears that we're using this instead of getAllowedTimeGrains.
-// I think we should deprecate this function as soon as possible.
-export function getTimeGrainOptions(start: Date, end: Date): TimeGrainOption[] {
-  const timeGrains: TimeGrainOption[] = [];
-  const timeRangeDurationMs = getTimeWidth(start, end);
-
-  for (const timeGrain of Object.values(TIME_GRAIN)) {
-    // only show a time grain if it results in a reasonable number of points on the line chart
-    const MINIMUM_POINTS_ON_LINE_CHART = 3;
-    const MAXIMUM_POINTS_ON_LINE_CHART = 2500;
-    const timeGrainDurationMs = durationToMillis(timeGrain.duration);
-    const pointsOnLineChart = timeRangeDurationMs / timeGrainDurationMs;
-    const showTimeGrain =
-      pointsOnLineChart >= MINIMUM_POINTS_ON_LINE_CHART &&
-      pointsOnLineChart <= MAXIMUM_POINTS_ON_LINE_CHART;
-    timeGrains.push({
-      ...timeGrain,
-      enabled: showTimeGrain,
-    });
-  }
-  return timeGrains;
 }
 
 // Get the default grain for a given time range.
@@ -72,9 +48,7 @@ export function getDefaultTimeGrain(start: Date, end: Date): TimeGrain {
   }
 }
 
-// Return time grains that are allowed for a given time range. Note that
-// this function is similar to getTimeGrainOptions. We should deprecate getTimeGrainOptions
-// in favor of this logic.
+// Return time grains that are allowed for a given time range.
 export function getAllowedTimeGrains(start: Date, end: Date): TimeGrain[] {
   const timeRangeDurationMs = getTimeWidth(start, end);
   if (

--- a/web-common/src/lib/time/types.ts
+++ b/web-common/src/lib/time/types.ts
@@ -162,11 +162,6 @@ export interface TimeGrain {
   formatDate: Intl.DateTimeFormatOptions;
 }
 
-// FIXME: is this needed?
-export interface TimeGrainOption extends TimeGrain {
-  enabled: boolean;
-}
-
 // limit the set of available time grains to those supported
 // by th dashboard.
 export type AvailableTimeGrain = Exclude<


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [x] Unit test coverage
- [x] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Reconfig time grains as per - https://www.notion.so/rilldata/Relationships-between-points-in-time-durations-time-ranges-offsets-and-natural-comparisons-a45146205f4e425fa5f3b325518ae12a?pvs=4#64319a0aa8de40df87d28fb4b613570c

#### Details:
- Deprecates and removes `getTimeGrainOptions`
- Enables time grain for ranges even if one value is possible

**Note**: Merge after #2131 
