### PR TITLE
Set time keys to undefined if no time series

### DIFF
--- a/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
@@ -133,8 +133,8 @@
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: timeStart,
-      timeEnd: timeEnd,
+      timeStart: hasTimeSeries ? timeStart : undefined,
+      timeEnd: hasTimeSeries ? timeEnd : undefined,
       filter: $dashboardStore?.filters,
     },
     {

--- a/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
@@ -133,8 +133,6 @@
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: hasTimeSeries ? timeStart : undefined,
-      timeEnd: hasTimeSeries ? timeEnd : undefined,
       filter: $dashboardStore?.filters,
     },
     {

--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -110,8 +110,8 @@
     {
       dimensionName: dimensionName,
       measureNames: selectedMeasureNames,
-      timeStart: timeStart,
-      timeEnd: timeEnd,
+      timeStart: hasTimeSeries ? timeStart : undefined,
+      timeEnd: hasTimeSeries ? timeEnd : undefined,
       filter: filterSet,
       limit: "250",
       offset: "0",
@@ -208,8 +208,8 @@
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: timeStart,
-      timeEnd: timeEnd,
+      timeStart: hasTimeSeries ? timeStart : undefined,
+      timeEnd: hasTimeSeries ? timeEnd : undefined,
     },
     {
       query: {

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -118,8 +118,8 @@
     {
       dimensionName: dimensionName,
       measureNames: [measure.name],
-      timeStart: timeStart,
-      timeEnd: timeEnd,
+      timeStart: hasTimeSeries ? timeStart : undefined,
+      timeEnd: hasTimeSeries ? timeEnd : undefined,
       filter: filterForDimension,
       limit: "250",
       offset: "0",

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -51,8 +51,8 @@
     metricViewName,
     {
       measureNames: selectedMeasureNames,
-      timeStart: timeStart,
-      timeEnd: timeEnd,
+      timeStart: hasTimeSeries ? timeStart : undefined,
+      timeEnd: hasTimeSeries ? timeEnd : undefined,
       filter: $dashboardStore?.filters,
     },
     {

--- a/web-common/src/features/dashboards/rows-viewer/RowsViewer.svelte
+++ b/web-common/src/features/dashboards/rows-viewer/RowsViewer.svelte
@@ -42,8 +42,8 @@
     {
       limit: $limit,
       filter: $dashboardStore.filters,
-      timeStart: timeStart,
-      timeEnd: timeEnd,
+      timeStart: hasTimeSeries ? timeStart : undefined,
+      timeEnd: hasTimeSeries ? timeEnd : undefined,
     },
     {
       query: {

--- a/web-common/src/features/dashboards/rows-viewer/RowsViewerAccordion.svelte
+++ b/web-common/src/features/dashboards/rows-viewer/RowsViewerAccordion.svelte
@@ -63,8 +63,8 @@
           expression: "count(*)",
         },
       ],
-      timeStart: timeStart,
-      timeEnd: timeEnd,
+      timeStart: hasTimeSeries ? timeStart : undefined,
+      timeEnd: hasTimeSeries ? timeEnd : undefined,
       filter: $dashboardStore?.filters,
     },
     {


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
https://rilldata.slack.com/archives/C02T907FEUB/p1687945434275359?thread_ts=1687812338.356339&cid=C02T907FEUB

#### Details:
For no time series dashboards, the time keys still had values in them. This PR set those keys to `undefined` if the dashboard has no time series.
