### PR TITLE
Deprecate app store in favor of derived store

### DIFF
--- a/web-common/src/features/dashboards/DashboardAssets.svelte
+++ b/web-common/src/features/dashboards/DashboardAssets.svelte
@@ -19,7 +19,7 @@
   import { featureFlags } from "@rilldata/web-common/features/feature-flags";
   import { SourceModelValidationStatus } from "@rilldata/web-common/features/metrics-views/errors.js";
   import { initBlankDashboardYAML } from "@rilldata/web-common/features/metrics-views/metrics-internal-store";
-  import { appStore } from "@rilldata/web-common/layout/app-store";
+  import { appScreen } from "@rilldata/web-common/layout/app-store";
   import { BehaviourEventMedium } from "@rilldata/web-common/metrics/service/BehaviourEventTypes";
   import {
     EntityTypeToScreenMap,
@@ -114,7 +114,7 @@
     );
     const sourceModelName = dashboardData.jsonRepresentation.model;
 
-    const previousActiveEntity = $appStore?.activeEntity?.type;
+    const previousActiveEntity = $appScreen?.type;
     goto(`/model/${sourceModelName}`);
     behaviourEvent.fireNavigationEvent(
       sourceModelName,
@@ -128,7 +128,7 @@
   const editMetrics = (dashboardName: string) => {
     goto(`/dashboard/${dashboardName}/edit`);
 
-    const previousActiveEntity = $appStore?.activeEntity?.type;
+    const previousActiveEntity = $appScreen?.type;
     behaviourEvent.fireNavigationEvent(
       dashboardName,
       BehaviourEventMedium.Menu,
@@ -151,13 +151,13 @@
       dashboardName,
       EntityType.MetricsDefinition,
       $deleteDashboard,
-      $appStore.activeEntity,
+      $appScreen,
       $dashboardNames.data
     );
 
     // redirect to model when metric is deleted
     const sourceModelName = dashboardData.jsonRepresentation.model;
-    if ($appStore.activeEntity.name === dashboardName) {
+    if ($appScreen?.name === dashboardName) {
       if (sourceModelName) {
         goto(`/model/${sourceModelName}`);
 

--- a/web-common/src/features/dashboards/DashboardAssets.svelte
+++ b/web-common/src/features/dashboards/DashboardAssets.svelte
@@ -22,7 +22,6 @@
   import { appScreen } from "@rilldata/web-common/layout/app-store";
   import { BehaviourEventMedium } from "@rilldata/web-common/metrics/service/BehaviourEventTypes";
   import {
-    EntityTypeToScreenMap,
     MetricsEventScreenName,
     MetricsEventSpace,
   } from "@rilldata/web-common/metrics/service/MetricsTypes";
@@ -120,7 +119,7 @@
       sourceModelName,
       BehaviourEventMedium.Menu,
       MetricsEventSpace.LeftPanel,
-      EntityTypeToScreenMap[previousActiveEntity],
+      previousActiveEntity,
       MetricsEventScreenName.Model
     );
   };
@@ -133,7 +132,7 @@
       dashboardName,
       BehaviourEventMedium.Menu,
       MetricsEventSpace.LeftPanel,
-      EntityTypeToScreenMap[previousActiveEntity],
+      previousActiveEntity,
       MetricsEventScreenName.MetricsDefinition
     );
   };

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -4,9 +4,7 @@
     useMetaQuery,
     useModelHasTimeSeries,
   } from "@rilldata/web-common/features/dashboards/selectors";
-  import { EntityType } from "@rilldata/web-common/features/entity-management/types";
   import { featureFlags } from "@rilldata/web-common/features/feature-flags";
-  import { appStore } from "@rilldata/web-common/layout/app-store";
   import { runtime } from "../../../runtime-client/runtime-store";
   import MeasuresContainer from "../big-number/MeasuresContainer.svelte";
   import { metricsExplorerStore, useDashboardStore } from "../dashboard-stores";
@@ -21,14 +19,6 @@
   export let hasTitle: boolean;
 
   export let leftMargin = undefined;
-
-  const switchToMetrics = async (metricViewName: string) => {
-    if (!metricViewName) return;
-
-    appStore.setActiveEntity(metricViewName, EntityType.MetricsExplorer);
-  };
-
-  $: switchToMetrics(metricViewName);
 
   $: metricsViewQuery = useMetaQuery($runtime.instanceId, metricViewName);
 

--- a/web-common/src/features/entity-management/types.ts
+++ b/web-common/src/features/entity-management/types.ts
@@ -1,11 +1,8 @@
-// TODO: Refactor to include Home, Splash and remove stale types
 export enum EntityType {
   Table = "Table",
   Model = "Model",
   Application = "Application",
   MetricsDefinition = "MetricsDefinition",
-  MeasureDefinition = "MeasureDefinition",
-  DimensionDefinition = "DimensionDefinition",
   MetricsExplorer = "MetricsExplorer",
 }
 

--- a/web-common/src/features/metrics-views/workspace/MetricsWorkspace.svelte
+++ b/web-common/src/features/metrics-views/workspace/MetricsWorkspace.svelte
@@ -2,7 +2,6 @@
   import { getFilePathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import { fileArtifactsStore } from "@rilldata/web-common/features/entity-management/file-artifacts-store";
   import { EntityType } from "@rilldata/web-common/features/entity-management/types";
-  import { appStore } from "@rilldata/web-common/layout/app-store";
   import {
     createRuntimeServiceGetCatalogEntry,
     createRuntimeServicePutFileAndReconcile,
@@ -51,14 +50,6 @@
   const { listenToNodeResize } = createResizeListenerActionFactory();
 
   $: instanceId = $runtime.instanceId;
-
-  const switchToMetrics = async (metricsDefName: string) => {
-    if (!metricsDefName) return;
-
-    appStore.setActiveEntity(metricsDefName, EntityType.MetricsDefinition);
-  };
-
-  $: switchToMetrics(metricsDefName);
 
   const metricMigrate = createRuntimeServicePutFileAndReconcile();
   async function callReconcileAndUpdateYaml(internalYamlString) {

--- a/web-common/src/features/models/navigation/ModelMenuItems.svelte
+++ b/web-common/src/features/models/navigation/ModelMenuItems.svelte
@@ -8,7 +8,7 @@
   import { getFilePathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import { fileArtifactsStore } from "@rilldata/web-common/features/entity-management/file-artifacts-store";
   import { EntityType } from "@rilldata/web-common/features/entity-management/types";
-  import { appStore } from "@rilldata/web-common/layout/app-store";
+  import { appScreen } from "@rilldata/web-common/layout/app-store";
   import { overlay } from "@rilldata/web-common/layout/overlay-store";
   import { behaviourEvent } from "@rilldata/web-common/metrics/initMetrics";
   import { BehaviourEventMedium } from "@rilldata/web-common/metrics/service/BehaviourEventTypes";
@@ -88,7 +88,7 @@
         onSuccess: (resp: V1ReconcileResponse) => {
           fileArtifactsStore.setErrors(resp.affectedPaths, resp.errors);
           goto(`/dashboard/${newDashboardName}`);
-          const previousActiveEntity = $appStore?.activeEntity?.type;
+          const previousActiveEntity = $appScreen?.type;
           behaviourEvent.fireNavigationEvent(
             newDashboardName,
             BehaviourEventMedium.Menu,
@@ -120,7 +120,7 @@
       modelName,
       EntityType.Model,
       $deleteModel,
-      $appStore.activeEntity,
+      $appScreen,
       $modelNames.data
     );
     toggleMenu();

--- a/web-common/src/features/models/navigation/ModelMenuItems.svelte
+++ b/web-common/src/features/models/navigation/ModelMenuItems.svelte
@@ -13,7 +13,6 @@
   import { behaviourEvent } from "@rilldata/web-common/metrics/initMetrics";
   import { BehaviourEventMedium } from "@rilldata/web-common/metrics/service/BehaviourEventTypes";
   import {
-    EntityTypeToScreenMap,
     MetricsEventScreenName,
     MetricsEventSpace,
   } from "@rilldata/web-common/metrics/service/MetricsTypes";
@@ -93,7 +92,7 @@
             newDashboardName,
             BehaviourEventMedium.Menu,
             MetricsEventSpace.LeftPanel,
-            EntityTypeToScreenMap[previousActiveEntity],
+            previousActiveEntity,
             MetricsEventScreenName.Dashboard
           );
           return invalidateAfterReconcile(

--- a/web-common/src/features/models/workspace/ModelWorkspace.svelte
+++ b/web-common/src/features/models/workspace/ModelWorkspace.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { EntityType } from "@rilldata/web-common/features/entity-management/types";
-  import { appStore } from "@rilldata/web-common/layout/app-store";
   import { WorkspaceContainer } from "../../../layout/workspace";
   import ModelInspector from "./inspector/ModelInspector.svelte";
   import ModelBody from "./ModelBody.svelte";
@@ -8,14 +6,6 @@
 
   export let modelName: string;
   export let focusEditorOnMount = false;
-
-  const switchToModel = async (modelName: string) => {
-    if (!modelName) return;
-
-    appStore.setActiveEntity(modelName, EntityType.Model);
-  };
-
-  $: switchToModel(modelName);
 </script>
 
 {#key modelName}

--- a/web-common/src/features/models/workspace/inspector/EmbeddedSourceReference.svelte
+++ b/web-common/src/features/models/workspace/inspector/EmbeddedSourceReference.svelte
@@ -7,7 +7,6 @@
   import * as classes from "@rilldata/web-local/lib/util/component-classes";
   import { getContext } from "svelte";
   import WithModelResultTooltip from "./WithModelResultTooltip.svelte";
-  import { goto } from "$app/navigation";
   import { behaviourEvent } from "@rilldata/web-common/metrics/initMetrics";
   import {
     MetricsEventScreenName,
@@ -33,8 +32,7 @@
     queryHighlight.set(undefined);
   }
 
-  function navigateToSource() {
-    goto(`/source/${entry.name}`);
+  function emitNavigationToSourceTelemetry() {
     behaviourEvent.fireNavigationEvent(
       entry.name,
       BehaviourEventMedium.Menu,
@@ -46,17 +44,15 @@
 </script>
 
 <WithModelResultTooltip {modelHasError}>
-  <div
+  <a
+    href="/source/{entry.name}"
     class=" w-full ui-copy-muted flex justify-between
    gap-x-4 {classes.QUERY_REFERENCE_TRIGGER} p-1 pl-4 pr-4"
     on:focus={focus(reference)}
     on:mouseover={focus(reference)}
     on:mouseleave={blur}
     on:blur={blur}
-    on:keydown={(e) => {
-      if (e.key === "Enter") navigateToSource();
-    }}
-    on:click={navigateToSource}
+    on:click={emitNavigationToSourceTelemetry}
     class:text-gray-500={modelHasError}
   >
     <EmbeddedSourceEntry connector={entry.source.connector} path={entry.path} />
@@ -66,7 +62,7 @@
         {`${formatCompactInteger(totalRows)} rows` || ""}
       {/if}
     </div>
-  </div>
+  </a>
 
   <svelte:fragment slot="tooltip-title">
     <div class="break-all">

--- a/web-common/src/features/models/workspace/inspector/EmbeddedSourceReference.svelte
+++ b/web-common/src/features/models/workspace/inspector/EmbeddedSourceReference.svelte
@@ -7,6 +7,13 @@
   import * as classes from "@rilldata/web-local/lib/util/component-classes";
   import { getContext } from "svelte";
   import WithModelResultTooltip from "./WithModelResultTooltip.svelte";
+  import { goto } from "$app/navigation";
+  import { behaviourEvent } from "@rilldata/web-common/metrics/initMetrics";
+  import {
+    MetricsEventScreenName,
+    MetricsEventSpace,
+  } from "@rilldata/web-common/metrics/service/MetricsTypes";
+  import { BehaviourEventMedium } from "@rilldata/web-common/metrics/service/BehaviourEventTypes";
 
   const queryHighlight = getContext("rill:app:query-highlight");
 
@@ -25,17 +32,31 @@
   function blur() {
     queryHighlight.set(undefined);
   }
+
+  function navigateToSource() {
+    goto(`/source/${entry.name}`);
+    behaviourEvent.fireNavigationEvent(
+      entry.name,
+      BehaviourEventMedium.Menu,
+      MetricsEventSpace.RightPanel,
+      MetricsEventScreenName.Model,
+      MetricsEventScreenName.Source
+    );
+  }
 </script>
 
 <WithModelResultTooltip {modelHasError}>
-  <a
-    href="/source/{entry.name}"
+  <div
     class=" w-full ui-copy-muted flex justify-between
    gap-x-4 {classes.QUERY_REFERENCE_TRIGGER} p-1 pl-4 pr-4"
     on:focus={focus(reference)}
     on:mouseover={focus(reference)}
     on:mouseleave={blur}
     on:blur={blur}
+    on:keydown={(e) => {
+      if (e.key === "Enter") navigateToSource();
+    }}
+    on:click={navigateToSource}
     class:text-gray-500={modelHasError}
   >
     <EmbeddedSourceEntry connector={entry.source.connector} path={entry.path} />
@@ -45,7 +66,7 @@
         {`${formatCompactInteger(totalRows)} rows` || ""}
       {/if}
     </div>
-  </a>
+  </div>
 
   <svelte:fragment slot="tooltip-title">
     <div class="break-all">

--- a/web-common/src/features/sources/add-source/LocalSource.svelte
+++ b/web-common/src/features/sources/add-source/LocalSource.svelte
@@ -7,7 +7,7 @@
     uploadTableFiles,
   } from "@rilldata/web-common/features/sources/add-source/file-upload";
   import { useSourceNames } from "@rilldata/web-common/features/sources/selectors";
-  import { appScreen, appStore } from "@rilldata/web-common/layout/app-store";
+  import { appScreen } from "@rilldata/web-common/layout/app-store";
   import { LIST_SLIDE_DURATION } from "@rilldata/web-common/layout/config";
   import { overlay } from "@rilldata/web-common/layout/overlay-store";
   import {
@@ -63,7 +63,7 @@
       tableName,
       EntityType.Table,
       $deleteSource,
-      $appStore.activeEntity,
+      $appScreen,
       $sourceNames.data,
       false
     );

--- a/web-common/src/features/sources/add-source/RemoteSource.svelte
+++ b/web-common/src/features/sources/add-source/RemoteSource.svelte
@@ -6,7 +6,7 @@
   import DialogFooter from "@rilldata/web-common/components/modal/dialog/DialogFooter.svelte";
   import { EntityType } from "@rilldata/web-common/features/entity-management/types";
   import { useSourceNames } from "@rilldata/web-common/features/sources/selectors";
-  import { appScreen, appStore } from "@rilldata/web-common/layout/app-store";
+  import { appScreen } from "@rilldata/web-common/layout/app-store";
   import { overlay } from "@rilldata/web-common/layout/overlay-store";
   import {
     ConnectorProperty,
@@ -139,7 +139,7 @@
               values.sourceName,
               EntityType.Table,
               $deleteSource,
-              $appStore.activeEntity,
+              $appScreen,
               $sourceNames.data,
               false
             );

--- a/web-common/src/features/sources/embedded/EmbeddedSourceMenuItems.svelte
+++ b/web-common/src/features/sources/embedded/EmbeddedSourceMenuItems.svelte
@@ -2,7 +2,7 @@
   import Model from "@rilldata/web-common/components/icons/Model.svelte";
   import RefreshIcon from "@rilldata/web-common/components/icons/RefreshIcon.svelte";
   import { MenuItem } from "@rilldata/web-common/components/menu";
-  import { appStore } from "@rilldata/web-common/layout/app-store";
+  import { appScreen } from "@rilldata/web-common/layout/app-store";
   import { overlay } from "@rilldata/web-common/layout/overlay-store";
   import { behaviourEvent } from "@rilldata/web-common/metrics/initMetrics";
   import { BehaviourEventMedium } from "@rilldata/web-common/metrics/service/BehaviourEventTypes";
@@ -36,7 +36,7 @@
 
   const handleCreateModel = async () => {
     try {
-      const previousActiveEntity = $appStore.activeEntity?.type;
+      const previousActiveEntity = $appScreen?.type;
       const newModelName = await createModelFromSource(
         queryClient,
         runtimeInstanceId,

--- a/web-common/src/features/sources/embedded/EmbeddedSourceMenuItems.svelte
+++ b/web-common/src/features/sources/embedded/EmbeddedSourceMenuItems.svelte
@@ -7,7 +7,6 @@
   import { behaviourEvent } from "@rilldata/web-common/metrics/initMetrics";
   import { BehaviourEventMedium } from "@rilldata/web-common/metrics/service/BehaviourEventTypes";
   import {
-    EntityTypeToScreenMap,
     MetricsEventScreenName,
     MetricsEventSpace,
   } from "@rilldata/web-common/metrics/service/MetricsTypes";
@@ -50,7 +49,7 @@
         newModelName,
         BehaviourEventMedium.Menu,
         MetricsEventSpace.LeftPanel,
-        EntityTypeToScreenMap[previousActiveEntity],
+        previousActiveEntity,
         MetricsEventScreenName.Model
       );
     } catch (err) {

--- a/web-common/src/features/sources/navigation/SourceMenuItems.svelte
+++ b/web-common/src/features/sources/navigation/SourceMenuItems.svelte
@@ -19,7 +19,6 @@
   import { behaviourEvent } from "@rilldata/web-common/metrics/initMetrics";
   import { BehaviourEventMedium } from "@rilldata/web-common/metrics/service/BehaviourEventTypes";
   import {
-    EntityTypeToScreenMap,
     MetricsEventScreenName,
     MetricsEventSpace,
   } from "@rilldata/web-common/metrics/service/MetricsTypes";
@@ -108,7 +107,7 @@
         newModelName,
         BehaviourEventMedium.Menu,
         MetricsEventSpace.LeftPanel,
-        EntityTypeToScreenMap[previousActiveEntity],
+        previousActiveEntity,
         MetricsEventScreenName.Model
       );
     } catch (err) {
@@ -143,7 +142,7 @@
             newDashboardName,
             BehaviourEventMedium.Menu,
             MetricsEventSpace.LeftPanel,
-            EntityTypeToScreenMap[previousActiveEntity],
+            previousActiveEntity,
             MetricsEventScreenName.Dashboard
           );
           return invalidateAfterReconcile(queryClient, runtimeInstanceId, resp);

--- a/web-common/src/features/sources/navigation/SourceMenuItems.svelte
+++ b/web-common/src/features/sources/navigation/SourceMenuItems.svelte
@@ -14,7 +14,7 @@
     useSourceFromYaml,
     useSourceNames,
   } from "@rilldata/web-common/features/sources/selectors";
-  import { appStore } from "@rilldata/web-common/layout/app-store";
+  import { appScreen } from "@rilldata/web-common/layout/app-store";
   import { overlay } from "@rilldata/web-common/layout/overlay-store";
   import { behaviourEvent } from "@rilldata/web-common/metrics/initMetrics";
   import { BehaviourEventMedium } from "@rilldata/web-common/metrics/service/BehaviourEventTypes";
@@ -86,7 +86,7 @@
       tableName,
       EntityType.Table,
       $deleteSource,
-      $appStore.activeEntity,
+      $appScreen,
       $sourceNames.data
     );
     toggleMenu();
@@ -94,7 +94,7 @@
 
   const handleCreateModel = async () => {
     try {
-      const previousActiveEntity = $appStore.activeEntity?.type;
+      const previousActiveEntity = $appScreen?.type;
       const newModelName = await createModelFromSource(
         queryClient,
         runtimeInstanceId,
@@ -138,7 +138,7 @@
         onSuccess: async (resp: V1ReconcileResponse) => {
           fileArtifactsStore.setErrors(resp.affectedPaths, resp.errors);
           goto(`/dashboard/${newDashboardName}`);
-          const previousActiveEntity = $appStore?.activeEntity?.type;
+          const previousActiveEntity = $appScreen?.type;
           behaviourEvent.fireNavigationEvent(
             newDashboardName,
             BehaviourEventMedium.Menu,

--- a/web-common/src/features/sources/workspace/SourceWorkspace.svelte
+++ b/web-common/src/features/sources/workspace/SourceWorkspace.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { EntityType } from "@rilldata/web-common/features/entity-management/types";
-  import { appStore } from "@rilldata/web-common/layout/app-store";
   import { WorkspaceContainer } from "../../../layout/workspace";
   import SourceInspector from "./SourceInspector.svelte";
   import SourceWorkspaceBody from "./SourceWorkspaceBody.svelte";
@@ -9,14 +7,6 @@
   export let sourceName: string;
   export let embedded = false;
   export let path: string = undefined;
-
-  const switchToSource = async (name: string) => {
-    if (!name) return;
-
-    appStore.setActiveEntity(name, EntityType.Table);
-  };
-
-  $: switchToSource(sourceName);
 </script>
 
 {#key sourceName}

--- a/web-common/src/layout/app-store.ts
+++ b/web-common/src/layout/app-store.ts
@@ -2,7 +2,10 @@ import type { EntityType } from "@rilldata/web-common/features/entity-management
 import { httpRequestQueue } from "@rilldata/web-common/runtime-client/http-client";
 import { Readable, derived, writable } from "svelte/store";
 import { page } from "$app/stores";
-import { MetricsEventScreenName } from "../metrics/service/MetricsTypes";
+import {
+  MetricsEventScreenName,
+  ScreenToEntityMap,
+} from "../metrics/service/MetricsTypes";
 
 export interface ActiveEntity {
   type: EntityType;
@@ -63,7 +66,10 @@ export const appScreen = derived(page, ($page) => {
       activeEntity = { name: "", type: MetricsEventScreenName.Home };
   }
 
-  appStore.setActiveEntity(activeEntity.name, activeEntity.type);
+  appStore.setActiveEntity(
+    activeEntity.name,
+    ScreenToEntityMap[activeEntity.type]
+  );
   return activeEntity;
 });
 
@@ -90,6 +96,6 @@ const appStoreReducers = {
   },
 };
 
-const appStore: Readable<AppStore> & typeof appStoreReducers = {
+const appStore: typeof appStoreReducers = {
   ...appStoreReducers,
 };

--- a/web-common/src/layout/app-store.ts
+++ b/web-common/src/layout/app-store.ts
@@ -1,6 +1,6 @@
 import type { EntityType } from "@rilldata/web-common/features/entity-management/types";
 import { httpRequestQueue } from "@rilldata/web-common/runtime-client/http-client";
-import { Readable, derived, writable } from "svelte/store";
+import { derived, writable } from "svelte/store";
 import { page } from "$app/stores";
 import {
   MetricsEventScreenName,
@@ -73,6 +73,7 @@ export const appScreen = derived(page, ($page) => {
   return activeEntity;
 });
 
+// TODO: Do we still need this?
 // App store is being utilized for making previous entity inactive in the HTTP request queue
 const { update } = writable({
   activeEntity: undefined,

--- a/web-common/src/layout/app-store.ts
+++ b/web-common/src/layout/app-store.ts
@@ -14,13 +14,61 @@ export interface ActiveEntity {
  * App wide store to store metadata
  * Currently caches active entity from URL
  */
-export interface AppStore {
+interface AppStore {
   activeEntity: ActiveEntity;
   previousActiveEntity: ActiveEntity;
 }
 
-// We should rewrite ActiveEntity using appScreen dervied store
-const { update, subscribe } = writable({
+export const appScreen = derived(page, ($page) => {
+  let activeEntity;
+  switch ($page.route.id) {
+    case "/(application)":
+      activeEntity = {
+        name: $page?.params?.name,
+        type: MetricsEventScreenName.Home,
+      };
+      break;
+    case "/(application)/source/[name]":
+      activeEntity = {
+        name: $page?.params?.name,
+        type: MetricsEventScreenName.Source,
+      };
+      break;
+    case "/(application)/model/[name]":
+      activeEntity = {
+        name: $page?.params?.name,
+        type: MetricsEventScreenName.Model,
+      };
+      break;
+    case "/(application)/dashboard/[name]":
+      activeEntity = {
+        name: $page?.params?.name,
+        type: MetricsEventScreenName.Dashboard,
+      };
+      break;
+    case "/(application)/dashboard/[name]/edit":
+      activeEntity = {
+        name: $page?.params?.name,
+        type: MetricsEventScreenName.MetricsDefinition,
+      };
+      break;
+    case "/(application)/welcome":
+      activeEntity = {
+        name: $page?.params?.name,
+        type: MetricsEventScreenName.Splash,
+      };
+      break;
+    default:
+      // Return home as default
+      activeEntity = { name: "", type: MetricsEventScreenName.Home };
+  }
+
+  appStore.setActiveEntity(activeEntity.name, activeEntity.type);
+  return activeEntity;
+});
+
+// App store is being utilized for making previous entity inactive in the HTTP request queue
+const { update } = writable({
   activeEntity: undefined,
   previousActiveEntity: undefined,
 } as AppStore);
@@ -28,6 +76,8 @@ const { update, subscribe } = writable({
 const appStoreReducers = {
   setActiveEntity(name: string, type: EntityType) {
     update((state) => {
+      state.previousActiveEntity = state.activeEntity;
+
       if (state.previousActiveEntity) {
         httpRequestQueue.inactiveByName(state.previousActiveEntity.name);
       }
@@ -35,33 +85,11 @@ const appStoreReducers = {
         name,
         type,
       };
-      state.previousActiveEntity = state.activeEntity;
       return state;
     });
   },
 };
 
-export const appStore: Readable<AppStore> & typeof appStoreReducers = {
-  subscribe,
+const appStore: Readable<AppStore> & typeof appStoreReducers = {
   ...appStoreReducers,
 };
-
-export const appScreen = derived(page, ($page) => {
-  switch ($page.route.id) {
-    case "/(application)":
-      return MetricsEventScreenName.Home;
-    case "/(application)/source/[name]":
-      return MetricsEventScreenName.Source;
-    case "/(application)/model/[name]":
-      return MetricsEventScreenName.Model;
-    case "/(application)/dashboard/[name]":
-      return MetricsEventScreenName.Dashboard;
-    case "/(application)/dashboard/[name]/edit":
-      return MetricsEventScreenName.MetricsDefinition;
-    case "/(application)/welcome":
-      return MetricsEventScreenName.Splash;
-    default:
-      // Return home as default
-      return MetricsEventScreenName.Home;
-  }
-});

--- a/web-common/src/layout/app-store.ts
+++ b/web-common/src/layout/app-store.ts
@@ -61,6 +61,12 @@ export const appScreen = derived(page, ($page) => {
         type: MetricsEventScreenName.Splash,
       };
       break;
+    case "/[organization]/[project]/[dashboard]":
+      activeEntity = {
+        name: $page?.params?.dashboard,
+        type: MetricsEventScreenName.Dashboard,
+      };
+      break;
     default:
       // Return home as default
       activeEntity = { name: "", type: MetricsEventScreenName.Home };

--- a/web-common/src/layout/app-store.ts
+++ b/web-common/src/layout/app-store.ts
@@ -79,7 +79,6 @@ export const appScreen = derived(page, ($page) => {
   return activeEntity;
 });
 
-// TODO: Do we still need this?
 // App store is being utilized for making previous entity inactive in the HTTP request queue
 const { update } = writable({
   activeEntity: undefined,

--- a/web-common/src/layout/navigation/NavigationEntry.svelte
+++ b/web-common/src/layout/navigation/NavigationEntry.svelte
@@ -12,6 +12,13 @@
   import { createCommandClickAction } from "@rilldata/web-local/lib/util/command-click-action";
   import { createShiftClickAction } from "../../lib/actions/shift-click-action";
   import { currentHref } from "./stores";
+  import { appScreen } from "@rilldata/web-common/layout/app-store";
+  import { behaviourEvent } from "@rilldata/web-common/metrics/initMetrics";
+  import { BehaviourEventMedium } from "@rilldata/web-common/metrics/service/BehaviourEventTypes";
+  import {
+    MetricsEventScreenName,
+    MetricsEventSpace,
+  } from "@rilldata/web-common/metrics/service/MetricsTypes";
 
   export let name: string;
   export let href: string;
@@ -29,6 +36,24 @@
 
   function onShowDetails() {
     showDetails = !showDetails;
+  }
+
+  function getNavURLToScreenMap(href: string) {
+    if (href.includes("/source/")) return MetricsEventScreenName.Source;
+    if (href.includes("/model/")) return MetricsEventScreenName.Model;
+    if (href.includes("/dashboard/")) return MetricsEventScreenName.Dashboard;
+  }
+
+  function emitNavigationTelemetry(href) {
+    const previousActiveEntity = $appScreen?.type;
+    const screenName = getNavURLToScreenMap(href);
+    behaviourEvent.fireNavigationEvent(
+      name,
+      BehaviourEventMedium.Menu,
+      MetricsEventSpace.LeftPanel,
+      previousActiveEntity,
+      screenName
+    );
   }
 
   const shiftClickHandler = async () => {
@@ -65,6 +90,7 @@
   <a
     {href}
     on:click={() => {
+      emitNavigationTelemetry(href);
       if (open) onShowDetails();
     }}
     on:mousedown={() => {

--- a/web-common/src/metrics/service/MetricsTypes.ts
+++ b/web-common/src/metrics/service/MetricsTypes.ts
@@ -38,14 +38,13 @@ export enum MetricsEventScreenName {
   Home = "home",
 }
 
-export const EntityTypeToScreenMap = {
-  [EntityType.Table]: MetricsEventScreenName.Source,
-  [EntityType.Model]: MetricsEventScreenName.Model,
-  [EntityType.Application]: MetricsEventScreenName.Source,
-  [EntityType.MetricsDefinition]: MetricsEventScreenName.MetricsDefinition,
-  [EntityType.MeasureDefinition]: MetricsEventScreenName.MetricsDefinition,
-  [EntityType.MetricsExplorer]: MetricsEventScreenName.Dashboard,
-  [EntityType.DimensionDefinition]: MetricsEventScreenName.Dashboard,
+export const ScreenToEntityMap = {
+  [MetricsEventScreenName.Source]: EntityType.Table,
+  [MetricsEventScreenName.Model]: EntityType.Model,
+  [MetricsEventScreenName.Dashboard]: EntityType.MetricsDefinition,
+  [MetricsEventScreenName.MetricsDefinition]: EntityType.MetricsDefinition,
+  [MetricsEventScreenName.Home]: EntityType.Application,
+  [MetricsEventScreenName.Splash]: EntityType.Application,
 };
 
 export interface ActiveEvent extends MetricsEvent {


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Uses `page` store from sveltekit to derive active entity
Adds missing navigation events
