### PR TITLE
Parse and dispaly string logs

### DIFF
--- a/web-admin/src/components/projects/ProjectDeploymentLogs.svelte
+++ b/web-admin/src/components/projects/ProjectDeploymentLogs.svelte
@@ -18,6 +18,7 @@
     try {
       return JSON.parse(logs).errors;
     } catch (e) {
+      if (logs) return [{ message: logs, filePath: "" }];
       return [];
     }
   }


### PR DESCRIPTION
## Checklist
- [ ] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Cloud status page doesn’t render logs that aren’t formatted as JSON #2556 

#### Details:
Parses a string log which is not a JSON as an error item.
