### PR TITLE
fix: Filters bar not rendering search results properly

### DIFF
--- a/web-common/src/components/chip/removable-list-chip/RemovableListMenu.spec.ts
+++ b/web-common/src/components/chip/removable-list-chip/RemovableListMenu.spec.ts
@@ -1,0 +1,100 @@
+import RemovableListMenu from "./RemovableListMenu.svelte";
+import { describe, it, expect, vi } from "vitest";
+import { render, waitFor, fireEvent, screen } from "@testing-library/svelte";
+import { writable } from "svelte/store";
+
+describe("RemovableListMenu", () => {
+  it("renders selected values by default", async () => {
+    const { unmount } = render(RemovableListMenu, {
+      excludeStore: writable(false),
+      selectedValues: ["foo", "bar"],
+      searchedValues: null,
+    });
+
+    const foo = screen.getByText("foo");
+    const bar = screen.getByText("bar");
+    expect(foo).toBeDefined();
+    expect(bar).toBeDefined();
+    unmount();
+  });
+
+  it("renders selected values if search text is empty", async () => {
+    const { unmount } = render(RemovableListMenu, {
+      excludeStore: writable(false),
+      selectedValues: ["foo", "bar"],
+      searchedValues: ["x"],
+    });
+
+    const foo = screen.getByText("foo");
+    const bar = screen.getByText("bar");
+    expect(foo).toBeDefined();
+    expect(bar).toBeDefined();
+    unmount();
+  });
+
+  it("renders search values if search text is populated", async () => {
+    const { unmount } = render(RemovableListMenu, {
+      excludeStore: writable(false),
+      selectedValues: ["foo", "bar"],
+      searchedValues: ["x"],
+    });
+
+    const searchInput = screen.getByRole("textbox", { name: "Search list" });
+    await fireEvent.input(searchInput, { target: { value: "x" } });
+
+    const x = screen.getByText("x");
+    const foo = screen.queryByText("foo");
+    expect(x).toBeDefined();
+    expect(foo).toBeNull();
+
+    unmount();
+  });
+
+  it("should render switch based on exclude store", async () => {
+    const excludeStore = writable(false);
+    const { unmount } = render(RemovableListMenu, {
+      excludeStore,
+      selectedValues: ["foo", "bar"],
+      searchedValues: ["x"],
+    });
+
+    const switchInput = screen.getByRole<HTMLInputElement>("switch");
+    expect(switchInput.checked).toBe(false);
+
+    excludeStore.set(true);
+    await waitFor(() => {
+      expect(switchInput.checked).toBe(true);
+    });
+
+    unmount();
+  });
+
+  it("should dispatch toggle, apply, and search events", async () => {
+    const excludeStore = writable(false);
+    const { unmount, component } = render(RemovableListMenu, {
+      excludeStore,
+      selectedValues: ["foo", "bar"],
+      searchedValues: ["x"],
+    });
+
+    const toggleSpy = vi.fn();
+    component.$on("toggle", toggleSpy);
+    const switchInput = screen.getByRole<HTMLInputElement>("switch");
+    await fireEvent.click(switchInput);
+    expect(toggleSpy).toHaveBeenCalledOnce();
+
+    const applySpy = vi.fn();
+    component.$on("apply", (e) => applySpy(e.detail));
+    const applyButton = screen.getByRole("menuitem", { name: "foo" });
+    await fireEvent.click(applyButton);
+    await waitFor(() => expect(applySpy).toHaveBeenCalledWith("foo"));
+
+    const searchSpy = vi.fn();
+    component.$on("search", (e) => searchSpy(e.detail));
+    const searchInput = screen.getByRole("textbox", { name: "Search list" });
+    await fireEvent.input(searchInput, { target: { value: "x" } });
+    expect(searchSpy).toHaveBeenCalledWith("x");
+
+    unmount();
+  });
+});

--- a/web-common/src/components/chip/removable-list-chip/RemovableListMenu.svelte
+++ b/web-common/src/components/chip/removable-list-chip/RemovableListMenu.svelte
@@ -63,7 +63,7 @@
 >
   <!-- the min-height is set to have about 3 entries in it -->
 
-  <Search bind:value={searchText} on:input={onSearch} />
+  <Search bind:value={searchText} on:input={onSearch} label="Search list" />
 
   <!-- apply a wrapped flex element to ensure proper bottom spacing between body and footer -->
   <div class="flex flex-col flex-1 overflow-auto w-full pb-1">

--- a/web-common/src/components/chip/removable-list-chip/RemovableListMenu.svelte
+++ b/web-common/src/components/chip/removable-list-chip/RemovableListMenu.svelte
@@ -32,6 +32,7 @@
   let candidateValues = [...selectedValues];
   let valuesToDisplay = [...candidateValues];
 
+  // If searchedValues === null, search has not finished yet. So continue rendering the previous list
   $: if (searchText && searchedValues !== null) {
     valuesToDisplay = [...searchedValues];
   } else if (!searchText) valuesToDisplay = [...candidateValues];

--- a/web-common/src/components/chip/removable-list-chip/RemovableListMenu.svelte
+++ b/web-common/src/components/chip/removable-list-chip/RemovableListMenu.svelte
@@ -7,11 +7,11 @@
   import { Menu, MenuItem } from "../../menu";
   import { Search } from "../../search";
   import Footer from "./Footer.svelte";
-  import { Writable } from "svelte/store";
+  import type { Writable } from "svelte/store";
 
   export let excludeStore: Writable<boolean>;
   export let selectedValues: string[];
-  export let searchedValues: string[] = [];
+  export let searchedValues: string[] | null = [];
 
   let searchText = "";
 
@@ -32,9 +32,9 @@
   let candidateValues = [...selectedValues];
   let valuesToDisplay = [...candidateValues];
 
-  $: if (searchText) {
+  $: if (searchText && searchedValues !== null) {
     valuesToDisplay = [...searchedValues];
-  } else valuesToDisplay = [...candidateValues];
+  } else if (!searchText) valuesToDisplay = [...candidateValues];
 
   $: numSelectedNotInSearch = selectedValues.filter(
     (v) => !valuesToDisplay.includes(v)

--- a/web-common/src/components/search/Search.svelte
+++ b/web-common/src/components/search/Search.svelte
@@ -8,6 +8,8 @@
   export let ref = null;
   /* Input value being searched */
   export let value;
+  /* Aria label for input */
+  export let label = "Search";
 
   function handleKeyDown(event) {
     if (event.code == "Enter") {
@@ -17,7 +19,8 @@
   }
 
   onMount(() => {
-    if (autofocus) window.requestAnimationFrame(() => ref.focus());
+    // Keep ref optional here. If component is unmounted before this animation frame runs, ref will be null and throw a TypeError
+    if (autofocus) window.requestAnimationFrame(() => ref?.focus());
   });
 </script>
 
@@ -37,6 +40,7 @@
       bind:value
       on:input
       on:keydown={handleKeyDown}
+      aria-label={label}
     />
   </div>
 </form>

--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -69,7 +69,7 @@ The main feature-set component for dashboard filters
 
   let topListQuery;
   let searchText = "";
-  let searchedValues = [];
+  let searchedValues: string[] | null = null;
   let activeDimensionName;
 
   $: metricTimeSeries = useModelHasTimeSeries(
@@ -82,7 +82,7 @@ The main feature-set component for dashboard filters
 
   $: if (activeDimensionName) {
     if (searchText == "") {
-      searchedValues = [];
+      searchedValues = null;
     } else {
       let topListParams = {
         dimensionName: activeDimensionName,
@@ -128,8 +128,10 @@ The main feature-set component for dashboard filters
 
   $: if (!$topListQuery?.isFetching && searchText != "") {
     const topListData = $topListQuery?.data?.data ?? [];
-    searchedValues =
-      topListData.map((datum) => datum[activeDimensionName]) ?? [];
+    const activeColumn =
+      dimensions.find((d) => d.name === activeDimensionName)?.column ??
+      activeDimensionName;
+    searchedValues = topListData.map((datum) => datum[activeColumn]) ?? [];
   }
 
   $: hasFilters = isFiltered(metricsExplorer?.filters);

--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -71,6 +71,9 @@ The main feature-set component for dashboard filters
   let searchText = "";
   let searchedValues: string[] | null = null;
   let activeDimensionName;
+  $: activeColumn =
+    dimensions.find((d) => d.name === activeDimensionName)?.column ??
+    activeDimensionName;
 
   $: metricTimeSeries = useModelHasTimeSeries(
     $runtime.instanceId,
@@ -128,9 +131,6 @@ The main feature-set component for dashboard filters
 
   $: if (!$topListQuery?.isFetching && searchText != "") {
     const topListData = $topListQuery?.data?.data ?? [];
-    const activeColumn =
-      dimensions.find((d) => d.name === activeDimensionName)?.column ??
-      activeDimensionName;
     searchedValues = topListData.map((datum) => datum[activeColumn]) ?? [];
   }
 


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [x] Unit test coverage
- [ ] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
Fixes bugs:
- Filter bar search results were not rendering properly. Showing "undefined" instead
- Filter bar search would flash an empty state on first search
- Search component had a race condition with autofocus that could cause a TypeError to throw

#### Details:
**Filter bar search results were not rendering properly. Showing "undefined" instead**: The Filters component tries to look up search result data based on the dimension id, but the API returns the data keyed by dimension column name. This PR adds a lookup of the column name and uses that to access the search result display value instead of the dimension id.

**Filter bar search would flash an empty state on first search**: By default, we pass an empty array of search results to the RemovableMenuList component. This component has no way of distinguishing between what are actually empty search results, and what is just missing data (say when a search has not yet happened). This causes the component to flash a "No results found" message when a search is started for the first time but hasn't actually finished. This PR adds the ability to pass `null` for the searchedValues of the RemovableMenuList, indicating to the component that we do not have any search results yet.

**- Search component had a race condition with autofocus that could cause a TypeError to throw**: The Search component tries to focus the input on the next animation frame after mounting. However, its possible that within the first frame the component could be unmounted again. In this case, the input no longer would exist and can't be focused. We add an optional check so that a TypeError isn't thrown.

## Steps to Verify
1. Open a dashboard
2. Apply some filters
3. Click on a filter pill and type a search term in
4. Observe the search results appearing after fetching, with proper display names and no intermediate state