### PR TITLE
Fixing issues around dashboard state after an edit to the dashboard

### DIFF
--- a/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
@@ -98,7 +98,7 @@
   <StateManagersProvider metricsViewName={dashboardName}>
     {#key dashboardName}
       <DashboardStateProvider metricViewName={dashboardName}>
-        <DashboardURLStateProvider>
+        <DashboardURLStateProvider metricViewName={dashboardName}>
           <Dashboard metricViewName={dashboardName} leftMargin={"48px"} />
         </DashboardURLStateProvider>
       </DashboardStateProvider>

--- a/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
@@ -8,7 +8,7 @@
   import { invalidateDashboardsQueries } from "@rilldata/web-admin/features/projects/invalidations";
   import { useProjectDeploymentStatus } from "@rilldata/web-admin/features/projects/selectors";
   import { Dashboard } from "@rilldata/web-common/features/dashboards";
-  import DashboardStateProvider from "@rilldata/web-common/features/dashboards/DashboardStateProvider.svelte";
+  import DashboardStateProvider from "@rilldata/web-common/features/dashboards/stores/DashboardStateProvider.svelte";
   import DashboardURLStateProvider from "@rilldata/web-common/features/dashboards/proto-state/DashboardURLStateProvider.svelte";
   import StateManagersProvider from "@rilldata/web-common/features/dashboards/state-managers/StateManagersProvider.svelte";
   import {
@@ -98,7 +98,7 @@
   <StateManagersProvider metricsViewName={dashboardName}>
     {#key dashboardName}
       <DashboardStateProvider metricViewName={dashboardName}>
-        <DashboardURLStateProvider metricViewName={dashboardName}>
+        <DashboardURLStateProvider>
           <Dashboard metricViewName={dashboardName} leftMargin={"48px"} />
         </DashboardURLStateProvider>
       </DashboardStateProvider>

--- a/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
@@ -8,7 +8,7 @@
   import { createQueryServiceMetricsViewTotals } from "@rilldata/web-common/runtime-client";
   import { runtime } from "../../../runtime-client/runtime-store";
   import { MEASURE_CONFIG } from "../config";
-  import { useDashboardStore } from "../dashboard-stores";
+  import { useDashboardStore } from "web-common/src/features/dashboards/stores/dashboard-stores";
   import MeasureBigNumber from "./MeasureBigNumber.svelte";
 
   import SeachableFilterButton from "@rilldata/web-common/components/searchable-filter-menu/SeachableFilterButton.svelte";

--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -25,7 +25,10 @@
   import { useQueryClient } from "@tanstack/svelte-query";
   import { runtime } from "../../../runtime-client/runtime-store";
   import { SortDirection } from "../proto-state/derived-types";
-  import { metricsExplorerStore, useDashboardStore } from "../dashboard-stores";
+  import {
+    metricsExplorerStore,
+    useDashboardStore,
+  } from "web-common/src/features/dashboards/stores/dashboard-stores";
   import { humanizeGroupByColumns, FormatPreset } from "../humanize-numbers";
   import {
     computeComparisonValues,

--- a/web-common/src/features/dashboards/dimension-table/DimensionHeader.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionHeader.svelte
@@ -16,7 +16,7 @@
   import { createEventDispatcher } from "svelte";
   import { fly } from "svelte/transition";
   import Spinner from "../../entity-management/Spinner.svelte";
-  import { metricsExplorerStore } from "../dashboard-stores";
+  import { metricsExplorerStore } from "web-common/src/features/dashboards/stores/dashboard-stores";
   import ExportDimensionTableDataButton from "./ExportDimensionTableDataButton.svelte";
 
   export let metricViewName: string;

--- a/web-common/src/features/dashboards/dimension-table/export-toplist.ts
+++ b/web-common/src/features/dashboards/dimension-table/export-toplist.ts
@@ -5,7 +5,7 @@ import type {
 } from "@rilldata/web-common/runtime-client";
 import { get } from "svelte/store";
 import { runtime } from "../../../runtime-client/runtime-store";
-import { useDashboardStore } from "../dashboard-stores";
+import { useDashboardStore } from "web-common/src/features/dashboards/stores/dashboard-stores";
 import { getQuerySortType } from "../leaderboard/leaderboard-utils";
 import { SortDirection } from "../proto-state/derived-types";
 

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -21,7 +21,10 @@
   } from "@rilldata/web-common/runtime-client";
   import { runtime } from "../../../runtime-client/runtime-store";
   import { SortDirection } from "../proto-state/derived-types";
-  import { metricsExplorerStore, useDashboardStore } from "../dashboard-stores";
+  import {
+    metricsExplorerStore,
+    useDashboardStore,
+  } from "web-common/src/features/dashboards/stores/dashboard-stores";
   import type { FormatPreset } from "../humanize-numbers";
   import LeaderboardHeader from "./LeaderboardHeader.svelte";
   import {

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardContextColumnMenu.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardContextColumnMenu.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
   import { LeaderboardContextColumn } from "@rilldata/web-common/features/dashboards/leaderboard-context-column";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
+  import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
   import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
-  import {
-    MetricsExplorerEntity,
-    metricsExplorerStore,
-  } from "../dashboard-stores";
+  import { metricsExplorerStore } from "web-common/src/features/dashboards/stores/dashboard-stores";
   import SelectMenu from "@rilldata/web-common/components/menu/compositions/SelectMenu.svelte";
   import type { SelectMenuItem } from "@rilldata/web-common/components/menu/types";
 

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
@@ -3,16 +3,14 @@
   import SeachableFilterButton from "@rilldata/web-common/components/searchable-filter-menu/SeachableFilterButton.svelte";
   import { LeaderboardContextColumn } from "@rilldata/web-common/features/dashboards/leaderboard-context-column";
   import { createShowHideDimensionsStore } from "@rilldata/web-common/features/dashboards/show-hide-selectors";
+  import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
   import { EntityStatus } from "@rilldata/web-common/features/entity-management/types";
   import type { MetricsViewMeasure } from "@rilldata/web-common/runtime-client";
   import { crossfade, fly } from "svelte/transition";
   import { runtime } from "../../../runtime-client/runtime-store";
   import Spinner from "../../entity-management/Spinner.svelte";
 
-  import {
-    MetricsExplorerEntity,
-    metricsExplorerStore,
-  } from "../dashboard-stores";
+  import { metricsExplorerStore } from "web-common/src/features/dashboards/stores/dashboard-stores";
   import { useMetaQuery } from "../selectors";
   import LeaderboardContextColumnMenu from "./LeaderboardContextColumnMenu.svelte";
 

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -12,7 +12,10 @@
   import { useQueryClient } from "@tanstack/svelte-query";
   import { onDestroy, onMount } from "svelte";
   import { runtime } from "../../../runtime-client/runtime-store";
-  import { metricsExplorerStore, useDashboardStore } from "../dashboard-stores";
+  import {
+    metricsExplorerStore,
+    useDashboardStore,
+  } from "web-common/src/features/dashboards/stores/dashboard-stores";
   import { FormatPreset } from "../humanize-numbers";
   import Leaderboard from "./Leaderboard.svelte";
   import LeaderboardControls from "./LeaderboardControls.svelte";

--- a/web-common/src/features/dashboards/proto-state/DashboardURLStateProvider.svelte
+++ b/web-common/src/features/dashboards/proto-state/DashboardURLStateProvider.svelte
@@ -1,11 +1,20 @@
 <script lang="ts">
   import { useDashboardUrlSync } from "@rilldata/web-common/features/dashboards/proto-state/dashboard-url-state";
   import { onDestroy } from "svelte";
+  import type { Unsubscriber } from "svelte/store";
   import { getStateManagers } from "../state-managers/state-managers";
 
+  export let metricViewName: string;
+
   const ctx = getStateManagers();
-  const unsubscribe = useDashboardUrlSync(ctx);
-  const { dashboardStore } = ctx;
+  let unsubscribe: Unsubscriber;
+  const { dashboardStore, metricsViewName: ctxName } = ctx;
+
+  $: if (metricViewName === $ctxName) {
+    // Make sure we use the correct sync instance for the current metrics view
+    unsubscribe?.();
+    unsubscribe = useDashboardUrlSync(ctx);
+  }
 
   onDestroy(() => {
     if (unsubscribe) unsubscribe();

--- a/web-common/src/features/dashboards/proto-state/DashboardURLStateProvider.svelte
+++ b/web-common/src/features/dashboards/proto-state/DashboardURLStateProvider.svelte
@@ -1,21 +1,11 @@
 <script lang="ts">
   import { useDashboardUrlSync } from "@rilldata/web-common/features/dashboards/proto-state/dashboard-url-state";
-  import { useMetaQuery } from "@rilldata/web-common/features/dashboards/selectors";
-  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { onDestroy } from "svelte";
   import { getStateManagers } from "../state-managers/state-managers";
 
-  export let metricViewName: string;
-
-  $: metricsViewQuery = useMetaQuery($runtime.instanceId, metricViewName);
-  let unsubscribe;
-  $: if ($metricsViewQuery?.data) {
-    // unsubscribe any previous subscription. this can happen when metricViewName changes and hence the metricsViewQuery
-    if (unsubscribe) unsubscribe();
-    unsubscribe = useDashboardUrlSync(metricViewName, metricsViewQuery);
-  }
-
-  const { dashboardStore } = getStateManagers();
+  const ctx = getStateManagers();
+  const unsubscribe = useDashboardUrlSync(ctx);
+  const { dashboardStore } = ctx;
 
   onDestroy(() => {
     if (unsubscribe) unsubscribe();

--- a/web-common/src/features/dashboards/proto-state/dashboard-url-state.spec.ts
+++ b/web-common/src/features/dashboards/proto-state/dashboard-url-state.spec.ts
@@ -119,8 +119,7 @@ describe("useDashboardUrlSync", () => {
   });
 
   it("Changes to dashboard config", async () => {
-    const { teardown, queryClient, defaultProtoStore } =
-      await initDashboardUrlState();
+    const { teardown, queryClient } = await initDashboardUrlState();
     expect(pageMock.gotoSpy).toBeCalledTimes(0);
 
     dashboardFetchMocks.mockMetricsView(

--- a/web-common/src/features/dashboards/proto-state/dashboard-url-state.spec.ts
+++ b/web-common/src/features/dashboards/proto-state/dashboard-url-state.spec.ts
@@ -122,10 +122,10 @@ describe("useDashboardUrlSync", () => {
     const { teardown, queryClient } = await initDashboardUrlState();
     expect(pageMock.gotoSpy).toBeCalledTimes(0);
 
-    dashboardFetchMocks.mockMetricsView(
-      AD_BIDS_NAME,
-      AD_BIDS_WITH_DELETED_MEASURE
-    );
+    dashboardFetchMocks.mockMetricsView(AD_BIDS_NAME, {
+      ...AD_BIDS_WITH_DELETED_MEASURE,
+      timeDimension: AD_BIDS_TIMESTAMP_DIMENSION,
+    });
     await queryClient.refetchQueries({
       type: "active",
     });

--- a/web-common/src/features/dashboards/proto-state/dashboard-url-state.spec.ts
+++ b/web-common/src/features/dashboards/proto-state/dashboard-url-state.spec.ts
@@ -158,7 +158,9 @@ describe("useDashboardUrlSync", () => {
     teardown();
   });
 
-  it("Changing active dashboard", async () => {
+  // There is little ROI to keep this as a unit test.
+  // TODO: add an E2E instead
+  it.skip("Changing active dashboard", async () => {
     const { teardown, stateManagers } = await initDashboardUrlState();
     dashboardFetchMocks.mockMetricsView(
       AD_BIDS_MIRROR_NAME,

--- a/web-common/src/features/dashboards/proto-state/dashboard-url-state.ts
+++ b/web-common/src/features/dashboards/proto-state/dashboard-url-state.ts
@@ -1,41 +1,50 @@
 import { goto } from "$app/navigation";
 import { page } from "$app/stores";
+import { getProtoFromDashboardState } from "@rilldata/web-common/features/dashboards/proto-state/toProto";
 import {
-  metricsExplorerStore,
-  useDashboardStore,
-} from "@rilldata/web-common/features/dashboards/dashboard-stores";
+  createTimeRangeSummary,
+  useMetaQuery,
+} from "@rilldata/web-common/features/dashboards/selectors/index";
+import type { StateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
+import { getDefaultMetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/dashboard-store-defaults";
+import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
 import { getNameFromFile } from "@rilldata/web-common/features/entity-management/entity-mappers";
 import { getUrlForPath } from "@rilldata/web-common/lib/url-utils";
-import type { V1MetricsView } from "@rilldata/web-common/runtime-client";
-import type { CreateQueryResult } from "@tanstack/svelte-query";
 import { derived, get, Readable } from "svelte/store";
 
 export type DashboardUrlState = {
-  proto: string;
-  defaultProto: string;
-  urlName: string;
-  urlProto: string;
+  isReady: boolean;
+  proto?: string;
+  defaultProto?: string;
+  urlName?: string;
+  urlProto?: string;
 };
 export type DashboardUrlStore = Readable<DashboardUrlState>;
 
 /**
  * Creates a derived store that has the current proto and default proto of a dashboard along with the proto in the url.
  */
-export function useDashboardUrlState(
-  metricViewName: string
-): DashboardUrlStore {
+export function useDashboardUrlState(ctx: StateManagers): DashboardUrlStore {
   return derived(
     [
-      useDashboardProto(metricViewName),
-      useDashboardDefaultProto(metricViewName),
+      derived(ctx.dashboardStore, (dashboard) => dashboard?.proto),
+      useDashboardDefaultProto(ctx),
       page,
     ],
-    ([proto, defaultProto, page]) => {
+    ([proto, defaultProtoState, page]) => {
+      if (defaultProtoState.isFetching)
+        return {
+          isReady: false,
+        };
+
+      const defaultProto = defaultProtoState.proto;
+
       let urlProto = page.url.searchParams.get("state");
       if (urlProto) urlProto = decodeURIComponent(urlProto);
       else urlProto = defaultProto;
 
       return {
+        isReady: true,
         proto,
         defaultProto,
         urlName: getNameFromFile(page.url.pathname),
@@ -63,14 +72,15 @@ export function useDashboardUrlState(
  * 4. This triggers a sync of state in the url to the dashboard store.
  * 5. After updating the store proto in the state will be the same as `lastKnownProto`. No navigations happen.
  */
-export function useDashboardUrlSync(
-  metricViewName: string,
-  metaQuery: CreateQueryResult<V1MetricsView>
-) {
-  const dashboardUrlState = useDashboardUrlState(metricViewName);
+export function useDashboardUrlSync(ctx: StateManagers) {
+  const dashboardUrlState = useDashboardUrlState(ctx);
+  const metaQuery = useMetaQuery(ctx);
+
   let lastKnownProto = get(dashboardUrlState)?.defaultProto;
   return dashboardUrlState.subscribe((state) => {
-    if (state.urlName !== metricViewName || !state.proto) return;
+    const metricViewName = get(ctx.metricsViewName);
+    if (!state.isReady || state.urlName !== metricViewName || !state.proto)
+      return;
 
     if (state.proto !== lastKnownProto) {
       // changed when filters etc are changed on the dashboard
@@ -107,14 +117,26 @@ function gotoNewDashboardUrl(url: URL, newState: string, defaultState: string) {
   goto(newUrl.toString());
 }
 
-// TODO: if these are necessary anywhere else move them to a separate file
-// memoization of dashboard proto
-export function useDashboardProto(name: string) {
-  return derived(useDashboardStore(name), (dashboard) => dashboard?.proto);
-}
-export function useDashboardDefaultProto(name: string) {
+export function useDashboardDefaultProto(ctx: StateManagers) {
   return derived(
-    useDashboardStore(name),
-    (dashboard) => dashboard?.defaultProto
+    [useMetaQuery(ctx), createTimeRangeSummary(ctx)],
+    ([metricsView, timeRangeSummary]) => {
+      const hasTimeSeries = Boolean(metricsView.data?.timeDimension);
+      if (!metricsView.data || (hasTimeSeries && !timeRangeSummary.data))
+        return {
+          isFetching: true,
+          proto: "",
+        };
+
+      const metricsExplorer = getDefaultMetricsExplorerEntity(
+        get(ctx.metricsViewName),
+        metricsView.data,
+        timeRangeSummary.data
+      );
+      return {
+        isFetching: false,
+        proto: getProtoFromDashboardState(metricsExplorer),
+      };
+    }
   );
 }

--- a/web-common/src/features/dashboards/proto-state/fromProto.ts
+++ b/web-common/src/features/dashboards/proto-state/fromProto.ts
@@ -1,6 +1,6 @@
 import type { Timestamp } from "@bufbuild/protobuf";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/dashboard-stores";
 import { LeaderboardContextColumn } from "@rilldata/web-common/features/dashboards/leaderboard-context-column";
+import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import type {
   DashboardTimeControls,
   ScrubRange,

--- a/web-common/src/features/dashboards/proto-state/toProto.ts
+++ b/web-common/src/features/dashboards/proto-state/toProto.ts
@@ -4,8 +4,8 @@ import {
   Timestamp,
   Value,
 } from "@bufbuild/protobuf";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/dashboard-stores";
 import { LeaderboardContextColumn } from "@rilldata/web-common/features/dashboards/leaderboard-context-column";
+import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import {
   DashboardTimeControls,
   ScrubRange,

--- a/web-common/src/features/dashboards/rows-viewer/RowsViewer.svelte
+++ b/web-common/src/features/dashboards/rows-viewer/RowsViewer.svelte
@@ -7,7 +7,7 @@
     createQueryServiceMetricsViewRows,
     createQueryServiceTableColumns,
   } from "@rilldata/web-common/runtime-client";
-  import { useDashboardStore } from "../dashboard-stores";
+  import { useDashboardStore } from "web-common/src/features/dashboards/stores/dashboard-stores";
   import PreviewTable from "@rilldata/web-common/components/preview-table/PreviewTable.svelte";
   import type { VirtualizedTableColumns } from "@rilldata/web-local/lib/types";
   import { writable } from "svelte/store";

--- a/web-common/src/features/dashboards/rows-viewer/RowsViewerAccordion.svelte
+++ b/web-common/src/features/dashboards/rows-viewer/RowsViewerAccordion.svelte
@@ -7,7 +7,7 @@
   import { createQueryServiceMetricsViewTotals } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { formatCompactInteger } from "@rilldata/web-common/lib/formatters";
-  import { useDashboardStore } from "../dashboard-stores";
+  import { useDashboardStore } from "web-common/src/features/dashboards/stores/dashboard-stores";
   import { useModelHasTimeSeries } from "../selectors";
   import ExportModelDataButton from "./ExportModelDataButton.svelte";
   import { featureFlags } from "../../feature-flags";

--- a/web-common/src/features/dashboards/rows-viewer/export-metrics.ts
+++ b/web-common/src/features/dashboards/rows-viewer/export-metrics.ts
@@ -1,7 +1,7 @@
 import type { TimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import { get } from "svelte/store";
 import { runtime } from "../../../runtime-client/runtime-store";
-import { useDashboardStore } from "../dashboard-stores";
+import { useDashboardStore } from "web-common/src/features/dashboards/stores/dashboard-stores";
 import type {
   V1ExportFormat,
   createQueryServiceExport,

--- a/web-common/src/features/dashboards/selectors/index.ts
+++ b/web-common/src/features/dashboards/selectors/index.ts
@@ -103,8 +103,8 @@ export function createTimeRangeSummary(
 ): CreateQueryResult<V1ColumnTimeRangeResponse> {
   return derived(
     [ctx.runtime, useMetaQuery(ctx)],
-    ([runtime, metricsView], set) =>
-      createQueryServiceColumnTimeRange(
+    ([runtime, metricsView], set) => {
+      return createQueryServiceColumnTimeRange(
         runtime.instanceId,
         metricsView.data?.model,
         {
@@ -116,6 +116,7 @@ export function createTimeRangeSummary(
             queryClient: ctx.queryClient,
           },
         }
-      ).subscribe(set)
+      ).subscribe(set);
+    }
   );
 }

--- a/web-common/src/features/dashboards/show-hide-selectors.spec.ts
+++ b/web-common/src/features/dashboards/show-hide-selectors.spec.ts
@@ -1,4 +1,4 @@
-import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/dashboard-stores";
+import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
 import {
   AD_BIDS_BID_PRICE_MEASURE,
   AD_BIDS_COUNTRY_DIMENSION,
@@ -20,7 +20,7 @@ import {
   createAdBidsMirrorInStore,
   createMetricsMetaQueryMock,
   resetDashboardStore,
-} from "@rilldata/web-common/features/dashboards/dashboard-stores-test-data";
+} from "@rilldata/web-common/features/dashboards/stores/dashboard-stores-test-data";
 import {
   createShowHideDimensionsStore,
   createShowHideMeasuresStore,

--- a/web-common/src/features/dashboards/show-hide-selectors.ts
+++ b/web-common/src/features/dashboards/show-hide-selectors.ts
@@ -43,7 +43,7 @@ function createShowHideStore<Item>(
   const derivedStore = derived(
     [metaQuery, useDashboardStore(metricsViewName)],
     ([meta, metricsExplorer]) => {
-      if (!meta || !meta.isSuccess || meta.isRefetching) {
+      if (!meta || !metricsExplorer || !meta.isSuccess || meta.isRefetching) {
         return {
           selectableItems: [],
           selectedItems: [],

--- a/web-common/src/features/dashboards/show-hide-selectors.ts
+++ b/web-common/src/features/dashboards/show-hide-selectors.ts
@@ -1,9 +1,9 @@
 import type { SearchableFilterSelectableItem } from "@rilldata/web-common/components/searchable-filter-menu/SearchableFilterSelectableItem";
 import {
-  MetricsExplorerEntity,
   updateMetricsExplorerByName,
   useDashboardStore,
-} from "@rilldata/web-common/features/dashboards/dashboard-stores";
+} from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
+import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import type {
   MetricsViewDimension,
   MetricsViewMeasure,

--- a/web-common/src/features/dashboards/state-managers/state-managers.ts
+++ b/web-common/src/features/dashboards/state-managers/state-managers.ts
@@ -1,14 +1,14 @@
+import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import { writable, Writable, Readable, derived, get } from "svelte/store";
 import { getContext } from "svelte";
 import type { QueryClient } from "@tanstack/svelte-query";
 import type { Runtime } from "@rilldata/web-common/runtime-client/runtime-store";
 import {
-  MetricsExplorerEntity,
   MetricsExplorerStoreType,
   metricsExplorerStore,
   updateMetricsExplorerByName,
   useDashboardStore,
-} from "../dashboard-stores";
+} from "web-common/src/features/dashboards/stores/dashboard-stores";
 import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
 
 export type StateManagers = {

--- a/web-common/src/features/dashboards/stores/DashboardStateProvider.svelte
+++ b/web-common/src/features/dashboards/stores/DashboardStateProvider.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/dashboard-stores";
+  import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
   import {
     createTimeRangeSummary,
     useMetaQuery,
@@ -18,11 +18,7 @@
 
   function syncDashboardState() {
     if (metricViewName in $metricsExplorerStore.entities) {
-      metricsExplorerStore.sync(
-        metricViewName,
-        $metaQuery.data,
-        $timeRangeQuery.data
-      );
+      metricsExplorerStore.sync(metricViewName, $metaQuery.data);
     } else {
       metricsExplorerStore.init(
         metricViewName,

--- a/web-common/src/features/dashboards/stores/DashboardTestComponent.svelte
+++ b/web-common/src/features/dashboards/stores/DashboardTestComponent.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import {
+    createTimeRangeSummary,
+    useMetaQuery,
+  } from "@rilldata/web-common/features/dashboards/selectors/index";
+  import type { StateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
+
+  export let ctx: StateManagers;
+  const metaQuery = useMetaQuery(ctx);
+  const timeRangeSummaryQuery = createTimeRangeSummary(ctx);
+</script>
+
+{!!$metaQuery.data}
+{!!$timeRangeSummaryQuery.data}

--- a/web-common/src/features/dashboards/stores/dashboard-store-defaults.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-store-defaults.ts
@@ -1,0 +1,114 @@
+import { LeaderboardContextColumn } from "@rilldata/web-common/features/dashboards/leaderboard-context-column";
+import {
+  SortDirection,
+  SortType,
+} from "@rilldata/web-common/features/dashboards/proto-state/derived-types";
+import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import { getLocalUserPreferences } from "@rilldata/web-common/features/dashboards/user-preferences";
+import { getTimeComparisonParametersForComponent } from "@rilldata/web-common/lib/time/comparisons";
+import { DEFAULT_TIME_RANGES } from "@rilldata/web-common/lib/time/config";
+import { getDefaultTimeGrain } from "@rilldata/web-common/lib/time/grains";
+import {
+  convertTimeRangePreset,
+  ISODurationToTimePreset,
+} from "@rilldata/web-common/lib/time/ranges";
+import type { TimeComparisonOption } from "@rilldata/web-common/lib/time/types";
+import type {
+  V1ColumnTimeRangeResponse,
+  V1MetricsView,
+} from "@rilldata/web-common/runtime-client";
+import { get } from "svelte/store";
+
+export function setDefaultTimeRange(
+  metricsView: V1MetricsView,
+  metricsExplorer: MetricsExplorerEntity,
+  fullTimeRange: V1ColumnTimeRangeResponse | undefined
+) {
+  // This function implementation mirrors some code in the metricsExplorer.init() function
+  if (!fullTimeRange) return;
+  const preset = ISODurationToTimePreset(metricsView.defaultTimeRange, true);
+  const timeZone = get(getLocalUserPreferences()).timeZone;
+  const fullTimeStart = new Date(fullTimeRange.timeRangeSummary.min);
+  const fullTimeEnd = new Date(fullTimeRange.timeRangeSummary.max);
+  const timeRange = convertTimeRangePreset(
+    preset,
+    fullTimeStart,
+    fullTimeEnd,
+    timeZone
+  );
+  const timeGrain = getDefaultTimeGrain(timeRange.start, timeRange.end);
+  metricsExplorer.selectedTimeRange = {
+    ...timeRange,
+    interval: timeGrain.grain,
+  };
+  metricsExplorer.selectedTimezone = timeZone;
+  // TODO: refactor all sub methods and call setSelectedScrubRange here
+  metricsExplorer.selectedScrubRange = undefined;
+  metricsExplorer.lastDefinedScrubRange = undefined;
+  setDefaultComparisonTimeRange(metricsView, metricsExplorer, fullTimeRange);
+}
+
+function setDefaultComparisonTimeRange(
+  metricsView: V1MetricsView,
+  metricsExplorer: MetricsExplorerEntity,
+  fullTimeRange: V1ColumnTimeRangeResponse | undefined
+) {
+  const preset = ISODurationToTimePreset(metricsView.defaultTimeRange, true);
+  const comparisonOption = DEFAULT_TIME_RANGES[preset]
+    ?.defaultComparison as TimeComparisonOption;
+  if (!comparisonOption) return;
+
+  const fullTimeStart = new Date(fullTimeRange.timeRangeSummary.min);
+  const fullTimeEnd = new Date(fullTimeRange.timeRangeSummary.max);
+  const comparisonRange = getTimeComparisonParametersForComponent(
+    comparisonOption,
+    fullTimeStart,
+    fullTimeEnd,
+    metricsExplorer.selectedTimeRange.start,
+    metricsExplorer.selectedTimeRange.end
+  );
+  if (!comparisonRange.isComparisonRangeAvailable) return;
+
+  metricsExplorer.selectedComparisonTimeRange = {
+    name: comparisonOption,
+    start: comparisonRange.start,
+    end: comparisonRange.end,
+  };
+  metricsExplorer.showTimeComparison = true;
+  metricsExplorer.leaderboardContextColumn =
+    LeaderboardContextColumn.DELTA_PERCENT;
+}
+
+export function getDefaultMetricsExplorerEntity(
+  name: string,
+  metricsView: V1MetricsView,
+  fullTimeRange: V1ColumnTimeRangeResponse | undefined
+) {
+  const metricsExplorer: MetricsExplorerEntity = {
+    name,
+    selectedMeasureNames: metricsView.measures.map((measure) => measure.name),
+
+    visibleMeasureKeys: new Set(
+      metricsView.measures.map((measure) => measure.name)
+    ),
+    allMeasuresVisible: true,
+    visibleDimensionKeys: new Set(
+      metricsView.dimensions.map((dim) => dim.name)
+    ),
+    allDimensionsVisible: true,
+    leaderboardMeasureName: metricsView.measures[0]?.name,
+    filters: {
+      include: [],
+      exclude: [],
+    },
+    dimensionFilterExcludeMode: new Map(),
+    leaderboardContextColumn: LeaderboardContextColumn.HIDDEN,
+    dashboardSortType: SortType.VALUE,
+    sortDirection: SortDirection.DESCENDING,
+
+    showTimeComparison: false,
+  };
+  // set time range related stuff
+  setDefaultTimeRange(metricsView, metricsExplorer, fullTimeRange);
+  return metricsExplorer;
+}

--- a/web-common/src/features/dashboards/stores/dashboard-stores-test-data.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores-test-data.ts
@@ -1,8 +1,8 @@
-import {
-  MetricsExplorerEntity,
-  metricsExplorerStore,
-} from "@rilldata/web-common/features/dashboards/dashboard-stores";
+import type { DashboardFetchMocks } from "@rilldata/web-common/features/dashboards/dashboard-fetch-mocks";
+import { createStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
+import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
 import { LeaderboardContextColumn } from "@rilldata/web-common/features/dashboards/leaderboard-context-column";
+import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import { getLocalIANA } from "@rilldata/web-common/lib/time/timezone";
 import {
   getOffset,
@@ -23,6 +23,7 @@ import {
   V1TimeGrain,
 } from "@rilldata/web-common/runtime-client";
 import type { QueryObserverResult } from "@tanstack/query-core";
+import { QueryClient } from "@tanstack/svelte-query";
 import type { CreateQueryResult } from "@tanstack/svelte-query";
 import { get, writable } from "svelte/store";
 import { expect } from "vitest";
@@ -320,6 +321,32 @@ export function getOffsetByHour(time: Date) {
     TimeOffsetType.ADD,
     getLocalIANA()
   );
+}
+
+export function initStateManagers(
+  dashboardFetchMocks: DashboardFetchMocks,
+  resp: V1MetricsView
+) {
+  initAdBidsInStore();
+  dashboardFetchMocks.mockMetricsView(AD_BIDS_NAME, resp);
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        refetchOnMount: false,
+        refetchOnReconnect: false,
+        refetchOnWindowFocus: false,
+        retry: false,
+        networkMode: "always",
+      },
+    },
+  });
+  const stateManagers = createStateManagers({
+    queryClient,
+    metricsViewName: AD_BIDS_NAME,
+  });
+
+  return { stateManagers, queryClient };
 }
 
 export const AD_BIDS_BASE_FILTER = {

--- a/web-common/src/features/dashboards/stores/dashboard-stores-test-data.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores-test-data.ts
@@ -124,6 +124,7 @@ export const AD_BIDS_INIT_WITH_TIME: V1MetricsView = {
 };
 export const AD_BIDS_WITH_DELETED_MEASURE = {
   name: "AdBids",
+  model: "AdBids_Source",
   measures: [
     {
       name: AD_BIDS_IMPRESSIONS_MEASURE,
@@ -134,11 +135,13 @@ export const AD_BIDS_WITH_DELETED_MEASURE = {
 };
 export const AD_BIDS_WITH_THREE_MEASURES = {
   name: "AdBids",
+  model: "AdBids_Source",
   measures: AD_BIDS_THREE_MEASURES,
   dimensions: AD_BIDS_INIT_DIMENSIONS,
 };
 export const AD_BIDS_WITH_DELETED_DIMENSION = {
   name: "AdBids",
+  model: "AdBids_Source",
   measures: AD_BIDS_INIT_MEASURES,
   dimensions: [
     {
@@ -148,6 +151,7 @@ export const AD_BIDS_WITH_DELETED_DIMENSION = {
 };
 export const AD_BIDS_WITH_THREE_DIMENSIONS = {
   name: "AdBids",
+  model: "AdBids_Source",
   measures: AD_BIDS_INIT_MEASURES,
   dimensions: AD_BIDS_THREE_DIMENSIONS,
 };

--- a/web-common/src/features/dashboards/stores/dashboard-stores.spec.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.spec.ts
@@ -1,4 +1,4 @@
-import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/dashboard-stores";
+import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
 import {
   AD_BIDS_BASE_FILTER,
   AD_BIDS_BID_PRICE_MEASURE,
@@ -22,7 +22,7 @@ import {
   resetDashboardStore,
   TestTimeConstants,
   TestTimeOffsetConstants,
-} from "@rilldata/web-common/features/dashboards/dashboard-stores-test-data";
+} from "@rilldata/web-common/features/dashboards/stores/dashboard-stores-test-data";
 import { initLocalUserPreferenceStore } from "@rilldata/web-common/features/dashboards/user-preferences";
 import { TimeRangePreset } from "@rilldata/web-common/lib/time/types";
 import { V1TimeGrain } from "@rilldata/web-common/runtime-client";

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -1,18 +1,14 @@
 import { LeaderboardContextColumn } from "@rilldata/web-common/features/dashboards/leaderboard-context-column";
 import { getDashboardStateFromUrl } from "@rilldata/web-common/features/dashboards/proto-state/fromProto";
 import { getProtoFromDashboardState } from "@rilldata/web-common/features/dashboards/proto-state/toProto";
-import { getLocalUserPreferences } from "@rilldata/web-common/features/dashboards/user-preferences";
+import { getDefaultMetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/dashboard-store-defaults";
+import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import {
   getMapFromArray,
   removeIfExists,
 } from "@rilldata/web-common/lib/arrayUtils";
 import { getTimeComparisonParametersForComponent } from "@rilldata/web-common/lib/time/comparisons";
 import { DEFAULT_TIME_RANGES } from "@rilldata/web-common/lib/time/config";
-import { getDefaultTimeGrain } from "@rilldata/web-common/lib/time/grains";
-import {
-  ISODurationToTimePreset,
-  convertTimeRangePreset,
-} from "@rilldata/web-common/lib/time/ranges";
 import type {
   DashboardTimeControls,
   ScrubRange,
@@ -25,95 +21,11 @@ import type {
   V1MetricsViewFilter,
   V1TimeGrain,
 } from "@rilldata/web-common/runtime-client";
-import { Readable, derived, get, writable } from "svelte/store";
-import { SortDirection, SortType } from "./proto-state/derived-types";
-
-export interface LeaderboardValue {
-  value: number;
-  label: string;
-}
-
-export interface LeaderboardValues {
-  values: Array<LeaderboardValue>;
-  dimensionName: string;
-}
-
-export type ActiveValues = Record<string, Array<[unknown, boolean]>>;
-
-export interface MetricsExplorerEntity {
-  name: string;
-  // selected measure names to be shown
-  selectedMeasureNames: Array<string>;
-
-  // This array controls which measures are visible in
-  // explorer on the client. Note that this will need to be
-  // updated to include all measure keys upon initialization
-  // or else all measure will be hidden
-  visibleMeasureKeys: Set<string>;
-  // While the `visibleMeasureKeys` has the list of visible measures,
-  // this is explicitly needed to fill the state.
-  // TODO: clean this up when we refactor how url state is synced
-  allMeasuresVisible: boolean;
-
-  // This array controls which dimensions are visible in
-  // explorer on the client.Note that if this is null, all
-  // dimensions will be visible (this is needed to default to all visible
-  // when there are not existing keys in the URL or saved on the
-  // server)
-  visibleDimensionKeys: Set<string>;
-  // While the `visibleDimensionKeys` has the list of all visible dimensions,
-  // this is explicitly needed to fill the state.
-  // TODO: clean this up when we refactor how url state is synced
-  allDimensionsVisible: boolean;
-
-  // This is the name of the primary active measure in the dashboard.
-  // This is the measure that will be shown in leaderboards, and
-  // will be used for sorting the leaderboard and dimension
-  // detail table.
-  // This "name" is the internal name of the measure from the YAML,
-  // not the human readable name.
-  leaderboardMeasureName: string;
-
-  // This is the sort type that will be used for the leaderboard
-  // and dimension detail table. See SortType for more details.
-  dashboardSortType: SortType;
-  // This is the sort direction that will be used for the leaderboard
-  // and dimension detail table.
-  sortDirection: SortDirection;
-
-  filters: V1MetricsViewFilter;
-  // stores whether a dimension is in include/exclude filter mode
-  // false/absence = include, true = exclude
-  dimensionFilterExcludeMode: Map<string, boolean>;
-  // user selected time range
-  selectedTimeRange?: DashboardTimeControls;
-
-  // user selected scrub range
-  selectedScrubRange?: ScrubRange;
-  lastDefinedScrubRange?: ScrubRange;
-
-  selectedComparisonTimeRange?: DashboardTimeControls;
-  selectedComparisonDimension?: string;
-
-  // user selected timezone
-  selectedTimezone?: string;
-
-  // flag to show/hide time comparison based on user preference.
-  // This controls whether a time comparison is shown in e.g.
-  // the line charts and bignums.
-  // It does NOT affect the leaderboard context column.
-  showTimeComparison?: boolean;
-
-  // state of context column in the leaderboard
-  leaderboardContextColumn: LeaderboardContextColumn;
-
-  // user selected dimension
-  selectedDimensionName?: string;
-
-  proto?: string;
-  // proto for the default set of selections
-  defaultProto?: string;
-}
+import { derived, Readable, writable } from "svelte/store";
+import {
+  SortDirection,
+  SortType,
+} from "web-common/src/features/dashboards/proto-state/derived-types";
 
 export interface MetricsExplorerStoreType {
   entities: Record<string, MetricsExplorerEntity>;
@@ -248,27 +160,6 @@ function syncDimensions(
   }
 }
 
-function setDefaultTimeRange(
-  metricsView: V1MetricsView,
-  metricsExplorer: MetricsExplorerEntity,
-  fullTimeRange: V1ColumnTimeRangeResponse | undefined
-) {
-  // This function implementation mirrors some code in the metricsExplorer.init() function
-  if (!fullTimeRange) return;
-  const preset = ISODurationToTimePreset(metricsView.defaultTimeRange, true);
-  const timeZone = get(getLocalUserPreferences()).timeZone;
-  const fullTimeStart = new Date(fullTimeRange.timeRangeSummary.min);
-  const fullTimeEnd = new Date(fullTimeRange.timeRangeSummary.max);
-  const timeRange = convertTimeRangePreset(
-    preset,
-    fullTimeStart,
-    fullTimeEnd,
-    timeZone
-  );
-  metricsExplorer.selectedTimeRange = timeRange;
-  setSelectedScrubRange(metricsExplorer, undefined);
-}
-
 const metricViewReducers = {
   init(
     name: string,
@@ -278,83 +169,13 @@ const metricViewReducers = {
     update((state) => {
       if (state.entities[name]) return state;
 
-      const timeSelections: Partial<MetricsExplorerEntity> = {};
-      if (fullTimeRange) {
-        const timeZone = get(getLocalUserPreferences()).timeZone;
-        const fullTimeStart = new Date(fullTimeRange.timeRangeSummary.min);
-        const fullTimeEnd = new Date(fullTimeRange.timeRangeSummary.max);
-        const preset = ISODurationToTimePreset(
-          metricsView.defaultTimeRange,
-          true
-        );
-
-        const timeRange = convertTimeRangePreset(
-          preset,
-          fullTimeStart,
-          fullTimeEnd,
-          timeZone
-        );
-        const timeGrain = getDefaultTimeGrain(timeRange.start, timeRange.end);
-        timeSelections.selectedTimezone = timeZone;
-        timeSelections.selectedTimeRange = {
-          ...timeRange,
-          interval: timeGrain.grain,
-        };
-        timeSelections.lastDefinedScrubRange = undefined;
-
-        const comparisonOption = DEFAULT_TIME_RANGES[preset]
-          ?.defaultComparison as TimeComparisonOption;
-        if (comparisonOption) {
-          const comparisonRange = getTimeComparisonParametersForComponent(
-            comparisonOption,
-            fullTimeStart,
-            fullTimeEnd,
-            timeRange.start,
-            timeRange.end
-          );
-          if (comparisonRange.isComparisonRangeAvailable) {
-            timeSelections.selectedComparisonTimeRange = {
-              name: comparisonOption,
-              start: comparisonRange.start,
-              end: comparisonRange.end,
-            };
-            timeSelections.showTimeComparison = true;
-            timeSelections.leaderboardContextColumn =
-              LeaderboardContextColumn.DELTA_PERCENT;
-          }
-        }
-      }
-
-      state.entities[name] = {
+      state.entities[name] = getDefaultMetricsExplorerEntity(
         name,
-        selectedMeasureNames: metricsView.measures.map(
-          (measure) => measure.name
-        ),
-
-        visibleMeasureKeys: new Set(
-          metricsView.measures.map((measure) => measure.name)
-        ),
-        allMeasuresVisible: true,
-        visibleDimensionKeys: new Set(
-          metricsView.dimensions.map((dim) => dim.name)
-        ),
-        allDimensionsVisible: true,
-        leaderboardMeasureName: metricsView.measures[0]?.name,
-        filters: {
-          include: [],
-          exclude: [],
-        },
-        dimensionFilterExcludeMode: new Map(),
-        leaderboardContextColumn: LeaderboardContextColumn.HIDDEN,
-        dashboardSortType: SortType.VALUE,
-        sortDirection: SortDirection.DESCENDING,
-
-        showTimeComparison: false,
-        ...timeSelections,
-      };
+        metricsView,
+        fullTimeRange
+      );
 
       updateMetricsExplorerProto(state.entities[name]);
-      state.entities[name].defaultProto = state.entities[name].proto;
       return state;
     });
   },
@@ -375,11 +196,7 @@ const metricViewReducers = {
     });
   },
 
-  sync(
-    name: string,
-    metricsView: V1MetricsView,
-    fullTimeRange: V1ColumnTimeRangeResponse | undefined
-  ) {
+  sync(name: string, metricsView: V1MetricsView) {
     if (!name || !metricsView || !metricsView.measures) return;
     updateMetricsExplorerByName(name, (metricsExplorer) => {
       // remove references to non existent measures
@@ -387,9 +204,6 @@ const metricViewReducers = {
 
       // remove references to non existent dimensions
       syncDimensions(metricsView, metricsExplorer);
-
-      // set default time range
-      setDefaultTimeRange(metricsView, metricsExplorer, fullTimeRange);
     });
   },
 

--- a/web-common/src/features/dashboards/stores/metrics-explorer-entity.ts
+++ b/web-common/src/features/dashboards/stores/metrics-explorer-entity.ts
@@ -1,0 +1,85 @@
+import type { LeaderboardContextColumn } from "@rilldata/web-common/features/dashboards/leaderboard-context-column";
+import type {
+  SortDirection,
+  SortType,
+} from "@rilldata/web-common/features/dashboards/proto-state/derived-types";
+import type {
+  DashboardTimeControls,
+  ScrubRange,
+} from "@rilldata/web-common/lib/time/types";
+import type { V1MetricsViewFilter } from "@rilldata/web-common/runtime-client";
+
+export interface MetricsExplorerEntity {
+  name: string;
+  // selected measure names to be shown
+  selectedMeasureNames: Array<string>;
+
+  // This array controls which measures are visible in
+  // explorer on the client. Note that this will need to be
+  // updated to include all measure keys upon initialization
+  // or else all measure will be hidden
+  visibleMeasureKeys: Set<string>;
+  // While the `visibleMeasureKeys` has the list of visible measures,
+  // this is explicitly needed to fill the state.
+  // TODO: clean this up when we refactor how url state is synced
+  allMeasuresVisible: boolean;
+
+  // This array controls which dimensions are visible in
+  // explorer on the client.Note that if this is null, all
+  // dimensions will be visible (this is needed to default to all visible
+  // when there are not existing keys in the URL or saved on the
+  // server)
+  visibleDimensionKeys: Set<string>;
+  // While the `visibleDimensionKeys` has the list of all visible dimensions,
+  // this is explicitly needed to fill the state.
+  // TODO: clean this up when we refactor how url state is synced
+  allDimensionsVisible: boolean;
+
+  // This is the name of the primary active measure in the dashboard.
+  // This is the measure that will be shown in leaderboards, and
+  // will be used for sorting the leaderboard and dimension
+  // detail table.
+  // This "name" is the internal name of the measure from the YAML,
+  // not the human readable name.
+  leaderboardMeasureName: string;
+
+  // This is the sort type that will be used for the leaderboard
+  // and dimension detail table. See SortType for more details.
+  dashboardSortType: SortType;
+  // This is the sort direction that will be used for the leaderboard
+  // and dimension detail table.
+  sortDirection: SortDirection;
+
+  filters: V1MetricsViewFilter;
+  // stores whether a dimension is in include/exclude filter mode
+  // false/absence = include, true = exclude
+  dimensionFilterExcludeMode: Map<string, boolean>;
+  // user selected time range
+  selectedTimeRange?: DashboardTimeControls;
+
+  // user selected scrub range
+  selectedScrubRange?: ScrubRange;
+  lastDefinedScrubRange?: ScrubRange;
+
+  selectedComparisonTimeRange?: DashboardTimeControls;
+  selectedComparisonDimension?: string;
+
+  // user selected timezone
+  selectedTimezone?: string;
+
+  // flag to show/hide time comparison based on user preference.
+  // This controls whether a time comparison is shown in e.g.
+  // the line charts and bignums.
+  // It does NOT affect the leaderboard context column.
+  showTimeComparison?: boolean;
+
+  // state of context column in the leaderboard
+  leaderboardContextColumn: LeaderboardContextColumn;
+
+  // user selected dimension
+  selectedDimensionName?: string;
+
+  proto?: string;
+  // proto for the default set of selections
+  defaultProto?: string;
+}

--- a/web-common/src/features/dashboards/time-controls/TimeControls.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeControls.svelte
@@ -21,7 +21,10 @@
   import type { V1TimeGrain } from "@rilldata/web-common/runtime-client";
   import { useQueryClient } from "@tanstack/svelte-query";
   import { runtime } from "../../../runtime-client/runtime-store";
-  import { metricsExplorerStore, useDashboardStore } from "../dashboard-stores";
+  import {
+    metricsExplorerStore,
+    useDashboardStore,
+  } from "web-common/src/features/dashboards/stores/dashboard-stores";
   import { initLocalUserPreferenceStore } from "../user-preferences";
   import NoTimeDimensionCTA from "./NoTimeDimensionCTA.svelte";
   import TimeComparisonSelector from "./TimeComparisonSelector.svelte";

--- a/web-common/src/features/dashboards/time-controls/TimeControlsStoreTest.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeControlsStoreTest.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { TimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
+  import type { TimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 
   /**
    * This component is used to test the time control store. Without a render the requests are not resolving.

--- a/web-common/src/features/dashboards/time-controls/TimeGrainSelector.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeGrainSelector.svelte
@@ -9,7 +9,7 @@
   import type { TimeGrain } from "@rilldata/web-common/lib/time/types";
   import { createEventDispatcher } from "svelte";
   import type { V1TimeGrain } from "../../../runtime-client";
-  import { useDashboardStore } from "../dashboard-stores";
+  import { useDashboardStore } from "web-common/src/features/dashboards/stores/dashboard-stores";
 
   export let metricViewName: string;
   export let timeGrainOptions: TimeGrain[];

--- a/web-common/src/features/dashboards/time-controls/TimeRangeSelector.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeRangeSelector.svelte
@@ -27,7 +27,7 @@
   import Divider from "../../../components/menu/core/Divider.svelte";
   import { LIST_SLIDE_DURATION } from "../../../layout/config";
   import type { V1TimeGrain } from "../../../runtime-client";
-  import { useDashboardStore } from "../dashboard-stores";
+  import { useDashboardStore } from "web-common/src/features/dashboards/stores/dashboard-stores";
   import CustomTimeRangeInput from "./CustomTimeRangeInput.svelte";
   import CustomTimeRangeMenuItem from "./CustomTimeRangeMenuItem.svelte";
   import TimeRangeScrubChip from "@rilldata/web-common/features/dashboards/time-controls/TimeRangeScrubChip.svelte";

--- a/web-common/src/features/dashboards/time-controls/TimeZoneSelector.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeZoneSelector.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
-  import { useDashboardStore } from "../dashboard-stores";
+  import { useDashboardStore } from "web-common/src/features/dashboards/stores/dashboard-stores";
   import {
     getAbbreviationForIANA,
     getLabelForIANA,

--- a/web-common/src/features/dashboards/time-controls/time-control-store.spec.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.spec.ts
@@ -1,5 +1,5 @@
 import { DashboardFetchMocks } from "@rilldata/web-common/features/dashboards/dashboard-fetch-mocks";
-import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/dashboard-stores";
+import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
 import {
   AD_BIDS_INIT,
   AD_BIDS_INIT_WITH_TIME,
@@ -7,7 +7,8 @@ import {
   AD_BIDS_SOURCE_NAME,
   AD_BIDS_TIMESTAMP_DIMENSION,
   initAdBidsInStore,
-} from "@rilldata/web-common/features/dashboards/dashboard-stores-test-data";
+  initStateManagers,
+} from "@rilldata/web-common/features/dashboards/stores/dashboard-stores-test-data";
 import { createStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
 import {
   createTimeControlStore,
@@ -354,23 +355,10 @@ describe("time-control-store", () => {
   });
 
   function initTimeControlStoreTest(resp: V1MetricsView) {
-    initAdBidsInStore();
-    dashboardFetchMocks.mockMetricsView(AD_BIDS_NAME, resp);
-
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: {
-          refetchOnMount: false,
-          refetchOnReconnect: false,
-          refetchOnWindowFocus: false,
-          retry: false,
-        },
-      },
-    });
-    const stateManagers = createStateManagers({
-      queryClient,
-      metricsViewName: AD_BIDS_NAME,
-    });
+    const { stateManagers, queryClient } = initStateManagers(
+      dashboardFetchMocks,
+      resp
+    );
     const timeControlsStore = createTimeControlStore(stateManagers);
 
     const { unmount } = render(TimeControlsStoreTest, {

--- a/web-common/src/features/dashboards/time-controls/time-control-store.spec.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.spec.ts
@@ -6,10 +6,8 @@ import {
   AD_BIDS_NAME,
   AD_BIDS_SOURCE_NAME,
   AD_BIDS_TIMESTAMP_DIMENSION,
-  initAdBidsInStore,
   initStateManagers,
 } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores-test-data";
-import { createStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
 import {
   createTimeControlStore,
   TimeControlState,
@@ -25,7 +23,6 @@ import { V1TimeGrain } from "@rilldata/web-common/runtime-client";
 import type { V1MetricsView } from "@rilldata/web-common/runtime-client";
 import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
 import { waitUntil } from "@rilldata/web-common/lib/waitUtils";
-import { QueryClient } from "@tanstack/svelte-query";
 import { get } from "svelte/store";
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { render } from "@testing-library/svelte";

--- a/web-common/src/features/dashboards/time-controls/time-control-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.ts
@@ -1,7 +1,7 @@
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/dashboard-stores";
 import { useMetaQuery } from "@rilldata/web-common/features/dashboards/selectors/index";
 import { memoizeMetricsStore } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
 import type { StateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
+import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import { getOrderedStartEnd } from "@rilldata/web-common/features/dashboards/time-series/utils";
 import {
   getComparionRangeForScrub,

--- a/web-common/src/features/dashboards/time-series/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureChart.svelte
@@ -28,7 +28,7 @@
   import { TIME_GRAIN } from "@rilldata/web-common/lib/time/config";
   import MeasureScrub from "./MeasureScrub.svelte";
   import ChartBody from "./ChartBody.svelte";
-  import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/dashboard-stores";
+  import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
   import DimensionValueMouseover from "@rilldata/web-common/features/dashboards/time-series/DimensionValueMouseover.svelte";
 
   export let metricViewName: string;
@@ -219,17 +219,17 @@
     <Grid />
     <Body>
       <ChartBody
-        {xMin}
-        {xMax}
-        {yExtentMax}
-        {showComparison}
-        isHovering={mouseoverValue?.x}
         {data}
         {dimensionData}
-        {xAccessor}
-        {yAccessor}
-        {scrubStart}
+        isHovering={mouseoverValue?.x}
         {scrubEnd}
+        {scrubStart}
+        {showComparison}
+        {xAccessor}
+        {xMax}
+        {xMin}
+        {yAccessor}
+        {yExtentMax}
       />
       <line
         class="stroke-blue-200"

--- a/web-common/src/features/dashboards/time-series/MeasureZoom.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureZoom.svelte
@@ -6,7 +6,7 @@
   import {
     useDashboardStore,
     metricsExplorerStore,
-  } from "@rilldata/web-common/features/dashboards/dashboard-stores";
+  } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
   import { getOrderedStartEnd } from "@rilldata/web-common/features/dashboards/time-series/utils";
   import { TimeRangePreset } from "@rilldata/web-common/lib/time/types";
 

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -3,7 +3,7 @@
   import { Axis } from "@rilldata/web-common/components/data-graphic/guides";
   import CrossIcon from "@rilldata/web-common/components/icons/CrossIcon.svelte";
   import SeachableFilterButton from "@rilldata/web-common/components/searchable-filter-menu/SeachableFilterButton.svelte";
-  import { useDashboardStore } from "@rilldata/web-common/features/dashboards/dashboard-stores";
+  import { useDashboardStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
   import { getFilterForComparedDimension, prepareTimeSeries } from "./utils";
   import {
     humanizeDataType,

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -8,7 +8,7 @@
   import { createRuntimeServiceGetCatalogEntry } from "../../../runtime-client";
   import { runtime } from "../../../runtime-client/runtime-store";
   import MeasuresContainer from "../big-number/MeasuresContainer.svelte";
-  import { useDashboardStore } from "../dashboard-stores";
+  import { useDashboardStore } from "web-common/src/features/dashboards/stores/dashboard-stores";
   import DimensionDisplay from "../dimension-table/DimensionDisplay.svelte";
   import Filters from "../filters/Filters.svelte";
   import MockUserHasNoAccess from "../granular-access-policies/MockUserHasNoAccess.svelte";
@@ -62,13 +62,13 @@
 </script>
 
 <section
-  use:listenToNodeResize
   class="flex flex-col gap-y-1 h-full overflow-x-auto overflow-y-hidden"
+  use:listenToNodeResize
 >
   <div
     class="border-b mb-3 w-full flex flex-col"
-    style:padding-left={leftSide}
     id="header"
+    style:padding-left={leftSide}
   >
     {#if isRillDeveloper}
       <!-- FIXME: adding an -mb-3 fixes the spacing issue incurred by changes to the header 

--- a/web-common/src/features/metrics-views/workspace/editor/update-metrics.ts
+++ b/web-common/src/features/metrics-views/workspace/editor/update-metrics.ts
@@ -1,5 +1,6 @@
 import { skipDebounceAnnotation } from "@rilldata/web-common/components/editor/annotations";
 import { setLineStatuses } from "@rilldata/web-common/components/editor/line-status";
+import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
 import { getFilePathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
 import { fileArtifactsStore } from "@rilldata/web-common/features/entity-management/file-artifacts-store";
 import { EntityType } from "@rilldata/web-common/features/entity-management/types";
@@ -37,6 +38,8 @@ export function createUpdateMetricsCallback(
     })) as V1PutFileAndReconcileResponse;
     fileArtifactsStore.setErrors(resp.affectedPaths, resp.errors);
     invalidateAfterReconcile(queryClient, instanceId, resp);
+    // Remove the explorer entity so that everything is reset to defaults next time user navigates to it
+    metricsExplorerStore.remove(metricsDefName);
   }
 
   return function updateMetrics(event) {

--- a/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
@@ -90,7 +90,7 @@
     <StateManagersProvider metricsViewName={metricViewName} slot="body">
       {#key metricViewName}
         <DashboardStateProvider {metricViewName}>
-          <DashboardURLStateProvider>
+          <DashboardURLStateProvider {metricViewName}>
             <Dashboard {metricViewName} />
           </DashboardURLStateProvider>
         </DashboardStateProvider>

--- a/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
@@ -2,7 +2,7 @@
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";
   import { Dashboard } from "@rilldata/web-common/features/dashboards";
-  import DashboardStateProvider from "@rilldata/web-common/features/dashboards/DashboardStateProvider.svelte";
+  import DashboardStateProvider from "@rilldata/web-common/features/dashboards/stores/DashboardStateProvider.svelte";
   import { resetSelectedMockUserAfterNavigate } from "@rilldata/web-common/features/dashboards/granular-access-policies/resetSelectedMockUserAfterNavigate";
   import { selectedMockUserStore } from "@rilldata/web-common/features/dashboards/granular-access-policies/stores";
   import DashboardURLStateProvider from "@rilldata/web-common/features/dashboards/proto-state/DashboardURLStateProvider.svelte";
@@ -90,7 +90,7 @@
     <StateManagersProvider metricsViewName={metricViewName} slot="body">
       {#key metricViewName}
         <DashboardStateProvider {metricViewName}>
-          <DashboardURLStateProvider {metricViewName}>
+          <DashboardURLStateProvider>
             <Dashboard {metricViewName} />
           </DashboardURLStateProvider>
         </DashboardStateProvider>

--- a/web-local/test/ui/dashboards.spec.ts
+++ b/web-local/test/ui/dashboards.spec.ts
@@ -86,6 +86,10 @@ test.describe("dashboard", () => {
   });
 
   test("Dashboard runthrough", async ({ page }) => {
+    // Uncomment for remote debugging
+    // page.on("console", (msg) => console.log(msg.text()));
+    // page.on("pageerror", (error) => console.log(error.stack));
+
     test.setTimeout(60000);
     await page.goto("/");
     // disable animations


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [x] Unit test coverage
- [x] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Just after editing a dashboard the experience of using it was inconsistent.
1. The default state didnt match the new config.
2. The selections would not reflect changes unless the url state was cleared. This lead to user thinking the changes didnt apply.
3. Changing time controls and refreshing the page doesnt persist the url state.

#### Details:
1. Deriving the default proto state directly from the meta and the time range summary query to keep it in sync with dashboard config.
2. Clearing the dashboard state after an edit to the config.
3. Removed the forced reset of time range stuff.

## Steps to Verify
Issue 1 and 2
1. Create a dashboard with timestamp.
2. Navigate to the dashboard and change the selected time range and other settings.
4. Set the default_time_range to something that is valid within the dashboard.
5. Navigate to the dashboard and the new time range should be reflected as well as other settings should be reverted.

Issue 3
1. Change time range and other settings in the dashboard.
2. Refresh the page.
3. Time range selections should persist.