### PR TITLE
Fix up `MenuItem` component

### DIFF
--- a/web-common/src/components/menu/core/MenuItem.svelte
+++ b/web-common/src/components/menu/core/MenuItem.svelte
@@ -71,6 +71,12 @@
   }
   let hovered = false;
 
+  function onMouseOver() {
+    if (!disabled) {
+      hovered = true;
+    }
+  }
+
   function onFocus() {
     if (!disabled) {
       $currentItem = itemID;
@@ -124,6 +130,7 @@
     ? 'rgb(75, 85, 99)'
     : 'rgb(235, 235, 235)'}"
   class="
+        w-full
         text-left
         py-1
         {icon ? 'px-2' : 'px-3'}
@@ -146,7 +153,7 @@
   class:selected
   class:cursor-not-allowed={disabled}
   aria-disabled={disabled}
-  on:mouseover={onFocus}
+  on:mouseover={onMouseOver}
   on:mouseleave={onBlur}
   on:focus={onFocus}
   on:blur={() => {
@@ -154,7 +161,7 @@
       hovered = false;
     }
   }}
-  on:click|stopPropagation={handleClick}
+  on:click={handleClick}
 >
   {#if icon}
     <div
@@ -182,7 +189,10 @@
     </div>
   </div>
   {#if $$slots["right"]}
-    <div class="text-right ui-copy-muted">
+    <div
+      class="grid place-content-center text-right ui-copy-muted"
+      style:height="18px"
+    >
       <slot name="right" {focused} />
     </div>
   {/if}


### PR DESCRIPTION
Our `MenuItem` component had a few shortcomings that I had to address in https://github.com/rilldata/rill/pull/3047. To ensure there aren't any side effects to these changes, I've created this PR to test/accept it in isolation.

Specifically:
- The background color on hover didn't fill the full width of some menus
- Focus was applied on hover
- Clicks weren't propagating to parent components
- Content placed in the "right" slot wasn't centered