### PR TITLE
Fixing url state with value based visuals

### DIFF
--- a/web-common/src/features/dashboards/proto-state/fromProto.ts
+++ b/web-common/src/features/dashboards/proto-state/fromProto.ts
@@ -88,12 +88,18 @@ export function getDashboardStateFromProto(
   }
   if (dashboard.selectedDimension) {
     entity.selectedDimensionName = dashboard.selectedDimension;
+  } else {
+    entity.selectedDimensionName = undefined;
   }
   if (dashboard.expandedMeasure) {
     entity.expandedMeasureName = dashboard.expandedMeasure;
+  } else {
+    entity.expandedMeasureName = undefined;
   }
   if (dashboard.comparisonDimension) {
     entity.selectedComparisonDimension = dashboard.comparisonDimension;
+  } else {
+    entity.selectedComparisonDimension = undefined;
   }
 
   if (dashboard.selectedTimezone) {

--- a/web-common/src/features/dashboards/proto-state/toProto.ts
+++ b/web-common/src/features/dashboards/proto-state/toProto.ts
@@ -82,8 +82,7 @@ export function getProtoFromDashboardState(
   if (metrics.expandedMeasureName) {
     state.expandedMeasure = metrics.expandedMeasureName;
   }
-  if (metrics.selectedDimensionName && !state.showTimeComparison) {
-    // TODO: we need an enum to decide what is being selected for comparison. This should be reflected in proto as well.
+  if (metrics.selectedDimensionName) {
     state.selectedDimension = metrics.selectedDimensionName;
   }
 

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -197,9 +197,6 @@ const metricViewReducers = {
       if (!partial.showTimeComparison) {
         metricsExplorer.showTimeComparison = false;
       }
-      if (!partial.selectedComparisonDimension) {
-        metricsExplorer.selectedComparisonDimension = undefined;
-      }
       metricsExplorer.dimensionFilterExcludeMode =
         includeExcludeModeFromFilters(partial.filters);
     });


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Going back by using back button fails for TDD and DimensionTable.

#### Details:
Making sure absence of TDD measure and DimensionTable dimension marks it as undefined in `fromProto`. In the long run we should enums to denote what is being shown instead of the method we have.

## Steps to Verify
1. Create a dashboard with a timeseries.
2. Go to TDD view.
3. Click back button.
4. TDD view should go away.