### PR TITLE
Deployment admin access tokens + stubs for runtime admin driver

### DIFF
--- a/admin/database/database.go
+++ b/admin/database/database.go
@@ -133,6 +133,11 @@ type DB interface {
 	DeleteServiceAuthToken(ctx context.Context, id string) error
 	DeleteExpiredServiceAuthTokens(ctx context.Context, retention time.Duration) error
 
+	FindDeploymentAuthToken(ctx context.Context, id string) (*DeploymentAuthToken, error)
+	InsertDeploymentAuthToken(ctx context.Context, opts *InsertDeploymentAuthTokenOptions) (*DeploymentAuthToken, error)
+	UpdateDeploymentAuthTokenUsedOn(ctx context.Context, ids []string) error
+	DeleteExpiredDeploymentAuthToken(ctx context.Context, retention time.Duration) error
+
 	FindDeviceAuthCodeByDeviceCode(ctx context.Context, deviceCode string) (*DeviceAuthCode, error)
 	FindPendingDeviceAuthCodeByUserCode(ctx context.Context, userCode string) (*DeviceAuthCode, error)
 	InsertDeviceAuthCode(ctx context.Context, deviceCode, userCode, clientID string, expiresOn time.Time) (*DeviceAuthCode, error)
@@ -441,7 +446,7 @@ type InsertUserAuthTokenOptions struct {
 	ExpiresOn          *time.Time
 }
 
-// ServiceAuthToken is a persistent API token for a service.
+// ServiceAuthToken is a persistent API token for an external (tenant managed) service.
 type ServiceAuthToken struct {
 	ID         string
 	SecretHash []byte     `db:"secret_hash"`
@@ -457,6 +462,24 @@ type InsertServiceAuthTokenOptions struct {
 	SecretHash []byte
 	ServiceID  string
 	ExpiresOn  *time.Time
+}
+
+// DeploymentAuthToken is a persistent API token for a deployment.
+type DeploymentAuthToken struct {
+	ID           string
+	SecretHash   []byte     `db:"secret_hash"`
+	DeploymentID string     `db:"deployment_id"`
+	CreatedOn    time.Time  `db:"created_on"`
+	ExpiresOn    *time.Time `db:"expires_on"`
+	UsedOn       time.Time  `db:"used_on"`
+}
+
+// InsertDeploymentAuthTokenOptions defines options for creating a DeploymentAuthToken.
+type InsertDeploymentAuthTokenOptions struct {
+	ID           string
+	SecretHash   []byte
+	DeploymentID string
+	ExpiresOn    *time.Time
 }
 
 // AuthClient is a client that requests and consumes auth tokens.

--- a/admin/database/database.go
+++ b/admin/database/database.go
@@ -136,7 +136,7 @@ type DB interface {
 	FindDeploymentAuthToken(ctx context.Context, id string) (*DeploymentAuthToken, error)
 	InsertDeploymentAuthToken(ctx context.Context, opts *InsertDeploymentAuthTokenOptions) (*DeploymentAuthToken, error)
 	UpdateDeploymentAuthTokenUsedOn(ctx context.Context, ids []string) error
-	DeleteExpiredDeploymentAuthToken(ctx context.Context, retention time.Duration) error
+	DeleteExpiredDeploymentAuthTokens(ctx context.Context, retention time.Duration) error
 
 	FindDeviceAuthCodeByDeviceCode(ctx context.Context, deviceCode string) (*DeviceAuthCode, error)
 	FindPendingDeviceAuthCodeByUserCode(ctx context.Context, userCode string) (*DeviceAuthCode, error)

--- a/admin/database/postgres/migrations/0016.sql
+++ b/admin/database/postgres/migrations/0016.sql
@@ -3,7 +3,7 @@ CREATE TABLE deployment_auth_tokens (
 	secret_hash BYTEA NOT NULL,
 	deployment_id UUID NOT NULL REFERENCES deployments (id) ON DELETE CASCADE,
 	created_on TIMESTAMPTZ DEFAULT now() NOT NULL,
-    used_on TIMESTAMPTZ DEFAULT now() NOT NULL,
+	used_on TIMESTAMPTZ DEFAULT now() NOT NULL,
 	expires_on TIMESTAMPTZ
 );
 

--- a/admin/database/postgres/migrations/0016.sql
+++ b/admin/database/postgres/migrations/0016.sql
@@ -1,0 +1,10 @@
+CREATE TABLE deployment_auth_tokens (
+	id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+	secret_hash BYTEA NOT NULL,
+	deployment_id UUID NOT NULL REFERENCES deployments (id) ON DELETE CASCADE,
+	created_on TIMESTAMPTZ DEFAULT now() NOT NULL,
+    used_on TIMESTAMPTZ DEFAULT now() NOT NULL,
+	expires_on TIMESTAMPTZ
+);
+
+CREATE INDEX deployment_auth_tokens_deployment_idx ON deployment_auth_tokens (deployment_id);

--- a/admin/database/postgres/postgres.go
+++ b/admin/database/postgres/postgres.go
@@ -861,7 +861,7 @@ func (c *connection) UpdateDeploymentAuthTokenUsedOn(ctx context.Context, ids []
 	return nil
 }
 
-func (c *connection) DeleteExpiredDeploymentAuthToken(ctx context.Context, retention time.Duration) error {
+func (c *connection) DeleteExpiredDeploymentAuthTokens(ctx context.Context, retention time.Duration) error {
 	_, err := c.getDB(ctx).ExecContext(ctx, "DELETE FROM deployment_auth_tokens WHERE expires_on IS NOT NULL AND expires_on + $1 < now()", retention)
 	return parseErr("deployment auth token", err)
 }

--- a/admin/database/postgres/postgres.go
+++ b/admin/database/postgres/postgres.go
@@ -827,6 +827,45 @@ func (c *connection) DeleteExpiredServiceAuthTokens(ctx context.Context, retenti
 	return parseErr("service auth token", err)
 }
 
+func (c *connection) FindDeploymentAuthToken(ctx context.Context, id string) (*database.DeploymentAuthToken, error) {
+	res := &database.DeploymentAuthToken{}
+	err := c.getDB(ctx).QueryRowxContext(ctx, "SELECT t.* FROM deployment_auth_tokens t WHERE t.id=$1", id).StructScan(res)
+	if err != nil {
+		return nil, parseErr("deployment auth token", err)
+	}
+	return res, nil
+}
+
+func (c *connection) InsertDeploymentAuthToken(ctx context.Context, opts *database.InsertDeploymentAuthTokenOptions) (*database.DeploymentAuthToken, error) {
+	if err := database.Validate(opts); err != nil {
+		return nil, err
+	}
+
+	res := &database.DeploymentAuthToken{}
+	err := c.getDB(ctx).QueryRowxContext(ctx, `
+		INSERT INTO deployment_auth_tokens (id, secret_hash, deployment_id, expires_on)
+		VALUES ($1, $2, $3, $4) RETURNING *`,
+		opts.ID, opts.SecretHash, opts.DeploymentID, opts.ExpiresOn,
+	).StructScan(res)
+	if err != nil {
+		return nil, parseErr("deployment auth token", err)
+	}
+	return res, nil
+}
+
+func (c *connection) UpdateDeploymentAuthTokenUsedOn(ctx context.Context, ids []string) error {
+	_, err := c.getDB(ctx).ExecContext(ctx, "UPDATE deployment_auth_tokens SET used_on=now() WHERE id=ANY($1)", ids)
+	if err != nil {
+		return parseErr("deployment auth token", err)
+	}
+	return nil
+}
+
+func (c *connection) DeleteExpiredDeploymentAuthToken(ctx context.Context, retention time.Duration) error {
+	_, err := c.getDB(ctx).ExecContext(ctx, "DELETE FROM deployment_auth_tokens WHERE expires_on IS NOT NULL AND expires_on + $1 < now()", retention)
+	return parseErr("deployment auth token", err)
+}
+
 func (c *connection) FindDeviceAuthCodeByDeviceCode(ctx context.Context, deviceCode string) (*database.DeviceAuthCode, error) {
 	authCode := &database.DeviceAuthCode{}
 	err := c.getDB(ctx).QueryRowxContext(ctx, "SELECT * FROM device_auth_codes WHERE device_code = $1", deviceCode).StructScan(authCode)

--- a/admin/permissions.go
+++ b/admin/permissions.go
@@ -46,6 +46,12 @@ func (s *Service) OrganizationPermissionsForService(ctx context.Context, orgID, 
 	return &adminv1.OrganizationPermissions{}, nil
 }
 
+// OrganizationPermissionsForDeployment resolves organization permissions for a deployment.
+// A deployment does not get any permissions on the org it belongs to. It only has permissions on the project it belongs to.
+func (s *Service) OrganizationPermissionsForDeployment(ctx context.Context, orgID, deploymentID string) (*adminv1.OrganizationPermissions, error) {
+	return &adminv1.OrganizationPermissions{}, nil
+}
+
 // ProjectPermissionsForUser resolves project permissions for a user.
 func (s *Service) ProjectPermissionsForUser(ctx context.Context, projectID, userID string, orgPerms *adminv1.OrganizationPermissions) (*adminv1.ProjectPermissions, error) {
 	// ManageProjects permission on the org gives full access to all projects in the org (only org admins have this)
@@ -92,6 +98,33 @@ func (s *Service) ProjectPermissionsForService(ctx context.Context, projectID, s
 			ManageDev:            true,
 			ReadProjectMembers:   true,
 			ManageProjectMembers: true,
+		}, nil
+	}
+
+	return &adminv1.ProjectPermissions{}, nil
+}
+
+// ProjectPermissionsForDeployment resolves project permissions for a deployment.
+// A deployment currently gets full read and no write permissions on the project it belongs to.
+func (s *Service) ProjectPermissionsForDeployment(ctx context.Context, projectID, deploymentID string, orgPerms *adminv1.OrganizationPermissions) (*adminv1.ProjectPermissions, error) {
+	depl, err := s.DB.FindDeployment(ctx, deploymentID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Deployments get full read and no write permissions on the project they belong to
+	if projectID == depl.ProjectID {
+		return &adminv1.ProjectPermissions{
+			ReadProject:          true,
+			ManageProject:        false,
+			ReadProd:             true,
+			ReadProdStatus:       true,
+			ManageProd:           false,
+			ReadDev:              true,
+			ReadDevStatus:        true,
+			ManageDev:            false,
+			ReadProjectMembers:   true,
+			ManageProjectMembers: false,
 		}, nil
 	}
 

--- a/admin/pkg/authtoken/authtoken.go
+++ b/admin/pkg/authtoken/authtoken.go
@@ -21,14 +21,15 @@ const Prefix = "rill"
 type Type string
 
 const (
-	TypeUser    Type = "usr"
-	TypeService Type = "svc"
+	TypeUser       Type = "usr"
+	TypeService    Type = "svc"
+	TypeDeployment Type = "dpl"
 )
 
 // Validate checks that the type is a known enum value.
 func (t Type) Validate() bool {
 	switch t {
-	case TypeUser, TypeService:
+	case TypeUser, TypeService, TypeDeployment:
 		return true
 	default:
 		return false

--- a/admin/server/auth/claims.go
+++ b/admin/server/auth/claims.go
@@ -16,9 +16,10 @@ import (
 type OwnerType string
 
 const (
-	OwnerTypeAnon    OwnerType = "anon"
-	OwnerTypeUser    OwnerType = "user"
-	OwnerTypeService OwnerType = "service"
+	OwnerTypeAnon       OwnerType = "anon"
+	OwnerTypeUser       OwnerType = "user"
+	OwnerTypeService    OwnerType = "service"
+	OwnerTypeDeployment OwnerType = "deployment"
 )
 
 // Claims resolves permissions for a requester.
@@ -105,6 +106,8 @@ func (c *authTokenClaims) OwnerType() OwnerType {
 		return OwnerTypeUser
 	case authtoken.TypeService:
 		return OwnerTypeService
+	case authtoken.TypeDeployment:
+		return OwnerTypeDeployment
 	default:
 		panic(fmt.Errorf("unexpected token type %q", t))
 	}
@@ -124,6 +127,9 @@ func (c *authTokenClaims) Superuser(ctx context.Context) bool {
 		// continue
 	case authtoken.TypeService:
 		// services can't be superusers
+		return false
+	case authtoken.TypeDeployment:
+		// deployments can't be superusers
 		return false
 	default:
 		panic(fmt.Errorf("unexpected token type %q", c.token.Token().Type))
@@ -174,6 +180,8 @@ func (c *authTokenClaims) ProjectPermissions(ctx context.Context, orgID, project
 		perm, err = c.admin.ProjectPermissionsForUser(ctx, projectID, c.token.OwnerID(), orgPerms)
 	case authtoken.TypeService:
 		perm, err = c.admin.ProjectPermissionsForService(ctx, projectID, c.token.OwnerID(), orgPerms)
+	case authtoken.TypeDeployment:
+		perm, err = c.admin.ProjectPermissionsForDeployment(ctx, projectID, c.token.OwnerID(), orgPerms)
 	default:
 		err = fmt.Errorf("unexpected token type %q", c.token.Token().Type)
 	}
@@ -202,6 +210,8 @@ func (c *authTokenClaims) organizationPermissionsUnsafe(ctx context.Context, org
 		perm, err = c.admin.OrganizationPermissionsForUser(ctx, orgID, c.token.OwnerID())
 	case authtoken.TypeService:
 		perm, err = c.admin.OrganizationPermissionsForService(ctx, orgID, c.token.OwnerID())
+	case authtoken.TypeDeployment:
+		perm, err = c.admin.OrganizationPermissionsForDeployment(ctx, orgID, c.token.OwnerID())
 	default:
 		err = fmt.Errorf("unexpected token type %q", c.token.Token().Type)
 	}

--- a/admin/used_flusher.go
+++ b/admin/used_flusher.go
@@ -16,32 +16,34 @@ const (
 )
 
 type usedFlusher struct {
-	db            database.DB
-	logger        *zap.Logger
-	mu            sync.Mutex
-	deployments   map[string]bool
-	users         map[string]bool
-	service       map[string]bool
-	userTokens    map[string]bool
-	serviceTokens map[string]bool
-	ctx           context.Context
-	cancel        context.CancelFunc
-	flushWg       sync.WaitGroup
+	db               database.DB
+	logger           *zap.Logger
+	mu               sync.Mutex
+	deployments      map[string]bool
+	users            map[string]bool
+	service          map[string]bool
+	userTokens       map[string]bool
+	serviceTokens    map[string]bool
+	deploymentTokens map[string]bool
+	ctx              context.Context
+	cancel           context.CancelFunc
+	flushWg          sync.WaitGroup
 }
 
 func newUsedFlusher(logger *zap.Logger, db database.DB) *usedFlusher {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	used := &usedFlusher{
-		db:            db,
-		logger:        logger,
-		deployments:   make(map[string]bool),
-		users:         make(map[string]bool),
-		service:       make(map[string]bool),
-		userTokens:    make(map[string]bool),
-		serviceTokens: make(map[string]bool),
-		ctx:           ctx,
-		cancel:        cancel,
+		db:               db,
+		logger:           logger,
+		deployments:      make(map[string]bool),
+		users:            make(map[string]bool),
+		service:          make(map[string]bool),
+		userTokens:       make(map[string]bool),
+		serviceTokens:    make(map[string]bool),
+		deploymentTokens: make(map[string]bool),
+		ctx:              ctx,
+		cancel:           cancel,
 	}
 	go used.runBackground()
 
@@ -83,6 +85,13 @@ func (u *usedFlusher) ServiceToken(id string) {
 	u.serviceTokens[id] = true
 }
 
+func (u *usedFlusher) DeploymentToken(id string) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	u.deploymentTokens[id] = true
+}
+
 func (u *usedFlusher) Close() {
 	u.cancel()
 	u.flush()
@@ -107,29 +116,40 @@ func (u *usedFlusher) flush() {
 	defer u.flushWg.Done()
 
 	u.mu.Lock()
-	deployments := u.deployments
+	var deployments map[string]bool
 	if len(u.deployments) > 0 {
+		deployments = u.deployments
 		u.deployments = make(map[string]bool)
 	}
 
-	users := u.users
+	var users map[string]bool
 	if len(u.users) > 0 {
+		users = u.users
 		u.users = make(map[string]bool)
 	}
 
-	service := u.service
+	var service map[string]bool
 	if len(u.service) > 0 {
+		service = u.service
 		u.service = make(map[string]bool)
 	}
 
-	userTokens := u.userTokens
+	var userTokens map[string]bool
 	if len(u.userTokens) > 0 {
+		userTokens = u.userTokens
 		u.userTokens = make(map[string]bool)
 	}
 
-	serviceTokens := u.serviceTokens
+	var serviceTokens map[string]bool
 	if len(u.serviceTokens) > 0 {
+		serviceTokens = u.serviceTokens
 		u.serviceTokens = make(map[string]bool)
+	}
+
+	var deploymentTokens map[string]bool
+	if len(u.deploymentTokens) > 0 {
+		deploymentTokens = u.deploymentTokens
+		u.deploymentTokens = make(map[string]bool)
 	}
 	u.mu.Unlock()
 
@@ -147,6 +167,9 @@ func (u *usedFlusher) flush() {
 
 	// Flush service tokens
 	u.flushToDB(serviceTokens, u.db.UpdateServiceAuthTokenUsedOn, "service tokens")
+
+	// Flush deployment tokens
+	u.flushToDB(deploymentTokens, u.db.UpdateDeploymentAuthTokenUsedOn, "deployment tokens")
 }
 
 // Helper function to perform the flushing of used_on to the database.

--- a/admin/worker/delete_expired_token.go
+++ b/admin/worker/delete_expired_token.go
@@ -5,7 +5,20 @@ import (
 	"time"
 )
 
-func (w *Worker) deleteExpiredUserAuthTokens(ctx context.Context) error {
-	// Delete user auth tokens that have been expired for more than 24 hours.
-	return w.admin.DB.DeleteExpiredUserAuthTokens(ctx, 24*time.Hour)
+func (w *Worker) deleteExpiredAuthTokens(ctx context.Context) error {
+	// Delete auth tokens that have been expired for more than 24 hours
+	retention := 24 * time.Hour
+	err := w.admin.DB.DeleteExpiredUserAuthTokens(ctx, retention)
+	if err != nil {
+		return err
+	}
+	err = w.admin.DB.DeleteExpiredServiceAuthTokens(ctx, retention)
+	if err != nil {
+		return err
+	}
+	err = w.admin.DB.DeleteExpiredDeploymentAuthTokens(ctx, retention)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/admin/worker/worker.go
+++ b/admin/worker/worker.go
@@ -37,7 +37,7 @@ func (w *Worker) Run(ctx context.Context) error {
 	group, ctx := errgroup.WithContext(ctx)
 	group.Go(func() error { return w.schedule(ctx, "check_slots", w.checkSlots, 15*time.Minute) })
 	group.Go(func() error {
-		return w.schedule(ctx, "delete_expired_tokens", w.deleteExpiredUserAuthTokens, 6*time.Hour)
+		return w.schedule(ctx, "delete_expired_tokens", w.deleteExpiredAuthTokens, 6*time.Hour)
 	})
 	group.Go(func() error {
 		return w.schedule(ctx, "delete_expired_device_auth_codes", w.deleteExpiredDeviceAuthCodes, 6*time.Hour)

--- a/runtime/drivers/admin/admin.go
+++ b/runtime/drivers/admin/admin.go
@@ -1,0 +1,141 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/rilldata/rill/runtime/drivers"
+	"github.com/rilldata/rill/runtime/pkg/activity"
+	"go.uber.org/zap"
+)
+
+var spec = drivers.Spec{
+	DisplayName: "Rill Admin",
+	ConfigProperties: []drivers.PropertySchema{
+		{
+			Key:    "access_token",
+			Secret: true,
+		},
+	},
+}
+
+func init() {
+	drivers.Register("admin", driver{})
+}
+
+type driver struct{}
+
+var _ drivers.Driver = driver{}
+
+type configProperties struct {
+	AccessToken string `mapstructure:"access_token"`
+}
+
+func (d driver) Open(cfgMap map[string]any, shared bool, client activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+	if shared {
+		return nil, fmt.Errorf("admin driver can't be shared")
+	}
+
+	cfg := &configProperties{}
+	err := mapstructure.Decode(cfgMap, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	h := &Handle{
+		config: cfg,
+		logger: logger,
+	}
+	return h, nil
+}
+
+func (d driver) Drop(config map[string]any, logger *zap.Logger) error {
+	return drivers.ErrDropNotSupported
+}
+
+func (d driver) Spec() drivers.Spec {
+	return spec
+}
+
+func (d driver) HasAnonymousSourceAccess(ctx context.Context, props map[string]any, logger *zap.Logger) (bool, error) {
+	return false, fmt.Errorf("not implemented")
+}
+
+func (d driver) TertiarySourceConnectors(ctx context.Context, src map[string]any, logger *zap.Logger) ([]string, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+type Handle struct {
+	config *configProperties
+	logger *zap.Logger
+}
+
+var _ drivers.Handle = &Handle{}
+
+// Driver implements drivers.Handle.
+func (c *Handle) Driver() string {
+	return "admin"
+}
+
+// Config implements drivers.Handle.
+func (c *Handle) Config() map[string]any {
+	m := make(map[string]any, 0)
+	_ = mapstructure.Decode(c.config, &m)
+	return m
+}
+
+// Migrate implements drivers.Handle.
+func (c *Handle) Migrate(ctx context.Context) (err error) {
+	return nil
+}
+
+// MigrationStatus implements drivers.Handle.
+func (c *Handle) MigrationStatus(ctx context.Context) (current, desired int, err error) {
+	return 0, 0, nil
+}
+
+// Close implements drivers.Handle.
+func (c *Handle) Close() error {
+	return nil
+}
+
+// Registry implements drivers.Handle.
+func (c *Handle) AsRegistry() (drivers.RegistryStore, bool) {
+	return nil, false
+}
+
+// Catalog implements drivers.Handle.
+func (c *Handle) AsCatalogStore(instanceID string) (drivers.CatalogStore, bool) {
+	return nil, false
+}
+
+// Repo implements drivers.Handle.
+func (c *Handle) AsRepoStore(instanceID string) (drivers.RepoStore, bool) {
+	return nil, false
+}
+
+// OLAP implements drivers.Handle.
+func (c *Handle) AsOLAP(instanceID string) (drivers.OLAPStore, bool) {
+	return nil, false
+}
+
+// AsObjectStore implements drivers.Handle.
+func (c *Handle) AsObjectStore() (drivers.ObjectStore, bool) {
+	return nil, false
+}
+
+// AsFileStore implements drivers.Handle.
+func (c *Handle) AsFileStore() (drivers.FileStore, bool) {
+	return nil, false
+}
+
+// AsTransporter implements drivers.Handle.
+func (c *Handle) AsTransporter(from, to drivers.Handle) (drivers.Transporter, bool) {
+	return nil, false
+}
+
+// AsSQLStore implements drivers.Handle.
+func (c *Handle) AsSQLStore() (drivers.SQLStore, bool) {
+	return nil, false
+}


### PR DESCRIPTION
Adds an `admin` driver to runtime, and during provisioning, generates a deployment-specific admin access token and sets it on the instance.

This enables the runtime to "phone home" to the control plane to pull config. This will be used to:
- Only send scheduled reports to project members
- Fetch user attributes for each recipient for granular access policies in scheduled reports
- Pulling ad-hoc artifacts (not in Github) from the admin server to the runtime
- Deprecate the `github` driver (which requires our master Github app credentials to be available on each runtime) and instead call the admin server to get Git credentials for the runtime