### PR TITLE
Add fetching status to Big Number

### DIFF
--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -237,7 +237,7 @@
     <!-- FIXME: this is pending the remaining state work for show/hide measures and dimensions -->
     {#each renderedMeasures as measure (measure.name)}
       <!-- FIXME: I can't select the big number by the measure id. -->
-      {@const bigNum = totals?.[measure.name] ?? 0}
+      {@const bigNum = totals?.[measure.name]}
       {@const isBeingHovered =
         !expandedMeasureName && hoveredMeasure === measure.name}
       {@const comparisonValue = totalsComparisons?.[measure.name]}

--- a/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
+++ b/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
@@ -152,7 +152,7 @@ export function createTimeSeriesDataStore(ctx: StateManagers) {
 
           if (!primary?.data || !primaryTotal?.data || !unfilteredTotal?.data) {
             return {
-              isFetching: metricsView.isFetching,
+              isFetching: metricsView.isFetching || primaryTotal?.isFetching,
             };
           }
 


### PR DESCRIPTION
Bug Bash -  https://www.notion.so/rilldata/Bug-Bash-Rill-GA-6867ccc289494508ae5f8d966d8902c5?pvs=4#c4b33949bb5d4c24b6f2c8c69865798e

Adds fetching status when totals data is not ready. This shows a spinner instead of 0 value.