### PR TITLE
Fix broken OpenAPI bindings generator

### DIFF
--- a/proto/buf.gen.openapi-admin.yaml
+++ b/proto/buf.gen.openapi-admin.yaml
@@ -4,7 +4,7 @@ managed:
   go_package_prefix:
     default: github.com/rilldata/rill
 plugins:
-  - plugin: buf.build/grpc-ecosystem/openapiv2
+  - plugin: buf.build/grpc-ecosystem/openapiv2:v2.16.2
     out: gen
     opt:
       - logtostderr=true

--- a/proto/buf.gen.openapi-runtime.yaml
+++ b/proto/buf.gen.openapi-runtime.yaml
@@ -4,7 +4,7 @@ managed:
   go_package_prefix:
     default: github.com/rilldata/rill
 plugins:
-  - plugin: buf.build/grpc-ecosystem/openapiv2
+  - plugin: buf.build/grpc-ecosystem/openapiv2:v2.16.2
     out: gen
     opt:
       - logtostderr=true

--- a/proto/gen/rill/admin/v1/admin.swagger.yaml
+++ b/proto/gen/rill/admin/v1/admin.swagger.yaml
@@ -9,1399 +9,1399 @@ consumes:
 produces:
   - application/json
 paths:
-  /v1/deployments/{deploymentId}/reconcile: |
+  /v1/deployments/{deploymentId}/reconcile:
     post:
-        summary: TriggerReconcile triggers reconcile for the project's prod deployment
-        operationId: AdminService_TriggerReconcile
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1TriggerReconcileResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: deploymentId
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-        tags:
-            - AdminService
-  /v1/deployments/{deploymentId}/refresh: |
+      summary: TriggerReconcile triggers reconcile for the project's prod deployment
+      operationId: AdminService_TriggerReconcile
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1TriggerReconcileResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: deploymentId
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+      tags:
+        - AdminService
+  /v1/deployments/{deploymentId}/refresh:
     post:
-        summary: TriggerRefreshSources refresh the source for production deployment
-        operationId: AdminService_TriggerRefreshSources
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1TriggerRefreshSourcesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: deploymentId
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    sources:
-                        type: array
-                        items:
-                            type: string
-        tags:
-            - AdminService
-  /v1/github/repositories: |
+      summary: TriggerRefreshSources refresh the source for production deployment
+      operationId: AdminService_TriggerRefreshSources
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1TriggerRefreshSourcesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: deploymentId
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              sources:
+                type: array
+                items:
+                  type: string
+      tags:
+        - AdminService
+  /v1/github/repositories:
     get:
-        summary: |-
-            GetGithubRepoRequest returns info about a Github repo based on the caller's installations.
-            If the caller has not granted access to the repository, instructions for granting access are returned.
-        operationId: AdminService_GetGithubRepoStatus
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1GetGithubRepoStatusResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: githubUrl
-              in: query
-              required: false
-              type: string
-        tags:
-            - AdminService
-  /v1/organizations: |
+      summary: |-
+        GetGithubRepoRequest returns info about a Github repo based on the caller's installations.
+        If the caller has not granted access to the repository, instructions for granting access are returned.
+      operationId: AdminService_GetGithubRepoStatus
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1GetGithubRepoStatusResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: githubUrl
+          in: query
+          required: false
+          type: string
+      tags:
+        - AdminService
+  /v1/organizations:
     get:
-        summary: ListOrganizations lists all the organizations currently managed by the admin
-        operationId: AdminService_ListOrganizations
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ListOrganizationsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: pageSize
-              in: query
-              required: false
-              type: integer
-              format: int64
-            - name: pageToken
-              in: query
-              required: false
-              type: string
-        tags:
-            - AdminService
+      summary: ListOrganizations lists all the organizations currently managed by the admin
+      operationId: AdminService_ListOrganizations
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListOrganizationsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: pageSize
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: pageToken
+          in: query
+          required: false
+          type: string
+      tags:
+        - AdminService
     post:
-        summary: CreateOrganization creates a new organization
-        operationId: AdminService_CreateOrganization
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1CreateOrganizationResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: body
-              in: body
-              required: true
-              schema:
-                $ref: '#/definitions/v1CreateOrganizationRequest'
-        tags:
-            - AdminService
-  /v1/organizations/{name}: |
+      summary: CreateOrganization creates a new organization
+      operationId: AdminService_CreateOrganization
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1CreateOrganizationResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1CreateOrganizationRequest'
+      tags:
+        - AdminService
+  /v1/organizations/{name}:
     get:
-        summary: GetOrganization returns information about a specific organization
-        operationId: AdminService_GetOrganization
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1GetOrganizationResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: name
-              in: path
-              required: true
-              type: string
-        tags:
-            - AdminService
+      summary: GetOrganization returns information about a specific organization
+      operationId: AdminService_GetOrganization
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1GetOrganizationResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          in: path
+          required: true
+          type: string
+      tags:
+        - AdminService
     delete:
-        summary: DeleteOrganization deletes an organizations
-        operationId: AdminService_DeleteOrganization
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1DeleteOrganizationResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: name
-              in: path
-              required: true
-              type: string
-        tags:
-            - AdminService
+      summary: DeleteOrganization deletes an organizations
+      operationId: AdminService_DeleteOrganization
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1DeleteOrganizationResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          in: path
+          required: true
+          type: string
+      tags:
+        - AdminService
     patch:
-        summary: UpdateOrganization deletes an organizations
-        operationId: AdminService_UpdateOrganization
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1UpdateOrganizationResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: name
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    description:
-                        type: string
-                    newName:
-                        type: string
-        tags:
-            - AdminService
-  /v1/organizations/{organizationName}/projects: |
+      summary: UpdateOrganization deletes an organizations
+      operationId: AdminService_UpdateOrganization
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1UpdateOrganizationResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              description:
+                type: string
+              newName:
+                type: string
+      tags:
+        - AdminService
+  /v1/organizations/{organization}/invites:
     get:
-        summary: ListProjectsForOrganization lists all the projects currently available for given organizations
-        operationId: AdminService_ListProjectsForOrganization
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ListProjectsForOrganizationResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organizationName
-              in: path
-              required: true
-              type: string
-            - name: pageSize
-              in: query
-              required: false
-              type: integer
-              format: int64
-            - name: pageToken
-              in: query
-              required: false
-              type: string
-        tags:
-            - AdminService
+      summary: ListOrganizationInvites lists all the org invites
+      operationId: AdminService_ListOrganizationInvites
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListOrganizationInvitesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organization
+          in: path
+          required: true
+          type: string
+        - name: pageSize
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: pageToken
+          in: query
+          required: false
+          type: string
+      tags:
+        - AdminService
+  /v1/organizations/{organization}/members:
+    get:
+      summary: ListOrganizationMembers lists all the org members
+      operationId: AdminService_ListOrganizationMembers
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListOrganizationMembersResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organization
+          in: path
+          required: true
+          type: string
+        - name: pageSize
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: pageToken
+          in: query
+          required: false
+          type: string
+      tags:
+        - AdminService
     post:
-        summary: CreateProject creates a new project
-        operationId: AdminService_CreateProject
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1CreateProjectResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organizationName
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    name:
-                        type: string
-                    description:
-                        type: string
-                    public:
-                        type: boolean
-                    region:
-                        type: string
-                    prodOlapDriver:
-                        type: string
-                    prodOlapDsn:
-                        type: string
-                    prodSlots:
-                        type: string
-                        format: int64
-                    subpath:
-                        type: string
-                    prodBranch:
-                        type: string
-                    githubUrl:
-                        type: string
-                    variables:
-                        type: object
-                        additionalProperties:
-                            type: string
-        tags:
-            - AdminService
-  /v1/organizations/{organizationName}/projects/{name}: |
-    get:
-        summary: GetProject returns information about a specific project
-        operationId: AdminService_GetProject
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1GetProjectResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organizationName
-              in: path
-              required: true
-              type: string
-            - name: name
-              in: path
-              required: true
-              type: string
-        tags:
-            - AdminService
+      summary: AddOrganizationMember lists all the org members
+      operationId: AdminService_AddOrganizationMember
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1AddOrganizationMemberResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organization
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              email:
+                type: string
+              role:
+                type: string
+      tags:
+        - AdminService
+  /v1/organizations/{organization}/members/{email}:
     delete:
-        summary: DeleteProject deletes an project
-        operationId: AdminService_DeleteProject
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1DeleteProjectResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organizationName
-              in: path
-              required: true
-              type: string
-            - name: name
-              in: path
-              required: true
-              type: string
-        tags:
-            - AdminService
-    patch:
-        summary: UpdateProject updates a project
-        operationId: AdminService_UpdateProject
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1UpdateProjectResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organizationName
-              in: path
-              required: true
-              type: string
-            - name: name
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    description:
-                        type: string
-                    public:
-                        type: boolean
-                    prodBranch:
-                        type: string
-                    githubUrl:
-                        type: string
-                    prodSlots:
-                        type: string
-                        format: int64
-                    region:
-                        type: string
-                    newName:
-                        type: string
-                    prodTtlSeconds:
-                        type: string
-                        format: int64
-        tags:
-            - AdminService
-  /v1/organizations/{organizationName}/projects/{name}/variables: |
-    get:
-        summary: 'GetProjectVariables returns project variables. NOTE: Get project API doesn''t return variables.'
-        operationId: AdminService_GetProjectVariables
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1GetProjectVariablesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organizationName
-              in: path
-              required: true
-              type: string
-            - name: name
-              in: path
-              required: true
-              type: string
-        tags:
-            - AdminService
+      summary: RemoveOrganizationMember removes member from the organization
+      operationId: AdminService_RemoveOrganizationMember
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1RemoveOrganizationMemberResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organization
+          in: path
+          required: true
+          type: string
+        - name: email
+          in: path
+          required: true
+          type: string
+        - name: keepProjectRoles
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - AdminService
     put:
-        summary: 'UpdateProjectVariables updates variables for a project. NOTE: Update project API doesn''t update variables.'
-        operationId: AdminService_UpdateProjectVariables
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1UpdateProjectVariablesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organizationName
-              in: path
-              required: true
-              type: string
-            - name: name
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    variables:
-                        type: object
-                        additionalProperties:
-                            type: string
-        tags:
-            - AdminService
-  /v1/organizations/{organizationName}/services: |
-    get:
-        summary: ListService returns all the services per organization
-        operationId: AdminService_ListServices
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ListServicesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organizationName
-              in: path
-              required: true
-              type: string
-        tags:
-            - AdminService
-    post:
-        summary: CreateService creates a new service per organization
-        operationId: AdminService_CreateService
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1CreateServiceResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organizationName
-              in: path
-              required: true
-              type: string
-            - name: name
-              in: query
-              required: false
-              type: string
-        tags:
-            - AdminService
-  /v1/organizations/{organizationName}/services/{name}: |
+      summary: SetOrganizationMemberRole sets the role for the member
+      operationId: AdminService_SetOrganizationMemberRole
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1SetOrganizationMemberRoleResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organization
+          in: path
+          required: true
+          type: string
+        - name: email
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              role:
+                type: string
+      tags:
+        - AdminService
+  /v1/organizations/{organization}/members/current:
     delete:
-        summary: DeleteService deletes a service per organization
-        operationId: AdminService_DeleteService
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1DeleteServiceResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organizationName
-              in: path
-              required: true
-              type: string
-            - name: name
-              in: path
-              required: true
-              type: string
-        tags:
-            - AdminService
-    patch:
-        summary: UpdateService updates a service per organization
-        operationId: AdminService_UpdateService
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1UpdateServiceResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organizationName
-              in: path
-              required: true
-              type: string
-            - name: name
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    newName:
-                        type: string
-        tags:
-            - AdminService
-  /v1/organizations/{organizationName}/services/{serviceName}/tokens: |
+      summary: LeaveOrganization removes the current user from the organization
+      operationId: AdminService_LeaveOrganization
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1LeaveOrganizationResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organization
+          in: path
+          required: true
+          type: string
+      tags:
+        - AdminService
+  /v1/organizations/{organization}/projects/{project}/git-credentials:
     get:
-        summary: ListServiceAuthTokens lists all the service auth tokens
-        operationId: AdminService_ListServiceAuthTokens
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ListServiceAuthTokensResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organizationName
-              in: path
-              required: true
-              type: string
-            - name: serviceName
-              in: path
-              required: true
-              type: string
-        tags:
-            - AdminService
+      summary: GetGitCredentials returns credentials and other details for a project's Git repository.
+      operationId: AdminService_GetGitCredentials
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1GetGitCredentialsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organization
+          in: path
+          required: true
+          type: string
+        - name: project
+          in: path
+          required: true
+          type: string
+      tags:
+        - AdminService
+  /v1/organizations/{organization}/projects/{project}/invites:
+    get:
+      summary: ListProjectInvites lists all the project invites
+      operationId: AdminService_ListProjectInvites
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListProjectInvitesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organization
+          in: path
+          required: true
+          type: string
+        - name: project
+          in: path
+          required: true
+          type: string
+        - name: pageSize
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: pageToken
+          in: query
+          required: false
+          type: string
+      tags:
+        - AdminService
+  /v1/organizations/{organization}/projects/{project}/members:
+    get:
+      summary: ListProjectMembers lists all the project members
+      operationId: AdminService_ListProjectMembers
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListProjectMembersResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organization
+          in: path
+          required: true
+          type: string
+        - name: project
+          in: path
+          required: true
+          type: string
+        - name: pageSize
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: pageToken
+          in: query
+          required: false
+          type: string
+      tags:
+        - AdminService
     post:
-        summary: IssueServiceAuthToken returns the temporary token for given service account
-        operationId: AdminService_IssueServiceAuthToken
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1IssueServiceAuthTokenResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organizationName
-              in: path
-              required: true
-              type: string
-            - name: serviceName
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-        tags:
-            - AdminService
-  /v1/organizations/{organization}/invites: |
-    get:
-        summary: ListOrganizationInvites lists all the org invites
-        operationId: AdminService_ListOrganizationInvites
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ListOrganizationInvitesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organization
-              in: path
-              required: true
-              type: string
-            - name: pageSize
-              in: query
-              required: false
-              type: integer
-              format: int64
-            - name: pageToken
-              in: query
-              required: false
-              type: string
-        tags:
-            - AdminService
-  /v1/organizations/{organization}/members: |
-    get:
-        summary: ListOrganizationMembers lists all the org members
-        operationId: AdminService_ListOrganizationMembers
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ListOrganizationMembersResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organization
-              in: path
-              required: true
-              type: string
-            - name: pageSize
-              in: query
-              required: false
-              type: integer
-              format: int64
-            - name: pageToken
-              in: query
-              required: false
-              type: string
-        tags:
-            - AdminService
-    post:
-        summary: AddOrganizationMember lists all the org members
-        operationId: AdminService_AddOrganizationMember
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1AddOrganizationMemberResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organization
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    email:
-                        type: string
-                    role:
-                        type: string
-        tags:
-            - AdminService
-  /v1/organizations/{organization}/members/current: |
+      summary: AddProjectMember adds a member to the project
+      operationId: AdminService_AddProjectMember
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1AddProjectMemberResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organization
+          in: path
+          required: true
+          type: string
+        - name: project
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              email:
+                type: string
+              role:
+                type: string
+      tags:
+        - AdminService
+  /v1/organizations/{organization}/projects/{project}/members/{email}:
     delete:
-        summary: LeaveOrganization removes the current user from the organization
-        operationId: AdminService_LeaveOrganization
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1LeaveOrganizationResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organization
-              in: path
-              required: true
-              type: string
-        tags:
-            - AdminService
-  /v1/organizations/{organization}/members/{email}: |
-    delete:
-        summary: RemoveOrganizationMember removes member from the organization
-        operationId: AdminService_RemoveOrganizationMember
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1RemoveOrganizationMemberResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organization
-              in: path
-              required: true
-              type: string
-            - name: email
-              in: path
-              required: true
-              type: string
-            - name: keepProjectRoles
-              in: query
-              required: false
-              type: boolean
-        tags:
-            - AdminService
+      summary: RemoveProjectMember removes member from the project
+      operationId: AdminService_RemoveProjectMember
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1RemoveProjectMemberResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organization
+          in: path
+          required: true
+          type: string
+        - name: project
+          in: path
+          required: true
+          type: string
+        - name: email
+          in: path
+          required: true
+          type: string
+      tags:
+        - AdminService
     put:
-        summary: SetOrganizationMemberRole sets the role for the member
-        operationId: AdminService_SetOrganizationMemberRole
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1SetOrganizationMemberRoleResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organization
-              in: path
-              required: true
-              type: string
-            - name: email
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    role:
-                        type: string
-        tags:
-            - AdminService
-  /v1/organizations/{organization}/projects/{project}/git-credentials: |
+      summary: SetProjectMemberRole sets the role for the member
+      operationId: AdminService_SetProjectMemberRole
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1SetProjectMemberRoleResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organization
+          in: path
+          required: true
+          type: string
+        - name: project
+          in: path
+          required: true
+          type: string
+        - name: email
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              role:
+                type: string
+      tags:
+        - AdminService
+  /v1/organizations/{organization}/whitelisted:
     get:
-        summary: GetGitCredentials returns credentials and other details for a project's Git repository.
-        operationId: AdminService_GetGitCredentials
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1GetGitCredentialsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organization
-              in: path
-              required: true
-              type: string
-            - name: project
-              in: path
-              required: true
-              type: string
-        tags:
-            - AdminService
-  /v1/organizations/{organization}/projects/{project}/invites: |
-    get:
-        summary: ListProjectInvites lists all the project invites
-        operationId: AdminService_ListProjectInvites
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ListProjectInvitesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organization
-              in: path
-              required: true
-              type: string
-            - name: project
-              in: path
-              required: true
-              type: string
-            - name: pageSize
-              in: query
-              required: false
-              type: integer
-              format: int64
-            - name: pageToken
-              in: query
-              required: false
-              type: string
-        tags:
-            - AdminService
-  /v1/organizations/{organization}/projects/{project}/members: |
-    get:
-        summary: ListProjectMembers lists all the project members
-        operationId: AdminService_ListProjectMembers
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ListProjectMembersResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organization
-              in: path
-              required: true
-              type: string
-            - name: project
-              in: path
-              required: true
-              type: string
-            - name: pageSize
-              in: query
-              required: false
-              type: integer
-              format: int64
-            - name: pageToken
-              in: query
-              required: false
-              type: string
-        tags:
-            - AdminService
+      summary: ListWhitelistedDomains lists all the whitelisted domains for the organization
+      operationId: AdminService_ListWhitelistedDomains
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListWhitelistedDomainsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organization
+          in: path
+          required: true
+          type: string
+      tags:
+        - AdminService
     post:
-        summary: AddProjectMember adds a member to the project
-        operationId: AdminService_AddProjectMember
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1AddProjectMemberResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organization
-              in: path
-              required: true
-              type: string
-            - name: project
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    email:
-                        type: string
-                    role:
-                        type: string
-        tags:
-            - AdminService
-  /v1/organizations/{organization}/projects/{project}/members/{email}: |
+      summary: CreateWhitelistedDomain adds a domain to the whitelist
+      operationId: AdminService_CreateWhitelistedDomain
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1CreateWhitelistedDomainResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organization
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              domain:
+                type: string
+              role:
+                type: string
+      tags:
+        - AdminService
+  /v1/organizations/{organization}/whitelisted/{domain}:
     delete:
-        summary: RemoveProjectMember removes member from the project
-        operationId: AdminService_RemoveProjectMember
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1RemoveProjectMemberResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organization
-              in: path
-              required: true
-              type: string
-            - name: project
-              in: path
-              required: true
-              type: string
-            - name: email
-              in: path
-              required: true
-              type: string
-        tags:
-            - AdminService
-    put:
-        summary: SetProjectMemberRole sets the role for the member
-        operationId: AdminService_SetProjectMemberRole
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1SetProjectMemberRoleResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organization
-              in: path
-              required: true
-              type: string
-            - name: project
-              in: path
-              required: true
-              type: string
-            - name: email
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
+      summary: RemoveWhitelistedDomain removes a domain from the whitelist list
+      operationId: AdminService_RemoveWhitelistedDomain
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1RemoveWhitelistedDomainResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organization
+          in: path
+          required: true
+          type: string
+        - name: domain
+          in: path
+          required: true
+          type: string
+      tags:
+        - AdminService
+  /v1/organizations/{organizationName}/projects:
+    get:
+      summary: ListProjectsForOrganization lists all the projects currently available for given organizations
+      operationId: AdminService_ListProjectsForOrganization
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListProjectsForOrganizationResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organizationName
+          in: path
+          required: true
+          type: string
+        - name: pageSize
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: pageToken
+          in: query
+          required: false
+          type: string
+      tags:
+        - AdminService
+    post:
+      summary: CreateProject creates a new project
+      operationId: AdminService_CreateProject
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1CreateProjectResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organizationName
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+              description:
+                type: string
+              public:
+                type: boolean
+              region:
+                type: string
+              prodOlapDriver:
+                type: string
+              prodOlapDsn:
+                type: string
+              prodSlots:
+                type: string
+                format: int64
+              subpath:
+                type: string
+              prodBranch:
+                type: string
+              githubUrl:
+                type: string
+              variables:
                 type: object
-                properties:
-                    role:
-                        type: string
-        tags:
-            - AdminService
-  /v1/organizations/{organization}/whitelisted: |
+                additionalProperties:
+                  type: string
+      tags:
+        - AdminService
+  /v1/organizations/{organizationName}/projects/{name}:
     get:
-        summary: ListWhitelistedDomains lists all the whitelisted domains for the organization
-        operationId: AdminService_ListWhitelistedDomains
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ListWhitelistedDomainsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organization
-              in: path
-              required: true
-              type: string
-        tags:
-            - AdminService
-    post:
-        summary: CreateWhitelistedDomain adds a domain to the whitelist
-        operationId: AdminService_CreateWhitelistedDomain
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1CreateWhitelistedDomainResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organization
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    domain:
-                        type: string
-                    role:
-                        type: string
-        tags:
-            - AdminService
-  /v1/organizations/{organization}/whitelisted/{domain}: |
+      summary: GetProject returns information about a specific project
+      operationId: AdminService_GetProject
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1GetProjectResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organizationName
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+      tags:
+        - AdminService
     delete:
-        summary: RemoveWhitelistedDomain removes a domain from the whitelist list
-        operationId: AdminService_RemoveWhitelistedDomain
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1RemoveWhitelistedDomainResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: organization
-              in: path
-              required: true
-              type: string
-            - name: domain
-              in: path
-              required: true
-              type: string
-        tags:
-            - AdminService
-  /v1/ping: |
-    get:
-        summary: Ping returns information about the server
-        operationId: AdminService_Ping
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1PingResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        tags:
-            - AdminService
-  /v1/projects/-/redeploy: |
-    post:
-        summary: TriggerRedeploy creates a new deployment and teardown the old deployment for production deployment
-        operationId: AdminService_TriggerRedeploy
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1TriggerRedeployResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: body
-              in: body
-              required: true
-              schema:
-                $ref: '#/definitions/v1TriggerRedeployRequest'
-        tags:
-            - AdminService
-  /v1/services/tokens/{tokenId}: |
-    delete:
-        summary: RevokeServiceAuthToken revoke the service auth token
-        operationId: AdminService_RevokeServiceAuthToken
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1RevokeServiceAuthTokenResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: tokenId
-              in: path
-              required: true
-              type: string
-        tags:
-            - AdminService
-  /v1/superuser/members: |
-    get:
-        summary: ListSuperusers lists all the superusers
-        operationId: AdminService_ListSuperusers
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ListSuperusersResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        tags:
-            - AdminService
-    post:
-        summary: SetSuperuser adds/remove a superuser
-        operationId: AdminService_SetSuperuser
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1SetSuperuserResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: body
-              in: body
-              required: true
-              schema:
-                $ref: '#/definitions/v1SetSuperuserRequest'
-        tags:
-            - AdminService
-  /v1/superuser/projects/search: |
-    get:
-        summary: SearchProjectNames returns project names matching the pattern
-        operationId: AdminService_SearchProjectNames
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1SearchProjectNamesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: namePattern
-              in: query
-              required: false
-              type: string
-            - name: pageSize
-              in: query
-              required: false
-              type: integer
-              format: int64
-            - name: pageToken
-              in: query
-              required: false
-              type: string
-        tags:
-            - AdminService
-  /v1/superuser/quotas/organization: |
+      summary: DeleteProject deletes an project
+      operationId: AdminService_DeleteProject
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1DeleteProjectResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organizationName
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+      tags:
+        - AdminService
     patch:
-        summary: SudoUpdateOrganizationQuotas update the quotas available for orgs
-        operationId: AdminService_SudoUpdateOrganizationQuotas
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1SudoUpdateOrganizationQuotasResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: body
-              in: body
-              required: true
-              schema:
-                $ref: '#/definitions/v1SudoUpdateOrganizationQuotasRequest'
-        tags:
-            - AdminService
-  /v1/superuser/quotas/user: |
-    patch:
-        summary: SudoUpdateUserQuotas update the quotas for users
-        operationId: AdminService_SudoUpdateUserQuotas
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1SudoUpdateUserQuotasResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: body
-              in: body
-              required: true
-              schema:
-                $ref: '#/definitions/v1SudoUpdateUserQuotasRequest'
-        tags:
-            - AdminService
-  /v1/superuser/resource: |
+      summary: UpdateProject updates a project
+      operationId: AdminService_UpdateProject
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1UpdateProjectResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organizationName
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              description:
+                type: string
+              public:
+                type: boolean
+              prodBranch:
+                type: string
+              githubUrl:
+                type: string
+              prodSlots:
+                type: string
+                format: int64
+              region:
+                type: string
+              newName:
+                type: string
+              prodTtlSeconds:
+                type: string
+                format: int64
+      tags:
+        - AdminService
+  /v1/organizations/{organizationName}/projects/{name}/variables:
     get:
-        summary: SudoGetResource returns details about a resource by ID lookup
-        operationId: AdminService_SudoGetResource
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1SudoGetResourceResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: userId
-              in: query
-              required: false
-              type: string
-            - name: orgId
-              in: query
-              required: false
-              type: string
-            - name: projectId
-              in: query
-              required: false
-              type: string
-            - name: deploymentId
-              in: query
-              required: false
-              type: string
-            - name: instanceId
-              in: query
-              required: false
-              type: string
-        tags:
-            - AdminService
-  /v1/tokens/current: |
-    delete:
-        summary: RevokeCurrentAuthToken revoke the current auth token
-        operationId: AdminService_RevokeCurrentAuthToken
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1RevokeCurrentAuthTokenResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        tags:
-            - AdminService
-  /v1/tokens/represent: |
-    post:
-        summary: IssueRepresentativeAuthToken returns the temporary token for given email
-        operationId: AdminService_IssueRepresentativeAuthToken
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1IssueRepresentativeAuthTokenResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: body
-              in: body
-              required: true
-              schema:
-                $ref: '#/definitions/v1IssueRepresentativeAuthTokenRequest'
-        tags:
-            - AdminService
-  /v1/users: |
-    get:
-        summary: GetUser returns user by email
-        operationId: AdminService_GetUser
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1GetUserResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: email
-              in: query
-              required: false
-              type: string
-        tags:
-            - AdminService
-  /v1/users/bookmarks: |
-    get:
-        summary: ListBookmarks lists all the bookmarks for the user
-        operationId: AdminService_ListBookmarks
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ListBookmarksResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: projectId
-              in: query
-              required: false
-              type: string
-        tags:
-            - AdminService
-    post:
-        summary: CreateBookmark creates a bookmark for the given user for the given project
-        operationId: AdminService_CreateBookmark
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1CreateBookmarkResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: body
-              in: body
-              required: true
-              schema:
-                $ref: '#/definitions/v1CreateBookmarkRequest'
-        tags:
-            - AdminService
-  /v1/users/bookmarks/{bookmarkId}: |
-    get:
-        summary: GetBookmark returns the bookmark for the given user for the given project
-        operationId: AdminService_GetBookmark
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1GetBookmarkResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: bookmarkId
-              in: path
-              required: true
-              type: string
-        tags:
-            - AdminService
-    delete:
-        summary: RemoveBookmark removes the bookmark for the given user for the given project
-        operationId: AdminService_RemoveBookmark
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1RemoveBookmarkResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: bookmarkId
-              in: path
-              required: true
-              type: string
-        tags:
-            - AdminService
-  /v1/users/current: |
-    get:
-        summary: GetCurrentUser returns the currently authenticated user (if any)
-        operationId: AdminService_GetCurrentUser
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1GetCurrentUserResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        tags:
-            - AdminService
-  /v1/users/preferences: |
+      summary: 'GetProjectVariables returns project variables. NOTE: Get project API doesn''t return variables.'
+      operationId: AdminService_GetProjectVariables
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1GetProjectVariablesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organizationName
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+      tags:
+        - AdminService
     put:
-        summary: UpdateUserPreferences updates the preferences for the user
-        operationId: AdminService_UpdateUserPreferences
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1UpdateUserPreferencesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: body
-              in: body
-              required: true
-              schema:
-                $ref: '#/definitions/v1UpdateUserPreferencesRequest'
-        tags:
-            - AdminService
-  /v1/users/search: |
+      summary: 'UpdateProjectVariables updates variables for a project. NOTE: Update project API doesn''t update variables.'
+      operationId: AdminService_UpdateProjectVariables
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1UpdateProjectVariablesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organizationName
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              variables:
+                type: object
+                additionalProperties:
+                  type: string
+      tags:
+        - AdminService
+  /v1/organizations/{organizationName}/services:
     get:
-        summary: GetUsersByEmail returns users by email
-        operationId: AdminService_SearchUsers
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1SearchUsersResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: emailPattern
-              in: query
-              required: false
-              type: string
-            - name: pageSize
-              in: query
-              required: false
-              type: integer
-              format: int64
-            - name: pageToken
-              in: query
-              required: false
-              type: string
-        tags:
-            - AdminService
+      summary: ListService returns all the services per organization
+      operationId: AdminService_ListServices
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListServicesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organizationName
+          in: path
+          required: true
+          type: string
+      tags:
+        - AdminService
+    post:
+      summary: CreateService creates a new service per organization
+      operationId: AdminService_CreateService
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1CreateServiceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organizationName
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: query
+          required: false
+          type: string
+      tags:
+        - AdminService
+  /v1/organizations/{organizationName}/services/{name}:
+    delete:
+      summary: DeleteService deletes a service per organization
+      operationId: AdminService_DeleteService
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1DeleteServiceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organizationName
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+      tags:
+        - AdminService
+    patch:
+      summary: UpdateService updates a service per organization
+      operationId: AdminService_UpdateService
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1UpdateServiceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organizationName
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              newName:
+                type: string
+      tags:
+        - AdminService
+  /v1/organizations/{organizationName}/services/{serviceName}/tokens:
+    get:
+      summary: ListServiceAuthTokens lists all the service auth tokens
+      operationId: AdminService_ListServiceAuthTokens
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListServiceAuthTokensResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organizationName
+          in: path
+          required: true
+          type: string
+        - name: serviceName
+          in: path
+          required: true
+          type: string
+      tags:
+        - AdminService
+    post:
+      summary: IssueServiceAuthToken returns the temporary token for given service account
+      operationId: AdminService_IssueServiceAuthToken
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1IssueServiceAuthTokenResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: organizationName
+          in: path
+          required: true
+          type: string
+        - name: serviceName
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+      tags:
+        - AdminService
+  /v1/ping:
+    get:
+      summary: Ping returns information about the server
+      operationId: AdminService_Ping
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1PingResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      tags:
+        - AdminService
+  /v1/projects/-/redeploy:
+    post:
+      summary: TriggerRedeploy creates a new deployment and teardown the old deployment for production deployment
+      operationId: AdminService_TriggerRedeploy
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1TriggerRedeployResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1TriggerRedeployRequest'
+      tags:
+        - AdminService
+  /v1/services/tokens/{tokenId}:
+    delete:
+      summary: RevokeServiceAuthToken revoke the service auth token
+      operationId: AdminService_RevokeServiceAuthToken
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1RevokeServiceAuthTokenResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: tokenId
+          in: path
+          required: true
+          type: string
+      tags:
+        - AdminService
+  /v1/superuser/members:
+    get:
+      summary: ListSuperusers lists all the superusers
+      operationId: AdminService_ListSuperusers
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListSuperusersResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      tags:
+        - AdminService
+    post:
+      summary: SetSuperuser adds/remove a superuser
+      operationId: AdminService_SetSuperuser
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1SetSuperuserResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1SetSuperuserRequest'
+      tags:
+        - AdminService
+  /v1/superuser/projects/search:
+    get:
+      summary: SearchProjectNames returns project names matching the pattern
+      operationId: AdminService_SearchProjectNames
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1SearchProjectNamesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: namePattern
+          in: query
+          required: false
+          type: string
+        - name: pageSize
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: pageToken
+          in: query
+          required: false
+          type: string
+      tags:
+        - AdminService
+  /v1/superuser/quotas/organization:
+    patch:
+      summary: SudoUpdateOrganizationQuotas update the quotas available for orgs
+      operationId: AdminService_SudoUpdateOrganizationQuotas
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1SudoUpdateOrganizationQuotasResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1SudoUpdateOrganizationQuotasRequest'
+      tags:
+        - AdminService
+  /v1/superuser/quotas/user:
+    patch:
+      summary: SudoUpdateUserQuotas update the quotas for users
+      operationId: AdminService_SudoUpdateUserQuotas
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1SudoUpdateUserQuotasResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1SudoUpdateUserQuotasRequest'
+      tags:
+        - AdminService
+  /v1/superuser/resource:
+    get:
+      summary: SudoGetResource returns details about a resource by ID lookup
+      operationId: AdminService_SudoGetResource
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1SudoGetResourceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: userId
+          in: query
+          required: false
+          type: string
+        - name: orgId
+          in: query
+          required: false
+          type: string
+        - name: projectId
+          in: query
+          required: false
+          type: string
+        - name: deploymentId
+          in: query
+          required: false
+          type: string
+        - name: instanceId
+          in: query
+          required: false
+          type: string
+      tags:
+        - AdminService
+  /v1/tokens/current:
+    delete:
+      summary: RevokeCurrentAuthToken revoke the current auth token
+      operationId: AdminService_RevokeCurrentAuthToken
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1RevokeCurrentAuthTokenResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      tags:
+        - AdminService
+  /v1/tokens/represent:
+    post:
+      summary: IssueRepresentativeAuthToken returns the temporary token for given email
+      operationId: AdminService_IssueRepresentativeAuthToken
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1IssueRepresentativeAuthTokenResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1IssueRepresentativeAuthTokenRequest'
+      tags:
+        - AdminService
+  /v1/users:
+    get:
+      summary: GetUser returns user by email
+      operationId: AdminService_GetUser
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1GetUserResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: email
+          in: query
+          required: false
+          type: string
+      tags:
+        - AdminService
+  /v1/users/bookmarks:
+    get:
+      summary: ListBookmarks lists all the bookmarks for the user
+      operationId: AdminService_ListBookmarks
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListBookmarksResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: projectId
+          in: query
+          required: false
+          type: string
+      tags:
+        - AdminService
+    post:
+      summary: CreateBookmark creates a bookmark for the given user for the given project
+      operationId: AdminService_CreateBookmark
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1CreateBookmarkResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1CreateBookmarkRequest'
+      tags:
+        - AdminService
+  /v1/users/bookmarks/{bookmarkId}:
+    get:
+      summary: GetBookmark returns the bookmark for the given user for the given project
+      operationId: AdminService_GetBookmark
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1GetBookmarkResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: bookmarkId
+          in: path
+          required: true
+          type: string
+      tags:
+        - AdminService
+    delete:
+      summary: RemoveBookmark removes the bookmark for the given user for the given project
+      operationId: AdminService_RemoveBookmark
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1RemoveBookmarkResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: bookmarkId
+          in: path
+          required: true
+          type: string
+      tags:
+        - AdminService
+  /v1/users/current:
+    get:
+      summary: GetCurrentUser returns the currently authenticated user (if any)
+      operationId: AdminService_GetCurrentUser
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1GetCurrentUserResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      tags:
+        - AdminService
+  /v1/users/preferences:
+    put:
+      summary: UpdateUserPreferences updates the preferences for the user
+      operationId: AdminService_UpdateUserPreferences
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1UpdateUserPreferencesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1UpdateUserPreferencesRequest'
+      tags:
+        - AdminService
+  /v1/users/search:
+    get:
+      summary: GetUsersByEmail returns users by email
+      operationId: AdminService_SearchUsers
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1SearchUsersResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: emailPattern
+          in: query
+          required: false
+          type: string
+        - name: pageSize
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: pageToken
+          in: query
+          required: false
+          type: string
+      tags:
+        - AdminService
 definitions:
   protobufAny:
     type: object

--- a/proto/gen/rill/runtime/v1/runtime.swagger.yaml
+++ b/proto/gen/rill/runtime/v1/runtime.swagger.yaml
@@ -11,2196 +11,2196 @@ consumes:
 produces:
   - application/json
 paths:
-  /v1/bigquery/datasets: |
+  /v1/bigquery/datasets:
     get:
-        summary: BigQueryListDatasets list all datasets in a bigquery project
-        operationId: ConnectorService_BigQueryListDatasets
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1BigQueryListDatasetsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: query
-              required: false
-              type: string
-            - name: connector
-              in: query
-              required: false
-              type: string
-            - name: pageSize
-              in: query
-              required: false
-              type: integer
-              format: int64
-            - name: pageToken
-              in: query
-              required: false
-              type: string
-        tags:
-            - ConnectorService
-  /v1/bigquery/tables: |
+      summary: BigQueryListDatasets list all datasets in a bigquery project
+      operationId: ConnectorService_BigQueryListDatasets
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1BigQueryListDatasetsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: query
+          required: false
+          type: string
+        - name: connector
+          in: query
+          required: false
+          type: string
+        - name: pageSize
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: pageToken
+          in: query
+          required: false
+          type: string
+      tags:
+        - ConnectorService
+  /v1/bigquery/tables:
     get:
-        summary: BigQueryListTables list all tables in a bigquery project:dataset
-        operationId: ConnectorService_BigQueryListTables
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1BigQueryListTablesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: query
-              required: false
-              type: string
-            - name: connector
-              in: query
-              required: false
-              type: string
-            - name: dataset
-              in: query
-              required: false
-              type: string
-            - name: pageSize
-              in: query
-              required: false
-              type: integer
-              format: int64
-            - name: pageToken
-              in: query
-              required: false
-              type: string
-        tags:
-            - ConnectorService
-  /v1/connectors/meta: |
+      summary: BigQueryListTables list all tables in a bigquery project:dataset
+      operationId: ConnectorService_BigQueryListTables
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1BigQueryListTablesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: query
+          required: false
+          type: string
+        - name: connector
+          in: query
+          required: false
+          type: string
+        - name: dataset
+          in: query
+          required: false
+          type: string
+        - name: pageSize
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: pageToken
+          in: query
+          required: false
+          type: string
+      tags:
+        - ConnectorService
+  /v1/connectors/meta:
     get:
-        summary: |-
-            ListConnectors returns a description of all the connectors implemented in the runtime,
-            including their schema and validation rules
-        operationId: RuntimeService_ListConnectors
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ListConnectorsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        tags:
-            - RuntimeService
-  /v1/delete-and-reconcile: |
+      summary: |-
+        ListConnectors returns a description of all the connectors implemented in the runtime,
+        including their schema and validation rules
+      operationId: RuntimeService_ListConnectors
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListConnectorsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      tags:
+        - RuntimeService
+  /v1/delete-and-reconcile:
     post:
-        summary: DeleteFileAndReconcile combines RenameFile and Reconcile in a single endpoint to reduce latency.
-        operationId: RuntimeService_DeleteFileAndReconcile
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1DeleteFileAndReconcileResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: body
-              in: body
-              required: true
-              schema:
-                $ref: '#/definitions/v1DeleteFileAndReconcileRequest'
-        tags:
-            - RuntimeService
-  /v1/dev-jwt: |
+      summary: DeleteFileAndReconcile combines RenameFile and Reconcile in a single endpoint to reduce latency.
+      operationId: RuntimeService_DeleteFileAndReconcile
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1DeleteFileAndReconcileResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1DeleteFileAndReconcileRequest'
+      tags:
+        - RuntimeService
+  /v1/dev-jwt:
     get:
-        operationId: RuntimeService_IssueDevJWT
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1IssueDevJWTResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: name
-              in: query
-              required: false
-              type: string
-            - name: email
-              in: query
-              required: false
-              type: string
-            - name: groups
-              in: query
-              required: false
-              type: array
-              items:
-                type: string
-              collectionFormat: multi
-            - name: admin
-              in: query
-              required: false
-              type: boolean
-        tags:
-            - RuntimeService
-  /v1/examples: |
+      operationId: RuntimeService_IssueDevJWT
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1IssueDevJWTResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: name
+          in: query
+          required: false
+          type: string
+        - name: email
+          in: query
+          required: false
+          type: string
+        - name: groups
+          in: query
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+        - name: admin
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - RuntimeService
+  /v1/examples:
     get:
-        summary: ListExamples lists all the examples embedded into binary
-        operationId: RuntimeService_ListExamples
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ListExamplesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        tags:
-            - RuntimeService
-  /v1/gcs/bucket/{bucket}/objects: |
+      summary: ListExamples lists all the examples embedded into binary
+      operationId: RuntimeService_ListExamples
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListExamplesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      tags:
+        - RuntimeService
+  /v1/gcs/bucket/{bucket}/objects:
     get:
-        summary: GCSListObjects lists objects for the given bucket.
-        operationId: ConnectorService_GCSListObjects
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1GCSListObjectsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: bucket
-              in: path
-              required: true
-              type: string
-            - name: instanceId
-              in: query
-              required: false
-              type: string
-            - name: connector
-              in: query
-              required: false
-              type: string
-            - name: pageSize
-              in: query
-              required: false
-              type: integer
-              format: int64
-            - name: pageToken
-              in: query
-              required: false
-              type: string
-            - name: prefix
-              in: query
-              required: false
-              type: string
-            - name: startOffset
-              in: query
-              required: false
-              type: string
-            - name: endOffset
-              in: query
-              required: false
-              type: string
-            - name: delimiter
-              in: query
-              required: false
-              type: string
-        tags:
-            - ConnectorService
-  /v1/gcs/buckets: |
+      summary: GCSListObjects lists objects for the given bucket.
+      operationId: ConnectorService_GCSListObjects
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1GCSListObjectsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: bucket
+          in: path
+          required: true
+          type: string
+        - name: instanceId
+          in: query
+          required: false
+          type: string
+        - name: connector
+          in: query
+          required: false
+          type: string
+        - name: pageSize
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: pageToken
+          in: query
+          required: false
+          type: string
+        - name: prefix
+          in: query
+          required: false
+          type: string
+        - name: startOffset
+          in: query
+          required: false
+          type: string
+        - name: endOffset
+          in: query
+          required: false
+          type: string
+        - name: delimiter
+          in: query
+          required: false
+          type: string
+      tags:
+        - ConnectorService
+  /v1/gcs/buckets:
     get:
-        summary: GCSListBuckets lists buckets accessible with the configured credentials.
-        operationId: ConnectorService_GCSListBuckets
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1GCSListBucketsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: query
-              required: false
-              type: string
-            - name: connector
-              in: query
-              required: false
-              type: string
-            - name: pageSize
-              in: query
-              required: false
-              type: integer
-              format: int64
-            - name: pageToken
-              in: query
-              required: false
-              type: string
-        tags:
-            - ConnectorService
-  /v1/gcs/credentials_info: |
+      summary: GCSListBuckets lists buckets accessible with the configured credentials.
+      operationId: ConnectorService_GCSListBuckets
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1GCSListBucketsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: query
+          required: false
+          type: string
+        - name: connector
+          in: query
+          required: false
+          type: string
+        - name: pageSize
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: pageToken
+          in: query
+          required: false
+          type: string
+      tags:
+        - ConnectorService
+  /v1/gcs/credentials_info:
     get:
-        summary: GCSGetCredentialsInfo returns metadata for the given bucket.
-        operationId: ConnectorService_GCSGetCredentialsInfo
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1GCSGetCredentialsInfoResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: query
-              required: false
-              type: string
-            - name: connector
-              in: query
-              required: false
-              type: string
-        tags:
-            - ConnectorService
-  /v1/instances: |
+      summary: GCSGetCredentialsInfo returns metadata for the given bucket.
+      operationId: ConnectorService_GCSGetCredentialsInfo
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1GCSGetCredentialsInfoResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: query
+          required: false
+          type: string
+        - name: connector
+          in: query
+          required: false
+          type: string
+      tags:
+        - ConnectorService
+  /v1/instances:
     get:
-        summary: ListInstances lists all the instances currently managed by the runtime
-        operationId: RuntimeService_ListInstances
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ListInstancesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: pageSize
-              in: query
-              required: false
-              type: integer
-              format: int64
-            - name: pageToken
-              in: query
-              required: false
-              type: string
-        tags:
-            - RuntimeService
+      summary: ListInstances lists all the instances currently managed by the runtime
+      operationId: RuntimeService_ListInstances
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListInstancesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: pageSize
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: pageToken
+          in: query
+          required: false
+          type: string
+      tags:
+        - RuntimeService
     post:
-        summary: CreateInstance creates a new instance
-        operationId: RuntimeService_CreateInstance
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1CreateInstanceResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: body
-              description: |-
-                Request message for RuntimeService.CreateInstance.
-                See message Instance for field descriptions.
-              in: body
-              required: true
-              schema:
-                $ref: '#/definitions/v1CreateInstanceRequest'
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}: |
+      summary: CreateInstance creates a new instance
+      operationId: RuntimeService_CreateInstance
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1CreateInstanceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          description: |-
+            Request message for RuntimeService.CreateInstance.
+            See message Instance for field descriptions.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1CreateInstanceRequest'
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}:
     get:
-        summary: GetInstance returns information about a specific instance
-        operationId: RuntimeService_GetInstance
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1GetInstanceResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-        tags:
-            - RuntimeService
+      summary: GetInstance returns information about a specific instance
+      operationId: RuntimeService_GetInstance
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1GetInstanceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+      tags:
+        - RuntimeService
     post:
-        summary: DeleteInstance deletes an instance
-        operationId: RuntimeService_DeleteInstance
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1DeleteInstanceResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    dropDb:
-                        type: boolean
-                title: Request message for RuntimeService.DeleteInstance
-        tags:
-            - RuntimeService
+      summary: DeleteInstance deletes an instance
+      operationId: RuntimeService_DeleteInstance
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1DeleteInstanceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              dropDb:
+                type: boolean
+            title: Request message for RuntimeService.DeleteInstance
+      tags:
+        - RuntimeService
     put:
-        summary: EditInstanceVariables edits the instance variable
-        operationId: RuntimeService_EditInstanceVariables
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1EditInstanceVariablesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
+      summary: EditInstanceVariables edits the instance variable
+      operationId: RuntimeService_EditInstanceVariables
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1EditInstanceVariablesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              variables:
                 type: object
-                properties:
-                    variables:
-                        type: object
-                        additionalProperties:
-                            type: string
-                description: Request message for RuntimeService.EditInstanceVariables.
-        tags:
-            - RuntimeService
+                additionalProperties:
+                  type: string
+            description: Request message for RuntimeService.EditInstanceVariables.
+      tags:
+        - RuntimeService
     patch:
-        summary: EditInstance edits an existing instance
-        operationId: RuntimeService_EditInstance
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1EditInstanceResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
+      summary: EditInstance edits an existing instance
+      operationId: RuntimeService_EditInstance
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1EditInstanceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              olapDriver:
+                type: string
+              repoDriver:
+                type: string
+              embedCatalog:
+                type: boolean
+              ingestionLimitBytes:
+                type: string
+                format: int64
+              connectors:
+                type: array
+                items:
+                  type: object
+                  $ref: '#/definitions/v1Connector'
+              annotations:
                 type: object
-                properties:
-                    olapDriver:
-                        type: string
-                    repoDriver:
-                        type: string
-                    embedCatalog:
-                        type: boolean
-                    ingestionLimitBytes:
-                        type: string
-                        format: int64
-                    connectors:
-                        type: array
-                        items:
-                            type: object
-                            $ref: '#/definitions/v1Connector'
-                    annotations:
-                        type: object
-                        additionalProperties:
-                            type: string
-                description: |-
-                    Request message for RuntimeService.EditInstance.
-                    See message Instance for field descriptions.
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}/annotations: |
+                additionalProperties:
+                  type: string
+            description: |-
+              Request message for RuntimeService.EditInstance.
+              See message Instance for field descriptions.
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}/annotations:
     put:
-        summary: EditInstanceAnnotations edits the instance annotations
-        operationId: RuntimeService_EditInstanceAnnotations
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1EditInstanceAnnotationsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
+      summary: EditInstanceAnnotations edits the instance annotations
+      operationId: RuntimeService_EditInstanceAnnotations
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1EditInstanceAnnotationsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              annotations:
                 type: object
-                properties:
-                    annotations:
-                        type: object
-                        additionalProperties:
-                            type: string
-                description: Request message for RuntimeService.EditInstanceAnnotations.
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}/catalog: |
+                additionalProperties:
+                  type: string
+            description: Request message for RuntimeService.EditInstanceAnnotations.
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}/catalog:
     get:
-        summary: ListCatalogEntries lists all the entries registered in an instance's catalog (like tables, sources or metrics views)
-        operationId: RuntimeService_ListCatalogEntries
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ListCatalogEntriesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: type
-              in: query
-              required: false
-              type: string
-              enum:
-                - OBJECT_TYPE_UNSPECIFIED
-                - OBJECT_TYPE_TABLE
-                - OBJECT_TYPE_SOURCE
-                - OBJECT_TYPE_MODEL
-                - OBJECT_TYPE_METRICS_VIEW
-              default: OBJECT_TYPE_UNSPECIFIED
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}/catalog/{name}: |
+      summary: ListCatalogEntries lists all the entries registered in an instance's catalog (like tables, sources or metrics views)
+      operationId: RuntimeService_ListCatalogEntries
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListCatalogEntriesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: type
+          in: query
+          required: false
+          type: string
+          enum:
+            - OBJECT_TYPE_UNSPECIFIED
+            - OBJECT_TYPE_TABLE
+            - OBJECT_TYPE_SOURCE
+            - OBJECT_TYPE_MODEL
+            - OBJECT_TYPE_METRICS_VIEW
+          default: OBJECT_TYPE_UNSPECIFIED
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}/catalog/{name}:
     get:
-        summary: GetCatalogEntry returns information about a specific entry in the catalog
-        operationId: RuntimeService_GetCatalogEntry
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1GetCatalogEntryResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: name
-              in: path
-              required: true
-              type: string
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}/catalog/{name}/refresh: |
+      summary: GetCatalogEntry returns information about a specific entry in the catalog
+      operationId: RuntimeService_GetCatalogEntry
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1GetCatalogEntryResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}/catalog/{name}/refresh:
     post:
-        summary: |-
-            TriggerRefresh triggers a refresh of a refreshable catalog object.
-            It currently only supports sources (which will be re-ingested), but will also support materialized models in the future.
-            It does not respond until the refresh has completed (will move to async jobs when the task scheduler is in place).
-        operationId: RuntimeService_TriggerRefresh
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1TriggerRefreshResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: name
-              in: path
-              required: true
-              type: string
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}/files: |
+      summary: |-
+        TriggerRefresh triggers a refresh of a refreshable catalog object.
+        It currently only supports sources (which will be re-ingested), but will also support materialized models in the future.
+        It does not respond until the refresh has completed (will move to async jobs when the task scheduler is in place).
+      operationId: RuntimeService_TriggerRefresh
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1TriggerRefreshResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: name
+          in: path
+          required: true
+          type: string
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}/files:
     get:
-        summary: |-
-            ListFiles lists all the files matching a glob in a repo.
-            The files are sorted by their full path.
-        operationId: RuntimeService_ListFiles
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ListFilesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: glob
-              in: query
-              required: false
-              type: string
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}/files/-/{path}: |
+      summary: |-
+        ListFiles lists all the files matching a glob in a repo.
+        The files are sorted by their full path.
+      operationId: RuntimeService_ListFiles
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListFilesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: glob
+          in: query
+          required: false
+          type: string
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}/files/-/{path}:
     get:
-        summary: GetFile returns the contents of a specific file in a repo.
-        operationId: RuntimeService_GetFile
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1GetFileResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: path
-              in: path
-              required: true
-              type: string
-              pattern: .+
-        tags:
-            - RuntimeService
+      summary: GetFile returns the contents of a specific file in a repo.
+      operationId: RuntimeService_GetFile
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1GetFileResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: path
+          in: path
+          required: true
+          type: string
+          pattern: .+
+      tags:
+        - RuntimeService
     delete:
-        summary: DeleteFile deletes a file from a repo
-        operationId: RuntimeService_DeleteFile
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1DeleteFileResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: path
-              in: path
-              required: true
-              type: string
-              pattern: .+
-        tags:
-            - RuntimeService
+      summary: DeleteFile deletes a file from a repo
+      operationId: RuntimeService_DeleteFile
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1DeleteFileResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: path
+          in: path
+          required: true
+          type: string
+          pattern: .+
+      tags:
+        - RuntimeService
     post:
-        summary: PutFile creates or updates a file in a repo
-        operationId: RuntimeService_PutFile
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1PutFileResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: path
-              in: path
-              required: true
-              type: string
-              pattern: .+
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    blob:
-                        type: string
-                    create:
-                        type: boolean
-                        title: Create indicates whether to create the file if it doesn't already exist
-                    createOnly:
-                        type: boolean
-                        description: |-
-                            Will cause the operation to fail if the file already exists.
-                            It should only be set when create = true.
-                title: Request message for RuntimeService.PutFile
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}/files/rename: |
+      summary: PutFile creates or updates a file in a repo
+      operationId: RuntimeService_PutFile
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1PutFileResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: path
+          in: path
+          required: true
+          type: string
+          pattern: .+
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              blob:
+                type: string
+              create:
+                type: boolean
+                title: Create indicates whether to create the file if it doesn't already exist
+              createOnly:
+                type: boolean
+                description: |-
+                  Will cause the operation to fail if the file already exists.
+                  It should only be set when create = true.
+            title: Request message for RuntimeService.PutFile
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}/files/rename:
     post:
-        summary: RenameFile renames a file in a repo
-        operationId: RuntimeService_RenameFile
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1RenameFileResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    fromPath:
-                        type: string
-                    toPath:
-                        type: string
-                title: Request message for RuntimeService.RenameFile
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}/files/unpack-empty: |
+      summary: RenameFile renames a file in a repo
+      operationId: RuntimeService_RenameFile
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1RenameFileResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              fromPath:
+                type: string
+              toPath:
+                type: string
+            title: Request message for RuntimeService.RenameFile
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}/files/unpack-empty:
     post:
-        summary: UnpackEmpty unpacks an empty project
-        operationId: RuntimeService_UnpackEmpty
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1UnpackEmptyResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    title:
-                        type: string
-                    force:
-                        type: boolean
-                title: Request message for RuntimeService.UnpackEmpty
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}/files/unpack-example: |
+      summary: UnpackEmpty unpacks an empty project
+      operationId: RuntimeService_UnpackEmpty
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1UnpackEmptyResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              title:
+                type: string
+              force:
+                type: boolean
+            title: Request message for RuntimeService.UnpackEmpty
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}/files/unpack-example:
     post:
-        summary: UnpackExample unpacks an example project
-        operationId: RuntimeService_UnpackExample
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1UnpackExampleResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    name:
-                        type: string
-                    force:
-                        type: boolean
-                title: Request message for RuntimeService.UnpackExample
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}/files/watch: |
+      summary: UnpackExample unpacks an example project
+      operationId: RuntimeService_UnpackExample
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1UnpackExampleResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+              force:
+                type: boolean
+            title: Request message for RuntimeService.UnpackExample
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}/files/watch:
     get:
-        summary: WatchFiles streams repo file update events. It is not supported on all backends.
-        operationId: RuntimeService_WatchFiles
-        responses:
-            "200":
-                description: A successful response.(streaming responses)
-                schema:
-                    type: object
-                    properties:
-                        result:
-                            $ref: '#/definitions/v1WatchFilesResponse'
-                        error:
-                            $ref: '#/definitions/rpcStatus'
-                    title: Stream result of v1WatchFilesResponse
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: replay
-              in: query
-              required: false
-              type: boolean
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}/logs: |
+      summary: WatchFiles streams repo file update events. It is not supported on all backends.
+      operationId: RuntimeService_WatchFiles
+      responses:
+        "200":
+          description: A successful response.(streaming responses)
+          schema:
+            type: object
+            properties:
+              result:
+                $ref: '#/definitions/v1WatchFilesResponse'
+              error:
+                $ref: '#/definitions/rpcStatus'
+            title: Stream result of v1WatchFilesResponse
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: replay
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}/logs:
     get:
-        summary: GetLogs returns recent logs from a controller
-        operationId: RuntimeService_GetLogs
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1GetLogsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: ascending
-              in: query
-              required: false
-              type: boolean
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}/logs/watch: |
+      summary: GetLogs returns recent logs from a controller
+      operationId: RuntimeService_GetLogs
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1GetLogsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: ascending
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}/logs/watch:
     get:
-        summary: WatchLogs streams new logs emitted from a controller
-        operationId: RuntimeService_WatchLogs
-        responses:
-            "200":
-                description: A successful response.(streaming responses)
-                schema:
-                    type: object
-                    properties:
-                        result:
-                            $ref: '#/definitions/v1WatchLogsResponse'
-                        error:
-                            $ref: '#/definitions/rpcStatus'
-                    title: Stream result of v1WatchLogsResponse
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: replay
-              in: query
-              required: false
-              type: boolean
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}/queries/column-cardinality/tables/{tableName}: |
+      summary: WatchLogs streams new logs emitted from a controller
+      operationId: RuntimeService_WatchLogs
+      responses:
+        "200":
+          description: A successful response.(streaming responses)
+          schema:
+            type: object
+            properties:
+              result:
+                $ref: '#/definitions/v1WatchLogsResponse'
+              error:
+                $ref: '#/definitions/rpcStatus'
+            title: Stream result of v1WatchLogsResponse
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: replay
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}/queries/column-cardinality/tables/{tableName}:
     get:
-        summary: Get cardinality for a column
-        operationId: QueryService_ColumnCardinality
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ColumnCardinalityResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: tableName
-              in: path
-              required: true
-              type: string
-            - name: columnName
-              in: query
-              required: false
-              type: string
-            - name: priority
-              in: query
-              required: false
-              type: integer
-              format: int32
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/columns-profile/tables/{tableName}: |
+      summary: Get cardinality for a column
+      operationId: QueryService_ColumnCardinality
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ColumnCardinalityResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: tableName
+          in: path
+          required: true
+          type: string
+        - name: columnName
+          in: query
+          required: false
+          type: string
+        - name: priority
+          in: query
+          required: false
+          type: integer
+          format: int32
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/columns-profile/tables/{tableName}:
     post:
-        summary: TableColumns returns column profiles
-        operationId: QueryService_TableColumns
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1TableColumnsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: tableName
-              in: path
-              required: true
-              type: string
-            - name: priority
-              in: query
-              required: false
-              type: integer
-              format: int32
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/descriptive-statistics/tables/{tableName}: |
+      summary: TableColumns returns column profiles
+      operationId: QueryService_TableColumns
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1TableColumnsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: tableName
+          in: path
+          required: true
+          type: string
+        - name: priority
+          in: query
+          required: false
+          type: integer
+          format: int32
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/descriptive-statistics/tables/{tableName}:
     get:
-        summary: Get basic stats for a numeric column like min, max, mean, stddev, etc
-        operationId: QueryService_ColumnDescriptiveStatistics
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ColumnDescriptiveStatisticsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: tableName
-              in: path
-              required: true
-              type: string
-            - name: columnName
-              in: query
-              required: false
-              type: string
-            - name: priority
-              in: query
-              required: false
-              type: integer
-              format: int32
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/export: |
+      summary: Get basic stats for a numeric column like min, max, mean, stddev, etc
+      operationId: QueryService_ColumnDescriptiveStatistics
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ColumnDescriptiveStatisticsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: tableName
+          in: path
+          required: true
+          type: string
+        - name: columnName
+          in: query
+          required: false
+          type: string
+        - name: priority
+          in: query
+          required: false
+          type: integer
+          format: int32
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/export:
     post:
-        summary: Export builds a URL to download the results of a query as a file.
-        operationId: QueryService_Export
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ExportResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    limit:
-                        type: string
-                        format: int64
-                    format:
-                        $ref: '#/definitions/v1ExportFormat'
-                    metricsViewToplistRequest:
-                        $ref: '#/definitions/v1MetricsViewToplistRequest'
-                    metricsViewRowsRequest:
-                        $ref: '#/definitions/v1MetricsViewRowsRequest'
-                    metricsViewTimeSeriesRequest:
-                        $ref: '#/definitions/v1MetricsViewTimeSeriesRequest'
-                title: Request message for QueryService.Export
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/metrics-views/{metricsViewName}/compare-toplist: |
+      summary: Export builds a URL to download the results of a query as a file.
+      operationId: QueryService_Export
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ExportResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              limit:
+                type: string
+                format: int64
+              format:
+                $ref: '#/definitions/v1ExportFormat'
+              metricsViewToplistRequest:
+                $ref: '#/definitions/v1MetricsViewToplistRequest'
+              metricsViewRowsRequest:
+                $ref: '#/definitions/v1MetricsViewRowsRequest'
+              metricsViewTimeSeriesRequest:
+                $ref: '#/definitions/v1MetricsViewTimeSeriesRequest'
+            title: Request message for QueryService.Export
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/metrics-views/{metricsViewName}/compare-toplist:
     post:
-        operationId: QueryService_MetricsViewComparisonToplist
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1MetricsViewComparisonToplistResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: metricsViewName
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    dimensionName:
-                        type: string
-                    measureNames:
-                        type: array
-                        items:
-                            type: string
-                    inlineMeasures:
-                        type: array
-                        items:
-                            type: object
-                            $ref: '#/definitions/v1InlineMeasure'
-                    baseTimeRange:
-                        $ref: '#/definitions/v1TimeRange'
-                    comparisonTimeRange:
-                        $ref: '#/definitions/v1TimeRange'
-                    sort:
-                        type: array
-                        items:
-                            type: object
-                            $ref: '#/definitions/v1MetricsViewComparisonSort'
-                    filter:
-                        $ref: '#/definitions/v1MetricsViewFilter'
-                    limit:
-                        type: string
-                        format: int64
-                    offset:
-                        type: string
-                        format: int64
-                    priority:
-                        type: integer
-                        format: int32
-                title: Request message for QueryService.MetricsViewComparisonToplist
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/metrics-views/{metricsViewName}/rows: |
+      operationId: QueryService_MetricsViewComparisonToplist
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1MetricsViewComparisonToplistResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: metricsViewName
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              dimensionName:
+                type: string
+              measureNames:
+                type: array
+                items:
+                  type: string
+              inlineMeasures:
+                type: array
+                items:
+                  type: object
+                  $ref: '#/definitions/v1InlineMeasure'
+              baseTimeRange:
+                $ref: '#/definitions/v1TimeRange'
+              comparisonTimeRange:
+                $ref: '#/definitions/v1TimeRange'
+              sort:
+                type: array
+                items:
+                  type: object
+                  $ref: '#/definitions/v1MetricsViewComparisonSort'
+              filter:
+                $ref: '#/definitions/v1MetricsViewFilter'
+              limit:
+                type: string
+                format: int64
+              offset:
+                type: string
+                format: int64
+              priority:
+                type: integer
+                format: int32
+            title: Request message for QueryService.MetricsViewComparisonToplist
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/metrics-views/{metricsViewName}/rows:
     post:
-        summary: MetricsViewRows returns the underlying model rows matching a metrics view time range and filter(s).
-        operationId: QueryService_MetricsViewRows
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1MetricsViewRowsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: metricsViewName
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    timeStart:
-                        type: string
-                        format: date-time
-                    timeEnd:
-                        type: string
-                        format: date-time
-                    timeGranularity:
-                        $ref: '#/definitions/v1TimeGrain'
-                    filter:
-                        $ref: '#/definitions/v1MetricsViewFilter'
-                    sort:
-                        type: array
-                        items:
-                            type: object
-                            $ref: '#/definitions/v1MetricsViewSort'
-                    limit:
-                        type: integer
-                        format: int32
-                    offset:
-                        type: string
-                        format: int64
-                    priority:
-                        type: integer
-                        format: int32
-                    timeZone:
-                        type: string
-                title: Request message for QueryService.MetricsViewRows
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/metrics-views/{metricsViewName}/time-range-summary: |
+      summary: MetricsViewRows returns the underlying model rows matching a metrics view time range and filter(s).
+      operationId: QueryService_MetricsViewRows
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1MetricsViewRowsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: metricsViewName
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              timeStart:
+                type: string
+                format: date-time
+              timeEnd:
+                type: string
+                format: date-time
+              timeGranularity:
+                $ref: '#/definitions/v1TimeGrain'
+              filter:
+                $ref: '#/definitions/v1MetricsViewFilter'
+              sort:
+                type: array
+                items:
+                  type: object
+                  $ref: '#/definitions/v1MetricsViewSort'
+              limit:
+                type: integer
+                format: int32
+              offset:
+                type: string
+                format: int64
+              priority:
+                type: integer
+                format: int32
+              timeZone:
+                type: string
+            title: Request message for QueryService.MetricsViewRows
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/metrics-views/{metricsViewName}/time-range-summary:
     post:
-        summary: MetricsViewTimeRange Get the time range summaries (min, max) for time column in a metrics view
-        operationId: QueryService_MetricsViewTimeRange
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1MetricsViewTimeRangeResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: metricsViewName
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    priority:
-                        type: integer
-                        format: int32
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/metrics-views/{metricsViewName}/timeseries: |
+      summary: MetricsViewTimeRange Get the time range summaries (min, max) for time column in a metrics view
+      operationId: QueryService_MetricsViewTimeRange
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1MetricsViewTimeRangeResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: metricsViewName
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              priority:
+                type: integer
+                format: int32
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/metrics-views/{metricsViewName}/timeseries:
     post:
-        summary: |-
-            MetricsViewTimeSeries returns time series for the measures in the metrics view.
-            It's a convenience API for querying a metrics view.
-        operationId: QueryService_MetricsViewTimeSeries
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1MetricsViewTimeSeriesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: metricsViewName
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    measureNames:
-                        type: array
-                        items:
-                            type: string
-                    inlineMeasures:
-                        type: array
-                        items:
-                            type: object
-                            $ref: '#/definitions/v1InlineMeasure'
-                    timeStart:
-                        type: string
-                        format: date-time
-                    timeEnd:
-                        type: string
-                        format: date-time
-                    timeGranularity:
-                        $ref: '#/definitions/v1TimeGrain'
-                    filter:
-                        $ref: '#/definitions/v1MetricsViewFilter'
-                    timeZone:
-                        type: string
-                    priority:
-                        type: integer
-                        format: int32
-                title: Request message for QueryService.MetricsViewTimeSeries
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/metrics-views/{metricsViewName}/toplist: |
+      summary: |-
+        MetricsViewTimeSeries returns time series for the measures in the metrics view.
+        It's a convenience API for querying a metrics view.
+      operationId: QueryService_MetricsViewTimeSeries
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1MetricsViewTimeSeriesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: metricsViewName
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              measureNames:
+                type: array
+                items:
+                  type: string
+              inlineMeasures:
+                type: array
+                items:
+                  type: object
+                  $ref: '#/definitions/v1InlineMeasure'
+              timeStart:
+                type: string
+                format: date-time
+              timeEnd:
+                type: string
+                format: date-time
+              timeGranularity:
+                $ref: '#/definitions/v1TimeGrain'
+              filter:
+                $ref: '#/definitions/v1MetricsViewFilter'
+              timeZone:
+                type: string
+              priority:
+                type: integer
+                format: int32
+            title: Request message for QueryService.MetricsViewTimeSeries
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/metrics-views/{metricsViewName}/toplist:
     post:
-        summary: |-
-            MetricsViewToplist returns the top dimension values of a metrics view sorted by one or more measures.
-            It's a convenience API for querying a metrics view.
-        operationId: QueryService_MetricsViewToplist
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1MetricsViewToplistResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: metricsViewName
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    dimensionName:
-                        type: string
-                    measureNames:
-                        type: array
-                        items:
-                            type: string
-                    inlineMeasures:
-                        type: array
-                        items:
-                            type: object
-                            $ref: '#/definitions/v1InlineMeasure'
-                    timeStart:
-                        type: string
-                        format: date-time
-                    timeEnd:
-                        type: string
-                        format: date-time
-                    limit:
-                        type: string
-                        format: int64
-                    offset:
-                        type: string
-                        format: int64
-                    sort:
-                        type: array
-                        items:
-                            type: object
-                            $ref: '#/definitions/v1MetricsViewSort'
-                    filter:
-                        $ref: '#/definitions/v1MetricsViewFilter'
-                    priority:
-                        type: integer
-                        format: int32
-                title: Request message for QueryService.MetricsViewToplist
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/metrics-views/{metricsViewName}/totals: |
+      summary: |-
+        MetricsViewToplist returns the top dimension values of a metrics view sorted by one or more measures.
+        It's a convenience API for querying a metrics view.
+      operationId: QueryService_MetricsViewToplist
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1MetricsViewToplistResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: metricsViewName
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              dimensionName:
+                type: string
+              measureNames:
+                type: array
+                items:
+                  type: string
+              inlineMeasures:
+                type: array
+                items:
+                  type: object
+                  $ref: '#/definitions/v1InlineMeasure'
+              timeStart:
+                type: string
+                format: date-time
+              timeEnd:
+                type: string
+                format: date-time
+              limit:
+                type: string
+                format: int64
+              offset:
+                type: string
+                format: int64
+              sort:
+                type: array
+                items:
+                  type: object
+                  $ref: '#/definitions/v1MetricsViewSort'
+              filter:
+                $ref: '#/definitions/v1MetricsViewFilter'
+              priority:
+                type: integer
+                format: int32
+            title: Request message for QueryService.MetricsViewToplist
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/metrics-views/{metricsViewName}/totals:
     post:
-        summary: |-
-            MetricsViewTotals returns totals over a time period for the measures in a metrics view.
-            It's a convenience API for querying a metrics view.
-        operationId: QueryService_MetricsViewTotals
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1MetricsViewTotalsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: metricsViewName
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    measureNames:
-                        type: array
-                        items:
-                            type: string
-                    inlineMeasures:
-                        type: array
-                        items:
-                            type: object
-                            $ref: '#/definitions/v1InlineMeasure'
-                    timeStart:
-                        type: string
-                        format: date-time
-                    timeEnd:
-                        type: string
-                        format: date-time
-                    filter:
-                        $ref: '#/definitions/v1MetricsViewFilter'
-                    priority:
-                        type: integer
-                        format: int32
-                title: Request message for QueryService.MetricsViewTotals
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/null-count/tables/{tableName}: |
+      summary: |-
+        MetricsViewTotals returns totals over a time period for the measures in a metrics view.
+        It's a convenience API for querying a metrics view.
+      operationId: QueryService_MetricsViewTotals
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1MetricsViewTotalsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: metricsViewName
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              measureNames:
+                type: array
+                items:
+                  type: string
+              inlineMeasures:
+                type: array
+                items:
+                  type: object
+                  $ref: '#/definitions/v1InlineMeasure'
+              timeStart:
+                type: string
+                format: date-time
+              timeEnd:
+                type: string
+                format: date-time
+              filter:
+                $ref: '#/definitions/v1MetricsViewFilter'
+              priority:
+                type: integer
+                format: int32
+            title: Request message for QueryService.MetricsViewTotals
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/null-count/tables/{tableName}:
     get:
-        summary: Get the number of nulls in a column
-        operationId: QueryService_ColumnNullCount
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ColumnNullCountResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: tableName
-              in: path
-              required: true
-              type: string
-            - name: columnName
-              in: query
-              required: false
-              type: string
-            - name: priority
-              in: query
-              required: false
-              type: integer
-              format: int32
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/numeric-histogram/tables/{tableName}: |
+      summary: Get the number of nulls in a column
+      operationId: QueryService_ColumnNullCount
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ColumnNullCountResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: tableName
+          in: path
+          required: true
+          type: string
+        - name: columnName
+          in: query
+          required: false
+          type: string
+        - name: priority
+          in: query
+          required: false
+          type: integer
+          format: int32
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/numeric-histogram/tables/{tableName}:
     get:
-        summary: Get the histogram for values in a column
-        operationId: QueryService_ColumnNumericHistogram
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ColumnNumericHistogramResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: tableName
-              in: path
-              required: true
-              type: string
-            - name: columnName
-              in: query
-              required: false
-              type: string
-            - name: histogramMethod
-              in: query
-              required: false
-              type: string
-              enum:
-                - HISTOGRAM_METHOD_UNSPECIFIED
-                - HISTOGRAM_METHOD_FD
-                - HISTOGRAM_METHOD_DIAGNOSTIC
-              default: HISTOGRAM_METHOD_UNSPECIFIED
-            - name: priority
-              in: query
-              required: false
-              type: integer
-              format: int32
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/rollup-interval/tables/{tableName}: |
+      summary: Get the histogram for values in a column
+      operationId: QueryService_ColumnNumericHistogram
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ColumnNumericHistogramResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: tableName
+          in: path
+          required: true
+          type: string
+        - name: columnName
+          in: query
+          required: false
+          type: string
+        - name: histogramMethod
+          in: query
+          required: false
+          type: string
+          enum:
+            - HISTOGRAM_METHOD_UNSPECIFIED
+            - HISTOGRAM_METHOD_FD
+            - HISTOGRAM_METHOD_DIAGNOSTIC
+          default: HISTOGRAM_METHOD_UNSPECIFIED
+        - name: priority
+          in: query
+          required: false
+          type: integer
+          format: int32
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/rollup-interval/tables/{tableName}:
     post:
-        summary: ColumnRollupInterval returns the minimum time granularity (as well as the time range) for a specified timestamp column
-        operationId: QueryService_ColumnRollupInterval
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ColumnRollupIntervalResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: tableName
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    columnName:
-                        type: string
-                    priority:
-                        type: integer
-                        format: int32
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/rows/tables/{tableName}: |
+      summary: ColumnRollupInterval returns the minimum time granularity (as well as the time range) for a specified timestamp column
+      operationId: QueryService_ColumnRollupInterval
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ColumnRollupIntervalResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: tableName
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              columnName:
+                type: string
+              priority:
+                type: integer
+                format: int32
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/rows/tables/{tableName}:
     get:
-        summary: TableRows returns table rows
-        operationId: QueryService_TableRows
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1TableRowsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: tableName
-              in: path
-              required: true
-              type: string
-            - name: limit
-              in: query
-              required: false
-              type: integer
-              format: int32
-            - name: priority
-              in: query
-              required: false
-              type: integer
-              format: int32
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/rug-histogram/tables/{tableName}: |
+      summary: TableRows returns table rows
+      operationId: QueryService_TableRows
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1TableRowsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: tableName
+          in: path
+          required: true
+          type: string
+        - name: limit
+          in: query
+          required: false
+          type: integer
+          format: int32
+        - name: priority
+          in: query
+          required: false
+          type: integer
+          format: int32
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/rug-histogram/tables/{tableName}:
     get:
-        summary: Get outliers for a numeric column
-        operationId: QueryService_ColumnRugHistogram
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ColumnRugHistogramResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: tableName
-              in: path
-              required: true
-              type: string
-            - name: columnName
-              in: query
-              required: false
-              type: string
-            - name: priority
-              in: query
-              required: false
-              type: integer
-              format: int32
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/smallest-time-grain/tables/{tableName}: |
+      summary: Get outliers for a numeric column
+      operationId: QueryService_ColumnRugHistogram
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ColumnRugHistogramResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: tableName
+          in: path
+          required: true
+          type: string
+        - name: columnName
+          in: query
+          required: false
+          type: string
+        - name: priority
+          in: query
+          required: false
+          type: integer
+          format: int32
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/smallest-time-grain/tables/{tableName}:
     get:
-        summary: Estimates the smallest time grain present in the column
-        operationId: QueryService_ColumnTimeGrain
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ColumnTimeGrainResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: tableName
-              in: path
-              required: true
-              type: string
-            - name: columnName
-              in: query
-              required: false
-              type: string
-            - name: priority
-              in: query
-              required: false
-              type: integer
-              format: int32
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/table-cardinality/tables/{tableName}: |
+      summary: Estimates the smallest time grain present in the column
+      operationId: QueryService_ColumnTimeGrain
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ColumnTimeGrainResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: tableName
+          in: path
+          required: true
+          type: string
+        - name: columnName
+          in: query
+          required: false
+          type: string
+        - name: priority
+          in: query
+          required: false
+          type: integer
+          format: int32
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/table-cardinality/tables/{tableName}:
     get:
-        summary: TableCardinality returns row count
-        operationId: QueryService_TableCardinality
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1TableCardinalityResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: tableName
-              in: path
-              required: true
-              type: string
-            - name: priority
-              in: query
-              required: false
-              type: integer
-              format: int32
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/time-range-summary/tables/{tableName}: |
+      summary: TableCardinality returns row count
+      operationId: QueryService_TableCardinality
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1TableCardinalityResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: tableName
+          in: path
+          required: true
+          type: string
+        - name: priority
+          in: query
+          required: false
+          type: integer
+          format: int32
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/time-range-summary/tables/{tableName}:
     get:
-        summary: Get the time range summaries (min, max) for a column
-        operationId: QueryService_ColumnTimeRange
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ColumnTimeRangeResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: tableName
-              in: path
-              required: true
-              type: string
-            - name: columnName
-              in: query
-              required: false
-              type: string
-            - name: priority
-              in: query
-              required: false
-              type: integer
-              format: int32
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/timeseries/tables/{tableName}: |
+      summary: Get the time range summaries (min, max) for a column
+      operationId: QueryService_ColumnTimeRange
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ColumnTimeRangeResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: tableName
+          in: path
+          required: true
+          type: string
+        - name: columnName
+          in: query
+          required: false
+          type: string
+        - name: priority
+          in: query
+          required: false
+          type: integer
+          format: int32
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/timeseries/tables/{tableName}:
     post:
-        summary: Generate time series for the given measures (aggregation expressions) along with the sparkline timeseries
-        operationId: QueryService_ColumnTimeSeries
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ColumnTimeSeriesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: tableName
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    measures:
-                        type: array
-                        items:
-                            type: object
-                            $ref: '#/definitions/ColumnTimeSeriesRequestBasicMeasure'
-                    timestampColumnName:
-                        type: string
-                    timeRange:
-                        $ref: '#/definitions/v1TimeSeriesTimeRange'
-                    pixels:
-                        type: integer
-                        format: int32
-                    sampleSize:
-                        type: integer
-                        format: int32
-                    priority:
-                        type: integer
-                        format: int32
-                    timeZone:
-                        type: string
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/queries/topk/tables/{tableName}: |
+      summary: Generate time series for the given measures (aggregation expressions) along with the sparkline timeseries
+      operationId: QueryService_ColumnTimeSeries
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ColumnTimeSeriesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: tableName
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              measures:
+                type: array
+                items:
+                  type: object
+                  $ref: '#/definitions/ColumnTimeSeriesRequestBasicMeasure'
+              timestampColumnName:
+                type: string
+              timeRange:
+                $ref: '#/definitions/v1TimeSeriesTimeRange'
+              pixels:
+                type: integer
+                format: int32
+              sampleSize:
+                type: integer
+                format: int32
+              priority:
+                type: integer
+                format: int32
+              timeZone:
+                type: string
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/queries/topk/tables/{tableName}:
     post:
-        summary: |-
-            Get TopK elements from a table for a column given an agg function
-            agg function and k are optional, defaults are count(*) and 50 respectively
-        operationId: QueryService_ColumnTopK
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ColumnTopKResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: tableName
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    columnName:
-                        type: string
-                    agg:
-                        type: string
-                        title: default is count(*)
-                    k:
-                        type: integer
-                        format: int32
-                        title: default is 50
-                    priority:
-                        type: integer
-                        format: int32
-                description: Request for QueryService.ColumnTopK. Returns the top K values for a given column using agg function for table table_name.
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/query: |
+      summary: |-
+        Get TopK elements from a table for a column given an agg function
+        agg function and k are optional, defaults are count(*) and 50 respectively
+      operationId: QueryService_ColumnTopK
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ColumnTopKResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: tableName
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              columnName:
+                type: string
+              agg:
+                type: string
+                title: default is count(*)
+              k:
+                type: integer
+                format: int32
+                title: default is 50
+              priority:
+                type: integer
+                format: int32
+            description: Request for QueryService.ColumnTopK. Returns the top K values for a given column using agg function for table table_name.
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/query:
     post:
-        summary: Query runs a SQL query against the instance's OLAP datastore.
-        operationId: QueryService_Query
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1QueryResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              description: Instance to query
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    sql:
-                        type: string
-                        title: SELECT statement
-                    args:
-                        type: array
-                        items: {}
-                        title: Args to interpolate into the statement
-                    priority:
-                        type: integer
-                        format: int32
-                        title: Query priority (not supported by all backends)
-                    dryRun:
-                        type: boolean
-                        title: If true, will only validate the query, not execute it
-                    limit:
-                        type: integer
-                        format: int32
-                title: Request message for QueryService.Query
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/query/batch: |
+      summary: Query runs a SQL query against the instance's OLAP datastore.
+      operationId: QueryService_Query
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1QueryResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          description: Instance to query
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              sql:
+                type: string
+                title: SELECT statement
+              args:
+                type: array
+                items: {}
+                title: Args to interpolate into the statement
+              priority:
+                type: integer
+                format: int32
+                title: Query priority (not supported by all backends)
+              dryRun:
+                type: boolean
+                title: If true, will only validate the query, not execute it
+              limit:
+                type: integer
+                format: int32
+            title: Request message for QueryService.Query
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/query/batch:
     post:
-        summary: Batch request with different queries
-        operationId: QueryService_QueryBatch
-        responses:
-            "200":
-                description: A successful response.(streaming responses)
-                schema:
-                    type: object
-                    properties:
-                        result:
-                            $ref: '#/definitions/v1QueryBatchResponse'
-                        error:
-                            $ref: '#/definitions/rpcStatus'
-                    title: Stream result of v1QueryBatchResponse
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    queries:
-                        type: array
-                        items:
-                            type: object
-                            $ref: '#/definitions/v1QueryBatchEntry'
-        tags:
-            - QueryService
-  /v1/instances/{instanceId}/reconcile: |
+      summary: Batch request with different queries
+      operationId: QueryService_QueryBatch
+      responses:
+        "200":
+          description: A successful response.(streaming responses)
+          schema:
+            type: object
+            properties:
+              result:
+                $ref: '#/definitions/v1QueryBatchResponse'
+              error:
+                $ref: '#/definitions/rpcStatus'
+            title: Stream result of v1QueryBatchResponse
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              queries:
+                type: array
+                items:
+                  type: object
+                  $ref: '#/definitions/v1QueryBatchEntry'
+      tags:
+        - QueryService
+  /v1/instances/{instanceId}/reconcile:
     post:
-        summary: |-
-            Reconcile applies a full set of artifacts from a repo to the catalog and infra.
-            It attempts to infer a minimal number of migrations to apply to reconcile the current state with
-            the desired state expressed in the artifacts. Any existing objects not described in the submitted
-            artifacts will be deleted.
-        operationId: RuntimeService_Reconcile
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ReconcileResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              description: Instance to reconcile
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    changedPaths:
-                        type: array
-                        items:
-                            type: string
-                        description: |-
-                            Changed paths provides a way to "hint" what files have changed in the repo, enabling
-                            reconciliation to execute faster by not scanning all code artifacts for changes.
-                    forcedPaths:
-                        type: array
-                        items:
-                            type: string
-                        description: |-
-                            Forced paths is used to force run reconcile on certain files.
-                            This is mainly used by UI to reconcile paths missing in catalog and get errors if any.
-                    dry:
-                        type: boolean
-                        title: If true, will validate the file artifacts, but not actually execute any migrations
-                    strict:
-                        type: boolean
-                        title: |-
-                            If true, will not execute any migrations if any artifact fails to validate.
-                            Otherwise, it will execute a best-effort reconciliation (including dropping objects with
-                            artifacts that fail to validate.)
-                title: Request message for RuntimeService.Reconcile
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}/resource: |
+      summary: |-
+        Reconcile applies a full set of artifacts from a repo to the catalog and infra.
+        It attempts to infer a minimal number of migrations to apply to reconcile the current state with
+        the desired state expressed in the artifacts. Any existing objects not described in the submitted
+        artifacts will be deleted.
+      operationId: RuntimeService_Reconcile
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ReconcileResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          description: Instance to reconcile
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              changedPaths:
+                type: array
+                items:
+                  type: string
+                description: |-
+                  Changed paths provides a way to "hint" what files have changed in the repo, enabling
+                  reconciliation to execute faster by not scanning all code artifacts for changes.
+              forcedPaths:
+                type: array
+                items:
+                  type: string
+                description: |-
+                  Forced paths is used to force run reconcile on certain files.
+                  This is mainly used by UI to reconcile paths missing in catalog and get errors if any.
+              dry:
+                type: boolean
+                title: If true, will validate the file artifacts, but not actually execute any migrations
+              strict:
+                type: boolean
+                title: |-
+                  If true, will not execute any migrations if any artifact fails to validate.
+                  Otherwise, it will execute a best-effort reconciliation (including dropping objects with
+                  artifacts that fail to validate.)
+            title: Request message for RuntimeService.Reconcile
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}/resource:
     get:
-        summary: GetResource looks up a specific catalog resource
-        operationId: RuntimeService_GetResource
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1GetResourceResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: name.kind
-              in: query
-              required: false
-              type: string
-            - name: name.name
-              in: query
-              required: false
-              type: string
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}/resources: |
+      summary: GetResource looks up a specific catalog resource
+      operationId: RuntimeService_GetResource
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1GetResourceResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: name.kind
+          in: query
+          required: false
+          type: string
+        - name: name.name
+          in: query
+          required: false
+          type: string
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}/resources:
     get:
-        summary: ListResources lists the resources stored in the catalog
-        operationId: RuntimeService_ListResources
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1ListResourcesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: kind
-              in: query
-              required: false
-              type: string
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}/resources/-/watch: |
+      summary: ListResources lists the resources stored in the catalog
+      operationId: RuntimeService_ListResources
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListResourcesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: kind
+          in: query
+          required: false
+          type: string
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}/resources/-/watch:
     get:
-        summary: WatchResources streams updates to catalog resources (including creation and deletion events)
-        operationId: RuntimeService_WatchResources
-        responses:
-            "200":
-                description: A successful response.(streaming responses)
-                schema:
-                    type: object
-                    properties:
-                        result:
-                            $ref: '#/definitions/v1WatchResourcesResponse'
-                        error:
-                            $ref: '#/definitions/rpcStatus'
-                    title: Stream result of v1WatchResourcesResponse
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: kind
-              in: query
-              required: false
-              type: string
-            - name: replay
-              in: query
-              required: false
-              type: boolean
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}/sync: |
+      summary: WatchResources streams updates to catalog resources (including creation and deletion events)
+      operationId: RuntimeService_WatchResources
+      responses:
+        "200":
+          description: A successful response.(streaming responses)
+          schema:
+            type: object
+            properties:
+              result:
+                $ref: '#/definitions/v1WatchResourcesResponse'
+              error:
+                $ref: '#/definitions/rpcStatus'
+            title: Stream result of v1WatchResourcesResponse
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: kind
+          in: query
+          required: false
+          type: string
+        - name: replay
+          in: query
+          required: false
+          type: boolean
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}/sync:
     post:
-        summary: |-
-            TriggerSync syncronizes the instance's catalog with the underlying OLAP's information schema.
-            If the instance has exposed=true, tables found in the information schema will be added to the catalog.
-        operationId: RuntimeService_TriggerSync
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1TriggerSyncResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-        tags:
-            - RuntimeService
-  /v1/instances/{instanceId}/trigger: |
+      summary: |-
+        TriggerSync syncronizes the instance's catalog with the underlying OLAP's information schema.
+        If the instance has exposed=true, tables found in the information schema will be added to the catalog.
+      operationId: RuntimeService_TriggerSync
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1TriggerSyncResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+      tags:
+        - RuntimeService
+  /v1/instances/{instanceId}/trigger:
     post:
-        summary: |-
-            CreateTrigger creates a trigger in the catalog.
-            Triggers are ephemeral resources that will be cleaned up by the controller.
-        operationId: RuntimeService_CreateTrigger
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1CreateTriggerResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: path
-              required: true
-              type: string
-            - name: body
-              in: body
-              required: true
-              schema:
-                type: object
-                properties:
-                    pullTriggerSpec:
-                        $ref: '#/definitions/v1PullTriggerSpec'
-                    refreshTriggerSpec:
-                        $ref: '#/definitions/v1RefreshTriggerSpec'
-        tags:
-            - RuntimeService
-  /v1/olap/tables: |
+      summary: |-
+        CreateTrigger creates a trigger in the catalog.
+        Triggers are ephemeral resources that will be cleaned up by the controller.
+      operationId: RuntimeService_CreateTrigger
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1CreateTriggerResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: path
+          required: true
+          type: string
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              pullTriggerSpec:
+                $ref: '#/definitions/v1PullTriggerSpec'
+              refreshTriggerSpec:
+                $ref: '#/definitions/v1RefreshTriggerSpec'
+      tags:
+        - RuntimeService
+  /v1/olap/tables:
     get:
-        summary: OLAPListTables list all tables across all databases on motherduck
-        operationId: ConnectorService_OLAPListTables
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1OLAPListTablesResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: query
-              required: false
-              type: string
-            - name: connector
-              in: query
-              required: false
-              type: string
-        tags:
-            - ConnectorService
-  /v1/ping: |
+      summary: OLAPListTables list all tables across all databases on motherduck
+      operationId: ConnectorService_OLAPListTables
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1OLAPListTablesResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: query
+          required: false
+          type: string
+        - name: connector
+          in: query
+          required: false
+          type: string
+      tags:
+        - ConnectorService
+  /v1/ping:
     get:
-        summary: Ping returns information about the runtime
-        operationId: RuntimeService_Ping
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1PingResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        tags:
-            - RuntimeService
-  /v1/put-and-reconcile: |
+      summary: Ping returns information about the runtime
+      operationId: RuntimeService_Ping
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1PingResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      tags:
+        - RuntimeService
+  /v1/put-and-reconcile:
     post:
-        summary: |-
-            PutFileAndReconcile combines PutFile and Reconcile in a single endpoint to reduce latency.
-            It is equivalent to calling the two RPCs sequentially.
-        operationId: RuntimeService_PutFileAndReconcile
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1PutFileAndReconcileResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: body
-              in: body
-              required: true
-              schema:
-                $ref: '#/definitions/v1PutFileAndReconcileRequest'
-        tags:
-            - RuntimeService
-  /v1/refresh-and-reconcile: |
+      summary: |-
+        PutFileAndReconcile combines PutFile and Reconcile in a single endpoint to reduce latency.
+        It is equivalent to calling the two RPCs sequentially.
+      operationId: RuntimeService_PutFileAndReconcile
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1PutFileAndReconcileResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1PutFileAndReconcileRequest'
+      tags:
+        - RuntimeService
+  /v1/refresh-and-reconcile:
     post:
-        operationId: RuntimeService_RefreshAndReconcile
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1RefreshAndReconcileResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: body
-              in: body
-              required: true
-              schema:
-                $ref: '#/definitions/v1RefreshAndReconcileRequest'
-        tags:
-            - RuntimeService
-  /v1/rename-and-reconcile: |
+      operationId: RuntimeService_RefreshAndReconcile
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1RefreshAndReconcileResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1RefreshAndReconcileRequest'
+      tags:
+        - RuntimeService
+  /v1/rename-and-reconcile:
     post:
-        summary: RenameFileAndReconcile combines RenameFile and Reconcile in a single endpoint to reduce latency.
-        operationId: RuntimeService_RenameFileAndReconcile
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1RenameFileAndReconcileResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: body
-              in: body
-              required: true
-              schema:
-                $ref: '#/definitions/v1RenameFileAndReconcileRequest'
-        tags:
-            - RuntimeService
-  /v1/s3/bucket/{bucket}/metadata: |
+      summary: RenameFileAndReconcile combines RenameFile and Reconcile in a single endpoint to reduce latency.
+      operationId: RuntimeService_RenameFileAndReconcile
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1RenameFileAndReconcileResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1RenameFileAndReconcileRequest'
+      tags:
+        - RuntimeService
+  /v1/s3/bucket/{bucket}/metadata:
     get:
-        summary: S3GetBucketMetadata returns metadata for the given bucket.
-        operationId: ConnectorService_S3GetBucketMetadata
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1S3GetBucketMetadataResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: bucket
-              in: path
-              required: true
-              type: string
-            - name: instanceId
-              in: query
-              required: false
-              type: string
-            - name: connector
-              in: query
-              required: false
-              type: string
-        tags:
-            - ConnectorService
-  /v1/s3/bucket/{bucket}/objects: |
+      summary: S3GetBucketMetadata returns metadata for the given bucket.
+      operationId: ConnectorService_S3GetBucketMetadata
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1S3GetBucketMetadataResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: bucket
+          in: path
+          required: true
+          type: string
+        - name: instanceId
+          in: query
+          required: false
+          type: string
+        - name: connector
+          in: query
+          required: false
+          type: string
+      tags:
+        - ConnectorService
+  /v1/s3/bucket/{bucket}/objects:
     get:
-        summary: S3ListBuckets lists objects for the given bucket.
-        operationId: ConnectorService_S3ListObjects
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1S3ListObjectsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: bucket
-              in: path
-              required: true
-              type: string
-            - name: instanceId
-              in: query
-              required: false
-              type: string
-            - name: connector
-              in: query
-              required: false
-              type: string
-            - name: pageSize
-              in: query
-              required: false
-              type: integer
-              format: int64
-            - name: pageToken
-              in: query
-              required: false
-              type: string
-            - name: region
-              in: query
-              required: false
-              type: string
-            - name: prefix
-              in: query
-              required: false
-              type: string
-            - name: startAfter
-              in: query
-              required: false
-              type: string
-            - name: delimiter
-              in: query
-              required: false
-              type: string
-        tags:
-            - ConnectorService
-  /v1/s3/buckets: |
+      summary: S3ListBuckets lists objects for the given bucket.
+      operationId: ConnectorService_S3ListObjects
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1S3ListObjectsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: bucket
+          in: path
+          required: true
+          type: string
+        - name: instanceId
+          in: query
+          required: false
+          type: string
+        - name: connector
+          in: query
+          required: false
+          type: string
+        - name: pageSize
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: pageToken
+          in: query
+          required: false
+          type: string
+        - name: region
+          in: query
+          required: false
+          type: string
+        - name: prefix
+          in: query
+          required: false
+          type: string
+        - name: startAfter
+          in: query
+          required: false
+          type: string
+        - name: delimiter
+          in: query
+          required: false
+          type: string
+      tags:
+        - ConnectorService
+  /v1/s3/buckets:
     get:
-        summary: S3ListBuckets lists buckets accessible with the configured credentials.
-        operationId: ConnectorService_S3ListBuckets
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1S3ListBucketsResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: query
-              required: false
-              type: string
-            - name: connector
-              in: query
-              required: false
-              type: string
-            - name: pageSize
-              in: query
-              required: false
-              type: integer
-              format: int64
-            - name: pageToken
-              in: query
-              required: false
-              type: string
-        tags:
-            - ConnectorService
-  /v1/s3/credentials_info: |
+      summary: S3ListBuckets lists buckets accessible with the configured credentials.
+      operationId: ConnectorService_S3ListBuckets
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1S3ListBucketsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: query
+          required: false
+          type: string
+        - name: connector
+          in: query
+          required: false
+          type: string
+        - name: pageSize
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: pageToken
+          in: query
+          required: false
+          type: string
+      tags:
+        - ConnectorService
+  /v1/s3/credentials_info:
     get:
-        summary: S3GetCredentialsInfo returns metadata for the given bucket.
-        operationId: ConnectorService_S3GetCredentialsInfo
-        responses:
-            "200":
-                description: A successful response.
-                schema:
-                    $ref: '#/definitions/v1S3GetCredentialsInfoResponse'
-            default:
-                description: An unexpected error response.
-                schema:
-                    $ref: '#/definitions/rpcStatus'
-        parameters:
-            - name: instanceId
-              in: query
-              required: false
-              type: string
-            - name: connector
-              in: query
-              required: false
-              type: string
-        tags:
-            - ConnectorService
+      summary: S3GetCredentialsInfo returns metadata for the given bucket.
+      operationId: ConnectorService_S3GetCredentialsInfo
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1S3GetCredentialsInfoResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: instanceId
+          in: query
+          required: false
+          type: string
+        - name: connector
+          in: query
+          required: false
+          type: string
+      tags:
+        - ConnectorService
 definitions:
   ColumnTimeSeriesRequestBasicMeasure:
     type: object


### PR DESCRIPTION
We were not pinned to a specific version of the `grpc-ecosystem/openapiv2` plugin, so started running into this issue when 2.17 was released: https://github.com/grpc-ecosystem/grpc-gateway/issues/3557

Fixing by pinning to 2.16.2 for now.