### PR TITLE
Options to improve ingest performance

### DIFF
--- a/admin/deployments.go
+++ b/admin/deployments.go
@@ -72,6 +72,21 @@ func (s *Service) createDeployment(ctx context.Context, opts *createDeploymentOp
 		ingestionLimit = alloc.StorageBytes
 
 		olapDSN = fmt.Sprintf("%s.db?rill_pool_size=%d&max_memory=%dGB", path.Join(alloc.DataDir, instanceID), alloc.CPU, alloc.MemoryGB)
+	} else if olapDriver == "duckdb-vip" {
+		if olapDSN != "" {
+			return nil, fmt.Errorf("passing a DSN is not allowed for driver 'duckdb-vip'")
+		}
+		if opts.ProdSlots == 0 {
+			return nil, fmt.Errorf("slot count can't be 0 for driver 'duckdb-vip'")
+		}
+
+		// NOTE: Rewriting to a "duckdb" driver without CPU, memory, or storage limits
+
+		embedCatalog = true
+		ingestionLimit = 0
+
+		olapDriver = "duckdb"
+		olapDSN = fmt.Sprintf("%s.db?rill_pool_size=8", path.Join(alloc.DataDir, instanceID))
 	}
 
 	// Open a runtime client

--- a/runtime/drivers/blob/blobdownloader.go
+++ b/runtime/drivers/blob/blobdownloader.go
@@ -22,7 +22,7 @@ import (
 // increasing this limit can increase speed ingestion
 // but may increase bottleneck at duckdb or network/db IO
 // set without any benchamarks
-const _concurrentBlobDownloadLimit = 8
+const _concurrentBlobDownloadLimit = 32
 
 // map of supoprted extensions for partial downloads vs readers
 // zipped csv files can't be partialled downloaded

--- a/runtime/server/server.go
+++ b/runtime/server/server.go
@@ -250,7 +250,7 @@ func HTTPErrorHandler(ctx context.Context, mux *gateway.ServeMux, marshaler gate
 
 func timeoutSelector(fullMethodName string) time.Duration {
 	if strings.HasPrefix(fullMethodName, "/rill.runtime.v1.RuntimeService") && (strings.Contains(fullMethodName, "/Trigger") || strings.HasSuffix(fullMethodName, "Reconcile")) {
-		return time.Minute * 30
+		return time.Minute * 59 // Not 60 to avoid forced timeout on ingress
 	}
 
 	if strings.HasPrefix(fullMethodName, "/rill.runtime.v1.QueryService") {


### PR DESCRIPTION
- [x] Add `duckdb-vip` driver that doesn't enforce any limits
- [x] Increase reconcile timeout to 59 minutes (not 60, to avoid force termination at ingress)
- [x] Increase concurrent file downloads to 32 (from 8)
- [ ] Consider: Configure insert batches by GBs downloaded instead of number of files downloaded