### PR TITLE
Add spinner while waiting for initial dashboard state

### DIFF
--- a/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
@@ -73,7 +73,10 @@
   $: isDashboardNotFound =
     $dashboard.isError &&
     ($dashboard.error as QueryError)?.response?.status === 404;
-  $: isDashboardErrored = !!$dashboard.data?.meta?.reconcileError;
+  // We check for metricsView.state.validSpec instead of meta.reconcileError. validSpec persists
+  // from previous valid dashboards, allowing display even when the current dashboard spec is invalid
+  // and a meta.reconcileError exists.
+  $: isDashboardErrored = !$dashboard.data?.metricsView?.state?.validSpec;
 
   // If no dashboard is found, show a 404 page
   $: if (isProjectBuilt && isDashboardNotFound) {

--- a/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
@@ -70,7 +70,6 @@
   }
 
   $: dashboard = useDashboard(instanceId, dashboardName);
-  $: isDashboardOK = $dashboard.isSuccess;
   $: isDashboardNotFound =
     $dashboard.isError &&
     ($dashboard.error as QueryError)?.response?.status === 404;
@@ -95,7 +94,7 @@
 
 {#if isProjectPending && isDashboardNotFound}
   <ProjectBuilding organization={orgName} project={projectName} />
-{:else if isDashboardOK}
+{:else if $dashboard.isSuccess}
   {#if isDashboardErrored}
     <ProjectErrored organization={orgName} project={projectName} />
   {:else}

--- a/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
@@ -74,7 +74,7 @@
   $: isDashboardNotFound =
     $dashboard.isError &&
     ($dashboard.error as QueryError)?.response?.status === 404;
-  $: isDashboardErrored = !$dashboard.data?.metricsView?.state?.validSpec;
+  $: isDashboardErrored = !!$dashboard.data?.meta?.reconcileError;
 
   // If no dashboard is found, show a 404 page
   $: if (isProjectBuilt && isDashboardNotFound) {
@@ -97,7 +97,6 @@
   <ProjectBuilding organization={orgName} project={projectName} />
 {:else if isDashboardOK}
   {#if isDashboardErrored}
-    <!-- TODO: we should show the reconcile error -->
     <ProjectErrored organization={orgName} project={projectName} />
   {:else}
     <StateManagersProvider metricsViewName={dashboardName}>

--- a/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
@@ -9,10 +9,10 @@
   import ProjectErrored from "@rilldata/web-admin/features/projects/ProjectErrored.svelte";
   import { useProjectDeploymentStatus } from "@rilldata/web-admin/features/projects/selectors";
   import { Dashboard } from "@rilldata/web-common/features/dashboards";
-  import DashboardStateProvider from "@rilldata/web-common/features/dashboards/stores/DashboardStateProvider.svelte";
   import DashboardURLStateProvider from "@rilldata/web-common/features/dashboards/proto-state/DashboardURLStateProvider.svelte";
   import { useDashboard } from "@rilldata/web-common/features/dashboards/selectors";
   import StateManagersProvider from "@rilldata/web-common/features/dashboards/state-managers/StateManagersProvider.svelte";
+  import DashboardStateProvider from "@rilldata/web-common/features/dashboards/stores/DashboardStateProvider.svelte";
   import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
   import { getRuntimeServiceGetResourceQueryKey } from "@rilldata/web-common/runtime-client";
   import type { QueryError } from "@rilldata/web-common/runtime-client/error";
@@ -35,13 +35,9 @@
   $: isProjectPending =
     $projectDeploymentStatus.data ===
     V1DeploymentStatus.DEPLOYMENT_STATUS_PENDING;
-  $: isProjectReconciling = false;
-  // $projectDeploymentStatus.data ===
-  // V1DeploymentStatus.DEPLOYMENT_STATUS_RECONCILING;
   $: isProjectErrored =
     $projectDeploymentStatus.data ===
     V1DeploymentStatus.DEPLOYMENT_STATUS_ERROR;
-  $: isProjectBuilding = isProjectPending || isProjectReconciling;
   $: isProjectBuilt = isProjectOK || isProjectErrored;
 
   let isProjectOK: boolean;
@@ -97,7 +93,7 @@
 <!-- Note: Project and dashboard states might appear to diverge. A project could be errored 
   because dashboard #1 is errored, but dashboard #2 could be OK.  -->
 
-{#if isProjectBuilding && isDashboardNotFound}
+{#if isProjectPending && isDashboardNotFound}
   <ProjectBuilding organization={orgName} project={projectName} />
 {:else if isDashboardOK}
   {#if isDashboardErrored}

--- a/web-common/src/features/dashboards/stores/DashboardStateProvider.svelte
+++ b/web-common/src/features/dashboards/stores/DashboardStateProvider.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
-  import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
   import {
     createTimeRangeSummary,
     useMetaQuery,
     useModelHasTimeSeries,
   } from "@rilldata/web-common/features/dashboards/selectors/index";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
+  import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
   import { initLocalUserPreferenceStore } from "@rilldata/web-common/features/dashboards/user-preferences";
+  import Spinner from "../../entity-management/Spinner.svelte";
+  import { EntityStatus } from "../../entity-management/types";
 
   export let metricViewName: string;
 
@@ -31,8 +33,14 @@
   $: if ($metaQuery.data && ($timeRangeQuery.data || !$hasTimeSeries.data)) {
     syncDashboardState();
   }
+
+  $: ready = metricViewName in $metricsExplorerStore.entities;
 </script>
 
-{#if metricViewName in $metricsExplorerStore.entities}
+{#if ready}
   <slot />
+{:else}
+  <div class="grid place-items-center mt-40">
+    <Spinner status={EntityStatus.Running} size="40px" />
+  </div>
 {/if}


### PR DESCRIPTION
This PR adds a spinner while we wait for the dashboard to first load. Specifically, the initial query to `MetricsViewTimeRange` can take a while when the query queue is full, so we need a loading state under this circumstance.

[Slack report](https://rilldata.slack.com/archives/C02T907FEUB/p1697701218945499)