### PR TITLE
Fixing histogram bucket ordering

### DIFF
--- a/runtime/queries/column_numeric_histogram.go
+++ b/runtime/queries/column_numeric_histogram.go
@@ -204,6 +204,7 @@ func (q *ColumnNumericHistogram) calculateFDMethod(ctx context.Context, rt *runt
             -- fill in the case where we've filtered out the highest value and need to recompute it, otherwise use count.
             CASE WHEN high = (SELECT max(high) from histogram_stage) THEN count + (select c from right_edge) ELSE count END AS count
             FROM histogram_stage
+            ORDER BY bucket
 	      `,
 		selectColumn,
 		sanitizedColumnName,
@@ -332,6 +333,7 @@ func (q *ColumnNumericHistogram) calculateDiagnosticMethod(ctx context.Context, 
 		-- fill in the case where we've filtered out the highest value and need to recompute it, otherwise use count.
 			CASE WHEN high = (SELECT max(high) from histogram_stage) THEN count + (select c from right_edge) ELSE count END AS count
 		FROM histogram_stage
+    ORDER BY bucket
 		`,
 		selectColumn,
 		sanitizedColumnName,


### PR DESCRIPTION
Histograms are broken right now. Every now and then the ordering of the buckets are broken. Adding a temporary fix to add and additional order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Refactor:
- Enhanced the SQL queries in the codebase by adding an `ORDER BY` clause. This change will ensure the output is sorted by the `bucket` column, providing a more organized data view for end-users. No modifications were made to function signatures, global data structures, or return values, maintaining the existing interface for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->