### PR TITLE
CLI: Refactor rill project reconcile

### DIFF
--- a/cli/cmd/project/project.go
+++ b/cli/cmd/project/project.go
@@ -27,6 +27,8 @@ func ProjectCmd(cfg *config.Config) *cobra.Command {
 	projectCmd.AddCommand(DeleteCmd(cfg))
 	projectCmd.AddCommand(ListCmd(cfg))
 	projectCmd.AddCommand(ReconcileCmd(cfg))
+	projectCmd.AddCommand(RefreshCmd(cfg))
+	projectCmd.AddCommand(ResetCmd(cfg))
 	projectCmd.AddCommand(JwtCmd(cfg))
 	projectCmd.AddCommand(RenameCmd(cfg))
 	projectCmd.AddCommand(LogsCmd(cfg))

--- a/cli/cmd/project/reconcile.go
+++ b/cli/cmd/project/reconcile.go
@@ -11,7 +11,7 @@ import (
 
 func ReconcileCmd(cfg *config.Config) *cobra.Command {
 	var project, path string
-	var refresh, reset bool
+	var refresh, reset, force bool
 	var refreshSources []string
 
 	reconcileCmd := &cobra.Command{
@@ -50,6 +50,13 @@ func ReconcileCmd(cfg *config.Config) *cobra.Command {
 			}
 
 			if reset || resp.ProdDeployment == nil {
+				if !force {
+					msg := "This will create a new deployment, causing downtime as data sources are reloaded from scratch. If you just need to refresh data, use `rill project refresh`. Do you want to continue?"
+					if !cmdutil.ConfirmPrompt(msg, "", false) {
+						return nil
+					}
+				}
+
 				_, err = client.TriggerRedeploy(ctx, &adminv1.TriggerRedeployRequest{Organization: cfg.Org, Project: project})
 				if err != nil {
 					return err
@@ -86,6 +93,7 @@ func ReconcileCmd(cfg *config.Config) *cobra.Command {
 	reconcileCmd.Flags().BoolVar(&refresh, "refresh", false, "Refresh all sources")
 	reconcileCmd.Flags().StringSliceVar(&refreshSources, "refresh-source", nil, "Refresh specific source(s)")
 	reconcileCmd.Flags().BoolVar(&reset, "reset", false, "Reset and redeploy the project from scratch")
+	reconcileCmd.Flags().BoolVar(&force, "force", false, "Force the operation")
 
 	reconcileCmd.MarkFlagsMutuallyExclusive("reset", "refresh")
 	reconcileCmd.MarkFlagsMutuallyExclusive("reset", "refresh-source")

--- a/cli/cmd/project/reconcile.go
+++ b/cli/cmd/project/reconcile.go
@@ -18,6 +18,7 @@ func ReconcileCmd(cfg *config.Config) *cobra.Command {
 		Use:               "reconcile [<project-name>]",
 		Args:              cobra.MaximumNArgs(1),
 		Short:             "Send trigger to deployment",
+		Hidden:            true,
 		PersistentPreRunE: cmdutil.CheckChain(cmdutil.CheckAuth(cfg), cmdutil.CheckOrganization(cfg)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/cli/cmd/project/refresh.go
+++ b/cli/cmd/project/refresh.go
@@ -11,7 +11,7 @@ import (
 
 func RefreshCmd(cfg *config.Config) *cobra.Command {
 	var project, path string
-	var refreshSources []string
+	var source []string
 
 	refreshCmd := &cobra.Command{
 		Use:               "refresh [<project-name>]",
@@ -47,9 +47,9 @@ func RefreshCmd(cfg *config.Config) *cobra.Command {
 				return err
 			}
 
-			_, err = client.TriggerRefreshSources(ctx, &adminv1.TriggerRefreshSourcesRequest{DeploymentId: resp.ProdDeployment.Id, Sources: refreshSources})
+			_, err = client.TriggerRefreshSources(ctx, &adminv1.TriggerRefreshSourcesRequest{DeploymentId: resp.ProdDeployment.Id, Sources: source})
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to trigger refresh: %w", err)
 			}
 
 			fmt.Printf("Triggered refresh. To see status, run `rill project status --project %s`.\n", project)
@@ -61,7 +61,7 @@ func RefreshCmd(cfg *config.Config) *cobra.Command {
 	refreshCmd.Flags().SortFlags = false
 	refreshCmd.Flags().StringVar(&project, "project", "", "Project name")
 	refreshCmd.Flags().StringVar(&path, "path", ".", "Project directory")
-	refreshCmd.Flags().StringSliceVar(&refreshSources, "refresh-source", nil, "Refresh specific source(s)")
+	refreshCmd.Flags().StringSliceVar(&source, "source", nil, "Refresh specific source(s)")
 
 	return refreshCmd
 }

--- a/cli/cmd/project/refresh.go
+++ b/cli/cmd/project/refresh.go
@@ -1,0 +1,67 @@
+package project
+
+import (
+	"fmt"
+
+	"github.com/rilldata/rill/cli/pkg/cmdutil"
+	"github.com/rilldata/rill/cli/pkg/config"
+	adminv1 "github.com/rilldata/rill/proto/gen/rill/admin/v1"
+	"github.com/spf13/cobra"
+)
+
+func RefreshCmd(cfg *config.Config) *cobra.Command {
+	var project, path string
+	var refreshSources []string
+
+	refreshCmd := &cobra.Command{
+		Use:               "refresh [<project-name>]",
+		Args:              cobra.MaximumNArgs(1),
+		Short:             "Refresh project",
+		PersistentPreRunE: cmdutil.CheckChain(cmdutil.CheckAuth(cfg), cmdutil.CheckOrganization(cfg)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			client, err := cmdutil.Client(cfg)
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			if len(args) > 0 {
+				project = args[0]
+			}
+
+			if !cmd.Flags().Changed("project") && len(args) == 0 && cfg.Interactive {
+				var err error
+				project, err = inferProjectName(ctx, client, cfg.Org, path)
+				if err != nil {
+					return err
+				}
+			}
+
+			resp, err := client.GetProject(ctx, &adminv1.GetProjectRequest{
+				OrganizationName: cfg.Org,
+				Name:             project,
+			})
+			if err != nil {
+				return err
+			}
+
+			_, err = client.TriggerRefreshSources(ctx, &adminv1.TriggerRefreshSourcesRequest{DeploymentId: resp.ProdDeployment.Id, Sources: refreshSources})
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Triggered refresh. To see status, run `rill project status --project %s`.\n", project)
+
+			return nil
+		},
+	}
+
+	refreshCmd.Flags().SortFlags = false
+	refreshCmd.Flags().StringVar(&project, "project", "", "Project name")
+	refreshCmd.Flags().StringVar(&path, "path", ".", "Project directory")
+	refreshCmd.Flags().StringSliceVar(&refreshSources, "refresh-source", nil, "Refresh specific source(s)")
+
+	return refreshCmd
+}

--- a/cli/cmd/project/reset.go
+++ b/cli/cmd/project/reset.go
@@ -1,0 +1,57 @@
+package project
+
+import (
+	"fmt"
+
+	"github.com/rilldata/rill/cli/pkg/cmdutil"
+	"github.com/rilldata/rill/cli/pkg/config"
+	adminv1 "github.com/rilldata/rill/proto/gen/rill/admin/v1"
+	"github.com/spf13/cobra"
+)
+
+func ResetCmd(cfg *config.Config) *cobra.Command {
+	var project, path string
+
+	resetCmd := &cobra.Command{
+		Use:               "reset [<project-name>]",
+		Args:              cobra.MaximumNArgs(1),
+		Short:             "Reset project",
+		PersistentPreRunE: cmdutil.CheckChain(cmdutil.CheckAuth(cfg), cmdutil.CheckOrganization(cfg)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			client, err := cmdutil.Client(cfg)
+			if err != nil {
+				return err
+			}
+			defer client.Close()
+
+			if len(args) > 0 {
+				project = args[0]
+			}
+
+			if !cmd.Flags().Changed("project") && len(args) == 0 && cfg.Interactive {
+				var err error
+				project, err = inferProjectName(ctx, client, cfg.Org, path)
+				if err != nil {
+					return err
+				}
+			}
+
+			_, err = client.TriggerRedeploy(ctx, &adminv1.TriggerRedeployRequest{Organization: cfg.Org, Project: project})
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Triggered project reset. To see status, run `rill project status --project %s`.\n", project)
+
+			return nil
+		},
+	}
+
+	resetCmd.Flags().SortFlags = false
+	resetCmd.Flags().StringVar(&project, "project", "", "Project name")
+	resetCmd.Flags().StringVar(&path, "path", ".", "Project directory")
+
+	return resetCmd
+}

--- a/cli/cmd/project/reset.go
+++ b/cli/cmd/project/reset.go
@@ -11,6 +11,7 @@ import (
 
 func ResetCmd(cfg *config.Config) *cobra.Command {
 	var project, path string
+	var force bool
 
 	resetCmd := &cobra.Command{
 		Use:               "reset [<project-name>]",
@@ -38,6 +39,13 @@ func ResetCmd(cfg *config.Config) *cobra.Command {
 				}
 			}
 
+			if !force {
+				msg := "This will create a new deployment, causing downtime as data sources are reloaded from scratch. If you just need to refresh data, use `rill project refresh`. Do you want to continue?"
+				if !cmdutil.ConfirmPrompt(msg, "", false) {
+					return nil
+				}
+			}
+
 			_, err = client.TriggerRedeploy(ctx, &adminv1.TriggerRedeployRequest{Organization: cfg.Org, Project: project})
 			if err != nil {
 				return err
@@ -52,6 +60,6 @@ func ResetCmd(cfg *config.Config) *cobra.Command {
 	resetCmd.Flags().SortFlags = false
 	resetCmd.Flags().StringVar(&project, "project", "", "Project name")
 	resetCmd.Flags().StringVar(&path, "path", ".", "Project directory")
-
+	resetCmd.Flags().BoolVar(&force, "force", false, "Force reset even if project is already deployed")
 	return resetCmd
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

New Feature:
- Added "Refresh" and "Reset" commands to the CLI tool.
  - The "Refresh" command allows users to easily update a project, with options to specify the project directory and specific sources to refresh. This enhances the software's usability by providing a simple way to keep projects up-to-date.
  - The "Reset" command offers a quick way to reset and redeploy a project. It intelligently infers the project name from the context if not provided, making it more user-friendly.

Refactor:
- The "Reconcile" command is now hidden from the help output, reducing clutter and improving the help interface's clarity. This change is not directly visible to users but contributes to a cleaner, more intuitive user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->