### PR TITLE
Adding support for round_to_grain for APIs

### DIFF
--- a/runtime/queries/metricsview_aggregation.go
+++ b/runtime/queries/metricsview_aggregation.go
@@ -194,7 +194,7 @@ func (q *MetricsViewAggregation) buildMetricsAggregationSQL(mv *runtimev1.Metric
 	whereClause := ""
 	if mv.TimeDimension != "" {
 		timeCol := safeName(mv.TimeDimension)
-		clause, err := timeRangeClause(q.TimeRange, dialect, timeCol, &args)
+		clause, err := timeRangeClause(q.TimeRange, mv, dialect, timeCol, &args)
 		if err != nil {
 			return "", nil, err
 		}

--- a/runtime/queries/metricsview_comparison_toplist.go
+++ b/runtime/queries/metricsview_comparison_toplist.go
@@ -6,14 +6,15 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	// Load IANA time zone data
-	_ "time/tzdata"
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/pkg/pbutil"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	// Load IANA time zone data
+	_ "time/tzdata"
 )
 
 type MetricsViewComparison struct {

--- a/runtime/queries/metricsview_comparison_toplist.go
+++ b/runtime/queries/metricsview_comparison_toplist.go
@@ -804,7 +804,7 @@ func timeRangeClause(tr *runtimev1.TimeRange, mv *runtimev1.MetricsViewSpec, dia
 		return clause, nil
 	}
 
-	start, end, err := StartTimeForRange(tr, mv)
+	start, end, err := ResolveTimeRange(tr, mv)
 	if err != nil {
 		return "", err
 	}

--- a/runtime/queries/metricsview_timeseries.go
+++ b/runtime/queries/metricsview_timeseries.go
@@ -347,67 +347,6 @@ func (q *MetricsViewTimeSeries) buildDuckDBSQL(args []any, mv *runtimev1.Metrics
 	return sql
 }
 
-func TruncateTime(start time.Time, tg runtimev1.TimeGrain, tz *time.Location, firstDay, firstMonth int) time.Time {
-	switch tg {
-	case runtimev1.TimeGrain_TIME_GRAIN_MILLISECOND:
-		return start.Truncate(time.Millisecond)
-	case runtimev1.TimeGrain_TIME_GRAIN_SECOND:
-		return start.Truncate(time.Second)
-	case runtimev1.TimeGrain_TIME_GRAIN_MINUTE:
-		return start.Truncate(time.Minute)
-	case runtimev1.TimeGrain_TIME_GRAIN_HOUR:
-		start = start.In(tz)
-		start = time.Date(start.Year(), start.Month(), start.Day(), start.Hour(), 0, 0, 0, tz)
-		return start.In(time.UTC)
-	case runtimev1.TimeGrain_TIME_GRAIN_DAY:
-		start = start.In(tz)
-		start = time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, tz)
-		return start.In(time.UTC)
-	case runtimev1.TimeGrain_TIME_GRAIN_WEEK:
-		start = start.In(tz)
-		weekday := int(start.Weekday())
-		if weekday == 0 {
-			weekday = 7
-		}
-		if firstDay < 1 {
-			firstDay = 1
-		}
-		if firstDay > 7 {
-			firstDay = 7
-		}
-
-		daysToSubtract := -(weekday - firstDay)
-		if weekday < firstDay {
-			daysToSubtract = -7 + daysToSubtract
-		}
-		start = time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, tz)
-		start = start.AddDate(0, 0, daysToSubtract)
-		return start.In(time.UTC)
-	case runtimev1.TimeGrain_TIME_GRAIN_MONTH:
-		start = start.In(tz)
-		start = time.Date(start.Year(), start.Month(), 1, 0, 0, 0, 0, tz)
-		start = start.In(time.UTC)
-		return start
-	case runtimev1.TimeGrain_TIME_GRAIN_QUARTER:
-		monthsToSubtract := 1 - int(start.Month())%3 // todo first month of year
-		start = start.In(tz)
-		start = time.Date(start.Year(), start.Month(), 1, 0, 0, 0, 0, tz)
-		start = start.AddDate(0, monthsToSubtract, 0)
-		return start.In(time.UTC)
-	case runtimev1.TimeGrain_TIME_GRAIN_YEAR:
-		start = start.In(tz)
-		year := start.Year()
-		if int(start.Month()) < firstMonth {
-			year = start.Year() - 1
-		}
-
-		start = time.Date(year, time.Month(firstMonth), 1, 0, 0, 0, 0, tz)
-		return start.In(time.UTC)
-	}
-
-	return start
-}
-
 func generateNullRecords(schema *runtimev1.StructType) *structpb.Struct {
 	nullStruct := structpb.Struct{Fields: make(map[string]*structpb.Value, len(schema.Fields))}
 	for _, f := range schema.Fields {

--- a/runtime/queries/metricsview_timeseries_test.go
+++ b/runtime/queries/metricsview_timeseries_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	// "fmt"
 	"testing"
-	"time"
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
@@ -178,70 +177,4 @@ func TestMetricsViewsTimeseries_year_grain_IST(t *testing.T) {
 	require.Equal(t, parseTime(t, "2022-12-31T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
 	i++
 	require.Equal(t, parseTime(t, "2023-12-31T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
-}
-
-func TestTruncateTime(t *testing.T) {
-	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:07Z"), queries.TruncateTime(parseTestTime(t, "2019-01-07T04:20:07.29Z"), runtimev1.TimeGrain_TIME_GRAIN_SECOND, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:00Z"), queries.TruncateTime(parseTestTime(t, "2019-01-07T04:20:07Z"), runtimev1.TimeGrain_TIME_GRAIN_MINUTE, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-07T04:00:00Z"), queries.TruncateTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_HOUR, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-07T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_DAY, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-09T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-01T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2019-01-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_MONTH, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-04-01T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2019-05-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-01T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2019-02-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, time.UTC, 1, 1))
-}
-
-func TestTruncateTime_Kathmandu(t *testing.T) {
-	tz, err := time.LoadLocation("Asia/Kathmandu")
-	require.NoError(t, err)
-	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:07Z"), queries.TruncateTime(parseTestTime(t, "2019-01-07T04:20:07.29Z"), runtimev1.TimeGrain_TIME_GRAIN_SECOND, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:00Z"), queries.TruncateTime(parseTestTime(t, "2019-01-07T04:20:07Z"), runtimev1.TimeGrain_TIME_GRAIN_MINUTE, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-07T04:15:00Z"), queries.TruncateTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_HOUR, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-06T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_DAY, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-08T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-31T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2019-02-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_MONTH, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-03-31T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2019-05-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2018-12-31T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2019-02-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 1, 1))
-}
-
-func TestTruncateTime_UTC_first_day(t *testing.T) {
-	tz := time.UTC
-	require.Equal(t, parseTestTime(t, "2023-10-08T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 7, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-10T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-10T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-11T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-10T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-10T00:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
-}
-
-func TestTruncateTime_Kathmandu_first_day(t *testing.T) {
-	tz, err := time.LoadLocation("Asia/Kathmandu")
-	require.NoError(t, err)
-	require.Equal(t, parseTestTime(t, "2023-10-07T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 7, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-09T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-09T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-11T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-09T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-09T18:16:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
-}
-
-func TestTruncateTime_UTC_first_month(t *testing.T) {
-	tz := time.UTC
-	require.Equal(t, parseTestTime(t, "2023-02-01T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 2))
-	require.Equal(t, parseTestTime(t, "2023-03-01T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
-	require.Equal(t, parseTestTime(t, "2023-03-01T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-03-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
-	require.Equal(t, parseTestTime(t, "2022-12-01T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 12))
-	require.Equal(t, parseTestTime(t, "2023-01-01T00:00:00Z"), queries.TruncateTime(parseTestTime(t, "2023-01-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 1))
-}
-
-func TestTruncateTime_Kathmandu_first_month(t *testing.T) {
-	tz, err := time.LoadLocation("Asia/Kathmandu")
-	require.NoError(t, err)
-	require.Equal(t, parseTestTime(t, "2023-01-31T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 2))
-	require.Equal(t, parseTestTime(t, "2023-02-28T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
-	require.Equal(t, parseTestTime(t, "2023-02-28T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-03-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
-	require.Equal(t, parseTestTime(t, "2022-11-30T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 12))
-	require.Equal(t, parseTestTime(t, "2022-12-31T18:15:00Z"), queries.TruncateTime(parseTestTime(t, "2023-01-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 1))
-}
-
-func parseTestTime(tst *testing.T, t string) time.Time {
-	ts, err := time.Parse(time.RFC3339, t)
-	require.NoError(tst, err)
-	return ts
 }

--- a/runtime/queries/metricsview_timeseries_test.go
+++ b/runtime/queries/metricsview_timeseries_test.go
@@ -137,7 +137,10 @@ func TestMetricsViewsTimeseries_quarter_grain_IST(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, q.Result)
 	rows := q.Result.Data
+	require.Len(t, rows, 6)
 	i := 0
+	require.Equal(t, parseTime(t, "2022-10-31T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
+	i++
 	require.Equal(t, parseTime(t, "2022-12-31T18:30:00Z").AsTime(), rows[i].Ts.AsTime())
 	i++
 	require.Equal(t, parseTime(t, "2023-03-31T18:30:00Z").AsTime(), rows[i].Ts.AsTime())

--- a/runtime/queries/timeutil.go
+++ b/runtime/queries/timeutil.go
@@ -1,0 +1,96 @@
+package queries
+
+import (
+	"time"
+	// Load IANA time zone data
+	_ "time/tzdata"
+
+	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
+)
+
+func TruncateTime(start time.Time, tg runtimev1.TimeGrain, tz *time.Location, firstDay, firstMonth int) time.Time {
+	switch tg {
+	case runtimev1.TimeGrain_TIME_GRAIN_MILLISECOND:
+		return start.Truncate(time.Millisecond)
+	case runtimev1.TimeGrain_TIME_GRAIN_SECOND:
+		return start.Truncate(time.Second)
+	case runtimev1.TimeGrain_TIME_GRAIN_MINUTE:
+		return start.Truncate(time.Minute)
+	case runtimev1.TimeGrain_TIME_GRAIN_HOUR:
+		start = start.In(tz)
+		start = time.Date(start.Year(), start.Month(), start.Day(), start.Hour(), 0, 0, 0, tz)
+		return start.In(time.UTC)
+	case runtimev1.TimeGrain_TIME_GRAIN_DAY:
+		start = start.In(tz)
+		start = time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, tz)
+		return start.In(time.UTC)
+	case runtimev1.TimeGrain_TIME_GRAIN_WEEK:
+		start = start.In(tz)
+		weekday := int(start.Weekday())
+		if weekday == 0 {
+			weekday = 7
+		}
+		if firstDay < 1 {
+			firstDay = 1
+		}
+		if firstDay > 7 {
+			firstDay = 7
+		}
+
+		daysToSubtract := -(weekday - firstDay)
+		if weekday < firstDay {
+			daysToSubtract = -7 + daysToSubtract
+		}
+		start = time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, tz)
+		start = start.AddDate(0, 0, daysToSubtract)
+		return start.In(time.UTC)
+	case runtimev1.TimeGrain_TIME_GRAIN_MONTH:
+		start = start.In(tz)
+		start = time.Date(start.Year(), start.Month(), 1, 0, 0, 0, 0, tz)
+		start = start.In(time.UTC)
+		return start
+	case runtimev1.TimeGrain_TIME_GRAIN_QUARTER:
+		monthsToSubtract := 1 - int(start.Month())%3 // todo first month of year
+		start = start.In(tz)
+		start = time.Date(start.Year(), start.Month(), 1, 0, 0, 0, 0, tz)
+		start = start.AddDate(0, monthsToSubtract, 0)
+		return start.In(time.UTC)
+	case runtimev1.TimeGrain_TIME_GRAIN_YEAR:
+		start = start.In(tz)
+		year := start.Year()
+		if int(start.Month()) < firstMonth {
+			year = start.Year() - 1
+		}
+
+		start = time.Date(year, time.Month(firstMonth), 1, 0, 0, 0, 0, tz)
+		return start.In(time.UTC)
+	}
+
+	return start
+}
+
+func CeilTime(start time.Time, tg runtimev1.TimeGrain, tz *time.Location, firstDay, firstMonth int) time.Time {
+	switch tg {
+	case runtimev1.TimeGrain_TIME_GRAIN_UNSPECIFIED:
+		return start
+	case runtimev1.TimeGrain_TIME_GRAIN_MILLISECOND:
+		start = start.Add(time.Millisecond)
+	case runtimev1.TimeGrain_TIME_GRAIN_SECOND:
+		start = start.Add(time.Second)
+	case runtimev1.TimeGrain_TIME_GRAIN_MINUTE:
+		start = start.Add(time.Minute)
+	case runtimev1.TimeGrain_TIME_GRAIN_HOUR:
+		start = start.Add(time.Hour)
+	case runtimev1.TimeGrain_TIME_GRAIN_DAY:
+		start = start.AddDate(0, 0, 1)
+	case runtimev1.TimeGrain_TIME_GRAIN_WEEK:
+		start = start.AddDate(0, 0, 7)
+	case runtimev1.TimeGrain_TIME_GRAIN_MONTH:
+		start = start.AddDate(0, 1, 0)
+	case runtimev1.TimeGrain_TIME_GRAIN_QUARTER:
+		start = start.AddDate(0, 3, 0)
+	case runtimev1.TimeGrain_TIME_GRAIN_YEAR:
+		start = start.AddDate(1, 0, 0)
+	}
+	return TruncateTime(start, tg, tz, firstDay, firstMonth)
+}

--- a/runtime/queries/timeutil.go
+++ b/runtime/queries/timeutil.go
@@ -3,11 +3,12 @@ package queries
 import (
 	"fmt"
 	"time"
-	// Load IANA time zone data
-	_ "time/tzdata"
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime/pkg/duration"
+
+	// Load IANA time zone data
+	_ "time/tzdata"
 )
 
 func TruncateTime(start time.Time, tg runtimev1.TimeGrain, tz *time.Location, firstDay, firstMonth int) time.Time {

--- a/runtime/queries/timeutil.go
+++ b/runtime/queries/timeutil.go
@@ -171,7 +171,7 @@ func StartTimeForRange(tr *runtimev1.TimeRange, mv *runtimev1.MetricsViewSpec) (
 			start = TruncateTime(start, tr.RoundToGrain, tz, fdow, fmoy)
 		}
 		if !end.IsZero() {
-			end = CeilTime(end, tr.RoundToGrain, tz, fdow, fmoy)
+			end = TruncateTime(end, tr.RoundToGrain, tz, fdow, fmoy)
 		}
 	}
 

--- a/runtime/queries/timeutil.go
+++ b/runtime/queries/timeutil.go
@@ -53,10 +53,10 @@ func TruncateTime(start time.Time, tg runtimev1.TimeGrain, tz *time.Location, fi
 		start = start.In(time.UTC)
 		return start
 	case runtimev1.TimeGrain_TIME_GRAIN_QUARTER:
-		monthsToSubtract := 1 - int(start.Month())%3 // todo first month of year
+		monthsToSubtract := (3 + int(start.Month()) - firstMonth%3) % 3
 		start = start.In(tz)
 		start = time.Date(start.Year(), start.Month(), 1, 0, 0, 0, 0, tz)
-		start = start.AddDate(0, monthsToSubtract, 0)
+		start = start.AddDate(0, -monthsToSubtract, 0)
 		return start.In(time.UTC)
 	case runtimev1.TimeGrain_TIME_GRAIN_YEAR:
 		start = start.In(tz)
@@ -72,35 +72,8 @@ func TruncateTime(start time.Time, tg runtimev1.TimeGrain, tz *time.Location, fi
 	return start
 }
 
-func CeilTime(start time.Time, tg runtimev1.TimeGrain, tz *time.Location, firstDay, firstMonth int) time.Time {
-	switch tg {
-	case runtimev1.TimeGrain_TIME_GRAIN_UNSPECIFIED:
-		return start
-	case runtimev1.TimeGrain_TIME_GRAIN_MILLISECOND:
-		start = start.Add(time.Millisecond)
-	case runtimev1.TimeGrain_TIME_GRAIN_SECOND:
-		start = start.Add(time.Second)
-	case runtimev1.TimeGrain_TIME_GRAIN_MINUTE:
-		start = start.Add(time.Minute)
-	case runtimev1.TimeGrain_TIME_GRAIN_HOUR:
-		start = start.Add(time.Hour)
-	case runtimev1.TimeGrain_TIME_GRAIN_DAY:
-		start = start.AddDate(0, 0, 1)
-	case runtimev1.TimeGrain_TIME_GRAIN_WEEK:
-		start = start.AddDate(0, 0, 7)
-	case runtimev1.TimeGrain_TIME_GRAIN_MONTH:
-		start = start.AddDate(0, 1, 0)
-	case runtimev1.TimeGrain_TIME_GRAIN_QUARTER:
-		start = start.AddDate(0, 3, 0)
-	case runtimev1.TimeGrain_TIME_GRAIN_YEAR:
-		start = start.AddDate(1, 0, 0)
-	}
-	return TruncateTime(start, tg, tz, firstDay, firstMonth)
-}
-
-func StartTimeForRange(tr *runtimev1.TimeRange, mv *runtimev1.MetricsViewSpec) (time.Time, time.Time, error) {
+func ResolveTimeRange(tr *runtimev1.TimeRange, mv *runtimev1.MetricsViewSpec) (time.Time, time.Time, error) {
 	tz := time.UTC
-	tr.TimeZone = "America/Los_Angeles"
 
 	if tr.TimeZone != "" {
 		var err error

--- a/runtime/queries/timeutil.go
+++ b/runtime/queries/timeutil.go
@@ -1,11 +1,13 @@
 package queries
 
 import (
+	"fmt"
 	"time"
 	// Load IANA time zone data
 	_ "time/tzdata"
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
+	"github.com/rilldata/rill/runtime/pkg/duration"
 )
 
 func TruncateTime(start time.Time, tg runtimev1.TimeGrain, tz *time.Location, firstDay, firstMonth int) time.Time {
@@ -93,4 +95,85 @@ func CeilTime(start time.Time, tg runtimev1.TimeGrain, tz *time.Location, firstD
 		start = start.AddDate(1, 0, 0)
 	}
 	return TruncateTime(start, tg, tz, firstDay, firstMonth)
+}
+
+func StartTimeForRange(tr *runtimev1.TimeRange, mv *runtimev1.MetricsViewSpec) (time.Time, time.Time, error) {
+	tz := time.UTC
+	tr.TimeZone = "America/Los_Angeles"
+
+	if tr.TimeZone != "" {
+		var err error
+		tz, err = time.LoadLocation(tr.TimeZone)
+		if err != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("invalid time_range.time_zone %q: %w", tr.TimeZone, err)
+		}
+	}
+
+	var start, end time.Time
+	if tr.Start != nil {
+		start = tr.Start.AsTime().In(tz)
+	}
+	if tr.End != nil {
+		end = tr.End.AsTime().In(tz)
+	}
+
+	isISO := false
+
+	if tr.IsoDuration != "" {
+		if !start.IsZero() && !end.IsZero() {
+			return time.Time{}, time.Time{}, fmt.Errorf("only two of time_range.{start,end,iso_duration} can be specified")
+		}
+
+		d, err := duration.ParseISO8601(tr.IsoDuration)
+		if err != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("invalid iso_duration %q: %w", tr.IsoDuration, err)
+		}
+
+		if !start.IsZero() {
+			end = d.Add(start)
+		} else if !end.IsZero() {
+			start = d.Sub(end)
+		} else {
+			return time.Time{}, time.Time{}, fmt.Errorf("one of time_range.{start,end} must be specified with time_range.iso_duration")
+		}
+
+		isISO = true
+	}
+
+	if tr.IsoOffset != "" {
+		d, err := duration.ParseISO8601(tr.IsoOffset)
+		if err != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("invalid iso_offset %q: %w", tr.IsoOffset, err)
+		}
+
+		if !start.IsZero() {
+			start = d.Add(start)
+		}
+		if !end.IsZero() {
+			end = d.Add(end)
+		}
+
+		isISO = true
+	}
+
+	// Only modify the start and end if ISO duration or offset was sent.
+	// This is to maintain backwards compatibility for calls from the UI.
+	if isISO {
+		fdow := int(mv.FirstDayOfWeek)
+		if mv.FirstDayOfWeek > 7 || mv.FirstDayOfWeek <= 0 {
+			fdow = 1
+		}
+		fmoy := int(mv.FirstMonthOfYear)
+		if mv.FirstMonthOfYear > 12 || mv.FirstMonthOfYear <= 0 {
+			fmoy = 1
+		}
+		if !start.IsZero() {
+			start = TruncateTime(start, tr.RoundToGrain, tz, fdow, fmoy)
+		}
+		if !end.IsZero() {
+			end = CeilTime(end, tr.RoundToGrain, tz, fdow, fmoy)
+		}
+	}
+
+	return start, end, nil
 }

--- a/runtime/queries/timeutil_test.go
+++ b/runtime/queries/timeutil_test.go
@@ -1,0 +1,135 @@
+package queries
+
+import (
+	"testing"
+	"time"
+
+	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTruncateTime(t *testing.T) {
+	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:07Z"), TruncateTime(parseTestTime(t, "2019-01-07T04:20:07.29Z"), runtimev1.TimeGrain_TIME_GRAIN_SECOND, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:00Z"), TruncateTime(parseTestTime(t, "2019-01-07T04:20:07Z"), runtimev1.TimeGrain_TIME_GRAIN_MINUTE, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-07T04:00:00Z"), TruncateTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_HOUR, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-07T00:00:00Z"), TruncateTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_DAY, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-09T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-01T00:00:00Z"), TruncateTime(parseTestTime(t, "2019-01-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_MONTH, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-04-01T00:00:00Z"), TruncateTime(parseTestTime(t, "2019-05-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-01T00:00:00Z"), TruncateTime(parseTestTime(t, "2019-02-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, time.UTC, 1, 1))
+}
+
+func TestTruncateTime_Kathmandu(t *testing.T) {
+	tz, err := time.LoadLocation("Asia/Kathmandu")
+	require.NoError(t, err)
+	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:07Z"), TruncateTime(parseTestTime(t, "2019-01-07T04:20:07.29Z"), runtimev1.TimeGrain_TIME_GRAIN_SECOND, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:00Z"), TruncateTime(parseTestTime(t, "2019-01-07T04:20:07Z"), runtimev1.TimeGrain_TIME_GRAIN_MINUTE, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-07T04:15:00Z"), TruncateTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_HOUR, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-06T18:15:00Z"), TruncateTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_DAY, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-08T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-31T18:15:00Z"), TruncateTime(parseTestTime(t, "2019-02-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_MONTH, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-03-31T18:15:00Z"), TruncateTime(parseTestTime(t, "2019-05-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2018-12-31T18:15:00Z"), TruncateTime(parseTestTime(t, "2019-02-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 1, 1))
+}
+
+func TestTruncateTime_UTC_first_day(t *testing.T) {
+	tz := time.UTC
+	require.Equal(t, parseTestTime(t, "2023-10-08T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 7, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-10T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-10T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-10-11T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-10T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-10-10T00:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
+}
+
+func TestTruncateTime_Kathmandu_first_day(t *testing.T) {
+	tz, err := time.LoadLocation("Asia/Kathmandu")
+	require.NoError(t, err)
+	require.Equal(t, parseTestTime(t, "2023-10-07T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 7, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-09T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-09T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-10-11T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-09T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-10-09T18:16:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
+}
+
+func TestTruncateTime_UTC_first_month(t *testing.T) {
+	tz := time.UTC
+	require.Equal(t, parseTestTime(t, "2023-02-01T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 2))
+	require.Equal(t, parseTestTime(t, "2023-03-01T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
+	require.Equal(t, parseTestTime(t, "2023-03-01T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-03-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
+	require.Equal(t, parseTestTime(t, "2022-12-01T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 12))
+	require.Equal(t, parseTestTime(t, "2023-01-01T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-01-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 1))
+}
+
+func TestTruncateTime_Kathmandu_first_month(t *testing.T) {
+	tz, err := time.LoadLocation("Asia/Kathmandu")
+	require.NoError(t, err)
+	require.Equal(t, parseTestTime(t, "2023-01-31T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 2))
+	require.Equal(t, parseTestTime(t, "2023-02-28T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
+	require.Equal(t, parseTestTime(t, "2023-02-28T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-03-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
+	require.Equal(t, parseTestTime(t, "2022-11-30T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 12))
+	require.Equal(t, parseTestTime(t, "2022-12-31T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-01-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 1))
+}
+
+func TestCeilTime(t *testing.T) {
+	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:08Z"), CeilTime(parseTestTime(t, "2019-01-07T04:20:07.29Z"), runtimev1.TimeGrain_TIME_GRAIN_SECOND, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-07T04:21:00Z"), CeilTime(parseTestTime(t, "2019-01-07T04:20:07Z"), runtimev1.TimeGrain_TIME_GRAIN_MINUTE, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-07T05:00:00Z"), CeilTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_HOUR, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-08T00:00:00Z"), CeilTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_DAY, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-16T00:00:00Z"), CeilTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-02-01T00:00:00Z"), CeilTime(parseTestTime(t, "2019-01-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_MONTH, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-07-01T00:00:00Z"), CeilTime(parseTestTime(t, "2019-05-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, time.UTC, 1, 1))
+	require.Equal(t, parseTestTime(t, "2020-01-01T00:00:00Z"), CeilTime(parseTestTime(t, "2019-02-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, time.UTC, 1, 1))
+}
+
+func TestCeilTime_Kathmandu(t *testing.T) {
+	tz, err := time.LoadLocation("Asia/Kathmandu")
+	require.NoError(t, err)
+	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:08Z"), CeilTime(parseTestTime(t, "2019-01-07T04:20:07.29Z"), runtimev1.TimeGrain_TIME_GRAIN_SECOND, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-07T04:21:00Z"), CeilTime(parseTestTime(t, "2019-01-07T04:20:07Z"), runtimev1.TimeGrain_TIME_GRAIN_MINUTE, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-07T05:15:00Z"), CeilTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_HOUR, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-01-07T18:15:00Z"), CeilTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_DAY, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-15T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-02-28T18:15:00Z"), CeilTime(parseTestTime(t, "2019-02-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_MONTH, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-06-30T18:15:00Z"), CeilTime(parseTestTime(t, "2019-05-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, tz, 1, 1))
+	require.Equal(t, parseTestTime(t, "2019-12-31T18:15:00Z"), CeilTime(parseTestTime(t, "2019-02-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 1, 1))
+}
+
+func TestCeilTime_UTC_first_day(t *testing.T) {
+	tz := time.UTC
+	require.Equal(t, parseTestTime(t, "2023-10-15T00:00:00Z"), CeilTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 7, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-17T00:00:00Z"), CeilTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-17T00:00:00Z"), CeilTime(parseTestTime(t, "2023-10-11T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-17T00:00:00Z"), CeilTime(parseTestTime(t, "2023-10-10T00:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
+}
+
+func TestCeilTime_Kathmandu_first_day(t *testing.T) {
+	tz, err := time.LoadLocation("Asia/Kathmandu")
+	require.NoError(t, err)
+	require.Equal(t, parseTestTime(t, "2023-10-14T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 7, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-16T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-16T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-11T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
+	require.Equal(t, parseTestTime(t, "2023-10-16T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-09T18:16:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
+}
+
+func TestCeilTime_UTC_first_month(t *testing.T) {
+	tz := time.UTC
+	require.Equal(t, parseTestTime(t, "2024-02-01T00:00:00Z"), CeilTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 2))
+	require.Equal(t, parseTestTime(t, "2024-03-01T00:00:00Z"), CeilTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
+	require.Equal(t, parseTestTime(t, "2024-03-01T00:00:00Z"), CeilTime(parseTestTime(t, "2023-03-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
+	require.Equal(t, parseTestTime(t, "2023-12-01T00:00:00Z"), CeilTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 12))
+	require.Equal(t, parseTestTime(t, "2024-01-01T00:00:00Z"), CeilTime(parseTestTime(t, "2023-01-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 1))
+}
+
+func TestCeilTime_Kathmandu_first_month(t *testing.T) {
+	tz, err := time.LoadLocation("Asia/Kathmandu")
+	require.NoError(t, err)
+	require.Equal(t, parseTestTime(t, "2023-01-31T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 2))
+	require.Equal(t, parseTestTime(t, "2023-02-28T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
+	require.Equal(t, parseTestTime(t, "2023-02-28T18:15:00Z"), CeilTime(parseTestTime(t, "2023-03-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
+	require.Equal(t, parseTestTime(t, "2022-11-30T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 12))
+	require.Equal(t, parseTestTime(t, "2022-12-31T18:15:00Z"), CeilTime(parseTestTime(t, "2023-01-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 1))
+}
+
+func parseTestTime(tst *testing.T, t string) time.Time {
+	ts, err := time.Parse(time.RFC3339, t)
+	require.NoError(tst, err)
+	return ts
+}

--- a/runtime/queries/timeutil_test.go
+++ b/runtime/queries/timeutil_test.go
@@ -138,14 +138,20 @@ func TestStartTimeForRange(t *testing.T) {
 		{
 			"day light savings start US/Canada",
 			&runtimev1.TimeRange{End: timeToPB("2023-03-12T12:00:00Z"), IsoDuration: "PT4H", TimeZone: "America/Los_Angeles"},
-			"2023-03-12 00:00:00 -0800 PST",
-			"2023-03-12 05:00:00 -0700 PDT",
+			"2023-03-12T08:00:00Z",
+			"2023-03-12T12:00:00Z",
 		},
 		{
 			"day light savings end US/Canada",
 			&runtimev1.TimeRange{Start: timeToPB("2023-11-05T08:00:00.000Z"), IsoDuration: "PT4H", TimeZone: "America/Los_Angeles"},
-			"2023-11-05 01:00:00 -0700 PDT",
-			"2023-11-05 04:00:00 -0800 PST",
+			"2023-11-05T08:00:00Z",
+			"2023-11-05T12:00:00Z",
+		},
+		{
+			"going through feb",
+			&runtimev1.TimeRange{Start: timeToPB("2023-01-05T00:00:00Z"), IsoDuration: "P1M"},
+			"2023-01-05T00:00:00Z",
+			"2023-02-05T00:00:00Z",
 		},
 	}
 
@@ -156,8 +162,8 @@ func TestStartTimeForRange(t *testing.T) {
 				FirstMonthOfYear: 1,
 			})
 			require.NoError(t, err)
-			require.Equal(t, tc.start, start.String())
-			require.Equal(t, tc.end, end.String())
+			require.Equal(t, parseTestTime(t, tc.start), start.UTC())
+			require.Equal(t, parseTestTime(t, tc.end), end.UTC())
 		})
 	}
 }

--- a/runtime/queries/timeutil_test.go
+++ b/runtime/queries/timeutil_test.go
@@ -52,6 +52,13 @@ func TestTruncateTime_Kathmandu_first_day(t *testing.T) {
 
 func TestTruncateTime_UTC_first_month(t *testing.T) {
 	tz := time.UTC
+	require.Equal(t, parseTestTime(t, "2023-08-01T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, tz, 2, 2))
+	require.Equal(t, parseTestTime(t, "2023-11-01T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-11-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, tz, 2, 5))
+	require.Equal(t, parseTestTime(t, "2023-09-01T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, tz, 2, 3))
+	require.Equal(t, parseTestTime(t, "2023-09-01T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-11-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, tz, 2, 6))
+	require.Equal(t, parseTestTime(t, "2022-12-01T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-02-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, tz, 2, 3))
+	require.Equal(t, parseTestTime(t, "2022-12-01T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-02-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, tz, 2, 6))
+
 	require.Equal(t, parseTestTime(t, "2023-02-01T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 2))
 	require.Equal(t, parseTestTime(t, "2023-03-01T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
 	require.Equal(t, parseTestTime(t, "2023-03-01T00:00:00Z"), TruncateTime(parseTestTime(t, "2023-03-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
@@ -62,6 +69,13 @@ func TestTruncateTime_UTC_first_month(t *testing.T) {
 func TestTruncateTime_Kathmandu_first_month(t *testing.T) {
 	tz, err := time.LoadLocation("Asia/Kathmandu")
 	require.NoError(t, err)
+	require.Equal(t, parseTestTime(t, "2023-07-31T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, tz, 2, 2))
+	require.Equal(t, parseTestTime(t, "2023-10-31T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-11-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, tz, 2, 5))
+	require.Equal(t, parseTestTime(t, "2023-08-31T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, tz, 2, 3))
+	require.Equal(t, parseTestTime(t, "2023-08-31T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-11-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, tz, 2, 6))
+	require.Equal(t, parseTestTime(t, "2022-11-30T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-02-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, tz, 2, 3))
+	require.Equal(t, parseTestTime(t, "2022-11-30T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-02-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, tz, 2, 6))
+
 	require.Equal(t, parseTestTime(t, "2023-01-31T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 2))
 	require.Equal(t, parseTestTime(t, "2023-02-28T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
 	require.Equal(t, parseTestTime(t, "2023-02-28T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-03-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
@@ -69,67 +83,7 @@ func TestTruncateTime_Kathmandu_first_month(t *testing.T) {
 	require.Equal(t, parseTestTime(t, "2022-12-31T18:15:00Z"), TruncateTime(parseTestTime(t, "2023-01-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 1))
 }
 
-func TestCeilTime(t *testing.T) {
-	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:08Z"), CeilTime(parseTestTime(t, "2019-01-07T04:20:07.29Z"), runtimev1.TimeGrain_TIME_GRAIN_SECOND, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-07T04:21:00Z"), CeilTime(parseTestTime(t, "2019-01-07T04:20:07Z"), runtimev1.TimeGrain_TIME_GRAIN_MINUTE, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-07T05:00:00Z"), CeilTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_HOUR, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-08T00:00:00Z"), CeilTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_DAY, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-16T00:00:00Z"), CeilTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-02-01T00:00:00Z"), CeilTime(parseTestTime(t, "2019-01-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_MONTH, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-07-01T00:00:00Z"), CeilTime(parseTestTime(t, "2019-05-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, time.UTC, 1, 1))
-	require.Equal(t, parseTestTime(t, "2020-01-01T00:00:00Z"), CeilTime(parseTestTime(t, "2019-02-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, time.UTC, 1, 1))
-}
-
-func TestCeilTime_Kathmandu(t *testing.T) {
-	tz, err := time.LoadLocation("Asia/Kathmandu")
-	require.NoError(t, err)
-	require.Equal(t, parseTestTime(t, "2019-01-07T04:20:08Z"), CeilTime(parseTestTime(t, "2019-01-07T04:20:07.29Z"), runtimev1.TimeGrain_TIME_GRAIN_SECOND, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-07T04:21:00Z"), CeilTime(parseTestTime(t, "2019-01-07T04:20:07Z"), runtimev1.TimeGrain_TIME_GRAIN_MINUTE, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-07T05:15:00Z"), CeilTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_HOUR, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-01-07T18:15:00Z"), CeilTime(parseTestTime(t, "2019-01-07T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_DAY, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-15T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-02-28T18:15:00Z"), CeilTime(parseTestTime(t, "2019-02-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_MONTH, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-06-30T18:15:00Z"), CeilTime(parseTestTime(t, "2019-05-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_QUARTER, tz, 1, 1))
-	require.Equal(t, parseTestTime(t, "2019-12-31T18:15:00Z"), CeilTime(parseTestTime(t, "2019-02-07T01:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 1, 1))
-}
-
-func TestCeilTime_UTC_first_day(t *testing.T) {
-	tz := time.UTC
-	require.Equal(t, parseTestTime(t, "2023-10-15T00:00:00Z"), CeilTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 7, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-17T00:00:00Z"), CeilTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-17T00:00:00Z"), CeilTime(parseTestTime(t, "2023-10-11T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-17T00:00:00Z"), CeilTime(parseTestTime(t, "2023-10-10T00:01:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
-}
-
-func TestCeilTime_Kathmandu_first_day(t *testing.T) {
-	tz, err := time.LoadLocation("Asia/Kathmandu")
-	require.NoError(t, err)
-	require.Equal(t, parseTestTime(t, "2023-10-14T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 7, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-16T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-10T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-16T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-11T04:20:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
-	require.Equal(t, parseTestTime(t, "2023-10-16T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-09T18:16:01Z"), runtimev1.TimeGrain_TIME_GRAIN_WEEK, tz, 2, 1))
-}
-
-func TestCeilTime_UTC_first_month(t *testing.T) {
-	tz := time.UTC
-	require.Equal(t, parseTestTime(t, "2024-02-01T00:00:00Z"), CeilTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 2))
-	require.Equal(t, parseTestTime(t, "2024-03-01T00:00:00Z"), CeilTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
-	require.Equal(t, parseTestTime(t, "2024-03-01T00:00:00Z"), CeilTime(parseTestTime(t, "2023-03-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
-	require.Equal(t, parseTestTime(t, "2023-12-01T00:00:00Z"), CeilTime(parseTestTime(t, "2023-10-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 12))
-	require.Equal(t, parseTestTime(t, "2024-01-01T00:00:00Z"), CeilTime(parseTestTime(t, "2023-01-01T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 1))
-}
-
-func TestCeilTime_Kathmandu_first_month(t *testing.T) {
-	tz, err := time.LoadLocation("Asia/Kathmandu")
-	require.NoError(t, err)
-	require.Equal(t, parseTestTime(t, "2024-01-31T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 2))
-	require.Equal(t, parseTestTime(t, "2024-02-29T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
-	require.Equal(t, parseTestTime(t, "2024-02-29T18:15:00Z"), CeilTime(parseTestTime(t, "2023-03-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
-	require.Equal(t, parseTestTime(t, "2023-11-30T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 12))
-	require.Equal(t, parseTestTime(t, "2023-12-31T18:15:00Z"), CeilTime(parseTestTime(t, "2023-01-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 1))
-}
-
-func TestStartTimeForRange(t *testing.T) {
+func TestResolveTimeRange(t *testing.T) {
 	cases := []struct {
 		title      string
 		tr         *runtimev1.TimeRange
@@ -157,7 +111,7 @@ func TestStartTimeForRange(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.title, func(t *testing.T) {
-			start, end, err := StartTimeForRange(tc.tr, &runtimev1.MetricsViewSpec{
+			start, end, err := ResolveTimeRange(tc.tr, &runtimev1.MetricsViewSpec{
 				FirstDayOfWeek:   1,
 				FirstMonthOfYear: 1,
 			})

--- a/runtime/queries/timeutil_test.go
+++ b/runtime/queries/timeutil_test.go
@@ -122,11 +122,11 @@ func TestCeilTime_UTC_first_month(t *testing.T) {
 func TestCeilTime_Kathmandu_first_month(t *testing.T) {
 	tz, err := time.LoadLocation("Asia/Kathmandu")
 	require.NoError(t, err)
-	require.Equal(t, parseTestTime(t, "2023-01-31T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 2))
-	require.Equal(t, parseTestTime(t, "2023-02-28T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
-	require.Equal(t, parseTestTime(t, "2023-02-28T18:15:00Z"), CeilTime(parseTestTime(t, "2023-03-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
-	require.Equal(t, parseTestTime(t, "2022-11-30T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 12))
-	require.Equal(t, parseTestTime(t, "2022-12-31T18:15:00Z"), CeilTime(parseTestTime(t, "2023-01-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 1))
+	require.Equal(t, parseTestTime(t, "2024-01-31T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 2))
+	require.Equal(t, parseTestTime(t, "2024-02-29T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
+	require.Equal(t, parseTestTime(t, "2024-02-29T18:15:00Z"), CeilTime(parseTestTime(t, "2023-03-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 3))
+	require.Equal(t, parseTestTime(t, "2023-11-30T18:15:00Z"), CeilTime(parseTestTime(t, "2023-10-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 12))
+	require.Equal(t, parseTestTime(t, "2023-12-31T18:15:00Z"), CeilTime(parseTestTime(t, "2023-01-02T00:20:00Z"), runtimev1.TimeGrain_TIME_GRAIN_YEAR, tz, 2, 1))
 }
 
 func TestStartTimeForRange(t *testing.T) {

--- a/runtime/reconcilers/report.go
+++ b/runtime/reconcilers/report.go
@@ -320,6 +320,7 @@ func buildQuery(rep *runtimev1.Report, t time.Time) (*runtimev1.Query, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid properties for query %q: %w", rep.Spec.QueryName, err)
 		}
+		req.TimeRange = fillTimeRange(req.TimeRange, t)
 	case "MetricsViewToplist":
 		req := &runtimev1.MetricsViewToplistRequest{}
 		qry.Query = &runtimev1.Query_MetricsViewToplistRequest{MetricsViewToplistRequest: req}
@@ -348,6 +349,7 @@ func buildQuery(rep *runtimev1.Report, t time.Time) (*runtimev1.Query, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid properties for query %q: %w", rep.Spec.QueryName, err)
 		}
+		req.TimeRange = fillTimeRange(req.TimeRange, t)
 	default:
 		return nil, fmt.Errorf("query %q not supported for reports", rep.Spec.QueryName)
 	}
@@ -366,4 +368,16 @@ func formatExportFormat(f runtimev1.ExportFormat) string {
 	default:
 		return f.String()
 	}
+}
+
+func fillTimeRange(tr *runtimev1.TimeRange, t time.Time) *runtimev1.TimeRange {
+	if tr == nil {
+		tr = &runtimev1.TimeRange{}
+	}
+
+	// TODO: does it make sense to override start/end here? Or should we keep the user defined start/end?
+	tr.End = timestamppb.New(t)
+	tr.Start = nil
+
+	return tr
 }

--- a/runtime/reconcilers/report.go
+++ b/runtime/reconcilers/report.go
@@ -320,7 +320,7 @@ func buildQuery(rep *runtimev1.Report, t time.Time) (*runtimev1.Query, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid properties for query %q: %w", rep.Spec.QueryName, err)
 		}
-		req.TimeRange = fillTimeRange(req.TimeRange, t)
+		req.TimeRange = overrideTimeRange(req.TimeRange, t)
 	case "MetricsViewToplist":
 		req := &runtimev1.MetricsViewToplistRequest{}
 		qry.Query = &runtimev1.Query_MetricsViewToplistRequest{MetricsViewToplistRequest: req}
@@ -349,7 +349,7 @@ func buildQuery(rep *runtimev1.Report, t time.Time) (*runtimev1.Query, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid properties for query %q: %w", rep.Spec.QueryName, err)
 		}
-		req.TimeRange = fillTimeRange(req.TimeRange, t)
+		req.TimeRange = overrideTimeRange(req.TimeRange, t)
 	default:
 		return nil, fmt.Errorf("query %q not supported for reports", rep.Spec.QueryName)
 	}
@@ -370,14 +370,12 @@ func formatExportFormat(f runtimev1.ExportFormat) string {
 	}
 }
 
-func fillTimeRange(tr *runtimev1.TimeRange, t time.Time) *runtimev1.TimeRange {
+func overrideTimeRange(tr *runtimev1.TimeRange, t time.Time) *runtimev1.TimeRange {
 	if tr == nil {
 		tr = &runtimev1.TimeRange{}
 	}
 
-	// TODO: does it make sense to override start/end here? Or should we keep the user defined start/end?
 	tr.End = timestamppb.New(t)
-	tr.Start = nil
 
 	return tr
 }


### PR DESCRIPTION
UI rounds time ranges based on selected time grain. We need the same support for reports.

This PR adds,
- [x] Support for round_to_grain.
- [x] Verify the new method `CeilTime`
- [x] First day and first month support.
- [x] Update report generation to use this.
- [x] Add tests for day light savings.