### PR TITLE
Fixing some edge cases with async reconcile in modelling

### DIFF
--- a/web-common/src/features/dashboards/DashboardAssets.svelte
+++ b/web-common/src/features/dashboards/DashboardAssets.svelte
@@ -102,7 +102,7 @@
       $fileArtifactsStore.entities,
       dashboardName
     );
-    const sourceModelName = dashboardData.jsonRepresentation.model;
+    const sourceModelName = dashboardData.jsonRepresentation?.model;
 
     const previousActiveEntity = $appScreen?.type;
     goto(`/model/${sourceModelName}`);

--- a/web-common/src/features/dashboards/granular-access-policies/resetSelectedMockUserAfterNavigate.ts
+++ b/web-common/src/features/dashboards/granular-access-policies/resetSelectedMockUserAfterNavigate.ts
@@ -1,6 +1,8 @@
 import { afterNavigate } from "$app/navigation";
+import { selectedMockUserStore } from "@rilldata/web-common/features/dashboards/granular-access-policies/stores";
 import { updateDevJWT } from "@rilldata/web-common/features/dashboards/granular-access-policies/updateDevJWT";
 import type { QueryClient } from "@tanstack/svelte-query";
+import { get } from "svelte/store";
 
 /**
  * Remove the selected mock user (if any) when navigating to a dashboard
@@ -13,7 +15,10 @@ import type { QueryClient } from "@tanstack/svelte-query";
  */
 export function resetSelectedMockUserAfterNavigate(queryClient: QueryClient) {
   afterNavigate((nav) => {
-    if (nav.from.params.name !== nav.to.params.name) {
+    if (
+      nav.from.params.name !== nav.to.params.name &&
+      get(selectedMockUserStore) !== null
+    ) {
       updateDevJWT(queryClient, null);
     }
   });

--- a/web-common/src/features/entity-management/resource-invalidations.ts
+++ b/web-common/src/features/entity-management/resource-invalidations.ts
@@ -1,4 +1,7 @@
-import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
+import {
+  resourceHasValidData,
+  ResourceKind,
+} from "@rilldata/web-common/features/entity-management/resource-selectors";
 import { resourcesStore } from "@rilldata/web-common/features/entity-management/resources-store";
 import {
   getRuntimeServiceGetResourceQueryKey,
@@ -79,9 +82,12 @@ async function invalidateResource(
   instanceId: string,
   resource: V1Resource
 ) {
+  refreshResource(queryClient, instanceId, resource);
+
+  if (resource.meta.reconcileStatus !== V1ReconcileStatus.RECONCILE_STATUS_IDLE)
+    return;
   const failed = !!resource.meta.reconcileError;
 
-  refreshResource(queryClient, instanceId, resource);
   switch (resource.meta.name.kind) {
     case ResourceKind.Source:
     case ResourceKind.Model:

--- a/web-common/src/features/entity-management/resource-invalidations.ts
+++ b/web-common/src/features/entity-management/resource-invalidations.ts
@@ -1,7 +1,4 @@
-import {
-  resourceHasValidData,
-  ResourceKind,
-} from "@rilldata/web-common/features/entity-management/resource-selectors";
+import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
 import { resourcesStore } from "@rilldata/web-common/features/entity-management/resources-store";
 import {
   getRuntimeServiceGetResourceQueryKey,

--- a/web-common/src/features/entity-management/resource-selectors.ts
+++ b/web-common/src/features/entity-management/resource-selectors.ts
@@ -115,3 +115,18 @@ export function resourceIsLoading(resource: V1Resource) {
     resource.meta?.reconcileStatus !== V1ReconcileStatus.RECONCILE_STATUS_IDLE
   );
 }
+
+export function resourceHasValidData(resource: V1Resource) {
+  switch (resource.meta.name.kind) {
+    case ResourceKind.Source:
+      return !!resource.source?.state?.table;
+
+    case ResourceKind.Model:
+      return !!resource.model?.state?.table;
+
+    case ResourceKind.MetricsView:
+      return !!resource.metricsView.state.validSpec;
+  }
+
+  return true;
+}

--- a/web-common/src/features/entity-management/resource-selectors.ts
+++ b/web-common/src/features/entity-management/resource-selectors.ts
@@ -115,18 +115,3 @@ export function resourceIsLoading(resource: V1Resource) {
     resource.meta?.reconcileStatus !== V1ReconcileStatus.RECONCILE_STATUS_IDLE
   );
 }
-
-export function resourceHasValidData(resource: V1Resource) {
-  switch (resource.meta.name.kind) {
-    case ResourceKind.Source:
-      return !!resource.source?.state?.table;
-
-    case ResourceKind.Model:
-      return !!resource.model?.state?.table;
-
-    case ResourceKind.MetricsView:
-      return !!resource.metricsView.state.validSpec;
-  }
-
-  return true;
-}

--- a/web-common/src/features/metrics-views/workspace/editor/update-metrics.ts
+++ b/web-common/src/features/metrics-views/workspace/editor/update-metrics.ts
@@ -1,5 +1,6 @@
 import { skipDebounceAnnotation } from "@rilldata/web-common/components/editor/annotations";
 import { setLineStatuses } from "@rilldata/web-common/components/editor/line-status";
+import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
 import { getFileAPIPathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
 import { EntityType } from "@rilldata/web-common/features/entity-management/types";
 import { createDebouncer } from "@rilldata/web-common/lib/create-debouncer";
@@ -28,6 +29,8 @@ export function createUpdateMetricsCallback(
         create: false,
       },
     });
+    // Remove the explorer entity so that everything is reset to defaults next time user navigates to it
+    metricsExplorerStore.remove(metricsDefName);
   }
 
   return function updateMetrics(event) {

--- a/web-common/src/features/models/workspace/ModelWorkspaceCTAs.svelte
+++ b/web-common/src/features/models/workspace/ModelWorkspaceCTAs.svelte
@@ -8,6 +8,7 @@
   import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
   import Forward from "@rilldata/web-common/components/icons/Forward.svelte";
   import { Menu, MenuItem } from "@rilldata/web-common/components/menu";
+  import type { V1Resource } from "@rilldata/web-common/runtime-client";
   import { RuntimeUrl } from "@rilldata/web-local/lib/application-state-stores/initialize-node-store-contexts";
 
   import ResponsiveButtonText from "@rilldata/web-common/components/panel/ResponsiveButtonText.svelte";
@@ -16,7 +17,7 @@
   import { runtime } from "../../../runtime-client/runtime-store";
   import CreateDashboardButton from "./CreateDashboardButton.svelte";
 
-  export let availableDashboards;
+  export let availableDashboards: Array<V1Resource>;
   export let modelName: string;
   export let suppressTooltips = false;
   export let modelHasError = false;
@@ -94,7 +95,7 @@
   <Tooltip distance={8} alignment="end">
     <Button
       on:click={() => {
-        goto(`/dashboard/${availableDashboards[0].name}`);
+        goto(`/dashboard/${availableDashboards[0].meta.name.name}`);
       }}
     >
       <IconSpaceFixer pullLeft pullRight={collapse}>

--- a/web-common/src/features/models/workspace/inspector/ModelInspector.svelte
+++ b/web-common/src/features/models/workspace/inspector/ModelInspector.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
+  import { getFilePathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import ReconcilingSpinner from "@rilldata/web-common/features/entity-management/ReconcilingSpinner.svelte";
   import { resourceIsLoading } from "@rilldata/web-common/features/entity-management/resource-selectors.js";
+  import { getFileHasErrors } from "@rilldata/web-common/features/entity-management/resources-store";
+  import { EntityType } from "@rilldata/web-common/features/entity-management/types";
   import { createResizeListenerActionFactory } from "@rilldata/web-common/lib/actions/create-resize-listener-factory";
+  import { useQueryClient } from "@tanstack/svelte-query";
   import { runtime } from "../../../../runtime-client/runtime-store";
   import { useModel, useModelFileIsEmpty } from "../../selectors";
   import ModelInspectorHeader from "./ModelInspectorHeader.svelte";
@@ -9,7 +13,11 @@
 
   export let modelName: string;
 
+  const queryClient = useQueryClient();
+
+  $: path = getFilePathFromNameAndType(modelName, EntityType.Model);
   $: modelQuery = useModel($runtime?.instanceId, modelName);
+  $: modelHasError = getFileHasErrors(queryClient, $runtime?.instanceId, path);
 
   const { observedNode, listenToNodeResize } =
     createResizeListenerActionFactory();
@@ -22,7 +30,7 @@
     <div class="mt-6">
       <ReconcilingSpinner />
     </div>
-  {:else}
+  {:else if !$modelHasError}
     <div>
       {#key modelName}
         <div use:listenToNodeResize>


### PR DESCRIPTION
1. Navigating between dashboards refreshes everything. Added safeguards for view-as value.
2. During the async reconcile merge a fix for resetting dashboard time controls got reverted.
3. Modelling errors put the modeller into a weird state. Temporarily disabling profiling on errors. This needs a proper fix from the controller where any update sends an extra event just before scheduling with reconcileStatus != IDLE.
4. Go to dashboard button in model is broken. Updated to use Resource instead of Catalog.