### PR TITLE
fix: wait for menu to close during test

### DIFF
--- a/web-local/test/ui/dashboards.spec.ts
+++ b/web-local/test/ui/dashboards.spec.ts
@@ -619,6 +619,11 @@ async function runThroughLeaderboardContextColumnFlows(page: Page) {
   // Add a time comparison
   await page.getByLabel("Select time range").click();
   await page.getByRole("menuitem", { name: "Last 6 Hours" }).click();
+  // Wait for menu to close
+  await expect(
+    page.getByRole("menuitem", { name: "Last 6 Hours" })
+  ).not.toBeVisible();
+
   // check that the percent of total button remains pressed after adding a time comparison
   await expect(
     page.getByRole("button", { name: "Toggle percent of total" })


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [x] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
e2e tests are commonly failing because our menus animate closing and sometimes you need to wait for that animation to finish before playwright can interact with the browser.

#### Details:
This PR makes sure the menu is closed before continuing with tests

## Steps to Verify
