### PR TITLE
Fixing http used for dashboard redirect

### DIFF
--- a/web-common/src/lib/url-utils.spec.ts
+++ b/web-common/src/lib/url-utils.spec.ts
@@ -1,4 +1,7 @@
-import { getFullUrlForPath } from "@rilldata/web-common/lib/url-utils";
+import {
+  getFullUrlForPath,
+  getUrlForPath,
+} from "@rilldata/web-common/lib/url-utils";
 import type { Page } from "@sveltejs/kit";
 import { Readable, writable } from "svelte/store";
 import { beforeAll, describe, it, SpyInstance, vi, expect } from "vitest";
@@ -57,11 +60,19 @@ describe("url-utils", () => {
       getFullUrlForPath("/new/path/to/dashboard", ["state", "partner"])
     ).toBe("/new/path/to/dashboard?state=qwerty&partner=asdfgh");
   });
+
+  it("getFullUrl with https link", () => {
+    pageMock.setUrl("https://ui.rilldata.com/path/to/dashboard");
+    expect(getUrlForPath("/new/path/to/dashboard").toString()).toBe(
+      "https://ui.rilldata.com/new/path/to/dashboard"
+    );
+  });
 });
 
 type PageMock = Readable<Page> & {
   updateState: (state: string) => void;
   goto: (path: string) => void;
+  setUrl: (url: string) => void;
   gotoSpy: SpyInstance;
 };
 function createPageMock() {
@@ -73,6 +84,12 @@ function createPageMock() {
   pageMock.goto = (path: string) => {
     update((page) => {
       page.url = new URL(`http://localhost${path}`);
+      return page;
+    });
+  };
+  pageMock.setUrl = (url: string) => {
+    update((page) => {
+      page.url = new URL(url);
       return page;
     });
   };

--- a/web-common/src/lib/url-utils.ts
+++ b/web-common/src/lib/url-utils.ts
@@ -4,7 +4,7 @@ import { get } from "svelte/store";
 export function getUrlForPath(path: string, retainParams = ["features"]): URL {
   const url = get(page).url;
   if (!path.startsWith("/")) path = "/" + path;
-  const newUrl = new URL(`http://${url.host}${path}`);
+  const newUrl = new URL(`${url.protocol}//${url.host}${path}`);
 
   for (const param of retainParams) {
     if (!url.searchParams.has(param)) continue;


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [x] Unit test coverage
- [x] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
Fixes the issue mentioned [here](https://rilldata.slack.com/archives/C02T907FEUB/p1691751534383459)

#### Details:
We were hardcoding http protocol while redirecting dashboard url with state. Updating it to be based on the protocol of the url.

## Steps to Verify
Hard to do this locally.