### PR TITLE
remove checkpoint during data ingestion

### DIFF
--- a/runtime/drivers/duckdb/transporter/objectStore_to_duckDB.go
+++ b/runtime/drivers/duckdb/transporter/objectStore_to_duckDB.go
@@ -150,9 +150,9 @@ func (a *appender) appendData(ctx context.Context, files []string, format string
 
 	var query string
 	if a.allowSchemaRelaxation {
-		query = fmt.Sprintf("INSERT INTO %q BY NAME (SELECT * FROM %s); CHECKPOINT;", a.sink.Table, from)
+		query = fmt.Sprintf("INSERT INTO %q BY NAME (SELECT * FROM %s);", a.sink.Table, from)
 	} else {
-		query = fmt.Sprintf("INSERT INTO %q (SELECT * FROM %s); CHECKPOINT;", a.sink.Table, from)
+		query = fmt.Sprintf("INSERT INTO %q (SELECT * FROM %s);", a.sink.Table, from)
 	}
 	a.logger.Debug("generated query", zap.String("query", query), observability.ZapCtx(ctx))
 	err = a.to.Exec(ctx, &drivers.Statement{Query: query, Priority: 1})
@@ -167,7 +167,7 @@ func (a *appender) appendData(ctx context.Context, files []string, format string
 		return fmt.Errorf("failed to update schema %w", err)
 	}
 
-	query = fmt.Sprintf("INSERT INTO %q BY NAME (SELECT * FROM %s); CHECKPOINT;", a.sink.Table, from)
+	query = fmt.Sprintf("INSERT INTO %q BY NAME (SELECT * FROM %s);", a.sink.Table, from)
 	a.logger.Debug("generated query", zap.String("query", query), observability.ZapCtx(ctx))
 	return a.to.Exec(ctx, &drivers.Statement{Query: query, Priority: 1})
 }


### PR DESCRIPTION
We expect that the error reported [here](https://rilldata.slack.com/archives/C01190F1R1D/p1692654170064749?thread_ts=1692652651.922889&cid=C01190F1R1D) is due to `checkpoint` that was introduced recently.