### PR TITLE
Never return errors for failed telemetry uploads

### DIFF
--- a/cli/pkg/local/app.go
+++ b/cli/pkg/local/app.go
@@ -434,7 +434,8 @@ func (a *App) trackingHandler(info *localInfo) http.Handler {
 		// Proxy request to rill intake
 		proxyReq, err := http.NewRequest(r.Method, "https://intake.rilldata.io/events/data-modeler-metrics", r.Body)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadGateway)
+			a.BaseLogger.Info("failed to create telemetry request", zap.Error(err))
+			w.WriteHeader(http.StatusOK)
 			return
 		}
 
@@ -446,7 +447,8 @@ func (a *App) trackingHandler(info *localInfo) http.Handler {
 		// Send proxied request
 		resp, err := http.DefaultClient.Do(proxyReq)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadGateway)
+			a.BaseLogger.Info("failed to send telemetry", zap.Error(err))
+			w.WriteHeader(http.StatusOK)
 			return
 		}
 		defer resp.Body.Close()


### PR DESCRIPTION
- The frontend crashes on source refresh if telemetry tracking errors
- This PR fixes the issue on the backend by never returning errors for telemetry tracking, even when it fails