### PR TITLE
removing threads constraint from rill projects

### DIFF
--- a/admin/deployments.go
+++ b/admin/deployments.go
@@ -71,7 +71,7 @@ func (s *Service) createDeployment(ctx context.Context, opts *createDeploymentOp
 		embedCatalog = true
 		ingestionLimit = alloc.StorageBytes
 
-		olapDSN = fmt.Sprintf("%s.db?rill_pool_size=%d&threads=%d&max_memory=%dGB", path.Join(alloc.DataDir, instanceID), alloc.CPU, alloc.CPU, alloc.MemoryGB)
+		olapDSN = fmt.Sprintf("%s.db?rill_pool_size=%d&max_memory=%dGB", path.Join(alloc.DataDir, instanceID), alloc.CPU, alloc.MemoryGB)
 	}
 
 	// Open a runtime client


### PR DESCRIPTION
We are seeing that `.wal` file sometimes explodes during ingestion. On debugging it is seen that this consistently happens when `threads`, `memory` and `max db connections` constraints are applied together.
Removing threads constraint for now till further debugging has been done.