### PR TITLE
Remove duplicate top-line comment in dashboard YAML

### DIFF
--- a/web-common/src/features/models/navigation/ModelMenuItems.svelte
+++ b/web-common/src/features/models/navigation/ModelMenuItems.svelte
@@ -29,10 +29,7 @@
   import { runtime } from "../../../runtime-client/runtime-store";
   import { deleteFileArtifact } from "../../entity-management/actions";
   import { getName } from "../../entity-management/name-utils";
-  import {
-    addQuickMetricsToDashboardYAML,
-    initBlankDashboardYAML,
-  } from "../../metrics-views/metrics-internal-store";
+  import { generateDashboardYAMLForModel } from "../../metrics-views/metrics-internal-store";
   import { useModelNames } from "../selectors";
 
   export let modelName: string;
@@ -64,10 +61,9 @@
       `${modelName}_dashboard`,
       $dashboardNames.data
     );
-    const blankDashboardYAML = initBlankDashboardYAML(newDashboardName);
-    const fullDashboardYAML = addQuickMetricsToDashboardYAML(
-      blankDashboardYAML,
-      model
+    const dashboardYAML = generateDashboardYAMLForModel(
+      model,
+      newDashboardName
     );
     $createFileMutation.mutate(
       {
@@ -77,7 +73,7 @@
             newDashboardName,
             EntityType.MetricsDefinition
           ),
-          blob: fullDashboardYAML,
+          blob: dashboardYAML,
           create: true,
           createOnly: true,
           strict: false,

--- a/web-common/src/features/models/workspace/CreateDashboardButton.svelte
+++ b/web-common/src/features/models/workspace/CreateDashboardButton.svelte
@@ -26,10 +26,7 @@
   import { useQueryClient } from "@tanstack/svelte-query";
   import { runtime } from "../../../runtime-client/runtime-store";
   import { getName } from "../../entity-management/name-utils";
-  import {
-    addQuickMetricsToDashboardYAML,
-    initBlankDashboardYAML,
-  } from "../../metrics-views/metrics-internal-store";
+  import { generateDashboardYAMLForModel } from "../../metrics-views/metrics-internal-store";
 
   export let modelName: string;
   export let hasError = false;
@@ -53,10 +50,9 @@
       `${modelName}_dashboard`,
       $dashboardNames.data
     );
-    const blankDashboardYAML = initBlankDashboardYAML(newDashboardName);
-    const fullDashboardYAML = addQuickMetricsToDashboardYAML(
-      blankDashboardYAML,
-      model
+    const dashboardYAML = generateDashboardYAMLForModel(
+      model,
+      newDashboardName
     );
 
     $createFileMutation.mutate(
@@ -67,7 +63,7 @@
             newDashboardName,
             EntityType.MetricsDefinition
           ),
-          blob: fullDashboardYAML,
+          blob: dashboardYAML,
           create: true,
           createOnly: true,
           strict: false,

--- a/web-common/src/features/sources/createDashboard.ts
+++ b/web-common/src/features/sources/createDashboard.ts
@@ -11,10 +11,7 @@ import {
   CreateMutationOptions,
   MutationFunction,
 } from "@tanstack/svelte-query";
-import {
-  addQuickMetricsToDashboardYAML,
-  initBlankDashboardYAML,
-} from "../metrics-views/metrics-internal-store";
+import { generateDashboardYAMLForModel } from "../metrics-views/metrics-internal-store";
 
 export interface CreateDashboardFromSourceRequest {
   instanceId: string;
@@ -61,10 +58,9 @@ export const useCreateDashboardFromSource = <
       data.instanceId,
       data.newModelName
     );
-    const blankDashboardYAML = initBlankDashboardYAML(data.newDashboardName);
-    const fullDashboardYAML = addQuickMetricsToDashboardYAML(
-      blankDashboardYAML,
-      model.entry.model
+    const dashboardYAML = generateDashboardYAMLForModel(
+      model.entry.model,
+      data.newDashboardName
     );
 
     const response = await runtimeServicePutFileAndReconcile({
@@ -73,7 +69,7 @@ export const useCreateDashboardFromSource = <
         data.newDashboardName,
         EntityType.MetricsDefinition
       ),
-      blob: fullDashboardYAML,
+      blob: dashboardYAML,
       create: true,
       createOnly: true,
       strict: false,


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Some buttons to create a dashboard are adding a duplicate top-line comment to the YAML file. See [this bug report](https://rilldata.slack.com/archives/CTZ8XBQ85/p1691173690275799?thread_ts=1691173650.441909&cid=CTZ8XBQ85) in Slack.

#### Details:
This PR fixes the bug and, in the process, does a small refactor of the code to generate dashboard YAML.

## Steps to Verify
1. Create dashboards in every possible way.
2. Verify that the dashboard YAML is correct.