### PR TITLE
fix: tweak row viewer design to look like a drawer

### DIFF
--- a/web-common/src/features/dashboards/rows-viewer/RowsViewerAccordion.svelte
+++ b/web-common/src/features/dashboards/rows-viewer/RowsViewerAccordion.svelte
@@ -102,13 +102,13 @@
     on:click={toggle}
     aria-label="Toggle rows viewer"
   >
+    {#if isOpen}
+      <CaretDownIcon size="14px" />
+    {:else}
+      <CaretUpIcon size="14px" />
+    {/if}
     <span class="font-bold">Model Data</span>
     {label}
-    {#if isOpen}
-      <CaretUpIcon size="14px" />
-    {:else}
-      <CaretDownIcon size="14px" />
-    {/if}
   </button>
   {#if isOpen}
     <RowsViewer {metricViewName} />


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
Per @jkhwu's design feedback, we are flipping the dash row viewer caret direction and moving it to the left of the label in order to represent it as a Drawer instead of as an Accordion.

#### Details:
![CleanShot 2023-06-29 at 10 31 31](https://github.com/rilldata/rill/assets/5554373/e4b34a94-c477-43a9-a78e-54786d4df88e)

## Steps to Verify
