### PR TITLE
fix: missing background colors in table headers

### DIFF
--- a/web-common/src/components/virtualized-table/sections/ColumnHeaders.svelte
+++ b/web-common/src/components/virtualized-table/sections/ColumnHeaders.svelte
@@ -11,7 +11,7 @@
   export let noPin = false;
   export let showDataIcon = false;
   export let selectedColumn: string = null;
-  export let fallbackBGClass: string = "";
+  export let fallbackBGClass = "";
 
   const getColumnHeaderProps = (header) => {
     const name = columns[header.index]?.label || columns[header.index]?.name;

--- a/web-common/src/components/virtualized-table/sections/ColumnHeaders.svelte
+++ b/web-common/src/components/virtualized-table/sections/ColumnHeaders.svelte
@@ -11,6 +11,7 @@
   export let noPin = false;
   export let showDataIcon = false;
   export let selectedColumn: string = null;
+  export let fallbackBGClass: string = "";
 
   const getColumnHeaderProps = (header) => {
     const name = columns[header.index]?.label || columns[header.index]?.name;
@@ -49,7 +50,7 @@
       on:reset-column-size
       bgClass={props.isSelected || isHighlightedColumn(header?.key)
         ? `bg-gray-50`
-        : ""}
+        : fallbackBGClass}
       {...props}
       {header}
       {noPin}

--- a/web-common/src/features/dashboards/dimension-table/DimensionTable.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionTable.svelte
@@ -251,6 +251,7 @@ TableCells – the cell contents.
           noPin={true}
           selectedColumn={sortByColumn}
           columns={measureColumns}
+          fallbackBGClass="bg-white"
           on:click-column={handleColumnHeaderClick}
         />
 

--- a/web-common/src/features/dashboards/dimension-table/DimensionValueHeader.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionValueHeader.svelte
@@ -45,6 +45,7 @@
     enableResize={false}
     position="top-left"
     borderRight={horizontalScrolling}
+    bgClass="bg-white"
   >
     <span class="px-1">{column?.label || column?.name}</span>
   </StickyHeader>
@@ -55,6 +56,7 @@
       position="left"
       header={{ size: width, start: row.start }}
       borderRight={horizontalScrolling}
+      bgClass="bg-white"
     >
       <Cell
         positionStatic


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
Fixes https://github.com/rilldata/rill/issues/2682, where the background color of the dimension details table headers was transparent so on scroll, you would see overflowed values behind it.

#### Details:
Adds explicit "bg-white" classes to all dimension table headers

## Steps to Verify
1. Run `npm run dev`
2. Open localhost:3000 and navigate to a dashboard
3. Open a dimension details table
4. Minimize the height of the screen until you have to vertically scroll in the dimension details table
5. Observe that the scrolled values are hidden behind the sticky table headers