### PR TITLE
Fix `Dialog` component bug

### DIFF
--- a/web-common/src/components/modal/dialog/Dialog.svelte
+++ b/web-common/src/components/modal/dialog/Dialog.svelte
@@ -54,7 +54,7 @@
 <ModalContainer on:cancel {focusTriggerOnClose}>
   <div
     class="grid place-items-center w-screen h-screen"
-    on:click|self={() => {
+    on:mousedown|self={() => {
       dispatch("cancel");
     }}
     on:keydown={() => {


### PR DESCRIPTION
Issue: A dialog closes when you begin your click (mousedown) inside the modal and end your click (mouseup) outside the modal. [Bug report in Slack.](https://rilldata.slack.com/archives/C0415QK8DK6/p1692285215926799)

This PR changes the `Dialog` behavior to close on mousedown. This is a bit of a hack, but the net result is a better experience. In the future, rather than rolling our own dialog component, we should move to a headless component library like https://svelte-headlessui.goss.io/.