### PR TITLE
CLI: Fix sources requiring credentials being printed twice

### DIFF
--- a/cli/cmd/deploy/deploy.go
+++ b/cli/cmd/deploy/deploy.go
@@ -492,7 +492,7 @@ func variablesFlow(ctx context.Context, projectPath, projectName string) {
 	if err != nil {
 		return
 	}
-	parser, err := rillv1.Parse(ctx, repo, instanceID, "", nil)
+	parser, err := rillv1.Parse(ctx, repo, instanceID, "duckdb", []string{"duckdb"})
 	if err != nil {
 		return
 	}

--- a/cli/cmd/env/configure.go
+++ b/cli/cmd/env/configure.go
@@ -14,11 +14,8 @@ import (
 	adminv1 "github.com/rilldata/rill/proto/gen/rill/admin/v1"
 	"github.com/rilldata/rill/runtime/compilers/rillv1"
 	"github.com/rilldata/rill/runtime/compilers/rillv1beta"
-	"github.com/rilldata/rill/runtime/drivers"
-	"github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/rilldata/rill/runtime/pkg/fileutil"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 )
 
 func ConfigureCmd(cfg *config.Config) *cobra.Command {
@@ -143,15 +140,11 @@ func ConfigureCmd(cfg *config.Config) *cobra.Command {
 }
 
 func VariablesFlow(ctx context.Context, projectPath string, tel *telemetry.Telemetry) (map[string]string, error) {
-	// Create an ad-hoc file repo for projectPath
-	instanceID := "default"
-	repoHandle, err := drivers.Open("file", map[string]any{"dsn": projectPath}, false, activity.NewNoopClient(), zap.NewNop())
-	if err != nil {
-		return nil, fmt.Errorf("failed to open project repo: %w", err)
-	}
-	repo, _ := repoHandle.AsRepoStore(instanceID)
-
 	// Parse the project's connectors
+	repo, instanceID, err := cmdutil.RepoForProjectPath(projectPath)
+	if err != nil {
+		return nil, err
+	}
 	parser, err := rillv1.Parse(ctx, repo, instanceID, "duckdb", []string{"duckdb"})
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse project: %w", err)

--- a/runtime/compilers/rillv1/connectors.go
+++ b/runtime/compilers/rillv1/connectors.go
@@ -139,7 +139,17 @@ func (a *connectorAnalyzer) trackConnector(connector string, r *Resource, anonAc
 		a.result[connector] = res
 	}
 
-	res.Resources = append(res.Resources, r)
+	found := false
+	for _, existing := range res.Resources {
+		if r.Name.Normalized() == existing.Name.Normalized() {
+			found = true
+			break
+		}
+	}
+	if !found {
+		res.Resources = append(res.Resources, r)
+	}
+
 	if !anonAccess {
 		res.AnonymousAccess = false
 	}


### PR DESCRIPTION
Note: Only the changes in `deploy.go` were needed, but ended up making a few other minor changes during debugging.

Closes https://github.com/rilldata/rill/issues/3399

