### PR TITLE
Removing calendly download

### DIFF
--- a/web-local/src/app.html
+++ b/web-local/src/app.html
@@ -1,59 +1,55 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <link rel="stylesheet" href="%sveltekit.assets%/fonts/fonts.css" />
+    <link href="%sveltekit.assets%/fonts/fonts.css" rel="stylesheet" />
     <!-- preloaded fonts -->
     <link
-      rel="preload"
+      as="font"
+      crossorigin
       href="%sveltekit.assets%/fonts/source-code/SourceCodePro-VariableFont_wght.ttf"
-      as="font"
+      rel="preload"
       type="font/woff2"
-      crossorigin
     />
     <link
-      rel="preload"
+      as="font"
+      crossorigin
       href="%sveltekit.assets%/fonts/inter/Inter-Regular.woff2?v=3.19"
-      as="font"
+      rel="preload"
       type="font/woff2"
-      crossorigin
     />
     <link
-      rel="preload"
+      as="font"
+      crossorigin
       href="%sveltekit.assets%/fonts/inter/Inter-Medium.woff2?v=3.19"
-      as="font"
+      rel="preload"
       type="font/woff2"
-      crossorigin
     />
     <link
-      rel="preload"
+      as="font"
+      crossorigin
       href="%sveltekit.assets%/fonts/inter/Inter-SemiBold.woff2?v=3.19"
-      as="font"
+      rel="preload"
       type="font/woff2"
-      crossorigin
     />
     <link
-      rel="preload"
+      as="font"
+      crossorigin
       href="%sveltekit.assets%/fonts/inter/Inter-Bold.woff2?v=3.19"
-      as="font"
+      rel="preload"
       type="font/woff2"
-      crossorigin
     />
     <link
-      rel="preload"
-      href="%sveltekit.assets%/fonts/inter/Inter-ExtraBold.woff2?v=3.19"
       as="font"
-      type="font/woff2"
       crossorigin
+      href="%sveltekit.assets%/fonts/inter/Inter-ExtraBold.woff2?v=3.19"
+      rel="preload"
+      type="font/woff2"
     />
     <meta charset="utf-8" />
     <meta content="" name="description" />
     <link href="%sveltekit.assets%/favicon.png" rel="icon" />
     <meta content="width=device-width, initial-scale=1" name="viewport" />
     %sveltekit.head%
-    <script
-      src="https://assets.calendly.com/assets/external/widget.js"
-      type="text/javascript"
-    ></script>
   </head>
   <body>
     <div id="svelte">%sveltekit.body%</div>


### PR DESCRIPTION
We do not use calendly anymore. Removing the redundant download of its javascript.