### PR TITLE
Show sign up auth page when suggested

### DIFF
--- a/web-auth/src/components/Auth.svelte
+++ b/web-auth/src/components/Auth.svelte
@@ -36,6 +36,10 @@
       decodeURIComponent(escape(window.atob(configParams)))
     );
 
+    if (config?.extraParams?.screen_hint === "signup") {
+      isLoginPage = false;
+    }
+
     if (cloudClientIDsArr.includes(config?.clientID)) {
       isRillCloud = true;
     }


### PR DESCRIPTION
## Checklist
- [ ] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Users are always redirected to Login auth page. For invite links, we want to show Sing Up page.

#### Details:
Uses the extra param sent in the URL to decide which page to show

Related: #2720 