### PR TITLE
Fixing default time range broken after dashboard init changes

### DIFF
--- a/web-common/src/features/dashboards/dashboard-stores-test-data.ts
+++ b/web-common/src/features/dashboards/dashboard-stores-test-data.ts
@@ -187,6 +187,9 @@ export function createDashboardState(
     leaderboardContextColumn: LeaderboardContextColumn.HIDDEN,
 
     selectedTimeRange: timeRange,
+
+    dashboardSortType: undefined,
+    sortDirection: undefined,
   };
 }
 

--- a/web-common/src/features/dashboards/dashboard-stores.spec.ts
+++ b/web-common/src/features/dashboards/dashboard-stores.spec.ts
@@ -6,24 +6,33 @@ import {
   AD_BIDS_DOMAIN_DIMENSION,
   AD_BIDS_EXCLUDE_FILTER,
   AD_BIDS_IMPRESSIONS_MEASURE,
+  AD_BIDS_INIT,
   AD_BIDS_MIRROR_NAME,
   AD_BIDS_NAME,
   AD_BIDS_PUBLISHER_DIMENSION,
   AD_BIDS_WITH_DELETED_DIMENSION,
   ALL_TIME_PARSED_TEST_CONTROLS,
+  assertMetricsView,
+  assertMetricsViewRaw,
+  createAdBidsMirrorInStore,
+  createMetricsMetaQueryMock,
   CUSTOM_TEST_CONTROLS,
   LAST_6_HOURS_TEST_CONTROLS,
   LAST_6_HOURS_TEST_PARSED_CONTROLS,
-  assertMetricsView,
-  createAdBidsMirrorInStore,
-  createMetricsMetaQueryMock,
   resetDashboardStore,
-  AD_BIDS_INIT,
-  assertMetricsViewRaw,
   TestTimeConstants,
 } from "@rilldata/web-common/features/dashboards/dashboard-stores-test-data";
 import { initLocalUserPreferenceStore } from "@rilldata/web-common/features/dashboards/user-preferences";
-import { TimeRangePreset } from "@rilldata/web-common/lib/time/types";
+import { getLocalIANA } from "@rilldata/web-common/lib/time/timezone";
+import {
+  getOffset,
+  getStartOfPeriod,
+} from "@rilldata/web-common/lib/time/transforms";
+import {
+  Period,
+  TimeOffsetType,
+  TimeRangePreset,
+} from "@rilldata/web-common/lib/time/types";
 import { V1TimeGrain } from "@rilldata/web-common/runtime-client";
 import { get } from "svelte/store";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -229,8 +238,22 @@ describe("dashboard-stores", () => {
     assertMetricsView(AD_BIDS_NAME, undefined, {
       name: TimeRangePreset.LAST_SIX_HOURS,
       interval: V1TimeGrain.TIME_GRAIN_HOUR,
-      start: new Date("2023-08-25T00:30:00.000Z"),
-      end: new Date("2023-08-25T06:30:00.000Z"),
+      start: getOffset(
+        getStartOfPeriod(
+          TestTimeConstants.LAST_6_HOURS,
+          Period.HOUR,
+          getLocalIANA()
+        ),
+        Period.HOUR,
+        TimeOffsetType.ADD,
+        getLocalIANA()
+      ),
+      end: getOffset(
+        getStartOfPeriod(TestTimeConstants.NOW, Period.HOUR, getLocalIANA()),
+        Period.HOUR,
+        TimeOffsetType.ADD,
+        getLocalIANA()
+      ),
     });
   });
 

--- a/web-common/src/features/dashboards/dashboard-stores.spec.ts
+++ b/web-common/src/features/dashboards/dashboard-stores.spec.ts
@@ -20,7 +20,6 @@ import {
   resetDashboardStore,
   AD_BIDS_INIT,
   assertMetricsViewRaw,
-  initAdBidsInStore,
   TestTimeConstants,
 } from "@rilldata/web-common/features/dashboards/dashboard-stores-test-data";
 import { initLocalUserPreferenceStore } from "@rilldata/web-common/features/dashboards/user-preferences";

--- a/web-common/src/features/dashboards/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/dashboard-stores.ts
@@ -9,12 +9,12 @@ import {
 } from "@rilldata/web-common/lib/arrayUtils";
 import { getComparionRangeForScrub } from "@rilldata/web-common/lib/time/comparisons";
 import { getDefaultTimeGrain } from "@rilldata/web-common/lib/time/grains";
-import { convertTimeRangePreset } from "@rilldata/web-common/lib/time/ranges";
-import type { DashboardTimeControls } from "@rilldata/web-common/lib/time/types";
 import {
-  ScrubRange,
-  TimeRangePreset,
-} from "@rilldata/web-common/lib/time/types";
+  convertTimeRangePreset,
+  ISODurationToTimePreset,
+} from "@rilldata/web-common/lib/time/ranges";
+import type { DashboardTimeControls } from "@rilldata/web-common/lib/time/types";
+import type { ScrubRange } from "@rilldata/web-common/lib/time/types";
 import type {
   V1ColumnTimeRangeResponse,
   V1MetricsView,
@@ -255,7 +255,7 @@ const metricViewReducers = {
       if (fullTimeRange) {
         const timeZone = get(getLocalUserPreferences()).timeZone;
         const timeRange = convertTimeRangePreset(
-          TimeRangePreset.ALL_TIME,
+          ISODurationToTimePreset(metricsView.defaultTimeRange, true),
           new Date(fullTimeRange.timeRangeSummary.min),
           new Date(fullTimeRange.timeRangeSummary.max),
           timeZone

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardContextColumnMenu.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardContextColumnMenu.svelte
@@ -21,11 +21,6 @@
   let metricsExplorer: MetricsExplorerEntity;
   $: metricsExplorer = $metricsExplorerStore.entities[metricViewName];
 
-  $: console.log(
-    "leaderboardContextColumn",
-    metricsExplorer?.leaderboardContextColumn
-  );
-
   const handleContextValueButtonGroupClick = (evt) => {
     const value: SelectMenuItem = evt.detail;
     const key = value.key;
@@ -65,18 +60,15 @@
   $: selection = options.find(
     (option) => option.key === metricsExplorer?.leaderboardContextColumn
   );
-  $: console.log("options", options);
-
-  $: console.log("selection", selection);
 </script>
 
 <SelectMenu
-  {options}
-  {selection}
-  fixedText="with"
-  ariaLabel="Select a context column"
-  paddingTop={2}
-  paddingBottom={2}
   alignment="end"
+  ariaLabel="Select a context column"
+  fixedText="with"
   on:select={handleContextValueButtonGroupClick}
+  {options}
+  paddingBottom={2}
+  paddingTop={2}
+  {selection}
 />

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardContextColumnMenu.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardContextColumnMenu.svelte
@@ -21,6 +21,11 @@
   let metricsExplorer: MetricsExplorerEntity;
   $: metricsExplorer = $metricsExplorerStore.entities[metricViewName];
 
+  $: console.log(
+    "leaderboardContextColumn",
+    metricsExplorer?.leaderboardContextColumn
+  );
+
   const handleContextValueButtonGroupClick = (evt) => {
     const value: SelectMenuItem = evt.detail;
     const key = value.key;
@@ -60,15 +65,18 @@
   $: selection = options.find(
     (option) => option.key === metricsExplorer?.leaderboardContextColumn
   );
+  $: console.log("options", options);
+
+  $: console.log("selection", selection);
 </script>
 
 <SelectMenu
-  alignment="end"
-  ariaLabel="Select a context column"
-  fixedText="with"
-  on:select={handleContextValueButtonGroupClick}
   {options}
-  paddingBottom={2}
-  paddingTop={2}
   {selection}
+  fixedText="with"
+  ariaLabel="Select a context column"
+  paddingTop={2}
+  paddingBottom={2}
+  alignment="end"
+  on:select={handleContextValueButtonGroupClick}
 />


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [x] Unit test coverage
- [ ] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
closes #2961

#### Details:
<!-- PROVIDE DETAILS ON WHAT THE CHANGE IS, WHY, AND HOW IF APPLICABLE -->

## Steps to Verify
1. Create a dashboard with timestamp
2. Update the default time range to one of the supported ones. https://github.com/rilldata/rill/blob/main/web-common/src/lib/time/ranges/index.ts#L105
3. Go to dashboard. The time range wont change if the dashboard was already opened. (Is a different issue around state initialization)
4. Refresh the dashboard and the default time range should show up.