### PR TITLE
Don't publish latest image

### DIFF
--- a/.github/workflows/rill-cloud.yml
+++ b/.github/workflows/rill-cloud.yml
@@ -45,9 +45,7 @@ jobs:
           gcloud auth configure-docker
 
           docker build -t gcr.io/rilldata/rill-headless:${GITHUB_SHA} .
-          docker tag gcr.io/rilldata/rill-headless:${GITHUB_SHA} gcr.io/rilldata/rill-headless
           docker push gcr.io/rilldata/rill-headless:${GITHUB_SHA}
-          docker push gcr.io/rilldata/rill-headless
 
           if [ ${RELEASE} == "true" ]; then
             docker tag gcr.io/rilldata/rill-headless:${GITHUB_SHA} gcr.io/rilldata/rill-headless:${GITHUB_REF_NAME}


### PR DESCRIPTION
its confusing

```
$ docker pull gcr.io/rilldata/rill-headless
Using default tag: latest
Error response from daemon: manifest for gcr.io/rilldata/rill-headless:latest not found: manifest unknown: Failed to fetch "latest" from request "/v2/rilldata/rill-headless/manifests/latest".
```