### PR TITLE
Removing watcher clients from cloud

### DIFF
--- a/web-admin/src/features/projects/ProjectDashboardsListener.svelte
+++ b/web-admin/src/features/projects/ProjectDashboardsListener.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { listenAndInvalidateDashboards } from "@rilldata/web-admin/features/projects/dashboards";
+  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
+  import { useQueryClient } from "@tanstack/svelte-query";
+  import type { Unsubscriber } from "svelte/store";
+
+  const queryClient = useQueryClient();
+
+  let unsubscribe: Unsubscriber;
+  $: if ($runtime?.instanceId) {
+    unsubscribe?.();
+    unsubscribe = listenAndInvalidateDashboards(
+      queryClient,
+      $runtime?.instanceId
+    );
+  }
+</script>
+
+<slot />

--- a/web-admin/src/features/projects/ProjectDeploymentStatusChip.svelte
+++ b/web-admin/src/features/projects/ProjectDeploymentStatusChip.svelte
@@ -17,7 +17,6 @@
   import Spinner from "@rilldata/web-common/features/entity-management/Spinner.svelte";
   import { EntityStatus } from "@rilldata/web-common/features/entity-management/types";
   import { getRuntimeServiceListResourcesQueryKey } from "@rilldata/web-common/runtime-client";
-  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { CreateQueryResult, useQueryClient } from "@tanstack/svelte-query";
   import type { SvelteComponent } from "svelte";
 

--- a/web-admin/src/features/projects/ProjectDeploymentStatusChip.svelte
+++ b/web-admin/src/features/projects/ProjectDeploymentStatusChip.svelte
@@ -33,8 +33,14 @@
   );
   let deploymentStatus: V1DeploymentStatus;
 
+  $: instanceId = $proj?.data?.prodDeployment?.runtimeInstanceId;
+
   let deploymentStatusFromDashboards: CreateQueryResult<V1DeploymentStatus>;
-  $: deploymentStatusFromDashboards = useDashboardsStatus($runtime?.instanceId);
+  $: if ($proj?.data)
+    deploymentStatusFromDashboards = useDashboardsStatus(
+      instanceId,
+      $proj?.data
+    );
 
   const queryClient = useQueryClient();
 
@@ -53,7 +59,7 @@
 
       // Invalidate the queries used to compose the dashboard list in the breadcrumbs
       queryClient.invalidateQueries(
-        getRuntimeServiceListResourcesQueryKey($runtime?.instanceId, {
+        getRuntimeServiceListResourcesQueryKey(instanceId, {
           kind: ResourceKind.MetricsView,
         })
       );
@@ -126,13 +132,16 @@
 
   // Merge the status from deployment and dashboards to show the chip
   let currentStatusDisplay: StatusDisplay;
-  $: if (deploymentStatus || $deploymentStatusFromDashboards.data) {
-    if (deploymentStatus !== V1DeploymentStatus.DEPLOYMENT_STATUS_OK) {
+  $: if (deploymentStatus || $deploymentStatusFromDashboards?.data) {
+    if (
+      deploymentStatus !== V1DeploymentStatus.DEPLOYMENT_STATUS_OK ||
+      !$deploymentStatusFromDashboards
+    ) {
       currentStatusDisplay = statusDisplays[deploymentStatus];
     } else {
       currentStatusDisplay =
         statusDisplays[
-          $deploymentStatusFromDashboards.data ??
+          $deploymentStatusFromDashboards?.data ??
             V1DeploymentStatus.DEPLOYMENT_STATUS_UNSPECIFIED
         ];
     }

--- a/web-admin/src/features/projects/dashboards.ts
+++ b/web-admin/src/features/projects/dashboards.ts
@@ -1,10 +1,24 @@
+import { V1DeploymentStatus } from "@rilldata/web-admin/client";
 import type { V1GetProjectResponse } from "@rilldata/web-admin/client";
+import {
+  PollTimeDuringError,
+  PollTimeDuringReconcile,
+  PollTimeWhenProjectReady,
+} from "@rilldata/web-admin/features/projects/selectors";
+import { refreshResource } from "@rilldata/web-common/features/entity-management/resource-invalidations";
 import {
   ResourceKind,
   useFilteredResources,
 } from "@rilldata/web-common/features/entity-management/resource-selectors";
+import {
+  createRuntimeServiceListResources,
+  V1ReconcileStatus,
+} from "@rilldata/web-common/runtime-client";
 import type { V1Resource } from "@rilldata/web-common/runtime-client";
+import { invalidateMetricsViewData } from "@rilldata/web-common/runtime-client/invalidation";
+import type { QueryClient } from "@tanstack/svelte-query";
 import Axios from "axios";
+import { derived } from "svelte/store";
 
 export interface DashboardListItem {
   name: string;
@@ -47,4 +61,110 @@ export async function getDashboardsForProject(
 
 export function useDashboards(instanceId: string) {
   return useFilteredResources(instanceId, ResourceKind.MetricsView);
+}
+
+export function useDashboardsStatus(instanceId: string) {
+  return createRuntimeServiceListResources(
+    instanceId,
+    {
+      kind: ResourceKind.MetricsView,
+    },
+    {
+      query: {
+        select: (data): V1DeploymentStatus => {
+          let isPending = false;
+          let isError = false;
+          for (const resource of data.resources) {
+            if (
+              resource.meta.reconcileStatus !==
+              V1ReconcileStatus.RECONCILE_STATUS_IDLE
+            ) {
+              isPending = true;
+              continue;
+            }
+
+            if (
+              resource.meta.reconcileError ||
+              !resource.metricsView?.state?.validSpec
+            ) {
+              isError = true;
+            }
+          }
+
+          if (isPending) return V1DeploymentStatus.DEPLOYMENT_STATUS_PENDING;
+          if (isError) return V1DeploymentStatus.DEPLOYMENT_STATUS_ERROR;
+          return V1DeploymentStatus.DEPLOYMENT_STATUS_OK;
+        },
+
+        refetchInterval: (data) => {
+          switch (data) {
+            case V1DeploymentStatus.DEPLOYMENT_STATUS_PENDING:
+              return PollTimeDuringReconcile;
+
+            case V1DeploymentStatus.DEPLOYMENT_STATUS_ERROR:
+            case V1DeploymentStatus.DEPLOYMENT_STATUS_UNSPECIFIED:
+              return PollTimeDuringError;
+
+            case V1DeploymentStatus.DEPLOYMENT_STATUS_OK:
+              return PollTimeWhenProjectReady;
+
+            default:
+              return PollTimeWhenProjectReady;
+          }
+        },
+      },
+    }
+  );
+}
+
+export function listenAndInvalidateDashboards(
+  queryClient: QueryClient,
+  instanceId: string
+) {
+  const store = derived(
+    [useDashboardsStatus(instanceId), useDashboards(instanceId)],
+    (state) => state
+  );
+
+  const dashboards = new Map<string, Date>();
+
+  return store.subscribe(([status, dashboardsResp]) => {
+    if (
+      // Let through error and ok states
+      status.data === V1DeploymentStatus.DEPLOYMENT_STATUS_PENDING ||
+      status.data === V1DeploymentStatus.DEPLOYMENT_STATUS_UNSPECIFIED ||
+      !dashboardsResp.data
+    )
+      return;
+
+    const existingDashboards = new Set<string>();
+    for (const [name] of dashboards) {
+      existingDashboards.add(name);
+    }
+
+    for (const dashboardResource of dashboardsResp.data) {
+      const stateUpdatedOn = new Date(dashboardResource.meta.stateUpdatedOn);
+
+      if (dashboards.has(dashboardResource.meta.name.name)) {
+        // if the dashboard existed then check if it was updated since last seen
+        const prevStateUpdatedOn = dashboards.get(
+          dashboardResource.meta.name.name
+        );
+        if (prevStateUpdatedOn.getTime() < stateUpdatedOn.getTime()) {
+          // invalidate if it was updated
+          refreshResource(queryClient, instanceId, dashboardResource).then(() =>
+            invalidateMetricsViewData(queryClient, instanceId, false)
+          );
+        }
+      }
+
+      existingDashboards.delete(dashboardResource.meta.name.name);
+      dashboards.set(dashboardResource.meta.name.name, stateUpdatedOn);
+    }
+
+    // cleanup of older dashboards
+    for (const oldName of existingDashboards) {
+      dashboards.delete(oldName);
+    }
+  });
 }

--- a/web-admin/src/features/projects/selectors.ts
+++ b/web-admin/src/features/projects/selectors.ts
@@ -11,9 +11,9 @@ export function getProjectPermissions(orgName: string, projName: string) {
   });
 }
 
-const PollTimeDuringReconcile = 1000;
-const PollTimeDuringError = 5000;
-const PollTimeWhenProjectReady = 60 * 1000;
+export const PollTimeDuringReconcile = 1000;
+export const PollTimeDuringError = 5000;
+export const PollTimeWhenProjectReady = 60 * 1000;
 
 export function useProjectDeploymentStatus(orgName: string, projName: string) {
   return createAdminServiceGetProject<V1DeploymentStatus>(orgName, projName, {

--- a/web-admin/src/routes/[organization]/[project]/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/+layout.svelte
@@ -1,14 +1,10 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";
-  import { startWatchResourcesClient } from "@rilldata/web-common/features/entity-management/watch-resources-client";
+  import ProjectDashboardsListener from "@rilldata/web-admin/features/projects/ProjectDashboardsListener.svelte";
   import RuntimeProvider from "@rilldata/web-common/runtime-client/RuntimeProvider.svelte";
-  import { useQueryClient } from "@tanstack/svelte-query";
-  import { onMount } from "svelte";
   import { useProjectRuntime } from "../../../features/projects/selectors";
   import { viewAsUserStore } from "../../../features/view-as-user/viewAsUserStore";
-
-  const queryClient = useQueryClient();
 
   $: projRuntime = useProjectRuntime(
     $page.params.organization,
@@ -21,9 +17,6 @@
     // Redirect any nested routes (notably dashboards) to the project page
     goto(`/${$page.params.organization}/${$page.params.project}`);
   }
-
-  // start the global resource watcher
-  onMount(() => startWatchResourcesClient(queryClient));
 </script>
 
 <!-- Note: we don't provide the runtime here when the user is being spoofed via the "View As" functionality.
@@ -34,7 +27,9 @@
     instanceId={$projRuntime.data.instanceId}
     jwt={$projRuntime.data?.jwt}
   >
-    <slot />
+    <ProjectDashboardsListener>
+      <slot />
+    </ProjectDashboardsListener>
   </RuntimeProvider>
 {:else}
   <slot />

--- a/web-common/src/features/dashboards/time-controls/time-control-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.ts
@@ -96,6 +96,7 @@ export function createTimeControlStore(ctx: StateManagers) {
       const hasTimeSeries = Boolean(metricsView.data?.timeDimension);
       if (
         !metricsExplorer ||
+        !metricsView.data ||
         !timeRangeResponse ||
         !timeRangeResponse.isSuccess
       ) {

--- a/web-common/src/features/entity-management/resource-invalidations.ts
+++ b/web-common/src/features/entity-management/resource-invalidations.ts
@@ -151,7 +151,7 @@ function shouldSkipResource(
   return false;
 }
 
-function refreshResource(
+export function refreshResource(
   queryClient: QueryClient,
   instanceId: string,
   res: V1Resource


### PR DESCRIPTION
Adding the watcher client in the cloud would mean that all the users with a dashboard open would have an open connection with the server.

Removing the watcher client and going back to periodic refresh. The list all resources has a periodic refresh and any updated dashboards are invalidated.