### PR TITLE
Fix: Replace null string with null cell

### DIFF
--- a/web-common/src/features/dashboards/pivot/Pivot.svelte
+++ b/web-common/src/features/dashboards/pivot/Pivot.svelte
@@ -74,6 +74,12 @@
           structuredClone(LOADING_CELL)
         );
       }
+      // Replace null values inside the header with null placeholders
+      // Assumes that the second item in the array is always the measure
+      // value
+      else if (r?.[1]?.value === null) {
+        row_headers[i][1].value = NULL_CELL;
+      }
     });
 
     let data = getBodyData({ x0, x1, y0, y1 });


### PR DESCRIPTION
Replace null strings present in measure column in TDD table to Null cells.

Before: 
![image](https://github.com/rilldata/rill/assets/4402679/0236217d-b449-4774-a020-2f1582fd653a)

After: 
![image](https://github.com/rilldata/rill/assets/4402679/945daa57-e9d9-4e3b-8c38-d946cfc016f2)
