### PR TITLE
fix timeseries caching

### DIFF
--- a/runtime/queries/column_timeseries.go
+++ b/runtime/queries/column_timeseries.go
@@ -45,7 +45,7 @@ type ColumnTimeseries struct {
 	// MetricsView-related fields. These can be removed when MetricsViewTimeSeries is refactored to a standalone implementation.
 	MetricsView       *runtimev1.MetricsView             `json:"-"`
 	MetricsViewFilter *runtimev1.MetricsViewFilter       `json:"filters"`
-	MetricsViewPolicy *runtime.ResolvedMetricsViewPolicy `json:"-"`
+	MetricsViewPolicy *runtime.ResolvedMetricsViewPolicy `json:"policy"`
 }
 
 var _ runtime.Query = &ColumnTimeseries{}


### PR DESCRIPTION
since https://github.com/rilldata/rill/pull/2925 is not merged yet, we are still using this instead of MV query so cache key will have metricsview policy