### PR TITLE
Cloud UI: handle project hibernation on the new project page

### DIFF
--- a/web-admin/src/components/projects/ProjectDeploymentLogs.svelte
+++ b/web-admin/src/components/projects/ProjectDeploymentLogs.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import CLICommandDisplay from "@rilldata/web-common/components/commands/CLICommandDisplay.svelte";
   import { createAdminServiceGetProject } from "../../client";
 
   export let organization: string;
@@ -27,14 +26,7 @@
 
 {#if $proj.isSuccess}
   <ul class="w-full">
-    {#if $proj.data && !$proj.data.prodDeployment}
-      <li class="px-12 py-2 text-gray-800 border-b flex items-center gap-x-5">
-        This project does not currently have a deployment. To redeploy the
-        project, run this command in the Rill CLI: <CLICommandDisplay
-          command="rill project reconcile --project {$proj.data.project.name}"
-        />
-      </li>
-    {:else if !hasReadAccess}
+    {#if !hasReadAccess}
       <li class="px-12 py-2 font-semibold text-gray-500 border-b">
         You don't have permission to view project logs
       </li>

--- a/web-admin/src/components/projects/ProjectDeploymentStatus.svelte
+++ b/web-admin/src/components/projects/ProjectDeploymentStatus.svelte
@@ -8,6 +8,7 @@
   export let project: string;
 
   $: proj = createAdminServiceGetProject(organization, project);
+  $: isProjectDeployed = $proj?.data && $proj.data.prodDeployment;
 
   function handleViewLogs() {
     goto(`/${organization}/${project}/-/logs`);
@@ -36,7 +37,9 @@
       </span>
     {/if}
   </div>
-  <div>
-    <Button type="secondary" on:click={handleViewLogs}>View logs</Button>
-  </div>
+  {#if isProjectDeployed}
+    <div>
+      <Button type="secondary" on:click={handleViewLogs}>View logs</Button>
+    </div>
+  {/if}
 </div>

--- a/web-admin/src/components/projects/ProjectHero.svelte
+++ b/web-admin/src/components/projects/ProjectHero.svelte
@@ -23,7 +23,4 @@
       </div>
     </svelte:fragment>
   </ProjectAccessControls>
-  <span class="text-gray-500 text-base font-normal leading-normal"
-    >Check out your dashboards below.</span
-  >
 </div>

--- a/web-admin/src/components/projects/RedeployProjectCTA.svelte
+++ b/web-admin/src/components/projects/RedeployProjectCTA.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import CLICommandDisplay from "@rilldata/web-common/components/commands/CLICommandDisplay.svelte";
+  import ProjectAccessControls from "./ProjectAccessControls.svelte";
+
+  export let organization: string;
+  export let project: string;
+</script>
+
+<div class="text-gray-800 flex flex-col gap-y-1">
+  <ProjectAccessControls {organization} {project}>
+    <span slot="manage-project">
+      This project does not currently have a deployment. To redeploy the
+      project, run this command in the Rill CLI:
+    </span>
+    <CLICommandDisplay command="rill project reconcile --project {project}" />
+    <span slot="read-project">
+      This project is not currently deployed. Contact your project's
+      administrator to redeploy the project.
+    </span>
+  </ProjectAccessControls>
+</div>

--- a/web-admin/src/routes/[organization]/[project]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/+page.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
   import { page } from "$app/stores";
   import VerticalScrollContainer from "@rilldata/web-common/layout/VerticalScrollContainer.svelte";
+  import { createAdminServiceGetProject } from "../../../client";
   import DashboardList from "../../../components/projects/DashboardList.svelte";
   import ProjectHero from "../../../components/projects/ProjectHero.svelte";
 
   $: organization = $page.params.organization;
   $: project = $page.params.project;
+
+  $: proj = createAdminServiceGetProject(organization, project);
+  $: isProjectDeployed = $proj?.data && $proj.data.prodDeployment;
 </script>
 
 <svelte:head>
@@ -16,6 +20,11 @@
     class="mx-8 my-8 sm:my-16 sm:mx-16 lg:mx-32 lg:my-24 2xl:mx-40 flex flex-col gap-y-4"
   >
     <ProjectHero {organization} {project} />
-    <DashboardList {organization} {project} />
+    {#if isProjectDeployed}
+      <span class="text-gray-500 text-base font-normal leading-normal"
+        >Check out your dashboards below.</span
+      >
+      <DashboardList {organization} {project} />
+    {/if}
   </div>
 </VerticalScrollContainer>

--- a/web-admin/src/routes/[organization]/[project]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/+page.svelte
@@ -4,12 +4,14 @@
   import { createAdminServiceGetProject } from "../../../client";
   import DashboardList from "../../../components/projects/DashboardList.svelte";
   import ProjectHero from "../../../components/projects/ProjectHero.svelte";
+  import RedeployProjectCta from "../../../components/projects/RedeployProjectCTA.svelte";
 
   $: organization = $page.params.organization;
   $: project = $page.params.project;
 
   $: proj = createAdminServiceGetProject(organization, project);
   $: isProjectDeployed = $proj?.data && $proj.data.prodDeployment;
+  $: isProjectHibernating = $proj?.data && !$proj.data.prodDeployment;
 </script>
 
 <svelte:head>
@@ -25,6 +27,8 @@
         >Check out your dashboards below.</span
       >
       <DashboardList {organization} {project} />
+    {:else if isProjectHibernating}
+      <RedeployProjectCta {organization} {project} />
     {/if}
   </div>
 </VerticalScrollContainer>


### PR DESCRIPTION
This PR:
- Hides the "View logs" button when a project is hibernating
- Hides the (empty) dashboard list component when a project is hibernating
- Moves the call-to-action to redeploy a hibernated project from the Project Logs page `{org}/{project}/-/logs` to the Project page `{org}/{project}`
- Differentiates the CTA betweeen project Admins and Viewers