### PR TITLE
Fix zoom scrub with Z key

### DIFF
--- a/web-common/src/features/dashboards/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/dashboard-stores.ts
@@ -569,7 +569,11 @@ export function useComparisonRange(name: string) {
   return derived(metricsExplorerStore, ($store) => {
     const entity = $store.entities[name];
 
-    if (!entity?.showComparison) {
+    if (
+      !entity?.showComparison ||
+      !entity.selectedComparisonTimeRange?.start ||
+      !entity.selectedComparisonTimeRange?.end
+    ) {
       return {
         start: undefined,
         end: undefined,

--- a/web-common/src/features/dashboards/time-series/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureChart.svelte
@@ -153,14 +153,14 @@
   }
 
   function zoomScrub() {
+    resetScrub();
+
     const { start, end } = getOrderedStartEnd(scrubStart, scrubEnd);
     metricsExplorerStore.setSelectedTimeRange(metricViewName, {
       name: TimeRangePreset.CUSTOM,
       start,
       end,
     });
-
-    resetScrub();
   }
 
   function updateScrub(start, end, isScrubbing) {


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
The zoom on a scrub with the key `Z` is broken

#### Details:
There were some race conditions resulting in the error. This PR reorders certain state calls.

## Steps to Verify
1. Create a scrub
2. Zoom using the key `Z`
3. The dashboard should not break 
 -->