### PR TITLE
Runtime: ingest in batches when using duckdb sql

### DIFF
--- a/runtime/drivers/bigquery/sql_store.go
+++ b/runtime/drivers/bigquery/sql_store.go
@@ -111,10 +111,6 @@ func (f *fileIterator) Close() error {
 	return os.Remove(f.tempFilePath)
 }
 
-// KeepFilesUntilClose implements drivers.FileIterator.
-func (f *fileIterator) KeepFilesUntilClose(keepFilesUntilClose bool) {
-}
-
 // Next implements drivers.FileIterator.
 // TODO :: currently it downloads all records in a single file. Need to check if it is efficient to ingest a single file with size in tens of GBs or more.
 func (f *fileIterator) Next() ([]string, error) {

--- a/runtime/drivers/blob/blobdownloader.go
+++ b/runtime/drivers/blob/blobdownloader.go
@@ -149,7 +149,7 @@ func NewIterator(ctx context.Context, bucket *blob.Bucket, opts Options, l *zap.
 
 	// For cases where there's only one file, we want to prefetch it to return the error early (from NewIterator instead of Next)
 	if len(objects) == 1 {
-		it.KeepFilesUntilClose(true)
+		it.opts.KeepFilesUntilClose = true
 		batch, err := it.Next()
 		if err != nil {
 			it.Close()
@@ -159,10 +159,6 @@ func NewIterator(ctx context.Context, bucket *blob.Bucket, opts Options, l *zap.
 	}
 
 	return it, nil
-}
-
-func (it *blobIterator) KeepFilesUntilClose(keepFilesUntilClose bool) {
-	it.opts.KeepFilesUntilClose = keepFilesUntilClose
 }
 
 func (it *blobIterator) Close() error {
@@ -447,10 +443,6 @@ type prefetchedIterator struct {
 	batch      []string
 	done       bool
 	underlying *blobIterator
-}
-
-func (it *prefetchedIterator) KeepFilesUntilClose(keep bool) {
-	// Nothing to do – already set on the underlying iterator
 }
 
 func (it *prefetchedIterator) Close() error {

--- a/runtime/drivers/duckdb/transporter/transporter_test.go
+++ b/runtime/drivers/duckdb/transporter/transporter_test.go
@@ -156,8 +156,8 @@ mum,8.2`)
 	tests = append(tests, queryTests...)
 
 	mockConnector := &mockObjectStore{}
-	for i, test := range tests {
-		t.Run(fmt.Sprintf("%d - query=%v", i, test.query), func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s - query=%v", test.name, test.query), func(t *testing.T) {
 			mockConnector.mockIterator = &mockIterator{batches: test.files}
 			olap := runOLAPStore(t)
 			ctx := context.Background()
@@ -165,7 +165,7 @@ mum,8.2`)
 
 			var src map[string]any
 			if test.query {
-				src = map[string]any{"sql": "select * from read_csv_auto('path',union_by_name=true,sample_size=200000)"}
+				src = map[string]any{"sql": "select * from read_csv_auto('path',union_by_name=true,sample_size=200000)", "allow_schema_relaxation": true}
 			} else {
 				src = map[string]any{"allow_schema_relaxation": true}
 			}
@@ -409,7 +409,7 @@ func TestIterativeParquetIngestionWithVariableSchema(t *testing.T) {
 
 			var src map[string]any
 			if test.query {
-				src = map[string]any{"sql": "select * from read_parquet('path',union_by_name=true,hive_partitioning=true)"}
+				src = map[string]any{"sql": "select * from read_parquet('path',union_by_name=true,hive_partitioning=true)", "allow_schema_relaxation": true}
 			} else {
 				src = map[string]any{"allow_schema_relaxation": true}
 			}
@@ -541,8 +541,8 @@ func TestIterativeJSONIngestionWithVariableSchema(t *testing.T) {
 	tests = append(tests, queryTests...)
 
 	mockConnector := &mockObjectStore{}
-	for i, test := range tests {
-		t.Run(fmt.Sprintf("%d - query=%v", i, test.query), func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s - query=%v", test.name, test.query), func(t *testing.T) {
 			mockConnector.mockIterator = &mockIterator{batches: test.files}
 			olap := runOLAPStore(t)
 			ctx := context.Background()
@@ -550,7 +550,7 @@ func TestIterativeJSONIngestionWithVariableSchema(t *testing.T) {
 
 			var src map[string]any
 			if test.query {
-				src = map[string]any{"sql": "select * from read_json('path',format='auto',union_by_name=true,auto_detect=true,sample_size=200000)"}
+				src = map[string]any{"sql": "select * from read_json('path',format='auto',union_by_name=true,auto_detect=true,sample_size=200000)", "batch_size": "-1"}
 			} else {
 				src = map[string]any{"allow_schema_relaxation": true}
 			}

--- a/runtime/drivers/duckdb/transporter/transporter_test.go
+++ b/runtime/drivers/duckdb/transporter/transporter_test.go
@@ -45,9 +45,6 @@ func (m *mockIterator) Size(unit drivers.ProgressUnit) (int64, bool) {
 	return 0, false
 }
 
-func (m *mockIterator) KeepFilesUntilClose(keepFilesUntilClose bool) {
-}
-
 func (m *mockIterator) Format() string {
 	return ""
 }

--- a/runtime/drivers/duckdb/transporter/utils.go
+++ b/runtime/drivers/duckdb/transporter/utils.go
@@ -109,11 +109,15 @@ func parseFileSourceProperties(props map[string]any) (*fileSourceProperties, err
 	}
 
 	if cfg.BatchSize != "" {
-		b, err := datasize.ParseString(cfg.BatchSize)
-		if err != nil {
-			return nil, err
+		if cfg.BatchSize == "-1" { // special placeholder for disabling batching
+			cfg.BatchSizeBytes = -1
+		} else {
+			b, err := datasize.ParseString(cfg.BatchSize)
+			if err != nil {
+				return nil, err
+			}
+			cfg.BatchSizeBytes = int64(b.Bytes())
 		}
-		cfg.BatchSizeBytes = int64(b.Bytes())
 	}
 
 	return cfg, nil

--- a/runtime/drivers/duckdb/transporter/utils.go
+++ b/runtime/drivers/duckdb/transporter/utils.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/c2h5oh/datasize"
 	"github.com/mitchellh/mapstructure"
 	"github.com/rilldata/rill/runtime/drivers"
 )
@@ -65,7 +64,6 @@ type fileSourceProperties struct {
 	Format                string         `mapstructure:"format"`
 	AllowSchemaRelaxation bool           `mapstructure:"allow_schema_relaxation"`
 	BatchSize             string         `mapstructure:"batch_size"`
-	BatchSizeBytes        int64          `mapstructure:"-"` // Inferred from BatchSize
 
 	// Backwards compatibility
 	HivePartitioning            *bool  `mapstructure:"hive_partitioning"`
@@ -107,19 +105,6 @@ func parseFileSourceProperties(props map[string]any) (*fileSourceProperties, err
 			return nil, fmt.Errorf("if any of `columns`,`types`,`dtypes` is set `allow_schema_relaxation` must be disabled")
 		}
 	}
-
-	if cfg.BatchSize != "" {
-		if cfg.BatchSize == "-1" { // special placeholder for disabling batching
-			cfg.BatchSizeBytes = -1
-		} else {
-			b, err := datasize.ParseString(cfg.BatchSize)
-			if err != nil {
-				return nil, err
-			}
-			cfg.BatchSizeBytes = int64(b.Bytes())
-		}
-	}
-
 	return cfg, nil
 }
 

--- a/runtime/drivers/gcs/gcs.go
+++ b/runtime/drivers/gcs/gcs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"os"
 	"strings"
@@ -283,9 +284,14 @@ func (c *Connection) DownloadFiles(ctx context.Context, props map[string]any) (d
 		return nil, fmt.Errorf("failed to open bucket %q, %w", conf.url.Host, err)
 	}
 
-	batchSize, err := datasize.ParseString(conf.BatchSize)
-	if err != nil {
-		return nil, err
+	var batchSize datasize.ByteSize
+	if conf.BatchSize == "-1" {
+		batchSize = math.MaxInt64 // download everything in one batch
+	} else {
+		batchSize, err = datasize.ParseString(conf.BatchSize)
+		if err != nil {
+			return nil, err
+		}
 	}
 	// prepare fetch configs
 	opts := rillblob.Options{
@@ -296,6 +302,7 @@ func (c *Connection) DownloadFiles(ctx context.Context, props map[string]any) (d
 		GlobPattern:           conf.url.Path,
 		ExtractPolicy:         conf.extractPolicy,
 		BatchSizeBytes:        int64(batchSize.Bytes()),
+		KeepFilesUntilClose:   conf.BatchSize == "-1",
 	}
 
 	iter, err := rillblob.NewIterator(ctx, bucketObj, opts, c.logger)

--- a/runtime/drivers/object_store.go
+++ b/runtime/drivers/object_store.go
@@ -18,9 +18,6 @@ type FileIterator interface {
 	// Size returns size of data downloaded in unit.
 	// Returns 0,false if not able to compute size in given unit
 	Size(unit ProgressUnit) (int64, bool)
-	// KeepFilesUntilClose marks the iterator to keep the files until close is called.
-	// This is used when the entire list of files is used at once in certain cases.
-	KeepFilesUntilClose(keepFilesUntilClose bool)
 	// Format returns general file format (json, csv, parquet, etc)
 	// Returns an empty string if there is no general format
 	Format() string

--- a/runtime/drivers/s3/s3.go
+++ b/runtime/drivers/s3/s3.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -287,9 +288,14 @@ func (c *Connection) DownloadFiles(ctx context.Context, src map[string]any) (dri
 		return nil, fmt.Errorf("failed to open bucket %q, %w", conf.url.Host, err)
 	}
 
-	batchSize, err := datasize.ParseString(conf.BatchSize)
-	if err != nil {
-		return nil, err
+	var batchSize datasize.ByteSize
+	if conf.BatchSize == "-1" {
+		batchSize = math.MaxInt64 // download everything in one batch
+	} else {
+		batchSize, err = datasize.ParseString(conf.BatchSize)
+		if err != nil {
+			return nil, err
+		}
 	}
 	// prepare fetch configs
 	opts := rillblob.Options{
@@ -300,6 +306,7 @@ func (c *Connection) DownloadFiles(ctx context.Context, src map[string]any) (dri
 		GlobPattern:           conf.url.Path,
 		ExtractPolicy:         conf.extractPolicy,
 		BatchSizeBytes:        int64(batchSize.Bytes()),
+		KeepFilesUntilClose:   conf.BatchSize == "-1",
 	}
 
 	it, err := rillblob.NewIterator(ctx, bucketObj, opts, c.logger)


### PR DESCRIPTION
1. We ingest in batches when using duckdb sql since runtime is crashing with OOM if ingesting large amount of data in one query. 
2. It may not be possible to always  ingest in batches when using duckDB sql (example having a group by clause) in these cases batch ingestion can be disabled using `batch_size: -1` in source.yaml
3. Also added a dumb(very) retry logic to fix error listed in [issue](https://github.com/rilldata/rill/issues/3323). Seeing this very frequently now both on local and cloud.
