### PR TITLE
Fixing dashbaord refresh due to source refresh

### DIFF
--- a/web-common/src/features/dashboards/workspace/DashboardCTAs.svelte
+++ b/web-common/src/features/dashboards/workspace/DashboardCTAs.svelte
@@ -30,7 +30,7 @@
 
   $: dashboardQuery = useDashboard($runtime.instanceId, metricViewName);
   $: dashboardIsIdle =
-    $dashboardQuery.data.meta.reconcileStatus ===
+    $dashboardQuery.data?.meta?.reconcileStatus ===
     V1ReconcileStatus.RECONCILE_STATUS_IDLE;
 
   function viewMetrics(metricViewName: string) {

--- a/web-common/src/features/entity-management/resource-status-utils.ts
+++ b/web-common/src/features/entity-management/resource-status-utils.ts
@@ -162,7 +162,8 @@ export function waitForResourceUpdate(
 export function getResourceStatusStore(
   queryClient: QueryClient,
   instanceId: string,
-  filePath: string
+  filePath: string,
+  validator?: (res: V1Resource) => boolean
 ): Readable<ResourceStatusState> {
   return derived(
     [
@@ -189,10 +190,15 @@ export function getResourceStatusStore(
         };
       }
 
-      const isBusy =
-        resourceResp.isFetching ||
-        resourceResp.data?.meta?.reconcileStatus !==
-          V1ReconcileStatus.RECONCILE_STATUS_IDLE;
+      let isBusy: boolean;
+      if (validator && resourceResp.data) {
+        isBusy = !validator(resourceResp.data);
+      } else {
+        isBusy =
+          resourceResp.isFetching ||
+          resourceResp.data?.meta?.reconcileStatus !==
+            V1ReconcileStatus.RECONCILE_STATUS_IDLE;
+      }
 
       return {
         status: isBusy ? ResourceStatus.Busy : ResourceStatus.Idle,

--- a/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
@@ -45,7 +45,8 @@
   $: resourceStatusStore = getResourceStatusStore(
     queryClient,
     $runtime.instanceId,
-    filePath
+    filePath,
+    (res) => !!res?.metricsView?.state?.validSpec
   );
   let showErrorPage = false;
   $: if (metricViewName) {


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
closes #3388

#### Details:
There was a null check missing due to which dashboard meta query refresh would crash the app.

## Steps to Verify
1. Create a source (preferably a local file) with a refresh.
2. Create a dashboard out of this.
3. While the dashboard is active it should refresh periodically and not crash the app.