### PR TITLE
Adding local_file sql source support

### DIFF
--- a/runtime/pkg/fileutil/fileutil.go
+++ b/runtime/pkg/fileutil/fileutil.go
@@ -146,6 +146,24 @@ func ExpandHome(path string) (string, error) {
 	return filepath.Join(usr.HomeDir, path[1:]), nil
 }
 
+func ResolveLocalPath(path, root string, allowHostAccess bool) (string, error) {
+	path, err := ExpandHome(path)
+	if err != nil {
+		return "", err
+	}
+
+	finalPath := path
+	if !filepath.IsAbs(path) {
+		finalPath = filepath.Join(root, path)
+	}
+
+	if !allowHostAccess && !strings.HasPrefix(finalPath, root) {
+		// path is outside the repo root
+		return "", fmt.Errorf("path is outside repo root")
+	}
+	return finalPath, nil
+}
+
 // OpenTempFileInDir opens a temp file in given dir
 // If dir doesn't exist it creates full dir path (recursively if required)
 func OpenTempFileInDir(dir, filePath string) (*os.File, error) {

--- a/runtime/services/catalog/migrator/sources/sources.go
+++ b/runtime/services/catalog/migrator/sources/sources.go
@@ -302,12 +302,15 @@ func mergeFromParsedQuery(apiSource *runtimev1.Source, env map[string]string, re
 	if !ok {
 		return errors.New("unknown source")
 	}
-	if c == "local_file" {
+	switch c {
+	case "https":
+		return nil
+	case "local_file":
 		queryStr, err = rewriteLocalRelativePath(ast, repoRoot, strings.EqualFold(env["allow_host_access"], "true"))
 		if err != nil {
 			return err
 		}
-	} else {
+	default:
 		apiSource.Connector = c
 		props["path"] = p
 	}

--- a/runtime/services/catalog/migrator/sources/sources.go
+++ b/runtime/services/catalog/migrator/sources/sources.go
@@ -11,6 +11,7 @@ import (
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/pkg/duckdbsql"
+	"github.com/rilldata/rill/runtime/pkg/fileutil"
 	"github.com/rilldata/rill/runtime/services/catalog/migrator"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -197,7 +198,7 @@ func ingestSource(ctx context.Context, olap drivers.OLAPStore, repo drivers.Repo
 	var err error
 	// TODO: this should go in the parser in the new reconcile
 	if apiSource.Connector == "duckdb" {
-		err = mergeFromParsedQuery(apiSource)
+		err = mergeFromParsedQuery(apiSource, convertLower(opts.InstanceEnv), repo.Root())
 		if err != nil {
 			return err
 		}
@@ -268,7 +269,7 @@ func ingestSource(ctx context.Context, olap drivers.OLAPStore, repo drivers.Repo
 	return err
 }
 
-func mergeFromParsedQuery(apiSource *runtimev1.Source) error {
+func mergeFromParsedQuery(apiSource *runtimev1.Source, env map[string]string, repoRoot string) error {
 	props := apiSource.Properties.AsMap()
 	query, ok := props["sql"]
 	if !ok {
@@ -302,11 +303,15 @@ func mergeFromParsedQuery(apiSource *runtimev1.Source) error {
 		return errors.New("unknown source")
 	}
 	if c == "local_file" {
-		return nil
+		queryStr, err = rewriteLocalRelativePath(ast, repoRoot, strings.EqualFold(env["allow_host_access"], "true"))
+		if err != nil {
+			return err
+		}
+	} else {
+		apiSource.Connector = c
+		props["path"] = p
 	}
 
-	apiSource.Connector = c
-	props["path"] = p
 	props["sql"] = queryStr
 
 	pbProps, err := structpb.NewStruct(props)
@@ -315,6 +320,39 @@ func mergeFromParsedQuery(apiSource *runtimev1.Source) error {
 	}
 	apiSource.Properties = pbProps
 	return nil
+}
+
+func rewriteLocalRelativePath(ast *duckdbsql.AST, repoRoot string, allowRootAccess bool) (string, error) {
+	var resolveErr error
+	err := ast.RewriteTableRefs(func(table *duckdbsql.TableRef) (*duckdbsql.TableRef, bool) {
+		newPaths := make([]string, 0)
+		for _, p := range table.Paths {
+			if strings.Contains(p, "/") {
+				p, err := fileutil.ResolveLocalPath(p, repoRoot, allowRootAccess)
+				if err != nil {
+					resolveErr = err
+					return nil, false
+				}
+				newPaths = append(newPaths, p)
+			} else {
+				newPaths = append(newPaths, p)
+			}
+		}
+
+		return &duckdbsql.TableRef{
+			Function:   table.Function,
+			Paths:      newPaths,
+			Properties: table.Properties,
+		}, true
+	})
+	if resolveErr != nil {
+		return "", resolveErr
+	}
+	if err != nil {
+		return "", err
+	}
+
+	return ast.Format()
 }
 
 type progress struct {

--- a/runtime/services/catalog/migrator/sources/sources_test.go
+++ b/runtime/services/catalog/migrator/sources/sources_test.go
@@ -69,6 +69,9 @@ func TestConnectorWithSourceVariations(t *testing.T) {
 		{"duckdb", "", map[string]any{
 			"sql": fmt.Sprintf(`select * from read_csv_auto('%s')`, filepath.Join(testdataPathAbs, "AdBids.csv")),
 		}},
+		{"duckdb", "", map[string]any{
+			"sql": `select * from read_csv_auto('./AdBids.csv')`,
+		}},
 		// something wrong with this particular file. duckdb fails to extract
 		// TODO: move the generator to go and fix the parquet file
 		//{"local_file", testdataPath + "AdBids.parquet.gz", nil},

--- a/web-common/src/features/sources/sourceUtils.ts
+++ b/web-common/src/features/sources/sourceUtils.ts
@@ -25,8 +25,7 @@ export function compileCreateSourceYAML(
     case "s3":
     case "gcs":
     case "https":
-      // Local file needs rewrite for files uploaded.
-      // case "local_file":
+    case "local_file":
       connectorName = "duckdb";
       values.sql = buildDuckDbQuery(values.path as string);
       delete values.path;


### PR DESCRIPTION
When we added sql sources we didnt fully support local files. Local files with path relative to repo root is not replaced.

This PR updates the local file code path to rewrite relative paths.