### PR TITLE
Logging cleanup from async reconcile

### DIFF
--- a/web-common/src/features/entity-management/resource-invalidations.ts
+++ b/web-common/src/features/entity-management/resource-invalidations.ts
@@ -38,9 +38,6 @@ export function invalidateResourceResponse(
 ) {
   // only process for the `ResourceKind` present in `UsedResourceKinds`
   if (!UsedResourceKinds[res.name.kind]) return;
-  console.log(
-    `[${res.resource.meta.reconcileStatus}] ${res.name.kind}/${res.name.name}`
-  );
 
   const instanceId = get(runtime).instanceId;
   if (

--- a/web-common/src/features/entity-management/watch-files-client.ts
+++ b/web-common/src/features/entity-management/watch-files-client.ts
@@ -23,7 +23,6 @@ function handleWatchFileResponse(
   res: V1WatchFilesResponse
 ) {
   if (res.path.includes(".db")) return;
-  console.log(`[${res.event}] ${res.path}`);
   // Watch file returns events for all files under the project. Ignore everything except .sql, .yaml & .yml
   if (
     !res.path.endsWith(".sql") &&

--- a/web-common/src/features/models/workspace/ModelBody.svelte
+++ b/web-common/src/features/models/workspace/ModelBody.svelte
@@ -42,12 +42,6 @@
 
   const limit = 150;
 
-  $: tableQuery = createQueryServiceTableRows(runtimeInstanceId, modelName, {
-    limit,
-  });
-
-  $: runtimeError = ($tableQuery.error as any)?.response.data;
-
   // track innerHeight to calculate the size of the editor element.
   let innerHeight: number;
 
@@ -72,6 +66,16 @@
     modelPath
   );
   $: modelError = $allErrors?.[0]?.message;
+
+  $: tableQuery = createQueryServiceTableRows(
+    runtimeInstanceId,
+    $modelQuery.data?.model?.state?.table,
+    {
+      limit,
+    }
+  );
+
+  $: runtimeError = ($tableQuery.error as any)?.response.data;
 
   const outputLayout = getContext(
     "rill:app:output-layout"

--- a/web-common/src/runtime-client/watch-request-client.ts
+++ b/web-common/src/runtime-client/watch-request-client.ts
@@ -54,11 +54,7 @@ export class WatchRequestClient<Res extends WatchResponse> {
         }
         return;
       }
-      if (!this.prevFocus) {
-        console.log("Focus reconnect");
-        // Call onReconnect on page focus to make sure we didnt miss anything
-        this.onReconnect();
-      }
+      const prevFocus = this.prevFocus;
       this.prevInstanceId = runtimeState.instanceId;
       this.prevHost = runtimeState.host;
       this.prevFocus = true;
@@ -68,6 +64,10 @@ export class WatchRequestClient<Res extends WatchResponse> {
         this.outOfFocusThrottler.cancel();
         // The client is already running. Do not cancel the client.
         return;
+      }
+      // Call onReconnect on page focus to make sure we didnt miss anything
+      if (!prevFocus) {
+        this.onReconnect();
       }
       this.controller?.abort();
       if (!runtimeState?.instanceId) return;
@@ -107,7 +107,6 @@ export class WatchRequestClient<Res extends WatchResponse> {
           else if (res.result) this.onResponse(res.result);
         }
       } catch (err) {
-        console.log(err);
         if (!(await this.tracker.failed())) {
           return;
         }


### PR DESCRIPTION
1. Cleaning up logging around the watcher clients.
2. Fixing reload of requests on focus all the time.
3. Fixing unnecessary error shown in modelling.