### PR TITLE
Change internal gRPC port to 49009

### DIFF
--- a/cli/cmd/runtime/ping.go
+++ b/cli/cmd/runtime/ping.go
@@ -33,7 +33,7 @@ func PingCmd(cfg *config.Config) *cobra.Command {
 		},
 	}
 
-	pingCmd.Flags().StringVar(&runtimeURL, "url", "http://localhost:9010", "Base URL for the runtime")
+	pingCmd.Flags().StringVar(&runtimeURL, "url", "http://localhost:49009", "Base URL for the runtime")
 
 	return pingCmd
 }

--- a/cli/cmd/start/start.go
+++ b/cli/cmd/start/start.go
@@ -116,7 +116,7 @@ func StartCmd(cfg *config.Config) *cobra.Command {
 	startCmd.Flags().StringVar(&olapDSN, "db", local.DefaultOLAPDSN, "Database DSN")
 	startCmd.Flags().StringVar(&olapDriver, "db-driver", local.DefaultOLAPDriver, "Database driver")
 	startCmd.Flags().IntVar(&httpPort, "port", 9009, "Port for HTTP")
-	startCmd.Flags().IntVar(&grpcPort, "port-grpc", 9010, "Port for gRPC")
+	startCmd.Flags().IntVar(&grpcPort, "port-grpc", 49009, "Port for gRPC (internal)")
 	startCmd.Flags().BoolVar(&readonly, "readonly", false, "Show only dashboards in UI")
 	startCmd.Flags().BoolVar(&noUI, "no-ui", false, "Serve only the backend")
 	startCmd.Flags().BoolVar(&verbose, "verbose", false, "Sets the log level to debug")
@@ -126,3 +126,4 @@ func StartCmd(cfg *config.Config) *cobra.Command {
 
 	return startCmd
 }
+49152–65535 

--- a/cli/cmd/start/start.go
+++ b/cli/cmd/start/start.go
@@ -126,4 +126,3 @@ func StartCmd(cfg *config.Config) *cobra.Command {
 
 	return startCmd
 }
-49152–65535 

--- a/docs/docs/reference/cli/start.md
+++ b/docs/docs/reference/cli/start.md
@@ -16,7 +16,7 @@ rill start [<path>] [flags]
       --db string           Database DSN (default "stage.db")
       --db-driver string    Database driver (default "duckdb")
       --port int            Port for HTTP (default 9009)
-      --port-grpc int       Port for gRPC (default 9010)
+      --port-grpc int       Port for gRPC (default 49009)
       --readonly            Show only dashboards in UI
       --no-ui               Serve only the backend
       --verbose             Sets the log level to debug

--- a/docs/docs/reference/cli/start.md
+++ b/docs/docs/reference/cli/start.md
@@ -16,7 +16,7 @@ rill start [<path>] [flags]
       --db string           Database DSN (default "stage.db")
       --db-driver string    Database driver (default "duckdb")
       --port int            Port for HTTP (default 9009)
-      --port-grpc int       Port for gRPC (default 49009)
+      --port-grpc int       Port for gRPC (internal) (default 49009)
       --readonly            Show only dashboards in UI
       --no-ui               Serve only the backend
       --verbose             Sets the log level to debug


### PR DESCRIPTION
It seems some users run into conflicts on the internal gRPC port 9010. This changes it to something higher/rarer.

Based on https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers, 49009 is not officially used, and is outside the range of 49152–65535 from which other services may acquire temporary ports