### PR TITLE
Rename format preset type

### DIFF
--- a/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
@@ -13,7 +13,7 @@
   import {
     formatMeasurePercentageDifference,
     humanizeDataType,
-    NicelyFormattedTypes,
+    FormatPreset,
   } from "../humanize-numbers";
 
   export let value: number;
@@ -25,10 +25,9 @@
   export let status: EntityStatus;
   export let description: string = undefined;
   export let withTimeseries = true;
-  export let formatPreset: string; // workaround, since unable to cast `string` to `NicelyFormattedTypes` within MetricsTimeSeriesCharts.svelte's `#each` block
+  export let formatPreset: string; // workaround, since unable to cast `string` to `FormatPreset` within MetricsTimeSeriesCharts.svelte's `#each` block
 
-  $: formatPresetEnum =
-    (formatPreset as NicelyFormattedTypes) || NicelyFormattedTypes.HUMANIZE;
+  $: formatPresetEnum = (formatPreset as FormatPreset) || FormatPreset.HUMANIZE;
   $: valueIsPresent = value !== undefined && value !== null;
 
   $: isComparisonPositive = comparisonPercChange && comparisonPercChange >= 0;
@@ -39,7 +38,7 @@
   $: noChange = !diff;
 
   /** when the measure is a percentage, we don't show a percentage change. */
-  $: measureIsPercentage = formatPresetEnum === NicelyFormattedTypes.PERCENTAGE;
+  $: measureIsPercentage = formatPresetEnum === FormatPreset.PERCENTAGE;
 </script>
 
 <div class="flex flex-col pl-1 {withTimeseries ? 'mt-2' : 'justify-between'}">
@@ -69,7 +68,7 @@
           <Tooltip distance={8} location="bottom" alignment="start">
             <div class="w-max">
               <WithTween {value} tweenProps={{ duration: 500 }} let:output>
-                {#if formatPresetEnum !== NicelyFormattedTypes.NONE}
+                {#if formatPresetEnum !== FormatPreset.NONE}
                   {humanizeDataType(output, formatPresetEnum)}
                 {:else}
                   {output}
@@ -94,7 +93,7 @@
                       let:output
                     >
                       {@const formattedValue =
-                        formatPresetEnum !== NicelyFormattedTypes.NONE
+                        formatPresetEnum !== FormatPreset.NONE
                           ? humanizeDataType(diff, formatPresetEnum)
                           : diff}
                       {#if !noChange}
@@ -135,7 +134,7 @@
                 {:else}
                   {TIME_COMPARISON[comparisonOption].shorthand}
                   <span class="font-semibold"
-                    >{formatPresetEnum !== NicelyFormattedTypes.NONE
+                    >{formatPresetEnum !== FormatPreset.NONE
                       ? humanizeDataType(comparisonValue, formatPresetEnum)
                       : comparisonValue}</span
                   >{#if !measureIsPercentage}

--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -27,10 +27,7 @@
   import { useQueryClient } from "@tanstack/svelte-query";
   import { runtime } from "../../../runtime-client/runtime-store";
   import { metricsExplorerStore, useDashboardStore } from "../dashboard-stores";
-  import {
-    humanizeGroupByColumns,
-    NicelyFormattedTypes,
-  } from "../humanize-numbers";
+  import { humanizeGroupByColumns, FormatPreset } from "../humanize-numbers";
   import {
     computeComparisonValues,
     computePercentOfTotal,
@@ -263,7 +260,7 @@
       columnNames.splice(sortByColumnIndex + 1, 0, `${sortByColumn}_delta`);
 
       // Only push percentage delta column if selected measure is not a percentage
-      if (selectedMeasure?.format != NicelyFormattedTypes.PERCENTAGE) {
+      if (selectedMeasure?.format != FormatPreset.PERCENTAGE) {
         percentOfTotalSpliceIndex = 3;
         columnNames.splice(
           sortByColumnIndex + 2,
@@ -374,7 +371,7 @@
     const measureFormatSpec = columns?.map((column) => {
       return {
         columnName: column.name,
-        formatPreset: column.format as NicelyFormattedTypes,
+        formatPreset: column.format as FormatPreset,
       };
     });
     if (measureFormatSpec) {

--- a/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
@@ -7,7 +7,7 @@ import type {
   V1MetricsViewToplistResponseDataItem,
 } from "../../../runtime-client";
 import {
-  NicelyFormattedTypes,
+  FormatPreset,
   formatMeasurePercentageDifference,
 } from "../humanize-numbers";
 import PercentOfTotal from "./PercentOfTotal.svelte";
@@ -156,7 +156,7 @@ export function getComparisonProperties(
     return {
       label: DeltaChangePercentage,
       type: "RILL_PERCENTAGE_CHANGE",
-      format: NicelyFormattedTypes.PERCENTAGE,
+      format: FormatPreset.PERCENTAGE,
       description: "Perc. change over comparison period",
     };
   else if (measureName.includes("_delta")) {
@@ -170,7 +170,7 @@ export function getComparisonProperties(
     return {
       label: PercentOfTotal,
       type: "RILL_PERCENTAGE_CHANGE",
-      format: NicelyFormattedTypes.PERCENTAGE,
+      format: FormatPreset.PERCENTAGE,
       description: "Percent of total",
     };
   }

--- a/web-common/src/features/dashboards/humanize-numbers.ts
+++ b/web-common/src/features/dashboards/humanize-numbers.ts
@@ -32,22 +32,6 @@ interface ColFormatSpec {
   formatPreset: NicelyFormattedTypes;
 }
 
-export const nicelyFormattedTypesSelectorOptions = [
-  { value: NicelyFormattedTypes.HUMANIZE, label: "Humanize" },
-  {
-    value: NicelyFormattedTypes.NONE,
-    label: "No formatting",
-  },
-  {
-    value: NicelyFormattedTypes.CURRENCY,
-    label: "Currency (USD)",
-  },
-  {
-    value: NicelyFormattedTypes.PERCENTAGE,
-    label: "Percentage",
-  },
-];
-
 export function humanizeGroupValues(
   values: Array<Record<string, number | string>>,
   type: NicelyFormattedTypes,

--- a/web-common/src/features/dashboards/humanize-numbers.ts
+++ b/web-common/src/features/dashboards/humanize-numbers.ts
@@ -12,32 +12,29 @@ import { PerRangeFormatter } from "@rilldata/web-common/lib/number-formatting/st
 const shortHandSymbols = ["Q", "T", "B", "M", "k", "none"] as const;
 export type ShortHandSymbols = (typeof shortHandSymbols)[number];
 
-interface HumanizeOptions {
-  scale?: ShortHandSymbols;
-  excludeDecimalZeros?: boolean;
-  columnName?: string;
-}
-
-type formatterOptions = Intl.NumberFormatOptions & HumanizeOptions;
-
-export enum NicelyFormattedTypes {
+/**
+ * This enum represents all of the valid strings that can be
+ * used in the `format_preset` field of a measure definition.
+ */
+export enum FormatPreset {
   HUMANIZE = "humanize",
   NONE = "none",
   CURRENCY = "currency_usd",
   PERCENTAGE = "percentage",
+  INTERVAL = "interval_ms",
 }
 
 interface ColFormatSpec {
   columnName: string;
-  formatPreset: NicelyFormattedTypes;
+  formatPreset: FormatPreset;
 }
 
 export function humanizeGroupValues(
   values: Array<Record<string, number | string>>,
-  type: NicelyFormattedTypes,
-  options?: formatterOptions
+  type: FormatPreset,
+  columnName?: string
 ) {
-  const valueKey = options.columnName ? options.columnName : "value";
+  const valueKey = columnName ?? "value";
   let numValues = values.map((v) => v[valueKey]);
 
   const areAllNumbers = numValues.some((e) => typeof e === "number");
@@ -62,10 +59,8 @@ export function humanizeGroupByColumns(
   return columnFormatSpec.reduce((valuesObj, column) => {
     return humanizeGroupValues(
       valuesObj,
-      column.formatPreset || NicelyFormattedTypes.HUMANIZE,
-      {
-        columnName: column.columnName,
-      }
+      column.formatPreset || FormatPreset.HUMANIZE,
+      column.columnName
     );
   }, values);
 }
@@ -79,26 +74,26 @@ export function humanizeGroupByColumns(
 // can deprecate any left over code that is no longer needed.
 
 export const nicelyFormattedTypesToNumberKind = (
-  type: NicelyFormattedTypes | string
+  type: FormatPreset | string
 ) => {
   switch (type) {
-    case NicelyFormattedTypes.CURRENCY:
+    case FormatPreset.CURRENCY:
       return NumberKind.DOLLAR;
 
-    case NicelyFormattedTypes.PERCENTAGE:
+    case FormatPreset.PERCENTAGE:
       return NumberKind.PERCENT;
 
     default:
       // captures:
-      // NicelyFormattedTypes.NONE
-      // NicelyFormattedTypes.HUMANIZE
+      // FormatPreset.NONE
+      // FormatPreset.HUMANIZE
       return NumberKind.ANY;
   }
 };
 
 export function humanizeDataType(
   value: unknown,
-  type: NicelyFormattedTypes,
+  type: FormatPreset,
   options?: FormatterFactoryOptions
 ): string {
   if (value === undefined || value === null) return "";
@@ -107,7 +102,7 @@ export function humanizeDataType(
   const numberKind = nicelyFormattedTypesToNumberKind(type);
 
   let innerOptions: FormatterFactoryOptions = options;
-  if (type === NicelyFormattedTypes.NONE) {
+  if (type === FormatPreset.NONE) {
     innerOptions = {
       strategy: "none",
       numberKind,
@@ -129,12 +124,9 @@ export function humanizeDataType(
 }
 
 /** This function is used primarily in the leaderboard and the detail tables. */
-function humanizeGroupValuesUtil2(
-  values: number[],
-  type: NicelyFormattedTypes
-) {
+function humanizeGroupValuesUtil2(values: number[], type: FormatPreset) {
   if (!values.length) return values;
-  if (type == NicelyFormattedTypes.NONE) return values;
+  if (type == FormatPreset.NONE) return values;
 
   const numberKind = nicelyFormattedTypesToNumberKind(type);
 

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -25,7 +25,7 @@
   import { runtime } from "../../../runtime-client/runtime-store";
   import { metricsExplorerStore, useDashboardStore } from "../dashboard-stores";
   import { getFilterForComparsion } from "../dimension-table/dimension-table-utils";
-  import type { NicelyFormattedTypes } from "../humanize-numbers";
+  import type { FormatPreset } from "../humanize-numbers";
   import LeaderboardHeader from "./LeaderboardHeader.svelte";
   import { prepareLeaderboardItemData } from "./leaderboard-utils";
   import LeaderboardListItem from "./LeaderboardListItem.svelte";
@@ -39,7 +39,7 @@
   export let referenceValue: number;
   export let unfilteredTotal: number;
 
-  export let formatPreset: NicelyFormattedTypes;
+  export let formatPreset: FormatPreset;
   export let isSummableMeasure = false;
 
   let slice = 7;

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -14,7 +14,7 @@
   import { onDestroy, onMount } from "svelte";
   import { runtime } from "../../../runtime-client/runtime-store";
   import { metricsExplorerStore, useDashboardStore } from "../dashboard-stores";
-  import { NicelyFormattedTypes } from "../humanize-numbers";
+  import { FormatPreset } from "../humanize-numbers";
   import Leaderboard from "./Leaderboard.svelte";
   import LeaderboardControls from "./LeaderboardControls.svelte";
 
@@ -66,8 +66,7 @@
   );
 
   $: formatPreset =
-    (activeMeasure?.format as NicelyFormattedTypes) ??
-    NicelyFormattedTypes.HUMANIZE;
+    (activeMeasure?.format as FormatPreset) ?? FormatPreset.HUMANIZE;
 
   let referenceValue: number;
   $: if (activeMeasure?.name && $totalsQuery?.data?.data) {

--- a/web-common/src/features/dashboards/leaderboard/__stories__/LeaderboardListItem.stories.svelte
+++ b/web-common/src/features/dashboards/leaderboard/__stories__/LeaderboardListItem.stories.svelte
@@ -5,7 +5,7 @@
 
   import LeaderboardListItem from "../LeaderboardListItem.svelte";
 
-  import { NicelyFormattedTypes } from "../../humanize-numbers";
+  import { FormatPreset } from "../../humanize-numbers";
 
   const atLeastOneActive = true;
   const filterExcludeMode = true;
@@ -59,10 +59,10 @@
         type: "inline-radio",
       },
       options: [
-        NicelyFormattedTypes.HUMANIZE,
-        NicelyFormattedTypes.PERCENTAGE,
-        NicelyFormattedTypes.CURRENCY,
-        NicelyFormattedTypes.NONE,
+        FormatPreset.HUMANIZE,
+        FormatPreset.PERCENTAGE,
+        FormatPreset.CURRENCY,
+        FormatPreset.NONE,
       ],
     },
   }}

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -6,7 +6,7 @@
   import { useDashboardStore } from "@rilldata/web-common/features/dashboards/dashboard-stores";
   import {
     humanizeDataType,
-    NicelyFormattedTypes,
+    FormatPreset,
     nicelyFormattedTypesToNumberKind,
   } from "@rilldata/web-common/features/dashboards/humanize-numbers";
   import {
@@ -275,7 +275,7 @@
           ? (bigNum - comparisonValue) / comparisonValue
           : undefined}
       {@const formatPreset =
-        NicelyFormattedTypes[measure?.format] || NicelyFormattedTypes.HUMANIZE}
+        FormatPreset[measure?.format] || FormatPreset.HUMANIZE}
       <!-- FIXME: I can't select a time series by measure id. -->
       <MeasureBigNumber
         value={bigNum}
@@ -319,7 +319,7 @@
             }}
             numberKind={nicelyFormattedTypesToNumberKind(measure?.format)}
             mouseoverFormat={(value) =>
-              formatPreset === NicelyFormattedTypes.NONE
+              formatPreset === FormatPreset.NONE
                 ? `${value}`
                 : humanizeDataType(value, measure?.format)}
           />

--- a/web-local/src/routes/dev/data-graphic/empty-timeseries.svelte
+++ b/web-local/src/routes/dev/data-graphic/empty-timeseries.svelte
@@ -2,7 +2,7 @@
   import { SimpleDataGraphic } from "@rilldata/web-common/components/data-graphic/elements";
   import { WithBisector } from "@rilldata/web-common/components/data-graphic/functional-components";
   import { Axis } from "@rilldata/web-common/components/data-graphic/guides";
-  import { NicelyFormattedTypes } from "@rilldata/web-common/features/dashboards/humanize-numbers";
+  import { FormatPreset } from "@rilldata/web-common/features/dashboards/humanize-numbers";
   import TimeSeriesBody from "@rilldata/web-common/features/dashboards/workspace/metrics-container/TimeSeriesBody.svelte";
   import TimeSeriesChartContainer from "@rilldata/web-common/features/dashboards/workspace/metrics-container/TimeSeriesChartContainer.svelte";
 
@@ -100,7 +100,7 @@
     <div />
     <TimeSeriesBody
       bind:mouseoverValue
-      formatPreset={NicelyFormattedTypes.HUMANIZE}
+      formatPreset={FormatPreset.HUMANIZE}
       {data}
       {key}
       mouseover={point}


### PR DESCRIPTION
This PR does some minor cleanup, but primarily updates the type name `NicelyFormattedTypes`  to `FormatPreset` to match the string we've ended up adopting in the YAML spec for metrics.

@djbarnwal hoping for a quick review and merge on this since it's just a find a replace. Thanks!
