### PR TITLE
prevent chart unmount when filtering

### DIFF
--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -17,15 +17,15 @@
   import { EntityStatus } from "@rilldata/web-common/features/entity-management/types";
   import { TIME_GRAIN } from "@rilldata/web-common/lib/time/config";
   import {
+    getAdjustedChartTime,
+    getAdjustedFetchTime,
+  } from "@rilldata/web-common/lib/time/ranges";
+  import {
     createQueryServiceMetricsViewTimeSeries,
     createQueryServiceMetricsViewTotals,
     V1MetricsViewTimeSeriesResponse,
   } from "@rilldata/web-common/runtime-client";
   import type { CreateQueryResult } from "@tanstack/svelte-query";
-  import {
-    getAdjustedChartTime,
-    getAdjustedFetchTime,
-  } from "@rilldata/web-common/lib/time/ranges";
   import { runtime } from "../../../runtime-client/runtime-store";
   import Spinner from "../../entity-management/Spinner.svelte";
   import MeasureBigNumber from "../big-number/MeasureBigNumber.svelte";
@@ -255,11 +255,11 @@
     {/if}
   </div>
   <!-- bignumbers and line charts -->
-  {#if $metaQuery.data?.measures && $totalsQuery?.isSuccess}
+  {#if $metaQuery.data?.measures}
     <!-- FIXME: this is pending the remaining state work for show/hide measures and dimensions -->
     {#each $metaQuery.data?.measures.filter((_, i) => $showHideMeasures.selectedItems[i]) as measure, index (measure.name)}
       <!-- FIXME: I can't select the big number by the measure id. -->
-      {@const bigNum = $totalsQuery?.data.data?.[measure.name]}
+      {@const bigNum = $totalsQuery?.data?.data?.[measure.name]}
       {@const showComparison = displayComparison}
       {@const comparisonValue = totalsComparisons?.[measure.name]}
       {@const comparisonPercChange =


### PR DESCRIPTION
This PR is a quick fix to prevent charts from unmounting when filtering. Otherwise charts flicker when new data is fetched for the big number.