### PR TITLE
Do not select leaderboard item on shift click

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/LeaderboardListItem.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardListItem.svelte
@@ -26,6 +26,7 @@
     LeaderboardItemData,
     getFormatterValueForPercDiff,
   } from "./leaderboard-utils";
+  import ShiftKey from "@rilldata/web-common/components/tooltip/ShiftKey.svelte";
 
   export let itemData: LeaderboardItemData;
   $: label = itemData.label;
@@ -120,7 +121,8 @@
   <button
     class="flex flex-row w-full text-left transition-color"
     on:blur={onLeave}
-    on:click={() => {
+    on:click={(e) => {
+      if (e.shiftKey) return;
       dispatch("select-item", {
         label,
       });

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardListItem.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardListItem.svelte
@@ -26,7 +26,6 @@
     LeaderboardItemData,
     getFormatterValueForPercDiff,
   } from "./leaderboard-utils";
-  import ShiftKey from "@rilldata/web-common/components/tooltip/ShiftKey.svelte";
 
   export let itemData: LeaderboardItemData;
   $: label = itemData.label;


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
#3049 

#### Details:
Disable click action when pressed with shift key

## Steps to Verify
1. Shift click on a leaderboard item
2. Value should be copied but not included.
