### PR TITLE
Make scheduled reports timezone-aware

### DIFF
--- a/web-admin/src/features/scheduled-reports/history/ReportHistoryTable.svelte
+++ b/web-admin/src/features/scheduled-reports/history/ReportHistoryTable.svelte
@@ -24,6 +24,8 @@
       cell: (info) =>
         flexRender(ReportHistoryTableCompositeCell, {
           reportTime: info.row.original.reportTime,
+          timeZone:
+            $reportQuery.data.resource.report.spec.refreshSchedule.timeZone,
           errorMessage: info.row.original.errorMessage,
         }),
     },

--- a/web-admin/src/features/scheduled-reports/history/ReportHistoryTableCompositeCell.svelte
+++ b/web-admin/src/features/scheduled-reports/history/ReportHistoryTableCompositeCell.svelte
@@ -2,15 +2,16 @@
   import Tag from "@rilldata/web-common/components/tag/Tag.svelte";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
-  import { formatDateToCustomString } from "../tableUtils";
+  import { formatRunDate } from "../tableUtils";
 
   export let reportTime: string;
+  export let timeZone: string;
   export let errorMessage: string;
 </script>
 
 <div class="flex gap-x-2 items-center px-4 py-[10px]">
   <div class="text-gray-700 text-sm">
-    {formatDateToCustomString(new Date(reportTime))}
+    {formatRunDate(reportTime, timeZone)}
   </div>
   {#if errorMessage === ""}
     <Tag color="blue">Email sent</Tag>

--- a/web-admin/src/features/scheduled-reports/listing/ReportsTable.svelte
+++ b/web-admin/src/features/scheduled-reports/listing/ReportsTable.svelte
@@ -38,6 +38,7 @@
           title: info.row.original.report.spec.title,
           lastRun:
             info.row.original.report.state.executionHistory[0]?.reportTime,
+          timeZone: info.row.original.report.spec.refreshSchedule.timeZone,
           frequency: info.row.original.report.spec.refreshSchedule.cron,
           ownerId:
             info.row.original.report.spec.annotations["admin_owner_user_id"],

--- a/web-admin/src/features/scheduled-reports/listing/ReportsTableCompositeCell.svelte
+++ b/web-admin/src/features/scheduled-reports/listing/ReportsTableCompositeCell.svelte
@@ -4,13 +4,14 @@
   import ReportIcon from "@rilldata/web-common/components/icons/ReportIcon.svelte";
   import cronstrue from "cronstrue";
   import { createAdminServiceListProjectMembers } from "../../../client";
-  import { formatDateToCustomString } from "../tableUtils";
+  import { formatRunDate } from "../tableUtils";
 
   export let organization: string;
   export let project: string;
   export let id: string;
   export let title: string;
   export let lastRun: string | undefined;
+  export let timeZone: string;
   export let frequency: string;
   export let ownerId: string;
   export let lastRunErrorMessage: string | undefined;
@@ -44,7 +45,7 @@
     {#if !lastRun}
       <span>Hasn't run yet</span>
     {:else}
-      <span>Last run {formatDateToCustomString(new Date(lastRun))}</span>
+      <span>Last run {formatRunDate(lastRun, timeZone)}</span>
     {/if}
     <span>•</span>
     <span>{humanReadableFrequency}</span>

--- a/web-admin/src/features/scheduled-reports/metadata/ReportMetadata.svelte
+++ b/web-admin/src/features/scheduled-reports/metadata/ReportMetadata.svelte
@@ -31,7 +31,9 @@
     $reportQuery.data &&
     cronstrue.toString(
       $reportQuery.data.resource.report.spec.refreshSchedule.cron,
-      { verbose: true }
+      {
+        verbose: true,
+      }
     );
 
   // Get owner's name
@@ -144,7 +146,10 @@
         <div class="flex gap-x-6">
           <MetadataLabel>Next run</MetadataLabel>
           <MetadataValue>
-            {formatNextRunOn($reportQuery.data.resource.report.state.nextRunOn)}
+            {formatNextRunOn(
+              $reportQuery.data.resource.report.state.nextRunOn,
+              $reportQuery.data.resource.report.spec.refreshSchedule.timeZone
+            )}
           </MetadataValue>
         </div>
       </div>

--- a/web-admin/src/features/scheduled-reports/metadata/utils.ts
+++ b/web-admin/src/features/scheduled-reports/metadata/utils.ts
@@ -1,3 +1,4 @@
+import { DateTime } from "luxon";
 import { V1ExportFormat } from "../../../client";
 
 export function exportFormatToPrettyString(format: V1ExportFormat): string {
@@ -15,13 +16,8 @@ export function exportFormatToPrettyString(format: V1ExportFormat): string {
   }
 }
 
-export function formatNextRunOn(nextRunOn: string): string {
-  return new Date(nextRunOn).toLocaleString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "numeric",
-    hour12: true,
-  });
+export function formatNextRunOn(nextRunOn: string, timeZone: string): string {
+  return DateTime.fromISO(nextRunOn)
+    .setZone(timeZone)
+    .toLocaleString(DateTime.DATETIME_FULL);
 }

--- a/web-admin/src/features/scheduled-reports/tableUtils.ts
+++ b/web-admin/src/features/scheduled-reports/tableUtils.ts
@@ -1,20 +1,7 @@
-export function formatDateToCustomString(date: Date) {
-  const formattedDate = date.toLocaleString("en-US", {
-    month: "short",
-    day: "2-digit",
-    year: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-  });
+import { DateTime } from "luxon";
 
-  const dateParts = formattedDate.split(", ");
-  dateParts[0] = dateParts[0] + " " + dateParts[1];
-  dateParts.splice(1, 1);
+export function formatRunDate(lastRun: string, timeZone: string) {
+  const luxonDate = DateTime.fromISO(lastRun, { zone: timeZone || "UTC" });
 
-  return dateParts.join(", ").replace(" PM", "pm").replace(" AM", "am");
-}
-
-export function capitalizeFirstLetter(string: string) {
-  return string.charAt(0).toUpperCase() + string.slice(1);
+  return luxonDate.toFormat("MMM dd, yyyy, h:mm a ZZZZ");
 }

--- a/web-common/src/components/menu-v2/MenuItem.svelte
+++ b/web-common/src/components/menu-v2/MenuItem.svelte
@@ -15,7 +15,7 @@
     disabled: boolean;
   }) {
     return classNames(
-      "flex items-center gap-x-2 px-3 py-1.5 text-xs font-normal leading-none w-full",
+      "flex items-center gap-x-2 px-3 py-1.5 text-xs font-normal leading-none w-full whitespace-nowrap",
       active ? "bg-gray-100 text-gray-900 cursor-pointer" : "text-gray-700",
       disabled && "cursor-not-allowed opacity-50"
     );

--- a/web-common/src/components/menu-v2/MenuItems.svelte
+++ b/web-common/src/components/menu-v2/MenuItems.svelte
@@ -4,11 +4,11 @@
   export let positioningOverride = "";
 
   // Temporary approach for allowing various positioning options. See how it goes.
-  let positioning = positioningOverride || "absolute right-0";
+  let positioning = positioningOverride || "absolute left-0";
 </script>
 
 <MenuItems
-  class="{positioning} z-[1000] w-full mt-1 bg-white border border-slate-100 rounded-sm shadow outline-none max-h-60 overflow-y-auto focus:outline-none"
+  class="{positioning} z-[1000] w-fit mt-1 bg-white border border-slate-100 rounded-sm shadow outline-none max-h-60 overflow-y-auto focus:outline-none"
 >
   <slot />
 </MenuItems>

--- a/web-common/src/features/dashboards/dimension-table/ExportDimensionTableDataButton.svelte
+++ b/web-common/src/features/dashboards/dimension-table/ExportDimensionTableDataButton.svelte
@@ -139,11 +139,14 @@
   </Menu>
 </WithTogglableFloatingElement>
 
-{#if includeScheduledReport && CreateScheduledReportModal}
+<!-- Including `showScheduledReportDialog` in the conditional ensures we tear 
+  down the form state when the dialog closes -->
+{#if includeScheduledReport && CreateScheduledReportModal && showScheduledReportDialog}
   <svelte:component
     this={CreateScheduledReportModal}
     queryName="MetricsViewComparison"
     queryArgsJson={scheduledReportsQueryArgsJson}
+    dashboardTimeZone={$dashboardStore?.selectedTimezone}
     open={showScheduledReportDialog}
     on:close={() => (showScheduledReportDialog = false)}
   />

--- a/web-common/src/lib/time/timezone/index.ts
+++ b/web-common/src/lib/time/timezone/index.ts
@@ -1,5 +1,5 @@
-import { DateTime } from "luxon";
 import { timeZoneNameToAbbreviationMap } from "@rilldata/web-common/lib/time/timezone/abbreviationMap";
+import { DateTime } from "luxon";
 
 export function removeLocalTimezoneOffset(dt: Date) {
   return new Date(dt.getTime() + dt.getTimezoneOffset() * 60000);
@@ -19,6 +19,10 @@ export function getLocalIANA(): string {
   return Intl.DateTimeFormat().resolvedOptions().timeZone;
 }
 
+export function getUTCIANA(): string {
+  return "Etc/UTC";
+}
+
 export function getTimeZoneNameFromIANA(now: Date, iana: string): string {
   return DateTime.fromJSDate(now).setZone(iana).toFormat("ZZZZZ");
 }
@@ -35,6 +39,10 @@ export function getAbbreviationForIANA(now: Date, iana: string): string {
 
 export function getOffsetForIANA(now: Date, iana: string): string {
   return DateTime.fromJSDate(now).setZone(iana).toFormat("ZZ");
+}
+
+export function getHoursOffsetForIANA(now: Date, iana: string): number {
+  return DateTime.fromJSDate(now).setZone(iana).offset / 60;
 }
 
 export function getLabelForIANA(now: Date, iana: string) {


### PR DESCRIPTION
This PR:
- Adds a "Time zone" element to the scheduled reports form. The included options are:
    - The dashboard's current time zone (if time zone enabled)
    - The user's local time zone
    - UTC
- Accounts for the report's time zone throughout the report management UI (reports table, report metadata display, report recent run history)