### PR TITLE
Adding a redirect to source on import

### DIFF
--- a/web-common/src/features/sources/modal/FileDrop.svelte
+++ b/web-common/src/features/sources/modal/FileDrop.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { goto } from "$app/navigation";
   import Overlay from "@rilldata/web-common/components/overlay/Overlay.svelte";
   import { getFilePathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import { EntityType } from "@rilldata/web-common/features/entity-management/types";
@@ -58,6 +59,7 @@
           tableName,
           getFilePathFromNameAndType(tableName, EntityType.Table)
         );
+        goto(`/source/${tableName}`);
       } catch (err) {
         console.error(err);
       }

--- a/web-common/src/features/sources/modal/LocalSourceUpload.svelte
+++ b/web-common/src/features/sources/modal/LocalSourceUpload.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { goto } from "$app/navigation";
   import { Button } from "@rilldata/web-common/components/button";
   import { getFilePathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import { EntityType } from "@rilldata/web-common/features/entity-management/types";
@@ -67,6 +68,7 @@
           tableName,
           getFilePathFromNameAndType(tableName, EntityType.Table)
         );
+        goto(`/source/${tableName}`);
       } catch (err) {
         console.error(err);
       }

--- a/web-common/src/features/sources/modal/RemoteSourceForm.svelte
+++ b/web-common/src/features/sources/modal/RemoteSourceForm.svelte
@@ -72,16 +72,16 @@
 
 <div class="h-full w-full flex flex-col">
   <form
-    on:submit|preventDefault={handleSubmit}
-    id="remote-source-{connector.name}-form"
     class="pb-2 flex-grow overflow-y-auto"
+    id="remote-source-{connector.name}-form"
+    on:submit|preventDefault={handleSubmit}
   >
     <div class="pb-2">
       Need help? Refer to our
       <a
         href="https://docs.rilldata.com/develop/import-data"
-        target="_blank"
-        rel="noreferrer">docs</a
+        rel="noreferrer"
+        target="_blank">docs</a
       > for more information.
     </div>
     {#if rpcError}
@@ -132,10 +132,10 @@
   <div class="flex items-center space-x-2">
     <div class="grow" />
     <Button
-      type="primary"
-      submitForm
-      form="remote-source-{connector.name}-form"
       disabled={$isSubmitting}
+      form="remote-source-{connector.name}-form"
+      submitForm
+      type="primary"
     >
       Add source
     </Button>


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
On a fresh project local imports take some time after the file upload before redirecting to the source. This feels like nothing happened after an upload.

#### Details:
Adding a redirect to the source page so that the `ingesting` message is shown and there is a feedback after an upload.

## Steps to Verify
1. Start from a fresh project.
2. Upload a large file.
3. After the `importing` overlay is closed the page should redirect to source page where the `ingesting` message is shown.