### PR TITLE
Generate MetricsViewComparisonToplist as query

### DIFF
--- a/web-common/orval.config.ts
+++ b/web-common/orval.config.ts
@@ -58,6 +58,11 @@ export default defineConfig({
               useQuery: true,
             },
           },
+          QueryService_MetricsViewComparisonToplist: {
+            query: {
+              useQuery: true,
+            },
+          },
           QueryService_MetricsViewRows: {
             query: {
               useQuery: true,

--- a/web-common/src/runtime-client/gen/query-service/query-service.ts
+++ b/web-common/src/runtime-client/gen/query-service/query-service.ts
@@ -465,80 +465,99 @@ export const queryServiceMetricsViewComparisonToplist = (
   });
 };
 
-export const getQueryServiceMetricsViewComparisonToplistMutationOptions = <
-  TError = RpcStatus,
-  TContext = unknown
->(options?: {
-  mutation?: CreateMutationOptions<
-    Awaited<ReturnType<typeof queryServiceMetricsViewComparisonToplist>>,
-    TError,
-    {
-      instanceId: string;
-      metricsViewName: string;
-      data: QueryServiceMetricsViewComparisonToplistBody;
-    },
-    TContext
-  >;
-}): CreateMutationOptions<
+export const getQueryServiceMetricsViewComparisonToplistQueryKey = (
+  instanceId: string,
+  metricsViewName: string,
+  queryServiceMetricsViewComparisonToplistBody: QueryServiceMetricsViewComparisonToplistBody
+) =>
+  [
+    `/v1/instances/${instanceId}/queries/metrics-views/${metricsViewName}/compare-toplist`,
+    queryServiceMetricsViewComparisonToplistBody,
+  ] as const;
+
+export const getQueryServiceMetricsViewComparisonToplistQueryOptions = <
+  TData = Awaited<ReturnType<typeof queryServiceMetricsViewComparisonToplist>>,
+  TError = RpcStatus
+>(
+  instanceId: string,
+  metricsViewName: string,
+  queryServiceMetricsViewComparisonToplistBody: QueryServiceMetricsViewComparisonToplistBody,
+  options?: {
+    query?: CreateQueryOptions<
+      Awaited<ReturnType<typeof queryServiceMetricsViewComparisonToplist>>,
+      TError,
+      TData
+    >;
+  }
+): CreateQueryOptions<
   Awaited<ReturnType<typeof queryServiceMetricsViewComparisonToplist>>,
   TError,
-  {
-    instanceId: string;
-    metricsViewName: string;
-    data: QueryServiceMetricsViewComparisonToplistBody;
-  },
-  TContext
-> => {
-  const { mutation: mutationOptions } = options ?? {};
+  TData
+> & { queryKey: QueryKey } => {
+  const { query: queryOptions } = options ?? {};
 
-  const mutationFn: MutationFunction<
-    Awaited<ReturnType<typeof queryServiceMetricsViewComparisonToplist>>,
-    {
-      instanceId: string;
-      metricsViewName: string;
-      data: QueryServiceMetricsViewComparisonToplistBody;
-    }
-  > = (props) => {
-    const { instanceId, metricsViewName, data } = props ?? {};
-
-    return queryServiceMetricsViewComparisonToplist(
+  const queryKey =
+    queryOptions?.queryKey ??
+    getQueryServiceMetricsViewComparisonToplistQueryKey(
       instanceId,
       metricsViewName,
-      data
+      queryServiceMetricsViewComparisonToplistBody
     );
-  };
 
-  return { mutationFn, ...mutationOptions };
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof queryServiceMetricsViewComparisonToplist>>
+  > = () =>
+    queryServiceMetricsViewComparisonToplist(
+      instanceId,
+      metricsViewName,
+      queryServiceMetricsViewComparisonToplistBody
+    );
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: !!(instanceId && metricsViewName),
+    ...queryOptions,
+  };
 };
 
-export type QueryServiceMetricsViewComparisonToplistMutationResult =
-  NonNullable<
-    Awaited<ReturnType<typeof queryServiceMetricsViewComparisonToplist>>
-  >;
-export type QueryServiceMetricsViewComparisonToplistMutationBody =
-  QueryServiceMetricsViewComparisonToplistBody;
-export type QueryServiceMetricsViewComparisonToplistMutationError = RpcStatus;
+export type QueryServiceMetricsViewComparisonToplistQueryResult = NonNullable<
+  Awaited<ReturnType<typeof queryServiceMetricsViewComparisonToplist>>
+>;
+export type QueryServiceMetricsViewComparisonToplistQueryError = RpcStatus;
 
 export const createQueryServiceMetricsViewComparisonToplist = <
-  TError = RpcStatus,
-  TContext = unknown
->(options?: {
-  mutation?: CreateMutationOptions<
-    Awaited<ReturnType<typeof queryServiceMetricsViewComparisonToplist>>,
-    TError,
-    {
-      instanceId: string;
-      metricsViewName: string;
-      data: QueryServiceMetricsViewComparisonToplistBody;
-    },
-    TContext
-  >;
-}) => {
-  const mutationOptions =
-    getQueryServiceMetricsViewComparisonToplistMutationOptions(options);
+  TData = Awaited<ReturnType<typeof queryServiceMetricsViewComparisonToplist>>,
+  TError = RpcStatus
+>(
+  instanceId: string,
+  metricsViewName: string,
+  queryServiceMetricsViewComparisonToplistBody: QueryServiceMetricsViewComparisonToplistBody,
+  options?: {
+    query?: CreateQueryOptions<
+      Awaited<ReturnType<typeof queryServiceMetricsViewComparisonToplist>>,
+      TError,
+      TData
+    >;
+  }
+): CreateQueryResult<TData, TError> & { queryKey: QueryKey } => {
+  const queryOptions = getQueryServiceMetricsViewComparisonToplistQueryOptions(
+    instanceId,
+    metricsViewName,
+    queryServiceMetricsViewComparisonToplistBody,
+    options
+  );
 
-  return createMutation(mutationOptions);
+  const query = createQuery(queryOptions) as CreateQueryResult<
+    TData,
+    TError
+  > & { queryKey: QueryKey };
+
+  query.queryKey = queryOptions.queryKey;
+
+  return query;
 };
+
 /**
  * @summary MetricsViewRows returns the underlying model rows matching a metrics view time range and filter(s).
  */


### PR DESCRIPTION
Due to the complex request payload, the `MetricsViewComparisonToplist` API uses `POST` instead of `GET` (which doesn't allow for request bodies). We need to manually tell Orval to generate the TS bindings as a query and not a mutation (and that didn't happen in the original PR).