### PR TITLE
feat: update dashboard row viewer label

### DIFF
--- a/web-common/src/features/dashboards/rows-viewer/RowsViewerAccordion.svelte
+++ b/web-common/src/features/dashboards/rows-viewer/RowsViewerAccordion.svelte
@@ -102,7 +102,7 @@
     on:click={toggle}
     aria-label="Toggle rows viewer"
   >
-    <span class="font-bold">Source Data</span>
+    <span class="font-bold">Model Data</span>
     {label}
     {#if isOpen}
       <CaretUpIcon size="14px" />

--- a/web-local/test/ui/dashboards.spec.ts
+++ b/web-local/test/ui/dashboards.spec.ts
@@ -103,7 +103,7 @@ describe("dashboards", () => {
 
     // Check the row viewer accordion is visible
     await playwrightExpect(
-      page.getByText("Source Data 100k of 100k rows")
+      page.getByText("Model Data 100k of 100k rows")
     ).toBeVisible();
 
     // Change the metric trend granularity
@@ -119,7 +119,7 @@ describe("dashboards", () => {
 
     // Check the row viewer accordion is updated
     await playwrightExpect(
-      page.getByText("Source Data 272 of 100k rows")
+      page.getByText("Model Data 272 of 100k rows")
     ).toBeVisible();
 
     // Check row viewer is collapsed by looking for the cell value "7029", which should be in the table


### PR DESCRIPTION
## Checklist
- [X] Manual verification
- [ ] Unit test coverage
- [X] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
Relabeling "Source Data" >> "Model Data" in the dashboard row viewer accordion to avoid confusion with where the data is coming from in our taxonomy of Source > Model > Dashboard

#### Details:
Changed a text label and updated the e2e test so it will click the right button

## Steps to Verify
Open a dashboard and observe that the row viewer accordion says "Model Data"