### PR TITLE
fixes the e2e dashboard test where the number doesn't match the dash

### DIFF
--- a/web-local/test/ui/dashboards.spec.ts
+++ b/web-local/test/ui/dashboards.spec.ts
@@ -1,19 +1,19 @@
 import { describe, it } from "@jest/globals";
 import { expect as playwrightExpect } from "@playwright/test";
 import {
-  assertAdBidsDashboard,
-  createAdBidsModel,
-} from "./utils/dataSpecifcHelpers";
-import {
+  RequestMatcher,
   assertLeaderboards,
   clickOnFilter,
   createDashboardFromModel,
   createDashboardFromSource,
   metricsViewRequestFilterMatcher,
-  RequestMatcher,
   waitForTimeSeries,
   waitForTopLists,
 } from "./utils/dashboardHelpers";
+import {
+  assertAdBidsDashboard,
+  createAdBidsModel,
+} from "./utils/dataSpecifcHelpers";
 import { TestEntityType, wrapRetryAssertion } from "./utils/helpers";
 import { useRegisteredServer } from "./utils/serverConfigs";
 import { createOrReplaceSource } from "./utils/sourceHelpers";
@@ -187,7 +187,7 @@ describe("dashboards", () => {
     await timeRangeMenu.getByRole("button", { name: "Apply" }).click();
 
     // Check number
-    await playwrightExpect(page.getByText("Total records 65.1k")).toBeVisible();
+    await playwrightExpect(page.getByText("Total records 66.2k")).toBeVisible();
 
     // Flip back to All Time
     await page.getByLabel("Select time range").click();


### PR DESCRIPTION
`dashboards.spec.ts` in our e2e tests are actually failing. It appears tht the number after setting a custom range has not been updated to potentially match the actual value; either that, or the test is showing that our custom time range logic is wrong. I think whoever worked on that feature should check this test.

If the PR is right, and the number needed to be updated, we can merge this. If the PR is wrong & in fact our implementation is wrong, that too should be addressed and this PR should be closed.

## Steps to Verify
1. run the e2e tests. They should pass.