### PR TITLE
Disable timezone selector if no available zone present

### DIFF
--- a/web-common/src/features/dashboards/time-controls/TimeControls.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeControls.svelte
@@ -98,10 +98,16 @@
     availableTimeZones =
       $metricsViewQuery?.data?.entry?.metricsView?.availableTimeZones;
 
-    // For legacy dashboards, we need to set the available time
-    // zones to the default if they are not defined.
+    /**
+     * Remove the timezone selector if no timezone key is present
+     * or the available timezone list is empty. Set the default
+     * timezone to UTC in such cases.
+     *
+     */
+
     if (!availableTimeZones?.length) {
-      availableTimeZones = DEFAULT_TIMEZONES;
+      metricsExplorerStore.setTimeZone(metricViewName, "Etc/UTC");
+      localUserPreferences.set({ timeZone: "Etc/UTC" });
     }
   }
   $: allTimeRange = $allTimeRangeQuery?.data as TimeRange;
@@ -335,12 +341,14 @@
         metricsExplorerStore.setSelectedScrubRange(metricViewName, undefined);
       }}
     />
-    <TimeZoneSelector
-      on:select-time-zone={(e) => onSelectTimeZone(e.detail.timeZone)}
-      {metricViewName}
-      {availableTimeZones}
-      now={allTimeRange?.end}
-    />
+    {#if availableTimeZones?.length}
+      <TimeZoneSelector
+        on:select-time-zone={(e) => onSelectTimeZone(e.detail.timeZone)}
+        {metricViewName}
+        {availableTimeZones}
+        now={allTimeRange?.end}
+      />
+    {/if}
     <TimeComparisonSelector
       on:select-comparison={(e) => {
         onSelectComparisonRange(e.detail.name, e.detail.start, e.detail.end);


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
For dashboards without `available_time_zones` remove the timezone selector.

## Steps to Verify
1. On a dashboard without `available_time_zones`, the timezone should be UTC and timezone selector should be disabled
2. On a dashboard with `available_time_zones` key and atleast one zone present, the timezone selector should be shown.
