### PR TITLE
Use mutex instead of tx for DuckDB drop and replace table

### DIFF
--- a/runtime/drivers/druid/olap.go
+++ b/runtime/drivers/druid/olap.go
@@ -13,7 +13,7 @@ func (c *connection) Dialect() drivers.Dialect {
 	return drivers.DialectDruid
 }
 
-func (c *connection) WithConnection(ctx context.Context, priority int, longRunning bool, fn drivers.WithConnectionFunc) error {
+func (c *connection) WithConnection(ctx context.Context, priority int, longRunning, tx bool, fn drivers.WithConnectionFunc) error {
 	panic("not implemented")
 }
 

--- a/runtime/drivers/duckdb/duckdb_test.go
+++ b/runtime/drivers/duckdb/duckdb_test.go
@@ -163,7 +163,7 @@ func TestFatalErrConcurrent(t *testing.T) {
 			LEFT JOIN d ON b.b12 = d.d1
 			WHERE d.d2 IN ('');
 		`
-		err1 = olap.WithConnection(context.Background(), 0, false, func(ctx, ensuredCtx context.Context, _ *sql.Conn) error {
+		err1 = olap.WithConnection(context.Background(), 0, false, false, func(ctx, ensuredCtx context.Context, _ *sql.Conn) error {
 			time.Sleep(500 * time.Millisecond)
 			return olap.Exec(ctx, &drivers.Statement{Query: qry})
 		})
@@ -176,7 +176,7 @@ func TestFatalErrConcurrent(t *testing.T) {
 	var err2 error
 	go func() {
 		qry := `SELECT * FROM a;`
-		err2 = olap.WithConnection(context.Background(), 0, false, func(ctx, ensuredCtx context.Context, _ *sql.Conn) error {
+		err2 = olap.WithConnection(context.Background(), 0, false, false, func(ctx, ensuredCtx context.Context, _ *sql.Conn) error {
 			time.Sleep(1000 * time.Millisecond)
 			return olap.Exec(ctx, &drivers.Statement{Query: qry})
 		})
@@ -190,7 +190,7 @@ func TestFatalErrConcurrent(t *testing.T) {
 	go func() {
 		time.Sleep(250 * time.Millisecond)
 		qry := `SELECT * FROM a;`
-		err3 = olap.WithConnection(context.Background(), 0, false, func(ctx, ensuredCtx context.Context, _ *sql.Conn) error {
+		err3 = olap.WithConnection(context.Background(), 0, false, false, func(ctx, ensuredCtx context.Context, _ *sql.Conn) error {
 			return olap.Exec(ctx, &drivers.Statement{Query: qry})
 		})
 		wg.Done()

--- a/runtime/drivers/duckdb/olap.go
+++ b/runtime/drivers/duckdb/olap.go
@@ -30,14 +30,14 @@ func (c *connection) Dialect() drivers.Dialect {
 	return drivers.DialectDuckDB
 }
 
-func (c *connection) WithConnection(ctx context.Context, priority int, longRunning bool, fn drivers.WithConnectionFunc) error {
+func (c *connection) WithConnection(ctx context.Context, priority int, longRunning, tx bool, fn drivers.WithConnectionFunc) error {
 	// Check not nested
 	if connFromContext(ctx) != nil {
 		panic("nested WithConnection")
 	}
 
 	// Acquire connection
-	conn, release, err := c.acquireOLAPConn(ctx, priority, longRunning)
+	conn, release, err := c.acquireOLAPConn(ctx, priority, longRunning, tx)
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func (c *connection) Execute(ctx context.Context, stmt *drivers.Statement) (res 
 	}()
 
 	// Acquire connection
-	conn, release, err := c.acquireOLAPConn(ctx, stmt.Priority, stmt.LongRunning)
+	conn, release, err := c.acquireOLAPConn(ctx, stmt.Priority, stmt.LongRunning, false)
 	acquiredTime = time.Now()
 	if err != nil {
 		return nil, err

--- a/runtime/drivers/duckdb/transporter/motherduck_to_duckDB.go
+++ b/runtime/drivers/duckdb/transporter/motherduck_to_duckDB.go
@@ -40,7 +40,7 @@ func (t *motherduckToDuckDB) Transfer(ctx context.Context, srcProps, sinkProps m
 	}
 
 	config := t.from.Config()
-	err = t.to.WithConnection(ctx, 1, true, func(ctx, ensuredCtx context.Context, _ *sql.Conn) error {
+	err = t.to.WithConnection(ctx, 1, true, false, func(ctx, ensuredCtx context.Context, _ *sql.Conn) error {
 		res, err := t.to.Execute(ctx, &drivers.Statement{Query: "SELECT current_database();"})
 		if err != nil {
 			return err

--- a/runtime/drivers/olap.go
+++ b/runtime/drivers/olap.go
@@ -22,7 +22,7 @@ type WithConnectionFunc func(wrappedCtx context.Context, ensuredCtx context.Cont
 // OLAPStore is implemented by drivers that are capable of storing, transforming and serving analytical queries.
 type OLAPStore interface {
 	Dialect() Dialect
-	WithConnection(ctx context.Context, priority int, longRunning bool, fn WithConnectionFunc) error
+	WithConnection(ctx context.Context, priority int, longRunning, tx bool, fn WithConnectionFunc) error
 	Exec(ctx context.Context, stmt *Statement) error
 	Execute(ctx context.Context, stmt *Statement) (*Result, error)
 	InformationSchema() InformationSchema

--- a/runtime/queries/column_timeseries.go
+++ b/runtime/queries/column_timeseries.go
@@ -99,7 +99,7 @@ func (q *ColumnTimeseries) Resolve(ctx context.Context, rt *runtime.Runtime, ins
 		return nil
 	}
 
-	return olap.WithConnection(ctx, priority, false, func(ctx context.Context, ensuredCtx context.Context, _ *sql.Conn) error {
+	return olap.WithConnection(ctx, priority, false, false, func(ctx context.Context, ensuredCtx context.Context, _ *sql.Conn) error {
 		filter, args, err := buildFilterClauseForMetricsViewFilter(q.MetricsView, q.MetricsViewFilter, olap.Dialect(), q.MetricsViewPolicy)
 		if err != nil {
 			return err

--- a/runtime/queries/table_columns.go
+++ b/runtime/queries/table_columns.go
@@ -58,7 +58,7 @@ func (q *TableColumns) Resolve(ctx context.Context, rt *runtime.Runtime, instanc
 		return fmt.Errorf("not available for dialect '%s'", olap.Dialect())
 	}
 
-	return olap.WithConnection(ctx, priority, false, func(ctx context.Context, ensuredCtx context.Context, _ *sql.Conn) error {
+	return olap.WithConnection(ctx, priority, false, false, func(ctx context.Context, ensuredCtx context.Context, _ *sql.Conn) error {
 		// views return duplicate column names, so we need to create a temporary table
 		temporaryTableName := tempName("profile_columns_")
 		err = olap.Exec(ctx, &drivers.Statement{

--- a/runtime/services/catalog/migrator/sources/sources.go
+++ b/runtime/services/catalog/migrator/sources/sources.go
@@ -60,24 +60,18 @@ func (m *sourceMigrator) Update(ctx context.Context,
 		return err
 	}
 
-	return olap.WithConnection(ctx, 100, true, func(ctx, ensuredCtx context.Context, conn *sql.Conn) error {
-		tx, err := conn.BeginTx(ctx, nil)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = tx.Rollback() }()
-
-		_, err = tx.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", apiSource.Name))
+	return olap.WithConnection(ctx, 100, true, true, func(ctx, ensuredCtx context.Context, conn *sql.Conn) error {
+		_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", apiSource.Name))
 		if err != nil {
 			return err
 		}
 
-		_, err = tx.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s RENAME TO %s", tempName, apiSource.Name))
+		_, err = conn.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %s RENAME TO %s", tempName, apiSource.Name))
 		if err != nil {
 			return err
 		}
 
-		return tx.Commit()
+		return nil
 	})
 }
 


### PR DESCRIPTION
- We're seeing the DuckDB `.wal` explode in size when using a transaction to drop and replace a table. For a ~25GB dataset, we've observed a `.wal` size grow to ~250GB and freezing for almost an hour.
- This PR replaces the DB-level transaction with a `RWMutex` in the DuckDB driver. Regular queries take a read lock, "transactions" take a write lock.
- This loses the fault tolerance of transactions, but keeps consistency.