### PR TITLE
replace `~~`  with `Math.trunc`

### DIFF
--- a/web-common/src/components/column-profile/column-types/details/NumericPlot.svelte
+++ b/web-common/src/components/column-profile/column-types/details/NumericPlot.svelte
@@ -223,7 +223,7 @@ Otherwise, the page will jump around as the data is fetched.
                   class="fill-gray-500"
                   opacity={0.8}
                 >
-                  {formatInteger(~~point.count)} row{#if point.count !== 1}s{/if}
+                  {formatInteger(Math.trunc(point.count))} row{#if point.count !== 1}s{/if}
                   ({((point.count / totalRows) * 100).toFixed(2)}%)
                 </text>
               </g>

--- a/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampDetail.svelte
+++ b/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampDetail.svelte
@@ -255,17 +255,21 @@
   $: if ($zoomCoords.start.x && $zoomCoords.stop.x) {
     const xStart = $X.invert(Math.min($zoomCoords.start.x, $zoomCoords.stop.x));
     const xEnd = $X.invert(Math.max($zoomCoords.start.x, $zoomCoords.stop.x));
-    zoomedRows = ~~data
-      .filter((di) => {
-        return di[xAccessor] >= xStart && di[xAccessor] <= xEnd;
-      })
-      .reduce((sum, di) => (sum += di[yAccessor]), 0);
+    zoomedRows = Math.trunc(
+      data
+        .filter((di) => {
+          return di[xAccessor] >= xStart && di[xAccessor] <= xEnd;
+        })
+        .reduce((sum, di) => (sum += di[yAccessor]), 0)
+    );
   } else if (zoomedXStart && zoomedXEnd) {
-    zoomedRows = ~~data
-      .filter((di) => {
-        return di[xAccessor] >= zoomedXStart && di[xAccessor] <= zoomedXEnd;
-      })
-      .reduce((sum, di) => (sum += di[yAccessor]), 0);
+    zoomedRows = Math.trunc(
+      data
+        .filter((di) => {
+          return di[xAccessor] >= zoomedXStart && di[xAccessor] <= zoomedXEnd;
+        })
+        .reduce((sum, di) => (sum += di[yAccessor]), 0)
+    );
   }
 
   // Tooltip & timestamp range variables.
@@ -478,7 +482,7 @@
         tooltipPanShakeAmount={// we will shake the tooltip pan word
         $tooltipPanShakeAmount}
         {zoomedRows}
-        totalRows={~~data.reduce((a, b) => a + b[yAccessor], 0)}
+        totalRows={Math.trunc(data.reduce((a, b) => a + b[yAccessor], 0))}
         zoomed={$zoomCoords.start.x || zoomedXStart}
         zooming={zoomedXStart && !$zoomCoords.start.x}
         zoomWindowXMin={$zoomCoords.start.x

--- a/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampMouseoverAnnotation.svelte
+++ b/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampMouseoverAnnotation.svelte
@@ -71,7 +71,7 @@
       class="fill-gray-500"
       use:outline
     >
-      {formatInteger(~~point[yAccessor])} row{#if point[yAccessor] !== 1}s{/if}
+      {formatInteger(Math.trunc(point[yAccessor]))} row{#if point[yAccessor] !== 1}s{/if}
     </text>
   </g>
 </g>

--- a/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampPaths.svelte
+++ b/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampPaths.svelte
@@ -48,12 +48,16 @@
   $: windowWithoutZeros = dataWindow.filter((di) => {
     return di[yAccessor] !== 0;
   });
-  $: windowSize = dataWindow.length < 150 ? 30 : ~~(dataWindow.length / 25);
+  $: windowSize =
+    dataWindow.length < 150 ? 30 : Math.trunc(dataWindow.length / 25);
 
   $: smoothedData = data.map((di, i, arr) => {
     const dii = { ...di };
-    const window = Math.max(3, Math.min(~~windowSize, i));
-    const prev = arr.slice(i - ~~(window / 2), i + ~~(window / 2));
+    const window = Math.max(3, Math.min(Math.trunc(windowSize), i));
+    const prev = arr.slice(
+      i - Math.trunc(window / 2),
+      i + Math.trunc(window / 2)
+    );
     dii._smoothed = prev.reduce((a, b) => a + b.count, 0) / prev.length;
     return dii;
   });

--- a/web-common/src/components/data-graphic/marks/prevent-vertical-overlap.ts
+++ b/web-common/src/components/data-graphic/marks/prevent-vertical-overlap.ts
@@ -33,7 +33,7 @@ export function preventVerticalOverlap(
   if (!locations.length) return locations;
 
   // calculate the middle index.
-  const middle = ~~(locations.length / 2); // eslint-disable-line
+  const middle = Math.trunc(locations.length / 2); // eslint-disable-line
 
   // Adjust position of labels above the middle index
   let i = middle;

--- a/web-common/src/components/data-graphic/utils.ts
+++ b/web-common/src/components/data-graphic/utils.ts
@@ -111,7 +111,7 @@ export function getTicks(
   axisLength: number,
   isDate: boolean
 ) {
-  const tickCount = ~~(axisLength / (xOrY === "x" ? 100 : 50));
+  const tickCount = Math.trunc(axisLength / (xOrY === "x" ? 100 : 50));
 
   let ticks = scale.ticks(tickCount);
 

--- a/web-common/src/lib/formatters.ts
+++ b/web-common/src/lib/formatters.ts
@@ -90,14 +90,14 @@ export function microsToTimestring(microseconds: number) {
   // start with hours/
   const sign = Math.sign(microseconds);
   const micros = Math.abs(microseconds);
-  const hours = ~~(micros / 1000 / 1000 / 60 / 60);
+  const hours = Math.trunc(micros / 1000 / 1000 / 60 / 60);
   let remaining = micros - hours * 1000 * 1000 * 60 * 60;
-  const minutes = ~~(remaining / 1000 / 1000 / 60);
+  const minutes = Math.trunc(remaining / 1000 / 1000 / 60);
   //const seconds = (remaining - (minutes * 1000 * 1000 * 60)) / 1000 / 1000;
   remaining -= minutes * 1000 * 1000 * 60;
-  const seconds = ~~(remaining / 1000 / 1000);
+  const seconds = Math.trunc(remaining / 1000 / 1000);
   remaining -= seconds * 1000 * 1000;
-  const ms = ~~(remaining / 1000);
+  const ms = Math.trunc(remaining / 1000);
   if (hours === 0 && minutes === 0 && seconds === 0 && ms > 0) {
     return `${sign == 1 ? "" : "-"}${ms}ms`;
   }
@@ -143,7 +143,7 @@ export function formatCompactInteger(n: number) {
   let fmt: (number) => string;
   if (n <= 1000) {
     fmt = formatInteger;
-    return fmt(~~n);
+    return fmt(Math.trunc(n));
   } else {
     fmt = format(".3s");
     return fmt(n);

--- a/web-local/src/routes/dev/data-graphic/basic.svelte
+++ b/web-local/src/routes/dev/data-graphic/basic.svelte
@@ -8,7 +8,7 @@
 
   function makeData(intervalSize = 1000) {
     let v = 50;
-    const windowSize = 1 + ~~(Math.random() * 150);
+    const windowSize = 1 + Math.trunc(Math.random() * 150);
     const data = Array.from({ length: 200 }).map((_, i) => {
       v += 100 * (Math.random() - 0.5);
       return {

--- a/web-local/src/routes/dev/data-graphic/metrics.svelte
+++ b/web-local/src/routes/dev/data-graphic/metrics.svelte
@@ -24,8 +24,8 @@
   function makeData(intervalSize = 1000000) {
     let v1 = 36;
     let v2 = 50;
-    const windowSize1 = 1 + ~~(Math.random() * 5);
-    const windowSize2 = 1 + ~~(Math.random() * 5);
+    const windowSize1 = 1 + Math.trunc(Math.random() * 5);
+    const windowSize2 = 1 + Math.trunc(Math.random() * 5);
     const data = Array.from({ length: 50 }).map((_, i) => {
       v1 += 10 * (Math.random() - 0.5);
       v2 += 5 * (Math.random() - 0.5);

--- a/web-local/src/routes/dev/data-graphic/reactive.svelte
+++ b/web-local/src/routes/dev/data-graphic/reactive.svelte
@@ -125,12 +125,12 @@
                   range={[100, 60]}
                   let:scale
                 >
-                  <Body bg bgColor="hsl(217,5%,{~~scale($height)}%)">
+                  <Body bg bgColor="hsl(217,5%,{Math.trunc(scale($height))}%)">
                     <Line
                       data={data2}
                       xAccessor="period"
                       yAccessor="value"
-                      color="hsl({~~scale($height * 5)}, 50%, 50%)"
+                      color="hsl({Math.trunc(scale($height * 5))}, 50%, 50%)"
                     />
                   </Body>
                 </WithSimpleLinearScale>


### PR DESCRIPTION
While working on some formatting code, I encounterd this weird `~~` that I had to waste time going to look up. Turns out this is just an obfuscated way of writing `Math.trunc`, so I went through and quickly cleaned that up to de-obfuscate our codebase a bit.