### PR TITLE
update IntTimesPowerOfTenFormatter to handle edge cases with floating point errors

### DIFF
--- a/web-common/src/lib/number-formatting/strategies/IntTimesPowerOfTen.ts
+++ b/web-common/src/lib/number-formatting/strategies/IntTimesPowerOfTen.ts
@@ -109,28 +109,6 @@ export class IntTimesPowerOfTenFormatter implements Formatter {
         useTrailingDot
       );
 
-      // if (onInvalidInput === "consoleWarn" || onInvalidInput === "throw") {
-      //   // Valid inputs must have only one digit of precision,
-      //   // but because of floating point errors, we may have
-      //   // a number that is very close to an integer multiple
-      //   // of a power of ten. Therefore, we check that the
-      //   // formatted value satisfies the requirements of the
-      //   // formatter. This is kind of backwards, but ok for now.
-      //   const trailingDigits = numParts.int.slice(1);
-      //   const repeatedZeros = "0".repeat(trailingDigits.length);
-
-      //   if (trailingDigits !== repeatedZeros) {
-      //     const msg = `invalid input for IntTimesPowerOfTenFormatter: ${x}, ${JSON.stringify(
-      //       numParts
-      //     )})`;
-      //     if (onInvalidInput === "consoleWarn") {
-      //       console.warn(msg);
-      //     } else {
-      //       throw new Error(msg);
-      //     }
-      //   }
-      // }
-
       numParts.suffix = shortScaleSuffixIfAvailableForStr(numParts.suffix);
 
       if (this.options.upperCaseEForExponent !== true) {

--- a/web-common/src/lib/number-formatting/strategies/IntTimesPowerOfTen.ts
+++ b/web-common/src/lib/number-formatting/strategies/IntTimesPowerOfTen.ts
@@ -12,8 +12,37 @@ import {
   FormatterOptionsIntTimesPowerOfTenStrategy,
 } from "../humanizer-types";
 import { numberPartsToString } from "../utils/number-parts-utils";
-import { smallestPrecisionMagnitude } from "../utils/smallest-precision-magnitude";
 
+/**
+ * detects whether a number is within a floating point error
+ * of a single digit multiple of a power of ten.
+ */
+export const closeToIntTimesPowerOfTen = (x: number) =>
+  Math.abs(
+    x / 10 ** orderOfMagnitude(x) - Math.round(x / 10 ** orderOfMagnitude(x))
+  ) < 1e-6;
+
+/**
+ * This formatter handles numbers that MUST BE (*) a single digit
+ * integer multiple of a power of ten, such as the output of
+ * d3 scale ticks.
+ *
+ * Valid examples: 0.000040000, 1, 800, 6000, 5000000
+ *
+ * Invalid examples: 0.00004300, -12000, 180000, 503000
+ *
+ * (*) CAVEAT: Because of floating point errors, we accept numbers
+ * that are very close to a single digit multiple of a power of ten.
+ *
+ * The number will be formatted
+ * with a short scale suffix or an or engineering order
+ * of magnitude (a multiple of three). If the magnitude
+ * is 10^0, no suffix is used.
+ *
+ * A formatter using this strategy can be set to throw an error
+ * or log a warning if a of a non integer multiple of a power
+ * of ten given as an input.
+ */
 export class IntTimesPowerOfTenFormatter implements Formatter {
   options: FormatterOptionsCommon & FormatterOptionsIntTimesPowerOfTenStrategy;
   initialSample: number[];
@@ -56,9 +85,9 @@ export class IntTimesPowerOfTenFormatter implements Formatter {
       numParts = { int: "0", dot: "", frac: "", suffix: "" };
     } else {
       if (onInvalidInput === "consoleWarn" || onInvalidInput === "throw") {
-        // valid inputs must have only one digit of precision
-        // -- i.e, the leading OoM must match the OoM of the most precise digit
-        if (orderOfMagnitude(x) !== smallestPrecisionMagnitude(x)) {
+        // valid inputs must already be close to a single digit
+        //  integer multiple of a power of ten
+        if (!closeToIntTimesPowerOfTen(x)) {
           const msg = `recieved invalid input for IntTimesPowerOfTenFormatter: ${x}`;
           if (onInvalidInput === "consoleWarn") {
             console.warn(msg);
@@ -79,6 +108,28 @@ export class IntTimesPowerOfTenFormatter implements Formatter {
         padWithZeros,
         useTrailingDot
       );
+
+      // if (onInvalidInput === "consoleWarn" || onInvalidInput === "throw") {
+      //   // Valid inputs must have only one digit of precision,
+      //   // but because of floating point errors, we may have
+      //   // a number that is very close to an integer multiple
+      //   // of a power of ten. Therefore, we check that the
+      //   // formatted value satisfies the requirements of the
+      //   // formatter. This is kind of backwards, but ok for now.
+      //   const trailingDigits = numParts.int.slice(1);
+      //   const repeatedZeros = "0".repeat(trailingDigits.length);
+
+      //   if (trailingDigits !== repeatedZeros) {
+      //     const msg = `invalid input for IntTimesPowerOfTenFormatter: ${x}, ${JSON.stringify(
+      //       numParts
+      //     )})`;
+      //     if (onInvalidInput === "consoleWarn") {
+      //       console.warn(msg);
+      //     } else {
+      //       throw new Error(msg);
+      //     }
+      //   }
+      // }
 
       numParts.suffix = shortScaleSuffixIfAvailableForStr(numParts.suffix);
 

--- a/web-common/src/lib/number-formatting/utils/format-with-order-of-magnitude.ts
+++ b/web-common/src/lib/number-formatting/utils/format-with-order-of-magnitude.ts
@@ -3,7 +3,20 @@ import { smallestPrecisionMagnitude } from "./smallest-precision-magnitude";
 
 export const orderOfMagnitude = (x) => {
   if (x === 0) return 0;
-  return Math.floor(Math.log10(Math.abs(x)));
+  let mag = Math.floor(Math.log10(Math.abs(x)));
+  // having found the order of magnitude, if we divide it
+  // out of the number, we should get a number between 1 and 10.
+  // However, because of floating point errors, if we get a number
+  // very just less than 10, we may have a floating point error,
+  // in which we want to bump the order of magnitude up by one.
+  //
+  // Ex: 0.0009999999999999 has magnitude -4, but if multiply away
+  // the magnitude, we get:
+  // 0.0009999999999999 * 10**4 = 9.999999999999999
+  // -- just less than 10, so we want to bump the magnitude up to -3
+  // so that we can formar this as e.g. "1.0e-3"
+  if (10 - Math.abs(x) * 10 ** -mag < 1e-8) mag += 1;
+  return mag;
 };
 
 export const orderOfMagnitudeEng = (x) => {


### PR DESCRIPTION
hey @ericpgreen2, this should clear some of the warnings that may show up in the console re https://github.com/rilldata/rill/issues/3074.

Some of those warnings are actually a result of invalid inputs to a formatting function, but some just represent floating point imprecision that we can round away. This will solve all the cases of FP imprecision, but not the genuine bad inputs.

![image](https://github.com/rilldata/rill/assets/2380975/85e7fdf5-2ed3-47b7-9b95-68e2fb20e7f1)

(Interestingly, it seems like all the examples you show in the issue are actually bad inputs, whereas I was seeing a mix)