### PR TITLE
Fix: fallback to dashboard `name` when no `title` in the Cloud UI dashboards table

### DIFF
--- a/web-admin/src/features/dashboards/listing/DashboardsTableCompositeCell.svelte
+++ b/web-admin/src/features/dashboards/listing/DashboardsTableCompositeCell.svelte
@@ -24,7 +24,7 @@
   <div class="flex gap-x-2 items-center">
     <DashboardIcon size={"14px"} className="text-slate-500" />
     <div class="text-gray-700 text-sm font-semibold group-hover:text-blue-600">
-      {title}
+      {title !== "" ? title : name}
     </div>
     {#if error !== ""}
       <Tag color="red">Error</Tag>


### PR DESCRIPTION
Addresses this [bug bash report ](https://www.notion.so/rilldata/Bug-Bash-Rill-GA-6867ccc289494508ae5f8d966d8902c5?pvs=4#db7cecacc04141ee98b3db1a3735fa45)

See the third entry, which was previously blank: 
![image](https://github.com/rilldata/rill/assets/14206386/94088e8a-fe6d-4daa-a6c6-b330530198ef)
