### PR TITLE
Replace time_bucket with date_trunc

### DIFF
--- a/runtime/queries/metricsview_rows.go
+++ b/runtime/queries/metricsview_rows.go
@@ -240,8 +240,8 @@ func (q *MetricsViewRows) buildMetricsRowsSQL(mv *runtimev1.MetricsView, dialect
 		if q.TimeZone != "" {
 			timezone = q.TimeZone
 		}
-		args = append([]any{timezone}, args...)
-		rollup := fmt.Sprintf("time_bucket(INTERVAL '%s', %s::TIMESTAMPTZ, ?) AS %s", convertToDuckDBTimeBucketSpecifier(q.TimeGranularity), safeName(mv.TimeDimension), safeName(timeRollupColumnName))
+		args = append([]any{timezone, timezone}, args...)
+		rollup := fmt.Sprintf("timezone(?, date_trunc('%s', timezone(?, %s::TIMESTAMPTZ))) AS %s", convertToDateTruncSpecifier(q.TimeGranularity), safeName(mv.TimeDimension), safeName(timeRollupColumnName))
 
 		// Prepend the rollup column
 		selectColumns = append([]string{rollup}, selectColumns...)

--- a/runtime/queries/sqlutil.go
+++ b/runtime/queries/sqlutil.go
@@ -78,30 +78,6 @@ func convertToDruidTimeFloorSpecifier(specifier runtimev1.TimeGrain) string {
 	panic(fmt.Errorf("unconvertable time grain specifier: %v", specifier))
 }
 
-func convertToDuckDBTimeBucketSpecifier(specifier runtimev1.TimeGrain) string {
-	switch specifier {
-	case runtimev1.TimeGrain_TIME_GRAIN_MILLISECOND:
-		return "1 MILLISECOND"
-	case runtimev1.TimeGrain_TIME_GRAIN_SECOND:
-		return "1 SECOND"
-	case runtimev1.TimeGrain_TIME_GRAIN_MINUTE:
-		return "1 MINUTE"
-	case runtimev1.TimeGrain_TIME_GRAIN_HOUR:
-		return "1 HOUR"
-	case runtimev1.TimeGrain_TIME_GRAIN_DAY:
-		return "1 DAY"
-	case runtimev1.TimeGrain_TIME_GRAIN_WEEK:
-		return "1 WEEK"
-	case runtimev1.TimeGrain_TIME_GRAIN_MONTH:
-		return "1 MONTH"
-	case runtimev1.TimeGrain_TIME_GRAIN_QUARTER:
-		return "1 QUARTER"
-	case runtimev1.TimeGrain_TIME_GRAIN_YEAR:
-		return "1 YEAR"
-	}
-	panic(fmt.Errorf("unconvertable time grain specifier: %v", specifier))
-}
-
 func toTimeGrain(val string) runtimev1.TimeGrain {
 	switch strings.ToUpper(val) {
 	case "MILLISECOND":

--- a/runtime/server/queries_timeseries_test.go
+++ b/runtime/server/queries_timeseries_test.go
@@ -505,14 +505,12 @@ func TestServer_Timeseries_timezone_dst_backward(t *testing.T) {
 
 	require.NoError(t, err)
 	results := response.GetRollup().Results
-	require.Equal(t, 3, len(results))
+	require.Equal(t, 2, len(results))
 
-	require.Equal(t, "2023-10-29 00:00:00", results[0].Ts.AsTime().Format(time.DateTime))
-	require.Equal(t, 1.0, results[0].Records.Fields["count"].GetNumberValue())
-	require.Equal(t, "2023-10-29 01:00:00", results[1].Ts.AsTime().Format(time.DateTime))
+	require.Equal(t, "2023-10-29 01:00:00", results[0].Ts.AsTime().Format(time.DateTime))
+	require.Equal(t, 2.0, results[0].Records.Fields["count"].GetNumberValue())
+	require.Equal(t, "2023-10-29 02:00:00", results[1].Ts.AsTime().Format(time.DateTime))
 	require.Equal(t, 1.0, results[1].Records.Fields["count"].GetNumberValue())
-	require.Equal(t, "2023-10-29 02:00:00", results[2].Ts.AsTime().Format(time.DateTime))
-	require.Equal(t, 1.0, results[2].Records.Fields["count"].GetNumberValue())
 }
 
 func TestServer_Timeseries_timezone_kathmandu(t *testing.T) {


### PR DESCRIPTION
Performance regression due to `time_bucket`, ie:
```
========= time_bucket

Running tool: /opt/homebrew/opt/go/libexec/bin/go test -benchmem -run=^$ -bench ^BenchmarkMetricsViewsTimeSeries$ github.com/rilldata/rill/runtime/queries -count=1

goos: darwin
goarch: arm64
pkg: github.com/rilldata/rill/runtime/queries
BenchmarkMetricsViewsTimeSeries-10           415     2586518 ns/op     43838 B/op     1240 allocs/op
PASS
ok    github.com/rilldata/rill/runtime/queries  13.004s


====== time_bucket, 30s
/opt/homebrew/opt/go/libexec/bin/go test -benchmem -run=^$ -bench ^BenchmarkMetricsViewsTimeSeries$ github.com/rilldata/rill/runtime/queries -count=1 -benchtime=30s
goos: darwin
goarch: arm64
pkg: github.com/rilldata/rill/runtime/queries
BenchmarkMetricsViewsTimeSeries-10         28398           1142971 ns/op           43561 B/op       1234 allocs/op
PASS
ok      github.com/rilldata/rill/runtime/queries        39.987s


===== date_trunc
 /opt/homebrew/opt/go/libexec/bin/go test -benchmem -run=^$ -bench ^BenchmarkMetricsViewsTimeSeries$ github.com/rilldata/rill/runtime/queries -count=1
goos: darwin
goarch: arm64
pkg: github.com/rilldata/rill/runtime/queries
BenchmarkMetricsViewsTimeSeries-10           873           1711025 ns/op           43650 B/op       1237 allocs/op
PASS
ok      github.com/rilldata/rill/runtime/queries        3.265s

=== date_trunc, 30s
 /opt/homebrew/opt/go/libexec/bin/go test -benchmem -run=^$ -bench ^BenchmarkMetricsViewsTimeSeries$ github.com/rilldata/rill/runtime/queries -count=1 -benchtime=30s
goos: darwin
goarch: arm64
pkg: github.com/rilldata/rill/runtime/queries
BenchmarkMetricsViewsTimeSeries-10         30559           1169229 ns/op           43514 B/op       1234 allocs/op
PASS
ok      github.com/rilldata/rill/runtime/queries        49.447s
```