### PR TITLE
Hide dashboard error badge when reconciling

### DIFF
--- a/web-admin/src/components/projects/DashboardList.svelte
+++ b/web-admin/src/components/projects/DashboardList.svelte
@@ -65,7 +65,7 @@
             </span>
 
             <!-- Error tag -->
-            {#if !dashboardListItem.isValid}
+            {#if $proj.data.prodDeployment.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_RECONCILING && !dashboardListItem.isValid}
               <Tooltip distance={8} location="right">
                 <TooltipContent slot="tooltip-content">
                   <ProjectAccessControls {organization} {project}>


### PR DESCRIPTION
It's confusing when a dashboard is marked as errored when the project is reconciling. This PR hides any error badges while  the project is reconciling.

[Reported in Slack.](https://rilldata.slack.com/archives/C02T907FEUB/p1693892479745239)