### PR TITLE
Emit DuckDB query metrics

### DIFF
--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -87,6 +87,7 @@ func (d Driver) Open(config map[string]any, shared bool, client activity.Client,
 		shared:       shared,
 		ctx:          ctx,
 		cancel:       cancel,
+		activity:     client,
 	}
 
 	// Open the DB
@@ -168,8 +169,9 @@ type connection struct {
 	dbErr       error
 	shared      bool
 	// Cancellable context to control internal processes like emitting the stats
-	ctx    context.Context
-	cancel context.CancelFunc
+	ctx      context.Context
+	cancel   context.CancelFunc
+	activity activity.Client
 }
 
 // Driver implements drivers.Connection.

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -84,7 +84,6 @@ func (d Driver) Open(cfgMap map[string]any, shared bool, ac activity.Client, log
 		shared:       shared,
 		ctx:          ctx,
 		cancel:       cancel,
-		activity:     client,
 	}
 
 	// Open the DB
@@ -162,9 +161,8 @@ type connection struct {
 	dbErr       error
 	shared      bool
 	// Cancellable context to control internal processes like emitting the stats
-	ctx      context.Context
-	cancel   context.CancelFunc
-	activity activity.Client
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 // Driver implements drivers.Connection.

--- a/runtime/drivers/duckdb/olap.go
+++ b/runtime/drivers/duckdb/olap.go
@@ -90,18 +90,28 @@ func (c *connection) Execute(ctx context.Context, stmt *drivers.Statement) (res 
 		totalLatency := time.Since(start).Milliseconds()
 		queueLatency := acquiredTime.Sub(start).Milliseconds()
 
-		attrs := attribute.NewSet(
+		attrs := []attribute.KeyValue{
 			attribute.String("db", c.config.DBFilePath),
 			attribute.Bool("cancelled", errors.Is(outErr, context.Canceled)),
 			attribute.Bool("failed", outErr != nil),
-		)
+		}
 
-		queriesCounter.Add(ctx, 1, metric.WithAttributeSet(attrs))
-		queueLatencyHistogram.Record(ctx, queueLatency, metric.WithAttributeSet(attrs))
-		totalLatencyHistogram.Record(ctx, totalLatency, metric.WithAttributeSet(attrs))
+		attrSet := attribute.NewSet(attrs...)
+
+		queriesCounter.Add(ctx, 1, metric.WithAttributeSet(attrSet))
+		queueLatencyHistogram.Record(ctx, queueLatency, metric.WithAttributeSet(attrSet))
+		totalLatencyHistogram.Record(ctx, totalLatency, metric.WithAttributeSet(attrSet))
 		if acquired {
 			// Only track query latency when not cancelled in queue
-			queryLatencyHistogram.Record(ctx, totalLatency-queueLatency, metric.WithAttributeSet(attrs))
+			queryLatencyHistogram.Record(ctx, totalLatency-queueLatency, metric.WithAttributeSet(attrSet))
+		}
+
+		if c.activity != nil {
+			c.activity.Emit(ctx, "duckdb_queue_latency_ms", float64(queueLatency), attrs...)
+			c.activity.Emit(ctx, "duckdb_total_latency_ms", float64(totalLatency), attrs...)
+			if acquired {
+				c.activity.Emit(ctx, "duckdb_query_latency_ms", float64(totalLatency-queueLatency), attrs...)
+			}
 		}
 	}()
 


### PR DESCRIPTION
Introduced 3 DuckDB related metrics: `duckdb_queue_latency_ms`, `duckdb_total_latency_ms`, `duckdb_query_latency_ms`