### PR TITLE
Handle "repository not found" error

### DIFF
--- a/web-admin/src/components/errors/error-utils.ts
+++ b/web-admin/src/components/errors/error-utils.ts
@@ -1,5 +1,7 @@
 import { goto } from "$app/navigation";
+import { page } from "$app/stores";
 import type { AxiosError } from "axios";
+import { get } from "svelte/store";
 import type { RpcStatus } from "../../client";
 import { ADMIN_URL } from "../../client/http-client";
 import { ErrorStoreState, errorStore } from "./error-store";
@@ -8,6 +10,16 @@ export function globalErrorCallback(error: AxiosError): void {
   // If Unauthorized, redirect to login page
   if (error.response.status === 401) {
     goto(`${ADMIN_URL}/auth/login?redirect=${window.origin}`);
+    return;
+  }
+
+  // If on a Project page, and "repository not found", ignore the error and show the page
+  const isProjectPage = get(page).route.id === "/[organization]/[project]";
+  if (
+    isProjectPage &&
+    error.response.status === 400 &&
+    (error.response.data as RpcStatus).message === "repository not found"
+  ) {
     return;
   }
 


### PR DESCRIPTION
This PR fixes the problem [reported in Slack](https://rilldata.slack.com/archives/CTZ8XBQ85/p1689066245860979?thread_ts=1689049013.950719&cid=CTZ8XBQ85) that when a user deletes a project's GitHub repo, the project page is blocked with a full page "repository not found" 400 error.

Now, the project page displays as normal, with an error log that includes the message "repository does not exist".

<img width="1333" alt="image" src="https://github.com/rilldata/rill/assets/14206386/52d09944-9ab1-48c8-9fb7-e01553195dd0">
