### PR TITLE
Fix axis label format for intervals

### DIFF
--- a/web-common/src/components/data-graphic/guides/Axis.svelte
+++ b/web-common/src/components/data-graphic/guides/Axis.svelte
@@ -4,6 +4,7 @@ This component will draw an axis on the specified side.
 <script lang="ts">
   import { NumberKind } from "@rilldata/web-common/lib/number-formatting/humanizer-types";
   import { IntTimesPowerOfTenFormatter } from "@rilldata/web-common/lib/number-formatting/strategies/IntTimesPowerOfTen";
+  import { formatMsInterval } from "@rilldata/web-common/lib/number-formatting/strategies/intervals";
   import { timeFormat } from "d3-time-format";
   import { getContext } from "svelte";
   import { contexts } from "../constants";
@@ -182,7 +183,10 @@ This component will draw an axis on the specified side.
       onInvalidInput: "consoleWarn",
       padWithInsignificantZeros: false,
     });
-    formatterFunction = (x) => formatter.stringFormat(x);
+    formatterFunction = (x) =>
+      numberKind === "INTERVAL"
+        ? formatMsInterval(x)
+        : formatter.stringFormat(x);
   }
 
   let axisLength;

--- a/web-common/src/features/dashboards/humanize-numbers.ts
+++ b/web-common/src/features/dashboards/humanize-numbers.ts
@@ -87,6 +87,9 @@ export const nicelyFormattedTypesToNumberKind = (
     case FormatPreset.PERCENTAGE:
       return NumberKind.PERCENT;
 
+    case FormatPreset.INTERVAL:
+      return NumberKind.INTERVAL;
+
     default:
       // captures:
       // FormatPreset.NONE

--- a/web-common/src/lib/number-formatting/humanizer-types.ts
+++ b/web-common/src/lib/number-formatting/humanizer-types.ts
@@ -39,6 +39,7 @@ export type RichFormatNumber = {
 export enum NumberKind {
   DOLLAR = "DOLLAR",
   PERCENT = "PERCENT",
+  INTERVAL = "INTERVAL",
   ANY = "ANY",
 }
 


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
#2974 

## Steps to Verify
1. On a dashboard set format for a measure to `interval_ms`
2. Measure charts should have correctly formatted labels