### PR TITLE
Fix zone bug in custom date picker

### DIFF
--- a/web-common/src/features/dashboards/time-controls/CustomTimeRangeInput.svelte
+++ b/web-common/src/features/dashboards/time-controls/CustomTimeRangeInput.svelte
@@ -17,7 +17,7 @@
     shiftToUTC,
   } from "@rilldata/web-common/components/date-picker/util";
   import { getOffset } from "@rilldata/web-common/lib/time/transforms";
-  import { addZoneOffset } from "@rilldata/web-common/lib/time/timezone";
+  import { removeZoneOffset } from "@rilldata/web-common/lib/time/timezone";
 
   export let minTimeGrain: V1TimeGrain;
   export let boundaryStart: Date;
@@ -99,17 +99,19 @@
   $: min = getDateFromISOString(boundaryStart.toISOString());
 
   function applyCustomTimeRange() {
-    // Shift the selected dates to start in UTC instead of system timezone
-    const startDate = getISOStringFromDate(start, "UTC");
-    const endDate = getOffset(
+    let startDate = getISOStringFromDate(start, "UTC");
+    let endDate = getOffset(
       new Date(getISOStringFromDate(end, "UTC")),
       Period.DAY,
       TimeOffsetType.ADD
     ).toISOString();
 
+    startDate = removeZoneOffset(new Date(startDate), zone).toISOString();
+    endDate = removeZoneOffset(new Date(endDate), zone).toISOString();
+
     dispatch("apply", {
-      startDate: addZoneOffset(new Date(startDate), zone).toISOString(),
-      endDate: addZoneOffset(new Date(endDate), zone).toISOString(),
+      startDate,
+      endDate,
     });
   }
 


### PR DESCRIPTION
Previously if you select July 1- July 30 in PDT, it will show up as Jun 30 - Jul 30 in the picker. This PR fixes the bug in custom date picker when a timezone is selected.





