### PR TITLE
Enable comparisons only if time range is present

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -148,16 +148,18 @@
   $: timeRangeName = $dashboardStore?.selectedTimeRange?.name;
 
   // Compose the comparison /toplist query
-  $: displayComparison = $dashboardStore?.showComparison;
+  $: displayComparison = timeRangeName && $dashboardStore?.showComparison;
 
-  $: comparisonTimeRange = getComparisonRange(
-    $dashboardStore?.selectedTimeRange?.start,
-    $dashboardStore?.selectedTimeRange?.end,
-    ($dashboardStore?.selectedComparisonTimeRange
-      ?.name as TimeComparisonOption) ||
-      (DEFAULT_TIME_RANGES[timeRangeName]
-        .defaultComparison as TimeComparisonOption)
-  );
+  $: comparisonTimeRange =
+    displayComparison &&
+    getComparisonRange(
+      $dashboardStore?.selectedTimeRange?.start,
+      $dashboardStore?.selectedTimeRange?.end,
+      ($dashboardStore?.selectedComparisonTimeRange
+        ?.name as TimeComparisonOption) ||
+        (DEFAULT_TIME_RANGES[timeRangeName]
+          .defaultComparison as TimeComparisonOption)
+    );
   $: comparisonTimeStart =
     isFinite(comparisonTimeRange?.start?.getTime()) &&
     comparisonTimeRange.start.toISOString();


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Fixes #2706

#### Details:
Comparisons were being called even for dashboards without a timeseries. This PR prevents those cases.

## Steps to Verify
1. Create a dashboard without a timeseries
2. Expand dimension