### PR TITLE
Adding safeguard for creation of dashboard while model is being ingested

### DIFF
--- a/web-common/src/features/entity-management/resource-selectors.ts
+++ b/web-common/src/features/entity-management/resource-selectors.ts
@@ -4,13 +4,12 @@ import {
   createRuntimeServiceListResources,
   V1ListResourcesResponse,
   V1ModelV2,
-  V1OLAPGetTableResponse,
   V1ReconcileStatus,
   V1Resource,
   V1SourceV2,
 } from "@rilldata/web-common/runtime-client";
 import type { QueryClient } from "@tanstack/svelte-query";
-import { derived, Readable } from "svelte/store";
+import { derived } from "svelte/store";
 
 export enum ResourceKind {
   ProjectParser = "rill.runtime.v1.ProjectParser",

--- a/web-common/src/features/models/createDashboardFromModel.ts
+++ b/web-common/src/features/models/createDashboardFromModel.ts
@@ -1,0 +1,213 @@
+import { goto } from "$app/navigation";
+import { notifications } from "@rilldata/web-common/components/notifications";
+import { useDashboardFileNames } from "@rilldata/web-common/features/dashboards/selectors";
+import {
+  getFileAPIPathFromNameAndType,
+  getFilePathFromNameAndType,
+} from "@rilldata/web-common/features/entity-management/entity-mappers";
+import { getName } from "@rilldata/web-common/features/entity-management/name-utils";
+import {
+  createSchemaForTable,
+  ResourceKind,
+  useResource,
+} from "@rilldata/web-common/features/entity-management/resource-selectors";
+import { waitForResource } from "@rilldata/web-common/features/entity-management/resource-status-utils";
+import { EntityType } from "@rilldata/web-common/features/entity-management/types";
+import { generateDashboardYAMLForModel } from "@rilldata/web-common/features/metrics-views/metrics-internal-store";
+import { appScreen } from "@rilldata/web-common/layout/app-store";
+import { overlay } from "@rilldata/web-common/layout/overlay-store";
+import { behaviourEvent } from "@rilldata/web-common/metrics/initMetrics";
+import type { BehaviourEventMedium } from "@rilldata/web-common/metrics/service/BehaviourEventTypes";
+import {
+  MetricsEventScreenName,
+  MetricsEventSpace,
+} from "@rilldata/web-common/metrics/service/MetricsTypes";
+import {
+  RpcStatus,
+  runtimeServicePutFile,
+  V1ReconcileStatus,
+  V1StructType,
+} from "@rilldata/web-common/runtime-client";
+import {
+  createMutation,
+  CreateMutationOptions,
+  MutationFunction,
+  QueryClient,
+  useQueryClient,
+} from "@tanstack/svelte-query";
+import { derived, get } from "svelte/store";
+
+export interface CreateDashboardFromModelRequest {
+  instanceId: string;
+  modelName: string;
+  schema: V1StructType;
+  newDashboardName: string;
+}
+
+export const useCreateDashboardFromModel = <
+  TError = RpcStatus,
+  TContext = unknown
+>(options?: {
+  mutation?: CreateMutationOptions<
+    Awaited<Promise<void>>,
+    TError,
+    { data: CreateDashboardFromModelRequest },
+    TContext
+  >;
+}) => {
+  const { mutation: mutationOptions } = options ?? {};
+  const queryClient = mutationOptions?.queryClient ?? useQueryClient();
+
+  const mutationFn: MutationFunction<
+    Awaited<Promise<void>>,
+    { data: CreateDashboardFromModelRequest }
+  > = async (props) => {
+    const { data } = props ?? {};
+    if (!data.schema)
+      throw new Error("Failed to create dashboard: Model is not ready");
+
+    // create dashboard from model
+    const dashboardYAML = generateDashboardYAMLForModel(
+      data.modelName,
+      data.schema,
+      data.newDashboardName
+    );
+
+    await runtimeServicePutFile(
+      data.instanceId,
+      getFileAPIPathFromNameAndType(
+        data.newDashboardName,
+        EntityType.MetricsDefinition
+      ),
+      {
+        blob: dashboardYAML,
+        create: true,
+        createOnly: true,
+      }
+    );
+    await waitForResource(
+      queryClient,
+      data.instanceId,
+      getFilePathFromNameAndType(
+        data.newDashboardName,
+        EntityType.MetricsDefinition
+      )
+    );
+  };
+
+  return createMutation<
+    Awaited<Promise<void>>,
+    TError,
+    { data: CreateDashboardFromModelRequest },
+    TContext
+  >(mutationFn, mutationOptions);
+};
+
+function modelHasDataStore(
+  queryClient: QueryClient,
+  instanceId: string,
+  modelName: string
+) {
+  return derived(
+    [
+      useResource(
+        instanceId,
+        modelName,
+        ResourceKind.Model,
+        undefined,
+        queryClient
+      ),
+      createSchemaForTable(
+        instanceId,
+        modelName,
+        ResourceKind.Model,
+        queryClient
+      ),
+    ],
+    ([model, schema]) => {
+      return (
+        !model.isFetching &&
+        !!model.data &&
+        model.data.meta.reconcileStatus ===
+          V1ReconcileStatus.RECONCILE_STATUS_IDLE &&
+        !schema.isFetching &&
+        !!schema.data
+      );
+    }
+  );
+}
+
+function waitForModelHasData(
+  queryClient: QueryClient,
+  instanceId: string,
+  modelName: string
+) {
+  const store = modelHasDataStore(queryClient, instanceId, modelName);
+  if (get(store)) return;
+  return new Promise<void>((resolve) => {
+    const unsub = store.subscribe((hasData) => {
+      if (!hasData) return;
+      resolve();
+      unsub();
+    });
+  });
+}
+
+/**
+ * Wrapper function that takes care of UI side effects on top of creating a dashboard from model.
+ * TODO: where would this go?
+ */
+export function useCreateDashboardFromModelUIAction(
+  instanceId: string,
+  modelName: string,
+  queryClient: QueryClient,
+  behaviourEventMedium: BehaviourEventMedium,
+  metricsEventSpace: MetricsEventSpace
+) {
+  const createDashboardFromModelMutation = useCreateDashboardFromModel();
+  const dashboardNames = useDashboardFileNames(instanceId);
+  const schemaForModel = createSchemaForTable(
+    instanceId,
+    modelName,
+    ResourceKind.Model,
+    queryClient
+  );
+
+  return async () => {
+    overlay.set({
+      title: "Creating a dashboard for " + modelName,
+    });
+    const newDashboardName = getName(
+      `${modelName}_dashboard`,
+      get(dashboardNames).data
+    );
+
+    // Wait for model query to have data
+    await waitForModelHasData(queryClient, instanceId, modelName);
+
+    try {
+      await get(createDashboardFromModelMutation).mutateAsync({
+        data: {
+          instanceId,
+          modelName,
+          schema: get(schemaForModel).data.schema,
+          newDashboardName,
+        },
+      });
+      goto(`/dashboard/${newDashboardName}`);
+      behaviourEvent.fireNavigationEvent(
+        newDashboardName,
+        behaviourEventMedium,
+        metricsEventSpace,
+        get(appScreen)?.type,
+        MetricsEventScreenName.Dashboard
+      );
+    } catch (err) {
+      notifications.send({
+        message: "Failed to create a dashboard for " + modelName,
+        detail: err.response?.data?.message ?? err.message,
+      });
+    }
+    overlay.set(null);
+  };
+}

--- a/web-common/src/features/models/navigation/ModelMenuItems.svelte
+++ b/web-common/src/features/models/navigation/ModelMenuItems.svelte
@@ -1,37 +1,19 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
   import Cancel from "@rilldata/web-common/components/icons/Cancel.svelte";
   import EditIcon from "@rilldata/web-common/components/icons/EditIcon.svelte";
   import Explore from "@rilldata/web-common/components/icons/Explore.svelte";
   import { Divider, MenuItem } from "@rilldata/web-common/components/menu";
-  import { useDashboardFileNames } from "@rilldata/web-common/features/dashboards/selectors";
-  import {
-    getFileAPIPathFromNameAndType,
-    getFilePathFromNameAndType,
-  } from "@rilldata/web-common/features/entity-management/entity-mappers";
-  import { useSchemaForTable } from "@rilldata/web-common/features/entity-management/resource-selectors";
-  import { waitForResource } from "@rilldata/web-common/features/entity-management/resource-status-utils";
+  import { getFilePathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import { getFileHasErrors } from "@rilldata/web-common/features/entity-management/resources-store";
   import { EntityType } from "@rilldata/web-common/features/entity-management/types";
-  import { appScreen } from "@rilldata/web-common/layout/app-store";
-  import { overlay } from "@rilldata/web-common/layout/overlay-store";
-  import { waitUntil } from "@rilldata/web-common/lib/waitUtils";
-  import { behaviourEvent } from "@rilldata/web-common/metrics/initMetrics";
+  import { useCreateDashboardFromModelUIAction } from "@rilldata/web-common/features/models/createDashboardFromModel";
   import { BehaviourEventMedium } from "@rilldata/web-common/metrics/service/BehaviourEventTypes";
-  import {
-    MetricsEventScreenName,
-    MetricsEventSpace,
-  } from "@rilldata/web-common/metrics/service/MetricsTypes";
-  import {
-    createRuntimeServicePutFile,
-    V1ReconcileStatus,
-  } from "@rilldata/web-common/runtime-client";
+  import { MetricsEventSpace } from "@rilldata/web-common/metrics/service/MetricsTypes";
+  import { V1ReconcileStatus } from "@rilldata/web-common/runtime-client";
   import { useQueryClient } from "@tanstack/svelte-query";
   import { createEventDispatcher } from "svelte";
   import { runtime } from "../../../runtime-client/runtime-store";
   import { deleteFileArtifact } from "../../entity-management/actions";
-  import { getName } from "../../entity-management/name-utils";
-  import { generateDashboardYAMLForModel } from "../../metrics-views/metrics-internal-store";
   import { useModel, useModelFileNames } from "../selectors";
 
   export let modelName: string;
@@ -42,10 +24,7 @@
   const queryClient = useQueryClient();
   const dispatch = createEventDispatcher();
 
-  const createFileMutation = createRuntimeServicePutFile();
-
   $: modelNames = useModelFileNames($runtime.instanceId);
-  $: dashboardNames = useDashboardFileNames($runtime.instanceId);
   $: modelQuery = useModel($runtime.instanceId, modelName);
   $: modelHasError = getFileHasErrors(
     queryClient,
@@ -57,72 +36,18 @@
     V1ReconcileStatus.RECONCILE_STATUS_IDLE;
   $: disableCreateDashboard = $modelHasError || !modelIsIdle;
 
-  $: modelSchema = useSchemaForTable(
+  $: createDashboardFromModel = useCreateDashboardFromModelUIAction(
     $runtime.instanceId,
-    $modelQuery.data?.model
+    modelName,
+    queryClient,
+    BehaviourEventMedium.Menu,
+    MetricsEventSpace.LeftPanel
   );
 
-  const createDashboardFromModel = async (modelName: string) => {
-    if (!$modelQuery.data?.model) {
-      return;
-    }
-
-    overlay.set({
-      title: "Creating a dashboard for " + modelName,
-    });
-    const newDashboardName = getName(
-      `${modelName}_dashboard`,
-      $dashboardNames.data
-    );
-    await waitUntil(() => !!$modelSchema.data?.schema);
-    const dashboardYAML = generateDashboardYAMLForModel(
-      modelName,
-      $modelSchema.data?.schema,
-      newDashboardName
-    );
-    $createFileMutation.mutate(
-      {
-        instanceId: $runtime.instanceId,
-        path: getFileAPIPathFromNameAndType(
-          newDashboardName,
-          EntityType.MetricsDefinition
-        ),
-        data: {
-          blob: dashboardYAML,
-          create: true,
-          createOnly: true,
-        },
-      },
-      {
-        onSuccess: async () => {
-          await waitForResource(
-            queryClient,
-            $runtime.instanceId,
-            getFilePathFromNameAndType(
-              newDashboardName,
-              EntityType.MetricsDefinition
-            )
-          );
-          goto(`/dashboard/${newDashboardName}`);
-          const previousActiveEntity = $appScreen?.type;
-          behaviourEvent.fireNavigationEvent(
-            newDashboardName,
-            BehaviourEventMedium.Menu,
-            MetricsEventSpace.LeftPanel,
-            previousActiveEntity,
-            MetricsEventScreenName.Dashboard
-          );
-        },
-        onError: (err) => {
-          console.error(err);
-        },
-        onSettled: () => {
-          overlay.set(null);
-          toggleMenu(); // unmount component
-        },
-      }
-    );
-  };
+  async function createDashboardFromModelHandler() {
+    await createDashboardFromModel();
+    toggleMenu();
+  }
 
   const handleDeleteModel = async (modelName: string) => {
     await deleteFileArtifact(
@@ -138,7 +63,7 @@
 <MenuItem
   disabled={disableCreateDashboard}
   icon
-  on:select={() => createDashboardFromModel(modelName)}
+  on:select={() => createDashboardFromModelHandler()}
   propogateSelect={false}
 >
   <Explore slot="icon" />

--- a/web-common/src/features/models/workspace/CreateDashboardButton.svelte
+++ b/web-common/src/features/models/workspace/CreateDashboardButton.svelte
@@ -1,33 +1,15 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
   import { Button } from "@rilldata/web-common/components/button";
   import IconSpaceFixer from "@rilldata/web-common/components/button/IconSpaceFixer.svelte";
   import Add from "@rilldata/web-common/components/icons/Add.svelte";
   import ResponsiveButtonText from "@rilldata/web-common/components/panel/ResponsiveButtonText.svelte";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
-  import { useDashboardFileNames } from "@rilldata/web-common/features/dashboards/selectors";
-  import {
-    getFileAPIPathFromNameAndType,
-    getFilePathFromNameAndType,
-  } from "@rilldata/web-common/features/entity-management/entity-mappers.js";
-  import { useSchemaForTable } from "@rilldata/web-common/features/entity-management/resource-selectors";
-  import { waitForResource } from "@rilldata/web-common/features/entity-management/resource-status-utils";
-  import { EntityType } from "@rilldata/web-common/features/entity-management/types";
-  import { useModel } from "@rilldata/web-common/features/models/selectors";
-  import { overlay } from "@rilldata/web-common/layout/overlay-store";
-  import { waitUntil } from "@rilldata/web-common/lib/waitUtils";
-  import { behaviourEvent } from "@rilldata/web-common/metrics/initMetrics";
+  import { useCreateDashboardFromModelUIAction } from "@rilldata/web-common/features/models/createDashboardFromModel";
   import { BehaviourEventMedium } from "@rilldata/web-common/metrics/service/BehaviourEventTypes";
-  import {
-    MetricsEventScreenName,
-    MetricsEventSpace,
-  } from "@rilldata/web-common/metrics/service/MetricsTypes";
-  import { createRuntimeServicePutFile } from "@rilldata/web-common/runtime-client";
+  import { MetricsEventSpace } from "@rilldata/web-common/metrics/service/MetricsTypes";
   import { useQueryClient } from "@tanstack/svelte-query";
   import { runtime } from "../../../runtime-client/runtime-store";
-  import { getName } from "../../entity-management/name-utils";
-  import { generateDashboardYAMLForModel } from "../../metrics-views/metrics-internal-store";
 
   export let modelName: string;
   export let hasError = false;
@@ -35,80 +17,17 @@
 
   const queryClient = useQueryClient();
 
-  $: modelQuery = useModel($runtime.instanceId, modelName);
-  $: dashboardNames = useDashboardFileNames($runtime.instanceId);
-
-  $: modelSchema = useSchemaForTable(
+  $: createDashboardFromModel = useCreateDashboardFromModelUIAction(
     $runtime.instanceId,
-    $modelQuery.data?.model
+    modelName,
+    queryClient,
+    BehaviourEventMedium.Button,
+    MetricsEventSpace.RightPanel
   );
-
-  const createFileMutation = createRuntimeServicePutFile();
-
-  async function handleCreateDashboard() {
-    if (!$modelQuery.data?.model) {
-      return;
-    }
-
-    overlay.set({
-      title: "Creating a dashboard for " + modelName,
-    });
-    const newDashboardName = getName(
-      `${modelName}_dashboard`,
-      $dashboardNames.data
-    );
-    await waitUntil(() => !!$modelSchema.data?.schema);
-    const dashboardYAML = generateDashboardYAMLForModel(
-      modelName,
-      $modelSchema.data?.schema,
-      newDashboardName
-    );
-
-    $createFileMutation.mutate(
-      {
-        instanceId: $runtime.instanceId,
-        path: getFileAPIPathFromNameAndType(
-          newDashboardName,
-          EntityType.MetricsDefinition
-        ),
-        data: {
-          blob: dashboardYAML,
-          create: true,
-          createOnly: true,
-        },
-      },
-      {
-        onSuccess: async () => {
-          await waitForResource(
-            queryClient,
-            $runtime.instanceId,
-            getFilePathFromNameAndType(
-              newDashboardName,
-              EntityType.MetricsDefinition
-            )
-          );
-          goto(`/dashboard/${newDashboardName}`);
-          behaviourEvent.fireNavigationEvent(
-            newDashboardName,
-            BehaviourEventMedium.Button,
-            MetricsEventSpace.RightPanel,
-            MetricsEventScreenName.Model,
-            MetricsEventScreenName.Dashboard
-          );
-        },
-        onError: (err) => {
-          console.error(err);
-        },
-        onSettled: () => {
-          overlay.set(null);
-        },
-      }
-    );
-  }
 </script>
 
 <Tooltip alignment="right" distance={8} location="bottom">
-  <Button on:click={handleCreateDashboard} type="primary">
+  <Button on:click={createDashboardFromModel} type="primary">
     <IconSpaceFixer pullLeft pullRight={collapse}>
       <Add />
     </IconSpaceFixer>

--- a/web-common/src/features/models/workspace/CreateDashboardButton.svelte
+++ b/web-common/src/features/models/workspace/CreateDashboardButton.svelte
@@ -5,7 +5,10 @@
   import ResponsiveButtonText from "@rilldata/web-common/components/panel/ResponsiveButtonText.svelte";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
-  import { useCreateDashboardFromModelUIAction } from "@rilldata/web-common/features/models/createDashboardFromModel";
+  import {
+    useCreateDashboardFromModelUIAction,
+    useModelSchemaIsReady,
+  } from "@rilldata/web-common/features/models/createDashboardFromModel";
   import { BehaviourEventMedium } from "@rilldata/web-common/metrics/service/BehaviourEventTypes";
   import { MetricsEventSpace } from "@rilldata/web-common/metrics/service/MetricsTypes";
   import { useQueryClient } from "@tanstack/svelte-query";
@@ -17,6 +20,12 @@
 
   const queryClient = useQueryClient();
 
+  $: modelSchemaIsReady = useModelSchemaIsReady(
+    queryClient,
+    $runtime.instanceId,
+    modelName
+  );
+
   $: createDashboardFromModel = useCreateDashboardFromModelUIAction(
     $runtime.instanceId,
     modelName,
@@ -27,7 +36,11 @@
 </script>
 
 <Tooltip alignment="right" distance={8} location="bottom">
-  <Button on:click={createDashboardFromModel} type="primary">
+  <Button
+    disabled={!$modelSchemaIsReady}
+    on:click={createDashboardFromModel}
+    type="primary"
+  >
     <IconSpaceFixer pullLeft pullRight={collapse}>
       <Add />
     </IconSpaceFixer>


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
When model ingestion is slow create dashboard button can trigger for older data.

#### Details:
Adding a safeguard to make sure we wait before getting the schema before creating a dashboard. Note that pressing the button immediately after changing the model will still break this, but a user wont be that quick.

## Steps to Verify
<!-- PROVIDE INFORMATION ON HOW TO CHECK THIS ADDITION
For example, given a new button "Foo" in the dashboard:
1. Run `npm run dev`
2. Open localhost:3000 and navigate to a dashboard
3. Click the "Foo" button in corner
4. Observe the side effect
 -->