### PR TITLE
Using the correct field to show toplist delta

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -335,6 +335,7 @@
       $comparisonTopListQuery?.data,
       values,
       dimensionName,
+      dimensionColumn,
       leaderboardMeasureName
     );
   }

--- a/web-common/src/features/dashboards/dimension-table/dimension-table-utils.spec.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-utils.spec.ts
@@ -151,6 +151,7 @@ describe("computeComparisonValues", () => {
       comparisonResponse,
       values,
       "fruit",
+      "fruit",
       "measure_0"
     );
     expect(computedValues).toEqual(expectedData);

--- a/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
@@ -97,16 +97,17 @@ export function computeComparisonValues(
   comparisonData: V1MetricsViewToplistResponse,
   values: V1MetricsViewToplistResponseDataItem[],
   dimensionName: string,
+  dimensionColumn: string,
   measureName: string
 ) {
   if (comparisonData?.meta?.length !== 2) return values;
 
   const dimensionToValueMap = new Map(
-    comparisonData?.data?.map((obj) => [obj[dimensionName], obj[measureName]])
+    comparisonData?.data?.map((obj) => [obj[dimensionColumn], obj[measureName]])
   );
 
   for (const value of values) {
-    const prevValue = dimensionToValueMap.get(value[dimensionName]);
+    const prevValue = dimensionToValueMap.get(value[dimensionColumn]);
 
     if (prevValue === undefined) {
       value[measureName + "_delta"] = null;


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
We were using `dimensionName` to show toplist delta values in dimension detail table.

#### Details:
Using `dimensionColumn` to show the delta values. The values should now match the toplist from full dashboard.

## Steps to Verify
1. Go to a dashboard with comparison.
2. Compare delta values for a dimension in full dashboard and detail table. They should now match.