### PR TITLE
Fix default time range adding comparision

### DIFF
--- a/web-common/src/features/dashboards/dashboard-stores.spec.ts
+++ b/web-common/src/features/dashboards/dashboard-stores.spec.ts
@@ -255,6 +255,33 @@ describe("dashboard-stores", () => {
         getLocalIANA()
       ),
     });
+    const metrics = get(metricsExplorerStore).entities[AD_BIDS_NAME];
+    expect(metrics.showComparison).toBeTruthy();
+    expect(metrics.selectedComparisonTimeRange.name).toBe("CONTIGUOUS");
+    expect(metrics.selectedComparisonTimeRange.start).toEqual(
+      getOffset(
+        getStartOfPeriod(
+          TestTimeConstants.LAST_12_HOURS,
+          Period.HOUR,
+          getLocalIANA()
+        ),
+        Period.HOUR,
+        TimeOffsetType.ADD,
+        getLocalIANA()
+      )
+    );
+    expect(metrics.selectedComparisonTimeRange.end).toEqual(
+      getOffset(
+        getStartOfPeriod(
+          TestTimeConstants.LAST_6_HOURS,
+          Period.HOUR,
+          getLocalIANA()
+        ),
+        Period.HOUR,
+        TimeOffsetType.ADD,
+        getLocalIANA()
+      )
+    );
   });
 
   describe("Restore invalid state", () => {


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [x] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
When a default time range is selected in metrics config, comparison should be enabled by default if available.

#### Details:
<!-- PROVIDE DETAILS ON WHAT THE CHANGE IS, WHY, AND HOW IF APPLICABLE -->

## Steps to Verify
1. Create a dashboard with timestamp.
2. Set `default_time_range` to `P1D`.
3. Go to dashboard.
4. Time range should be last 24 hrs and comparison should be enabled to last day.