### PR TITLE
Fixing empty option shown when there is no default time range

### DIFF
--- a/web-common/src/features/dashboards/time-controls/TimeRangeSelector.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeRangeSelector.svelte
@@ -59,9 +59,9 @@
   let latestWindowTimeRanges: TimeRangeOption[];
   let periodToDateTimeRanges: TimeRangeOption[];
 
-  $: showDefaultItem = !(
-    $metaQuery.data?.defaultTimeRange in ISODurationToTimeRangePreset
-  );
+  $: showDefaultItem =
+    $metaQuery.data?.defaultTimeRange &&
+    !($metaQuery.data?.defaultTimeRange in ISODurationToTimeRangePreset);
 
   // get the available latest-window time ranges
   $: if (boundaryStart && boundaryEnd) {


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
When there is no `default_time_range` selected there is an additional option just stating `Last`.

#### Details:
Adding an empty string check to make sure we do not show any option when default_time_range is not present.

## Steps to Verify
1. Import any source with a timestamp.
2. Autogenerate dashboard.
3. There should be no option `Last` under `All Time`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Refactor:
- Updated the condition for `showDefaultItem` in the Time Range Selector. This change ensures that the default time range is only displayed when it is defined and not already present in the preset array, enhancing the user experience by avoiding redundancy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->