### PR TITLE
fix: handle missing time zone as UTC in Scheduled Report's Next run date

### DIFF
--- a/web-admin/src/features/scheduled-reports/metadata/utils.ts
+++ b/web-admin/src/features/scheduled-reports/metadata/utils.ts
@@ -17,6 +17,10 @@ export function exportFormatToPrettyString(format: V1ExportFormat): string {
 }
 
 export function formatNextRunOn(nextRunOn: string, timeZone: string): string {
+  // If the timezone is empty, interpret it as UTC
+  if (timeZone === "") {
+    timeZone = "UTC";
+  }
   return DateTime.fromISO(nextRunOn)
     .setZone(timeZone)
     .toLocaleString(DateTime.DATETIME_FULL);


### PR DESCRIPTION
This PR fixes a bug on the Scheduled Report page where the "Next run" date showed "Invalid DateTime" when the time zone was not specified. When a time zone is not specified, we interpret it as UTC.