### PR TITLE
Fixing comparision toplist in dimension table

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -169,6 +169,7 @@
   $: comparisonFilterSet = getFilterForComparisonTable(
     filterForDimension,
     dimensionName,
+    dimensionColumn,
     $topListQuery?.data?.data
   );
   $: comparisonTopListQuery = createQueryServiceMetricsViewToplist(

--- a/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
@@ -79,10 +79,11 @@ export function getFilterForComparsion(
 export function getFilterForComparisonTable(
   filterForDimension,
   dimensionName,
+  dimensionColumn,
   values
 ) {
   if (!values || !values.length) return filterForDimension;
-  const filterValues = values.map((v) => v[dimensionName]);
+  const filterValues = values.map((v) => v[dimensionColumn]);
   return getFilterForComparsion(
     filterForDimension,
     dimensionName,


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
https://rilldata.slack.com/archives/C04AGHL77PS/p1688065468472389
Comparison toplist is using `dimensionName` instead of `dimensionColumn` to get values.

#### Details:
Need to update the dimension table to use `dimensionColumn` to get values from the toplist.

## Steps to Verify
1. Make sure to have comparisons enabled on a dashboard.
2. Go to a dimension details table.
3. Comparison data in toplist should be the same as toplist from full dashboard.