### PR TITLE
Runtime: log and docs fix for postgres connector

### DIFF
--- a/docs/docs/deploy/credentials/postgres.md
+++ b/docs/docs/deploy/credentials/postgres.md
@@ -17,7 +17,7 @@ How you configure postgres connection string depends on whether you are developi
 When working on a local project, you have the option to specify a connection string when running Rill using the `--env` flag.
 An example of using this syntax in terminal:
 ```
-rill start --env connectors.postgres.database_url="postgresql://postgres:postgres@localhost:5432/postgres"
+rill start --env connector.postgres.database_url="postgresql://postgres:postgres@localhost:5432/postgres"
 ```
 
 Alternatively, you can include the connection string directly in the source code by adding the `database_url` parameter. 

--- a/runtime/drivers/postgres/postgres.go
+++ b/runtime/drivers/postgres/postgres.go
@@ -32,7 +32,7 @@ var spec = drivers.Spec{
 			Required:    false,
 			Href:        "https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING",
 			Placeholder: "postgresql://postgres:postgres@localhost:5432/postgres",
-			Hint:        "Either set this or pass --env connectors.postgres.database_url=... to rill start",
+			Hint:        "Either set this or pass --env connector.postgres.database_url=... to rill start",
 		},
 	},
 	ConfigProperties: []drivers.PropertySchema{

--- a/runtime/drivers/postgres/sql_store.go
+++ b/runtime/drivers/postgres/sql_store.go
@@ -28,7 +28,7 @@ func (c *connection) Query(ctx context.Context, props map[string]any) (drivers.R
 	} else if url, ok := c.config["database_url"].(string); ok && url != "" { // get from driver configs
 		dsn = url
 	} else {
-		return nil, fmt.Errorf("the property 'database_url' is required for Postgres. Provide 'database_url' in the YAML properties or pass '--env connectors.postgres.database_url=...' to 'rill start'")
+		return nil, fmt.Errorf("the property 'database_url' is required for Postgres. Provide 'database_url' in the YAML properties or pass '--env connector.postgres.database_url=...' to 'rill start'")
 	}
 
 	conn, err := pgx.Connect(ctx, dsn)


### PR DESCRIPTION
We moved to `connector.name.var`