### PR TITLE
fix: replace `ListProjectMembers` API with `SearchProjectUsers` to correctly fetch Scheduled Report owner

### DIFF
--- a/web-admin/src/features/scheduled-reports/listing/ReportOwnerBullet.svelte
+++ b/web-admin/src/features/scheduled-reports/listing/ReportOwnerBullet.svelte
@@ -1,20 +1,15 @@
 <script lang="ts">
-  import { createAdminServiceSearchProjectUsers } from "@rilldata/web-admin/client";
+  import { useReportOwnerName } from "../selectors";
 
   export let organization: string;
   export let project: string;
   export let ownerId: string;
 
-  const usersQuery = createAdminServiceSearchProjectUsers(
-    organization,
-    project,
-    { emailQuery: "%", pageSize: 1000, pageToken: undefined }
-  );
-  $: user = $usersQuery.data?.users.find((user) => user.id === ownerId);
+  const ownerName = useReportOwnerName(organization, project, ownerId);
 </script>
 
-<span
-  >{user?.displayName
-    ? `Created by ${user.displayName}`
-    : "Created through code"}</span
->
+{#if $ownerName.isSuccess}
+  <span>
+    {$ownerName.data ? `Created by ${$ownerName.data}` : "Created through code"}
+  </span>
+{/if}

--- a/web-admin/src/features/scheduled-reports/metadata/ReportOwnerBlock.svelte
+++ b/web-admin/src/features/scheduled-reports/metadata/ReportOwnerBlock.svelte
@@ -1,21 +1,17 @@
 <script lang="ts">
-  import { createAdminServiceSearchProjectUsers } from "@rilldata/web-admin/client";
+  import { useReportOwnerName } from "../selectors";
 
   export let organization: string;
   export let project: string;
   export let ownerId: string;
 
-  // Get owner's name
-  const usersQuery = createAdminServiceSearchProjectUsers(
-    organization,
-    project,
-    { emailQuery: "%", pageSize: 1000, pageToken: undefined }
-  );
-  $: user =
-    $usersQuery.data &&
-    $usersQuery.data.users.find((user) => user.id === ownerId);
+  const ownerName = useReportOwnerName(organization, project, ownerId);
 </script>
 
-{user?.displayName
-  ? `Report created by ${user.displayName}`
-  : "Report created through code"} •
+{#if $ownerName.isSuccess}
+  <span>
+    {$ownerName.data
+      ? `Report created by ${$ownerName.data}`
+      : "Report created through code"} •
+  </span>
+{/if}

--- a/web-admin/src/features/scheduled-reports/selectors.ts
+++ b/web-admin/src/features/scheduled-reports/selectors.ts
@@ -1,3 +1,4 @@
+import { createAdminServiceSearchProjectUsers } from "@rilldata/web-admin/client";
 import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
 import {
   createRuntimeServiceGetResource,
@@ -37,6 +38,27 @@ export function useReportDashboardName(instanceId: string, name: string) {
             null
           );
         },
+      },
+    }
+  );
+}
+
+export function useReportOwnerName(
+  organization: string,
+  project: string,
+  ownerId: string
+) {
+  return createAdminServiceSearchProjectUsers(
+    organization,
+    project,
+    {
+      emailQuery: "%",
+      pageSize: 1000,
+      pageToken: undefined,
+    },
+    {
+      query: {
+        select: (data) => data.users.find((u) => u.id === ownerId)?.displayName,
       },
     }
   );


### PR DESCRIPTION
This PR changes the logic used to fetch a Scheduled Report's owner's name. Previously, I used the `ListProjectMembers` API, but this API omits users that have access to a project via inheritance (e.g., an organization admin that has not been explicitly added to a project). Now, this PR uses the `SearchProjectUsers` API, which returns all users that have access to a project.