### PR TITLE
Call goto once for the same state

### DIFF
--- a/web-common/src/features/dashboards/proto-state/dashboard-url-state.spec.ts
+++ b/web-common/src/features/dashboards/proto-state/dashboard-url-state.spec.ts
@@ -9,7 +9,15 @@ import {
 import { useDashboardUrlSync } from "@rilldata/web-common/features/dashboards/proto-state/dashboard-url-state";
 import type { Page } from "@sveltejs/kit";
 import { get, Readable, writable } from "svelte/store";
-import { beforeEach, beforeAll, it, describe, vi, expect } from "vitest";
+import {
+  beforeEach,
+  beforeAll,
+  it,
+  describe,
+  vi,
+  expect,
+  SpyInstance,
+} from "vitest";
 
 const pageMock: PageMock = vi.hoisted(() => ({} as any));
 
@@ -41,6 +49,8 @@ describe("useDashboardUrlSync", () => {
     metricsExplorerStore.displayComparison(AD_BIDS_NAME, true);
     metricsExplorerStore.allDefaultsSelected(AD_BIDS_NAME);
 
+    expect(pageMock.gotoSpy).toBeCalledTimes(0);
+
     metricsExplorerStore.toggleFilter(
       AD_BIDS_NAME,
       AD_BIDS_PUBLISHER_DIMENSION,
@@ -51,6 +61,7 @@ describe("useDashboardUrlSync", () => {
     );
     const protoWithFilter =
       get(metricsExplorerStore).entities[AD_BIDS_NAME].proto;
+    expect(pageMock.gotoSpy).toBeCalledTimes(1);
 
     pageMock.goto("/dashboard/AdBids");
     expect(get(metricsExplorerStore).entities[AD_BIDS_NAME].proto).toEqual(
@@ -60,6 +71,7 @@ describe("useDashboardUrlSync", () => {
       include: [],
       exclude: [],
     });
+    expect(pageMock.gotoSpy).toBeCalledTimes(2);
 
     pageMock.updateState(protoWithFilter);
     expect(get(pageMock).url.searchParams.get("state")).toEqual(
@@ -74,6 +86,7 @@ describe("useDashboardUrlSync", () => {
       ],
       exclude: [],
     });
+    expect(pageMock.gotoSpy).toBeCalledTimes(2);
 
     unsubscribe();
   });
@@ -82,6 +95,7 @@ describe("useDashboardUrlSync", () => {
 type PageMock = Readable<Page> & {
   updateState: (state: string) => void;
   goto: (path: string) => void;
+  gotoSpy: SpyInstance;
 };
 function createPageMock() {
   const { update, subscribe } = writable<Page>({
@@ -107,4 +121,5 @@ function createPageMock() {
       return page;
     });
   };
+  pageMock.gotoSpy = vi.spyOn(pageMock, "goto");
 }

--- a/web-common/src/features/dashboards/proto-state/dashboard-url-state.ts
+++ b/web-common/src/features/dashboards/proto-state/dashboard-url-state.ts
@@ -68,12 +68,8 @@ export function useDashboardUrlSync(
   return dashboardUrlState.subscribe((state) => {
     if (state.proto !== lastKnownProto) {
       // changed when filters etc are changed on the dashboard
-      const pathName = get(page).url.pathname;
-      if (state.proto === state.defaultProto) {
-        goto(`${pathName}`);
-      } else {
-        goto(`${pathName}?state=${encodeURIComponent(state.proto)}`);
-      }
+      gotoNewDashboardUrl(get(page).url, state.proto, state.defaultProto);
+
       lastKnownProto = state.proto;
     } else if (state.urlProto !== lastKnownProto) {
       // changed when user updated the url manually
@@ -85,6 +81,22 @@ export function useDashboardUrlSync(
       lastKnownProto = state.urlProto;
     }
   });
+}
+
+function gotoNewDashboardUrl(url: URL, newState: string, defaultState: string) {
+  // this store the actual state. for default state it will be empty
+  let newStateInUrl = "";
+  // changed when filters etc are changed on the dashboard
+  let newPath = url.pathname;
+  if (newState !== defaultState) {
+    newStateInUrl = encodeURIComponent(newState);
+    newPath = `${newPath}?state=${newStateInUrl}`;
+  }
+
+  const currentStateInUrl = url.searchParams.get("state") ?? "";
+
+  if (newStateInUrl === currentStateInUrl) return;
+  goto(newPath);
 }
 
 // TODO: if these are necessary anywhere else move them to a separate file


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [x] Unit test coverage
- [ ] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
When a dashboard is opened, back button has to be pressed twice to go back to the previous page.

#### Details:
We were calling `goto` without any state twice initially when default state was selected.
Adding a safeguard to not call `goto` if the new state and state in url match.

## Steps to Verify
1. Go to a dashboard using the left nav from any other page.
2. Pressing back button once should take you back to the previous page.
3. This should apply when selecting various filters.