### PR TITLE
For anchored time ranges use the min of latest data and now

### DIFF
--- a/web-common/src/lib/time/config.ts
+++ b/web-common/src/lib/time/config.ts
@@ -200,7 +200,7 @@ export const PERIOD_TO_DATE_RANGES: Record<string, TimeRangeMeta> = {
     rangePreset: RangePresetType.PERIOD_ANCHORED,
     defaultComparison: TimeComparisonOption.DAY,
     start: {
-      reference: ReferencePoint.LATEST_DATA,
+      reference: ReferencePoint.MIN_OF_LATEST_DATA_AND_NOW,
       transformation: [
         {
           period: Period.DAY,
@@ -209,7 +209,7 @@ export const PERIOD_TO_DATE_RANGES: Record<string, TimeRangeMeta> = {
       ],
     },
     end: {
-      reference: ReferencePoint.LATEST_DATA,
+      reference: ReferencePoint.MIN_OF_LATEST_DATA_AND_NOW,
       transformation: [
         { duration: "P1D", operationType: TimeOffsetType.ADD },
         {
@@ -224,7 +224,7 @@ export const PERIOD_TO_DATE_RANGES: Record<string, TimeRangeMeta> = {
     rangePreset: RangePresetType.PERIOD_ANCHORED,
     defaultComparison: TimeComparisonOption.WEEK,
     start: {
-      reference: ReferencePoint.LATEST_DATA,
+      reference: ReferencePoint.MIN_OF_LATEST_DATA_AND_NOW,
       transformation: [
         {
           period: Period.WEEK,
@@ -233,7 +233,7 @@ export const PERIOD_TO_DATE_RANGES: Record<string, TimeRangeMeta> = {
       ],
     },
     end: {
-      reference: ReferencePoint.LATEST_DATA,
+      reference: ReferencePoint.MIN_OF_LATEST_DATA_AND_NOW,
       transformation: [
         { duration: "P1D", operationType: TimeOffsetType.ADD },
         {
@@ -248,7 +248,7 @@ export const PERIOD_TO_DATE_RANGES: Record<string, TimeRangeMeta> = {
     rangePreset: RangePresetType.PERIOD_ANCHORED,
     defaultComparison: TimeComparisonOption.MONTH,
     start: {
-      reference: ReferencePoint.LATEST_DATA,
+      reference: ReferencePoint.MIN_OF_LATEST_DATA_AND_NOW,
       transformation: [
         {
           period: Period.MONTH,
@@ -257,7 +257,7 @@ export const PERIOD_TO_DATE_RANGES: Record<string, TimeRangeMeta> = {
       ],
     },
     end: {
-      reference: ReferencePoint.LATEST_DATA,
+      reference: ReferencePoint.MIN_OF_LATEST_DATA_AND_NOW,
       transformation: [
         { duration: "P1D", operationType: TimeOffsetType.ADD },
         {
@@ -272,7 +272,7 @@ export const PERIOD_TO_DATE_RANGES: Record<string, TimeRangeMeta> = {
     rangePreset: RangePresetType.PERIOD_ANCHORED,
     defaultComparison: TimeComparisonOption.YEAR,
     start: {
-      reference: ReferencePoint.LATEST_DATA,
+      reference: ReferencePoint.MIN_OF_LATEST_DATA_AND_NOW,
       transformation: [
         {
           period: Period.YEAR,
@@ -281,7 +281,7 @@ export const PERIOD_TO_DATE_RANGES: Record<string, TimeRangeMeta> = {
       ],
     },
     end: {
-      reference: ReferencePoint.LATEST_DATA,
+      reference: ReferencePoint.MIN_OF_LATEST_DATA_AND_NOW,
       transformation: [
         { duration: "P1D", operationType: TimeOffsetType.ADD },
         {

--- a/web-common/src/lib/time/transforms/index.ts
+++ b/web-common/src/lib/time/transforms/index.ts
@@ -18,7 +18,7 @@ import {
 import { DateTime, Duration } from "luxon";
 import { Period, TimeOffsetType, TimeUnit } from "../types";
 
-/** Returns the current time. Might be deprecated later. */
+/** Returns the current time */
 export function getPresentTime() {
   return new Date();
 }
@@ -109,14 +109,26 @@ export function relativePointInTimeToAbsolute(
   let endDate: Date;
   if (typeof start === "string") startDate = new Date(start);
   else {
-    if (start.reference === ReferencePoint.NOW)
+    if (start.reference === ReferencePoint.NOW) {
       referenceTime = getPresentTime();
+    } else if (start.reference === ReferencePoint.MIN_OF_LATEST_DATA_AND_NOW) {
+      referenceTime = new Date(
+        Math.min(referenceTime.getTime(), getPresentTime().getTime())
+      );
+    }
+
     startDate = transformDate(referenceTime, start.transformation, zone);
   }
 
   if (typeof end === "string") endDate = new Date(end);
   else {
-    if (end.reference === ReferencePoint.NOW) referenceTime = getPresentTime();
+    if (end.reference === ReferencePoint.NOW) {
+      referenceTime = getPresentTime();
+    } else if (end.reference === ReferencePoint.MIN_OF_LATEST_DATA_AND_NOW) {
+      referenceTime = new Date(
+        Math.min(referenceTime.getTime(), getPresentTime().getTime())
+      );
+    }
     endDate = transformDate(referenceTime, end.transformation, zone);
   }
 

--- a/web-common/src/lib/time/types.ts
+++ b/web-common/src/lib/time/types.ts
@@ -38,6 +38,7 @@ export enum RangePresetType {
 export enum ReferencePoint {
   LATEST_DATA = "LatestData",
   NOW = "Now",
+  MIN_OF_LATEST_DATA_AND_NOW = "MinOfLatestDataAndNow",
 }
 
 /** An offset defines an operation on a point in time, primarily used to map from a


### PR DESCRIPTION
Closes #3199 
Fixes the case when anchored time ranges such as Today, Month to Date, Year to Date etc. would use the latest data as reference point instead of the current time in cases when latest data is in the future.

More - https://rilldata.slack.com/archives/CTZ8XBQ85/p1696875814646139