### PR TITLE
Wait for `selectedMeasures` before querying `/totals` API

### DIFF
--- a/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
@@ -141,6 +141,7 @@
     {
       query: {
         enabled:
+          selectedMeasureNames.length > 0 &&
           (hasTimeSeries ? !!timeStart && !!timeEnd : true) &&
           !!$dashboardStore?.filters,
       },

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -57,6 +57,7 @@
     {
       query: {
         enabled:
+          selectedMeasureNames.length > 0 &&
           (hasTimeSeries ? !!timeStart && !!timeEnd : true) &&
           !!$dashboardStore?.filters,
       },


### PR DESCRIPTION
This PR fixes the 400 error that flashes when refreshing a filtered dashboard in the Cloud UI.