### PR TITLE
Remove repeated time zone calls

### DIFF
--- a/web-common/src/features/dashboards/time-controls/TimeControls.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeControls.svelte
@@ -65,8 +65,10 @@
      * timezone to UTC in such cases.
      *
      */
-
-    if (!availableTimeZones?.length) {
+    if (
+      !availableTimeZones?.length &&
+      $dashboardStore?.selectedTimezone !== "Etc/UTC"
+    ) {
       metricsExplorerStore.setTimeZone(metricViewName, "Etc/UTC");
       localUserPreferences.set({ timeZone: "Etc/UTC" });
     }


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Scrub was not working on some of the charts. On further inspection saw that `setTimeZone` was being called every time the app re-rendered and dispatched a call to set the scrub as `undefined`. 

#### Details:
For dashboards without any time zone we were making repeated state calls. This PR fixes that issue.

## Steps to Verify
1. Scrub on a dashboard without any timezone keys defined
2. The scrub should work