### PR TITLE
Show last point for all cases

### DIFF
--- a/web-common/src/lib/time/ranges/index.ts
+++ b/web-common/src/lib/time/ranges/index.ts
@@ -402,6 +402,13 @@ export function getAdjustedChartTime(
     if (isGrainBigger(interval, smallestTimeGrain)) {
       adjustedEnd = getEndOfPeriod(adjustedEnd, grainDuration, zone);
     }
+  } else {
+    // Make sure end is always at the end of the period
+    adjustedEnd = getEndOfPeriod(
+      new Date(adjustedEnd.getTime() - 1),
+      grainDuration,
+      zone
+    );
   }
 
   adjustedEnd = getOffset(adjustedEnd, offsetDuration, TimeOffsetType.SUBTRACT);


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
For cases when time range is Last 12 months and the grain is weekly, the last point was not visible on the chart.

#### Details:
The issue was because it was assumed for defined presets that end time would always be a multiple of the selected grain. This is not true when offset applied is a month and grain selected is weekly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Bug Fixes:
- Adjusted the time range calculations to ensure consistent end-of-period settings. This change enhances the accuracy of time-based data representation, providing users with more reliable information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->