### PR TITLE
Add `mod` + `s` to save and refresh source file

### DIFF
--- a/web-common/src/features/sources/editor/SourceEditor.svelte
+++ b/web-common/src/features/sources/editor/SourceEditor.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
   import type { EditorView } from "@codemirror/view";
   import YAMLEditor from "@rilldata/web-common/components/editor/YAMLEditor.svelte";
+  import { useQueryClient } from "@tanstack/svelte-query";
   import { setLineStatuses } from "../../../components/editor/line-status";
+  import { overlay } from "../../../layout/overlay-store";
+  import { runtime } from "../../../runtime-client/runtime-store";
   import {
     fileArtifactsStore,
     getFileArtifactReconciliationErrors,
   } from "../../entity-management/file-artifacts-store";
   import { mapReconciliationErrorsToLines } from "../../metrics-views/errors";
+  import { saveAndRefresh } from "../saveAndRefresh";
+  import { useIsSourceUnsaved } from "../selectors";
   import { useSourceStore } from "../sources-store";
 
   export let sourceName: string;
@@ -15,7 +20,15 @@
   let editor: YAMLEditor;
   let view: EditorView;
 
+  const queryClient = useQueryClient();
   const sourceStore = useSourceStore(sourceName);
+
+  $: isSourceUnsavedQuery = useIsSourceUnsaved(
+    $runtime.instanceId,
+    sourceName,
+    $sourceStore.clientYAML
+  );
+  $: isSourceUnsaved = $isSourceUnsavedQuery.data;
 
   function handleUpdate(e: CustomEvent<{ content: string }>) {
     // Update the client-side store
@@ -39,7 +52,23 @@
     );
     if (view) setLineStatuses(lineBasedReconciliationErrors, view);
   }
+
+  async function handleModSave(event: KeyboardEvent) {
+    // Check if a Modifier Key + S is pressed
+    if (!(event.metaKey || event.ctrlKey) || event.key !== "s") return;
+
+    // Prevent default behaviour
+    event.preventDefault();
+
+    // Save the source, if it's unsaved
+    if (!isSourceUnsaved) return;
+    overlay.set({ title: `Importing ${sourceName}.yaml` });
+    await saveAndRefresh(queryClient, sourceName, $sourceStore.clientYAML);
+    overlay.set(null);
+  }
 </script>
+
+<svelte:window on:keydown={handleModSave} />
 
 <div class="editor flex flex-col border border-gray-200 rounded h-full">
   <div class="grow flex bg-white overflow-y-auto rounded">


### PR DESCRIPTION
This PR allows you to save & refresh a source file by pressing `mod` + `s`, where the modifier key is `cmd` on Mac and `ctrl` on Windows/Linux.