### PR TITLE
Fixing creating a dashboard after editing a model

### DIFF
--- a/web-common/src/features/entity-management/resource-invalidations.ts
+++ b/web-common/src/features/entity-management/resource-invalidations.ts
@@ -84,6 +84,9 @@ async function invalidateResource(
   const lastStateUpdatedOn = getLastStateUpdatedOn(resource);
   if (
     resource.meta.reconcileStatus !== V1ReconcileStatus.RECONCILE_STATUS_IDLE ||
+    // There is an event for a newly created resource with status = IDLE just before they are queued for reconcile.
+    // To keep everything else simple it is better to ignore those events.
+    !lastStateUpdatedOn ||
     lastStateUpdatedOn === resource.meta.stateUpdatedOn
   )
     return;

--- a/web-common/src/features/entity-management/resource-invalidations.ts
+++ b/web-common/src/features/entity-management/resource-invalidations.ts
@@ -83,10 +83,17 @@ async function invalidateResource(
 
   const lastStateUpdatedOn = getLastStateUpdatedOn(resource);
   if (
+    resource.meta.reconcileStatus !== V1ReconcileStatus.RECONCILE_STATUS_IDLE &&
+    !lastStateUpdatedOn
+  ) {
+    // When a resource is created it can send an event with status = IDLE just before it is queued for reconcile.
+    // So handle the case when it is 1st queued and status != IDLE
+    resourcesStore.setVersion(resource);
+    return;
+  }
+
+  if (
     resource.meta.reconcileStatus !== V1ReconcileStatus.RECONCILE_STATUS_IDLE ||
-    // There is an event for a newly created resource with status = IDLE just before they are queued for reconcile.
-    // To keep everything else simple it is better to ignore those events.
-    !lastStateUpdatedOn ||
     lastStateUpdatedOn === resource.meta.stateUpdatedOn
   )
     return;


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Every now and then creating a dashboard fails and redirects to edit page. But immediately going to the dashboard works without needing a refresh. This happens consistently when adding a column and removing it before autogenerating a dashboard.

#### Details:
Adding a workaround for an event for resource when it is created. Ignoring it when status=IDLE and we have not seen it before.

## Steps to Verify
1. Create a model with a timestamp and one dimension.
2. Create a dashboard and delete it.
3. Add `*` to the model and remove it.
4. Create a dashboard. (Make sure to wait a little, there is another issue not fixed in this PR if done too quickly)
5. Should work without an issue and redirect to the dashboard page.