### PR TITLE
Hide console warnings when parsing `rill.yaml`

### DIFF
--- a/web-common/src/features/project/selectors.ts
+++ b/web-common/src/features/project/selectors.ts
@@ -5,7 +5,9 @@ export function useProjectTitle(instanceId: string) {
   return createRuntimeServiceGetFile(instanceId, "rill.yaml", {
     query: {
       select: (data) => {
-        const projectData = parseDocument(data.blob)?.toJS();
+        const projectData = parseDocument(data.blob, {
+          logLevel: "error",
+        })?.toJS();
         return projectData?.title ?? projectData?.name;
       },
     },


### PR DESCRIPTION
When editing a `rill.yaml` document, there were occasionally not-very-useful warnings popping up in the browser console. 
Here's one: 
<img width="652" alt="image" src="https://github.com/rilldata/rill/assets/14206386/b203785c-c20f-4dab-a5e7-b5c100cc9854">

This PR hides these warnings.

Docs: https://eemeli.org/yaml/#document-options