### PR TITLE
Use new theme for SQL editor

### DIFF
--- a/web-common/src/features/models/workspace/Editor.svelte
+++ b/web-common/src/features/models/workspace/Editor.svelte
@@ -56,6 +56,7 @@
     V1Model,
   } from "@rilldata/web-common/runtime-client";
   import { createEventDispatcher, onMount } from "svelte";
+  import { editorTheme } from "../../../components/editor/theme";
   import { runtime } from "../../../runtime-client/runtime-store";
 
   export let modelName: string;
@@ -87,84 +88,6 @@
   let editor: EditorView;
   let editorContainer;
   let editorContainerComponent;
-
-  // DESIGN
-
-  const highlightBackground = "#f3f9ff";
-
-  // TODO: These hardcoded colors ain't good. Try to move this to app.css and use Tailwind
-  // colors. Might have to navigated CodeMirror generated classes.
-  const rillTheme = EditorView.theme({
-    "&.cm-editor": {
-      overflowX: "hidden",
-      width: "100%",
-      fontSize: "13px",
-      height: "100%",
-      "&.cm-focused": {
-        outline: "none",
-      },
-    },
-    ".cm-scroller": {
-      fontFamily: "var(--monospace)",
-    },
-    "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection":
-      { backgroundColor: "rgb(65 99 255 / 25%)" },
-    ".cm-selectionMatch": { backgroundColor: "rgb(189 233 255)" },
-    ".cm-activeLine": { backgroundColor: highlightBackground },
-
-    ".cm-activeLineGutter": {
-      backgroundColor: highlightBackground,
-    },
-    ".cm-gutters": {
-      backgroundColor: "white",
-      borderRight: "none",
-    },
-    ".cm-lineNumbers .cm-gutterElement": {
-      paddingLeft: "5px",
-      paddingRight: "10px",
-      minWidth: "32px",
-      backgroundColor: "white",
-    },
-    ".cm-breakpoint-gutter .cm-gutterElement": {
-      color: "red",
-      paddingLeft: "24px",
-      paddingRight: "24px",
-      cursor: "default",
-    },
-    ".cm-tooltip": {
-      border: "none",
-      borderRadius: "0.25rem",
-      backgroundColor: "rgb(243 249 255)",
-      color: "black",
-    },
-    ".cm-tooltip-autocomplete": {
-      "& > ul > li[aria-selected]": {
-        border: "none",
-        borderRadius: "0.25rem",
-        backgroundColor: "rgb(15 119 204 / .25)",
-        color: "black",
-      },
-    },
-    ".cm-completionLabel": {
-      fontSize: "13px",
-      fontFamily: "var(--monospace)",
-    },
-    ".cm-completionMatchedText": {
-      textDecoration: "none",
-      color: "rgb(15 119 204)",
-    },
-    ".cm-underline": {
-      backgroundColor: "rgb(254 240 138)",
-    },
-    ".ͼb": {
-      fontWeight: "700",
-    },
-    ".ͼe": {
-      fontStyle: "italic",
-      fontWeight: "600",
-      color: "hsl(200, 70%, 50%)",
-    },
-  });
 
   // AUTOCOMPLETE
 
@@ -245,6 +168,7 @@
       state: EditorState.create({
         doc: latestContent,
         extensions: [
+          editorTheme(),
           lineNumbers(),
           highlightActiveLineGutter(),
           highlightSpecialChars(),
@@ -289,7 +213,6 @@
           ),
           sql({ dialect: DuckDBSQL }),
           keymap.of([indentWithTab]),
-          rillTheme,
           EditorView.updateListener.of((v) => {
             if (v.focusChanged && v.view.hasFocus) {
               dispatch("receive-focus");


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
1) In adding the YAML editor, we've lost the appearance of highlights in the SQL editor. Somehow, the YAML and SQL themes are conflicting. ([Slack bug report](https://rilldata.slack.com/archives/CTZ8XBQ85/p1689718130861029))
2) We've designed a new editor theme, which we haven't yet applied to the SQL editor

#### Details:
This PR uses the new editor theme for the SQL editor.

Here's what it looks like:
![image](https://github.com/rilldata/rill/assets/14206386/0998fe39-7cc5-4a17-a8a8-abdab5b63b44)


## Steps to Verify
1. Write a SQL model & verify a pleasant, interactive editing experience.
2. Observe the new theme.