### PR TITLE
Fixing periodic page refresh on errored dashboard

### DIFF
--- a/web-common/src/features/dashboards/granular-access-policies/DevJWTProvider.svelte
+++ b/web-common/src/features/dashboards/granular-access-policies/DevJWTProvider.svelte
@@ -1,12 +1,23 @@
 <script lang="ts">
+  import { invalidateAllMetricsViews } from "@rilldata/web-common/runtime-client/invalidation";
+  import { useQueryClient } from "@tanstack/svelte-query";
   import { appScreen } from "../../../layout/app-store";
   import { MetricsEventScreenName } from "../../../metrics/service/MetricsTypes";
   import { selectedMockUserStore } from "./stores";
   import { useDevJWT } from "./useDevJWT";
 
+  export let instanceId: string;
+
   $: isDashboardPage = $appScreen?.type === MetricsEventScreenName.Dashboard;
   $: isMockUserSelected = $selectedMockUserStore !== null;
   $: devJWT = useDevJWT($selectedMockUserStore);
+
+  const queryClient = useQueryClient();
+
+  // TODO: this is temporary fix. We should avoid global reactive statement to invalidate queries.
+  //       perhaps move this to the place where we actually change the jwt in ViewAsButton.svelte
+  $: (devJWT || devJWT === null) &&
+    invalidateAllMetricsViews(queryClient, instanceId);
 </script>
 
 <slot jwt={isDashboardPage && isMockUserSelected ? $devJWT?.data?.jwt : null} />

--- a/web-common/src/features/dashboards/granular-access-policies/DevJWTProvider.svelte
+++ b/web-common/src/features/dashboards/granular-access-policies/DevJWTProvider.svelte
@@ -1,23 +1,11 @@
 <script lang="ts">
-  import { invalidateAllMetricsViews } from "@rilldata/web-common/runtime-client/invalidation";
-  import { useQueryClient } from "@tanstack/svelte-query";
   import { appScreen } from "../../../layout/app-store";
   import { MetricsEventScreenName } from "../../../metrics/service/MetricsTypes";
-  import { selectedMockUserStore } from "./stores";
-  import { useDevJWT } from "./useDevJWT";
-
-  export let instanceId: string;
+  import { selectedMockUserJWT } from "./stores";
 
   $: isDashboardPage = $appScreen?.type === MetricsEventScreenName.Dashboard;
-  $: isMockUserSelected = $selectedMockUserStore !== null;
-  $: devJWT = useDevJWT($selectedMockUserStore);
-
-  const queryClient = useQueryClient();
-
-  // TODO: this is temporary fix. We should avoid global reactive statement to invalidate queries.
-  //       perhaps move this to the place where we actually change the jwt in ViewAsButton.svelte
-  $: (devJWT || devJWT === null) &&
-    invalidateAllMetricsViews(queryClient, instanceId);
+  $: isMockUserSelected = $selectedMockUserJWT !== null;
+  $: devJWT = $selectedMockUserJWT;
 </script>
 
-<slot jwt={isDashboardPage && isMockUserSelected ? $devJWT?.data?.jwt : null} />
+<slot jwt={isDashboardPage && isMockUserSelected ? devJWT : null} />

--- a/web-common/src/features/dashboards/granular-access-policies/ViewAsButton.svelte
+++ b/web-common/src/features/dashboards/granular-access-policies/ViewAsButton.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { WithTogglableFloatingElement } from "@rilldata/web-common/components/floating-element";
+  import { updateDevJWT } from "@rilldata/web-common/features/dashboards/granular-access-policies/updateDevJWT";
+  import { useQueryClient } from "@tanstack/svelte-query";
   import { IconSpaceFixer } from "../../../components/button";
   import { Chip } from "../../../components/chip";
   import Add from "../../../components/icons/Add.svelte";
@@ -15,6 +17,8 @@
 
   let viewAsMenuOpen = false;
 
+  const queryClient = useQueryClient();
+
   $: mockUsers = useMockUsers($runtime.instanceId);
 
   const iconColor = "#15141A";
@@ -25,8 +29,8 @@
   distance={8}
   let:toggleFloatingElement
   location="bottom"
-  on:open={() => (viewAsMenuOpen = true)}
   on:close={() => (viewAsMenuOpen = false)}
+  on:open={() => (viewAsMenuOpen = true)}
 >
   {#if $selectedMockUserStore === null}
     <button
@@ -44,7 +48,7 @@
       on:click={toggleFloatingElement}
       on:remove={() => {
         if (viewAsMenuOpen) toggleFloatingElement();
-        selectedMockUserStore.set(null);
+        updateDevJWT(queryClient, null);
       }}
       active={viewAsMenuOpen}
     >
@@ -85,7 +89,7 @@
           selected={$selectedMockUserStore?.email === user?.email}
           on:select={() => {
             toggleFloatingElement();
-            selectedMockUserStore.set(user);
+            updateDevJWT(queryClient, user);
           }}
         >
           <svelte:fragment slot="icon">
@@ -107,7 +111,7 @@
         goto(`/rill.yaml?addMockUser=true`);
       }}
     >
-      <Add size="16px" slot="icon" color={iconColor} />
+      <Add color={iconColor} size="16px" slot="icon" />
       <span>Add mock user</span>
     </MenuItem>
   </Menu>

--- a/web-common/src/features/dashboards/granular-access-policies/resetSelectedMockUserAfterNavigate.ts
+++ b/web-common/src/features/dashboards/granular-access-policies/resetSelectedMockUserAfterNavigate.ts
@@ -1,5 +1,6 @@
 import { afterNavigate } from "$app/navigation";
-import { selectedMockUserStore } from "./stores";
+import { updateDevJWT } from "@rilldata/web-common/features/dashboards/granular-access-policies/updateDevJWT";
+import type { QueryClient } from "@tanstack/svelte-query";
 
 /**
  * Remove the selected mock user (if any) when navigating to a dashboard
@@ -10,10 +11,10 @@ import { selectedMockUserStore } from "./stores";
  * under this scenario, the catalog entry returns a 401, and it's required to enter the top-level
  * `Dashboard.svelte` component.
  */
-export function resetSelectedMockUserAfterNavigate() {
+export function resetSelectedMockUserAfterNavigate(queryClient: QueryClient) {
   afterNavigate((nav) => {
     if (nav.from.params.name !== nav.to.params.name) {
-      selectedMockUserStore.set(null);
+      updateDevJWT(queryClient, null);
     }
   });
 }

--- a/web-common/src/features/dashboards/granular-access-policies/stores.ts
+++ b/web-common/src/features/dashboards/granular-access-policies/stores.ts
@@ -2,3 +2,4 @@ import { writable } from "svelte/store";
 import type { MockUser } from "./useMockUsers";
 
 export const selectedMockUserStore = writable<MockUser | null>(null);
+export const selectedMockUserJWT = writable<string | null>(null);

--- a/web-common/src/features/dashboards/granular-access-policies/updateDevJWT.ts
+++ b/web-common/src/features/dashboards/granular-access-policies/updateDevJWT.ts
@@ -1,0 +1,40 @@
+import {
+  selectedMockUserJWT,
+  selectedMockUserStore,
+} from "@rilldata/web-common/features/dashboards/granular-access-policies/stores";
+import type { MockUser } from "@rilldata/web-common/features/dashboards/granular-access-policies/useMockUsers";
+import { runtimeServiceIssueDevJWT } from "@rilldata/web-common/runtime-client";
+import { invalidateAllMetricsViews } from "@rilldata/web-common/runtime-client/invalidation";
+import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
+import type { QueryClient } from "@tanstack/svelte-query";
+import { get } from "svelte/store";
+
+export async function updateDevJWT(
+  queryClient: QueryClient,
+  mockUser: MockUser | null
+) {
+  selectedMockUserStore.set(mockUser);
+  let jwt: string = null;
+
+  if (mockUser !== null) {
+    try {
+      const jwtResp = await runtimeServiceIssueDevJWT({
+        name: mockUser?.name ? mockUser.name : "Mock User",
+        email: mockUser?.email,
+        groups: mockUser?.groups ? mockUser.groups : [],
+        admin: !!mockUser?.admin,
+      });
+      jwt = jwtResp.jwt;
+    } catch (e) {
+      // no-op
+    }
+  }
+
+  console.log("update jwt", mockUser, jwt);
+  selectedMockUserJWT.set(jwt);
+  runtime.update((runtimeState) => {
+    runtimeState.jwt = jwt;
+    return runtimeState;
+  });
+  return invalidateAllMetricsViews(queryClient, get(runtime).instanceId);
+}

--- a/web-common/src/features/dashboards/granular-access-policies/updateDevJWT.ts
+++ b/web-common/src/features/dashboards/granular-access-policies/updateDevJWT.ts
@@ -30,7 +30,6 @@ export async function updateDevJWT(
     }
   }
 
-  console.log("update jwt", mockUser, jwt);
   selectedMockUserJWT.set(jwt);
   runtime.update((runtimeState) => {
     runtimeState.jwt = jwt;

--- a/web-common/src/runtime-client/RuntimeProvider.svelte
+++ b/web-common/src/runtime-client/RuntimeProvider.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { useQueryClient } from "@tanstack/svelte-query";
-  import { invalidateAllMetricsViews } from "./invalidation";
   import { runtime } from "./runtime-store";
 
   export let host: string;
@@ -12,13 +10,6 @@
     instanceId: instanceId,
     jwt: jwt,
   });
-
-  const queryClient = useQueryClient();
-
-  // Whenever the runtime's (dev) JWT changes (even to `null`), invalidate all metrics views.
-  // Metrics views may have a security policy, for which a JWT grants permission.
-  $: ($runtime?.jwt || $runtime?.jwt === null) &&
-    invalidateAllMetricsViews(queryClient, instanceId);
 </script>
 
 {#if $runtime.host !== undefined && $runtime.instanceId}

--- a/web-local/src/routes/(application)/+layout.svelte
+++ b/web-local/src/routes/(application)/+layout.svelte
@@ -24,7 +24,7 @@
 </script>
 
 <QueryClientProvider client={queryClient}>
-  <DevJWTProvider let:jwt>
+  <DevJWTProvider instanceId="default" let:jwt>
     <RuntimeProvider host={RuntimeUrl} instanceId="default" {jwt}>
       <RillDeveloperLayout>
         <slot />

--- a/web-local/src/routes/(application)/+layout.svelte
+++ b/web-local/src/routes/(application)/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { beforeNavigate } from "$app/navigation";
-  import DevJWTProvider from "@rilldata/web-common/features/dashboards/granular-access-policies/DevJWTProvider.svelte";
   import { retainFeaturesFlags } from "@rilldata/web-common/features/feature-flags";
   import RillDeveloperLayout from "@rilldata/web-common/layout/RillDeveloperLayout.svelte";
   import RuntimeProvider from "@rilldata/web-common/runtime-client/RuntimeProvider.svelte";
@@ -24,11 +23,9 @@
 </script>
 
 <QueryClientProvider client={queryClient}>
-  <DevJWTProvider let:jwt>
-    <RuntimeProvider host={RuntimeUrl} instanceId="default" {jwt}>
-      <RillDeveloperLayout>
-        <slot />
-      </RillDeveloperLayout>
-    </RuntimeProvider>
-  </DevJWTProvider>
+  <RuntimeProvider host={RuntimeUrl} instanceId="default">
+    <RillDeveloperLayout>
+      <slot />
+    </RillDeveloperLayout>
+  </RuntimeProvider>
 </QueryClientProvider>

--- a/web-local/src/routes/(application)/+layout.svelte
+++ b/web-local/src/routes/(application)/+layout.svelte
@@ -24,7 +24,7 @@
 </script>
 
 <QueryClientProvider client={queryClient}>
-  <DevJWTProvider instanceId="default" let:jwt>
+  <DevJWTProvider let:jwt>
     <RuntimeProvider host={RuntimeUrl} instanceId="default" {jwt}>
       <RillDeveloperLayout>
         <slot />

--- a/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
@@ -17,7 +17,10 @@
   } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { error } from "@sveltejs/kit";
+  import { useQueryClient } from "@tanstack/svelte-query";
   import { CATALOG_ENTRY_NOT_FOUND } from "../../../../lib/errors/messages";
+
+  const queryClient = useQueryClient();
 
   $: metricViewName = $page.params.name;
 
@@ -70,7 +73,7 @@
     }
   );
 
-  resetSelectedMockUserAfterNavigate();
+  resetSelectedMockUserAfterNavigate(queryClient);
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
For errored projects we periodically fetch the status to update the UI if the status changes. This along with a global reactive statement for jwt to refetch the entire dashboard leads to a periodic refresh for errored out projects.

#### Details:
Moving the setting of jwt to the action itself. This way unnecessary refetches are avoided.

## Steps to Verify
1. Start the cloud ui locally using `./scripts/devtool.sh`
2. Create a valid project with atleast 2 dashboard.
3. Update the project to mark one of the dashboard invalid and trigger refresh.
4. Open the valid dashboard.
5. The page should not refresh periodically.