### PR TITLE
Color singleton lines for dimension comparison

### DIFF
--- a/web-common/src/components/data-graphic/marks/ChunkedLine.svelte
+++ b/web-common/src/components/data-graphic/marks/ChunkedLine.svelte
@@ -106,6 +106,7 @@ Over time, we'll make this the default Line implementation, but it's not quite t
       x={$xScale(singleton[xAccessor]) - 0.75}
       y={Math.min($yScale(0), $yScale(singleton[yAccessor]))}
       width="1.5"
+      class={lineClasses}
       height={Math.abs($yScale(0) - $yScale(singleton[yAccessor]))}
       fill="hsla(217,60%, 55%, .5)"
     />


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Singleton lines were not being stroked in accordance to their comparison color

#### Details:

Before:
![image](https://github.com/rilldata/rill/assets/4402679/0d535e07-2599-4c77-9aca-1e6364c76d75)

After:
![image](https://github.com/rilldata/rill/assets/4402679/9f6639bd-72ff-4a4d-85aa-3dc6056b2c9a)


## Steps to Verify
1. Use a chart with a dimension which as singleton data (1 single value over a time period)
2. Compare that dimension


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- Style Update: Enhanced the visual representation of data graphics. A new style class has been added to the data line elements in our graphics, allowing for more flexible and dynamic styling. This change does not affect the functionality but improves the user experience by making the data visualization more aesthetically pleasing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->