### PR TITLE
Percent-of-total follow up tweaks

### DIFF
--- a/web-common/src/components/button-group/ButtonGroup.svelte
+++ b/web-common/src/components/button-group/ButtonGroup.svelte
@@ -77,7 +77,7 @@
 </script>
 
 <div
-  class="flex flex-row w-fit rounded border border-gray-400 divide-x divide-gray-400"
+  class="flex flex-row w-fit rounded border border-gray-300 divide-x divide-gray-300"
 >
   <slot />
 </div>

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
@@ -72,6 +72,11 @@
   $: validPercentOfTotal =
     activeLeaderboardMeasure?.validPercentOfTotal || false;
 
+  // if the percent of total is not valid for this measure, turn it off
+  $: if (!validPercentOfTotal) {
+    metricsExplorerStore.displayPercentOfTotal(metricViewName, false);
+  }
+
   $: showHideDimensions = createShowHideDimensionsStore(
     metricViewName,
     metaQuery


### PR DESCRIPTION
a couple tiny follow ups to the pct of total work:
- gray-300 for button group outlines
- hide percent of total if a measure without validPercentOfTotal is selected