### PR TITLE
Bugbash: fix timestamp column sizing in preview table

### DIFF
--- a/web-common/src/components/preview-table/PreviewTable.svelte
+++ b/web-common/src/components/preview-table/PreviewTable.svelte
@@ -108,7 +108,7 @@ PinnedColumns – any reference columns pinned on the right side of the overall 
         columnWidths[column.name] = largest;
 
         if (TIMESTAMPS.has(column.type)) {
-          columnWidths[column.name] = DATES.has(column.type) ? 13 : 22;
+          columnWidths[column.name] = DATES.has(column.type) ? 13 : 24;
         }
       });
     }


### PR DESCRIPTION
fixes bugbash issue re timestamp column widths: https://www.notion.so/rilldata/Bug-Bash-Rill-GA-6867ccc289494508ae5f8d966d8902c5?pvs=4#aed6a4ae5dba42a49d2a9ecd7dd92fe1