### PR TITLE
Adding a name safeguard for url state

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -90,7 +90,9 @@
   );
 
   let unfilteredTotal: number;
-  $: unfilteredTotal = $unfilteredTotalsQuery.data?.data?.[activeMeasure.name];
+  $: if (activeMeasure?.name) {
+    unfilteredTotal = $unfilteredTotalsQuery.data?.data?.[activeMeasure.name];
+  }
 
   let leaderboardExpanded;
 

--- a/web-common/src/features/dashboards/proto-state/dashboard-url-state.ts
+++ b/web-common/src/features/dashboards/proto-state/dashboard-url-state.ts
@@ -4,6 +4,7 @@ import {
   metricsExplorerStore,
   useDashboardStore,
 } from "@rilldata/web-common/features/dashboards/dashboard-stores";
+import { getNameFromFile } from "@rilldata/web-common/features/entity-management/entity-mappers";
 import type { V1MetricsView } from "@rilldata/web-common/runtime-client";
 import type { CreateQueryResult } from "@tanstack/svelte-query";
 import { derived, get, Readable } from "svelte/store";
@@ -11,6 +12,7 @@ import { derived, get, Readable } from "svelte/store";
 export type DashboardUrlState = {
   proto: string;
   defaultProto: string;
+  urlName: string;
   urlProto: string;
 };
 export type DashboardUrlStore = Readable<DashboardUrlState>;
@@ -35,6 +37,7 @@ export function useDashboardUrlState(
       return {
         proto,
         defaultProto,
+        urlName: getNameFromFile(page.url.pathname),
         urlProto,
       };
     }
@@ -66,6 +69,8 @@ export function useDashboardUrlSync(
   const dashboardUrlState = useDashboardUrlState(metricViewName);
   let lastKnownProto: string;
   return dashboardUrlState.subscribe((state) => {
+    if (state.urlName !== metricViewName) return;
+
     if (state.proto !== lastKnownProto) {
       // changed when filters etc are changed on the dashboard
       gotoNewDashboardUrl(get(page).url, state.proto, state.defaultProto);


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
Switching between dashboard is inconsistent with retaining all the selections.

#### Details:
There was a race condition in the url sync component. It would run with state of older dashboard for newer dashboard.

## Steps to Verify
1. Create 2 dashboards.
2. Go to one and select a few filters and change the time settings.
3. Go to the other and do the same.
4. Switching between these should retain the filters and time selections.