### PR TITLE
Move source properties backwards compatibility rules to drivers

### DIFF
--- a/runtime/drivers/duckdb/transporter/duckDB_to_duckDB.go
+++ b/runtime/drivers/duckdb/transporter/duckDB_to_duckDB.go
@@ -23,7 +23,7 @@ func NewDuckDBToDuckDB(to drivers.OLAPStore, logger *zap.Logger) drivers.Transpo
 var _ drivers.Transporter = &duckDBToDuckDB{}
 
 func (t *duckDBToDuckDB) Transfer(ctx context.Context, srcProps, sinkProps map[string]any, opts *drivers.TransferOpts, p drivers.Progress) error {
-	srcCfg, err := parseSourceProperties(srcProps)
+	srcCfg, err := parseDBSourceProperties(srcProps)
 	if err != nil {
 		return err
 	}

--- a/runtime/drivers/duckdb/transporter/motherduck_to_duckDB.go
+++ b/runtime/drivers/duckdb/transporter/motherduck_to_duckDB.go
@@ -29,7 +29,7 @@ func NewMotherduckToDuckDB(from drivers.Handle, to drivers.OLAPStore, logger *za
 
 // TODO: should it run count from user_query to set target in progress ?
 func (t *motherduckToDuckDB) Transfer(ctx context.Context, srcProps, sinkProps map[string]any, opts *drivers.TransferOpts, p drivers.Progress) error {
-	srcCfg, err := parseSourceProperties(srcProps)
+	srcCfg, err := parseDBSourceProperties(srcProps)
 	if err != nil {
 		return err
 	}

--- a/runtime/drivers/duckdb/transporter/utils.go
+++ b/runtime/drivers/duckdb/transporter/utils.go
@@ -64,14 +64,17 @@ func parseFileSourceProperties(props map[string]any) (*fileSourceProperties, err
 
 	if cfg.HivePartitioning != nil {
 		cfg.DuckDB["hive_partitioning"] = *cfg.HivePartitioning
+		cfg.HivePartitioning = nil
 	}
 
 	if cfg.CSVDelimiter != "" {
 		cfg.DuckDB["delim"] = fmt.Sprintf("'%v'", cfg.CSVDelimiter)
+		cfg.CSVDelimiter = ""
 	}
 
 	if cfg.IngestAllowSchemaRelaxation != nil {
 		cfg.AllowSchemaRelaxation = *cfg.IngestAllowSchemaRelaxation
+		cfg.IngestAllowSchemaRelaxation = nil
 	}
 
 	if cfg.AllowSchemaRelaxation {

--- a/runtime/drivers/duckdb/transporter/utils.go
+++ b/runtime/drivers/duckdb/transporter/utils.go
@@ -9,22 +9,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-type sourceProperties struct {
-	Database string `mapstructure:"db"`
-	SQL      string `mapstructure:"sql"`
-}
-
-func parseSourceProperties(props map[string]any) (*sourceProperties, error) {
-	cfg := &sourceProperties{}
-	if err := mapstructure.Decode(props, cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse source properties: %w", err)
-	}
-	if cfg.SQL == "" {
-		return nil, fmt.Errorf("property 'sql' is mandatory")
-	}
-	return cfg, nil
-}
-
 type sinkProperties struct {
 	Table string `mapstructure:"table"`
 }
@@ -34,6 +18,69 @@ func parseSinkProperties(props map[string]any) (*sinkProperties, error) {
 	if err := mapstructure.Decode(props, cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse sink properties: %w", err)
 	}
+	return cfg, nil
+}
+
+type dbSourceProperties struct {
+	Database string `mapstructure:"db"`
+	SQL      string `mapstructure:"sql"`
+}
+
+func parseDBSourceProperties(props map[string]any) (*dbSourceProperties, error) {
+	cfg := &dbSourceProperties{}
+	if err := mapstructure.Decode(props, cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse source properties: %w", err)
+	}
+	if cfg.SQL == "" {
+		return nil, fmt.Errorf("property 'sql' is mandatory")
+	}
+	return cfg, nil
+}
+
+type fileSourceProperties struct {
+	SQL                   string         `mapstructure:"sql"`
+	DuckDB                map[string]any `mapstructure:"duckdb"`
+	Format                string         `mapstructure:"format"`
+	AllowSchemaRelaxation bool           `mapstructure:"allow_schema_relaxation"`
+
+	// Backwards compatibility
+	HivePartitioning            *bool  `mapstructure:"hive_partitioning"`
+	CSVDelimiter                string `mapstructure:"csv.delimiter"`
+	IngestAllowSchemaRelaxation *bool  `mapstructure:"ingest.allow_schema_relaxation"`
+}
+
+func parseFileSourceProperties(props map[string]any) (*fileSourceProperties, error) {
+	cfg := &fileSourceProperties{}
+	if err := mapstructure.Decode(props, cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse source properties: %w", err)
+	}
+
+	if cfg.DuckDB == nil {
+		cfg.DuckDB = map[string]any{}
+	}
+
+	if cfg.HivePartitioning != nil {
+		cfg.DuckDB["hive_partitioning"] = *cfg.HivePartitioning
+	}
+
+	if cfg.CSVDelimiter != "" {
+		cfg.DuckDB["delim"] = fmt.Sprintf("'%v'", cfg.CSVDelimiter)
+	}
+
+	if cfg.IngestAllowSchemaRelaxation != nil {
+		cfg.AllowSchemaRelaxation = *cfg.IngestAllowSchemaRelaxation
+	}
+
+	if cfg.AllowSchemaRelaxation {
+		if val, ok := cfg.DuckDB["union_by_name"].(bool); ok && !val {
+			return nil, fmt.Errorf("can't set `union_by_name` and `allow_schema_relaxation` at the same time")
+		}
+
+		if hasKey(cfg.DuckDB, "columns", "types", "dtypes") {
+			return nil, fmt.Errorf("if any of `columns`,`types`,`dtypes` is set `allow_schema_relaxation` must be disabled")
+		}
+	}
+
 	return cfg, nil
 }
 
@@ -107,26 +154,6 @@ type duckDBTableSchemaResult struct {
 	Key        *string `db:"key"`
 	Default    *string `db:"default"`
 	Extra      *string `db:"extra"`
-}
-
-func schemaRelaxationProperty(prop map[string]interface{}) (bool, error) {
-	allowSchemaRelaxation, defined := prop["allow_schema_relaxation"].(bool)
-	val, ok := prop["union_by_name"].(bool)
-	if ok && !val && allowSchemaRelaxation {
-		// if union_by_name is set as false addition can't be done
-		return false, fmt.Errorf("if `union_by_name` is set `allow_schema_relaxation` must be disabled")
-	}
-
-	if hasKey(prop, "columns", "types", "dtypes") && allowSchemaRelaxation {
-		return false, fmt.Errorf("if any of `columns`,`types`,`dtypes` is set `allow_schema_relaxation` must be disabled")
-	}
-
-	// set default values
-	if !defined {
-		allowSchemaRelaxation = false
-	}
-
-	return allowSchemaRelaxation, nil
 }
 
 // utility functions

--- a/runtime/drivers/duckdb/transporter/utils_test.go
+++ b/runtime/drivers/duckdb/transporter/utils_test.go
@@ -1,0 +1,26 @@
+package transporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDuckDBPropertiesBackwardsCompatibility(t *testing.T) {
+	props := map[string]any{
+		"format":            "csv",
+		"csv.delimiter":     "|",
+		"hive_partitioning": true,
+	}
+
+	cfg, err := parseFileSourceProperties(props)
+	require.NoError(t, err)
+
+	require.Equal(t, cfg, &fileSourceProperties{
+		Format: "csv",
+		DuckDB: map[string]any{
+			"delim":             "'|'",
+			"hive_partitioning": true,
+		},
+	})
+}

--- a/runtime/drivers/gcs/gcs.go
+++ b/runtime/drivers/gcs/gcs.go
@@ -139,6 +139,7 @@ func (d driver) HasAnonymousSourceAccess(ctx context.Context, src map[string]any
 
 type sourceProperties struct {
 	Path                  string         `key:"path"`
+	URI                   string         `key:"uri"`
 	Extract               map[string]any `mapstructure:"extract"`
 	GlobMaxTotalSize      int64          `mapstructure:"glob.max_total_size"`
 	GlobMaxObjectsMatched int            `mapstructure:"glob.max_objects_matched"`
@@ -153,6 +154,11 @@ func parseSourceProperties(props map[string]any) (*sourceProperties, error) {
 	err := mapstructure.WeakDecode(props, conf)
 	if err != nil {
 		return nil, err
+	}
+
+	// Backwards compatibility for "uri" renamed to "path"
+	if conf.URI != "" {
+		conf.Path = conf.URI
 	}
 
 	if !doublestar.ValidatePattern(conf.Path) {

--- a/runtime/drivers/s3/s3.go
+++ b/runtime/drivers/s3/s3.go
@@ -211,6 +211,7 @@ func (c *Connection) AsSQLStore() (drivers.SQLStore, bool) {
 
 type sourceProperties struct {
 	Path                  string         `mapstructure:"path"`
+	URI                   string         `mapstructure:"uri"`
 	AWSRegion             string         `mapstructure:"region"`
 	GlobMaxTotalSize      int64          `mapstructure:"glob.max_total_size"`
 	GlobMaxObjectsMatched int            `mapstructure:"glob.max_objects_matched"`
@@ -227,6 +228,11 @@ func parseSourceProperties(props map[string]any) (*sourceProperties, error) {
 	err := mapstructure.WeakDecode(props, conf)
 	if err != nil {
 		return nil, err
+	}
+
+	// Backwards compatibility for "uri" renamed to "path"
+	if conf.URI != "" {
+		conf.Path = conf.URI
 	}
 
 	if !doublestar.ValidatePattern(conf.Path) {

--- a/runtime/services/catalog/artifacts/artifacts_test.go
+++ b/runtime/services/catalog/artifacts/artifacts_test.go
@@ -64,7 +64,7 @@ duckdb:
 					Name:      "S3Source",
 					Connector: "s3",
 					Properties: toProtoStruct(map[string]any{
-						"path":   "s3://bucket/path/file.csv",
+						"uri":    "s3://bucket/path/file.csv",
 						"region": "us-east-2",
 					}),
 				},
@@ -186,116 +186,6 @@ measures:
 			require.Equal(t, tt.Raw, string(b))
 		})
 	}
-}
-
-func TestCsvDelimiterBackwardCompatibility(t *testing.T) {
-	catalog := &drivers.CatalogEntry{
-		Name: "Source",
-		Path: "sources/Source.yaml",
-		Type: drivers.ObjectTypeSource,
-		Object: &runtimev1.Source{
-			Name:      "Source",
-			Connector: "local_file",
-			Properties: toProtoStruct(map[string]any{
-				"path":          "data/source.csv",
-				"format":        "csv",
-				"csv.delimiter": "|",
-			}),
-		},
-	}
-	raw := `type: local_file
-path: data/source.csv
-format: csv
-duckdb:
-    delim: '''|'''
-`
-	dir := t.TempDir()
-	fileStore, err := drivers.Open("file", map[string]any{"dsn": dir}, false, activity.NewNoopClient(), zap.NewNop())
-	require.NoError(t, err)
-	repoStore, _ := fileStore.AsRepoStore("")
-	ctx := context.Background()
-
-	err = artifacts.Write(ctx, repoStore, "test", catalog)
-	require.NoError(t, err)
-
-	readCatalog, err := artifacts.Read(ctx, repoStore, registryStore(t), "test", catalog.Path)
-	require.Equal(t, readCatalog, &drivers.CatalogEntry{
-		Name: "Source",
-		Path: "sources/Source.yaml",
-		Type: drivers.ObjectTypeSource,
-		Object: &runtimev1.Source{
-			Name:      "Source",
-			Connector: "local_file",
-			Properties: toProtoStruct(map[string]any{
-				"path":   "data/source.csv",
-				"format": "csv",
-				"duckdb": map[string]any{"delim": "'|'"},
-			}),
-		},
-	})
-	require.NoError(t, err)
-
-	err = artifacts.Write(ctx, repoStore, "test", readCatalog)
-	require.NoError(t, err)
-
-	b, err := os.ReadFile(path.Join(dir, readCatalog.Path))
-	require.NoError(t, err)
-	require.Equal(t, raw, string(b))
-}
-
-func TestHivePartitioningBackwardCompatibility(t *testing.T) {
-	catalog := &drivers.CatalogEntry{
-		Name: "Source",
-		Path: "sources/Source.yaml",
-		Type: drivers.ObjectTypeSource,
-		Object: &runtimev1.Source{
-			Name:      "Source",
-			Connector: "local_file",
-			Properties: toProtoStruct(map[string]any{
-				"path":              "data/source.csv",
-				"format":            "csv",
-				"hive_partitioning": true,
-			}),
-		},
-	}
-	raw := `type: local_file
-path: data/source.csv
-format: csv
-duckdb:
-    hive_partitioning: true
-`
-	dir := t.TempDir()
-	fileStore, err := drivers.Open("file", map[string]any{"dsn": dir}, false, activity.NewNoopClient(), zap.NewNop())
-	require.NoError(t, err)
-	repoStore, _ := fileStore.AsRepoStore("")
-	ctx := context.Background()
-
-	err = artifacts.Write(ctx, repoStore, "test", catalog)
-	require.NoError(t, err)
-
-	readCatalog, err := artifacts.Read(ctx, repoStore, registryStore(t), "test", catalog.Path)
-	require.Equal(t, readCatalog, &drivers.CatalogEntry{
-		Name: "Source",
-		Path: "sources/Source.yaml",
-		Type: drivers.ObjectTypeSource,
-		Object: &runtimev1.Source{
-			Name:      "Source",
-			Connector: "local_file",
-			Properties: toProtoStruct(map[string]any{
-				"path":   "data/source.csv",
-				"format": "csv",
-				"duckdb": map[string]any{"hive_partitioning": true},
-			}),
-		},
-	})
-	require.NoError(t, err)
-
-	err = artifacts.Write(ctx, repoStore, "test", readCatalog)
-	require.NoError(t, err)
-
-	b, err := os.ReadFile(path.Join(dir, readCatalog.Path))
-	require.NoError(t, err)
-	require.Equal(t, raw, string(b))
 }
 
 func TestMetricsLabelBackwardsCompatibility(t *testing.T) {
@@ -574,7 +464,7 @@ duckdb:
 					Name:      "Source",
 					Connector: "s3",
 					Properties: toProtoStruct(map[string]any{
-						"path":   "s3://bucket/file",
+						"uri":    "s3://bucket/file",
 						"format": "csv",
 						"region": "us-east-2",
 						"duckdb": map[string]any{"delim": "'|'"},

--- a/runtime/services/catalog/artifacts/yaml/objects.go
+++ b/runtime/services/catalog/artifacts/yaml/objects.go
@@ -23,26 +23,27 @@ import (
  * This file contains the mapping from CatalogObject to Yaml files
  */
 type Source struct {
-	Type                  string
-	Path                  string         `yaml:"path,omitempty"`
-	CsvDelimiter          string         `yaml:"csv.delimiter,omitempty" mapstructure:"csv.delimiter,omitempty"`
-	URI                   string         `yaml:"uri,omitempty"`
-	Region                string         `yaml:"region,omitempty" mapstructure:"region,omitempty"`
-	S3Endpoint            string         `yaml:"endpoint,omitempty" mapstructure:"endpoint,omitempty"`
-	GlobMaxTotalSize      int64          `yaml:"glob.max_total_size,omitempty" mapstructure:"glob.max_total_size,omitempty"`
-	GlobMaxObjectsMatched int            `yaml:"glob.max_objects_matched,omitempty" mapstructure:"glob.max_objects_matched,omitempty"`
-	GlobMaxObjectsListed  int64          `yaml:"glob.max_objects_listed,omitempty" mapstructure:"glob.max_objects_listed,omitempty"`
-	GlobPageSize          int            `yaml:"glob.page_size,omitempty" mapstructure:"glob.page_size,omitempty"`
-	HivePartition         *bool          `yaml:"hive_partitioning,omitempty" mapstructure:"hive_partitioning,omitempty"`
-	Timeout               int32          `yaml:"timeout,omitempty"`
-	Format                string         `yaml:"format,omitempty" mapstructure:"format,omitempty"`
-	Extract               map[string]any `yaml:"extract,omitempty" mapstructure:"extract,omitempty"`
-	DuckDBProps           map[string]any `yaml:"duckdb,omitempty" mapstructure:"duckdb,omitempty"`
-	Headers               map[string]any `yaml:"headers,omitempty" mapstructure:"headers,omitempty"`
-	AllowSchemaRelaxation *bool          `yaml:"ingest.allow_schema_relaxation,omitempty" mapstructure:"allow_schema_relaxation,omitempty"`
-	SQL                   string         `yaml:"sql,omitempty" mapstructure:"sql,omitempty"`
-	DB                    string         `yaml:"db,omitempty" mapstructure:"db,omitempty"`
-	ProjectID             string         `yaml:"project_id,omitempty" mapstructure:"project_id,omitempty"`
+	Type                        string
+	Path                        string         `yaml:"path,omitempty"`
+	CsvDelimiter                string         `yaml:"csv.delimiter,omitempty" mapstructure:"csv.delimiter,omitempty"`
+	URI                         string         `yaml:"uri,omitempty"`
+	Region                      string         `yaml:"region,omitempty" mapstructure:"region,omitempty"`
+	S3Endpoint                  string         `yaml:"endpoint,omitempty" mapstructure:"endpoint,omitempty"`
+	GlobMaxTotalSize            int64          `yaml:"glob.max_total_size,omitempty" mapstructure:"glob.max_total_size,omitempty"`
+	GlobMaxObjectsMatched       int            `yaml:"glob.max_objects_matched,omitempty" mapstructure:"glob.max_objects_matched,omitempty"`
+	GlobMaxObjectsListed        int64          `yaml:"glob.max_objects_listed,omitempty" mapstructure:"glob.max_objects_listed,omitempty"`
+	GlobPageSize                int            `yaml:"glob.page_size,omitempty" mapstructure:"glob.page_size,omitempty"`
+	HivePartition               *bool          `yaml:"hive_partitioning,omitempty" mapstructure:"hive_partitioning,omitempty"`
+	Timeout                     int32          `yaml:"timeout,omitempty"`
+	Format                      string         `yaml:"format,omitempty" mapstructure:"format,omitempty"`
+	Extract                     map[string]any `yaml:"extract,omitempty" mapstructure:"extract,omitempty"`
+	DuckDBProps                 map[string]any `yaml:"duckdb,omitempty" mapstructure:"duckdb,omitempty"`
+	Headers                     map[string]any `yaml:"headers,omitempty" mapstructure:"headers,omitempty"`
+	AllowSchemaRelaxation       *bool          `yaml:"allow_schema_relaxation,omitempty" mapstructure:"allow_schema_relaxation,omitempty"`
+	IngestAllowSchemaRelaxation *bool          `yaml:"ingest.allow_schema_relaxation,omitempty" mapstructure:"allow_schema_relaxation,omitempty"`
+	SQL                         string         `yaml:"sql,omitempty" mapstructure:"sql,omitempty"`
+	DB                          string         `yaml:"db,omitempty" mapstructure:"db,omitempty"`
+	ProjectID                   string         `yaml:"project_id,omitempty" mapstructure:"project_id,omitempty"`
 }
 
 type MetricsView struct {
@@ -124,11 +125,15 @@ func toMetricsViewArtifact(catalog *drivers.CatalogEntry) (*MetricsView, error) 
 
 func fromSourceArtifact(source *Source, path string) (*drivers.CatalogEntry, error) {
 	props := map[string]interface{}{}
-	if source.Type == "local_file" {
+
+	if source.Path != "" {
 		props["path"] = source.Path
-	} else if source.URI != "" {
-		props["path"] = source.URI
 	}
+
+	if source.URI != "" {
+		props["uri"] = source.URI
+	}
+
 	if source.Region != "" {
 		props["region"] = source.Region
 	}
@@ -142,19 +147,11 @@ func fromSourceArtifact(source *Source, path string) (*drivers.CatalogEntry, err
 	}
 
 	if source.CsvDelimiter != "" {
-		// backward compatibility
-		if _, defined := props["duckdb"]; !defined {
-			props["duckdb"] = map[string]any{}
-		}
-		props["duckdb"].(map[string]any)["delim"] = fmt.Sprintf("'%v'", source.CsvDelimiter)
+		props["csv.delimiter"] = source.CsvDelimiter
 	}
 
 	if source.HivePartition != nil {
-		// backward compatibility
-		if _, defined := props["duckdb"]; !defined {
-			props["duckdb"] = map[string]any{}
-		}
-		props["duckdb"].(map[string]any)["hive_partitioning"] = *source.HivePartition
+		props["hive_partitioning"] = *source.HivePartition
 	}
 
 	if source.GlobMaxTotalSize != 0 {
@@ -187,6 +184,10 @@ func fromSourceArtifact(source *Source, path string) (*drivers.CatalogEntry, err
 
 	if source.AllowSchemaRelaxation != nil {
 		props["allow_schema_relaxation"] = *source.AllowSchemaRelaxation
+	}
+
+	if source.IngestAllowSchemaRelaxation != nil {
+		props["ingest.allow_schema_relaxation"] = *source.IngestAllowSchemaRelaxation
 	}
 
 	if source.SQL != "" {

--- a/runtime/services/catalog/artifacts/yaml/objects.go
+++ b/runtime/services/catalog/artifacts/yaml/objects.go
@@ -41,7 +41,7 @@ type Source struct {
 	DuckDBProps                 map[string]any `yaml:"duckdb,omitempty" mapstructure:"duckdb,omitempty"`
 	Headers                     map[string]any `yaml:"headers,omitempty" mapstructure:"headers,omitempty"`
 	AllowSchemaRelaxation       *bool          `yaml:"allow_schema_relaxation,omitempty" mapstructure:"allow_schema_relaxation,omitempty"`
-	IngestAllowSchemaRelaxation *bool          `yaml:"ingest.allow_schema_relaxation,omitempty" mapstructure:"allow_schema_relaxation,omitempty"`
+	IngestAllowSchemaRelaxation *bool          `yaml:"ingest.allow_schema_relaxation,omitempty" mapstructure:"ingest.allow_schema_relaxation,omitempty"`
 	SQL                         string         `yaml:"sql,omitempty" mapstructure:"sql,omitempty"`
 	DB                          string         `yaml:"db,omitempty" mapstructure:"db,omitempty"`
 	ProjectID                   string         `yaml:"project_id,omitempty" mapstructure:"project_id,omitempty"`


### PR DESCRIPTION
- Moves backwards compatibility rules for source properties into the drivers
- Enables the backwards compatibility rules to also work for the new reconcile

Note: The parsing of `fileSourceProperties` in the DuckDB transporters isn't the cleanest, since a) ideally they would be parsed in the source driver, not sink driver, b) some of them are actually sink properties. But that was also an issue before, so we can clean that up later.