### PR TITLE
Wrap longer labels for big number

### DIFF
--- a/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
@@ -78,7 +78,8 @@
 >
   <Tooltip distance={16} location="top" alignment="start">
     <h2
-      class="break-words line-clamp-2"
+      style:overflow-wrap="anywhere"
+      class="line-clamp-2"
       style:font-size={withTimeseries ? "" : "0.8rem"}
     >
       {name}


### PR DESCRIPTION
`break-words` or `overflow-wrap: break-word` works for firefox but not for chrome. See https://github.com/tailwindlabs/tailwindcss/discussions/10545#discussioncomment-4925891