### PR TITLE
Periodically emit DuckDB database metrics

### DIFF
--- a/cli/cmd/runtime/start.go
+++ b/cli/cmd/runtime/start.go
@@ -117,35 +117,7 @@ func StartCmd(cliCfg *config.Config) *cobra.Command {
 				}
 			}()
 
-			// Init runtime
-			opts := &runtime.Options{
-				ConnectionCacheSize: conf.ConnectionCacheSize,
-				MetastoreDriver:     conf.MetastoreDriver,
-				MetastoreDSN:        conf.MetastoreURL,
-				QueryCacheSizeBytes: conf.QueryCacheSizeBytes,
-				AllowHostAccess:     conf.AllowHostAccess,
-				SafeSourceRefresh:   conf.SafeSourceRefresh,
-			}
-			rt, err := runtime.New(opts, logger)
-			if err != nil {
-				logger.Fatal("error: could not create runtime", zap.Error(err))
-			}
-			defer rt.Close()
-
-			// Create ctx that cancels on termination signals
-			ctx := graceful.WithCancelOnTerminate(context.Background())
-
-			var limiter ratelimit.Limiter
-			if conf.RedisURL == "" {
-				limiter = ratelimit.NewNoop()
-			} else {
-				opts, err := redis.ParseURL(conf.RedisURL)
-				if err != nil {
-					logger.Fatal("failed to parse redis url", zap.Error(err))
-				}
-				limiter = ratelimit.NewRedis(redis.NewClient(opts))
-			}
-
+			// Init activity client and sink to collect and emit activity events
 			var sink activity.Sink
 			switch conf.ActivitySinkType {
 			case "", "noop":
@@ -165,6 +137,35 @@ func StartCmd(cliCfg *config.Config) *cobra.Command {
 				Logger:     logger,
 			}
 			activityClient := activity.NewBufferedClient(activityOpts)
+
+			// Init runtime
+			opts := &runtime.Options{
+				ConnectionCacheSize: conf.ConnectionCacheSize,
+				MetastoreDriver:     conf.MetastoreDriver,
+				MetastoreDSN:        conf.MetastoreURL,
+				QueryCacheSizeBytes: conf.QueryCacheSizeBytes,
+				AllowHostAccess:     conf.AllowHostAccess,
+				SafeSourceRefresh:   conf.SafeSourceRefresh,
+			}
+			rt, err := runtime.New(opts, logger, activityClient)
+			if err != nil {
+				logger.Fatal("error: could not create runtime", zap.Error(err))
+			}
+			defer rt.Close()
+
+			// Create ctx that cancels on termination signals
+			ctx := graceful.WithCancelOnTerminate(context.Background())
+
+			var limiter ratelimit.Limiter
+			if conf.RedisURL == "" {
+				limiter = ratelimit.NewNoop()
+			} else {
+				opts, err := redis.ParseURL(conf.RedisURL)
+				if err != nil {
+					logger.Fatal("failed to parse redis url", zap.Error(err))
+				}
+				limiter = ratelimit.NewRedis(redis.NewClient(opts))
+			}
 
 			// Init server
 			srvOpts := &server.Options{

--- a/cli/cmd/start/start.go
+++ b/cli/cmd/start/start.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rilldata/rill/cli/pkg/gitutil"
 	"github.com/rilldata/rill/cli/pkg/local"
 	"github.com/rilldata/rill/runtime/compilers/rillv1beta"
+	"github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/spf13/cobra"
 )
 
@@ -84,7 +85,9 @@ func StartCmd(cfg *config.Config) *cobra.Command {
 				return fmt.Errorf("invalid log format %q", logFormat)
 			}
 
-			app, err := local.NewApp(cmd.Context(), cfg.Version, verbose, olapDriver, olapDSN, projectPath, parsedLogFormat, variables)
+			client := activity.NewNoopClient()
+
+			app, err := local.NewApp(cmd.Context(), cfg.Version, verbose, olapDriver, olapDSN, projectPath, parsedLogFormat, variables, client)
 			if err != nil {
 				return err
 			}

--- a/runtime/caches.go
+++ b/runtime/caches.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/rilldata/rill/runtime/pkg/observability"
 	"github.com/rilldata/rill/runtime/services/catalog"
+	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 )
 
@@ -65,7 +66,7 @@ func (c *connectionCache) Close() error {
 	return firstErr
 }
 
-func (c *connectionCache) get(ctx context.Context, instanceID, driver, dsn string) (drivers.Connection, error) {
+func (c *connectionCache) get(ctx context.Context, instanceID, driver, dsn string, activityDims []attribute.KeyValue) (drivers.Connection, error) {
 	// TODO: This locks for all instances for the duration of Open and Migrate.
 	// Adapt to lock only on the lookup, and then on the individual instance's Open and Migrate.
 
@@ -86,7 +87,7 @@ func (c *connectionCache) get(ctx context.Context, instanceID, driver, dsn strin
 		config := map[string]any{
 			"dsn":          dsn,
 			"activity":     c.activity,
-			"activityDims": activity.GetDimsFromContext(ctx),
+			"activityDims": activityDims,
 		}
 		conn, err := drivers.Open(driver, config, logger)
 		if err != nil {

--- a/runtime/caches.go
+++ b/runtime/caches.go
@@ -84,10 +84,16 @@ func (c *connectionCache) get(ctx context.Context, instanceID, driver, dsn strin
 		if instanceID != "default" {
 			logger = c.logger.With(zap.String("instance_id", instanceID), zap.String("driver", driver))
 		}
+
+		activityClient := c.activity
+		if activityClient != nil {
+			activityClient = activityClient.With(activityDims...)
+		}
+
 		config := map[string]any{
-			"dsn":          dsn,
-			"activity":     c.activity,
-			"activityDims": activityDims,
+			"dsn": dsn,
+			// TODO: remove activity from the config and pass it as a func parameter, similar to the logger
+			"activity": activityClient,
 		}
 		conn, err := drivers.Open(driver, config, logger)
 		if err != nil {

--- a/runtime/caches_test.go
+++ b/runtime/caches_test.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/google/uuid"
 	_ "github.com/rilldata/rill/runtime/drivers/sqlite"
+	"github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"github.com/rilldata/rill/runtime/pkg/activity"
 )
 
 func TestConnectionCache(t *testing.T) {

--- a/runtime/caches_test.go
+++ b/runtime/caches_test.go
@@ -8,13 +8,14 @@ import (
 	_ "github.com/rilldata/rill/runtime/drivers/sqlite"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"github.com/rilldata/rill/runtime/pkg/activity"
 )
 
 func TestConnectionCache(t *testing.T) {
 	ctx := context.Background()
 	id := uuid.NewString()
 
-	c := newConnectionCache(10, zap.NewNop())
+	c := newConnectionCache(10, zap.NewNop(), activity.NewNoopClient())
 	conn1, err := c.get(ctx, id, "sqlite", ":memory:")
 	require.NoError(t, err)
 	require.NotNil(t, conn1)

--- a/runtime/caches_test.go
+++ b/runtime/caches_test.go
@@ -16,15 +16,15 @@ func TestConnectionCache(t *testing.T) {
 	id := uuid.NewString()
 
 	c := newConnectionCache(10, zap.NewNop(), activity.NewNoopClient())
-	conn1, err := c.get(ctx, id, "sqlite", ":memory:")
+	conn1, err := c.get(ctx, id, "sqlite", ":memory:", nil)
 	require.NoError(t, err)
 	require.NotNil(t, conn1)
 
-	conn2, err := c.get(ctx, id, "sqlite", ":memory:")
+	conn2, err := c.get(ctx, id, "sqlite", ":memory:", nil)
 	require.NoError(t, err)
 	require.NotNil(t, conn2)
 
-	conn3, err := c.get(ctx, uuid.NewString(), "sqlite", ":memory:")
+	conn3, err := c.get(ctx, uuid.NewString(), "sqlite", ":memory:", nil)
 	require.NoError(t, err)
 	require.NotNil(t, conn3)
 

--- a/runtime/connections.go
+++ b/runtime/connections.go
@@ -23,7 +23,7 @@ func (r *Runtime) Repo(ctx context.Context, instanceID string) (drivers.RepoStor
 		return nil, err
 	}
 
-	conn, err := r.connCache.get(ctx, instanceID, inst.RepoDriver, inst.RepoDSN)
+	conn, err := r.connCache.get(ctx, instanceID, inst.RepoDriver, inst.RepoDSN, instanceAnnotationsToAttribs(inst))
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (r *Runtime) OLAP(ctx context.Context, instanceID string) (drivers.OLAPStor
 		return nil, err
 	}
 
-	conn, err := r.connCache.get(ctx, instanceID, inst.OLAPDriver, inst.OLAPDSN)
+	conn, err := r.connCache.get(ctx, instanceID, inst.OLAPDriver, inst.OLAPDSN, instanceAnnotationsToAttribs(inst))
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func (r *Runtime) Catalog(ctx context.Context, instanceID string) (drivers.Catal
 	}
 
 	if inst.EmbedCatalog {
-		conn, err := r.connCache.get(ctx, inst.ID, inst.OLAPDriver, inst.OLAPDSN)
+		conn, err := r.connCache.get(ctx, inst.ID, inst.OLAPDriver, inst.OLAPDSN, instanceAnnotationsToAttribs(inst))
 		if err != nil {
 			return nil, err
 		}

--- a/runtime/drivers/duckdb/config.go
+++ b/runtime/drivers/duckdb/config.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/rilldata/rill/runtime/pkg/activity"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 const poolSizeKey = "rill_pool_size"
@@ -21,12 +20,10 @@ type config struct {
 	DBFilePath string
 	// Activity client
 	Activity activity.Client
-	// Activity dimensions
-	ActivityDims []attribute.KeyValue
 }
 
 // activityDims and client are allowed to be nil, in this case DuckDB stats are not emitted
-func newConfig(dsn string, client activity.Client, activityDims []attribute.KeyValue) (*config, error) {
+func newConfig(dsn string, client activity.Client) (*config, error) {
 	// Parse DSN as URL
 	uri, err := url.Parse(dsn)
 	if err != nil {
@@ -58,11 +55,10 @@ func newConfig(dsn string, client activity.Client, activityDims []attribute.KeyV
 
 	// Return config
 	cfg := &config{
-		DSN:          dsn,
-		PoolSize:     poolSize,
-		DBFilePath:   uri.Path,
-		Activity:     client,
-		ActivityDims: activityDims,
+		DSN:        dsn,
+		PoolSize:   poolSize,
+		DBFilePath: uri.Path,
+		Activity:   client,
 	}
 	return cfg, nil
 }

--- a/runtime/drivers/duckdb/config.go
+++ b/runtime/drivers/duckdb/config.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+
+	"github.com/rilldata/rill/runtime/pkg/activity"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 const poolSizeKey = "rill_pool_size"
@@ -16,9 +19,13 @@ type config struct {
 	PoolSize int
 	// DBFilePath is the path where database is stored
 	DBFilePath string
+	// Activity dimensions
+	ActivityDims []attribute.KeyValue
+	// Activity client
+	Activity activity.Client
 }
 
-func newConfig(dsn string) (*config, error) {
+func newConfig(dsn string, activityDims []attribute.KeyValue, client activity.Client) (*config, error) {
 	// Parse DSN as URL
 	uri, err := url.Parse(dsn)
 	if err != nil {
@@ -50,9 +57,11 @@ func newConfig(dsn string) (*config, error) {
 
 	// Return config
 	cfg := &config{
-		DSN:        dsn,
-		PoolSize:   poolSize,
-		DBFilePath: uri.Path,
+		DSN:          dsn,
+		PoolSize:     poolSize,
+		DBFilePath:   uri.Path,
+		ActivityDims: activityDims,
+		Activity:     client,
 	}
 	return cfg, nil
 }

--- a/runtime/drivers/duckdb/config.go
+++ b/runtime/drivers/duckdb/config.go
@@ -19,13 +19,14 @@ type config struct {
 	PoolSize int
 	// DBFilePath is the path where database is stored
 	DBFilePath string
-	// Activity dimensions
-	ActivityDims []attribute.KeyValue
 	// Activity client
 	Activity activity.Client
+	// Activity dimensions
+	ActivityDims []attribute.KeyValue
 }
 
-func newConfig(dsn string, activityDims []attribute.KeyValue, client activity.Client) (*config, error) {
+// activityDims and client are allowed to be nil, in this case DuckDB stats are not emitted
+func newConfig(dsn string, client activity.Client, activityDims []attribute.KeyValue) (*config, error) {
 	// Parse DSN as URL
 	uri, err := url.Parse(dsn)
 	if err != nil {
@@ -60,8 +61,8 @@ func newConfig(dsn string, activityDims []attribute.KeyValue, client activity.Cl
 		DSN:          dsn,
 		PoolSize:     poolSize,
 		DBFilePath:   uri.Path,
-		ActivityDims: activityDims,
 		Activity:     client,
+		ActivityDims: activityDims,
 	}
 	return cfg, nil
 }

--- a/runtime/drivers/duckdb/config_test.go
+++ b/runtime/drivers/duckdb/config_test.go
@@ -7,40 +7,40 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	cfg, err := newConfig("")
+	cfg, err := newConfig("", nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, "", cfg.DSN)
 	require.Equal(t, 1, cfg.PoolSize)
 
-	cfg, err = newConfig("path/to/duck.db")
+	cfg, err = newConfig("path/to/duck.db", nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, "path/to/duck.db", cfg.DSN)
 	require.Equal(t, "path/to/duck.db", cfg.DBFilePath)
 	require.Equal(t, 1, cfg.PoolSize)
 
-	cfg, err = newConfig("path/to/duck.db?rill_pool_size=10")
+	cfg, err = newConfig("path/to/duck.db?rill_pool_size=10", nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, "path/to/duck.db", cfg.DSN)
 	require.Equal(t, "path/to/duck.db", cfg.DBFilePath)
 	require.Equal(t, 10, cfg.PoolSize)
 
-	cfg, err = newConfig("path/to/duck.db?rill_pool_size=10&hello=world")
+	cfg, err = newConfig("path/to/duck.db?rill_pool_size=10&hello=world", nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, "path/to/duck.db?hello=world", cfg.DSN)
 	require.Equal(t, 10, cfg.PoolSize)
 	require.Equal(t, "path/to/duck.db", cfg.DBFilePath)
 
-	cfg, err = newConfig("path/to/duck.db?rill_pool_size=abc&hello=world")
+	cfg, err = newConfig("path/to/duck.db?rill_pool_size=abc&hello=world", nil, nil)
 	require.Error(t, err)
 
-	cfg, err = newConfig("path/to/duck.db?rill_pool_size=0&hello=world")
+	cfg, err = newConfig("path/to/duck.db?rill_pool_size=0&hello=world", nil, nil)
 	require.Error(t, err)
 
-	cfg, err = newConfig("duck.db")
+	cfg, err = newConfig("duck.db", nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, "duck.db", cfg.DBFilePath)
 
-	cfg, err = newConfig("duck.db?rill_pool_size=10")
+	cfg, err = newConfig("duck.db?rill_pool_size=10", nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, "duck.db", cfg.DBFilePath)
 }

--- a/runtime/drivers/duckdb/config_test.go
+++ b/runtime/drivers/duckdb/config_test.go
@@ -5,51 +5,48 @@ import (
 
 	"github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 func TestConfig(t *testing.T) {
-	cfg, err := newConfig("", nil, nil)
+	cfg, err := newConfig("", nil)
 	require.NoError(t, err)
 	require.Equal(t, "", cfg.DSN)
 	require.Equal(t, 1, cfg.PoolSize)
 
-	cfg, err = newConfig("path/to/duck.db", nil, nil)
+	cfg, err = newConfig("path/to/duck.db", nil)
 	require.NoError(t, err)
 	require.Equal(t, "path/to/duck.db", cfg.DSN)
 	require.Equal(t, "path/to/duck.db", cfg.DBFilePath)
 	require.Equal(t, 1, cfg.PoolSize)
 
-	cfg, err = newConfig("path/to/duck.db?rill_pool_size=10", nil, nil)
+	cfg, err = newConfig("path/to/duck.db?rill_pool_size=10", nil)
 	require.NoError(t, err)
 	require.Equal(t, "path/to/duck.db", cfg.DSN)
 	require.Equal(t, "path/to/duck.db", cfg.DBFilePath)
 	require.Equal(t, 10, cfg.PoolSize)
 
-	cfg, err = newConfig("path/to/duck.db?rill_pool_size=10&hello=world", nil, nil)
+	cfg, err = newConfig("path/to/duck.db?rill_pool_size=10&hello=world", nil)
 	require.NoError(t, err)
 	require.Equal(t, "path/to/duck.db?hello=world", cfg.DSN)
 	require.Equal(t, 10, cfg.PoolSize)
 	require.Equal(t, "path/to/duck.db", cfg.DBFilePath)
 
-	cfg, err = newConfig("path/to/duck.db?rill_pool_size=abc&hello=world", nil, nil)
+	cfg, err = newConfig("path/to/duck.db?rill_pool_size=abc&hello=world", nil)
 	require.Error(t, err)
 
-	cfg, err = newConfig("path/to/duck.db?rill_pool_size=0&hello=world", nil, nil)
+	cfg, err = newConfig("path/to/duck.db?rill_pool_size=0&hello=world", nil)
 	require.Error(t, err)
 
-	cfg, err = newConfig("duck.db", nil, nil)
+	cfg, err = newConfig("duck.db", nil)
 	require.NoError(t, err)
 	require.Equal(t, "duck.db", cfg.DBFilePath)
 
-	cfg, err = newConfig("duck.db?rill_pool_size=10", nil, nil)
+	cfg, err = newConfig("duck.db?rill_pool_size=10", nil)
 	require.NoError(t, err)
 	require.Equal(t, "duck.db", cfg.DBFilePath)
 
 	client := activity.NewNoopClient()
-	activityDims := []attribute.KeyValue{attribute.String("key", "value")}
-	cfg, err = newConfig("path/to/duck.db", client, activityDims)
+	cfg, err = newConfig("path/to/duck.db", client)
 	require.NoError(t, err)
 	require.Equal(t, client, cfg.Activity)
-	require.Equal(t, activityDims, cfg.ActivityDims)
 }

--- a/runtime/drivers/duckdb/config_test.go
+++ b/runtime/drivers/duckdb/config_test.go
@@ -3,7 +3,9 @@ package duckdb
 import (
 	"testing"
 
+	"github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 func TestConfig(t *testing.T) {
@@ -43,4 +45,11 @@ func TestConfig(t *testing.T) {
 	cfg, err = newConfig("duck.db?rill_pool_size=10", nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, "duck.db", cfg.DBFilePath)
+
+	client := activity.NewNoopClient()
+	activityDims := []attribute.KeyValue{attribute.String("key", "value")}
+	cfg, err = newConfig("path/to/duck.db", client, activityDims)
+	require.NoError(t, err)
+	require.Equal(t, client, cfg.Activity)
+	require.Equal(t, activityDims, cfg.ActivityDims)
 }

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -469,7 +469,6 @@ func (c *connection) scheduleStatCollection() {
 
 			commonDims := []attribute.KeyValue{
 				attribute.String("olap.db.name", stat.DatabaseName),
-				attribute.Int64("olap.block.size", stat.BlockSize),
 			}
 			commonDims = append(commonDims, c.config.ActivityDims...)
 

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -5,15 +5,20 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/XSAM/otelsql"
 	"github.com/jmoiron/sqlx"
 	"github.com/marcboeker/go-duckdb"
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/drivers/duckdb/transporter"
+	activity "github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/rilldata/rill/runtime/pkg/priorityqueue"
+	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 	"golang.org/x/sync/semaphore"
 )
@@ -56,7 +61,25 @@ func (d Driver) Open(config map[string]any, logger *zap.Logger) (drivers.Connect
 		return nil, fmt.Errorf("require dsn to open duckdb connection")
 	}
 
-	cfg, err := newConfig(dsn)
+	var activityDims []attribute.KeyValue
+	activityDimsAny := config["activityDims"]
+	if activityDimsAny != nil {
+		if value, ok := activityDimsAny.(*[]attribute.KeyValue); !ok {
+			return nil, fmt.Errorf("couldn't cast activity dimensions")
+		} else if value != nil {
+			activityDims = *value
+		}
+	}
+
+	var client activity.Client
+	clientAny := config["activity"]
+	if clientAny != nil {
+		if client, ok = clientAny.(activity.Client); !ok {
+			return nil, fmt.Errorf("couldn't cast activity client")
+		}
+	}
+
+	cfg, err := newConfig(dsn, activityDims, client)
 	if err != nil {
 		return nil, err
 	}
@@ -67,6 +90,7 @@ func (d Driver) Open(config map[string]any, logger *zap.Logger) (drivers.Connect
 		olapSemSize = 1
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
 	c := &connection{
 		config:       cfg,
 		logger:       logger,
@@ -75,6 +99,8 @@ func (d Driver) Open(config map[string]any, logger *zap.Logger) (drivers.Connect
 		dbCond:       sync.NewCond(&sync.Mutex{}),
 		driverConfig: config,
 		driverName:   d.name,
+		ctx:          ctx,
+		cancel:       cancel,
 	}
 
 	// Open the DB
@@ -94,6 +120,8 @@ func (d Driver) Open(config map[string]any, logger *zap.Logger) (drivers.Connect
 		return nil, err
 	}
 
+	go c.scheduleStatCollection()
+
 	return c, nil
 }
 
@@ -103,7 +131,7 @@ func (d Driver) Drop(config map[string]any, logger *zap.Logger) error {
 		return fmt.Errorf("require dsn to drop duckdb connection")
 	}
 
-	cfg, err := newConfig(dsn)
+	cfg, err := newConfig(dsn, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -152,6 +180,9 @@ type connection struct {
 	dbCond      *sync.Cond
 	dbReopen    bool
 	dbErr       error
+	statTicker  *time.Ticker
+	ctx         context.Context
+	cancel      context.CancelFunc
 }
 
 // Driver implements drivers.Connection.
@@ -166,6 +197,7 @@ func (c *connection) Config() map[string]any {
 
 // Close implements drivers.Connection.
 func (c *connection) Close() error {
+	c.cancel()
 	return c.db.Close()
 }
 
@@ -408,4 +440,125 @@ func (c *connection) checkErr(err error) error {
 		}
 	}
 	return err
+}
+
+func (c *connection) scheduleStatCollection() {
+	if c.config.Activity == nil {
+		// Activity client isn't set, there is no need to report stats
+		return
+	}
+
+	c.statTicker = time.NewTicker(time.Minute)
+	for {
+		select {
+		case <-c.statTicker.C:
+			var stat dbStat
+			err := func() error {
+				conn, release, err := c.acquireMetaConn(c.ctx)
+				if err != nil {
+					return err
+				}
+				defer func() { _ = release() }()
+				err = conn.GetContext(c.ctx, &stat, "CALL pragma_database_size()")
+				return err
+			}()
+			if err != nil {
+				c.logger.Error("couldn't query DuckDB stats", zap.Error(err))
+				continue
+			}
+
+			commonDims := []attribute.KeyValue{
+				attribute.String("olap.db.name", stat.DatabaseName),
+				attribute.Int64("olap.block.size", stat.BlockSize),
+			}
+			commonDims = append(commonDims, c.config.ActivityDims...)
+
+			dbSize, err := humanReadableSizeToBytes(stat.DatabaseSize)
+			if err != nil {
+				c.logger.Error("couldn't convert duckdb size to bytes", zap.Error(err))
+			} else {
+				c.config.Activity.Emit(c.ctx, "olap_db_size_bytes", dbSize, commonDims...)
+			}
+
+			walSize, err := humanReadableSizeToBytes(stat.WalSize)
+			if err != nil {
+				c.logger.Error("couldn't convert duckdb wal size to bytes", zap.Error(err))
+			} else {
+				c.config.Activity.Emit(c.ctx, "olap_wal_size_bytes", walSize, commonDims...)
+			}
+
+			memoryUsage, err := humanReadableSizeToBytes(stat.MemoryUsage)
+			if err != nil {
+				c.logger.Error("couldn't convert duckdb memory usage to bytes", zap.Error(err))
+			} else {
+				c.config.Activity.Emit(c.ctx, "olap_memory_usage_bytes", memoryUsage, commonDims...)
+			}
+
+			memoryLimit, err := humanReadableSizeToBytes(stat.MemoryLimit)
+			if err != nil {
+				c.logger.Error("couldn't convert duckdb memory limit to bytes", zap.Error(err))
+			} else {
+				c.config.Activity.Emit(c.ctx, "olap_memory_limit_bytes", memoryLimit, commonDims...)
+			}
+
+			c.config.Activity.Emit(c.ctx, "olap_block_size_bytes", float64(stat.BlockSize), commonDims...)
+			c.config.Activity.Emit(c.ctx, "olap_total_blocks", float64(stat.TotalBlocks), commonDims...)
+			c.config.Activity.Emit(c.ctx, "olap_free_blocks", float64(stat.FreeBlocks), commonDims...)
+			c.config.Activity.Emit(c.ctx, "olap_used_blocks", float64(stat.UsedBlocks), commonDims...)
+
+		case <-c.ctx.Done():
+			c.statTicker.Stop()
+			return
+		}
+	}
+}
+
+// Reversed logic of StringUtil::BytesToHumanReadableString
+// see https://github.com/cran/duckdb/blob/master/src/duckdb/src/common/string_util.cpp#L157
+// Examples: 1 bytes, 2 bytes, 1KB, 1MB, 1TB, 1PB
+func humanReadableSizeToBytes(sizeStr string) (float64, error) {
+	var multiplier float64
+
+	re := regexp.MustCompile(`^([\d.]+)\s*(\S+)$`)
+	match := re.FindStringSubmatch(sizeStr)
+
+	if match == nil {
+		return 0, fmt.Errorf("invalid size format: '%s'", sizeStr)
+	}
+
+	sizeFloat, err := strconv.ParseFloat(match[1], 64)
+	if err != nil {
+		return 0, err
+	}
+
+	switch match[2] {
+	case "byte", "bytes":
+		multiplier = 1
+	case "KB":
+		multiplier = 1000
+	case "MB":
+		multiplier = 1000 * 1000
+	case "GB":
+		multiplier = 1000 * 1000 * 1000
+	case "TB":
+		multiplier = 1000 * 1000 * 1000 * 1000
+	case "PB":
+		multiplier = 1000 * 1000 * 1000 * 1000 * 1000
+	default:
+		return 0, fmt.Errorf("unknown size unit '%s' in '%s'", match[2], sizeStr)
+	}
+
+	return sizeFloat * multiplier, nil
+}
+
+type dbStat struct {
+	DatabaseName string `db:"database_name"`
+	DatabaseSize string `db:"database_size"`
+	BlockSize    int64  `db:"block_size"`
+	TotalBlocks  int64  `db:"total_blocks"`
+	UsedBlocks   int64  `db:"used_blocks"`
+	FreeBlocks   int64  `db:"free_blocks"`
+	WalSize      string `db:"wal_size"`
+	MemoryUsage  string `db:"memory_usage"`
+	MemoryLimit  string `db:"memory_limit"`
 }

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -61,21 +61,21 @@ func (d Driver) Open(config map[string]any, logger *zap.Logger) (drivers.Connect
 		return nil, fmt.Errorf("require dsn to open duckdb connection")
 	}
 
-	var activityDims []attribute.KeyValue
-	activityDimsAny := config["activityDims"]
-	if activityDimsAny != nil {
-		if value, ok := activityDimsAny.(*[]attribute.KeyValue); !ok {
-			return nil, fmt.Errorf("couldn't cast activity dimensions")
-		} else if value != nil {
-			activityDims = *value
-		}
-	}
-
 	var client activity.Client
 	clientAny := config["activity"]
 	if clientAny != nil {
 		if client, ok = clientAny.(activity.Client); !ok {
 			return nil, fmt.Errorf("couldn't cast activity client")
+		}
+	}
+
+	var activityDims []attribute.KeyValue
+	activityDimsAny := config["activityDims"]
+	if activityDimsAny != nil {
+		if value, ok := activityDimsAny.(*[]attribute.KeyValue); !ok {
+			return nil, fmt.Errorf("couldn't cast activity dimensions")
+		} else if value != nil { // activityDimsAny might be non-nil, but it may hold a reference == nil
+			activityDims = *value
 		}
 	}
 

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -79,7 +79,7 @@ func (d Driver) Open(config map[string]any, logger *zap.Logger) (drivers.Connect
 		}
 	}
 
-	cfg, err := newConfig(dsn, activityDims, client)
+	cfg, err := newConfig(dsn, client, activityDims)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -462,7 +462,7 @@ func (c *connection) periodicallyEmitStats(d time.Duration) {
 
 			// Emit collected stats as activity events
 			commonDims := []attribute.KeyValue{
-				attribute.String("olap.db.name", stat.DatabaseName),
+				attribute.String("duckdb.name", stat.DatabaseName),
 			}
 
 			dbSize, err := humanReadableSizeToBytes(stat.DatabaseSize)

--- a/runtime/drivers/duckdb/duckdb_test.go
+++ b/runtime/drivers/duckdb/duckdb_test.go
@@ -208,3 +208,38 @@ func TestFatalErrConcurrent(t *testing.T) {
 	err = handle.Close()
 	require.NoError(t, err)
 }
+
+func TestHumanReadableSizeToBytes(t *testing.T) {
+	tests := []struct {
+		input     string
+		expected  float64
+		shouldErr bool
+	}{
+		{"1 byte", 1, false},
+		{"2 bytes", 2, false},
+		{"1KB", 1000, false},
+		{"1.5KB", 1500, false},
+		{"1MB", 1000 * 1000, false},
+		{"2.5MB", 2.5 * 1000 * 1000, false},
+		{"1GB", 1000 * 1000 * 1000, false},
+		{"1.5GB", 1.5 * 1000 * 1000 * 1000, false},
+		{"1TB", 1000 * 1000 * 1000 * 1000, false},
+		{"1.5TB", 1.5 * 1000 * 1000 * 1000 * 1000, false},
+		{"1PB", 1000 * 1000 * 1000 * 1000 * 1000, false},
+		{"1.5PB", 1.5 * 1000 * 1000 * 1000 * 1000 * 1000, false},
+		{"invalid", 0, true},
+		{"123invalid", 0, true},
+		{"123 ZZ", 0, true},
+	}
+
+	for _, tt := range tests {
+		result, err := humanReadableSizeToBytes(tt.input)
+		if (err != nil) != tt.shouldErr {
+			t.Errorf("expected error: %v, got error: %v for input: %s", tt.shouldErr, err, tt.input)
+		}
+
+		if !tt.shouldErr && result != tt.expected {
+			t.Errorf("expected: %v, got: %v for input: %s", tt.expected, result, tt.input)
+		}
+	}
+}

--- a/runtime/registry.go
+++ b/runtime/registry.go
@@ -200,16 +200,16 @@ func (r *Runtime) evictCaches(ctx context.Context, inst *drivers.Instance) {
 // nil is returned if an error occurred or instance was not found
 func (r *Runtime) GetInstanceAttributes(ctx context.Context, instanceID string) []attribute.KeyValue {
 	instance, err := r.FindInstance(ctx, instanceID)
-
-	if err == nil && instance != nil {
-		return instanceAnnotationsToAttribs(instance)
+	if err != nil {
+		return nil
 	}
 
-	return nil
+	return instanceAnnotationsToAttribs(instance)
 }
 
 func instanceAnnotationsToAttribs(instance *drivers.Instance) []attribute.KeyValue {
-	attrs := []attribute.KeyValue{attribute.String("instance_id", instance.ID)}
+	attrs := make([]attribute.KeyValue, 0, len(instance.Annotations)+1)
+	attrs = append(attrs, attribute.String("instance_id", instance.ID))
 	for k, v := range instance.Annotations {
 		attrs = append(attrs, attribute.String(k, v))
 	}

--- a/runtime/registry_test.go
+++ b/runtime/registry_test.go
@@ -305,7 +305,7 @@ func NewTestRunTime(t *testing.T) *Runtime {
 		QueryCacheSizeBytes: int64(datasize.MB) * 100,
 		AllowHostAccess:     true,
 	}
-	rt, err := New(opts, zap.NewNop())
+	rt, err := New(opts, zap.NewNop(), nil)
 	t.Cleanup(func() {
 		rt.Close()
 	})

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -7,6 +7,7 @@ import (
 	"math"
 
 	"github.com/rilldata/rill/runtime/drivers"
+	"github.com/rilldata/rill/runtime/pkg/activity"
 	"go.uber.org/zap"
 )
 
@@ -28,7 +29,7 @@ type Runtime struct {
 	queryCache         *queryCache
 }
 
-func New(opts *Options, logger *zap.Logger) (*Runtime, error) {
+func New(opts *Options, logger *zap.Logger, client activity.Client) (*Runtime, error) {
 	// Open metadata db connection
 	metastore, err := drivers.Open(opts.MetastoreDriver, map[string]any{"dsn": opts.MetastoreDSN}, logger)
 	if err != nil {
@@ -49,7 +50,7 @@ func New(opts *Options, logger *zap.Logger) (*Runtime, error) {
 		opts:               opts,
 		metastore:          metastore,
 		logger:             logger,
-		connCache:          newConnectionCache(opts.ConnectionCacheSize, logger),
+		connCache:          newConnectionCache(opts.ConnectionCacheSize, logger, client),
 		migrationMetaCache: newMigrationMetaCache(math.MaxInt),
 		queryCache:         newQueryCache(opts.QueryCacheSizeBytes),
 	}, nil

--- a/runtime/server/server.go
+++ b/runtime/server/server.go
@@ -21,7 +21,6 @@ import (
 	"github.com/rilldata/rill/runtime/pkg/ratelimit"
 	"github.com/rilldata/rill/runtime/server/auth"
 	"github.com/rs/cors"
-	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -317,13 +316,6 @@ func (s *Server) checkRateLimit(ctx context.Context) (context.Context, error) {
 }
 
 func (s *Server) addInstanceRequestAttributes(ctx context.Context, instanceID string) {
-	instance, err := s.runtime.FindInstance(ctx, instanceID)
-
-	if err == nil && instance != nil {
-		var attrs []attribute.KeyValue
-		for k, v := range instance.Annotations {
-			attrs = append(attrs, attribute.String(k, v))
-		}
-		observability.AddRequestAttributes(ctx, attrs...)
-	}
+	attrs := s.runtime.GetInstanceAttributes(ctx, instanceID)
+	observability.AddRequestAttributes(ctx, attrs...)
 }

--- a/runtime/testruntime/testruntime.go
+++ b/runtime/testruntime/testruntime.go
@@ -39,7 +39,7 @@ func New(t TestingT) *runtime.Runtime {
 		QueryCacheSizeBytes: int64(datasize.MB * 100),
 		AllowHostAccess:     true,
 	}
-	rt, err := runtime.New(opts, zap.NewNop())
+	rt, err := runtime.New(opts, zap.NewNop(), nil)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		rt.Close()


### PR DESCRIPTION
Closes #2848 

The PR updates a cached DuckDB connection so that it can emit DuckDB stats.
Each cached connection is cached per instance id and dsn and hence can autonomously collect and emit required stats per instance id and dsn.