### PR TITLE
Rill Developer: account for long file names

### DIFF
--- a/web-common/src/components/button/Button.svelte
+++ b/web-common/src/components/button/Button.svelte
@@ -46,7 +46,7 @@
   }) {
     return `
   ${compact ? "px-2 py-0.5" : "px-3 py-0.5"} text-xs font-normal leading-snug
- flex flex-row gap-x-2 items-center transition-transform duration-100
+ flex flex-row gap-x-2 min-w-fit items-center transition-transform duration-100
   focus:outline-none focus:ring-2
   ${customClasses ? customClasses : levels[status][type]}
   ${disabledClasses}

--- a/web-common/src/features/sources/modal/SourceImportedModal.svelte
+++ b/web-common/src/features/sources/modal/SourceImportedModal.svelte
@@ -34,7 +34,9 @@
     <div class="w-6 m-auto ml-0 mr-0">
       <CheckCircleNew className="fill-blue-500" size="24px" />
     </div>
-    <div>Source "{$sourceImportedName}" imported successfully.</div>
+    <div class="break-all">
+      Source "{$sourceImportedName}" imported successfully.
+    </div>
   </div>
   <div class="flex flex-auto gap-x-2.5" slot="body">
     <div class="w-6" />

--- a/web-common/src/features/sources/workspace/SourceWorkspaceHeader.svelte
+++ b/web-common/src/features/sources/workspace/SourceWorkspaceHeader.svelte
@@ -192,7 +192,7 @@
         <div class="flex items-center pr-2 gap-x-2">
           {#if $sourceQuery && source?.state?.refreshedOn}
             <div
-              class="ui-copy-muted"
+              class="ml-2 ui-copy-muted line-clamp-2"
               style:font-size="11px"
               transition:fade|local={{ duration: 200 }}
             >

--- a/web-common/src/layout/workspace/WorkspaceHeader.svelte
+++ b/web-common/src/layout/workspace/WorkspaceHeader.svelte
@@ -52,7 +52,7 @@
 <svelte:window on:keydown={onKeydown} />
 <header
   class="grid items-center content-stretch justify-between pl-4 border-b border-gray-300"
-  style:grid-template-columns="[title] auto [controls] auto"
+  style:grid-template-columns="[title] minmax(0, 1fr) [controls] auto"
   style:height="var(--header-height)"
   use:listenToNodeResize
 >
@@ -60,7 +60,7 @@
     {#if titleInput !== undefined && titleInput !== null}
       <h1
         style:font-size="16px"
-        class="w-full overflow-x-hidden grid grid-flow-col justify-start items-center gap-x-1"
+        class="grid grid-flow-col justify-start items-center gap-x-1 overflow-hidden"
       >
         <Tooltip
           distance={8}
@@ -72,7 +72,6 @@
             autocomplete="off"
             disabled={!editable}
             id="model-title-input"
-            class:text-overflow-ellipsis={!editable}
             bind:this={titleInputElement}
             on:focus={() => {
               editingTitle = true;
@@ -84,7 +83,7 @@
                 editingTitle = true;
               }
             }}
-            class="w-full text-overflow-ellipses whitespace-wrap bg-transparent border border-transparent border-2 {editable
+            class="bg-transparent border border-transparent border-2 {editable
               ? 'hover:border-gray-400 cursor-pointer'
               : ''} rounded pl-2 pr-2"
             class:font-bold={editingTitle === false}


### PR DESCRIPTION
This PR accounts for long file names in two places:
- The new modal that shows after a source is imported ([bug bash](https://www.notion.so/rilldata/Bug-Bash-Rill-GA-6867ccc289494508ae5f8d966d8902c5?pvs=4#86498cb9142440d6bc90cfb52ec4dd6b))
- The workspace header ([bug bash](https://www.notion.so/rilldata/Bug-Bash-Rill-GA-6867ccc289494508ae5f8d966d8902c5?pvs=4#2d56975c436f46499aa60e0c220bdc17))