### PR TITLE
Change default `flip` behavior of menus

### DIFF
--- a/web-common/src/components/floating-element/WithTogglableFloatingElement.svelte
+++ b/web-common/src/components/floating-element/WithTogglableFloatingElement.svelte
@@ -12,7 +12,7 @@
   export let suppress = false;
   export let active = false;
   export let inline = false;
-  export let overflowFlipY = true;
+  export let overflowFlipY = false;
   export let mousePos = { x: 0, y: 0 };
 
   /** this passes down the dom element used for the "outside click" action.

--- a/web-common/src/components/menu/wrappers/WithSelectMenu.svelte
+++ b/web-common/src/components/menu/wrappers/WithSelectMenu.svelte
@@ -22,7 +22,7 @@ and the menu closes.
   export let paddingTop: number = undefined;
   export let paddingBottom: number = undefined;
   export let minWidth: string = undefined;
-  export let overflowFlipY = true;
+  export let overflowFlipY = false;
 
   export let active = false;
 


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed:

https://github.com/rilldata/rill/issues/2979, https://github.com/rilldata/rill/pull/2774

#### Details:
This PR removes the default behavior that menus flip over the Y axis when the content is long.

## Steps to Verify
Run through the app and double-check that no menus are obscured.