### PR TITLE
add uuid type

### DIFF
--- a/web-common/src/lib/duckdb-data-types.ts
+++ b/web-common/src/lib/duckdb-data-types.ts
@@ -90,8 +90,10 @@ export const STRING_LIKES = new Set([
   // Go Types
   "CODE_STRING",
   "CODE_BYTES",
+  "CODE_UUID",
 
   // Node Types
+  "UUID",
   "BYTE_ARRAY",
   "VARCHAR",
   "CHAR",


### PR DESCRIPTION
This quick fix adds the duckdb `UUID` type, which was reported as missing