### PR TITLE
set impossibly low timeout to confirm error

### DIFF
--- a/web-local/test/ui/dashboards.spec.ts
+++ b/web-local/test/ui/dashboards.spec.ts
@@ -436,7 +436,7 @@ describe("dashboards", () => {
     await updateMetricsInput(page, docWithCompleteMeasure);
     await playwrightExpect(
       page.getByRole("button", { name: "Go to dashboard" })
-    ).toBeEnabled({ timeout: 1 });
+    ).toBeEnabled({ timeout: 20000 });
 
     // Go to dashboard
     await page.getByRole("button", { name: "Go to dashboard" }).click();

--- a/web-local/test/ui/dashboards.spec.ts
+++ b/web-local/test/ui/dashboards.spec.ts
@@ -434,6 +434,8 @@ describe("dashboards", () => {
         `;
 
     await updateMetricsInput(page, docWithCompleteMeasure);
+    // FIXME: this timeout is a stopgap measure to prevent flakiness,
+    // but we should get to the bottom of why this test times out
     await playwrightExpect(
       page.getByRole("button", { name: "Go to dashboard" })
     ).toBeEnabled({ timeout: 60000 });

--- a/web-local/test/ui/dashboards.spec.ts
+++ b/web-local/test/ui/dashboards.spec.ts
@@ -436,7 +436,7 @@ describe("dashboards", () => {
     await updateMetricsInput(page, docWithCompleteMeasure);
     await playwrightExpect(
       page.getByRole("button", { name: "Go to dashboard" })
-    ).toBeEnabled({ timeout: 20000 });
+    ).toBeEnabled({ timeout: 60000 });
 
     // Go to dashboard
     await page.getByRole("button", { name: "Go to dashboard" }).click();

--- a/web-local/test/ui/dashboards.spec.ts
+++ b/web-local/test/ui/dashboards.spec.ts
@@ -436,7 +436,7 @@ describe("dashboards", () => {
     await updateMetricsInput(page, docWithCompleteMeasure);
     await playwrightExpect(
       page.getByRole("button", { name: "Go to dashboard" })
-    ).toBeEnabled();
+    ).toBeEnabled({ timeout: 1 });
 
     // Go to dashboard
     await page.getByRole("button", { name: "Go to dashboard" }).click();


### PR DESCRIPTION
looking into the intermittent CI failures that at least @begelundmuller and I have bumped into, see for example this CI log: https://github.com/rilldata/rill/actions/runs/5602447596/jobs/10250156408#step:15:128

It seems that it is caused by a new test that was added as part of @hamilton 's PR https://github.com/rilldata/rill/pull/2639 from last week; added a comment on the offending test here https://github.com/rilldata/rill/pull/2639/files#r1268680173

In this PR, I experimented with  extending the timeout on that expect to be 60 seconds. My hope was that since the test sometimes passes, there was just some operation that doesn't always quite have time to finish (perhaps resource contention on a CI server), but extending the timeout from default 5000ms to 60000ms didn't do the trick, so I think that theory is no good.

@hamilton you should probably dig deeper into whatever is going on -- all of this code is brand new so hopefully still fresh in your mind

