### PR TITLE
Fix/date picker locale bugs

### DIFF
--- a/web-common/src/components/date-picker/custom-picker.js
+++ b/web-common/src/components/date-picker/custom-picker.js
@@ -27,7 +27,7 @@ export default class Custompicker extends Litepicker {
     this.updateValues();
 
     this.options.startEl.addEventListener("blur", (e) => {
-      const maybeStartDate = parseLocaleStringDate(e.target.value); // new Date(e.target.value);
+      const maybeStartDate = parseLocaleStringDate(e.target.value);
       if (!isNaN(maybeStartDate.valueOf())) {
         this.datePicked[0] = new DateTime(maybeStartDate);
         this.emitChanged();
@@ -47,7 +47,7 @@ export default class Custompicker extends Litepicker {
     });
 
     this.options.endEl.addEventListener("blur", (e) => {
-      const maybeEndDate = parseLocaleStringDate(e.target.value); // new Date(e.target.value);
+      const maybeEndDate = parseLocaleStringDate(e.target.value);
       if (!isNaN(maybeEndDate.valueOf())) {
         this.datePicked[1] = new DateTime(maybeEndDate);
 

--- a/web-common/src/components/date-picker/custom-picker.js
+++ b/web-common/src/components/date-picker/custom-picker.js
@@ -84,10 +84,10 @@ export default class Custompicker extends Litepicker {
     const [start, end] = this.datePicked;
     const startString = start
       .toJSDate()
-      .toLocaleDateString(window.navigator.language);
+      .toLocaleDateString(Intl.DateTimeFormat().resolvedOptions().locale);
     const endString = end
       .toJSDate()
-      .toLocaleDateString(window.navigator.language);
+      .toLocaleDateString(Intl.DateTimeFormat().resolvedOptions().locale);
 
     if (startEl instanceof HTMLInputElement) {
       startEl.value = startString;

--- a/web-common/src/components/date-picker/util.ts
+++ b/web-common/src/components/date-picker/util.ts
@@ -243,3 +243,7 @@ export function parseLocaleStringDate(str: string, timeZone?: string) {
   if (!timeZone) return localDate;
   return new Date(localDate.toDateString() + " " + timeZone);
 }
+
+export function shiftToUTC(date: Date) {
+  return new Date(date.getTime() - date.getTimezoneOffset() * 60 * 1000);
+}

--- a/web-common/src/components/date-picker/util.ts
+++ b/web-common/src/components/date-picker/util.ts
@@ -225,7 +225,10 @@ export function getLocaleDateString(lang?: string) {
     "zu-ZA": "yyyy/MM/dd",
   };
 
-  return formats[lang ?? navigator.language] ?? "dd/MM/yyyy";
+  return (
+    formats[lang ?? Intl.DateTimeFormat().resolvedOptions().locale] ??
+    "dd/MM/yyyy"
+  );
 }
 
 // Using a timezone here SHIFTS the date as if it started in that timezone, rather than using the locale.

--- a/web-common/src/components/date-picker/util.ts
+++ b/web-common/src/components/date-picker/util.ts
@@ -241,8 +241,7 @@ export function parseLocaleStringDate(str: string, timeZone?: string) {
   let localDate = parse(str, format, new Date());
 
   // if date is still invalid, try parsing with default Date string parsing.
-  // Hack: if the string looks like an ISO date, Date() tries to parse it as ISO instead of as a locale date string. Add a space to the end to prevent this.
-  if (isNaN(localDate.valueOf())) localDate = new Date(`${str} `);
+  if (isNaN(localDate.valueOf())) localDate = new Date(`${str}`);
   if (!timeZone) return localDate;
   return new Date(localDate.toDateString() + " " + timeZone);
 }

--- a/web-common/src/features/dashboards/time-controls/CustomTimeRangeInput.svelte
+++ b/web-common/src/features/dashboards/time-controls/CustomTimeRangeInput.svelte
@@ -5,13 +5,14 @@
   } from "@rilldata/web-common/lib/time/grains";
   import { createEventDispatcher } from "svelte";
   import { Button } from "../../../components/button";
-  import type { DashboardTimeControls } from "../../../lib/time/types";
+  import { DashboardTimeControls, Period } from "../../../lib/time/types";
   import type { V1TimeGrain } from "../../../runtime-client";
   import Litepicker from "@rilldata/web-common/components/date-picker/Litepicker.svelte";
   import {
     parseLocaleStringDate,
     shiftToUTC,
   } from "@rilldata/web-common/components/date-picker/util";
+  import { getEndOfPeriod } from "@rilldata/web-common/lib/time/transforms";
 
   export let minTimeGrain: V1TimeGrain;
   export let boundaryStart: Date;
@@ -83,7 +84,11 @@
   function applyCustomTimeRange() {
     // Shift the selected dates to start in UTC instead of system timezone
     const startDate = getISOStringFromDate(start, "UTC");
-    const endDate = getISOStringFromDate(end, "UTC");
+    const endDate = getEndOfPeriod(
+      new Date(getISOStringFromDate(end, "UTC")),
+      Period.DAY
+    ).toISOString();
+
     dispatch("apply", {
       startDate,
       endDate,

--- a/web-common/src/features/dashboards/time-controls/CustomTimeRangeInput.svelte
+++ b/web-common/src/features/dashboards/time-controls/CustomTimeRangeInput.svelte
@@ -8,7 +8,10 @@
   import type { DashboardTimeControls } from "../../../lib/time/types";
   import type { V1TimeGrain } from "../../../runtime-client";
   import Litepicker from "@rilldata/web-common/components/date-picker/Litepicker.svelte";
-  import { parseLocaleStringDate } from "@rilldata/web-common/components/date-picker/util";
+  import {
+    parseLocaleStringDate,
+    shiftToUTC,
+  } from "@rilldata/web-common/components/date-picker/util";
 
   export let minTimeGrain: V1TimeGrain;
   export let boundaryStart: Date;
@@ -28,9 +31,12 @@
   // functions for extracting the right kind of date string out of
   // a Date object. Used in the input elements.
   export function getDateFromObject(date: Date): string {
-    return date.toLocaleDateString(window.navigator.language, {
-      timeZone: "UTC",
-    });
+    return date.toLocaleDateString(
+      Intl.DateTimeFormat().resolvedOptions().locale,
+      {
+        timeZone: "UTC",
+      }
+    );
   }
 
   export function getDateFromISOString(isoDate: string): string {
@@ -87,8 +93,8 @@
   let startEl, endEl, editingDate, isOpen;
 
   const handleDatePickerChange = (d) => {
-    start = getDateFromObject(d.detail.start);
-    end = getDateFromObject(d.detail.end);
+    start = getDateFromObject(shiftToUTC(d.detail.start));
+    end = getDateFromObject(shiftToUTC(d.detail.end));
   };
 
   const handleEditingChange = (d) => {

--- a/web-common/src/features/dashboards/time-controls/CustomTimeRangeInput.svelte
+++ b/web-common/src/features/dashboards/time-controls/CustomTimeRangeInput.svelte
@@ -73,7 +73,7 @@
   // HAM, you left off here.
   $: error = validateTimeRange(
     parseLocaleStringDate(start),
-    parseLocaleStringDate(end),
+    getEndOfPeriod(parseLocaleStringDate(end), Period.DAY),
     minTimeGrain
   );
   $: disabled = !start || !end || !!error;

--- a/web-local/test/ui/dashboards.spec.ts
+++ b/web-local/test/ui/dashboards.spec.ts
@@ -187,7 +187,7 @@ describe("dashboards", () => {
     await timeRangeMenu.getByRole("button", { name: "Apply" }).click();
 
     // Check number
-    await playwrightExpect(page.getByText("Total records 64.0k")).toBeVisible();
+    await playwrightExpect(page.getByText("Total records 65.1k")).toBeVisible();
 
     // Flip back to All Time
     await page.getByLabel("Select time range").click();


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
Fixes bugs:
- Local dates were not properly being shifted to UTC dates before getting applied
- Local dates were not always working across browsers/locales

#### Details:
This PR makes sure when a user selects a date in the calendar picker UI, we shift that date to be as if they picked that date in UTC before we update the state of the dates.

It also abandons `window.navigator.language` in favor of `Intl.DateTimeFormat().resolvedOptions().locale` for determining the user's locale settings, which works more reliably across browsers.

## Steps to Verify
<!-- PROVIDE INFORMATION ON HOW TO CHECK THIS ADDITION
For example, given a new button "Foo" in the dashboard:
1. Run `npm run dev`
2. Open localhost:3000 and navigate to a dashboard
3. Open the date picker and confirm the dates look formatted appropriately
 -->