### PR TITLE
Do not refetch profiling for failed model

### DIFF
--- a/web-common/src/features/models/workspace/ModelBody.svelte
+++ b/web-common/src/features/models/workspace/ModelBody.svelte
@@ -136,7 +136,7 @@
         httpRequestQueue.removeByName(modelName);
         // cancel all existing analytical queries currently running.
         await queryClient.cancelQueries({
-          fetching: true,
+          fetchStatus: "fetching",
           predicate: (query) => {
             return isProfilingQuery(query.queryHash, modelName);
           },


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Do not refetch profiling queries while modelling if the model fails.

#### Details:
We unnecessarily refetch profiling queries even if the model has failed. This will lead to a lot of unnecessary calls while actively typing a sql query.

Note that there is still a failed request for catalog entry. Non presence of a catalog entry means there is an error in the entity. So once we have refactored our app to the new architecture we need to revisit this logic.

## Steps to Verify
1. Create a model by typing down the query char by char.
2. While typing any failed sql should not output any 400s for profiling queries.