### PR TITLE
Send corring time controls to shceduled exports

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/ExportDimensionTableDataButton.svelte
+++ b/web-common/src/features/dashboards/dimension-table/ExportDimensionTableDataButton.svelte
@@ -1,18 +1,16 @@
 <script lang="ts">
   import { WithTogglableFloatingElement } from "@rilldata/web-common/components/floating-element";
   import { Menu, MenuItem } from "@rilldata/web-common/components/menu";
+  import { getDimensionTableExportArgs } from "@rilldata/web-common/features/dashboards/dimension-table/dimension-table-export-utils";
+  import { useMetaQuery } from "@rilldata/web-common/features/dashboards/selectors/index";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
   import {
     createQueryServiceExport,
     V1ExportFormat,
   } from "@rilldata/web-common/runtime-client";
-  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { onMount, SvelteComponent } from "svelte";
-  import { get } from "svelte/store";
   import CaretDownIcon from "../../../components/icons/CaretDownIcon.svelte";
-  import { getQuerySortType } from "../leaderboard/leaderboard-utils";
-  import { SortDirection } from "../proto-state/derived-types";
   import { useDashboardStore } from "../stores/dashboard-stores";
   import exportToplist from "./export-toplist";
 
@@ -23,7 +21,9 @@
   let showScheduledReportDialog = false;
 
   const dashboardStore = useDashboardStore(metricViewName);
-  const timeControlStore = useTimeControlStore(getStateManagers());
+  const ctx = getStateManagers();
+  const timeControlStore = useTimeControlStore(ctx);
+  const metaQuery = useMetaQuery(ctx);
 
   const exportDash = createQueryServiceExport();
   const handleExportTopList = async (format: V1ExportFormat) => {
@@ -46,33 +46,12 @@
     }
   });
 
-  $: scheduledReportsQueryArgsJson = JSON.stringify({
-    instanceId: get(runtime).instanceId,
-    metricsViewName: metricViewName,
-    dimension: {
-      name: $dashboardStore.selectedDimensionName,
-    },
-    measures: $dashboardStore.selectedMeasureNames.map((name) => ({
-      name: name,
-    })),
-    timeRange: {
-      start: $timeControlStore.timeStart,
-      end: $timeControlStore.timeEnd,
-    },
-    comparisonTimeRange: {
-      start: $timeControlStore.comparisonTimeStart,
-      end: $timeControlStore.comparisonTimeEnd,
-    },
-    sort: [
-      {
-        name: $dashboardStore.leaderboardMeasureName,
-        desc: $dashboardStore.sortDirection === SortDirection.DESCENDING,
-        type: getQuerySortType($dashboardStore.dashboardSortType),
-      },
-    ],
-    filter: $dashboardStore.filters,
-    offset: "0",
-  });
+  $: scheduledReportsQueryArgsJson = getDimensionTableExportArgs(
+    metricViewName,
+    $dashboardStore,
+    $timeControlStore,
+    $metaQuery.data
+  );
 </script>
 
 <WithTogglableFloatingElement
@@ -84,16 +63,16 @@
   on:open={() => (exportMenuOpen = true)}
 >
   <button
+    class="h-6 px-1.5 py-px flex items-center gap-[3px] rounded-sm hover:bg-gray-200 text-gray-700"
     on:click={(evt) => {
       evt.stopPropagation();
       toggleFloatingElement();
     }}
-    class="h-6 px-1.5 py-px flex items-center gap-[3px] rounded-sm hover:bg-gray-200 text-gray-700"
   >
     Export
     <CaretDownIcon
-      size="10px"
       className="transition-transform {exportMenuOpen && '-rotate-180'}"
+      size="10px"
     />
   </button>
   <Menu

--- a/web-common/src/features/dashboards/dimension-table/ExportDimensionTableDataButton.svelte
+++ b/web-common/src/features/dashboards/dimension-table/ExportDimensionTableDataButton.svelte
@@ -2,7 +2,6 @@
   import { WithTogglableFloatingElement } from "@rilldata/web-common/components/floating-element";
   import { Menu, MenuItem } from "@rilldata/web-common/components/menu";
   import { getDimensionTableExportArgs } from "@rilldata/web-common/features/dashboards/dimension-table/dimension-table-export-utils";
-  import { useMetaQuery } from "@rilldata/web-common/features/dashboards/selectors/index";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
   import {
@@ -11,7 +10,6 @@
   } from "@rilldata/web-common/runtime-client";
   import { onMount, SvelteComponent } from "svelte";
   import CaretDownIcon from "../../../components/icons/CaretDownIcon.svelte";
-  import { useDashboardStore } from "../stores/dashboard-stores";
   import exportToplist from "./export-toplist";
 
   export let includeScheduledReport: boolean;
@@ -20,10 +18,8 @@
   let exportMenuOpen = false;
   let showScheduledReportDialog = false;
 
-  const dashboardStore = useDashboardStore(metricViewName);
   const ctx = getStateManagers();
   const timeControlStore = useTimeControlStore(ctx);
-  const metaQuery = useMetaQuery(ctx);
 
   const exportDash = createQueryServiceExport();
   const handleExportTopList = async (format: V1ExportFormat) => {
@@ -46,12 +42,7 @@
     }
   });
 
-  $: scheduledReportsQueryArgsJson = getDimensionTableExportArgs(
-    metricViewName,
-    $dashboardStore,
-    $timeControlStore,
-    $metaQuery.data
-  );
+  $: scheduledReportsQueryArgsJson = getDimensionTableExportArgs(ctx);
 </script>
 
 <WithTogglableFloatingElement

--- a/web-common/src/features/dashboards/dimension-table/dimension-table-export-utils.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-export-utils.ts
@@ -1,0 +1,137 @@
+import { getQuerySortType } from "@rilldata/web-common/features/dashboards/leaderboard/leaderboard-utils";
+import { SortDirection } from "@rilldata/web-common/features/dashboards/proto-state/derived-types";
+import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { TimeControlState } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
+import {
+  TimeComparisonOption,
+  TimeRangePreset,
+  TimeRangeType,
+} from "@rilldata/web-common/lib/time/types";
+import type {
+  V1MetricsViewComparisonRequest,
+  V1MetricsViewSpec,
+  V1TimeRange,
+} from "@rilldata/web-common/runtime-client";
+import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
+import { get } from "svelte/store";
+
+// Temporary. A future PR will add iso to the selection itself.
+const TIME_RANGES_TO_ISO: Record<TimeRangeType, string> = {
+  [TimeRangePreset.ALL_TIME]: "inf",
+  [TimeRangePreset.LAST_SIX_HOURS]: "PT6H",
+  [TimeRangePreset.LAST_24_HOURS]: "PT24H",
+  [TimeRangePreset.LAST_7_DAYS]: "P7D",
+  [TimeRangePreset.LAST_14_DAYS]: "P14D",
+  [TimeRangePreset.LAST_4_WEEKS]: "P4W",
+  [TimeRangePreset.LAST_12_MONTHS]: "P12M",
+  [TimeRangePreset.TODAY]: "rill-TD",
+  [TimeRangePreset.WEEK_TO_DATE]: "rill-WTD",
+  [TimeRangePreset.MONTH_TO_DATE]: "rill-MTD",
+  [TimeRangePreset.QUARTER_TO_DATE]: "rill-QTD",
+  [TimeRangePreset.YEAR_TO_DATE]: "rill-YTD",
+};
+
+export function getDimensionTableExportArgs(
+  metricViewName: string,
+  dashboardStore: MetricsExplorerEntity,
+  timeControlState: TimeControlState,
+  metricsView: V1MetricsViewSpec | undefined
+): V1MetricsViewComparisonRequest | undefined {
+  if (!metricsView) return undefined;
+
+  const timeRange = getTimeRange(timeControlState, metricsView);
+
+  const comparisonTimeRange = getComparisonTimeRange(
+    dashboardStore,
+    timeControlState,
+    timeRange
+  );
+
+  return {
+    instanceId: get(runtime).instanceId,
+    metricsViewName: metricViewName,
+    dimension: {
+      name: dashboardStore.selectedDimensionName,
+    },
+    measures: dashboardStore.selectedMeasureNames.map((name) => ({
+      name: name,
+    })),
+    ...(timeRange ? { timeRange } : {}),
+    ...(comparisonTimeRange ? { comparisonTimeRange } : {}),
+    sort: [
+      {
+        name: dashboardStore.leaderboardMeasureName,
+        desc: dashboardStore.sortDirection === SortDirection.DESCENDING,
+        type: getQuerySortType(dashboardStore.dashboardSortType),
+      },
+    ],
+    filter: dashboardStore.filters,
+    offset: "0",
+  };
+}
+
+/**
+ * Fills in isoDuration based on selection.
+ * This is used by scheduled report by using report run time as end time.
+ */
+function getTimeRange(
+  timeControlState: TimeControlState,
+  metricsView: V1MetricsViewSpec
+) {
+  if (!timeControlState.selectedTimeRange?.name) return undefined;
+
+  const timeRange: V1TimeRange = {};
+  switch (timeControlState.selectedTimeRange.name) {
+    case TimeRangePreset.DEFAULT:
+      timeRange.isoDuration = metricsView.defaultTimeRange;
+      break;
+
+    case TimeRangePreset.CUSTOM:
+      timeRange.start = timeControlState.timeStart;
+      timeRange.end = timeControlState.timeEnd;
+      break;
+
+    default:
+      timeRange.isoDuration =
+        TIME_RANGES_TO_ISO[timeControlState.selectedTimeRange.name];
+      break;
+  }
+
+  return timeRange;
+}
+
+/**
+ * Fills in isoDuration and isoOffset based on selection.
+ * This is used by scheduled report by using report run time as end time.
+ */
+function getComparisonTimeRange(
+  dashboardStore: MetricsExplorerEntity,
+  timeControlState: TimeControlState,
+  timeRange: V1TimeRange | undefined
+) {
+  if (
+    !timeRange ||
+    dashboardStore.selectedComparisonDimension ||
+    !timeControlState.showComparison ||
+    !timeControlState.selectedComparisonTimeRange?.name
+  ) {
+    return undefined;
+  }
+
+  const comparisonTimeRange: V1TimeRange = {};
+  switch (timeControlState.selectedComparisonTimeRange.name) {
+    default:
+      comparisonTimeRange.isoOffset =
+        timeControlState.selectedComparisonTimeRange.name;
+    // eslint-disable-next-line no-fallthrough
+    case TimeComparisonOption.CONTIGUOUS:
+      comparisonTimeRange.isoDuration = timeRange.isoDuration;
+      break;
+
+    case TimeComparisonOption.CUSTOM:
+      comparisonTimeRange.start = timeControlState.comparisonTimeStart;
+      comparisonTimeRange.end = timeControlState.comparisonTimeEnd;
+      break;
+  }
+  return comparisonTimeRange;
+}


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Scheduled reports are to be run for the latest time period.

#### Details:
Fill in the isoDuration and isoOffset so that reporting can use it to run for the latest period.

## Steps to Verify
<!-- PROVIDE INFORMATION ON HOW TO CHECK THIS ADDITION
For example, given a new button "Foo" in the dashboard:
1. Run `npm run dev`
2. Open localhost:3000 and navigate to a dashboard
3. Click the "Foo" button in corner
4. Observe the side effect
 -->