### PR TITLE
fix: hide overflow on scroll in dimension details

### DIFF
--- a/web-common/src/components/virtualized-table/core/Cell.svelte
+++ b/web-common/src/components/virtualized-table/core/Cell.svelte
@@ -134,13 +134,13 @@
     >
       <button
         class="
-          {config.rowHeight <= 28 ? 'py-1' : 'py-2'}
           {isDimensionTable ? '' : 'px-4'}
           text-left w-full text-ellipsis overflow-x-hidden whitespace-nowrap
           "
         use:shiftClickAction
         on:shift-click={shiftClick}
         aria-label={label}
+        style:height="{row.size}px"
       >
         <FormattedDataType
           value={formattedValue || value}

--- a/web-common/src/features/dashboards/dimension-table/DimensionFilterGutter.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionFilterGutter.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <div
-  class="sticky left-0 top-0 z-20"
+  class="sticky left-0 top-0 z-20 bg-white"
   style:height="{totalHeight}px"
   style:width="{config.indexWidth}px"
 >


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
Fixes an issue where when horizontally scrolling in the dimension details table, cells that scrolled to the left behind the left gutter of the dimension table (where the filter checkmarks are shown) would be visible

#### Details:
2 parts to the fix:
1. Added a background color to the dimension gutter column so that cells scrolling behind it will not be visible
2. There was an issue with the embedded button in the BarAndLabel component of the cell where the button was rendering at 26px even though the cell wrapper is only 24px. This caused some visual overflow to be seen below the table while horizontally scrolling. This PR enforces the row height on the embedded button

## Steps to Verify
For example, given a new button "Foo" in the dashboard:
1. Open a dashboard
2. Add a time comparison period and open a dimension details table
3. Reduce the width of your browser until the dimension details table gets a scrollbar
4. Horizontally scroll that table and note that no overflow is seen on the left side


https://github.com/rilldata/rill/assets/5554373/a184dfb7-657c-470f-9c70-7b5f455896a5


