### PR TITLE
Enable Rill Developer to function offline

### DIFF
--- a/web-local/src/lib/svelte-query/globalQueryClient.ts
+++ b/web-local/src/lib/svelte-query/globalQueryClient.ts
@@ -1,9 +1,6 @@
-import { featureFlags } from "@rilldata/web-common/features/feature-flags";
 import { QueryClient } from "@tanstack/svelte-query";
-import { get } from "svelte/store";
 
 export function createQueryClient() {
-  const isLocal = !get(featureFlags)?.readOnly;
   return new QueryClient({
     defaultOptions: {
       queries: {
@@ -11,7 +8,10 @@ export function createQueryClient() {
         refetchOnReconnect: false,
         refetchOnWindowFocus: false,
         retry: false,
-        networkMode: isLocal ? "always" : "online",
+        networkMode: "always",
+      },
+      mutations: {
+        networkMode: "always",
       },
     },
   });


### PR DESCRIPTION
This PR enables Rill Developer to function offline by configuring TanStack Query's [Network Mode](https://tanstack.com/query/v4/docs/react/guides/network-mode).