### PR TITLE
Fix 1st time state being overriden

### DIFF
--- a/web-common/src/features/dashboards/proto-state/DashboardStateProvider.svelte
+++ b/web-common/src/features/dashboards/proto-state/DashboardStateProvider.svelte
@@ -8,7 +8,7 @@
 
   $: metricsViewQuery = useMetaQuery($runtime.instanceId, metricViewName);
   let unsubscribe;
-  $: {
+  $: if ($metricsViewQuery?.data) {
     // unsubscribe any previous subscription. this can happen when metricViewName changes and hence the metricsViewQuery
     if (unsubscribe) unsubscribe();
     unsubscribe = useDashboardUrlSync(metricViewName, metricsViewQuery);


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
In cloud url state is cleared and not applied to the dashboard.

#### Details:
The url state was being overriden by default state.

## Steps to Verify
1. Setup cloud locally.
2. Deploy some project.
3. Go to a dashboard, select some filters.
4. Refresh the page, filters should persist.