### PR TITLE
Fixes to Big number tooltips

### DIFF
--- a/web-common/src/features/dashboards/big-number/BigNumberTooltipContent.svelte
+++ b/web-common/src/features/dashboards/big-number/BigNumberTooltipContent.svelte
@@ -8,7 +8,7 @@
   import type { MetricsViewSpecMeasureV2 } from "@rilldata/web-common/runtime-client";
 
   export let measure: MetricsViewSpecMeasureV2;
-  export let value: any;
+  export let value = "";
 
   $: description =
     measure?.description || measure?.label || measure?.expression;

--- a/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
@@ -85,6 +85,7 @@
   <button
     use:shiftClickAction
     on:shift-click={() => shiftClickHandler(hoveredValue)}
+    class:big-number={!isMeasureExpanded}
     class="big-number m-0.5 rounded flex items-start {isMeasureExpanded
       ? 'cursor-default'
       : 'cursor-pointer'}"


### PR DESCRIPTION
- Don't show anything in the tooltip when value is `undefined`
- Do no show tile/card in TDD view.