### PR TITLE
feat: TDT async data 

### DIFF
--- a/web-common/src/features/dashboards/time-dimension-details/Pivot.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/Pivot.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { createVirtualizer, VirtualItem } from "@tanstack/svelte-virtual";
+  import { createEventDispatcher } from "svelte";
   import PivotVirtualRow from "./PivotVirtualRow.svelte";
   import PivotCell from "./PivotCell.svelte";
 
@@ -28,14 +29,26 @@
   let totalVerticalSize = 0;
   let paddingTop = 0;
   let paddingBottom = 0;
+  let virtualStart;
+  let virtualEnd;
   $: {
     virtualRows = $rowVirtualizer?.getVirtualItems() ?? [];
     totalVerticalSize = $rowVirtualizer?.getTotalSize() ?? 0;
+    virtualStart = virtualRows?.[0]?.index || 0;
+    virtualEnd = virtualRows?.at(-1)?.index || 0;
     paddingTop = virtualRows?.length > 0 ? virtualRows?.[0]?.start || 0 : 0;
     paddingBottom =
       virtualRows?.length > 0
         ? totalVerticalSize - (virtualRows?.at(-1)?.end || 0)
         : 0;
+  }
+
+  const dispatch = createEventDispatcher();
+  $: {
+    dispatch("virtualRange", {
+      start: virtualStart,
+      end: virtualEnd,
+    });
   }
 
   $: columnVirtualizer = createVirtualizer({

--- a/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDetailsTable.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDetailsTable.svelte
@@ -4,13 +4,15 @@
   import TimeDimensionDetailsTableCell from "./TimeDimensionDetailsTableCell.svelte";
   import TimeDimensionDetailsTableHeaderCell from "./TimeDimensionDetailsTableHeaderCell.svelte";
   import { createTimeDimensionDetailsStore } from "./time-dimension-details-store";
-  import { getBlock } from "./data";
+  import { data, fetchData } from "./mock-data";
+
+  // Mock data that is fetched from backend
+  const FIXED_COL_CT = data.metadata.fixedColumnCt;
 
   // Store of state to share between line chart and table
   let store = createTimeDimensionDetailsStore();
 
   // Mock state for now
-  const FIXED_COL_CT = 6;
   let state = {
     getRowSize: () => 35,
     getColumnWidth: (idx: number) => (idx < FIXED_COL_CT ? 60 : 100),
@@ -31,48 +33,11 @@
         lastFixed: colIdx === FIXED_COL_CT - 1,
       }),
   };
-
-  // Mock data that is fetched from backend
-  let data = {
-    data: [],
-    metadata: {
-      rowCt: 1000,
-      fixedColumnCt: FIXED_COL_CT,
-      pivotColumnCt: 100,
-    },
-  };
-  for (let r = 0; r < data.metadata.rowCt; r++) {
-    const row = new Array(
-      data.metadata.fixedColumnCt + data.metadata.pivotColumnCt
-    )
-      .fill(0)
-      .map((d, i) => ({
-        row: r,
-        col: i,
-      }));
-
-    data.data.push(row);
-  }
-
-  let virtualRange = [0, 0];
-  const handleVirtualRange = (e) => {
-    virtualRange = [e.detail.start, e.detail.end];
-  };
-  $: block = getBlock(100, virtualRange[0], virtualRange[1]);
-
-  // Feed block into data fetching query
-
-  // Provide that query into cells somehow for looking up their data?
-
-  // What do they do when their data isn't there?
-
-  // Block needs to include reference for its offset so cell can index it properly
 </script>
 
 <h1>Store</h1>
 <pre>
   {JSON.stringify($store, null, 2)}
-  block: {block}
 </pre>
 <h1>Table</h1>
 <Pivot
@@ -84,5 +49,4 @@
   getRowSize={state.getRowSize}
   renderCell={state.renderCell}
   renderHeaderCell={state.renderHeaderCell}
-  on:virtualRange={handleVirtualRange}
 />

--- a/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDetailsTable.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDetailsTable.svelte
@@ -4,6 +4,7 @@
   import TimeDimensionDetailsTableCell from "./TimeDimensionDetailsTableCell.svelte";
   import TimeDimensionDetailsTableHeaderCell from "./TimeDimensionDetailsTableHeaderCell.svelte";
   import { createTimeDimensionDetailsStore } from "./time-dimension-details-store";
+  import { getBlock } from "./data";
 
   // Store of state to share between line chart and table
   let store = createTimeDimensionDetailsStore();
@@ -52,11 +53,26 @@
 
     data.data.push(row);
   }
+
+  let virtualRange = [0, 0];
+  const handleVirtualRange = (e) => {
+    virtualRange = [e.detail.start, e.detail.end];
+  };
+  $: block = getBlock(100, virtualRange[0], virtualRange[1]);
+
+  // Feed block into data fetching query
+
+  // Provide that query into cells somehow for looking up their data?
+
+  // What do they do when their data isn't there?
+
+  // Block needs to include reference for its offset so cell can index it properly
 </script>
 
 <h1>Store</h1>
 <pre>
   {JSON.stringify($store, null, 2)}
+  block: {block}
 </pre>
 <h1>Table</h1>
 <Pivot
@@ -68,4 +84,5 @@
   getRowSize={state.getRowSize}
   renderCell={state.renderCell}
   renderHeaderCell={state.renderHeaderCell}
+  on:virtualRange={handleVirtualRange}
 />

--- a/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDetailsTable.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDetailsTable.svelte
@@ -4,7 +4,7 @@
   import TimeDimensionDetailsTableCell from "./TimeDimensionDetailsTableCell.svelte";
   import TimeDimensionDetailsTableHeaderCell from "./TimeDimensionDetailsTableHeaderCell.svelte";
   import { createTimeDimensionDetailsStore } from "./time-dimension-details-store";
-  import { data, fetchData } from "./mock-data";
+  import { data } from "./mock-data";
 
   // Mock data that is fetched from backend
   const FIXED_COL_CT = data.metadata.fixedColumnCt;

--- a/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDetailsTableCell.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDetailsTableCell.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Writable } from "svelte/store";
-  import { createQuery } from "@tanstack/svelte-query";
+  import { createQuery, CreateQueryResult } from "@tanstack/svelte-query";
   import type { TimeDimensionDetailsStore } from "./time-dimension-details-store";
   import { getBlock } from "./util";
   import { fetchData } from "./mock-data";
@@ -18,7 +18,7 @@
   const cellQuery = createQuery({
     queryKey: ["time-dimension-details", block[0], block[1]],
     queryFn: fetchData(block, 1000),
-  });
+  }) as CreateQueryResult<{ block: number[]; data: { d: string }[][] }>;
 
   $: {
     if (

--- a/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDetailsTableCell.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDetailsTableCell.svelte
@@ -1,12 +1,35 @@
 <script lang="ts">
   import type { Writable } from "svelte/store";
+  import { createQuery } from "@tanstack/svelte-query";
   import type { TimeDimensionDetailsStore } from "./time-dimension-details-store";
+  import { getBlock } from "./util";
+  import { fetchData } from "./mock-data";
 
   export let rowIdx: number;
   export let colIdx: number;
   export let fixed: boolean;
   export let lastFixed: boolean;
   export let store: Writable<TimeDimensionDetailsStore>;
+  // If the current data block has this cell, get the data. Otherwise for now assume "loading" state (can handle errors later)
+  let cellData = { d: "..." };
+  let block = getBlock(100, rowIdx, rowIdx);
+  $: block = getBlock(100, rowIdx, rowIdx);
+
+  const cellQuery = createQuery({
+    queryKey: ["time-dimension-details", block[0], block[1]],
+    queryFn: fetchData(block, 1000),
+  });
+
+  $: {
+    if (
+      $cellQuery.data &&
+      rowIdx >= $cellQuery.data.block[0] &&
+      rowIdx < $cellQuery.data.block[1]
+    ) {
+      cellData =
+        $cellQuery.data.data[rowIdx - $cellQuery.data.block[0]][colIdx];
+    } else cellData = { d: "..." };
+  }
 
   let _class = "";
   $: {
@@ -78,7 +101,7 @@
     on:mouseenter={handleMouseEnter}
     on:mouseleave={handleMouseLeave}
   >
-    cell {rowIdx},{colIdx}
+    {cellData?.d}
   </div>
 {/if}
 

--- a/web-common/src/features/dashboards/time-dimension-details/data.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/data.ts
@@ -1,0 +1,18 @@
+// given area, return block to fetch
+export const getBlock = (blockSize: number, start: number, end: number) => {
+  // If distance is bigger than possible block, error?
+  if (end - start > blockSize) {
+    throw new Error("Range is too big");
+  }
+  // Calculate the nearest block to the start
+  let startBlock = Math.floor(start / blockSize) * blockSize;
+  // Calculate the end of that block
+  let endBlock = startBlock + blockSize;
+
+  // If end is not in this block, increment the block by 1/2
+  if (end > endBlock) {
+    startBlock += blockSize * 0.5;
+    endBlock = startBlock + blockSize;
+  }
+  return [startBlock, endBlock];
+};

--- a/web-common/src/features/dashboards/time-dimension-details/mock-data.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/mock-data.ts
@@ -1,0 +1,35 @@
+const FIXED_COL_CT = 6;
+
+export const data = {
+  data: [],
+  metadata: {
+    rowCt: 1000,
+    fixedColumnCt: FIXED_COL_CT,
+    pivotColumnCt: 100,
+  },
+};
+
+// Populate mock data
+for (let r = 0; r < data.metadata.rowCt; r++) {
+  const row = new Array(
+    data.metadata.fixedColumnCt + data.metadata.pivotColumnCt
+  )
+    .fill(0)
+    .map((d, i) => ({
+      d: `cell ${r},${i}`,
+    }));
+
+  data.data.push(row);
+}
+
+// Mock data fetch
+export const fetchData = (block, delay) => async () => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        data: data.data.slice(block[0], block[1]),
+        block,
+      });
+    }, delay);
+  });
+};

--- a/web-common/src/features/dashboards/time-dimension-details/util.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/util.ts
@@ -1,6 +1,6 @@
 // given area, return block to fetch
 export const getBlock = (blockSize: number, start: number, end: number) => {
-  // If distance is bigger than possible block, error?
+  // If distance is bigger than possible block, throw an error
   if (end - start > blockSize) {
     throw new Error("Range is too big");
   }


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
Incremental step in adding the [time dimension details table](https://www.notion.so/rilldata/Time-Dimension-Detail-Design-Mocks-and-Specification-2dd22773d6e8479ca8d297f95877c669)

This PR adds async data fetching

#### Details:
Each cell of the table now has the ability to fetch its data via svelte-query. The cells look up which "block" of data they are in, then request that block. In this initial PR, we set the block size to 100, so data will be fetched in pages of 0-99, 100-199, etc. We can play with this number over time to find the best performing result. Svelte-query handles deduping these requests and serving from cache, so when many cells request the same block, they all get the same page.

The data fetching in this PR is just mocking a network call, with a configurable delay set to 1s. Once we have real backend APIs for TDT, we can swap this out.

## Steps to Verify
<!-- PROVIDE INFORMATION ON HOW TO CHECK THIS ADDITION
For example, given a new button "Foo" in the dashboard:
1. Run `npm run dev`
2. Open localhost:3000 and navigate to a localhost:3000/dev/table/<anything>
3. Scroll through the table. Watch how sometimes the cells switch into a "loading" state ("..."), and then after 1s render their data
 -->