### PR TITLE
Use trylock for catalog queries

### DIFF
--- a/runtime/services/catalog/catalog.go
+++ b/runtime/services/catalog/catalog.go
@@ -52,10 +52,12 @@ func (s *Service) FindEntries(ctx context.Context, typ drivers.ObjectType) ([]*d
 	if err != nil {
 		return nil, err
 	}
-	s.Meta.lock.RLock()
-	defer s.Meta.lock.RUnlock()
-	for _, entry := range entries {
-		s.Meta.fillDAGInEntry(entry)
+	if s.Meta.lock.TryRLock() {
+		defer s.Meta.lock.RUnlock()
+
+		for _, entry := range entries {
+			s.Meta.fillDAGInEntry(entry)
+		}
 	}
 	return entries, nil
 }
@@ -65,9 +67,11 @@ func (s *Service) FindEntry(ctx context.Context, name string) (*drivers.CatalogE
 	if err != nil {
 		return nil, err
 	}
-	s.Meta.lock.RLock()
-	defer s.Meta.lock.RUnlock()
-	s.Meta.fillDAGInEntry(entry)
+	if s.Meta.lock.TryRLock() {
+		defer s.Meta.lock.RUnlock()
+
+		s.Meta.fillDAGInEntry(entry)
+	}
 	return entry, nil
 }
 


### PR DESCRIPTION
List catalog queries takes lock which is shared with reconcile calls. This leads to the UI being blocked when a reconcile is running in background.

The lock is only needed for modeller to make sure the DAG is up to date to show dependancies. So to get the background reconcile to work in cloud we can use try lock to fill in DAG.