### PR TITLE
Fix zoom bugs

### DIFF
--- a/web-common/src/features/dashboards/time-series/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureChart.svelte
@@ -166,10 +166,13 @@
     resetScrub();
 
     const { start, end } = getOrderedStartEnd(scrubStart, scrubEnd);
+    const adjustedStart = start ? localToTimeZoneOffset(start, zone) : start;
+    const adjustedEnd = end ? localToTimeZoneOffset(end, zone) : end;
+
     metricsExplorerStore.setSelectedTimeRange(metricViewName, {
       name: TimeRangePreset.CUSTOM,
-      start,
-      end,
+      start: adjustedStart,
+      end: adjustedEnd,
     });
   }
 

--- a/web-common/src/features/dashboards/time-series/MeasureScrub.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureScrub.svelte
@@ -202,16 +202,6 @@
     moveStartDelta = 0;
     moveEndDelta = 0;
   }
-
-  function onKeyDown(e) {
-    // if key Z is pressed, zoom the scrub
-    if (e.key === "z") {
-      dispatch("zoom");
-    }
-    if (!isScrubbing && e.key === "Escape") {
-      dispatch("reset");
-    }
-  }
 </script>
 
 {#if start && stop}
@@ -274,8 +264,6 @@
     </g>
   </WithGraphicContexts>
 {/if}
-
-<svelte:window on:keydown={onKeyDown} />
 
 <defs>
   <linearGradient id="scrubbing-gradient" gradientUnits="userSpaceOnUse">


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
1. Zoom was broken on dashboards with high number of charts when keybinding `Z` was used
2. The zoomed in dates were not accurate due to timezone changes

#### Details:
1. Moves `<svelte:window>` to a component single component so to avoid multiple dispatches/state changes for the same keybinding.
2. Handles timezone offset when zoomed in

## Steps to Verify
Play around with zoom on a dashboard with 5 or more charts.