### PR TITLE
Disable bidirectional sync

### DIFF
--- a/web-common/src/features/entity-management/sync-file-system.ts
+++ b/web-common/src/features/entity-management/sync-file-system.ts
@@ -35,7 +35,7 @@ export async function syncFileSystemPeriodically(
   fileArtifactsStore: FileArtifactsStore
 ) {
   let syncFileSystemInterval: NodeJS.Timer;
-  // let syncFileSystemOnVisibleDocument: () => void;
+  let syncFileSystemOnVisibleDocument: () => void;
   let afterNavigateRanOnce: boolean;
 
   afterNavigate(async () => {
@@ -46,7 +46,7 @@ export async function syncFileSystemPeriodically(
     if (afterNavigateRanOnce) return;
 
     // Scenario 1: sync when the user navigates to a new page
-    // syncFileSystem(queryClient, runtimeInstanceId, page, fileArtifactsStore);
+    syncFileSystem(queryClient, runtimeInstanceId, page, fileArtifactsStore);
 
     // setup Scenario 2: sync every X seconds
     syncFileSystemInterval = setInterval(
@@ -61,17 +61,17 @@ export async function syncFileSystemPeriodically(
     );
 
     // setup Scenario 3: sync when the user returns focus to the browser tab
-    // syncFileSystemOnVisibleDocument = async () => {
-    //   if (document.visibilityState === "visible") {
-    //     await syncFileSystem(
-    //       queryClient,
-    //       runtimeInstanceId,
-    //       page,
-    //       fileArtifactsStore
-    //     );
-    //   }
-    // };
-    // window.addEventListener("focus", syncFileSystemOnVisibleDocument);
+    syncFileSystemOnVisibleDocument = async () => {
+      if (document.visibilityState === "visible") {
+        await syncFileSystem(
+          queryClient,
+          runtimeInstanceId,
+          page,
+          fileArtifactsStore
+        );
+      }
+    };
+    window.addEventListener("focus", syncFileSystemOnVisibleDocument);
 
     afterNavigateRanOnce = true;
   });
@@ -81,7 +81,7 @@ export async function syncFileSystemPeriodically(
     clearInterval(syncFileSystemInterval);
 
     // teardown Scenario 3
-    // window.removeEventListener("focus", syncFileSystemOnVisibleDocument);
+    window.removeEventListener("focus", syncFileSystemOnVisibleDocument);
 
     afterNavigateRanOnce = false;
   });

--- a/web-common/src/layout/RillDeveloperLayout.svelte
+++ b/web-common/src/layout/RillDeveloperLayout.svelte
@@ -4,10 +4,7 @@
   import { projectShareStore } from "@rilldata/web-common/features/dashboards/dashboard-stores.js";
   import DeployDashboardOverlay from "@rilldata/web-common/features/dashboards/workspace/DeployDashboardOverlay.svelte";
   import { fileArtifactsStore } from "@rilldata/web-common/features/entity-management/file-artifacts-store";
-  import {
-    addReconcilingOverlay,
-    syncFileSystemPeriodically,
-  } from "@rilldata/web-common/features/entity-management/sync-file-system";
+  import { addReconcilingOverlay } from "@rilldata/web-common/features/entity-management/sync-file-system";
   import { featureFlags } from "@rilldata/web-common/features/feature-flags";
   import DuplicateSource from "@rilldata/web-common/features/sources/add-source/DuplicateSource.svelte";
   import FileDrop from "@rilldata/web-common/features/sources/add-source/FileDrop.svelte";
@@ -15,18 +12,14 @@
   import BlockingOverlayContainer from "@rilldata/web-common/layout/BlockingOverlayContainer.svelte";
   import { initMetrics } from "@rilldata/web-common/metrics/initMetrics";
   import type { ApplicationBuildMetadata } from "@rilldata/web-local/lib/application-state-stores/build-metadata";
-  import { useQueryClient } from "@tanstack/svelte-query";
   import { getContext, onMount } from "svelte";
   import type { Writable } from "svelte/store";
   import { getArtifactErrors } from "../features/entity-management/getArtifactErrors";
   import PreparingImport from "../features/sources/add-source/PreparingImport.svelte";
   import WelcomePageRedirect from "../features/welcome/WelcomePageRedirect.svelte";
   import { runtimeServiceGetConfig } from "../runtime-client/manual-clients";
-  import { runtime } from "../runtime-client/runtime-store";
   import BasicLayout from "./BasicLayout.svelte";
   import { importOverlayVisible, overlay } from "./overlay-store";
-
-  const queryClient = useQueryClient();
 
   const appBuildMetaStore: Writable<ApplicationBuildMetadata> =
     getContext("rill:app:metadata");
@@ -48,13 +41,14 @@
     fileArtifactsStore.setErrors(res.affectedPaths, res.errors);
   });
 
-  syncFileSystemPeriodically(
-    queryClient,
-    runtime,
-    featureFlags,
-    page,
-    fileArtifactsStore
-  );
+  // Bidirectional sync is disabled for now
+  // syncFileSystemPeriodically(
+  //   queryClient,
+  //   runtime,
+  //   featureFlags,
+  //   page,
+  //   fileArtifactsStore
+  // );
   $: addReconcilingOverlay($page.url.pathname);
 
   let dbRunState = "disconnected";


### PR DESCRIPTION
This PR disables bidirectional sync, per [Slack discussion](https://rilldata.slack.com/archives/CTZ8XBQ85/p1689266955444809). The sporadic, blocking reconcile has confused users. 

Previously, the application had polled the filesystem under three scenarios:
1. The user navigates to a new page
2. Every X seconds
3. The user returns focus to the browser tab

Previously, we had disabled scenarios 1 & 3. This PR:
- reverts the work to disable scenarios 1 & 3
- disables the whole feature (scenarios 1-3)