### PR TITLE
Fix sqlite TIMESTAMP type in rare timezones

### DIFF
--- a/runtime/drivers/sqlite/sqlite.go
+++ b/runtime/drivers/sqlite/sqlite.go
@@ -1,6 +1,8 @@
 package sqlite
 
 import (
+	"strings"
+
 	"github.com/jmoiron/sqlx"
 	"github.com/rilldata/rill/runtime/drivers"
 	"go.uber.org/zap"
@@ -16,6 +18,16 @@ func init() {
 type driver struct{}
 
 func (d driver) Open(dsn string, logger *zap.Logger) (drivers.Connection, error) {
+	// The sqlite driver requires the DSN to contain "_time_format=sqlite" to support TIMESTAMP types in all timezones.
+	if !strings.Contains(dsn, "_time_format") {
+		if strings.Contains(dsn, "?") {
+			dsn += "&_time_format=sqlite"
+		} else {
+			dsn += "?_time_format=sqlite"
+		}
+	}
+
+	// Open DB handle
 	db, err := sqlx.Connect("sqlite", dsn)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Sqlite doesn't natively support `TIMESTAMP`s. The Go sqlite driver adds support for timestamps by serializing/deserializing timestamps to text.

For compatibility reasons, it uses Go's built-in time serialization by default, which for Kathmandu (and maybe other timezones) outputs a rare format that it cannot parse back:

```
# time.String() in CET:
2023-06-21T13:16:34.92806+02:00
# time.String() in Kathmandu:
2023-06-21 17:02:06.347726 +0545 +0545 m=+0.014533293
```

Setting `_time_format=sqlite` forces the sqlite driver to serialize in a predictable format.