### PR TITLE
Fix "Cannot read properties of undefined" error

### DIFF
--- a/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
@@ -141,7 +141,7 @@
     {
       query: {
         enabled:
-          selectedMeasureNames.length > 0 &&
+          selectedMeasureNames?.length > 0 &&
           (hasTimeSeries ? !!timeStart && !!timeEnd : true) &&
           !!$dashboardStore?.filters,
       },

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -57,7 +57,7 @@
     {
       query: {
         enabled:
-          selectedMeasureNames.length > 0 &&
+          selectedMeasureNames?.length > 0 &&
           (hasTimeSeries ? !!timeStart && !!timeEnd : true) &&
           !!$dashboardStore?.filters,
       },


### PR DESCRIPTION
This PR addresses [Himadri's bug report in Slack](https://rilldata.slack.com/archives/CTZ8XBQ85/p1686975790118379).

This bug is motivation for instantiating our Svelte stores higher in the component tree.