### PR TITLE
Support explicitly overriding DuckDB threads and max_memory configs

### DIFF
--- a/runtime/drivers/duckdb/config.go
+++ b/runtime/drivers/duckdb/config.go
@@ -97,7 +97,7 @@ func newConfig(cfgMap map[string]any) (*config, error) {
 		// For backwards compatibility, we also support overriding the pool size via the DSN when "rill_pool_size" is a query argument.
 
 		// Parse as integer
-		cfg.PoolSize, err = strconv.Atoi(qry.Get("rill_pool_size"))
+		poolSize, err = strconv.Atoi(qry.Get("rill_pool_size"))
 		if err != nil {
 			return nil, fmt.Errorf("could not parse dsn: 'rill_pool_size' is not an integer")
 		}
@@ -110,8 +110,9 @@ func newConfig(cfgMap map[string]any) (*config, error) {
 		if cfg.CPU != 0 && cfg.CPU < poolSize {
 			poolSize = cfg.CPU
 		}
+		poolSize = min(poolSizeMax, poolSize) // Only enforce max pool size when inferred from threads/CPU
 	}
-	poolSize = min(poolSizeMax, max(poolSizeMin, poolSize)) // Force poolSize to be between min and max values
+	poolSize = max(poolSizeMin, poolSize) // Always enforce min pool size
 	cfg.PoolSize = poolSize
 
 	// Rebuild DuckDB DSN (which should be "path?key=val&...")

--- a/runtime/drivers/duckdb/config.go
+++ b/runtime/drivers/duckdb/config.go
@@ -11,8 +11,8 @@ import (
 
 const (
 	cpuThreadRatio float64 = 0.5
+	poolSizeMin    int     = 2
 	poolSizeMax    int     = 5
-	poolSizeMin            = 2
 )
 
 // config represents the DuckDB driver config
@@ -35,7 +35,7 @@ type config struct {
 	StorageLimitBytes int64 `mapstructure:"storage_limit_bytes"`
 	// MaxMemoryOverride sets a hard override for the "max_memory" DuckDB setting
 	MaxMemoryGBOverride int `mapstructure:"max_memory_gb_override"`
-	// ThreadsOverride sets a hard override for the "threads" DuckDB setting
+	// ThreadsOverride sets a hard override for the "threads" DuckDB setting. Set to -1 for unlimited threads.
 	ThreadsOverride int `mapstructure:"threads_override"`
 	// BootQueries is queries to run on boot. Use ; to separate multiple queries. Common use case is to provide project specific memory and threads ratios.
 	BootQueries string `mapstructure:"boot_queries"`
@@ -87,7 +87,7 @@ func newConfig(cfgMap map[string]any) (*config, error) {
 			threads = 1
 		}
 	}
-	if threads != 0 {
+	if threads > 0 { // NOTE: threads=0 or threads=-1 means no limit
 		qry.Add("threads", strconv.Itoa(threads))
 	}
 

--- a/runtime/drivers/duckdb/config.go
+++ b/runtime/drivers/duckdb/config.go
@@ -9,7 +9,10 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-const cpuThreadRatio float64 = 0.5
+const (
+	cpuThreadRatio float64 = 0.5
+	maxPoolSize    int     = 5
+)
 
 // config represents the DuckDB driver config
 type config struct {
@@ -45,6 +48,7 @@ func newConfig(cfgMap map[string]any) (*config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not decode config: %w", err)
 	}
+	cfg.PoolSize = min(maxPoolSize, cfg.PoolSize)
 
 	// Parse DSN as URL
 	uri, err := url.Parse(cfg.DSN)
@@ -82,9 +86,9 @@ func newConfig(cfgMap map[string]any) (*config, error) {
 			threads = 1
 		}
 		qry.Add("threads", strconv.Itoa(threads))
-		// pool size between 2 and 10
+		// pool size between 2 and `maxPoolSize`
 		if _, ok := cfgMap["pool_size"]; !ok { // set only if not provided
-			cfg.PoolSize = min(10, max(2, min(cfg.CPU, threads)))
+			cfg.PoolSize = min(maxPoolSize, max(2, min(cfg.CPU, threads)))
 		}
 	}
 

--- a/runtime/drivers/duckdb/config.go
+++ b/runtime/drivers/duckdb/config.go
@@ -83,7 +83,9 @@ func newConfig(cfgMap map[string]any) (*config, error) {
 		}
 		qry.Add("threads", strconv.Itoa(threads))
 		// pool size between 2 and 10
-		cfg.PoolSize = min(10, max(2, min(cfg.CPU, threads)))
+		if _, ok := cfgMap["pool_size"]; !ok { // set only if not provided
+			cfg.PoolSize = min(10, max(2, min(cfg.CPU, threads)))
+		}
 	}
 
 	// Rebuild DuckDB DSN (which should be "path?key=val&...")

--- a/runtime/drivers/duckdb/config.go
+++ b/runtime/drivers/duckdb/config.go
@@ -93,17 +93,18 @@ func newConfig(cfgMap map[string]any) (*config, error) {
 
 	// Set pool size
 	poolSize := cfg.PoolSize
-	if poolSize == 0 && qry.Has("rill_pool_size") {
+	if qry.Has("rill_pool_size") {
 		// For backwards compatibility, we also support overriding the pool size via the DSN when "rill_pool_size" is a query argument.
 
+		// Remove from query string (so not passed into DuckDB config)
+		val := qry.Get("rill_pool_size")
+		qry.Del("rill_pool_size")
+
 		// Parse as integer
-		poolSize, err = strconv.Atoi(qry.Get("rill_pool_size"))
+		poolSize, err = strconv.Atoi(val)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse dsn: 'rill_pool_size' is not an integer")
 		}
-
-		// Remove from query string (so not passed into DuckDB config)
-		qry.Del("rill_pool_size")
 	}
 	if poolSize == 0 && threads != 0 {
 		poolSize = threads

--- a/runtime/drivers/duckdb/config_test.go
+++ b/runtime/drivers/duckdb/config_test.go
@@ -39,11 +39,11 @@ func TestConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "path/to/duck.db", cfg.DSN)
 	require.Equal(t, "path/to/duck.db", cfg.DBFilePath)
-	require.Equal(t, 10, cfg.PoolSize)
+	require.Equal(t, 5, cfg.PoolSize)
 
 	cfg, err = newConfig(map[string]any{"dsn": "path/to/duck.db", "pool_size": "10"})
 	require.NoError(t, err)
-	require.Equal(t, 10, cfg.PoolSize)
+	require.Equal(t, 5, cfg.PoolSize)
 
 	cfg, err = newConfig(map[string]any{"dsn": "path/to/duck.db?rill_pool_size=4", "pool_size": "10"})
 	require.NoError(t, err)

--- a/runtime/drivers/duckdb/config_test.go
+++ b/runtime/drivers/duckdb/config_test.go
@@ -39,15 +39,15 @@ func TestConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "path/to/duck.db", cfg.DSN)
 	require.Equal(t, "path/to/duck.db", cfg.DBFilePath)
-	require.Equal(t, 5, cfg.PoolSize)
+	require.Equal(t, 10, cfg.PoolSize)
 
 	cfg, err = newConfig(map[string]any{"dsn": "path/to/duck.db", "pool_size": "10"})
 	require.NoError(t, err)
-	require.Equal(t, 5, cfg.PoolSize)
+	require.Equal(t, 10, cfg.PoolSize)
 
 	cfg, err = newConfig(map[string]any{"dsn": "path/to/duck.db?rill_pool_size=4", "pool_size": "10"})
 	require.NoError(t, err)
-	require.Equal(t, 4, cfg.PoolSize)
+	require.Equal(t, 10, cfg.PoolSize)
 
 	cfg, err = newConfig(map[string]any{"dsn": "path/to/duck.db?rill_pool_size=10"})
 	require.NoError(t, err)
@@ -62,9 +62,6 @@ func TestConfig(t *testing.T) {
 	require.Equal(t, "path/to/duck.db", cfg.DBFilePath)
 
 	_, err = newConfig(map[string]any{"dsn": "path/to/duck.db?max_memory=4GB", "pool_size": "abc"})
-	require.Error(t, err)
-
-	_, err = newConfig(map[string]any{"dsn": "path/to/duck.db?max_memory=4GB", "pool_size": 0})
 	require.Error(t, err)
 
 	cfg, err = newConfig(map[string]any{"dsn": "duck.db"})

--- a/runtime/drivers/duckdb/config_test.go
+++ b/runtime/drivers/duckdb/config_test.go
@@ -47,7 +47,7 @@ func TestConfig(t *testing.T) {
 
 	cfg, err = newConfig(map[string]any{"dsn": "path/to/duck.db?rill_pool_size=4", "pool_size": "10"})
 	require.NoError(t, err)
-	require.Equal(t, 10, cfg.PoolSize)
+	require.Equal(t, 4, cfg.PoolSize)
 
 	cfg, err = newConfig(map[string]any{"dsn": "path/to/duck.db?rill_pool_size=10"})
 	require.NoError(t, err)

--- a/runtime/drivers/duckdb/config_test.go
+++ b/runtime/drivers/duckdb/config_test.go
@@ -110,8 +110,8 @@ func Test_specialCharInPath(t *testing.T) {
 	require.NoError(t, conn.Close())
 }
 
-func TestBootQueries(t *testing.T) {
-	cfgMap := map[string]any{"dsn": "duck.db", "memory_limit_gb": "4", "cpu": "2", "boot_queries": "SET max_memory='2GB';SET threads=10"}
+func TestOverrides(t *testing.T) {
+	cfgMap := map[string]any{"dsn": "duck.db", "memory_limit_gb": "4", "cpu": "2", "max_memory_gb_override": "2", "threads_override": "10"}
 	handle, err := Driver{}.Open(cfgMap, false, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 


### PR DESCRIPTION
1. Adds option to set custom duckdb configurations via `rill env set connector.duckdb.boot_queries "SET max_memory='12GB';SET threads=30" --project=rill-examples`
2. `pool_size` can be capped by `rill env set connector.duckdb.pool_size 2 --project=rill-examples`
3. Limits default pool size to a max of 5.