### PR TITLE
Remove rill.catalog primary key

### DIFF
--- a/runtime/drivers/duckdb/migrations/0001.sql
+++ b/runtime/drivers/duckdb/migrations/0001.sql
@@ -5,6 +5,5 @@ CREATE TABLE rill.catalog (
 	path TEXT NOT NULL,
 	created_on TIMESTAMPTZ NOT NULL,
 	updated_on TIMESTAMPTZ NOT NULL,
-	refreshed_on TIMESTAMPTZ NOT NULL,
-	PRIMARY KEY (name)
+	refreshed_on TIMESTAMPTZ NOT NULL
 );


### PR DESCRIPTION
It seems DuckDB can't remove an existing PK constraint, but this will hopefully fix the issue for new projects

See https://github.com/rilldata/rill/issues/2699 and related PRs for details