### PR TITLE
Fix missing error page

### DIFF
--- a/web-admin/src/features/errors/error-utils.ts
+++ b/web-admin/src/features/errors/error-utils.ts
@@ -57,10 +57,18 @@ export function globalErrorCallback(error: AxiosError): void {
 function createErrorStoreStateFromAxiosError(
   error: AxiosError
 ): ErrorStoreState {
-  const status = error.response?.status;
-  const msg = (error.response.data as RpcStatus).message;
+  // Handle network errors
+  if (error.message === "Network Error") {
+    return {
+      statusCode: null,
+      header: "Network Error",
+      body: "It seems we're having trouble reaching our servers. Check your connection or try again later.",
+    };
+  }
 
-  // Specifically handle some errors
+  // Handle some application errors
+  const status = error.response?.status;
+  const msg = (error?.response?.data as RpcStatus | undefined)?.message;
   if (status === 403) {
     return {
       statusCode: error.response.status,

--- a/web-admin/src/features/errors/error-utils.ts
+++ b/web-admin/src/features/errors/error-utils.ts
@@ -89,7 +89,7 @@ function createErrorStoreStateFromAxiosError(
     };
   }
 
-  // Fallback for all other errors
+  // Fallback for all other errors (including 5xx errors)
   return {
     statusCode: error.response?.status,
     header: "Sorry, unexpected error!",


### PR DESCRIPTION
This PR improves Cloud error handling to account for more cases. Now we:
- Check for network errors
- Show the error page for errors missing `response.status` or `response.data.message`