### PR TITLE
Fix: Do not call API for empty measure list

### DIFF
--- a/web-common/src/features/dashboards/time-series/multiple-dimension-queries.ts
+++ b/web-common/src/features/dashboards/time-series/multiple-dimension-queries.ts
@@ -59,6 +59,11 @@ export function getDimensionValuesForComparison(
       useTimeControlStore(ctx),
     ],
     ([runtime, name, dashboardStore, timeControls], set) => {
+      const isValidMeasureList =
+        measures?.length > 0 && measures?.every((m) => m !== undefined);
+
+      if (!isValidMeasureList) return;
+
       const dimensionName = dashboardStore?.selectedComparisonDimension;
       const isInTimeDimensionView = dashboardStore?.expandedMeasureName;
 
@@ -187,7 +192,10 @@ export function getDimensionValueTimeSeries(
         timeStore?.selectedTimeRange?.interval ?? timeStore?.minTimeGrain;
       const zone = dashboardStore?.selectedTimezone;
 
-      if (!dimensionName) return;
+      const isValidMeasureList =
+        measures?.length > 0 && measures?.every((m) => m !== undefined);
+
+      if (!isValidMeasureList || !dimensionName) return;
       if (dashboardStore?.selectedScrubRange?.isScrubbing) return;
 
       return derived(


### PR DESCRIPTION
Do not call Aggregation API when the measure list is empty.

https://rilldata.slack.com/archives/C04AGHL77PS/p1699904575728479