### PR TITLE
Cloud UI: rename "Logs" page to "Status"

### DIFF
--- a/web-admin/src/features/dashboards/listing/DashboardList.svelte
+++ b/web-admin/src/features/dashboards/listing/DashboardList.svelte
@@ -55,7 +55,7 @@
                     <svelte:fragment slot="manage-project">
                       <span class="text-xs">
                         This dashboard has an error. Please check the project
-                        logs.
+                        status.
                       </span>
                     </svelte:fragment>
                     <svelte:fragment slot="read-project">

--- a/web-admin/src/features/navigation/nav-utils.ts
+++ b/web-admin/src/features/navigation/nav-utils.ts
@@ -8,7 +8,7 @@ export function isProjectPage(page: Page): boolean {
   return (
     page.route.id === "/[organization]/[project]" ||
     page.route.id === "/[organization]/[project]/-/reports" ||
-    page.route.id === "/[organization]/[project]/-/logs"
+    page.route.id === "/[organization]/[project]/-/status"
   );
 }
 export function isDashboardPage(page: Page): boolean {

--- a/web-admin/src/features/projects/ProjectBuilding.svelte
+++ b/web-admin/src/features/projects/ProjectBuilding.svelte
@@ -12,8 +12,8 @@
   export let organization: string;
   export let project: string;
 
-  function handleViewProjectLogs() {
-    goto(`/${organization}/${project}/-/logs`);
+  function handleViewProjectStatus() {
+    goto(`/${organization}/${project}/-/status`);
   }
 
   function handleViewProject() {
@@ -36,8 +36,8 @@
     >
     <ProjectAccessControls {organization} {project}>
       <svelte:fragment slot="manage-project">
-        <CtaButton variant="primary-outline" on:click={handleViewProjectLogs}
-          >View project logs
+        <CtaButton variant="primary-outline" on:click={handleViewProjectStatus}
+          >View project status
         </CtaButton>
       </svelte:fragment>
       <svelte:fragment slot="read-project">

--- a/web-admin/src/features/projects/ProjectErrored.svelte
+++ b/web-admin/src/features/projects/ProjectErrored.svelte
@@ -7,8 +7,8 @@
   export let organization: string;
   export let project: string;
 
-  function handleViewProjectLogs() {
-    goto(`/${organization}/${project}/-/logs`);
+  function handleViewProjectStatus() {
+    goto(`/${organization}/${project}/-/status`);
   }
 
   function handleViewProject() {
@@ -25,7 +25,7 @@
     <p class="text-gray-500 text-base">
       <ProjectAccessControls {organization} {project}>
         <svelte:fragment slot="manage-project">
-          View project logs for errors that may help you find a fix.
+          View project status for errors that may help you find a fix.
         </svelte:fragment>
         <svelte:fragment slot="read-project">
           Contact your project's admin for help.
@@ -35,8 +35,8 @@
   </div>
   <ProjectAccessControls {organization} {project}>
     <svelte:fragment slot="manage-project">
-      <CtaButton variant="primary-outline" on:click={handleViewProjectLogs}
-        >View project logs
+      <CtaButton variant="primary-outline" on:click={handleViewProjectStatus}
+        >View project status
       </CtaButton>
     </svelte:fragment>
     <svelte:fragment slot="read-project">

--- a/web-admin/src/features/projects/ProjectParseErrors.svelte
+++ b/web-admin/src/features/projects/ProjectParseErrors.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { getProjectErrors } from "@rilldata/web-admin/features/projects/getProjectErrors";
-  import Logs from "@rilldata/web-common/components/icons/Logs.svelte";
+  import CheckCircle from "@rilldata/web-common/components/icons/CheckCircle.svelte";
   import type { V1ParseError } from "@rilldata/web-common/runtime-client";
   import { useQueryClient } from "@tanstack/svelte-query";
   import type { Readable } from "svelte/store";
@@ -27,14 +27,14 @@
   <div
     class="px-12 py-2 font-semibold text-gray-500 uppercase text-[10px] leading-none border-b border-gray-200"
   >
-    Logs
+    Errors
   </div>
-  <!-- Logs -->
+  <!-- Parse errors -->
   {#if $proj.isSuccess}
     {#if !$errors || $errors.length === 0}
       <div class="flex flex-col items-center gap-y-4 mt-40">
-        <Logs size="48px" className="text-slate-300" />
-        <div class="font-semibold text-gray-600">No logs</div>
+        <CheckCircle size="48px" className="text-slate-300" />
+        <div class="font-semibold text-gray-600">No errors</div>
       </div>
     {:else}
       <ul>

--- a/web-admin/src/features/projects/ProjectTabs.svelte
+++ b/web-admin/src/features/projects/ProjectTabs.svelte
@@ -26,8 +26,8 @@
         ];
         const adminTabs = [
           {
-            route: `/${organization}/${project}/-/logs`,
-            label: "Logs",
+            route: `/${organization}/${project}/-/status`,
+            label: "Status",
           },
         ];
 
@@ -75,7 +75,7 @@
         {#each tabs as tab}
           <Tab>
             {tab.label}
-            {#if tab.label === "Logs"}
+            {#if tab.label === "Status"}
               <ProjectDeploymentStatusChip
                 {organization}
                 {project}

--- a/web-admin/src/routes/[organization]/[project]/-/status/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/status/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { page } from "$app/stores";
-  import ProjectDeploymentLogs from "@rilldata/web-admin/features/projects/ProjectDeploymentLogs.svelte";
   import ProjectDeploymentStatus from "@rilldata/web-admin/features/projects/ProjectDeploymentStatus.svelte";
   import ProjectGithubConnection from "@rilldata/web-admin/features/projects/ProjectGithubConnection.svelte";
+  import ProjectParseErrors from "@rilldata/web-admin/features/projects/ProjectParseErrors.svelte";
   import VerticalScrollContainer from "@rilldata/web-common/layout/VerticalScrollContainer.svelte";
 
   $: organization = $page.params.organization;
@@ -15,6 +15,6 @@
       <ProjectDeploymentStatus {organization} {project} />
       <ProjectGithubConnection {organization} {project} />
     </div>
-    <ProjectDeploymentLogs {organization} {project} />
+    <ProjectParseErrors {organization} {project} />
   </div>
 </VerticalScrollContainer>


### PR DESCRIPTION
Changing the copy from "logs" to "status" more accurately reflects the contents of the page. The page does not contain running logs, it only shows one-point-in-time parse errors.