### PR TITLE
Telemetry improvements for ListResources and misc. other fixes

### DIFF
--- a/runtime/compilers/rillv1/template.go
+++ b/runtime/compilers/rillv1/template.go
@@ -94,9 +94,8 @@ func AnalyzeTemplate(tmpl string) (*TemplateMetadata, error) {
 			}
 			config[key] = parts[1]
 			return "", nil
-		} else {
-			return "", fmt.Errorf(`"configure" takes one or two arguments`)
 		}
+		return "", fmt.Errorf(`"configure" takes one or two arguments`)
 	}
 	funcMap["dependency"] = func(parts ...string) (string, error) {
 		name, err := resourceNameFromArgs(parts...)

--- a/runtime/connections.go
+++ b/runtime/connections.go
@@ -29,6 +29,11 @@ func (r *Runtime) AcquireHandle(ctx context.Context, instanceID, connector strin
 	if err != nil {
 		return nil, nil, err
 	}
+	if ctx.Err() != nil {
+		// Many code paths around connection acquisition leverage caches that won't actually touch the ctx.
+		// So we take this moment to make sure the ctx gets checked for cancellation at least every once in a while.
+		return nil, nil, ctx.Err()
+	}
 	return r.connCache.get(ctx, instanceID, driver, cfg, false)
 }
 

--- a/runtime/drivers/duckdb/transporter/utils.go
+++ b/runtime/drivers/duckdb/transporter/utils.go
@@ -130,9 +130,8 @@ func sourceReader(paths []string, format string, ingestionProps map[string]any) 
 	} else if containsAny(format, []string{".json", ".ndjson"}) {
 		// JSON reader
 		return generateReadJSONStatement(paths, ingestionProps)
-	} else {
-		return "", fmt.Errorf("file type not supported : %s", format)
 	}
+	return "", fmt.Errorf("file type not supported : %s", format)
 }
 
 func generateReadCsvStatement(paths []string, properties map[string]any) (string, error) {

--- a/runtime/queries/queries.go
+++ b/runtime/queries/queries.go
@@ -2,4 +2,4 @@ package queries
 
 import "time"
 
-const defaultExecutionTimeout = time.Minute * 2
+const defaultExecutionTimeout = time.Minute * 3

--- a/runtime/registry.go
+++ b/runtime/registry.go
@@ -10,6 +10,8 @@ import (
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/rilldata/rill/runtime/pkg/observability"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -31,6 +33,8 @@ func (r *Runtime) Instance(ctx context.Context, instanceID string) (*drivers.Ins
 // If the controller is currently initializing, the call will wait until the controller is ready.
 // If the controller has closed with a fatal error, that error will be returned here until it's restarted.
 func (r *Runtime) Controller(ctx context.Context, instanceID string) (*Controller, error) {
+	ctx, span := tracer.Start(ctx, "Runtime.Controller", trace.WithAttributes(attribute.String("instance_id", instanceID)))
+	defer span.End()
 	return r.registryCache.getController(ctx, instanceID)
 }
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -10,9 +10,12 @@ import (
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/rilldata/rill/runtime/pkg/email"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 )
+
+var tracer = otel.Tracer("github.com/rilldata/rill/runtime")
 
 type Options struct {
 	MetastoreConnector      string

--- a/runtime/server/controller.go
+++ b/runtime/server/controller.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rilldata/rill/runtime/pkg/observability"
 	"github.com/rilldata/rill/runtime/server/auth"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
 	"google.golang.org/grpc/codes"
@@ -219,6 +220,9 @@ func (s *Server) CreateTrigger(ctx context.Context, req *runtimev1.CreateTrigger
 // applySecurityPolicy applies relevant security policies to the resource.
 // The input resource will not be modified in-place (so no need to set clone=true when obtaining it from the catalog).
 func (s *Server) applySecurityPolicy(ctx context.Context, instID string, r *runtimev1.Resource) (*runtimev1.Resource, bool, error) {
+	ctx, span := tracer.Start(ctx, "applySecurityPolicy", trace.WithAttributes(attribute.String("instance_id", instID), attribute.String("kind", r.Meta.Name.Kind), attribute.String("name", r.Meta.Name.Name)))
+	defer span.End()
+
 	mv := r.GetMetricsView()
 	if mv == nil || mv.State.ValidSpec == nil || mv.State.ValidSpec.Security == nil {
 		// Allow if it's not a metrics view or it doesn't have a valid security policy.

--- a/runtime/server/server.go
+++ b/runtime/server/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rilldata/rill/runtime/pkg/securetoken"
 	"github.com/rilldata/rill/runtime/server/auth"
 	"github.com/rs/cors"
+	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -29,6 +30,8 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+var tracer = otel.Tracer("github.com/rilldata/rill/runtime/server")
 
 var ErrForbidden = status.Error(codes.Unauthenticated, "action not allowed")
 


### PR DESCRIPTION
- Check ctx cancellation when acquiring a connection (better than returning a cache eviction error)
- Add tracing to `Controller.Get(...)` and `Controller.List(...)` and `Runtime.Controller(...)`
- Increase query execution timeout to 3 minutes