### PR TITLE
Fix breadcrumbs with many menu items

### DIFF
--- a/web-admin/src/components/navigation/BreadcrumbItem.svelte
+++ b/web-admin/src/components/navigation/BreadcrumbItem.svelte
@@ -28,6 +28,7 @@
           key: menuKey,
           main: label,
         }}
+        overflowFlipY={false}
         on:select={({ detail: { key } }) => onSelectMenuOption(key)}
         let:toggleMenu
       >

--- a/web-common/src/components/floating-element/FloatingElement.svelte
+++ b/web-common/src/components/floating-element/FloatingElement.svelte
@@ -23,6 +23,9 @@ display:contents. This is useful when nesting a floating element within a toolti
   export let distance = 0;
   // edge padding
   export let pad = 8;
+  // whether to flip the element's location (from bottom to top) or (from top to bottom)
+  // if it overflows the window
+  export let overflowFlipY = true;
 
   let top = 0;
   let left = 0;
@@ -37,7 +40,8 @@ display:contents. This is useful when nesting a floating element within a toolti
     scrollXValue,
     scrollYvalue,
     windowWidth,
-    windowHeight
+    windowHeight,
+    overflowFlipY: boolean
   ) {
     if (!(parentBoundingClientRect && elementBoundingClientRect)) return;
     const [leftPos, topPos] = placeElement({
@@ -51,6 +55,7 @@ display:contents. This is useful when nesting a floating element within a toolti
       x: scrollXValue,
       windowWidth,
       windowHeight,
+      overflowFlipY,
     });
     top = topPos;
     left = leftPos;
@@ -79,7 +84,8 @@ display:contents. This is useful when nesting a floating element within a toolti
         scrollX,
         scrollY,
         innerWidth,
-        innerHeight
+        innerHeight,
+        overflowFlipY
       );
   } else {
     setLocation(
@@ -90,7 +96,8 @@ display:contents. This is useful when nesting a floating element within a toolti
       scrollX,
       scrollY,
       innerWidth,
-      innerHeight
+      innerHeight,
+      overflowFlipY
     );
   }
   $: getFirstValidChildElement(target);
@@ -108,7 +115,8 @@ display:contents. This is useful when nesting a floating element within a toolti
           scrollX,
           scrollY,
           innerWidth,
-          innerHeight
+          innerHeight,
+          overflowFlipY
         );
       });
       if (firstParentElement) {

--- a/web-common/src/components/floating-element/WithTogglableFloatingElement.svelte
+++ b/web-common/src/components/floating-element/WithTogglableFloatingElement.svelte
@@ -11,8 +11,8 @@
   export let pad = 8;
   export let suppress = false;
   export let active = false;
-
   export let inline = false;
+  export let overflowFlipY = true;
 
   /** this passes down the dom element used for the "outside click" action.
    * Since this element is not strictly within the parent of the menu (which is in a Portal),
@@ -52,6 +52,7 @@
           {alignment}
           {distance}
           {pad}
+          {overflowFlipY}
         >
           <slot name="floating-element" />
         </FloatingElement>

--- a/web-common/src/components/menu/wrappers/WithSelectMenu.svelte
+++ b/web-common/src/components/menu/wrappers/WithSelectMenu.svelte
@@ -22,6 +22,7 @@ and the menu closes.
   export let paddingTop: number = undefined;
   export let paddingBottom: number = undefined;
   export let minWidth: string = undefined;
+  export let overflowFlipY = true;
 
   export let active = false;
 
@@ -81,6 +82,7 @@ and the menu closes.
   {location}
   {alignment}
   {distance}
+  {overflowFlipY}
   let:handleClose
   let:toggleFloatingElement
 >

--- a/web-common/src/lib/place-element.ts
+++ b/web-common/src/lib/place-element.ts
@@ -49,6 +49,7 @@ export function placeElement({
   windowWidth = window.innerWidth,
   windowHeight = window.innerHeight,
   pad = 16 * 2,
+  overflowFlipY = true,
 }) {
   let left;
   let top;
@@ -65,13 +66,16 @@ export function placeElement({
 
   // Task 1: check if we need to reflect agains the location axis.
   if (location === "bottom") {
-    if (parentBottom + elementHeight + distance + pad > windowHeight + y) {
+    if (
+      overflowFlipY &&
+      parentBottom + elementHeight + distance + pad > windowHeight + y
+    ) {
       top = parentTop - elementHeight - distance;
     } else {
       top = parentBottom + distance;
     }
   } else if (location === "top") {
-    if (parentTop - elementHeight - distance - pad < y) {
+    if (overflowFlipY && parentTop - elementHeight - distance - pad < y) {
       top = parentBottom + distance;
     } else {
       top = parentTop - elementHeight - distance;


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
On short screens, for a project with many dashboards, the dashboard breadcrumb's menu renders off-screen.

<img width="756" alt="image" src="https://github.com/rilldata/rill/assets/14206386/4d742171-93ce-45b4-b445-05b76abe5020">

#### Details:

This PR adds an `overflowFlipY` boolean to the following components:
- `FloatingElement.svelte`
- `WithTogglableFloatingElement.svelte`
- `WithSelectMenu.svelte`

Previously, it was assumed that, if the content overflowed, we'd want to flip the content's location across the y axis. Now, if  `overflowFlipY` is `false`, the content will not be flipped. Instead, the window will scroll.

<img width="957" alt="image" src="https://github.com/rilldata/rill/assets/14206386/a4107a31-b8fd-4941-b209-47f2a9e8f50e">

## Steps to Verify
1. Go to a project with many dashboards (or mock the `menuOptions` in `Breadcrumbs.svelte`)
2. Open a dashboard
3. Shrink your window vertically
4. Open the dashboard dropdown
5. Ensure you can see all the options