### PR TITLE
`range` doesn't take into account time zone DST

### DIFF
--- a/runtime/server/queries.go
+++ b/runtime/server/queries.go
@@ -31,9 +31,12 @@ func (s *Server) Query(ctx context.Context, req *runtimev1.QueryRequest) (*runti
 		return nil, err
 	}
 
-	transformedSQL, err := ensureLimits(ctx, olap, req.Sql, int(req.Limit))
-	if err != nil {
-		return nil, err
+	transformedSQL := req.Sql
+	if req.Limit != 0 {
+		transformedSQL, err = ensureLimits(ctx, olap, req.Sql, int(req.Limit))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	res, err := olap.Execute(ctx, &drivers.Statement{

--- a/runtime/server/queries_timeseries_test.go
+++ b/runtime/server/queries_timeseries_test.go
@@ -471,18 +471,15 @@ func TestServer_Timeseries_timezone_dst_forward(t *testing.T) {
 
 	require.NoError(t, err)
 	results := response.GetRollup().Results
-	require.Equal(t, 5, len(results))
-
+	require.Equal(t, 4, len(results))
 	require.Equal(t, "2023-03-26 00:00:00", results[0].Ts.AsTime().Format(time.DateTime))
 	require.Equal(t, 1.0, results[0].Records.Fields["count"].GetNumberValue())
 	require.Equal(t, "2023-03-26 01:00:00", results[1].Ts.AsTime().Format(time.DateTime))
-	require.Equal(t, 0.0, results[1].Records.Fields["count"].GetNumberValue())
-	require.Equal(t, "2023-03-26 01:00:00", results[2].Ts.AsTime().Format(time.DateTime))
+	require.Equal(t, 1.0, results[1].Records.Fields["count"].GetNumberValue())
+	require.Equal(t, "2023-03-26 02:00:00", results[2].Ts.AsTime().Format(time.DateTime))
 	require.Equal(t, 1.0, results[2].Records.Fields["count"].GetNumberValue())
-	require.Equal(t, "2023-03-26 02:00:00", results[3].Ts.AsTime().Format(time.DateTime))
+	require.Equal(t, "2023-03-26 03:00:00", results[3].Ts.AsTime().Format(time.DateTime))
 	require.Equal(t, 1.0, results[3].Records.Fields["count"].GetNumberValue())
-	require.Equal(t, "2023-03-26 03:00:00", results[4].Ts.AsTime().Format(time.DateTime))
-	require.Equal(t, 1.0, results[4].Records.Fields["count"].GetNumberValue())
 
 }
 

--- a/runtime/server/queries_timeseries_test.go
+++ b/runtime/server/queries_timeseries_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rilldata/rill/runtime/testruntime"
 	"github.com/stretchr/testify/require"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	"strings"
 )
 
 func TestServer_Timeseries_EmptyModel(t *testing.T) {
@@ -306,11 +307,17 @@ func getTimeseriesTestServerWithDSTForward(t *testing.T) (*Server, string) {
 
 func getTimeseriesTestServerWithDSTBackward(t *testing.T) (*Server, string) {
 	rt, instanceID := testruntime.NewInstanceWithModel(t, "timeseries", `
+		SELECT 1.0 AS clicks, TIMESTAMP '2023-10-28 23:00:00' AS time, 'iphone' AS device
+		UNION ALL
 		SELECT 1.0 AS clicks, TIMESTAMP '2023-10-29 00:00:00' AS time, 'iphone' AS device
 		UNION ALL
 		SELECT 1.0 AS clicks, TIMESTAMP '2023-10-29 01:00:00' AS time, 'iphone' AS device
 		UNION ALL
 		SELECT 1.0 AS clicks, TIMESTAMP '2023-10-29 02:00:00' AS time, 'iphone' AS device
+		UNION ALL
+		SELECT 1.0 AS clicks, TIMESTAMP '2023-10-29 03:00:00' AS time, 'iphone' AS device
+		UNION ALL
+		SELECT 1.0 AS clicks, TIMESTAMP '2023-10-29 04:00:00' AS time, 'iphone' AS device
 	`)
 
 	server, err := NewServer(context.Background(), &Options{}, rt, nil, ratelimit.NewNoop())
@@ -443,6 +450,13 @@ func TestServer_Timeseries_timezone_dst_forward(t *testing.T) {
 	t.Parallel()
 	server, instanceID := getTimeseriesTestServerWithDSTForward(t)
 
+	resp, err := server.Query(testCtx(), &runtimev1.QueryRequest{
+		InstanceId: instanceID,
+		Sql:        "select current_setting('TimeZone') as value",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "UTC", resp.Data[0].Fields["value"].GetStringValue())
+
 	response, err := server.ColumnTimeSeries(testCtx(), &runtimev1.ColumnTimeSeriesRequest{
 		InstanceId:          instanceID,
 		TableName:           "timeseries",
@@ -457,16 +471,19 @@ func TestServer_Timeseries_timezone_dst_forward(t *testing.T) {
 
 	require.NoError(t, err)
 	results := response.GetRollup().Results
-	require.Equal(t, 4, len(results))
+	require.Equal(t, 5, len(results))
 
 	require.Equal(t, "2023-03-26 00:00:00", results[0].Ts.AsTime().Format(time.DateTime))
 	require.Equal(t, 1.0, results[0].Records.Fields["count"].GetNumberValue())
 	require.Equal(t, "2023-03-26 01:00:00", results[1].Ts.AsTime().Format(time.DateTime))
-	require.Equal(t, 1.0, results[1].Records.Fields["count"].GetNumberValue())
-	require.Equal(t, "2023-03-26 02:00:00", results[2].Ts.AsTime().Format(time.DateTime))
+	require.Equal(t, 0.0, results[1].Records.Fields["count"].GetNumberValue())
+	require.Equal(t, "2023-03-26 01:00:00", results[2].Ts.AsTime().Format(time.DateTime))
 	require.Equal(t, 1.0, results[2].Records.Fields["count"].GetNumberValue())
-	require.Equal(t, "2023-03-26 03:00:00", results[3].Ts.AsTime().Format(time.DateTime))
+	require.Equal(t, "2023-03-26 02:00:00", results[3].Ts.AsTime().Format(time.DateTime))
 	require.Equal(t, 1.0, results[3].Records.Fields["count"].GetNumberValue())
+	require.Equal(t, "2023-03-26 03:00:00", results[4].Ts.AsTime().Format(time.DateTime))
+	require.Equal(t, 1.0, results[4].Records.Fields["count"].GetNumberValue())
+
 }
 
 /*
@@ -496,8 +513,8 @@ func TestServer_Timeseries_timezone_dst_backward(t *testing.T) {
 		TableName:           "timeseries",
 		TimestampColumnName: "time",
 		TimeRange: &runtimev1.TimeSeriesTimeRange{
-			Start:    parseTimeToProtoTimeStamps(t, "2023-10-29T00:00:00Z"),
-			End:      parseTimeToProtoTimeStamps(t, "2023-10-29T03:00:00Z"),
+			Start:    parseTimeToProtoTimeStamps(t, "2023-10-28T23:00:00Z"),
+			End:      parseTimeToProtoTimeStamps(t, "2023-10-29T04:00:00Z"),
 			Interval: runtimev1.TimeGrain_TIME_GRAIN_HOUR,
 		},
 		TimeZone: "Europe/Copenhagen",
@@ -505,15 +522,20 @@ func TestServer_Timeseries_timezone_dst_backward(t *testing.T) {
 
 	require.NoError(t, err)
 	results := response.GetRollup().Results
-	require.Equal(t, 2, len(results))
+	require.Equal(t, 4, len(results))
 
-	require.Equal(t, "2023-10-29 01:00:00", results[0].Ts.AsTime().Format(time.DateTime))
-	require.Equal(t, 2.0, results[0].Records.Fields["count"].GetNumberValue())
-	require.Equal(t, "2023-10-29 02:00:00", results[1].Ts.AsTime().Format(time.DateTime))
-	require.Equal(t, 1.0, results[1].Records.Fields["count"].GetNumberValue())
+	require.Equal(t, "2023-10-28 23:00:00", results[0].Ts.AsTime().Format(time.DateTime))
+	require.Equal(t, 1.0, results[0].Records.Fields["count"].GetNumberValue())
+	require.Equal(t, "2023-10-29 01:00:00", results[1].Ts.AsTime().Format(time.DateTime))
+	require.Equal(t, 2.0, results[1].Records.Fields["count"].GetNumberValue())
+	require.Equal(t, "2023-10-29 02:00:00", results[2].Ts.AsTime().Format(time.DateTime))
+	require.Equal(t, 1.0, results[2].Records.Fields["count"].GetNumberValue())
+	require.Equal(t, "2023-10-29 03:00:00", results[3].Ts.AsTime().Format(time.DateTime))
+	require.Equal(t, 1.0, results[3].Records.Fields["count"].GetNumberValue())
+
 }
 
-func TestServer_Timeseries_timezone_kathmandu(t *testing.T) {
+func TestServer_Timeseries_timezone_Kathmandu_with_hour(t *testing.T) {
 	t.Parallel()
 	server, instanceID := getTimeseriesTestServerWithKathmandu(t)
 
@@ -539,4 +561,90 @@ func TestServer_Timeseries_timezone_kathmandu(t *testing.T) {
 	require.Equal(t, 1.0, results[1].Records.Fields["count"].GetNumberValue())
 	require.Equal(t, "2023-10-29 02:15:00", results[2].Ts.AsTime().Format(time.DateTime))
 	require.Equal(t, 1.0, results[2].Records.Fields["count"].GetNumberValue())
+}
+
+func getTimeseriesTestServerWithWeekGrain(t *testing.T) (*Server, string) {
+	selects := make([]string, 0, 12)
+	tm, err := time.Parse(time.DateOnly, "2022-09-01")
+	require.NoError(t, err)
+	for i := 0; i < 52; i++ {
+		selects = append(selects, `SELECT 1.0 AS clicks, TIMESTAMP '`+tm.Format(time.DateTime)+`' AS time, 'iphone' AS device`)
+		tm = tm.AddDate(0, 0, 7)
+	}
+
+	sql := strings.Join(selects, " UNION ALL ")
+	rt, instanceID := testruntime.NewInstanceWithModel(t, "timeseries", sql)
+
+	server, err := NewServer(context.Background(), &Options{}, rt, nil, ratelimit.NewNoop())
+	require.NoError(t, err)
+
+	return server, instanceID
+}
+
+func TestServer_Timeseries_Kathmandu_with_week(t *testing.T) {
+	t.Parallel()
+	server, instanceID := getTimeseriesTestServerWithWeekGrain(t)
+
+	response, err := server.ColumnTimeSeries(testCtx(), &runtimev1.ColumnTimeSeriesRequest{
+		InstanceId:          instanceID,
+		TableName:           "timeseries",
+		TimestampColumnName: "time",
+		Measures: []*runtimev1.ColumnTimeSeriesRequest_BasicMeasure{
+			{
+				Expression: "max(clicks)",
+				SqlName:    "max_clicks",
+			},
+		},
+		TimeRange: &runtimev1.TimeSeriesTimeRange{
+			Start:    parseTimeToProtoTimeStamps(t, "2022-09-01T00:00:00Z"),
+			End:      parseTimeToProtoTimeStamps(t, "2023-09-01T00:00:00Z"),
+			Interval: runtimev1.TimeGrain_TIME_GRAIN_WEEK,
+		},
+		TimeZone: "Asia/Kathmandu",
+	})
+
+	require.NoError(t, err)
+	results := response.GetRollup().Results
+	require.Equal(t, 52, len(results))
+
+	for i := 0; i < 52; i++ {
+		value := results[i].Records.Fields["max_clicks"]
+		n, ok := value.GetKind().(*structpb.Value_NumberValue)
+		require.True(t, ok, "Element %d %s", i, results[i].Ts.AsTime())
+		require.Equal(t, 1.0, n.NumberValue, "Element %d %s", i, results[i].Ts.AsTime())
+	}
+}
+
+func TestServer_Timeseries_Copenhagen_with_week(t *testing.T) {
+	t.Parallel()
+	server, instanceID := getTimeseriesTestServerWithWeekGrain(t)
+
+	response, err := server.ColumnTimeSeries(testCtx(), &runtimev1.ColumnTimeSeriesRequest{
+		InstanceId:          instanceID,
+		TableName:           "timeseries",
+		TimestampColumnName: "time",
+		Measures: []*runtimev1.ColumnTimeSeriesRequest_BasicMeasure{
+			{
+				Expression: "max(clicks)",
+				SqlName:    "max_clicks",
+			},
+		},
+		TimeRange: &runtimev1.TimeSeriesTimeRange{
+			Start:    parseTimeToProtoTimeStamps(t, "2022-09-01T00:00:00Z"),
+			End:      parseTimeToProtoTimeStamps(t, "2023-09-01T00:00:00Z"),
+			Interval: runtimev1.TimeGrain_TIME_GRAIN_WEEK,
+		},
+		TimeZone: "Europe/Copenhagen",
+	})
+
+	require.NoError(t, err)
+	results := response.GetRollup().Results
+	require.Equal(t, 52, len(results))
+
+	for i := 0; i < len(results); i++ {
+		value := results[i].Records.Fields["max_clicks"]
+		n, ok := value.GetKind().(*structpb.Value_NumberValue)
+		require.True(t, ok, "Element %d %s", i, results[i].Ts.AsTime())
+		require.Equal(t, 1.0, n.NumberValue, "Element %d %s", i, results[i].Ts.AsTime())
+	}
 }


### PR DESCRIPTION
For example:
```
D select time_bucket(interval '1 week', timestamptz '2022-10-25', 'Europe/Copenhagen') as week_start_copenhagen;
┌──────────────────────────┐
│  week_start_copenhagen   │
│ timestamp with time zone │
├──────────────────────────┤
│ 2022-10-23 22:00:00+00   │
└──────────────────────────┘
D select time_bucket(interval '1 week', timestamptz '2022-11-01', 'Europe/Copenhagen') as week_start_copenhagen;
┌──────────────────────────┐
│  week_start_copenhagen   │
│ timestamp with time zone │
├──────────────────────────┤
│ 2022-10-30 23:00:00+00   │
└──────────────────────────┘
D select * from range(time_bucket(interval '1 week', timestamptz '2022-10-25', 'Europe/Copenhagen'), time_bucket(interval '1 week', timestamptz '2022-11-01', 'Europe/Copenhagen'), interval '1 week') ;
┌──────────────────────────┐
│          range           │
│ timestamp with time zone │
├──────────────────────────┤
│ 2022-10-23 22:00:00+00   │
│ 2022-10-30 22:00:00+00   │
└──────────────────────────┘
```
1st and 2nd queries show different week starts in terms of the hour shift, 3rd shows the same for both weeks.