### PR TITLE
Fix buggy scrub move

### DIFF
--- a/web-common/src/features/dashboards/time-series/MeasureScrub.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureScrub.svelte
@@ -201,6 +201,17 @@
     showContextMenu = true;
   }
 
+  /***
+   * prevent unwanted scrub changes when clicked
+   * inside a scrub without any cursor move
+   */
+  function onMouseUp() {
+    isResizing = undefined;
+    isMovingScrub = false;
+    moveStartDelta = 0;
+    moveEndDelta = 0;
+  }
+
   function onKeyDown(e) {
     // if key Z is pressed, zoom the scrub
     if (e.key === "z") {
@@ -260,7 +271,7 @@
         stroke-width={strokeWidth}
       />
     </g>
-    <g opacity={isScrubbing ? "0.4" : "0.2"}>
+    <g on:mouseup={() => onMouseUp()} opacity={isScrubbing ? "0.4" : "0.2"}>
       <rect
         class:rect-shadow={isScrubbing}
         x={Math.min(xStart, xEnd)}


### PR DESCRIPTION
#### Issue Addressed - 
When single-clicked on the scrubbed area, the cursor stays in “grab” mode as you move it around, yet the scrubbed area doesn’t pan with the cursor
