### PR TITLE
fix: e2e test stability

### DIFF
--- a/web-local/test/ui/dashboards.spec.ts
+++ b/web-local/test/ui/dashboards.spec.ts
@@ -87,6 +87,15 @@ test.describe("dashboard", () => {
 
   test("Dashboard runthrough", async ({ page }) => {
     await page.goto("/");
+    // disable animations
+    await page.addStyleTag({
+      content: `
+        *, *::before, *::after {
+          animation-duration: 0s !important;
+          transition-duration: 0s !important;
+        }
+      `,
+    });
     await createAdBidsModel(page);
     await createDashboardFromModel(page, "AdBids_model");
 

--- a/web-local/test/ui/dashboards.spec.ts
+++ b/web-local/test/ui/dashboards.spec.ts
@@ -101,12 +101,9 @@ test.describe("dashboard", () => {
     await page.getByRole("menuitem", { name: "day" }).click();
 
     // Change the time range
-    await page.getByLabel("Select time range").click();
-    await page.getByRole("menuitem", { name: "Last 6 Hours" }).click();
-    // Wait for menu to close
-    await expect(
-      page.getByRole("menuitem", { name: "Last 6 Hours" })
-    ).not.toBeVisible();
+    await interactWithTimeRangeMenu(page, async () => {
+      await page.getByRole("menuitem", { name: "Last 6 Hours" }).click();
+    });
 
     // Change time zone to UTC
     await page.getByLabel("Timezone selector").click();
@@ -188,23 +185,26 @@ test.describe("dashboard", () => {
     await expect(page.getByLabel("Time comparison selector")).not.toBeVisible();
 
     // Switch to a custom time range
-    await page.getByLabel("Select time range").click();
+    await interactWithTimeRangeMenu(page, async () => {
+      const timeRangeMenu = page.getByRole("menu", {
+        name: "Time range selector",
+      });
 
-    const timeRangeMenu = page.getByRole("menu", {
-      name: "Time range selector",
+      await timeRangeMenu
+        .getByRole("menuitem", { name: "Custom range" })
+        .click();
+      await timeRangeMenu.getByLabel("Start date").fill("2022-02-01");
+      await timeRangeMenu.getByLabel("Start date").blur();
+      await timeRangeMenu.getByRole("button", { name: "Apply" }).click();
     });
-
-    await timeRangeMenu.getByRole("menuitem", { name: "Custom range" }).click();
-    await timeRangeMenu.getByLabel("Start date").fill("2022-02-01");
-    await timeRangeMenu.getByLabel("Start date").blur();
-    await timeRangeMenu.getByRole("button", { name: "Apply" }).click();
 
     // Check number
     await expect(page.getByText("Total records 65.1k")).toBeVisible();
 
     // Flip back to All Time
-    await page.getByLabel("Select time range").click();
-    await page.getByRole("menuitem", { name: "All Time" }).click();
+    await interactWithTimeRangeMenu(page, async () => {
+      await page.getByRole("menuitem", { name: "All Time" }).click();
+    });
 
     // Check number
     await expect(
@@ -539,8 +539,9 @@ async function runThroughLeaderboardContextColumnFlows(page: Page) {
   await page.getByRole("button", { name: "Go to dashboard" }).click();
 
   // make sure "All time" is selected to clear any time comparison
-  await page.getByLabel("Select time range").click();
-  await page.getByRole("menuitem", { name: "All Time" }).click();
+  await interactWithTimeRangeMenu(page, async () => {
+    await page.getByRole("menuitem", { name: "All Time" }).click();
+  });
 
   // Check "toggle percent change" button is disabled since there is no time comparison
   await expect(
@@ -552,8 +553,9 @@ async function runThroughLeaderboardContextColumnFlows(page: Page) {
   ).toBeDisabled();
 
   // Select a time range, which should automatically enable a time comparison (including context column)
-  await page.getByLabel("Select time range").click();
-  await page.getByRole("menuitem", { name: "Last 6 Hours" }).click();
+  await interactWithTimeRangeMenu(page, async () => {
+    await page.getByRole("menuitem", { name: "Last 6 Hours" }).click();
+  });
 
   // This regex matches a line that:
   // - starts with "Facebook"
@@ -585,8 +587,10 @@ async function runThroughLeaderboardContextColumnFlows(page: Page) {
   await expect(page.getByText(comparisonColumnRegex)).toBeVisible();
 
   // click back to "All time" to clear the time comparison
-  await page.getByLabel("Select time range").click();
-  await page.getByRole("menuitem", { name: "All Time" }).click();
+  await interactWithTimeRangeMenu(page, async () => {
+    await page.getByRole("menuitem", { name: "All Time" }).click();
+  });
+
   // Check that time comparison context column is hidden
   await expect(page.getByText(comparisonColumnRegex)).not.toBeVisible();
   await expect(page.getByText("Facebook 19.3k")).toBeVisible();
@@ -617,12 +621,9 @@ async function runThroughLeaderboardContextColumnFlows(page: Page) {
   await expect(page.getByText("Facebook $57.8k 19%")).toBeVisible();
 
   // Add a time comparison
-  await page.getByLabel("Select time range").click();
-  await page.getByRole("menuitem", { name: "Last 6 Hours" }).click();
-  // Wait for menu to close
-  await expect(
-    page.getByRole("menuitem", { name: "Last 6 Hours" })
-  ).not.toBeVisible();
+  await interactWithTimeRangeMenu(page, async () => {
+    await page.getByRole("menuitem", { name: "Last 6 Hours" }).click();
+  });
 
   // check that the percent of total button remains pressed after adding a time comparison
   await expect(
@@ -707,4 +708,19 @@ async function runThroughEmptyMetricsFlows(page) {
 
   // go back to the metrics page.
   await page.getByRole("button", { name: "Edit metrics" }).click();
+}
+
+// Helper that opens the time range menu, calls your interactions, and then waits until the menu closes
+async function interactWithTimeRangeMenu(
+  page: Page,
+  cb: () => void | Promise<void>
+) {
+  // Open the menu
+  await page.getByLabel("Select time range").click();
+  // Run the defined interactions
+  await cb();
+  // Wait for menu to close
+  await expect(
+    page.getByRole("menu", { name: "Time range selector" })
+  ).not.toBeVisible();
 }

--- a/web-local/test/ui/dashboards.spec.ts
+++ b/web-local/test/ui/dashboards.spec.ts
@@ -86,6 +86,7 @@ test.describe("dashboard", () => {
   });
 
   test("Dashboard runthrough", async ({ page }) => {
+    test.setTimeout(60000);
     await page.goto("/");
     // disable animations
     await page.addStyleTag({


### PR DESCRIPTION
## Checklist
- [ ] Manual verification
- [ ] Unit test coverage
- [x] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
Fixing test stability with the following changes:
- turning animations off during testing
- providing helper to make sure time selector menu has closed before continuing a test flow
- increasing allowed test run time