### PR TITLE
Fixing dashboards without timestamp

### DIFF
--- a/web-common/src/features/dashboards/DashboardStateProvider.svelte
+++ b/web-common/src/features/dashboards/DashboardStateProvider.svelte
@@ -3,6 +3,7 @@
   import {
     createTimeRangeSummary,
     useMetaQuery,
+    useModelHasTimeSeries,
   } from "@rilldata/web-common/features/dashboards/selectors/index";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { initLocalUserPreferenceStore } from "@rilldata/web-common/features/dashboards/user-preferences";
@@ -12,6 +13,7 @@
   $: initLocalUserPreferenceStore(metricViewName);
   const stateManagers = getStateManagers();
   const metaQuery = useMetaQuery(stateManagers);
+  const hasTimeSeries = useModelHasTimeSeries(stateManagers);
   const timeRangeQuery = createTimeRangeSummary(stateManagers);
 
   function syncDashboardState() {
@@ -26,7 +28,7 @@
     }
   }
 
-  $: if ($metaQuery.data && $timeRangeQuery.data) {
+  $: if ($metaQuery.data && ($timeRangeQuery.data || !$hasTimeSeries.data)) {
     syncDashboardState();
   }
 </script>

--- a/web-common/src/features/dashboards/dashboard-stores-test-data.ts
+++ b/web-common/src/features/dashboards/dashboard-stores-test-data.ts
@@ -246,6 +246,7 @@ export function createMetricsMetaQueryMock(
   return mock;
 }
 
+// Wrapper function to simplify assert call
 export function assertMetricsView(
   name: string,
   filters: V1MetricsViewFilter = {
@@ -254,6 +255,17 @@ export function assertMetricsView(
   },
   timeRange: DashboardTimeControls = AD_BIDS_DEFAULT_TIME_RANGE,
   selectedMeasure = AD_BIDS_IMPRESSIONS_MEASURE
+) {
+  assertMetricsViewRaw(name, filters, timeRange, selectedMeasure);
+}
+// Raw assert function without any optional params.
+// This allows us to assert for `undefined`
+// TODO: find a better solution that this hack
+export function assertMetricsViewRaw(
+  name: string,
+  filters: V1MetricsViewFilter,
+  timeRange: DashboardTimeControls,
+  selectedMeasure: string
 ) {
   const metricsView = get(metricsExplorerStore).entities[name];
   expect(metricsView.filters).toEqual(filters);

--- a/web-common/src/features/dashboards/dashboard-stores.spec.ts
+++ b/web-common/src/features/dashboards/dashboard-stores.spec.ts
@@ -18,6 +18,8 @@ import {
   createAdBidsMirrorInStore,
   createMetricsMetaQueryMock,
   resetDashboardStore,
+  AD_BIDS_INIT,
+  assertMetricsViewRaw,
 } from "@rilldata/web-common/features/dashboards/dashboard-stores-test-data";
 import { initLocalUserPreferenceStore } from "@rilldata/web-common/features/dashboards/user-preferences";
 import { get } from "svelte/store";
@@ -252,6 +254,45 @@ describe("dashboard-stores", () => {
         get(metricsExplorerStore).entities[AD_BIDS_MIRROR_NAME]
           .selectedDimensionName
       ).toBeUndefined();
+    });
+
+    it("Should work when time range is not available", () => {
+      const AD_BIDS_NO_TIMESTAMP_NAME = "AdBids_no_timestamp";
+      // const mock = createMetricsMetaQueryMock();
+      metricsExplorerStore.init(
+        AD_BIDS_NO_TIMESTAMP_NAME,
+        AD_BIDS_INIT,
+        undefined
+      );
+      assertMetricsViewRaw(
+        AD_BIDS_NO_TIMESTAMP_NAME,
+        { include: [], exclude: [] },
+        undefined,
+        AD_BIDS_IMPRESSIONS_MEASURE
+      );
+
+      // add filters
+      metricsExplorerStore.toggleFilter(
+        AD_BIDS_NO_TIMESTAMP_NAME,
+        AD_BIDS_PUBLISHER_DIMENSION,
+        "Google"
+      );
+      metricsExplorerStore.toggleFilter(
+        AD_BIDS_NO_TIMESTAMP_NAME,
+        AD_BIDS_PUBLISHER_DIMENSION,
+        "Facebook"
+      );
+      metricsExplorerStore.toggleFilter(
+        AD_BIDS_NO_TIMESTAMP_NAME,
+        AD_BIDS_DOMAIN_DIMENSION,
+        "google.com"
+      );
+      assertMetricsViewRaw(
+        AD_BIDS_NO_TIMESTAMP_NAME,
+        AD_BIDS_BASE_FILTER,
+        undefined,
+        AD_BIDS_IMPRESSIONS_MEASURE
+      );
     });
   });
 });


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [x] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Dashboards without timestamp are not rendered at all.

#### Details:
Our dashboard init assumes timestamp is always present. Refactored it a bit to support dashboards that do not have timestamps.

## Steps to Verify
1. Create a dashboard with timestamp.
2. Go to dashboard.
3. Remove the timestamp in the editor.
4. Go back to dashboard. It should render without issues.
5. Add back the timestamp.
6. Go back to dashboard. Time controls should be back and intearactable.