### PR TITLE
S3 public file access fix

### DIFF
--- a/runtime/drivers/blob/blobdownloader.go
+++ b/runtime/drivers/blob/blobdownloader.go
@@ -47,6 +47,9 @@ type blobIterator struct {
 	tempDir string
 	opts    *Options
 	logger  *zap.Logger
+	// data is already fetched during planning stage itself for single file cases
+	// TODO :: refactor this to return a different iterator maybe ?
+	nextPaths []string
 }
 
 var _ drivers.FileIterator = &blobIterator{}
@@ -121,6 +124,14 @@ func NewIterator(ctx context.Context, bucket *blob.Bucket, opts Options, l *zap.
 		return nil, err
 	}
 	it.objects = objects
+	if len(objects) == 1 {
+		it.nextPaths, err = it.NextBatch(1)
+		it.index = 0
+		if err != nil {
+			it.Close()
+			return nil, err
+		}
+	}
 
 	return it, nil
 }
@@ -144,6 +155,12 @@ func (it *blobIterator) HasNext() bool {
 func (it *blobIterator) NextBatch(n int) ([]string, error) {
 	if !it.HasNext() {
 		return nil, io.EOF
+	}
+	if len(it.nextPaths) != 0 {
+		paths := it.nextPaths
+		it.nextPaths = nil
+		it.index += len(it.nextPaths)
+		return paths, nil
 	}
 
 	// delete files created in last iteration

--- a/runtime/drivers/blob/blobdownloader.go
+++ b/runtime/drivers/blob/blobdownloader.go
@@ -158,8 +158,8 @@ func (it *blobIterator) NextBatch(n int) ([]string, error) {
 	}
 	if len(it.nextPaths) != 0 {
 		paths := it.nextPaths
+		it.index += len(paths)
 		it.nextPaths = nil
-		it.index += len(it.nextPaths)
 		return paths, nil
 	}
 


### PR DESCRIPTION
Post changes in PR #2557 no s3 api calls are done during iterator creation phase for single files. This causes issues for objects with public access since we rely on failures to retry with anonymous credentials. 
We now pre fetch data in cases of single files to check for access.

@ericpgreen2 @nishantmonu51 
