### PR TITLE
Fix error if export token is too long

### DIFF
--- a/runtime/pkg/securetoken/securetoken.go
+++ b/runtime/pkg/securetoken/securetoken.go
@@ -12,7 +12,9 @@ type Codec struct {
 func NewCodec(keyPairs [][]byte) *Codec {
 	codecs := securecookie.CodecsFromPairs(keyPairs...)
 	for _, c := range codecs {
-		c.(*securecookie.SecureCookie).SetSerializer(securecookie.JSONEncoder{})
+		sc := c.(*securecookie.SecureCookie)
+		sc.MaxLength(0)
+		sc.SetSerializer(securecookie.JSONEncoder{})
 	}
 	return &Codec{codecs: codecs}
 }


### PR DESCRIPTION
Seem like the library we're using to create download tokens has a default limit of 4kb