### PR TITLE
Idea for local feature flags passed to "rill start"

### DIFF
--- a/cli/cmd/start/start.go
+++ b/cli/cmd/start/start.go
@@ -28,6 +28,7 @@ func StartCmd(cfg *config.Config) *cobra.Command {
 	var strict bool
 	var logFormat string
 	var variables []string
+	var featureFlags []string
 
 	startCmd := &cobra.Command{
 		Use:   "start [<path>]",
@@ -84,7 +85,7 @@ func StartCmd(cfg *config.Config) *cobra.Command {
 				return fmt.Errorf("invalid log format %q", logFormat)
 			}
 
-			app, err := local.NewApp(cmd.Context(), cfg.Version, verbose, olapDriver, olapDSN, projectPath, parsedLogFormat, variables)
+			app, err := local.NewApp(cmd.Context(), cfg.Version, verbose, olapDriver, olapDSN, projectPath, parsedLogFormat, variables, featureFlags)
 			if err != nil {
 				return err
 			}
@@ -123,6 +124,14 @@ func StartCmd(cfg *config.Config) *cobra.Command {
 	startCmd.Flags().BoolVar(&strict, "strict", false, "Exit if project has build errors")
 	startCmd.Flags().StringVar(&logFormat, "log-format", "console", "Log format (options: \"console\", \"json\")")
 	startCmd.Flags().StringSliceVarP(&variables, "env", "e", []string{}, "Set project variables")
+
+	startCmd.Flags().StringSliceVar(&featureFlags, "feature", []string{}, "Set feature flags")
+	if cfg.IsDev() {
+		err := startCmd.Flags().MarkHidden("feature")
+		if err != nil {
+			panic(err)
+		}
+	}
 
 	return startCmd
 }

--- a/cli/pkg/local/app.go
+++ b/cli/pkg/local/app.go
@@ -59,11 +59,12 @@ type App struct {
 	Version               config.Version
 	Verbose               bool
 	ProjectPath           string
+	FeatureFlags          []string
 	observabilityShutdown observability.ShutdownFunc
 	loggerCleanUp         func()
 }
 
-func NewApp(ctx context.Context, ver config.Version, verbose bool, olapDriver, olapDSN, projectPath string, logFormat LogFormat, variables []string) (*App, error) {
+func NewApp(ctx context.Context, ver config.Version, verbose bool, olapDriver, olapDSN, projectPath string, logFormat LogFormat, variables, featureFlags []string) (*App, error) {
 	logger, cleanupFn := initLogger(verbose, logFormat)
 	// Init Prometheus telemetry
 	shutdown, err := observability.Start(ctx, logger, &observability.Options{
@@ -135,6 +136,7 @@ func NewApp(ctx context.Context, ver config.Version, verbose bool, olapDriver, o
 		Version:               ver,
 		Verbose:               verbose,
 		ProjectPath:           projectPath,
+		FeatureFlags:          featureFlags,
 		observabilityShutdown: shutdown,
 		loggerCleanUp:         cleanupFn,
 	}
@@ -234,6 +236,7 @@ func (a *App) Serve(httpPort, grpcPort int, enableUI, openBrowser, readonly bool
 		IsDev:            a.Version.IsDev(),
 		AnalyticsEnabled: enabled,
 		Readonly:         readonly,
+		FeatureFlags:     a.FeatureFlags,
 	}
 
 	// Create server logger.
@@ -324,17 +327,18 @@ func (a *App) pollServer(ctx context.Context, httpPort int, openOnHealthy bool) 
 }
 
 type localInfo struct {
-	InstanceID       string `json:"instance_id"`
-	GRPCPort         int    `json:"grpc_port"`
-	InstallID        string `json:"install_id"`
-	UserID           string `json:"user_id"`
-	ProjectPath      string `json:"project_path"`
-	Version          string `json:"version"`
-	BuildCommit      string `json:"build_commit"`
-	BuildTime        string `json:"build_time"`
-	IsDev            bool   `json:"is_dev"`
-	AnalyticsEnabled bool   `json:"analytics_enabled"`
-	Readonly         bool   `json:"readonly"`
+	InstanceID       string   `json:"instance_id"`
+	GRPCPort         int      `json:"grpc_port"`
+	InstallID        string   `json:"install_id"`
+	UserID           string   `json:"user_id"`
+	ProjectPath      string   `json:"project_path"`
+	Version          string   `json:"version"`
+	BuildCommit      string   `json:"build_commit"`
+	BuildTime        string   `json:"build_time"`
+	IsDev            bool     `json:"is_dev"`
+	AnalyticsEnabled bool     `json:"analytics_enabled"`
+	Readonly         bool     `json:"readonly"`
+	FeatureFlags     []string `json:"feature_flags"`
 }
 
 // infoHandler servers the local info struct.


### PR DESCRIPTION
Example usage:

```bash
> rill start --feature foo --feature BAR
```

Usage:

```bash
> curl http://localhost:9009/local/config
{..., "feature_flags":["foo","BAR"]} 
```

This would make the feature flags array available in `runtimeServiceGetConfig` on the frontend.