### PR TITLE
Timeseries time zone addNulls fix

### DIFF
--- a/runtime/queries/metricsview_timeseries.go
+++ b/runtime/queries/metricsview_timeseries.go
@@ -418,7 +418,6 @@ func generateNullRecords(schema *runtimev1.StructType) *structpb.Struct {
 
 func addNulls(data []*runtimev1.TimeSeriesValue, nullRecords *structpb.Struct, start, end time.Time, tg runtimev1.TimeGrain, tz *time.Location) []*runtimev1.TimeSeriesValue {
 	for start.Before(end) {
-		start = start.Add(11 * time.Second)
 		data = append(data, &runtimev1.TimeSeriesValue{
 			Ts:      timestamppb.New(start),
 			Records: nullRecords,

--- a/runtime/queries/metricsview_timeseries.go
+++ b/runtime/queries/metricsview_timeseries.go
@@ -161,21 +161,21 @@ func (q *MetricsViewTimeSeries) Resolve(ctx context.Context, rt *runtime.Runtime
 
 		if zeroTime.Equal(start) {
 			if q.TimeStart != nil {
-				start = truncateTime(q.TimeStart.AsTime(), q.TimeGranularity, tz, int(fdow), int(fmoy))
-				data = addNulls(data, nullRecords, start, t, q.TimeGranularity)
+				start = TruncateTime(q.TimeStart.AsTime(), q.TimeGranularity, tz, int(fdow), int(fmoy))
+				data = addNulls(data, nullRecords, start, t, q.TimeGranularity, tz)
 			}
 		} else {
-			data = addNulls(data, nullRecords, start, t, q.TimeGranularity)
+			data = addNulls(data, nullRecords, start, t, q.TimeGranularity, tz)
 		}
 
 		data = append(data, &runtimev1.TimeSeriesValue{
 			Ts:      timestamppb.New(t),
 			Records: records,
 		})
-		start = addTo(t, q.TimeGranularity)
+		start = addTo(t, q.TimeGranularity, tz)
 	}
 	if q.TimeEnd != nil && nullRecords != nil {
-		data = addNulls(data, nullRecords, start, q.TimeEnd.AsTime(), q.TimeGranularity)
+		data = addNulls(data, nullRecords, start, q.TimeEnd.AsTime(), q.TimeGranularity, tz)
 	}
 
 	meta := structTypeToMetricsViewColumn(rows.Schema)
@@ -347,7 +347,7 @@ func (q *MetricsViewTimeSeries) buildDuckDBSQL(args []any, mv *runtimev1.Metrics
 	return sql
 }
 
-func truncateTime(start time.Time, tg runtimev1.TimeGrain, tz *time.Location, firstDay, firstMonth int) time.Time {
+func TruncateTime(start time.Time, tg runtimev1.TimeGrain, tz *time.Location, firstDay, firstMonth int) time.Time {
 	switch tg {
 	case runtimev1.TimeGrain_TIME_GRAIN_MILLISECOND:
 		return start.Truncate(time.Millisecond)
@@ -416,18 +416,19 @@ func generateNullRecords(schema *runtimev1.StructType) *structpb.Struct {
 	return &nullStruct
 }
 
-func addNulls(data []*runtimev1.TimeSeriesValue, nullRecords *structpb.Struct, start, end time.Time, tg runtimev1.TimeGrain) []*runtimev1.TimeSeriesValue {
+func addNulls(data []*runtimev1.TimeSeriesValue, nullRecords *structpb.Struct, start, end time.Time, tg runtimev1.TimeGrain, tz *time.Location) []*runtimev1.TimeSeriesValue {
 	for start.Before(end) {
+		start = start.Add(11 * time.Second)
 		data = append(data, &runtimev1.TimeSeriesValue{
 			Ts:      timestamppb.New(start),
 			Records: nullRecords,
 		})
-		start = addTo(start, tg)
+		start = addTo(start, tg, tz)
 	}
 	return data
 }
 
-func addTo(start time.Time, tg runtimev1.TimeGrain) time.Time {
+func addTo(start time.Time, tg runtimev1.TimeGrain, tz *time.Location) time.Time {
 	switch tg {
 	case runtimev1.TimeGrain_TIME_GRAIN_MILLISECOND:
 		return start.Add(time.Millisecond)
@@ -442,9 +443,13 @@ func addTo(start time.Time, tg runtimev1.TimeGrain) time.Time {
 	case runtimev1.TimeGrain_TIME_GRAIN_WEEK:
 		return start.AddDate(0, 0, 7)
 	case runtimev1.TimeGrain_TIME_GRAIN_MONTH:
-		return start.AddDate(0, 1, 0)
+		start = start.In(tz)
+		start = start.AddDate(0, 1, 0)
+		return start.In(time.UTC)
 	case runtimev1.TimeGrain_TIME_GRAIN_QUARTER:
-		return start.AddDate(0, 3, 0)
+		start = start.In(tz)
+		start = start.AddDate(0, 3, 0)
+		return start.In(time.UTC)
 	case runtimev1.TimeGrain_TIME_GRAIN_YEAR:
 		return start.AddDate(1, 0, 0)
 	}

--- a/runtime/queries/metricsview_timeseries_test.go
+++ b/runtime/queries/metricsview_timeseries_test.go
@@ -1,71 +1,243 @@
-package queries
+package queries_test
 
 import (
+	"context"
+	// "fmt"
 	"testing"
 	"time"
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
+	"github.com/rilldata/rill/runtime"
+	"github.com/rilldata/rill/runtime/queries"
+	"github.com/rilldata/rill/runtime/testruntime"
 	"github.com/stretchr/testify/require"
 )
 
+func TestMetricsViewsTimeseries_month_grain(t *testing.T) {
+	rt, instanceID := testruntime.NewInstanceForProject(t, "timeseries")
+
+	ctrl, err := rt.Controller(context.Background(), instanceID)
+	require.NoError(t, err)
+	r, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "timeseries_year"}, false)
+	require.NoError(t, err)
+	mv := r.GetMetricsView()
+
+	q := &queries.MetricsViewTimeSeries{
+		MeasureNames:    []string{"max_clicks"},
+		MetricsViewName: "timeseries_year",
+		MetricsView:     mv.Spec,
+		TimeStart:       parseTime(t, "2023-01-01T00:00:00Z"),
+		TimeEnd:         parseTime(t, "2024-01-01T00:00:00Z"),
+		TimeGranularity: runtimev1.TimeGrain_TIME_GRAIN_MONTH,
+		Limit:           250,
+	}
+
+	err = q.Resolve(context.Background(), rt, instanceID, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, q.Result)
+	rows := q.Result.Data
+	i := 0
+	require.Equal(t, parseTime(t, "2023-01-01T00:00:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-02-01T00:00:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-03-01T00:00:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-04-01T00:00:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-05-01T00:00:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-06-01T00:00:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-07-01T00:00:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-08-01T00:00:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-09-01T00:00:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-10-01T00:00:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-11-01T00:00:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-12-01T00:00:00Z").AsTime(), rows[i].Ts.AsTime())
+}
+
+func TestMetricsViewsTimeseries_month_grain_IST(t *testing.T) {
+	rt, instanceID := testruntime.NewInstanceForProject(t, "timeseries")
+
+	ctrl, err := rt.Controller(context.Background(), instanceID)
+	require.NoError(t, err)
+	r, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "timeseries_year"}, false)
+	require.NoError(t, err)
+	mv := r.GetMetricsView()
+
+	q := &queries.MetricsViewTimeSeries{
+		MeasureNames:    []string{"max_clicks"},
+		MetricsViewName: "timeseries_year",
+		MetricsView:     mv.Spec,
+		TimeStart:       parseTime(t, "2022-12-31T18:30:00Z"),
+		TimeEnd:         parseTime(t, "2024-01-31T18:30:00Z"),
+		TimeGranularity: runtimev1.TimeGrain_TIME_GRAIN_MONTH,
+		TimeZone:        "Asia/Kolkata",
+		Limit:           250,
+	}
+
+	err = q.Resolve(context.Background(), rt, instanceID, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, q.Result)
+	rows := q.Result.Data
+	i := 0
+	require.Equal(t, parseTime(t, "2022-12-31T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-01-31T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-02-28T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-03-31T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-04-30T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-05-31T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-06-30T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-07-31T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-08-31T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-09-30T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-10-31T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-11-30T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-12-31T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+}
+
+func TestMetricsViewsTimeseries_quarter_grain_IST(t *testing.T) {
+	rt, instanceID := testruntime.NewInstanceForProject(t, "timeseries")
+
+	ctrl, err := rt.Controller(context.Background(), instanceID)
+	require.NoError(t, err)
+	r, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "timeseries_year"}, false)
+	require.NoError(t, err)
+	mv := r.GetMetricsView()
+
+	q := &queries.MetricsViewTimeSeries{
+		MeasureNames:    []string{"max_clicks"},
+		MetricsViewName: "timeseries_year",
+		MetricsView:     mv.Spec,
+		TimeStart:       parseTime(t, "2022-12-31T18:30:00Z"),
+		TimeEnd:         parseTime(t, "2024-01-31T18:30:00Z"),
+		TimeGranularity: runtimev1.TimeGrain_TIME_GRAIN_QUARTER,
+		TimeZone:        "Asia/Kolkata",
+		Limit:           250,
+	}
+
+	err = q.Resolve(context.Background(), rt, instanceID, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, q.Result)
+	rows := q.Result.Data
+	i := 0
+	require.Equal(t, parseTime(t, "2022-12-31T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-03-31T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-06-30T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-09-30T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-12-31T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+}
+
+func TestMetricsViewsTimeseries_year_grain_IST(t *testing.T) {
+	rt, instanceID := testruntime.NewInstanceForProject(t, "timeseries")
+
+	ctrl, err := rt.Controller(context.Background(), instanceID)
+	require.NoError(t, err)
+	r, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "timeseries_year"}, false)
+	require.NoError(t, err)
+	mv := r.GetMetricsView()
+
+	q := &queries.MetricsViewTimeSeries{
+		MeasureNames:    []string{"max_clicks"},
+		MetricsViewName: "timeseries_year",
+		MetricsView:     mv.Spec,
+		TimeStart:       parseTime(t, "2022-12-31T18:30:00Z"),
+		TimeEnd:         parseTime(t, "2024-12-31T00:00:00Z"),
+		TimeGranularity: runtimev1.TimeGrain_TIME_GRAIN_YEAR,
+		TimeZone:        "Asia/Kolkata",
+		Limit:           250,
+	}
+
+	err = q.Resolve(context.Background(), rt, instanceID, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, q.Result)
+	rows := q.Result.Data
+	i := 0
+	require.Equal(t, parseTime(t, "2022-12-31T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
+	require.Equal(t, parseTime(t, "2023-12-31T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+}
+
 func TestTruncateTime(t *testing.T) {
-	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:07Z"), truncateTime(parseTestTime(t, "2019-01-07T04:20:07.29Z"), runtimev1.TimeGrain_TIME_GRAIN_SECOND, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:00Z"), truncateTime(parseTestTime(t, "2019-01-07T04:20:07Z"), runtimev1.TimeGrain_TIME_GRAIN_MINUTE, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-07T04:00:00Z"), truncateTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_HOUR, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-07T00:00:00Z"), truncateTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_DAY, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-09T00:00:00Z"), truncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-01T00:00:00Z"), truncateTime(parseTestTime(t, "2019-01-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_MONTH, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-04-01T00:00:00Z"), truncateTime(parseTestTime(t, "2019-05-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-01T00:00:00Z"), truncateTime(parseTestTime(t, "2019-02-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:07Z"), queries.TruncateTime(parseTestTime(t, "2019-01-07T04:20:07.29Z"), runtimev1.TimeGrain_TIME_GRAIN_SECOND, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:00Z"), queries.TruncateTime(parseTestTime(t, "2019-01-07T04:20:07Z"), runtimev1.TimeGrain_TIME_GRAIN_MINUTE, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-07T04:00:00Z"), queries.TruncateTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_HOUR, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-07T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_DAY, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-09T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-01T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2019-01-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_MONTH, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-04-01T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2019-05-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-01T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2019-02-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, time.UTC, 1, 1))
 }
 
 func TestTruncateTime_Kathmandu(t *testing.T) {
 	tz, err := time.LoadLocation("Asia/Kathmandu")
 	require.NoError(t, err)
-	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:07Z"), truncateTime(parseTestTime(t, "2019-01-07T04:20:07.29Z"), runtimev1.TimeGrain_TIME_GRAIN_SECOND, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:00Z"), truncateTime(parseTestTime(t, "2019-01-07T04:20:07Z"), runtimev1.TimeGrain_TIME_GRAIN_MINUTE, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-07T04:15:00Z"), truncateTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_HOUR, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-06T18:15:00Z"), truncateTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_DAY, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-08T18:15:00Z"), truncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-31T18:15:00Z"), truncateTime(parseTestTime(t, "2019-02-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_MONTH, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-03-31T18:15:00Z"), truncateTime(parseTestTime(t, "2019-05-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2018-12-31T18:15:00Z"), truncateTime(parseTestTime(t, "2019-02-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:07Z"), queries.TruncateTime(parseTestTime(t, "2019-01-07T04:20:07.29Z"), runtimev1.TimeGrain_TIME_GRAIN_SECOND, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:00Z"), queries.TruncateTime(parseTestTime(t, "2019-01-07T04:20:07Z"), runtimev1.TimeGrain_TIME_GRAIN_MINUTE, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-07T04:15:00Z"), queries.TruncateTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_HOUR, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-06T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_DAY, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-08T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-31T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2019-02-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_MONTH, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-03-31T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2019-05-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2018-12-31T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2019-02-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 1, 1))
 }
 
 func TestTruncateTime_UTC_first_day(t *testing.T) {
 	tz := time.UTC
-	require.Equal(t, parseTestTime(t, "2023-10-08T00:00:00Z"), truncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 7, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-10T00:00:00Z"), truncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-10T00:00:00Z"), truncateTime(parseTestTime(t, "2023-10-11T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-10T00:00:00Z"), truncateTime(parseTestTime(t, "2023-10-10T00:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-08T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 7, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-10T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-10T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-11T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-10T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-10T00:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
 }
 
 func TestTruncateTime_Kathmandu_first_day(t *testing.T) {
 	tz, err := time.LoadLocation("Asia/Kathmandu")
 	require.NoError(t, err)
-	require.Equal(t, parseTestTime(t, "2023-10-07T18:15:00Z"), truncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 7, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-09T18:15:00Z"), truncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-09T18:15:00Z"), truncateTime(parseTestTime(t, "2023-10-11T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-09T18:15:00Z"), truncateTime(parseTestTime(t, "2023-10-09T18:16:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-07T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 7, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-09T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-09T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-11T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-09T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-09T18:16:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
 }
 
 func TestTruncateTime_UTC_first_month(t *testing.T) {
 	tz := time.UTC
-	require.Equal(t, parseTestTime(t, "2023-02-01T00:00:00Z"), truncateTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 2))
-	require.Equal(t, parseTestTime(t, "2023-03-01T00:00:00Z"), truncateTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
-	require.Equal(t, parseTestTime(t, "2023-03-01T00:00:00Z"), truncateTime(parseTestTime(t, "2023-03-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
-	require.Equal(t, parseTestTime(t, "2022-12-01T00:00:00Z"), truncateTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 12))
-	require.Equal(t, parseTestTime(t, "2023-01-01T00:00:00Z"), truncateTime(parseTestTime(t, "2023-01-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 1))
+	require.Equal(t, parseTestTime(t, "2023-02-01T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 2))
+	require.Equal(t, parseTestTime(t, "2023-03-01T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
+	require.Equal(t, parseTestTime(t, "2023-03-01T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-03-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
+	require.Equal(t, parseTestTime(t, "2022-12-01T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 12))
+	require.Equal(t, parseTestTime(t, "2023-01-01T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-01-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 1))
 }
 
 func TestTruncateTime_Kathmandu_first_month(t *testing.T) {
 	tz, err := time.LoadLocation("Asia/Kathmandu")
 	require.NoError(t, err)
-	require.Equal(t, parseTestTime(t, "2023-01-31T18:15:00Z"), truncateTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 2))
-	require.Equal(t, parseTestTime(t, "2023-02-28T18:15:00Z"), truncateTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
-	require.Equal(t, parseTestTime(t, "2023-02-28T18:15:00Z"), truncateTime(parseTestTime(t, "2023-03-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
-	require.Equal(t, parseTestTime(t, "2022-11-30T18:15:00Z"), truncateTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 12))
-	require.Equal(t, parseTestTime(t, "2022-12-31T18:15:00Z"), truncateTime(parseTestTime(t, "2023-01-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 1))
+	require.Equal(t, parseTestTime(t, "2023-01-31T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 2))
+	require.Equal(t, parseTestTime(t, "2023-02-28T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
+	require.Equal(t, parseTestTime(t, "2023-02-28T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-03-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
+	require.Equal(t, parseTestTime(t, "2022-11-30T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 12))
+	require.Equal(t, parseTestTime(t, "2022-12-31T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-01-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 1))
 }
 
 func parseTestTime(tst *testing.T, t string) time.Time {

--- a/runtime/testruntime/testdata/timeseries/dashboards/timeseries_year.yaml
+++ b/runtime/testruntime/testdata/timeseries/dashboards/timeseries_year.yaml
@@ -1,0 +1,21 @@
+model: timeseries_year_model
+display_name: Year time series
+description:
+
+timeseries: timestamp
+smallest_time_grain: 
+
+dimensions:
+  - name: device
+    column: device
+  - name: publisher
+    column: publisher
+  - name: country
+    column: country
+measures:
+  - name: max_clicks
+    expression: "max(clicks)"
+  - name: count
+    expression: "count(*)"
+  - name: sum_clicks
+    expression: "sum(clicks)"

--- a/runtime/testruntime/testdata/timeseries/models/timeseries_year_model.sql
+++ b/runtime/testruntime/testdata/timeseries/models/timeseries_year_model.sql
@@ -1,0 +1,3 @@
+select * from (select generate_series as timestamp from generate_series(TIMESTAMP '2022-01-01 00:00:00', TIMESTAMP '2025-12-01 00:00:00', INTERVAL '1' MONTH)) a
+cross join 
+(SELECT 1.0 AS clicks,  'android' AS device, 'Google' AS publisher, 'Canada' as country) b 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

New Features:
- Enhanced the `MetricsViewTimeSeries` function in the `queries` package to support different time granularities and time zones, improving data accuracy and flexibility.

Refactor:
- Renamed the function `truncateTime` to `TruncateTime` for better code readability.
- Updated the `addNulls` and `addTo` functions with an additional `tz *time.Location` parameter to handle different time zones.

Tests:
- Introduced new test cases for the `MetricsViewTimeSeries` function, ensuring robustness across different time granularities and time zones.

Chores:
- Added a SQL query in `timeseries_year_model.sql` for data selection, aiding in test data generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->