### PR TITLE
Bugfixes in Scheduled Reports table

### DIFF
--- a/web-admin/src/features/scheduled-reports/listing/ReportOwnerBullet.svelte
+++ b/web-admin/src/features/scheduled-reports/listing/ReportOwnerBullet.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { createAdminServiceListProjectMembers } from "@rilldata/web-admin/client";
+
+  export let organization: string;
+  export let project: string;
+  export let ownerId: string;
+
+  const membersQuery = createAdminServiceListProjectMembers(
+    organization,
+    project
+  );
+  $: owner = $membersQuery.data?.members.find(
+    (member) => member.userId === ownerId
+  );
+</script>
+
+<span
+  >{owner?.userName
+    ? `Created by ${owner.userName}`
+    : "Created through code"}</span
+>

--- a/web-admin/src/features/scheduled-reports/listing/ReportsTable.svelte
+++ b/web-admin/src/features/scheduled-reports/listing/ReportsTable.svelte
@@ -52,7 +52,7 @@
     },
     {
       id: "lastRun",
-      accessorFn: (row) => row.report.state.currentExecution.reportTime,
+      accessorFn: (row) => row.report.state.currentExecution?.reportTime,
     },
     // {
     //   id: "nextRun",

--- a/web-admin/src/features/scheduled-reports/listing/ReportsTableCompositeCell.svelte
+++ b/web-admin/src/features/scheduled-reports/listing/ReportsTableCompositeCell.svelte
@@ -3,8 +3,9 @@
   import CheckCircleOutline from "@rilldata/web-common/components/icons/CheckCircleOutline.svelte";
   import ReportIcon from "@rilldata/web-common/components/icons/ReportIcon.svelte";
   import cronstrue from "cronstrue";
-  import { createAdminServiceListProjectMembers } from "../../../client";
+  import ProjectAccessControls from "../../projects/ProjectAccessControls.svelte";
   import { formatRunDate } from "../tableUtils";
+  import ReportOwnerBullet from "./ReportOwnerBullet.svelte";
 
   export let organization: string;
   export let project: string;
@@ -17,14 +18,6 @@
   export let lastRunErrorMessage: string | undefined;
 
   const humanReadableFrequency = cronstrue.toString(frequency);
-
-  const membersQuery = createAdminServiceListProjectMembers(
-    organization,
-    project
-  );
-  $: owner = $membersQuery.data?.members.find(
-    (member) => member.userId === ownerId
-  );
 </script>
 
 <a href={`reports/${id}`} class="flex flex-col gap-y-0.5 group px-4 py-[5px]">
@@ -49,7 +42,11 @@
     {/if}
     <span>•</span>
     <span>{humanReadableFrequency}</span>
-    <span>•</span>
-    <span>Created by {owner?.userName || "a project admin"}</span>
+    <ProjectAccessControls {organization} {project}>
+      <svelte:fragment slot="manage-project">
+        <span>•</span>
+        <ReportOwnerBullet {organization} {project} {ownerId} />
+      </svelte:fragment>
+    </ProjectAccessControls>
   </div>
 </a>


### PR DESCRIPTION
This PR fixes two bugs in the scheduled reports table:
- Project Viewers would see a 403 error because they're not allowed to call `ListProjectMembers`
- The table header's search box threw an error when `reportTime` was undefined