### PR TITLE
Fix missing time controls

### DIFF
--- a/web-common/src/runtime-client/invalidation.ts
+++ b/web-common/src/runtime-client/invalidation.ts
@@ -137,10 +137,10 @@ export async function invalidateAllMetricsViews(
       query.queryKey[0].startsWith(`/v1/instances/${instanceId}/catalog`),
   });
 
-  // Second, remove queries for all metrics views. This will cause the active queries to refetch.
+  // Second, reset queries for all metrics views. This will cause the active queries to refetch.
   // Note: This is a confusing hack. At time of writing, neither `queryClient.refetchQueries`
   // nor `queryClient.invalidateQueries` were working as expected. Perhaps there's a race condition somewhere.
-  queryClient.removeQueries({
+  queryClient.resetQueries({
     predicate: (query: Query) => {
       return (
         typeof query.queryKey[0] === "string" &&
@@ -151,8 +151,8 @@ export async function invalidateAllMetricsViews(
     },
   });
 
-  // Additionally, remove the queries for the rows viewer, which have custom query keys
-  queryClient.removeQueries({
+  // Additionally, reset the queries for the rows viewer, which have custom query keys
+  queryClient.resetQueries({
     predicate: (query: Query) => {
       return (
         typeof query.queryKey[0] === "string" &&


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
On partner-filtered dashboards in Rill Developer, when removing a filter for a mock user, sometimes the Time Controls go missing. In these cases, the dashboard's time range is `undefined`.

#### Details:
This PR changes our use of `removeQueries` to `resetQueries` to ensure the `/time-range-summary` query (and others) get refreshed.

## Steps to Verify
1. On a partner-filtered dashboard, "view as" a mock user
2. Remove the filter
3. The time controls should be present