### PR TITLE
Support project-wide defaults in rill.yaml

### DIFF
--- a/runtime/compilers/rillv1/parse_metrics_view.go
+++ b/runtime/compilers/rillv1/parse_metrics_view.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -62,6 +61,11 @@ type metricsViewYAML struct {
 func (p *Parser) parseMetricsView(ctx context.Context, node *Node) error {
 	// Parse YAML
 	tmp := &metricsViewYAML{}
+	if p.RillYAML != nil && !p.RillYAML.Defaults.Dashboards.IsZero() {
+		if err := p.RillYAML.Defaults.Dashboards.Decode(tmp); err != nil {
+			return pathError{path: node.YAMLPath, err: fmt.Errorf("failed applying defaults from rill.yaml: %w", newYAMLError(err))}
+		}
+	}
 	if node.YAMLRaw != "" {
 		// Can't use node.YAML because we need to set KnownFields for metrics views
 		dec := yaml.NewDecoder(strings.NewReader(node.YAMLRaw))
@@ -266,23 +270,6 @@ func (p *Parser) parseMetricsView(ctx context.Context, node *Node) error {
 	spec.AvailableTimeZones = tmp.AvailableTimeZones
 	spec.FirstDayOfWeek = tmp.FirstDayOfWeek
 	spec.FirstMonthOfYear = tmp.FirstMonthOfYear
-	if tmp.FirstDayOfWeek == 0 && p.RillYAML.Dashboards["first_day_of_week"] != "" {
-		i, err := strconv.Atoi(p.RillYAML.Dashboards["first_day_of_week"])
-		if err != nil {
-			return err
-		}
-
-		spec.FirstDayOfWeek = uint32(i)
-	}
-
-	if tmp.FirstMonthOfYear == 0 && p.RillYAML.Dashboards["first_month_of_year"] != "" {
-		i, err := strconv.Atoi(p.RillYAML.Dashboards["first_month_of_year"])
-		if err != nil {
-			return err
-		}
-
-		spec.FirstMonthOfYear = uint32(i)
-	}
 
 	for _, dim := range tmp.Dimensions {
 		if dim.Ignore {

--- a/runtime/compilers/rillv1/parse_migration.go
+++ b/runtime/compilers/rillv1/parse_migration.go
@@ -15,6 +15,11 @@ type migrationYAML struct {
 func (p *Parser) parseMigration(ctx context.Context, node *Node) error {
 	// Parse YAML
 	tmp := &migrationYAML{}
+	if p.RillYAML != nil && !p.RillYAML.Defaults.Migrations.IsZero() {
+		if err := p.RillYAML.Defaults.Migrations.Decode(tmp); err != nil {
+			return pathError{path: node.YAMLPath, err: fmt.Errorf("failed applying defaults from rill.yaml: %w", newYAMLError(err))}
+		}
+	}
 	if node.YAML != nil {
 		if err := node.YAML.Decode(tmp); err != nil {
 			return pathError{path: node.YAMLPath, err: newYAMLError(err)}

--- a/runtime/compilers/rillv1/parse_model.go
+++ b/runtime/compilers/rillv1/parse_model.go
@@ -25,6 +25,11 @@ type modelYAML struct {
 func (p *Parser) parseModel(ctx context.Context, node *Node) error {
 	// Parse YAML
 	tmp := &modelYAML{}
+	if p.RillYAML != nil && !p.RillYAML.Defaults.Models.IsZero() {
+		if err := p.RillYAML.Defaults.Models.Decode(tmp); err != nil {
+			return pathError{path: node.YAMLPath, err: fmt.Errorf("failed applying defaults from rill.yaml: %w", newYAMLError(err))}
+		}
+	}
 	if node.YAML != nil {
 		if err := node.YAML.Decode(tmp); err != nil {
 			return pathError{path: node.YAMLPath, err: newYAMLError(err)}

--- a/runtime/compilers/rillv1/parse_rillyaml.go
+++ b/runtime/compilers/rillv1/parse_rillyaml.go
@@ -15,7 +15,15 @@ type RillYAML struct {
 	Description string
 	Connectors  []*ConnectorDef
 	Variables   []*VariableDef
-	Dashboards  map[string]string
+	Defaults    RillYAMLDefaults
+}
+
+// RillYAMLDefaults contains project-wide default YAML properties for different resources
+type RillYAMLDefaults struct {
+	Sources    yaml.Node
+	Models     yaml.Node
+	Dashboards yaml.Node
+	Migrations yaml.Node
 }
 
 // ConnectorDef is a subtype of RillYAML, defining connectors required by the project
@@ -41,7 +49,10 @@ type rillYAML struct {
 		Name     string            `yaml:"name"`
 		Defaults map[string]string `yaml:"defaults"`
 	} `yaml:"connectors"`
-	Dashboards map[string]string `yaml:"dashboards"`
+	Sources    yaml.Node `yaml:"sources"`
+	Models     yaml.Node `yaml:"models"`
+	Dashboards yaml.Node `yaml:"dashboards"`
+	Migrations yaml.Node `yaml:"migrations"`
 }
 
 // parseRillYAML parses rill.yaml
@@ -61,7 +72,12 @@ func (p *Parser) parseRillYAML(ctx context.Context, path string) error {
 		Description: tmp.Description,
 		Connectors:  make([]*ConnectorDef, len(tmp.Connectors)),
 		Variables:   make([]*VariableDef, len(tmp.Env)),
-		Dashboards:  tmp.Dashboards,
+		Defaults: RillYAMLDefaults{
+			Sources:    tmp.Sources,
+			Models:     tmp.Models,
+			Dashboards: tmp.Dashboards,
+			Migrations: tmp.Migrations,
+		},
 	}
 
 	for i, c := range tmp.Connectors {

--- a/runtime/compilers/rillv1/parse_source.go
+++ b/runtime/compilers/rillv1/parse_source.go
@@ -31,6 +31,11 @@ func (p *Parser) parseSource(ctx context.Context, node *Node) error {
 
 	// Parse YAML
 	tmp := &sourceYAML{}
+	if p.RillYAML != nil && !p.RillYAML.Defaults.Sources.IsZero() {
+		if err := p.RillYAML.Defaults.Sources.Decode(tmp); err != nil {
+			return pathError{path: node.YAMLPath, err: fmt.Errorf("failed applying defaults from rill.yaml: %w", newYAMLError(err))}
+		}
+	}
 	if node.YAML != nil {
 		if err := node.YAML.Decode(tmp); err != nil {
 			return pathError{path: node.YAMLPath, err: newYAMLError(err)}

--- a/runtime/compilers/rillv1/parser.go
+++ b/runtime/compilers/rillv1/parser.go
@@ -356,14 +356,6 @@ func (p *Parser) Reparse(ctx context.Context, paths []string) (*Diff, error) {
 	return diff, nil
 }
 
-func pathIsRillYAML(path string) bool {
-	return path == "/rill.yaml" || path == "/rill.yml"
-}
-
-func pathIsDotEnv(path string) bool {
-	return path == "/.env"
-}
-
 // parsePaths is the internal entrypoint for parsing a list of paths.
 // It assumes that the caller has already checked that the paths exist.
 // It also assumes that the caller has already removed any previous resources related to the paths,
@@ -742,6 +734,16 @@ func (p *Parser) addParseError(path string, err error) {
 		FilePath:      path,
 		StartLocation: loc,
 	})
+}
+
+// pathIsRillYAML returns true if the path is rill.yaml
+func pathIsRillYAML(path string) bool {
+	return path == "/rill.yaml" || path == "/rill.yml"
+}
+
+// pathIsDotEnv returns true if the path is .env
+func pathIsDotEnv(path string) bool {
+	return path == "/.env"
 }
 
 // normalizePath normalizes a user-provided path to the format returned from ListRecursive.

--- a/runtime/compilers/rillv1/parser.go
+++ b/runtime/compilers/rillv1/parser.go
@@ -225,7 +225,7 @@ func (p *Parser) Reparse(ctx context.Context, paths []string) (*Diff, error) {
 		// Skip files that aren't SQL or YAML or .env file
 		isSQL := strings.HasSuffix(path, ".sql")
 		isYAML := strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml")
-		isDotEnv := strings.EqualFold(path, "/.env")
+		isDotEnv := pathIsDotEnv(path)
 		if !isSQL && !isYAML && !isDotEnv {
 			continue
 		}
@@ -239,10 +239,10 @@ func (p *Parser) Reparse(ctx context.Context, paths []string) (*Diff, error) {
 		}
 
 		// Check if path is rill.yaml or .env and clear it (so we can re-parse it)
-		if path == "/rill.yaml" || path == "/rill.yml" {
+		if pathIsRillYAML(path) {
 			modifiedRillYAML = true
 			p.RillYAML = nil
-		} else if path == "/.env" {
+		} else if isDotEnv {
 			modifiedDotEnv = true
 			p.DotEnv = nil
 		}
@@ -356,6 +356,14 @@ func (p *Parser) Reparse(ctx context.Context, paths []string) (*Diff, error) {
 	return diff, nil
 }
 
+func pathIsRillYAML(path string) bool {
+	return path == "/rill.yaml" || path == "/rill.yml"
+}
+
+func pathIsDotEnv(path string) bool {
+	return path == "/.env"
+}
+
 // parsePaths is the internal entrypoint for parsing a list of paths.
 // It assumes that the caller has already checked that the paths exist.
 // It also assumes that the caller has already removed any previous resources related to the paths,
@@ -367,20 +375,30 @@ func (p *Parser) parsePaths(ctx context.Context, paths []string) error {
 		return fmt.Errorf("project exceeds file limit of %d", maxFiles)
 	}
 
-	// Sort paths such that we align files with the same name but different extensions next to each other.
-	// Then iterate over the sorted paths, processing all paths with the same stem at once (stem = path without extension).
-	slices.Sort(paths)
+	// Sort paths such that a) we always parse rill.yaml first (to pick up defaults),
+	// and b) we align files with the same name but different extensions next to each other.
+	slices.SortFunc(paths, func(a, b string) bool {
+		if pathIsRillYAML(a) {
+			return true
+		}
+		if pathIsRillYAML(b) {
+			return false
+		}
+		return a < b
+	})
+
+	// Iterate over the sorted paths, processing all paths with the same stem at once (stem = path without extension).
 	for i := 0; i < len(paths); {
 		// Handle rill.yaml and .env separately (if parsing of rill.yaml fails, we exit early instead of adding a ParseError)
 		path := paths[i]
-		if path == "/rill.yaml" || path == "/rill.yml" {
+		if pathIsRillYAML(path) {
 			err := p.parseRillYAML(ctx, path)
 			if err != nil {
 				return err
 			}
 			i++
 			continue
-		} else if path == "/.env" {
+		} else if pathIsDotEnv(path) {
 			err := p.parseDotEnv(ctx, path)
 			if err != nil {
 				p.addParseError(path, err)

--- a/runtime/compilers/rillv1/parser_test.go
+++ b/runtime/compilers/rillv1/parser_test.go
@@ -33,10 +33,6 @@ connectors:
 
 env:
   foo: bar
-
-dashboards:
-  first_day_of_week: 7
-  first_month_of_year: 3
 `,
 	})
 
@@ -55,9 +51,6 @@ dashboards:
 	require.Len(t, res.Variables, 1)
 	require.Equal(t, "foo", res.Variables[0].Name)
 	require.Equal(t, "bar", res.Variables[0].Default)
-
-	require.Equal(t, "7", res.Dashboards["first_day_of_week"])
-	require.Equal(t, "3", res.Dashboards["first_month_of_year"])
 }
 
 func TestComplete(t *testing.T) {
@@ -527,6 +520,138 @@ materialize: true
 		require.NoError(b, err)
 		require.Empty(b, p.Errors)
 	}
+}
+
+func TestProjectModelDefaults(t *testing.T) {
+	ctx := context.Background()
+	truth := true
+	falsity := false
+
+	files := map[string]string{
+		// Provide dashboard defaults in rill.yaml
+		`rill.yaml`: `
+models:
+  materialize: true
+`,
+		// Model that inherits defaults
+		`models/m1.sql`: `
+SELECT * FROM t1
+`,
+		// Model that overrides defaults
+		`models/m2.sql`: `
+-- @materialize: false
+SELECT * FROM t2
+`,
+	}
+
+	resources := []*Resource{
+		// m1
+		{
+			Name:  ResourceName{Kind: ResourceKindModel, Name: "m1"},
+			Paths: []string{"/models/m1.sql"},
+			ModelSpec: &runtimev1.ModelSpec{
+				Sql:         strings.TrimSpace(files["models/m1.sql"]),
+				Materialize: &truth,
+			},
+		},
+		// m2
+		{
+			Name:  ResourceName{Kind: ResourceKindModel, Name: "m2"},
+			Paths: []string{"/models/m2.sql"},
+			ModelSpec: &runtimev1.ModelSpec{
+				Sql:         strings.TrimSpace(files["models/m2.sql"]),
+				Materialize: &falsity,
+			},
+		},
+	}
+
+	repo := makeRepo(t, files)
+	p, err := Parse(ctx, repo, "", "", []string{""})
+	require.NoError(t, err)
+	requireResourcesAndErrors(t, p, resources, nil)
+}
+
+func TestProjectDashboardDefaults(t *testing.T) {
+	ctx := context.Background()
+	repo := makeRepo(t, map[string]string{
+		// Provide dashboard defaults in rill.yaml
+		`rill.yaml`: `
+dashboards:
+  first_day_of_week: 7
+  available_time_zones:
+    - America/New_York
+  security:
+    access: true
+`,
+		// Dashboard that inherits defaults
+		`dashboards/d1.yaml`: `
+table: t1
+dimensions:
+  - name: a
+measures:
+  - name: b
+    expression: count(*)
+`,
+		// Dashboard that overrides defaults
+		`dashboards/d2.yaml`: `
+table: t2
+dimensions:
+  - name: a
+measures:
+  - name: b
+    expression: count(*)
+first_day_of_week: 1
+available_time_zones: []
+security:
+  row_filter: true
+`,
+	})
+
+	resources := []*Resource{
+		// dashboard d1
+		{
+			Name:  ResourceName{Kind: ResourceKindMetricsView, Name: "d1"},
+			Paths: []string{"/dashboards/d1.yaml"},
+			MetricsViewSpec: &runtimev1.MetricsViewSpec{
+				Table: "t1",
+				Dimensions: []*runtimev1.MetricsViewSpec_DimensionV2{
+					{Name: "a"},
+				},
+				Measures: []*runtimev1.MetricsViewSpec_MeasureV2{
+					{Name: "b", Expression: "count(*)"},
+				},
+				FirstDayOfWeek:     7,
+				AvailableTimeZones: []string{"America/New_York"},
+				Security: &runtimev1.MetricsViewSpec_SecurityV2{
+					Access: "true",
+				},
+			},
+		},
+		// dashboard d2
+		{
+			Name:  ResourceName{Kind: ResourceKindMetricsView, Name: "d2"},
+			Paths: []string{"/dashboards/d2.yaml"},
+			MetricsViewSpec: &runtimev1.MetricsViewSpec{
+				Table: "t2",
+				Dimensions: []*runtimev1.MetricsViewSpec_DimensionV2{
+					{Name: "a"},
+				},
+				Measures: []*runtimev1.MetricsViewSpec_MeasureV2{
+					{Name: "b", Expression: "count(*)"},
+				},
+				FirstDayOfWeek:     1,
+				AvailableTimeZones: []string{},
+				Security: &runtimev1.MetricsViewSpec_SecurityV2{
+					Access:    "true",
+					RowFilter: "true",
+				},
+			},
+		},
+	}
+
+	p, err := Parse(ctx, repo, "", "", []string{""})
+	require.NoError(t, err)
+	requireResourcesAndErrors(t, p, resources, nil)
 }
 
 func requireResourcesAndErrors(t testing.TB, p *Parser, wantResources []*Resource, wantErrors []*runtimev1.ParseError) {


### PR DESCRIPTION
Fixes the nil pointer error introduced in https://github.com/rilldata/rill/pull/3176 (tests failing in https://github.com/rilldata/rill/pull/3092).

Also adds generic support for providing project-wide defaults for any source/model/dashboard property from rill.yaml.