### PR TITLE
Use 24 hour format for hours

### DIFF
--- a/web-common/src/lib/formatters.ts
+++ b/web-common/src/lib/formatters.ts
@@ -73,7 +73,7 @@ export function removeTimezoneOffset(dt: Date) {
 }
 
 export const standardTimestampFormat = (v, type = "TIMESTAMP") => {
-  let fmt = timeFormat("%Y-%m-%d %H:%M:%S");
+  let fmt = timeFormat("%Y-%m-%d %H:%M:%S Z");
   if (type === "DATE") {
     fmt = timeFormat("%Y-%m-%d");
   }

--- a/web-common/src/lib/formatters.ts
+++ b/web-common/src/lib/formatters.ts
@@ -73,7 +73,7 @@ export function removeTimezoneOffset(dt: Date) {
 }
 
 export const standardTimestampFormat = (v, type = "TIMESTAMP") => {
-  let fmt = timeFormat("%Y-%m-%d %I:%M:%S");
+  let fmt = timeFormat("%Y-%m-%d %H:%M:%S");
   if (type === "DATE") {
     fmt = timeFormat("%Y-%m-%d");
   }
@@ -81,12 +81,12 @@ export const standardTimestampFormat = (v, type = "TIMESTAMP") => {
 };
 
 export const fullTimestampFormat = (v) => {
-  const fmt = timeFormat("%Y-%m-%d %I:%M:%S.%L");
+  const fmt = timeFormat("%Y-%m-%d %H:%M:%S.%L");
   return fmt(removeTimezoneOffset(new Date(v)));
 };
 
 export const datePortion = timeFormat("%Y-%m-%d");
-export const timePortion = timeFormat("%I:%M:%S");
+export const timePortion = timeFormat("%H:%M:%S");
 
 export function microsToTimestring(microseconds: number) {
   // to format micros, we need to translate this to hh:mm:ss.


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
The timestamps returned from the runtime were not being displayed properly. 
https://rilldata.slack.com/archives/CTZ8XBQ85/p1686876647920379

#### Details:
We were using a 12 hour clock while formatting the timestamps. This PR switches it to a 24 hour clock. 
[D3 Locale format types](https://github.com/d3/d3-time-format#locale_format)

## Steps to Verify
1. Create a model
2. `SELECT cast('2022-01-01 00:00:00' as timestamp) as ts, cast('2022-01-01' as timestamptz) tsz`
3. The resulted rows should display `2022-01-01 00:00:00`
