### PR TITLE
Moving telemetry initialisation to the top

### DIFF
--- a/web-common/src/layout/RillDeveloperLayout.svelte
+++ b/web-common/src/layout/RillDeveloperLayout.svelte
@@ -33,6 +33,7 @@
 
   onMount(async () => {
     const config = await runtimeServiceGetConfig();
+    initMetrics(config);
 
     featureFlags.set({
       readOnly: config.readonly,
@@ -45,8 +46,6 @@
 
     const res = await getArtifactErrors(config.instance_id);
     fileArtifactsStore.setErrors(res.affectedPaths, res.errors);
-
-    initMetrics(config);
   });
 
   syncFileSystemPeriodically(


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
In a fresh project adding a source and auto creating a dashboard fails to load the new items in the side bar.

#### Details:
We are calling reconcile to get initial errors, this fails when project is fresh. Since we had telemetry initialisation after this reconcile the app would crash when calling telemetry methods.

## Steps to Verify
1. Remove dev-project folder
2. Run `npm run dev`
3. Upload a source and auto generate dashboard
4. New model and dashboard should appear in the left nav