### PR TITLE
Implement signed download tokens

### DIFF
--- a/runtime/pkg/symmetriccrypto/symmetriccrypto.go
+++ b/runtime/pkg/symmetriccrypto/symmetriccrypto.go
@@ -1,0 +1,81 @@
+package symmetriccrypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"errors"
+	"io"
+)
+
+func Must[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func GenerateKey(n int) ([]byte, error) {
+	res := make([]byte, n)
+	_, err := rand.Read(res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+type Encoder struct {
+	block cipher.Block
+	gcm   cipher.AEAD
+}
+
+func NewEphemeralEncoder(keySize int) (Encoder, error) {
+	key, err := GenerateKey(keySize)
+	if err != nil {
+		return Encoder{}, err
+	}
+
+	return NewEncoder(key)
+}
+
+func NewEncoder(key []byte) (Encoder, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return Encoder{}, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return Encoder{}, err
+	}
+
+	return Encoder{
+		block: block,
+		gcm:   gcm,
+	}, nil
+}
+
+func (e Encoder) Encrypt(data []byte) ([]byte, error) {
+	nonce := make([]byte, e.gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	res := e.gcm.Seal(nonce, nonce, data, nil)
+	return res, nil
+}
+
+func (e Encoder) Decrypt(data []byte) ([]byte, error) {
+	nonceSize := e.gcm.NonceSize()
+	if len(data) <= nonceSize {
+		return nil, errors.New("ciphertext is shorter than the nonce size")
+	}
+
+	nonce, cipherText := data[:nonceSize], data[nonceSize:]
+	res, err := e.gcm.Open(nil, nonce, cipherText, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/runtime/pkg/symmetriccrypto/symmetriccrypto_test.go
+++ b/runtime/pkg/symmetriccrypto/symmetriccrypto_test.go
@@ -1,0 +1,21 @@
+package symmetriccrypto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test(t *testing.T) {
+	enc, err := NewEphemeralEncoder(32)
+	require.NoError(t, err)
+
+	data := []byte("Hello, World!")
+
+	cipher, err := enc.Encrypt(data)
+	require.NoError(t, err)
+	plain, err := enc.Decrypt(cipher)
+	require.NoError(t, err)
+
+	require.Equal(t, data, plain)
+}

--- a/runtime/server/queries_metrics.go
+++ b/runtime/server/queries_metrics.go
@@ -444,6 +444,24 @@ func resolveMVAndSecurity(ctx context.Context, rt *runtime.Runtime, instanceID, 
 	return mv, resolvedSecurity, nil
 }
 
+func resolveMVAndSecurityFromAttributes(ctx context.Context, rt *runtime.Runtime, instanceID, metricsViewName string, attrs map[string]any) (*runtimev1.MetricsView, *runtime.ResolvedMetricsViewSecurity, error) {
+	mv, lastUpdatedOn, err := lookupMetricsView(ctx, rt, instanceID, metricsViewName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resolvedSecurity, err := rt.ResolveMetricsViewSecurity(attrs, instanceID, mv, lastUpdatedOn)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if resolvedSecurity != nil && !resolvedSecurity.Access {
+		return nil, nil, ErrForbidden
+	}
+
+	return mv, resolvedSecurity, nil
+}
+
 // returns the metrics view and the time the catalog was last updated
 func lookupMetricsView(ctx context.Context, rt *runtime.Runtime, instanceID, name string) (*runtimev1.MetricsView, time.Time, error) {
 	obj, err := rt.GetCatalogEntry(ctx, instanceID, name)


### PR DESCRIPTION
- Exports do not work in cloud because they require the JWT to be passed to the download handler.
- Passing the JWT is not trivial when initiating a download from the browser.
- This PR removes auth requirements from the download handler, leveraging a pre-signed (actually encrypted) download token containing the request and user attributes needed to resolve the download.
- It currently uses an ephemerally generated, in-memory encryption key. This will be reset every time the runtime is restarted. We should eventually replace this with an environment-configured key. Until it's replaced, download URLs will break when a runtime is restarted. This is acceptable since download URLs are usually very short-lived (seconds).