### PR TITLE
Percentage totals url state

### DIFF
--- a/proto/rill/ui/v1/dashboard.proto
+++ b/proto/rill/ui/v1/dashboard.proto
@@ -28,6 +28,8 @@ message DashboardState {
   optional bool all_measures_visible = 9;
   repeated string visible_dimensions = 10;
   optional bool all_dimensions_visible = 11;
+
+  optional bool show_percent_of_total = 12;
 }
 
 message DashboardTimeRange {

--- a/web-common/src/features/dashboards/proto-state/fromProto.ts
+++ b/web-common/src/features/dashboards/proto-state/fromProto.ts
@@ -79,6 +79,8 @@ export function getDashboardStateFromProto(
     entity.visibleDimensionKeys = new Set(dashboard.visibleDimensions);
   }
 
+  entity.showPercentOfTotal = Boolean(dashboard.showPercentOfTotal);
+
   return entity;
 }
 

--- a/web-common/src/features/dashboards/proto-state/toProto.ts
+++ b/web-common/src/features/dashboards/proto-state/toProto.ts
@@ -69,6 +69,8 @@ export function getProtoFromDashboardState(
     state.visibleDimensions = [...metrics.visibleDimensionKeys];
   }
 
+  state.showPercentOfTotal = Boolean(metrics.showPercentOfTotal);
+
   const message = new DashboardState(state);
   return protoToBase64(message.toBinary());
 }

--- a/web-common/src/features/metrics-views/metrics-internal-store.ts
+++ b/web-common/src/features/metrics-views/metrics-internal-store.ts
@@ -71,6 +71,7 @@ export function addQuickMetricsToDashboardYAML(yaml: string, model: V1Model) {
     name: "total_records",
     description: "Total number of records present",
     format_preset: "humanize",
+    valid_percent_of_total: true,
   });
   doc.set("measures", [measureNode]);
 

--- a/web-common/src/proto/gen/rill/ui/v1/dashboard_pb.ts
+++ b/web-common/src/proto/gen/rill/ui/v1/dashboard_pb.ts
@@ -81,6 +81,11 @@ export class DashboardState extends Message<DashboardState> {
    */
   allDimensionsVisible?: boolean;
 
+  /**
+   * @generated from field: optional bool show_percent_of_total = 12;
+   */
+  showPercentOfTotal?: boolean;
+
   constructor(data?: PartialMessage<DashboardState>) {
     super();
     proto3.util.initPartial(data, this);
@@ -100,6 +105,7 @@ export class DashboardState extends Message<DashboardState> {
     { no: 9, name: "all_measures_visible", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
     { no: 10, name: "visible_dimensions", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
     { no: 11, name: "all_dimensions_visible", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
+    { no: 12, name: "show_percent_of_total", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DashboardState {


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Persisting showing of percentage of totals to the url state.
Auto generation of dashboard should add `valid_percent_of_total` to the total records measure.

#### Details:


## Steps to Verify
1. Import a source with time stamp.
2. Autogenerate dashboard from it.
3. The dashboard created should have a measure with percent of totals enabled.
4. Toggling it should update the url state and refreshing should persist the toggle.