### PR TITLE
feat: support offline in local dev

### DIFF
--- a/web-local/src/lib/svelte-query/globalQueryClient.ts
+++ b/web-local/src/lib/svelte-query/globalQueryClient.ts
@@ -1,9 +1,9 @@
-/**
- * This is temporary until everything is moved to using svelte-query
- */
+import { featureFlags } from "@rilldata/web-common/features/feature-flags";
 import { QueryClient } from "@tanstack/svelte-query";
+import { get } from "svelte/store";
 
 export function createQueryClient() {
+  const isLocal = !get(featureFlags)?.readOnly;
   return new QueryClient({
     defaultOptions: {
       queries: {
@@ -11,6 +11,7 @@ export function createQueryClient() {
         refetchOnReconnect: false,
         refetchOnWindowFocus: false,
         retry: false,
+        networkMode: isLocal ? "always" : "online",
       },
     },
   });


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
https://www.notion.so/rilldata/Rill-Developer-doesn-t-work-offline-92cb9b608b5543c59d8eefe8d4159e6c

#### Details:
Rill Developer doesn't work when offline today, even though it should. The reason is that TanStack QueryClients are by default configured to not attempt requests when the network is offline. This PR adds a change where, if running Rill Developer, the QueryClient will use networkMode "always", which will configure TanStack to send requests even if offline.

## Steps to Verify
1. Run `npm run dev`
2. Turn wifi off
3. Open localhost:3000 and navigate between sources, models, and dashboards