### PR TITLE
fix duplicate active values in leaderboard

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -83,11 +83,18 @@
     dimensionName
   );
 
-  let activeValues: Array<unknown>;
-  $: activeValues =
-    $dashboardStore?.filters[filterKey]?.find((d) => d.name === dimension?.name)
-      ?.in ?? [];
-  $: atLeastOneActive = !!activeValues?.length;
+  // FIXME: it is possible for this way of accessing the filters
+  // to return the same value twice, which would seem to indicate
+  // a bug in the way we're setting the filters / active values.
+  // Need to investigate further to determine whether this is a
+  // problem with the runtime or the client, but for now wrapping
+  // it in a set dedupes the values.
+  $: activeValues = new Set(
+    ($dashboardStore?.filters[filterKey]?.find(
+      (d) => d.name === dimension?.name
+    )?.in as (number | string)[]) ?? []
+  );
+  $: atLeastOneActive = activeValues?.size > 0;
 
   const timeControlsStore = useTimeControlStore(getStateManagers());
 
@@ -149,7 +156,7 @@
         getLabeledComparisonFromComparisonRow(r, measure.name)
       ) ?? [],
       slice,
-      activeValues,
+      [...activeValues],
       unfilteredTotal,
       filterExcludeMode
     );

--- a/web-common/src/features/dashboards/leaderboard/leaderboard-utils.ts
+++ b/web-common/src/features/dashboards/leaderboard/leaderboard-utils.ts
@@ -146,8 +146,8 @@ export function prepareLeaderboardItemData(
   // selected values that _are_ in the API results.
   //
   // We also need to retain the original selection indices
-  let selectedButNotInAPIResults: [string | number, number][] =
-    selectedValues.map((v, i) => [v, i]);
+  const selectedButNotInAPIResults = new Map<string | number, number>();
+  selectedValues.map((v, i) => selectedButNotInAPIResults.set(v, i));
 
   values.forEach((v, i) => {
     const selectedIndex = selectedValues.findIndex(
@@ -155,16 +155,11 @@ export function prepareLeaderboardItemData(
     );
     // if we have found this selected value in the API results,
     // remove it from the selectedButNotInAPIResults array
-    if (selectedIndex > -1)
-      selectedButNotInAPIResults = selectedButNotInAPIResults.filter(
-        (value) => value[0] !== v.dimensionValue
-      );
+    if (selectedIndex > -1) selectedButNotInAPIResults.delete(v.dimensionValue);
 
     const defaultComparedIndex = comparisonDefaultSelection.findIndex(
       (value) => value === v.dimensionValue
     );
-    // if we have found this selected value in the API results,
-    // remove it from the selectedButNotInAPIResults array
 
     const cleanValue = cleanUpComparisonValue(
       v,
@@ -190,7 +185,7 @@ export function prepareLeaderboardItemData(
   // that pushes it out of the top N. In that case, we will follow
   // the previous strategy, and just push a dummy value with only
   // the dimension value and nulls for all measure values.
-  selectedButNotInAPIResults.forEach(([dimensionValue, selectedIndex]) => {
+  for (const [dimensionValue, selectedIndex] of selectedButNotInAPIResults) {
     const defaultComparedIndex = comparisonDefaultSelection.findIndex(
       (value) => value === dimensionValue
     );
@@ -205,7 +200,7 @@ export function prepareLeaderboardItemData(
       deltaRel: null,
       deltaAbs: null,
     });
-  });
+  }
 
   const noAvailableValues = values.length === 0;
   const showExpandTable = values.length > numberAboveTheFold;


### PR DESCRIPTION
it's somehow possible for an active value to appear more than once in the set of filters for a leaderboard, which can cause downstream breakage. This is a quick fix to workaround that until I can dig deeper (or someone else can)