### PR TITLE
Runtime: detach all duckdb dbs on handle close

### DIFF
--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -314,6 +314,8 @@ func (c *connection) Config() map[string]any {
 func (c *connection) Close() error {
 	c.cancel()
 	_ = c.registration.Unregister()
+	// detach all attached DBs otherwise duckdb leaks memory
+	c.detachAllDBs()
 	return c.db.Close()
 }
 
@@ -398,6 +400,8 @@ func (c *connection) AsFileStore() (drivers.FileStore, bool) {
 func (c *connection) reopenDB() error {
 	// If c.db is already open, close it first
 	if c.db != nil {
+		// detach all attached DBs otherwise duckdb leaks memory
+		c.detachAllDBs()
 		err := c.db.Close()
 		if err != nil {
 			return err
@@ -755,6 +759,36 @@ func (c *connection) periodicallyEmitStats(d time.Duration) {
 		case <-c.ctx.Done():
 			statTicker.Stop()
 			return
+		}
+	}
+}
+
+// detachAllDBs detaches all attached dbs if external_table_storage config is true
+func (c *connection) detachAllDBs() {
+	if !c.config.ExtTableStorage {
+		return
+	}
+	entries, err := os.ReadDir(c.config.ExtStoragePath)
+	if err != nil {
+		c.logger.Error("unable to read ExtStoragePath", zap.String("path", c.config.ExtStoragePath), zap.Error(err))
+		return
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		version, exist, err := c.tableVersion(entry.Name())
+		if err != nil {
+			continue
+		}
+		if !exist {
+			continue
+		}
+
+		db := dbName(entry.Name(), version)
+		_, err = c.db.ExecContext(context.Background(), fmt.Sprintf("DETACH %s", safeSQLName(db)))
+		if err != nil {
+			c.logger.Error("detach failed", zap.String("db", db), zap.Error(err))
 		}
 	}
 }


### PR DESCRIPTION
detach all dbs on handle close otherwise duckdb leaks memory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

New Features:
- Introduced a new method `detachAllDBs()` to improve database management. This method detaches all attached databases when the `ExtTableStorage` configuration is enabled, enhancing data security and system stability.

Refactor:
- Updated the `Close()` and `reopenDB()` methods to call `detachAllDBs()`, ensuring a clean state before closing or reopening the database, which contributes to better system performance.

Chores:
- Added new imports for the `os`, `fmt`, and `regexp` packages to support the new features and refactoring.
- Introduced a new global variable `humanReadableSizeRegex` to aid in data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->