### PR TITLE
Don't show comparison circles on exclude mode

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/DimensionFilterGutter.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionFilterGutter.svelte
@@ -39,7 +39,7 @@
   }
 
   function showCircleIcon(index) {
-    if (excludeMode && selectedIndex.length) {
+    if (isBeingCompared && excludeMode && selectedIndex.length) {
       if (selectedIndex.includes(index)) {
         return false;
       } else {


### PR DESCRIPTION
Fix bug when comparison circles were being shown on exclude mode without the dimension being compared.