### PR TITLE
fix: reset dash state provider on metric name

### DIFF
--- a/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
@@ -107,12 +107,14 @@
   <ProjectErrored organization={orgName} project={projectName} />
 {:else}
   <StateManagersProvider metricsViewName={dashboardName}>
-    <DashboardStateProvider metricViewName={dashboardName}>
-      <Dashboard
-        leftMargin={"48px"}
-        hasTitle={false}
-        metricViewName={dashboardName}
-      />
-    </DashboardStateProvider>
+    {#key dashboardName}
+      <DashboardStateProvider metricViewName={dashboardName}>
+        <Dashboard
+          leftMargin={"48px"}
+          hasTitle={false}
+          metricViewName={dashboardName}
+        />
+      </DashboardStateProvider>
+    {/key}
   </StateManagersProvider>
 {/if}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -92,8 +92,6 @@
   let unfilteredTotal: number;
   $: unfilteredTotal = $unfilteredTotalsQuery.data?.data?.[activeMeasure.name];
 
-  $: console.log("unfilteredTotal", unfilteredTotal);
-
   let leaderboardExpanded;
 
   function onSelectItem(event, item: MetricsViewDimension) {

--- a/web-common/src/features/dashboards/proto-state/DashboardStateProvider.svelte
+++ b/web-common/src/features/dashboards/proto-state/DashboardStateProvider.svelte
@@ -3,6 +3,8 @@
   import { useMetaQuery } from "@rilldata/web-common/features/dashboards/selectors";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { onDestroy } from "svelte";
+  import { getStateManagers } from "../state-managers/state-managers";
+  import { metricsExplorerStore } from "../dashboard-stores";
 
   export let metricViewName: string;
 
@@ -14,11 +16,17 @@
     unsubscribe = useDashboardUrlSync(metricViewName, metricsViewQuery);
   }
 
+  $: if ($metricsViewQuery.data) {
+    metricsExplorerStore.sync(metricViewName, $metricsViewQuery.data);
+  }
+
+  const { dashboardStore } = getStateManagers();
+
   onDestroy(() => {
     if (unsubscribe) unsubscribe();
   });
 </script>
 
-{#if $metricsViewQuery.data}
+{#if $dashboardStore}
   <slot />
 {/if}

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -7,7 +7,7 @@
   import { featureFlags } from "@rilldata/web-common/features/feature-flags";
   import { runtime } from "../../../runtime-client/runtime-store";
   import MeasuresContainer from "../big-number/MeasuresContainer.svelte";
-  import { metricsExplorerStore, useDashboardStore } from "../dashboard-stores";
+  import { useDashboardStore } from "../dashboard-stores";
   import DimensionDisplay from "../dimension-table/DimensionDisplay.svelte";
   import LeaderboardDisplay from "../leaderboard/LeaderboardDisplay.svelte";
   import MetricsTimeSeriesCharts from "../time-series/MetricsTimeSeriesCharts.svelte";
@@ -26,8 +26,8 @@
     if (!$featureFlags.readOnly && !$metricsViewQuery.data?.measures?.length) {
       goto(`/dashboard/${metricViewName}/edit`);
     }
-    metricsExplorerStore.sync(metricViewName, $metricsViewQuery.data);
   }
+
   $: if (!$featureFlags.readOnly && $metricsViewQuery.isError) {
     goto(`/dashboard/${metricViewName}/edit`);
   }

--- a/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
@@ -68,9 +68,11 @@
     inspector={false}
   >
     <StateManagersProvider metricsViewName={metricViewName} slot="body">
-      <DashboardStateProvider {metricViewName}>
-        <Dashboard {metricViewName} hasTitle />
-      </DashboardStateProvider>
+      {#key metricViewName}
+        <DashboardStateProvider {metricViewName}>
+          <Dashboard {metricViewName} hasTitle />
+        </DashboardStateProvider>
+      {/key}
     </StateManagersProvider>
   </WorkspaceContainer>
 {/if}


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
Our state navigation is currently broken in many ways. One critical bug is that in Cloud, it will try to render a dashboard before the dashboard store is ready on navigation, causing the entire dashboard to break and the app to freeze.

This PR fixes the critical bug by moving the step to hydrate a dashboard initially OUT of the dashboard component itself. It also for now resets the dashboard state provider using a metricViewName #key. This may or may not be a temporary step; it depends on how we fix the other state navigation bugs.

#### Details: