### PR TITLE
Set DuckDB pool size to 4 on local

### DIFF
--- a/admin/deployments.go
+++ b/admin/deployments.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -57,23 +58,24 @@ func (s *Service) createDeployment(ctx context.Context, opts *createDeploymentOp
 	// Build instance config
 	instanceID := strings.ReplaceAll(uuid.New().String(), "-", "")
 	olapDriver := opts.ProdOLAPDriver
-	olapDSN := opts.ProdOLAPDSN
+	olapConfig := map[string]string{}
 	var embedCatalog bool
 	var ingestionLimit int64
-	if olapDriver == "duckdb" {
-		if olapDSN != "" {
+	switch olapDriver {
+	case "duckdb":
+		if opts.ProdOLAPDSN != "" {
 			return nil, fmt.Errorf("passing a DSN is not allowed for driver 'duckdb'")
 		}
 		if opts.ProdSlots == 0 {
 			return nil, fmt.Errorf("slot count can't be 0 for driver 'duckdb'")
 		}
 
+		olapConfig["dsn"] = fmt.Sprintf("%s.db?max_memory=%dGB", path.Join(alloc.DataDir, instanceID), alloc.MemoryGB)
+		olapConfig["pool_size"] = strconv.Itoa(alloc.CPU)
 		embedCatalog = true
 		ingestionLimit = alloc.StorageBytes
-
-		olapDSN = fmt.Sprintf("%s.db?rill_pool_size=%d&max_memory=%dGB", path.Join(alloc.DataDir, instanceID), alloc.CPU, alloc.MemoryGB)
-	} else if olapDriver == "duckdb-vip" {
-		if olapDSN != "" {
+	case "duckdb-vip":
+		if opts.ProdOLAPDSN != "" {
 			return nil, fmt.Errorf("passing a DSN is not allowed for driver 'duckdb-vip'")
 		}
 		if opts.ProdSlots == 0 {
@@ -81,12 +83,15 @@ func (s *Service) createDeployment(ctx context.Context, opts *createDeploymentOp
 		}
 
 		// NOTE: Rewriting to a "duckdb" driver without CPU, memory, or storage limits
-
+		olapDriver = "duckdb"
+		olapConfig["dsn"] = fmt.Sprintf("%s.db", path.Join(alloc.DataDir, instanceID))
+		olapConfig["pool_size"] = "8"
 		embedCatalog = true
 		ingestionLimit = 0
-
-		olapDriver = "duckdb"
-		olapDSN = fmt.Sprintf("%s.db?rill_pool_size=8", path.Join(alloc.DataDir, instanceID))
+	default:
+		olapConfig["dsn"] = opts.ProdOLAPDSN
+		embedCatalog = false
+		ingestionLimit = 0
 	}
 
 	// Open a runtime client
@@ -109,7 +114,7 @@ func (s *Service) createDeployment(ctx context.Context, opts *createDeploymentOp
 			{
 				Name:   "olap",
 				Type:   olapDriver,
-				Config: map[string]string{"dsn": olapDSN},
+				Config: olapConfig,
 			},
 			{
 				Name:   "repo",

--- a/cli/pkg/local/app.go
+++ b/cli/pkg/local/app.go
@@ -126,6 +126,13 @@ func NewApp(ctx context.Context, ver config.Version, verbose, reset bool, olapDr
 			return nil, fmt.Errorf("failed to clean OLAP: %w", err)
 		}
 	}
+
+	// Set default DuckDB pool size to 4
+	olapCfg := map[string]string{"dsn": olapDSN}
+	if olapDriver == "duckdb" {
+		olapCfg["pool_size"] = "4"
+	}
+
 	// Create instance with its repo set to the project directory
 	inst := &drivers.Instance{
 		ID:            DefaultInstanceID,
@@ -143,7 +150,7 @@ func NewApp(ctx context.Context, ver config.Version, verbose, reset bool, olapDr
 			{
 				Type:   olapDriver,
 				Name:   "olap",
-				Config: map[string]string{"dsn": olapDSN},
+				Config: olapCfg,
 			},
 		},
 	}

--- a/runtime/drivers/drivers_test.go
+++ b/runtime/drivers/drivers_test.go
@@ -20,7 +20,7 @@ import (
 // This should be the only "real" test in the package. Other tests should be added
 // as subtests of TestAll.
 func TestAll(t *testing.T) {
-	var matrix = []func(t *testing.T, fn func(driver string, shared bool, dsn string)) error{
+	var matrix = []func(t *testing.T, fn func(driver string, shared bool, cfg map[string]any)) error{
 		withDuckDB,
 		withFile,
 		withPostgres,
@@ -29,9 +29,9 @@ func TestAll(t *testing.T) {
 	}
 
 	for _, withDriver := range matrix {
-		err := withDriver(t, func(driver string, shared bool, dsn string) {
+		err := withDriver(t, func(driver string, shared bool, cfg map[string]any) {
 			// Open
-			conn, err := drivers.Open(driver, map[string]any{"dsn": dsn}, shared, activity.NewNoopClient(), zap.NewNop())
+			conn, err := drivers.Open(driver, cfg, shared, activity.NewNoopClient(), zap.NewNop())
 			require.NoError(t, err)
 			require.NotNil(t, conn)
 
@@ -63,26 +63,26 @@ func TestAll(t *testing.T) {
 	}
 }
 
-func withDuckDB(t *testing.T, fn func(driver string, shared bool, dsn string)) error {
-	fn("duckdb", false, "?access_mode=read_write&rill_pool_size=4")
+func withDuckDB(t *testing.T, fn func(driver string, shared bool, cfg map[string]any)) error {
+	fn("duckdb", false, map[string]any{"dsn": "?access_mode=read_write", "pool_size": 4})
 	return nil
 }
 
-func withFile(t *testing.T, fn func(driver string, shared bool, dsn string)) error {
+func withFile(t *testing.T, fn func(driver string, shared bool, cfg map[string]any)) error {
 	dsn := t.TempDir()
-	fn("file", false, dsn)
+	fn("file", false, map[string]any{"dsn": dsn})
 	return nil
 }
 
-func withPostgres(t *testing.T, fn func(driver string, shared bool, dsn string)) error {
+func withPostgres(t *testing.T, fn func(driver string, shared bool, cfg map[string]any)) error {
 	pg := pgtestcontainer.New(t)
 	defer pg.Terminate(t)
 
-	fn("postgres", true, pg.DatabaseURL)
+	fn("postgres", true, map[string]any{"dsn": pg.DatabaseURL})
 	return nil
 }
 
-func withSQLite(t *testing.T, fn func(driver string, shared bool, dsn string)) error {
-	fn("sqlite", true, ":memory:")
+func withSQLite(t *testing.T, fn func(driver string, shared bool, cfg map[string]any)) error {
+	fn("sqlite", true, map[string]any{"dsn": ":memory:"})
 	return nil
 }

--- a/runtime/drivers/duckdb/config_test.go
+++ b/runtime/drivers/duckdb/config_test.go
@@ -3,50 +3,58 @@ package duckdb
 import (
 	"testing"
 
-	"github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConfig(t *testing.T) {
-	cfg, err := newConfig("", nil)
+	cfg, err := newConfig(map[string]any{})
 	require.NoError(t, err)
 	require.Equal(t, "", cfg.DSN)
 	require.Equal(t, 1, cfg.PoolSize)
 
-	cfg, err = newConfig("path/to/duck.db", nil)
+	cfg, err = newConfig(map[string]any{"dsn": "path/to/duck.db"})
 	require.NoError(t, err)
 	require.Equal(t, "path/to/duck.db", cfg.DSN)
 	require.Equal(t, "path/to/duck.db", cfg.DBFilePath)
 	require.Equal(t, 1, cfg.PoolSize)
 
-	cfg, err = newConfig("path/to/duck.db?rill_pool_size=10", nil)
+	cfg, err = newConfig(map[string]any{"dsn": "path/to/duck.db", "pool_size": 10})
 	require.NoError(t, err)
 	require.Equal(t, "path/to/duck.db", cfg.DSN)
 	require.Equal(t, "path/to/duck.db", cfg.DBFilePath)
 	require.Equal(t, 10, cfg.PoolSize)
 
-	cfg, err = newConfig("path/to/duck.db?rill_pool_size=10&hello=world", nil)
+	cfg, err = newConfig(map[string]any{"dsn": "path/to/duck.db", "pool_size": "10"})
 	require.NoError(t, err)
-	require.Equal(t, "path/to/duck.db?hello=world", cfg.DSN)
+	require.Equal(t, 10, cfg.PoolSize)
+
+	cfg, err = newConfig(map[string]any{"dsn": "path/to/duck.db?rill_pool_size=4", "pool_size": "10"})
+	require.NoError(t, err)
+	require.Equal(t, 4, cfg.PoolSize)
+
+	cfg, err = newConfig(map[string]any{"dsn": "path/to/duck.db?rill_pool_size=10"})
+	require.NoError(t, err)
+	require.Equal(t, "path/to/duck.db", cfg.DSN)
+	require.Equal(t, "path/to/duck.db", cfg.DBFilePath)
+	require.Equal(t, 10, cfg.PoolSize)
+
+	cfg, err = newConfig(map[string]any{"dsn": "path/to/duck.db?max_memory=4GB&rill_pool_size=10"})
+	require.NoError(t, err)
+	require.Equal(t, "path/to/duck.db?max_memory=4GB", cfg.DSN)
 	require.Equal(t, 10, cfg.PoolSize)
 	require.Equal(t, "path/to/duck.db", cfg.DBFilePath)
 
-	_, err = newConfig("path/to/duck.db?rill_pool_size=abc&hello=world", nil)
+	_, err = newConfig(map[string]any{"dsn": "path/to/duck.db?max_memory=4GB", "pool_size": "abc"})
 	require.Error(t, err)
 
-	_, err = newConfig("path/to/duck.db?rill_pool_size=0&hello=world", nil)
+	_, err = newConfig(map[string]any{"dsn": "path/to/duck.db?max_memory=4GB", "pool_size": 0})
 	require.Error(t, err)
 
-	cfg, err = newConfig("duck.db", nil)
+	cfg, err = newConfig(map[string]any{"dsn": "duck.db"})
 	require.NoError(t, err)
 	require.Equal(t, "duck.db", cfg.DBFilePath)
 
-	cfg, err = newConfig("duck.db?rill_pool_size=10", nil)
+	cfg, err = newConfig(map[string]any{"dsn": "duck.db?rill_pool_size=10"})
 	require.NoError(t, err)
 	require.Equal(t, "duck.db", cfg.DBFilePath)
-
-	client := activity.NewNoopClient()
-	cfg, err = newConfig("path/to/duck.db", client)
-	require.NoError(t, err)
-	require.Equal(t, client, cfg.Activity)
 }

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -55,16 +55,12 @@ type Driver struct {
 	name string
 }
 
-func (d Driver) Open(config map[string]any, shared bool, client activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+func (d Driver) Open(cfgMap map[string]any, shared bool, ac activity.Client, logger *zap.Logger) (drivers.Handle, error) {
 	if shared {
 		return nil, fmt.Errorf("duckdb driver can't be shared")
 	}
-	dsn, ok := config["dsn"].(string)
-	if !ok {
-		return nil, fmt.Errorf("require dsn to open duckdb connection")
-	}
 
-	cfg, err := newConfig(dsn, client)
+	cfg, err := newConfig(cfgMap)
 	if err != nil {
 		return nil, err
 	}
@@ -79,10 +75,11 @@ func (d Driver) Open(config map[string]any, shared bool, client activity.Client,
 	c := &connection{
 		config:       cfg,
 		logger:       logger,
+		activity:     ac,
 		metaSem:      semaphore.NewWeighted(1),
 		olapSem:      priorityqueue.NewSemaphore(olapSemSize),
 		dbCond:       sync.NewCond(&sync.Mutex{}),
-		driverConfig: config,
+		driverConfig: cfgMap,
 		driverName:   d.name,
 		shared:       shared,
 		ctx:          ctx,
@@ -111,13 +108,8 @@ func (d Driver) Open(config map[string]any, shared bool, client activity.Client,
 	return c, nil
 }
 
-func (d Driver) Drop(config map[string]any, logger *zap.Logger) error {
-	dsn, ok := config["dsn"].(string)
-	if !ok {
-		return fmt.Errorf("require dsn to drop duckdb connection")
-	}
-
-	cfg, err := newConfig(dsn, nil)
+func (d Driver) Drop(cfgMap map[string]any, logger *zap.Logger) error {
+	cfg, err := newConfig(cfgMap)
 	if err != nil {
 		return err
 	}
@@ -148,8 +140,9 @@ type connection struct {
 	driverConfig map[string]any
 	driverName   string
 	// config is parsed configs
-	config *config
-	logger *zap.Logger
+	config   *config
+	logger   *zap.Logger
+	activity activity.Client
 	// This driver may issue both OLAP and "meta" queries (like catalog info) against DuckDB.
 	// Meta queries are usually fast, but OLAP queries may take a long time. To enable predictable parallel performance,
 	// we gate queries with semaphores that limits the number of concurrent queries of each type.
@@ -439,7 +432,7 @@ func (c *connection) checkErr(err error) error {
 
 // Periodically collects stats using pragma_database_size() and emits as activity events
 func (c *connection) periodicallyEmitStats(d time.Duration) {
-	if c.config.Activity == nil {
+	if c.activity == nil {
 		// Activity client isn't set, there is no need to report stats
 		return
 	}
@@ -473,37 +466,37 @@ func (c *connection) periodicallyEmitStats(d time.Duration) {
 			if err != nil {
 				c.logger.Error("couldn't convert duckdb size to bytes", zap.Error(err))
 			} else {
-				c.config.Activity.Emit(c.ctx, "duckdb_size_bytes", dbSize, commonDims...)
+				c.activity.Emit(c.ctx, "duckdb_size_bytes", dbSize, commonDims...)
 			}
 
 			walSize, err := humanReadableSizeToBytes(stat.WalSize)
 			if err != nil {
 				c.logger.Error("couldn't convert duckdb wal size to bytes", zap.Error(err))
 			} else {
-				c.config.Activity.Emit(c.ctx, "duckdb_wal_size_bytes", walSize, commonDims...)
+				c.activity.Emit(c.ctx, "duckdb_wal_size_bytes", walSize, commonDims...)
 			}
 
 			memoryUsage, err := humanReadableSizeToBytes(stat.MemoryUsage)
 			if err != nil {
 				c.logger.Error("couldn't convert duckdb memory usage to bytes", zap.Error(err))
 			} else {
-				c.config.Activity.Emit(c.ctx, "duckdb_memory_usage_bytes", memoryUsage, commonDims...)
+				c.activity.Emit(c.ctx, "duckdb_memory_usage_bytes", memoryUsage, commonDims...)
 			}
 
 			memoryLimit, err := humanReadableSizeToBytes(stat.MemoryLimit)
 			if err != nil {
 				c.logger.Error("couldn't convert duckdb memory limit to bytes", zap.Error(err))
 			} else {
-				c.config.Activity.Emit(c.ctx, "duckdb_memory_limit_bytes", memoryLimit, commonDims...)
+				c.activity.Emit(c.ctx, "duckdb_memory_limit_bytes", memoryLimit, commonDims...)
 			}
 
-			c.config.Activity.Emit(c.ctx, "duckdb_block_size_bytes", float64(stat.BlockSize), commonDims...)
-			c.config.Activity.Emit(c.ctx, "duckdb_total_blocks", float64(stat.TotalBlocks), commonDims...)
-			c.config.Activity.Emit(c.ctx, "duckdb_free_blocks", float64(stat.FreeBlocks), commonDims...)
-			c.config.Activity.Emit(c.ctx, "duckdb_used_blocks", float64(stat.UsedBlocks), commonDims...)
+			c.activity.Emit(c.ctx, "duckdb_block_size_bytes", float64(stat.BlockSize), commonDims...)
+			c.activity.Emit(c.ctx, "duckdb_total_blocks", float64(stat.TotalBlocks), commonDims...)
+			c.activity.Emit(c.ctx, "duckdb_free_blocks", float64(stat.FreeBlocks), commonDims...)
+			c.activity.Emit(c.ctx, "duckdb_used_blocks", float64(stat.UsedBlocks), commonDims...)
 
 			estimatedDBSize, _ := c.EstimateSize()
-			c.config.Activity.Emit(c.ctx, "duckdb_estimated_size_bytes", float64(estimatedDBSize))
+			c.activity.Emit(c.ctx, "duckdb_estimated_size_bytes", float64(estimatedDBSize))
 
 		case <-c.ctx.Done():
 			statTicker.Stop()

--- a/runtime/drivers/duckdb/duckdb_test.go
+++ b/runtime/drivers/duckdb/duckdb_test.go
@@ -17,9 +17,9 @@ import (
 func TestOpenDrop(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "tmp.db")
 	walpath := path + ".wal"
-	dsn := path + "?rill_pool_size=2"
+	dsn := path
 
-	handle, err := Driver{}.Open(map[string]any{"dsn": dsn}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open(map[string]any{"dsn": dsn, "pool_size": 2}, false, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	olap, ok := handle.AsOLAP("")
@@ -42,10 +42,9 @@ func TestOpenDrop(t *testing.T) {
 func TestFatalErr(t *testing.T) {
 	// NOTE: Using this issue to create a fatal error: https://github.com/duckdb/duckdb/issues/7905
 
-	path := filepath.Join(t.TempDir(), "tmp.db")
-	dsn := path + "?rill_pool_size=2"
+	dsn := filepath.Join(t.TempDir(), "tmp.db")
 
-	handle, err := Driver{}.Open(map[string]any{"dsn": dsn}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open(map[string]any{"dsn": dsn, "pool_size": 2}, false, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	olap, ok := handle.AsOLAP("")
@@ -105,10 +104,9 @@ func TestFatalErr(t *testing.T) {
 func TestFatalErrConcurrent(t *testing.T) {
 	// NOTE: Using this issue to create a fatal error: https://github.com/duckdb/duckdb/issues/7905
 
-	path := filepath.Join(t.TempDir(), "tmp.db")
-	dsn := path + "?rill_pool_size=3"
+	dsn := filepath.Join(t.TempDir(), "tmp.db")
 
-	handle, err := Driver{}.Open(map[string]any{"dsn": dsn}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open(map[string]any{"dsn": dsn, "pool_size": 3}, false, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	olap, ok := handle.AsOLAP("")
@@ -185,7 +183,7 @@ func TestFatalErrConcurrent(t *testing.T) {
 		wg.Done()
 	}()
 
-	// Func 3 acquires conn after 250ms and runs query immediately. It will be enqueued (because the OLAP conns limit is rill_pool_size-1 = 2).
+	// Func 3 acquires conn after 250ms and runs query immediately. It will be enqueued (because the OLAP conns limit is pool_size-1 = 2).
 	// By the time it's dequeued, the DB will have been invalidated, and it will wait for the reopen before returning a conn. So the query should succeed.
 	wg.Add(1)
 	var err3 error

--- a/runtime/drivers/duckdb/olap_test.go
+++ b/runtime/drivers/duckdb/olap_test.go
@@ -204,7 +204,7 @@ func TestClose(t *testing.T) {
 }
 
 func prepareConn(t *testing.T) drivers.Handle {
-	conn, err := Driver{}.Open(map[string]any{"dsn": "?access_mode=read_write&rill_pool_size=4"}, false, activity.NewNoopClient(), zap.NewNop())
+	conn, err := Driver{}.Open(map[string]any{"dsn": "?access_mode=read_write", "pool_size": 4}, false, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	olap, ok := conn.AsOLAP("")

--- a/runtime/server/queries_test.go
+++ b/runtime/server/queries_test.go
@@ -134,7 +134,7 @@ func TestServer_UpdateLimit_UNION(t *testing.T) {
 }
 
 func prepareOLAPStore(t *testing.T) drivers.OLAPStore {
-	conn, err := drivers.Open("duckdb", map[string]any{"dsn": "?access_mode=read_write&rill_pool_size=4"}, false, activity.NewNoopClient(), zap.NewNop())
+	conn, err := drivers.Open("duckdb", map[string]any{"dsn": "?access_mode=read_write", "pool_size": 4}, false, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	olap, ok := conn.AsOLAP("")
 	require.True(t, ok)


### PR DESCRIPTION
- Adds support for configuring the DuckDB pool size through the config map (instead of the DSN)
- Sets the DuckDB pool size to 4 by default on local (was previously 1)