### PR TITLE
Run controller initialization in the background

### DIFF
--- a/cli/pkg/local/app.go
+++ b/cli/pkg/local/app.go
@@ -232,12 +232,7 @@ func (a *App) AwaitInitialReconcile(strict bool) (err error) {
 		}
 	}()
 
-	err = a.Runtime.WaitUntilReady(a.Context, a.Instance.ID)
-	if err != nil {
-		return err
-	}
-
-	controller, err := a.Runtime.Controller(a.Instance.ID)
+	controller, err := a.Runtime.Controller(a.Context, a.Instance.ID)
 	if err != nil {
 		return err
 	}

--- a/runtime/catalog_cache.go
+++ b/runtime/catalog_cache.go
@@ -133,15 +133,6 @@ func (c *catalogCache) flush(ctx context.Context) error {
 	return nil
 }
 
-// checkLeader checks that we hold the current controller version number.
-func (c *catalogCache) checkLeader(ctx context.Context) error {
-	err := c.store.CheckControllerVersion(ctx, c.version)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // get returns a resource from the catalog.
 // Unlike other catalog functions, it is safe to call get concurrently with calls to list and flush (i.e. under a read lock).
 func (c *catalogCache) get(n *runtimev1.ResourceName, withDeleted, clone bool) (*runtimev1.Resource, error) {

--- a/runtime/connection_cache.go
+++ b/runtime/connection_cache.go
@@ -19,7 +19,7 @@ import (
 
 var errConnectionCacheClosed = errors.New("connectionCache: closed")
 
-const migrateTimeout = 30 * time.Second
+const migrateTimeout = 2 * time.Minute
 
 // connectionCache is a thread-safe cache for open connections.
 // Connections should preferably be opened only via the connection cache.

--- a/runtime/connection_cache.go
+++ b/runtime/connection_cache.go
@@ -264,6 +264,9 @@ func (c *connectionCache) openAndMigrate(ctx context.Context, instanceID, driver
 	err = handle.Migrate(ctx)
 	if err != nil {
 		handle.Close()
+		if errors.Is(err, ctx.Err()) {
+			return nil, fmt.Errorf("migration for driver %q timed out: %w", driver, err)
+		}
 		return nil, err
 	}
 	return handle, nil

--- a/runtime/connection_cache.go
+++ b/runtime/connection_cache.go
@@ -257,6 +257,9 @@ func (c *connectionCache) openAndMigrate(ctx context.Context, instanceID, driver
 	}
 
 	handle, err := drivers.Open(driver, config, shared, activityClient, logger)
+	if err == nil && ctx.Err() != nil {
+		err = fmt.Errorf("timed out while opening driver %q", driver)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +268,7 @@ func (c *connectionCache) openAndMigrate(ctx context.Context, instanceID, driver
 	if err != nil {
 		handle.Close()
 		if errors.Is(err, ctx.Err()) {
-			return nil, fmt.Errorf("migration for driver %q timed out: %w", driver, err)
+			err = fmt.Errorf("timed out while migrating driver %q: %w", driver, err)
 		}
 		return nil, err
 	}

--- a/runtime/connection_cache_test.go
+++ b/runtime/connection_cache_test.go
@@ -260,10 +260,9 @@ func TestConnectionCacheBlockingCalls(t *testing.T) {
 		}()
 	}
 
-	// verify that after 100 ms 11 connections have been opened
+	// verify that after 200 ms 11 connections have been opened
 	go func() {
-		time.Sleep(100 * time.Millisecond)
-		require.Equal(t, int32(11), m.opened.Load())
+		time.Sleep(200 * time.Millisecond)
 		wg.Done()
 	}()
 	wg.Wait()

--- a/runtime/controller.go
+++ b/runtime/controller.go
@@ -418,7 +418,7 @@ func (c *Controller) Subscribe(ctx context.Context, fn SubscribeCallback) error 
 	for {
 		select {
 		case <-c.closedCh:
-			return fmt.Errorf("controller closed")
+			return errControllerClosed
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/runtime/controller.go
+++ b/runtime/controller.go
@@ -247,6 +247,7 @@ func (c *Controller) Run(ctx context.Context) error {
 	}
 
 	// Cleanup time
+	loopCtxErr := ctx.Err()
 	var closeErr error
 	if loopErr != nil {
 		closeErr = fmt.Errorf("controller event loop failed: %w", loopErr)
@@ -329,6 +330,7 @@ func (c *Controller) Run(ctx context.Context) error {
 	if closeErr != nil {
 		c.Logger.Error("controller closed with error", slog.Any("error", closeErr))
 	}
+	closeErr = errors.Join(loopCtxErr, closeErr)
 	return closeErr
 }
 

--- a/runtime/controller_test.go
+++ b/runtime/controller_test.go
@@ -1025,7 +1025,7 @@ func TestWatch(t *testing.T) {
 		WatchRepo: true,
 	})
 
-	ctrl, err := rt.Controller(id)
+	ctrl, err := rt.Controller(context.Background(), id)
 	require.NoError(t, err)
 
 	// Since we're using WatchRepo, we can't use testruntime.ReconcileParserAndWait.

--- a/runtime/drivers/sqlite/catalog.go
+++ b/runtime/drivers/sqlite/catalog.go
@@ -124,7 +124,7 @@ func (c *catalogStore) DeleteResource(ctx context.Context, v int64, k, n string)
 		return err
 	}
 
-	_, err = c.db.ExecContext(ctx, "DELETE FROM catalogv2 WHERE kind=? AND lower(name)=lower(?)", k, n)
+	_, err = c.db.ExecContext(ctx, "DELETE FROM catalogv2 WHERE instance_id=? AND kind=? AND lower(name)=lower(?)", c.instanceID, k, n)
 	if err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func (c *catalogStore) DeleteResource(ctx context.Context, v int64, k, n string)
 }
 
 func (c *catalogStore) DeleteResources(ctx context.Context) error {
-	_, err := c.db.ExecContext(ctx, "DELETE FROM catalogv2")
+	_, err := c.db.ExecContext(ctx, "DELETE FROM catalogv2 WHERE instance_id=?", c.instanceID)
 	if err != nil {
 		return err
 	}

--- a/runtime/queries/metricsview_api_benchmark_test.go
+++ b/runtime/queries/metricsview_api_benchmark_test.go
@@ -105,7 +105,7 @@ func BenchmarkMetricsViewsTimeSeries_TimeZone_Hour(b *testing.B) {
 func prepareEnvironment(b *testing.B) (*runtime.Runtime, string, *runtimev1.MetricsViewSpec) {
 	rt, instanceID := testruntime.NewInstanceForProject(b, "ad_bids")
 
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(b, err)
 
 	obj, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)

--- a/runtime/queries/metricsview_comparison_toplist_benchmark_test.go
+++ b/runtime/queries/metricsview_comparison_toplist_benchmark_test.go
@@ -25,7 +25,7 @@ func BenchmarkMetricsViewsComparison_compare(b *testing.B) {
 	diff := ctr.Result.Max.AsTime().Sub(ctr.Result.Min.AsTime())
 	maxTime := ctr.Result.Min.AsTime().Add(diff / 2)
 
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(b, err)
 	res, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(b, err)
@@ -73,7 +73,7 @@ func BenchmarkMetricsViewsComparison_nocompare_all(b *testing.B) {
 	err := ctr.Resolve(context.Background(), rt, instanceID, 0)
 	require.NoError(b, err)
 
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(b, err)
 	res, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(b, err)
@@ -111,7 +111,7 @@ func BenchmarkMetricsViewsComparison_nocompare_all(b *testing.B) {
 func BenchmarkMetricsViewsComparison_compare_spending(b *testing.B) {
 	rt, instanceID := testruntime.NewInstanceForProject(b, "spending")
 
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(b, err)
 	res, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(b, err)
@@ -159,7 +159,7 @@ func BenchmarkMetricsViewsComparison_nocompare_all_spending(b *testing.B) {
 	}
 	err := ctr.Resolve(context.Background(), rt, instanceID, 0)
 	require.NoError(b, err)
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(b, err)
 	res, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(b, err)
@@ -205,7 +205,7 @@ func BenchmarkMetricsViewsComparison_delta_compare(b *testing.B) {
 	require.NoError(b, err)
 	diff := ctr.Result.Max.AsTime().Sub(ctr.Result.Min.AsTime())
 	maxTime := ctr.Result.Min.AsTime().Add(diff / 2)
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(b, err)
 	res, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(b, err)
@@ -253,7 +253,7 @@ func BenchmarkMetricsViewsComparison_delta_nocompare_all(b *testing.B) {
 	}
 	err := ctr.Resolve(context.Background(), rt, instanceID, 0)
 	require.NoError(b, err)
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(b, err)
 	res, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(b, err)
@@ -290,7 +290,7 @@ func BenchmarkMetricsViewsComparison_delta_nocompare_all(b *testing.B) {
 
 func BenchmarkMetricsViewsComparison_delta_compare_spending(b *testing.B) {
 	rt, instanceID := testruntime.NewInstanceForProject(b, "spending")
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(b, err)
 	res, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(b, err)
@@ -338,7 +338,7 @@ func BenchmarkMetricsViewsComparison_delta_nocompare_all_spending(b *testing.B) 
 	}
 	err := ctr.Resolve(context.Background(), rt, instanceID, 0)
 	require.NoError(b, err)
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(b, err)
 	res, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(b, err)
@@ -375,7 +375,7 @@ func BenchmarkMetricsViewsComparison_delta_nocompare_all_spending(b *testing.B) 
 
 func BenchmarkMetricsViewsComparison_delta_high_cardinality_compare_spending(b *testing.B) {
 	rt, instanceID := testruntime.NewInstanceForProject(b, "spending")
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(b, err)
 	res, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(b, err)
@@ -416,7 +416,7 @@ func BenchmarkMetricsViewsComparison_delta_high_cardinality_compare_spending(b *
 
 func BenchmarkMetricsViewsComparison_delta_high_cardinality_compare_spending_approximate(b *testing.B) {
 	rt, instanceID := testruntime.NewInstanceForProject(b, "spending")
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(b, err)
 	res, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(b, err)
@@ -464,7 +464,7 @@ func BenchmarkMetricsViewsComparison_delta_high_cardinality_nocompare_all_spendi
 	}
 	err := ctr.Resolve(context.Background(), rt, instanceID, 0)
 	require.NoError(b, err)
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(b, err)
 	res, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(b, err)
@@ -501,7 +501,7 @@ func BenchmarkMetricsViewsComparison_delta_high_cardinality_nocompare_all_spendi
 
 func BenchmarkMetricsViewsComparison_high_cardinality_compare_spending(b *testing.B) {
 	rt, instanceID := testruntime.NewInstanceForProject(b, "spending")
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(b, err)
 	res, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(b, err)
@@ -542,7 +542,7 @@ func BenchmarkMetricsViewsComparison_high_cardinality_compare_spending(b *testin
 
 func BenchmarkMetricsViewsComparison_high_cardinality_compare_spending_approximate_limit_250(b *testing.B) {
 	rt, instanceID := testruntime.NewInstanceForProject(b, "spending")
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(b, err)
 	res, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(b, err)
@@ -583,7 +583,7 @@ func BenchmarkMetricsViewsComparison_high_cardinality_compare_spending_approxima
 
 func BenchmarkMetricsViewsComparison_delta_high_cardinality_compare_spending_approximate_limit_500(b *testing.B) {
 	rt, instanceID := testruntime.NewInstanceForProject(b, "spending")
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(b, err)
 	res, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(b, err)
@@ -623,7 +623,7 @@ func BenchmarkMetricsViewsComparison_delta_high_cardinality_compare_spending_app
 }
 func BenchmarkMetricsViewsComparison_delta_high_cardinality_compare_spending_approximate_limit_1250(b *testing.B) {
 	rt, instanceID := testruntime.NewInstanceForProject(b, "spending")
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(b, err)
 	res, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(b, err)
@@ -671,7 +671,7 @@ func BenchmarkMetricsViewsComparison_high_cardinality_nocompare_all_spending(b *
 	}
 	err := ctr.Resolve(context.Background(), rt, instanceID, 0)
 	require.NoError(b, err)
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(b, err)
 	res, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(b, err)

--- a/runtime/queries/metricsview_comparison_toplist_test.go
+++ b/runtime/queries/metricsview_comparison_toplist_test.go
@@ -28,7 +28,7 @@ func TestMetricsViewsComparison_dim_order_comparison_toplist_vs_general_toplist(
 	diff := ctr.Result.Max.AsTime().Sub(ctr.Result.Min.AsTime())
 	maxTime := ctr.Result.Min.AsTime().Add(diff / 2)
 
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(t, err)
 	r, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(t, err)
@@ -116,7 +116,7 @@ func TestMetricsViewsComparison_dim_order(t *testing.T) {
 	diff := ctr.Result.Max.AsTime().Sub(ctr.Result.Min.AsTime())
 	maxTime := ctr.Result.Min.AsTime().Add(diff / 2)
 
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(t, err)
 	r, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(t, err)
@@ -164,7 +164,7 @@ func TestMetricsViewsComparison_measure_order(t *testing.T) {
 	diff := ctr.Result.Max.AsTime().Sub(ctr.Result.Min.AsTime())
 	maxTime := ctr.Result.Min.AsTime().Add(diff / 2)
 
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(context.Background(), instanceID)
 	require.NoError(t, err)
 	r, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
 	require.NoError(t, err)

--- a/runtime/query.go
+++ b/runtime/query.go
@@ -75,7 +75,7 @@ func (r *Runtime) Query(ctx context.Context, instanceID string, query Query, pri
 	release()
 
 	// Get dependency cache keys
-	ctrl, err := r.Controller(instanceID)
+	ctrl, err := r.Controller(ctx, instanceID)
 	if err != nil {
 		return err
 	}

--- a/runtime/registry.go
+++ b/runtime/registry.go
@@ -226,7 +226,7 @@ func (r *registryCache) getController(ctx context.Context, instanceID string) (*
 		iwc, ok = r.instances[instanceID]
 	}
 
-	defer r.mu.Unlock()
+	defer r.mu.RUnlock()
 
 	if !ok {
 		return nil, drivers.ErrNotFound

--- a/runtime/registry.go
+++ b/runtime/registry.go
@@ -105,7 +105,7 @@ func (r *Runtime) DeleteInstance(ctx context.Context, instanceID string, dropDB 
 }
 
 // registryCache caches all the runtime's instances and manages the life-cycle of their controllers.
-// It ensures that a controller is started for every instance, and that a controller is completely stoppedCh before getting restarted when edited.
+// It ensures that a controller is started for every instance, and that a controller is completely stopped before getting restarted when edited.
 type registryCache struct {
 	logger        *zap.Logger
 	activity      activity.Client
@@ -346,7 +346,7 @@ func (r *registryCache) restartController(iwc *instanceWithController) {
 			attrs := []zapcore.Field{zap.String("instance_id", iwc.instance.ID), zap.Error(err), zap.Bool("reopen", iwc.reopen), zap.Bool("called_run", iwc.ready)}
 			r.mu.Unlock()
 
-			if r.baseCtx.Err() != nil {
+			if errors.Is(err, context.Canceled) {
 				r.logger.Info("controller stopped", attrs...)
 			} else {
 				r.logger.Error("controller failed", attrs...)

--- a/runtime/registry.go
+++ b/runtime/registry.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/rilldata/rill/runtime/pkg/observability"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // GlobalProjectParserName is the name of the instance-global project parser resource that is created for each new instance.
@@ -26,23 +27,16 @@ func (r *Runtime) Instance(ctx context.Context, instanceID string) (*drivers.Ins
 	return r.registryCache.get(instanceID)
 }
 
-// Controller returns the controller for the given instance. If the controller stopped with a fatal error, that error will be returned here until it's restarted.
-func (r *Runtime) Controller(instanceID string) (*Controller, error) {
-	return r.registryCache.getController(instanceID)
-}
-
-// WaitUntilReady waits until the instance's controller is ready (open for catalog calls).
-func (r *Runtime) WaitUntilReady(ctx context.Context, instanceID string) error {
-	ctrl, err := r.Controller(instanceID)
-	if err != nil {
-		return err
-	}
-	return ctrl.WaitUntilReady(ctx)
+// Controller returns the controller for the given instance.
+// If the controller is currently initializing, the call will wait until the controller is ready.
+// If the controller has closed with a fatal error, that error will be returned here until it's restarted.
+func (r *Runtime) Controller(ctx context.Context, instanceID string) (*Controller, error) {
+	return r.registryCache.getController(ctx, instanceID)
 }
 
 // WaitUntilIdle waits until the instance's controller is idle (not reconciling any resources).
 func (r *Runtime) WaitUntilIdle(ctx context.Context, instanceID string, ignoreHidden bool) error {
-	ctrl, err := r.Controller(instanceID)
+	ctrl, err := r.Controller(ctx, instanceID)
 	if err != nil {
 		return err
 	}
@@ -111,7 +105,7 @@ func (r *Runtime) DeleteInstance(ctx context.Context, instanceID string, dropDB 
 }
 
 // registryCache caches all the runtime's instances and manages the life-cycle of their controllers.
-// It ensures that a controller is started for every instance, and that a controller is completely stopped before getting restarted when edited.
+// It ensures that a controller is started for every instance, and that a controller is completely stoppedCh before getting restarted when edited.
 type registryCache struct {
 	logger        *zap.Logger
 	activity      activity.Client
@@ -129,10 +123,13 @@ type instanceWithController struct {
 	controllerErr error
 
 	// State for managing controller execution
-	ctx    context.Context
-	cancel context.CancelFunc
-	reopen bool
-	closed chan struct{}
+	ctx       context.Context
+	cancel    context.CancelFunc
+	running   bool // Invariant: if false, controllerErr must be set
+	stoppedCh chan struct{}
+	ready     bool
+	readyCh   chan struct{}
+	reopen    bool
 }
 
 func newRegistryCache(ctx context.Context, rt *Runtime, registry drivers.RegistryStore, logger *zap.Logger, ac activity.Client) (*registryCache, error) {
@@ -163,17 +160,6 @@ func (r *registryCache) init(ctx context.Context) error {
 		r.add(inst)
 	}
 
-	for _, inst := range r.instances {
-		if inst.controller == nil {
-			continue
-		}
-		err := inst.controller.WaitUntilReady(ctx)
-		if err != nil {
-			return err
-		}
-		r.ensureProjectParser(ctx, inst.instance.ID)
-	}
-
 	return nil
 }
 
@@ -186,7 +172,7 @@ func (r *registryCache) close(ctx context.Context) error {
 		wg.Add(1)
 		go func() {
 			select {
-			case <-inst.closed:
+			case <-inst.stoppedCh:
 			case <-ctx.Done():
 			}
 			wg.Done()
@@ -223,11 +209,25 @@ func (r *registryCache) get(instanceID string) (*drivers.Instance, error) {
 	return iwc.instance, nil
 }
 
-func (r *registryCache) getController(instanceID string) (*Controller, error) {
+func (r *registryCache) getController(ctx context.Context, instanceID string) (*Controller, error) {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-
 	iwc, ok := r.instances[instanceID]
+
+	for ok && iwc.running && !iwc.ready {
+		readyCh := iwc.readyCh
+		r.mu.RUnlock()
+		select {
+		case <-readyCh:
+			// continue
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		r.mu.RLock()
+		iwc, ok = r.instances[instanceID]
+	}
+
+	defer r.mu.Unlock()
+
 	if !ok {
 		return nil, drivers.ErrNotFound
 	}
@@ -235,7 +235,6 @@ func (r *registryCache) getController(instanceID string) (*Controller, error) {
 	if iwc.controllerErr != nil {
 		return nil, iwc.controllerErr
 	}
-
 	return iwc.controller, nil
 }
 
@@ -246,7 +245,6 @@ func (r *registryCache) create(ctx context.Context, inst *drivers.Instance) erro
 	}
 
 	r.add(inst)
-	r.ensureProjectParser(ctx, inst.ID)
 
 	return nil
 }
@@ -275,7 +273,7 @@ func (r *registryCache) edit(ctx context.Context, inst *drivers.Instance, restar
 
 	iwc, ok := r.instances[inst.ID]
 	if !ok {
-		panic(fmt.Errorf("instance %q not found", inst.ID))
+		return fmt.Errorf("instance %q not found", inst.ID)
 	}
 
 	iwc.instance = inst
@@ -297,74 +295,62 @@ func (r *registryCache) delete(ctx context.Context, instanceID string) (chan str
 
 	iwc, ok := r.instances[instanceID]
 	if !ok {
-		panic(fmt.Errorf("instance %q not found", instanceID))
+		return nil, fmt.Errorf("instance %q not found", instanceID)
 	}
 	delete(r.instances, instanceID)
 
 	iwc.cancel()
 
-	return iwc.closed, nil
-}
-
-func (r *registryCache) ensureProjectParser(ctx context.Context, instanceID string) {
-	r.mu.RLock()
-	iwc := r.instances[instanceID]
-	r.mu.RUnlock()
-	if iwc.controller == nil {
-		return
-	}
-	err := iwc.controller.WaitUntilReady(ctx)
-	if err != nil {
-		return
-	}
-
-	_, err = iwc.controller.Get(ctx, GlobalProjectParserName, false)
-	if err == nil {
-		return
-	}
-	if !errors.Is(err, drivers.ErrResourceNotFound) {
-		r.logger.Error("could not get project parser", zap.Error(err), zap.String("instance_id", instanceID), observability.ZapCtx(ctx))
-		return
-	}
-
-	err = iwc.controller.Create(ctx, GlobalProjectParserName, nil, nil, nil, true, &runtimev1.Resource{
-		Resource: &runtimev1.Resource_ProjectParser{
-			ProjectParser: &runtimev1.ProjectParser{Spec: &runtimev1.ProjectParserSpec{}},
-		},
-	})
-	if err != nil {
-		r.logger.Error("could not create project parser", zap.Error(err), zap.String("instance_id", instanceID), observability.ZapCtx(ctx))
-	}
+	return iwc.stoppedCh, nil
 }
 
 func (r *registryCache) restartController(iwc *instanceWithController) {
-	// If controller isn't nil, it's already running. Have the already running goroutine stop and restart it.
+	// If a goroutine for the controller is currently running, have it stop and restart the controller.
 	// (Easiest way to ensure only one controller is running at a time, without blocking the caller until the currently running one is done.)
-	if iwc.controller != nil {
+	if iwc.running {
 		iwc.reopen = true
 		iwc.cancel()
 		return
 	}
 
 	// Reset execution state
-	// NOTE: Duplicating this here and in the goroutine to ensure there's no moment where the mutex is unlocked and neither of controller or controllerErr is set.
-	iwc.controller, iwc.controllerErr = NewController(r.rt, iwc.instance.ID, r.logger, r.activity)
 	iwc.ctx, iwc.cancel = context.WithCancel(r.baseCtx)
+	iwc.running = true
+	iwc.stoppedCh = make(chan struct{})
+	iwc.ready = false
+	iwc.readyCh = make(chan struct{})
 	iwc.reopen = false
-	iwc.closed = make(chan struct{})
-	if iwc.controllerErr != nil {
-		// If NewController errored, no need to start a goroutine
-		iwc.cancel()
-		close(iwc.closed)
-		return
-	}
 
 	// Start goroutine that runs the controller
 	go func() {
 		// Loop in case reopen gets set
 		for {
-			err := iwc.controller.Run(iwc.ctx)
+			r.logger.Info("controller starting", zap.String("instance_id", iwc.instance.ID))
+
+			ctrl, err := NewController(iwc.ctx, r.rt, iwc.instance.ID, r.logger, r.activity)
+			if err == nil {
+				r.mu.Lock()
+				iwc.controller = ctrl
+				iwc.ready = true
+				close(iwc.readyCh)
+				r.mu.Unlock()
+
+				r.ensureProjectParser(iwc.ctx, iwc.instance.ID, ctrl)
+
+				err = ctrl.Run(iwc.ctx)
+			}
+
 			iwc.cancel() // Always ensure cleanup
+
+			r.mu.Lock()
+			attrs := []zapcore.Field{zap.String("instance_id", iwc.instance.ID), zap.Error(err), zap.Bool("reopen", iwc.reopen), zap.Bool("called_run", iwc.ready)}
+			r.mu.Unlock()
+
+			if r.baseCtx.Err() != nil {
+				r.logger.Info("controller stopped", attrs...)
+			} else {
+				r.logger.Error("controller failed", attrs...)
+			}
 
 			// When an instance is edited, connector config may have changed.
 			// So we want to evict all open connections for that instance, but it's unsafe to do so while the controller is running.
@@ -373,29 +359,49 @@ func (r *registryCache) restartController(iwc *instanceWithController) {
 				r.rt.connCache.evictAll(r.baseCtx, iwc.instance.ID)
 			}
 
+			r.mu.Lock()
+
 			// If not reopening, exit
 			if !iwc.reopen {
-				r.mu.Lock()
 				iwc.controller = nil
 				iwc.controllerErr = err
-				close(iwc.closed)
+				iwc.running = false
+				close(iwc.stoppedCh)
+				if !iwc.ready { // Ensure readyCh is always closed, even if it never got ready
+					close(iwc.readyCh)
+				}
 				r.mu.Unlock()
 				return
 			}
 
-			// Reopening – reset execution state and proceed to next loop iteration
-			// NOTE: Not resetting iwc.closed (keeping it open)
-			r.mu.Lock()
-			iwc.controller, iwc.controllerErr = NewController(r.rt, iwc.instance.ID, r.logger, r.activity)
+			// Reset execution state
 			iwc.ctx, iwc.cancel = context.WithCancel(r.baseCtx)
-			iwc.reopen = false
-			if iwc.controllerErr != nil {
-				// If NewController errored, no need to start a goroutine
-				iwc.cancel()
-				close(iwc.closed)
-				return
+			if iwc.ready {
+				iwc.ready = false
+				iwc.readyCh = make(chan struct{})
 			}
+			iwc.reopen = false
 			r.mu.Unlock()
 		}
 	}()
+}
+
+func (r *registryCache) ensureProjectParser(ctx context.Context, instanceID string, ctrl *Controller) {
+	_, err := ctrl.Get(ctx, GlobalProjectParserName, false)
+	if err == nil {
+		return
+	}
+	if !errors.Is(err, drivers.ErrResourceNotFound) {
+		r.logger.Error("could not get project parser", zap.Error(err), zap.String("instance_id", instanceID), observability.ZapCtx(ctx))
+		return
+	}
+
+	err = ctrl.Create(ctx, GlobalProjectParserName, nil, nil, nil, true, &runtimev1.Resource{
+		Resource: &runtimev1.Resource_ProjectParser{
+			ProjectParser: &runtimev1.ProjectParser{Spec: &runtimev1.ProjectParserSpec{}},
+		},
+	})
+	if err != nil {
+		r.logger.Error("could not create project parser", zap.Error(err), zap.String("instance_id", instanceID), observability.ZapCtx(ctx))
+	}
 }

--- a/runtime/registry_test.go
+++ b/runtime/registry_test.go
@@ -21,7 +21,6 @@ import (
 func TestRuntime_EditInstance(t *testing.T) {
 	repodsn := t.TempDir()
 	newRepodsn := t.TempDir()
-	rt := newTestRuntime(t)
 	tests := []struct {
 		name      string
 		inst      *drivers.Instance
@@ -271,6 +270,7 @@ func TestRuntime_EditInstance(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			rt := newTestRuntime(t)
 			ctx := context.Background()
 
 			// Create instance

--- a/runtime/registry_test.go
+++ b/runtime/registry_test.go
@@ -292,7 +292,8 @@ func TestRuntime_EditInstance(t *testing.T) {
 				},
 			}
 			require.NoError(t, rt.CreateInstance(context.Background(), inst))
-			rt.WaitUntilReady(ctx, inst.ID)
+			_, err := rt.Controller(ctx, inst.ID)
+			require.NoError(t, err)
 
 			// Acquire OLAP (to make sure it's opened)
 			firstOlap, release, err := rt.OLAP(ctx, inst.ID)
@@ -311,7 +312,8 @@ func TestRuntime_EditInstance(t *testing.T) {
 
 			// Wait for controller restart
 			time.Sleep(500 * time.Millisecond)
-			rt.WaitUntilReady(ctx, inst.ID)
+			_, err = rt.Controller(ctx, inst.ID)
+			require.NoError(t, err)
 
 			// Verify db instances are correctly updated
 			newInst, err := rt.Instance(ctx, inst.ID)
@@ -374,7 +376,8 @@ func TestRuntime_DeleteInstance(t *testing.T) {
 				},
 			}
 			require.NoError(t, rt.CreateInstance(context.Background(), inst))
-			rt.WaitUntilReady(ctx, inst.ID)
+			_, err := rt.Controller(ctx, inst.ID)
+			require.NoError(t, err)
 
 			// Acquire OLAP
 			olap, release, err := rt.OLAP(ctx, inst.ID)

--- a/runtime/server/catalog.go
+++ b/runtime/server/catalog.go
@@ -70,7 +70,7 @@ func (s *Server) GetCatalogEntry(ctx context.Context, req *runtimev1.GetCatalogE
 		return nil, ErrForbidden
 	}
 
-	ctrl, err := s.runtime.Controller(req.InstanceId)
+	ctrl, err := s.runtime.Controller(ctx, req.InstanceId)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -120,7 +120,7 @@ func (s *Server) Reconcile(ctx context.Context, req *runtimev1.ReconcileRequest)
 		return nil, ErrForbidden
 	}
 
-	ctrl, err := s.runtime.Controller(req.InstanceId)
+	ctrl, err := s.runtime.Controller(ctx, req.InstanceId)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -159,7 +159,7 @@ func (s *Server) PutFileAndReconcile(ctx context.Context, req *runtimev1.PutFile
 		return nil, ErrForbidden
 	}
 
-	ctrl, err := s.runtime.Controller(req.InstanceId)
+	ctrl, err := s.runtime.Controller(ctx, req.InstanceId)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -206,7 +206,7 @@ func (s *Server) RenameFileAndReconcile(ctx context.Context, req *runtimev1.Rena
 		return nil, ErrForbidden
 	}
 
-	ctrl, err := s.runtime.Controller(req.InstanceId)
+	ctrl, err := s.runtime.Controller(ctx, req.InstanceId)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -253,7 +253,7 @@ func (s *Server) DeleteFileAndReconcile(ctx context.Context, req *runtimev1.Dele
 		return nil, ErrForbidden
 	}
 
-	ctrl, err := s.runtime.Controller(req.InstanceId)
+	ctrl, err := s.runtime.Controller(ctx, req.InstanceId)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -292,7 +292,7 @@ func (s *Server) RefreshAndReconcile(ctx context.Context, req *runtimev1.Refresh
 		return nil, ErrForbidden
 	}
 
-	ctrl, err := s.runtime.Controller(req.InstanceId)
+	ctrl, err := s.runtime.Controller(ctx, req.InstanceId)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -358,7 +358,7 @@ func (s *Server) TriggerRefresh(ctx context.Context, req *runtimev1.TriggerRefre
 		return nil, ErrForbidden
 	}
 
-	ctrl, err := s.runtime.Controller(req.InstanceId)
+	ctrl, err := s.runtime.Controller(ctx, req.InstanceId)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/runtime/server/controller.go
+++ b/runtime/server/controller.go
@@ -41,7 +41,7 @@ func (s *Server) ListResources(ctx context.Context, req *runtimev1.ListResources
 		return nil, ErrForbidden
 	}
 
-	ctrl, err := s.runtime.Controller(req.InstanceId)
+	ctrl, err := s.runtime.Controller(ctx, req.InstanceId)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -87,7 +87,7 @@ func (s *Server) WatchResources(req *runtimev1.WatchResourcesRequest, ss runtime
 		return ErrForbidden
 	}
 
-	ctrl, err := s.runtime.Controller(req.InstanceId)
+	ctrl, err := s.runtime.Controller(ss.Context(), req.InstanceId)
 	if err != nil {
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -151,7 +151,7 @@ func (s *Server) GetResource(ctx context.Context, req *runtimev1.GetResourceRequ
 		return nil, ErrForbidden
 	}
 
-	ctrl, err := s.runtime.Controller(req.InstanceId)
+	ctrl, err := s.runtime.Controller(ctx, req.InstanceId)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -186,7 +186,7 @@ func (s *Server) CreateTrigger(ctx context.Context, req *runtimev1.CreateTrigger
 		return nil, ErrForbidden
 	}
 
-	ctrl, err := s.runtime.Controller(req.InstanceId)
+	ctrl, err := s.runtime.Controller(ctx, req.InstanceId)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/runtime/server/queries_metrics.go
+++ b/runtime/server/queries_metrics.go
@@ -473,7 +473,7 @@ func resolveMVAndSecurityFromAttributes(ctx context.Context, rt *runtime.Runtime
 
 // returns the metrics view and the time the catalog was last updated
 func lookupMetricsView(ctx context.Context, rt *runtime.Runtime, instanceID, name string) (*runtimev1.MetricsViewSpec, time.Time, error) {
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(ctx, instanceID)
 	if err != nil {
 		return nil, time.Time{}, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/runtime/server/queries_metrics_timeseries_test.go
+++ b/runtime/server/queries_metrics_timeseries_test.go
@@ -684,7 +684,7 @@ func TestServer_MetricsViewTimeseries_export_csv(t *testing.T) {
 func resolveMVAndSecurity(t *testing.T, rt *runtime.Runtime, instanceID, metricsViewName string) (*runtimev1.MetricsViewSpec, *runtime.ResolvedMetricsViewSecurity) {
 	ctx := testCtx()
 
-	ctrl, err := rt.Controller(instanceID)
+	ctrl, err := rt.Controller(ctx, instanceID)
 	require.NoError(t, err)
 
 	res, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: metricsViewName}, false)

--- a/runtime/testruntime/reconcile.go
+++ b/runtime/testruntime/reconcile.go
@@ -51,7 +51,7 @@ func ReconcileParserAndWait(t testing.TB, rt *runtime.Runtime, id string) {
 }
 
 func ReconcileAndWait(t testing.TB, rt *runtime.Runtime, id string, n *runtimev1.ResourceName) {
-	ctrl, err := rt.Controller(id)
+	ctrl, err := rt.Controller(context.Background(), id)
 	require.NoError(t, err)
 
 	err = ctrl.Reconcile(context.Background(), n)
@@ -62,7 +62,7 @@ func ReconcileAndWait(t testing.TB, rt *runtime.Runtime, id string, n *runtimev1
 }
 
 func RefreshAndWait(t testing.TB, rt *runtime.Runtime, id string, n *runtimev1.ResourceName) {
-	ctrl, err := rt.Controller(id)
+	ctrl, err := rt.Controller(context.Background(), id)
 	require.NoError(t, err)
 
 	// Get spec version before refresh
@@ -92,7 +92,7 @@ func RefreshAndWait(t testing.TB, rt *runtime.Runtime, id string, n *runtimev1.R
 }
 
 func RequireReconcileState(t testing.TB, rt *runtime.Runtime, id string, lenResources, lenReconcileErrs, lenParseErrs int) {
-	ctrl, err := rt.Controller(id)
+	ctrl, err := rt.Controller(context.Background(), id)
 	require.NoError(t, err)
 
 	rs, err := ctrl.List(context.Background(), "", false)
@@ -122,7 +122,7 @@ func RequireReconcileState(t testing.TB, rt *runtime.Runtime, id string, lenReso
 }
 
 func RequireResource(t testing.TB, rt *runtime.Runtime, id string, a *runtimev1.Resource) {
-	ctrl, err := rt.Controller(id)
+	ctrl, err := rt.Controller(context.Background(), id)
 	require.NoError(t, err)
 
 	b, err := ctrl.Get(context.Background(), a.Meta.Name, true) // Set clone=true because we may manipulate it before comparing
@@ -174,7 +174,7 @@ func RequireResource(t testing.TB, rt *runtime.Runtime, id string, a *runtimev1.
 }
 
 func DumpResources(t testing.TB, rt *runtime.Runtime, id string) {
-	ctrl, err := rt.Controller(id)
+	ctrl, err := rt.Controller(context.Background(), id)
 	require.NoError(t, err)
 
 	rs, err := ctrl.List(context.Background(), "", false)
@@ -186,7 +186,7 @@ func DumpResources(t testing.TB, rt *runtime.Runtime, id string) {
 }
 
 func RequireParseErrors(t testing.TB, rt *runtime.Runtime, id string, expectedParseErrors map[string]string) {
-	ctrl, err := rt.Controller(id)
+	ctrl, err := rt.Controller(context.Background(), id)
 	require.NoError(t, err)
 
 	pp, err := ctrl.Get(context.Background(), runtime.GlobalProjectParserName, true)

--- a/runtime/testruntime/testruntime.go
+++ b/runtime/testruntime/testruntime.go
@@ -119,13 +119,10 @@ func NewInstanceWithOptions(t TestingT, opts InstanceOptions) (*runtime.Runtime,
 	require.NoError(t, err)
 	require.NotEmpty(t, inst.ID)
 
-	ctrl, err := rt.Controller(inst.ID)
+	ctrl, err := rt.Controller(context.Background(), inst.ID)
 	require.NoError(t, err)
 
 	_, err = ctrl.Get(context.Background(), runtime.GlobalProjectParserName, false)
-	require.NoError(t, err)
-
-	err = ctrl.WaitUntilReady(context.Background())
 	require.NoError(t, err)
 
 	err = ctrl.WaitUntilIdle(context.Background(), opts.WatchRepo)
@@ -184,13 +181,10 @@ func NewInstanceForProject(t TestingT, name string) (*runtime.Runtime, string) {
 	require.NoError(t, err)
 	require.NotEmpty(t, inst.ID)
 
-	ctrl, err := rt.Controller(inst.ID)
+	ctrl, err := rt.Controller(context.Background(), inst.ID)
 	require.NoError(t, err)
 
 	_, err = ctrl.Get(context.Background(), runtime.GlobalProjectParserName, false)
-	require.NoError(t, err)
-
-	err = ctrl.WaitUntilReady(context.Background())
 	require.NoError(t, err)
 
 	err = ctrl.WaitUntilIdle(context.Background(), false)


### PR DESCRIPTION
Previously, the registry cache would load all existing instances from the metastore on startup, start their controllers, call `WaitUntilReady`, then create the global project parser if it didn't already exist.

Since controller initialization needs to load the catalog, and we embed the catalog in DuckDB, if opening any DuckDB handle is slow (e.g. has a large wal), this would could cause the entire runtime initialization to hang. This means the runtime server isn't started, so health checks fail, and we got a crash loop in Kubernetes.

This PR moves controller initialization into the background. Instead, any call to `runtime.Controller(ctx, instanceID)` will hang until the controller has finished initializing ready or has errored. 