### PR TITLE
Add .DS_Store to .gitignore for new empty projects

### DIFF
--- a/runtime/compilers/rillv1/init.go
+++ b/runtime/compilers/rillv1/init.go
@@ -29,7 +29,7 @@ func InitEmpty(ctx context.Context, repo drivers.RepoStore, instanceID, title st
 	if gitignore != "" {
 		gitignore += "\n"
 	}
-	gitignore += "# Rill\n*.db\n*.db.tmp\n*.db.wal\n.env\n"
+	gitignore += ".DS_Store\n\n# Rill\n*.db\n*.db.tmp\n*.db.wal\n.env\n"
 
 	err = repo.Put(ctx, ".gitignore", strings.NewReader(gitignore))
 	if err != nil {

--- a/runtime/compilers/rillv1beta/project.go
+++ b/runtime/compilers/rillv1beta/project.go
@@ -40,7 +40,7 @@ func (c *Codec) InitEmpty(ctx context.Context, title string) error {
 	if gitignore != "" {
 		gitignore += "\n"
 	}
-	gitignore += "# Rill\n*.db\n*.db.tmp\n*.db.wal\n"
+	gitignore += ".DS_Store\n\n# Rill\n*.db\n*.db.tmp\n*.db.wal\n"
 
 	err = c.Repo.Put(ctx, ".gitignore", strings.NewReader(gitignore))
 	if err != nil {


### PR DESCRIPTION
Have seen a few projects that had `.DS_Store` committed by accident