### PR TITLE
CLI: Add "rill upgrade" command

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rilldata/rill/cli/cmd/service"
 	"github.com/rilldata/rill/cli/cmd/start"
 	"github.com/rilldata/rill/cli/cmd/sudo"
+	"github.com/rilldata/rill/cli/cmd/upgrade"
 	"github.com/rilldata/rill/cli/cmd/user"
 	versioncmd "github.com/rilldata/rill/cli/cmd/version"
 	"github.com/rilldata/rill/cli/cmd/whoami"
@@ -132,6 +133,7 @@ func runCmd(ctx context.Context, ver config.Version) error {
 	rootCmd.AddCommand(completionCmd)
 	rootCmd.AddCommand(verifyInstallCmd(cfg))
 	rootCmd.AddCommand(versioncmd.VersionCmd())
+	rootCmd.AddCommand(upgrade.UpgradeCmd(cfg))
 	rootCmd.AddCommand(whoami.WhoamiCmd(cfg))
 
 	// Add sub-commands for admin

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -1,0 +1,55 @@
+package upgrade
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+
+	"github.com/rilldata/rill/cli/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+const installScriptURL = "https://cdn.rilldata.com/install.sh"
+
+func UpgradeCmd(cfg *config.Config) *cobra.Command {
+	var nightly bool
+
+	upgradeCmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade Rill to the latest version",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			// Download the install script to a temporary file
+			f, err := os.CreateTemp("", "install*.sh")
+			if err != nil {
+				return err
+			}
+			defer os.Remove(f.Name())
+
+			resp, err := http.Get(installScriptURL)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+
+			_, err = io.Copy(f, resp.Body)
+			if err != nil {
+				return err
+			}
+			f.Close()
+
+			// Run the install script with bash
+			args := []string{f.Name()}
+			if nightly {
+				args = append(args, "--nightly")
+			}
+			cmd := exec.Command("/bin/bash", args...)
+			return cmd.Run()
+		},
+	}
+
+	upgradeCmd.Flags().BoolVar(&nightly, "nightly", false, "Install the latest nightly build")
+
+	return upgradeCmd
+}

--- a/cli/cmd/version/version.go
+++ b/cli/cmd/version/version.go
@@ -8,8 +8,7 @@ import (
 func VersionCmd() *cobra.Command {
 	versionCmd := &cobra.Command{
 		Use:   "version",
-		Short: "Show rill version",
-		Long:  `A longer description`,
+		Short: "Show Rill version",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			root := cmd.Root()
 			root.SetArgs([]string{"--version"})

--- a/cli/pkg/update/update.go
+++ b/cli/pkg/update/update.go
@@ -43,8 +43,8 @@ func CheckVersion(ctx context.Context, currentVersion string) error {
 	}
 
 	if v1.LessThan(v2) {
-		fmt.Printf("\n%s %s → %s\n\n",
-			color.YellowString("A new version of rill is available:"),
+		fmt.Printf("%s %s → %s\n\n",
+			color.YellowString("A new version of rill is available (run `rill upgrade`):"),
 			color.CyanString(currentVersion),
 			color.CyanString(latestVersion))
 		return nil

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -61,6 +61,9 @@ curl -s <https://cdn.rilldata.com/install.sh> | bash
 You can download platform-specific binaries from our [releases page on Github](https://github.com/rilldata/rill/releases). A manual download will not make Rill Developer globally accessible, so you'll need to reference the full path of the binary when executing CLI commands.
 
 ## Frequently Asked Questions 
+### How do I upgrade Rill to the latest version?
+If you installed Rill using the installation script described above, you can upgrade by running `rill upgrade` or by re-running the installation script.
+
 ### Rill cannot be opened because it is from an unidentified developer.
 This occurs when Rill binary is downloaded via browser. You need to change the permissions to make it executable and remove it from Apple Developer identification quarantine. 
 Below CLI commands will help you to do that: 


### PR DESCRIPTION
This PR adds a `rill upgrade` command that downloads and runs the installation script. It also supports a `--nightly` flag to install the latest nightly build.

I called the command `rill upgrade` instead of `rill update` to avoid ambiguity with source refreshes.

Closes https://github.com/rilldata/rill/issues/2969

