### PR TITLE
Avoid a blank error page

### DIFF
--- a/web-admin/src/features/errors/ErrorPage.svelte
+++ b/web-admin/src/features/errors/ErrorPage.svelte
@@ -13,11 +13,13 @@
 
 <CtaLayoutContainer>
   <CtaContentContainer>
-    <h1
-      class="text-8xl font-extrabold bg-gradient-to-b from-[#CBD5E1] to-[#E2E8F0] text-transparent bg-clip-text"
-    >
-      {statusCode}
-    </h1>
+    {#if statusCode}
+      <h1
+        class="text-8xl font-extrabold bg-gradient-to-b from-[#CBD5E1] to-[#E2E8F0] text-transparent bg-clip-text"
+      >
+        {statusCode}
+      </h1>
+    {/if}
     <h2 class="text-lg font-semibold">{header}</h2>
     <CtaMessage>
       {body}

--- a/web-admin/src/features/errors/error-utils.ts
+++ b/web-admin/src/features/errors/error-utils.ts
@@ -17,7 +17,7 @@ export function globalErrorCallback(error: AxiosError): void {
   if (isProjectPage) {
     // If "repository not found", ignore the error and show the page
     if (
-      error.response.status === 400 &&
+      error.response?.status === 400 &&
       (error.response.data as RpcStatus).message === "repository not found"
     ) {
       return;
@@ -29,7 +29,7 @@ export function globalErrorCallback(error: AxiosError): void {
     // If a dashboard wasn't found, let +page.svelte handle the error.
     // Because the project may be reconciling, in which case we want to show a loading spinner not a 404.
     if (
-      error.response.status === 404 &&
+      error.response?.status === 404 &&
       (error.response.data as RpcStatus).message === "not found"
     ) {
       return;
@@ -37,13 +37,13 @@ export function globalErrorCallback(error: AxiosError): void {
 
     // When a JWT doesn't permit access to a metrics view, the metrics view APIs return 401s.
     // In this scenario, `GetCatalog` returns a 404. We ignore the 401s so we can show the 404.
-    if (error.response.status === 401) {
+    if (error.response?.status === 401) {
       return;
     }
   }
 
   // If Unauthorized, redirect to login page
-  if (error.response.status === 401) {
+  if (error.response?.status === 401) {
     goto(`${ADMIN_URL}/auth/login?redirect=${window.origin}`);
     return;
   }
@@ -57,7 +57,7 @@ export function globalErrorCallback(error: AxiosError): void {
 function createErrorStoreStateFromAxiosError(
   error: AxiosError
 ): ErrorStoreState {
-  const status = error.response.status;
+  const status = error.response?.status;
   const msg = (error.response.data as RpcStatus).message;
 
   // Specifically handle some errors
@@ -69,13 +69,13 @@ function createErrorStoreStateFromAxiosError(
     };
   } else if (msg === "org not found") {
     return {
-      statusCode: error.response.status,
+      statusCode: error.response?.status,
       header: "Organization not found",
       body: "The organization you requested could not be found. Please check that you have provided a valid organization name.",
     };
   } else if (msg === "project not found") {
     return {
-      statusCode: error.response.status,
+      statusCode: error.response?.status,
       header: "Project not found",
       body: "The project you requested could not be found. Please check that you have provided a valid project name.",
     };
@@ -83,7 +83,7 @@ function createErrorStoreStateFromAxiosError(
 
   // Fallback for all other errors
   return {
-    statusCode: error.response.status,
+    statusCode: error.response?.status,
     header: "Sorry, unexpected error!",
     body: "Try refreshing the page, and reach out to us if that doesn't fix the error.",
   };


### PR DESCRIPTION
Upon navigating to a dashboard with a 502 error (at the time of writing, [this one](https://ui.rilldata.com/demo/rill-app-engagement/moble_app_engagement)), the Error Page is blank with the following message in the browser console:
![image](https://github.com/rilldata/rill/assets/14206386/db46f275-3a3a-423b-9857-387f1f99ddf0)

This PR protects against accessing an undefined `status` field.