### PR TITLE
Fixing histogram query on duckdb 0.9

### DIFF
--- a/runtime/queries/column_numeric_histogram.go
+++ b/runtime/queries/column_numeric_histogram.go
@@ -139,6 +139,14 @@ func (q *ColumnNumericHistogram) calculateFDMethod(ctx context.Context, rt *runt
 		return fmt.Errorf("not available for dialect '%s'", olap.Dialect())
 	}
 
+	min, max, rng, err := getMinMaxRange(ctx, olap, q.ColumnName, q.TableName, priority)
+	if err != nil {
+		return err
+	}
+	if !min.Valid || !max.Valid || !rng.Valid {
+		return nil
+	}
+
 	sanitizedColumnName := safeName(q.ColumnName)
 	bucketSize, err := q.calculateBucketSize(ctx, olap, instanceID, priority)
 	if err != nil {
@@ -156,26 +164,20 @@ func (q *ColumnNumericHistogram) calculateFDMethod(ctx context.Context, rt *runt
             SELECT %[1]s as %[2]s 
             FROM %[3]s
             WHERE %[2]s IS NOT NULL
-          ), S AS (
-            SELECT 
-              min(%[2]s) as minVal,
-              max(%[2]s) as maxVal,
-              (max(%[2]s) - min(%[2]s)) as range
-              FROM data_table
           ), values AS (
             SELECT %[2]s as value from data_table
             WHERE %[2]s IS NOT NULL
           ), buckets AS (
             SELECT
               range as bucket,
-              (range) * (select range FROM S) / %[4]v + (select minVal from S) as low,
-              (range + 1) * (select range FROM S) / %[4]v + (select minVal from S) as high
+              (range) * (%[7]v) / %[4]v + (%[5]v) as low,
+              (range + 1) * (%[7]v) / %[4]v + (%[5]v) as high
             FROM range(0, %[4]v, 1)
           ),
           -- bin the values
           binned_data AS (
             SELECT 
-              FLOOR((value - (select minVal from S)) / (select range from S) * %[4]v) as bucket
+              FLOOR((value - (%[5]v)) / (%[7]v) * %[4]v) as bucket
             from values
           ),
           -- join the bucket set with the binned values to generate the histogram
@@ -193,7 +195,7 @@ func (q *ColumnNumericHistogram) calculateFDMethod(ctx context.Context, rt *runt
           -- calculate the right edge, sine in histogram_stage we don't look at the values that
           -- might be the largest.
           right_edge AS (
-            SELECT count(*) as c from values WHERE value = (select maxVal from S)
+            SELECT count(*) as c from values WHERE value = %[6]v
           )
           SELECT 
             bucket,
@@ -207,6 +209,9 @@ func (q *ColumnNumericHistogram) calculateFDMethod(ctx context.Context, rt *runt
 		sanitizedColumnName,
 		safeName(q.TableName),
 		bucketSize,
+		min.Float64,
+		max.Float64,
+		rng.Float64,
 	)
 
 	histogramRows, err := olap.Execute(ctx, &drivers.Statement{
@@ -251,39 +256,10 @@ func (q *ColumnNumericHistogram) calculateDiagnosticMethod(ctx context.Context, 
 		return fmt.Errorf("not available for dialect '%s'", olap.Dialect())
 	}
 
-	sanitizedColumnName := safeName(q.ColumnName)
-	minMaxSQL := fmt.Sprintf(
-		`
-			SELECT
-				min(%[2]s) as min,
-				max(%[2]s) as max,
-				max(%[2]s) - min(%[2]s) as range
-			FROM %[1]s
-			WHERE %[2]s IS NOT NULL
-		`,
-		safeName(q.TableName),
-		sanitizedColumnName,
-	)
-
-	minMaxRow, err := olap.Execute(ctx, &drivers.Statement{
-		Query:            minMaxSQL,
-		Priority:         priority,
-		ExecutionTimeout: defaultExecutionTimeout,
-	})
+	min, max, rng, err := getMinMaxRange(ctx, olap, q.ColumnName, q.TableName, priority)
 	if err != nil {
 		return err
 	}
-
-	var min, max, rng sql.NullFloat64
-	if minMaxRow.Next() {
-		err = minMaxRow.Scan(&min, &max, &rng)
-		if err != nil {
-			minMaxRow.Close()
-			return err
-		}
-	}
-
-	minMaxRow.Close()
 	if !min.Valid || !max.Valid || !rng.Valid {
 		return nil
 	}
@@ -299,6 +275,7 @@ func (q *ColumnNumericHistogram) calculateDiagnosticMethod(ctx context.Context, 
 		bucketCount++
 	}
 
+	sanitizedColumnName := safeName(q.ColumnName)
 	selectColumn := fmt.Sprintf("%s::DOUBLE", sanitizedColumnName)
 	histogramSQL := fmt.Sprintf(
 		`
@@ -395,4 +372,44 @@ func (q *ColumnNumericHistogram) calculateDiagnosticMethod(ctx context.Context, 
 	q.Result = histogramBins
 
 	return nil
+}
+
+// getMinMaxRange get min, max and range of values for a given column. This is needed since nesting it in query is throwing error in 0.9.x
+func getMinMaxRange(ctx context.Context, olap drivers.OLAPStore, columnName, tableName string, priority int) (sql.NullFloat64, sql.NullFloat64, sql.NullFloat64, error) {
+	sanitizedColumnName := safeName(columnName)
+	selectColumn := fmt.Sprintf("%s::DOUBLE", sanitizedColumnName)
+	minMaxSQL := fmt.Sprintf(
+		`
+			SELECT
+				min(%[2]s) as min,
+				max(%[2]s) as max,
+				max(%[2]s) - min(%[2]s) as range
+			FROM %[1]s
+			WHERE %[2]s IS NOT NULL
+		`,
+		safeName(tableName),
+		selectColumn,
+	)
+
+	minMaxRow, err := olap.Execute(ctx, &drivers.Statement{
+		Query:            minMaxSQL,
+		Priority:         priority,
+		ExecutionTimeout: defaultExecutionTimeout,
+	})
+	if err != nil {
+		return sql.NullFloat64{}, sql.NullFloat64{}, sql.NullFloat64{}, err
+	}
+
+	var min, max, rng sql.NullFloat64
+	if minMaxRow.Next() {
+		err = minMaxRow.Scan(&min, &max, &rng)
+		if err != nil {
+			minMaxRow.Close()
+			return sql.NullFloat64{}, sql.NullFloat64{}, sql.NullFloat64{}, err
+		}
+	}
+
+	minMaxRow.Close()
+
+	return min, max, rng, nil
 }

--- a/runtime/server/queries_columns_test.go
+++ b/runtime/server/queries_columns_test.go
@@ -555,6 +555,31 @@ func TestServer_GetCardinalityOfColumn(t *testing.T) {
 	require.Equal(t, 3.0, res.CategoricalSummary.GetCardinality())
 }
 
+func TestServer_HistogramQueryBinderErrors(t *testing.T) {
+	srv, instanceID := getMetricsTestServer(t, "ad_bids")
+
+	_, err := srv.ColumnNumericHistogram(
+		testCtx(),
+		&runtimev1.ColumnNumericHistogramRequest{
+			InstanceId:      instanceID,
+			TableName:       "ad_bids_errored",
+			ColumnName:      "bid_price",
+			HistogramMethod: runtimev1.HistogramMethod_HISTOGRAM_METHOD_FD,
+		},
+	)
+	require.NoError(t, err)
+
+	_, err = srv.ColumnRugHistogram(
+		testCtx(),
+		&runtimev1.ColumnRugHistogramRequest{
+			InstanceId: instanceID,
+			TableName:  "ad_bids_errored",
+			ColumnName: "bid_price",
+		},
+	)
+	require.NoError(t, err)
+}
+
 func getColumnTestServer(t *testing.T) (*server.Server, string) {
 	sql := `
 		SELECT 'abc' AS col, 1 AS val, TIMESTAMP '2022-11-01 00:00:00' AS times, DATE '2007-04-01' AS dates

--- a/runtime/testruntime/testdata/ad_bids/models/ad_bids_errored.sql
+++ b/runtime/testruntime/testdata/ad_bids/models/ad_bids_errored.sql
@@ -1,0 +1,1 @@
+select timestamp, bid_price from ad_bids_source where bid_price > 4

--- a/web-common/src/components/column-profile/column-types/NumericProfile.svelte
+++ b/web-common/src/components/column-profile/column-types/NumericProfile.svelte
@@ -57,16 +57,16 @@
     active
   );
   let fdHistogram;
-  // $: if (isFloat(type)) {
-  //   fdHistogram = getNumericHistogram(
-  //     $runtime?.instanceId,
-  //     objectName,
-  //     columnName,
-  //     QueryServiceColumnNumericHistogramHistogramMethod.HISTOGRAM_METHOD_FD,
-  //     enableProfiling,
-  //     active
-  //   );
-  // }
+  $: if (isFloat(type)) {
+    fdHistogram = getNumericHistogram(
+      $runtime?.instanceId,
+      objectName,
+      columnName,
+      QueryServiceColumnNumericHistogramHistogramMethod.HISTOGRAM_METHOD_FD,
+      enableProfiling,
+      active
+    );
+  }
 
   /**
    * We have two choices of histogram method: diagnostic and freedman-diaconis.
@@ -74,13 +74,12 @@
    * the most viable of diagnostic and freedman-diaconis. We'll remove
    * this once we've refactored floating-point columns toward a KDE plot.
    */
-  // $: histogramData = isFloat(type)
-  //   ? chooseBetweenDiagnosticAndStatistical(
-  //       $diagnosticHistogram?.data,
-  //       $fdHistogram?.data
-  //     )
-  //   : $diagnosticHistogram?.data;
-  $: histogramData = $diagnosticHistogram?.data;
+  $: histogramData = isFloat(type)
+    ? chooseBetweenDiagnosticAndStatistical(
+        $diagnosticHistogram?.data,
+        $fdHistogram?.data
+      )
+    : $diagnosticHistogram?.data;
 
   $: rug = createQueryServiceColumnRugHistogram(
     $runtime?.instanceId,
@@ -126,10 +125,9 @@
     httpRequestQueue.prioritiseColumn(objectName, columnName, active);
   }
 
-  // $: fetchingSummaries = FLOATS.has(type)
-  //   ? isFetching($nulls, $diagnosticHistogram, $fdHistogram)
-  //   : isFetching($nulls, $diagnosticHistogram);
-  $: fetchingSummaries = isFetching($nulls, $diagnosticHistogram);
+  $: fetchingSummaries = FLOATS.has(type)
+    ? isFetching($nulls, $diagnosticHistogram, $fdHistogram)
+    : isFetching($nulls, $diagnosticHistogram);
 
   /** if we have a singleton where all summary information is the same, let's construct a single bin. */
   $: if (

--- a/web-common/src/components/column-profile/column-types/NumericProfile.svelte
+++ b/web-common/src/components/column-profile/column-types/NumericProfile.svelte
@@ -57,16 +57,16 @@
     active
   );
   let fdHistogram;
-  $: if (isFloat(type)) {
-    fdHistogram = getNumericHistogram(
-      $runtime?.instanceId,
-      objectName,
-      columnName,
-      QueryServiceColumnNumericHistogramHistogramMethod.HISTOGRAM_METHOD_FD,
-      enableProfiling,
-      active
-    );
-  }
+  // $: if (isFloat(type)) {
+  //   fdHistogram = getNumericHistogram(
+  //     $runtime?.instanceId,
+  //     objectName,
+  //     columnName,
+  //     QueryServiceColumnNumericHistogramHistogramMethod.HISTOGRAM_METHOD_FD,
+  //     enableProfiling,
+  //     active
+  //   );
+  // }
 
   /**
    * We have two choices of histogram method: diagnostic and freedman-diaconis.
@@ -74,12 +74,13 @@
    * the most viable of diagnostic and freedman-diaconis. We'll remove
    * this once we've refactored floating-point columns toward a KDE plot.
    */
-  $: histogramData = isFloat(type)
-    ? chooseBetweenDiagnosticAndStatistical(
-        $diagnosticHistogram?.data,
-        $fdHistogram?.data
-      )
-    : $diagnosticHistogram?.data;
+  // $: histogramData = isFloat(type)
+  //   ? chooseBetweenDiagnosticAndStatistical(
+  //       $diagnosticHistogram?.data,
+  //       $fdHistogram?.data
+  //     )
+  //   : $diagnosticHistogram?.data;
+  $: histogramData = $diagnosticHistogram?.data;
 
   $: rug = createQueryServiceColumnRugHistogram(
     $runtime?.instanceId,
@@ -125,9 +126,10 @@
     httpRequestQueue.prioritiseColumn(objectName, columnName, active);
   }
 
-  $: fetchingSummaries = FLOATS.has(type)
-    ? isFetching($nulls, $diagnosticHistogram, $fdHistogram)
-    : isFetching($nulls, $diagnosticHistogram);
+  // $: fetchingSummaries = FLOATS.has(type)
+  //   ? isFetching($nulls, $diagnosticHistogram, $fdHistogram)
+  //   : isFetching($nulls, $diagnosticHistogram);
+  $: fetchingSummaries = isFetching($nulls, $diagnosticHistogram);
 
   /** if we have a singleton where all summary information is the same, let's construct a single bin. */
   $: if (


### PR DESCRIPTION
Histogram queries throw an error when run on duckdb 0.9.
`Error: INTERNAL Error: Failed to bind column reference "SUBQUERY" [476.0] (bindings: [401.0])`

Found a workaround where calculating min, max and range outside of the CTE fixes this.