### PR TITLE
Fix Project deployment status to show loading while dashboard list is loading.

### DIFF
--- a/web-admin/src/features/projects/ProjectDeploymentStatusChip.svelte
+++ b/web-admin/src/features/projects/ProjectDeploymentStatusChip.svelte
@@ -97,17 +97,6 @@
       textClass: "text-purple-600",
       wrapperClass: "bg-purple-50 border-purple-300",
     },
-    // [V1DeploymentStatus.DEPLOYMENT_STATUS_RECONCILING]: {
-    //   icon: Spinner,
-    //   iconProps: {
-    //     bg: "linear-gradient(90deg, #22D3EE -0.5%, #6366F1 98.5%)",
-    //     className: "text-purple-600 hover:text-purple-500",
-    //     status: EntityStatus.Running,
-    //   },
-    //   text: "syncing",
-    //   textClass: "text-purple-600",
-    //   wrapperClass: "bg-purple-50 border-purple-300",
-    // },
     [V1DeploymentStatus.DEPLOYMENT_STATUS_ERROR]: {
       icon: CancelCircle,
       iconProps: { className: "text-red-600 hover:text-red-500" },
@@ -136,15 +125,17 @@
       currentStatusDisplay =
         statusDisplays[
           $deploymentStatusFromDashboards?.data ??
-            ($deploymentStatusFromDashboards.isFetching
-              ? V1DeploymentStatus.DEPLOYMENT_STATUS_PENDING
-              : V1DeploymentStatus.DEPLOYMENT_STATUS_UNSPECIFIED)
+            V1DeploymentStatus.DEPLOYMENT_STATUS_UNSPECIFIED
         ];
     }
   }
 </script>
 
-{#if deploymentStatus}
+{#if $deploymentStatusFromDashboards.isFetching && !$deploymentStatusFromDashboards?.data}
+  <div class="p-0.5">
+    <Spinner status={EntityStatus.Running} size="16px" />
+  </div>
+{:else if deploymentStatus}
   {#if iconOnly}
     <div class="pb-0.5">
       <svelte:component

--- a/web-admin/src/features/projects/ProjectDeploymentStatusChip.svelte
+++ b/web-admin/src/features/projects/ProjectDeploymentStatusChip.svelte
@@ -136,7 +136,9 @@
       currentStatusDisplay =
         statusDisplays[
           $deploymentStatusFromDashboards?.data ??
-            V1DeploymentStatus.DEPLOYMENT_STATUS_UNSPECIFIED
+            ($deploymentStatusFromDashboards.isFetching
+              ? V1DeploymentStatus.DEPLOYMENT_STATUS_PENDING
+              : V1DeploymentStatus.DEPLOYMENT_STATUS_UNSPECIFIED)
         ];
     }
   }


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
We were using DEPLOYMENT_STATUS_UNSPECIFIED while the dashboard list is loading.

#### Details:
Using DEPLOYMENT_STATUS_PENDING while the dashboard list is loading.

## Steps to Verify
<!-- PROVIDE INFORMATION ON HOW TO CHECK THIS ADDITION
For example, given a new button "Foo" in the dashboard:
1. Run `npm run dev`
2. Open localhost:3000 and navigate to a dashboard
3. Click the "Foo" button in corner
4. Observe the side effect
 -->