### PR TITLE
Updating timeseries API to new validations

### DIFF
--- a/web-common/src/components/column-profile/queries.ts
+++ b/web-common/src/components/column-profile/queries.ts
@@ -146,6 +146,11 @@ export function getTimeSeriesAndSpark(
     // FIXME: convert pixel back to number once the API
     {
       timestampColumnName: columnName,
+      measures: [
+        {
+          expression: "count(*)",
+        },
+      ],
       pixels: 92,
       priority: getPriorityForColumn("timeseries", active),
     }


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Since we added strict validations to APIs, timeseries profiling is broken.

#### Details:
Passing `measures` to make sure API validation succeeds.

## Steps to Verify
1. Use a data source with time stamp column.
2. Profiling for the time stamp column should show the chart in both sources and model pages.