### PR TITLE
Add types to Pivot table

### DIFF
--- a/web-common/src/features/dashboards/pivot/Pivot.svelte
+++ b/web-common/src/features/dashboards/pivot/Pivot.svelte
@@ -102,10 +102,10 @@
   function style_row_th(th: HTMLTableCellElement) {
     const meta = table.getMeta(th);
     const numFixedCols = meta?.row_header?.length;
-    const x = meta?.row_header_x;
-    const y = meta?.y;
-    th.setAttribute("__col", String(x! - numFixedCols!));
-    th.setAttribute("__row", String(y!));
+    const x = meta?.row_header_x!;
+    const y = meta?.y!;
+    th.setAttribute("__col", String(x - numFixedCols!));
+    th.setAttribute("__row", String(y));
 
     const maybeWidth = getRowHeaderWidth(x);
     if (maybeWidth) {
@@ -131,7 +131,10 @@
   }
 
   function style_td(td: HTMLTableCellElement) {
-    const { x, y, value } = table.getMeta(td);
+    const meta = table.getMeta(td);
+    const x = meta?.x!;
+    const y = meta?.y!;
+    const value = meta?.value;
     td.setAttribute("__col", String(x));
     td.setAttribute("__row", String(y));
 
@@ -155,8 +158,8 @@
 
   function style_column_th(th: HTMLTableCellElement) {
     const meta = table.getMeta(th);
-    const x = meta.x;
-    const y = meta.column_header_y;
+    const x = meta.x!;
+    const y = meta.column_header_y!;
     th.setAttribute("__col", String(x));
     th.setAttribute("__row", String(y));
 
@@ -188,8 +191,10 @@
   function style_row_corner(th: HTMLTableCellElement) {
     const meta = table.getMeta(th);
 
+    const x = meta.row_header_x!;
+
     if (meta.column_header_y === columnHeaderDepth - 1) {
-      const maybeWidth = getRowHeaderWidth(meta.row_header_x);
+      const maybeWidth = getRowHeaderWidth(x);
       if (maybeWidth) {
         th.style.width = `${maybeWidth}px`;
         th.style.minWidth = `${maybeWidth}px`;
@@ -198,8 +203,8 @@
     }
 
     const maybeVal = renderRowCorner({
-      x: meta.row_header_x,
-      y: meta.column_header_y,
+      x: meta.row_header_x!,
+      y: meta.column_header_y!,
       value: meta.value,
       element: th,
     });

--- a/web-common/src/features/dashboards/pivot/Pivot.svelte
+++ b/web-common/src/features/dashboards/pivot/Pivot.svelte
@@ -102,8 +102,10 @@
   function style_row_th(th: HTMLTableCellElement) {
     const meta = table.getMeta(th);
     const numFixedCols = meta?.row_header?.length;
-    const x = meta?.row_header_x!;
-    const y = meta?.y!;
+    const x = meta?.row_header_x;
+    const y = meta?.y;
+
+    if (typeof x !== "number" || typeof y !== "number") return;
     th.setAttribute("__col", String(x - numFixedCols!));
     th.setAttribute("__row", String(y));
 
@@ -132,8 +134,10 @@
 
   function style_td(td: HTMLTableCellElement) {
     const meta = table.getMeta(td);
-    const x = meta?.x!;
-    const y = meta?.y!;
+    const x = meta?.x;
+    const y = meta?.y;
+    if (typeof x !== "number" || typeof y !== "number") return;
+
     const value = meta?.value;
     td.setAttribute("__col", String(x));
     td.setAttribute("__row", String(y));
@@ -158,8 +162,10 @@
 
   function style_column_th(th: HTMLTableCellElement) {
     const meta = table.getMeta(th);
-    const x = meta.x!;
-    const y = meta.column_header_y!;
+    const x = meta.x;
+    const y = meta.column_header_y;
+    if (typeof x !== "number" || typeof y !== "number") return;
+
     th.setAttribute("__col", String(x));
     th.setAttribute("__row", String(y));
 
@@ -191,7 +197,8 @@
   function style_row_corner(th: HTMLTableCellElement) {
     const meta = table.getMeta(th);
 
-    const x = meta.row_header_x!;
+    const x = meta.row_header_x;
+    if (typeof x !== "number") return;
 
     if (meta.column_header_y === columnHeaderDepth - 1) {
       const maybeWidth = getRowHeaderWidth(x);

--- a/web-common/src/features/dashboards/pivot/Pivot.svelte
+++ b/web-common/src/features/dashboards/pivot/Pivot.svelte
@@ -30,7 +30,7 @@
 
   const dispatch = createEventDispatcher();
 
-  let table: RegularTableElement = undefined;
+  let table: RegularTableElement;
   let initialized = false;
   export function draw() {
     if (initialized) table.draw();
@@ -101,11 +101,11 @@
 
   function style_row_th(th: HTMLTableCellElement) {
     const meta = table.getMeta(th);
-    const numFixedCols = meta.row_header.length;
-    const x = meta.row_header_x;
-    const y = meta.y;
-    th.setAttribute("__col", String(x - numFixedCols));
-    th.setAttribute("__row", String(y));
+    const numFixedCols = meta?.row_header?.length;
+    const x = meta?.row_header_x;
+    const y = meta?.y;
+    th.setAttribute("__col", String(x! - numFixedCols!));
+    th.setAttribute("__row", String(y!));
 
     const maybeWidth = getRowHeaderWidth(x);
     if (maybeWidth) {

--- a/web-common/src/features/dashboards/pivot/Pivot.svelte
+++ b/web-common/src/features/dashboards/pivot/Pivot.svelte
@@ -96,7 +96,7 @@
       column_headers,
     };
 
-    return dataSlice;
+    return Promise.resolve(dataSlice);
   };
 
   function style_row_th(th: HTMLTableCellElement) {


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Continuation of #3317

#### Details:
Apparently `regular-table` has examples and support for APIs which are not present in their type signatures. To address this have modified the APIs so that they are in line with their types



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- Refactor: Enhanced the Pivot table component in the dashboard feature. This includes improved handling of table styling and data representation, providing a more consistent and reliable user experience.
- Bug Fix: Fixed issues with the `scrollToCell` function, which now accurately navigates to the correct cell in the Pivot table, improving navigation within the table.
- Style: Updated the visual representation of loading and null cells in the Pivot table, making it easier for users to understand the table's state.
- Refactor: Improved the type definitions used in the Pivot table component, increasing the reliability of the code and reducing potential errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->