### PR TITLE
Add og image for web admin social previews

### DIFF
--- a/web-admin/src/app.html
+++ b/web-admin/src/app.html
@@ -52,6 +52,11 @@
       name="viewport"
       content="width=1024, initial-scale=1.0, user-scalable=yes"
     />
+    <!-- Set the og image for thumbnail previews -->
+    <meta
+      property="og:image"
+      content="https://storage.googleapis.com/prod-cdn.rilldata.com/images/rill-admin.png"
+    />
     %sveltekit.head%
   </head>
   <body>


### PR DESCRIPTION
## Checklist
- [ ] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
https://www.notion.so/rilldata/Add-an-Open-Graph-image-to-Rill-Cloud-70e43a27c54a4cdaa4eac6cf9aa81cc9

#### Details:
Adds a meta tag which links to the image stored in Prod CDN

## Steps to Verify
Can be verified after merging and seeing the Rill admin staging link for a dashboard on Slack