### PR TITLE
Enable table columns to be resizable

### DIFF
--- a/web-common/src/features/dashboards/pivot/Pivot.svelte
+++ b/web-common/src/features/dashboards/pivot/Pivot.svelte
@@ -219,8 +219,6 @@
       element: th,
     });
 
-    console.log("called");
-
     if (maybeVal)
       th.innerHTML = maybeVal + `<span class="rt-column-resize"></span>`;
   }

--- a/web-common/src/features/dashboards/pivot/Pivot.svelte
+++ b/web-common/src/features/dashboards/pivot/Pivot.svelte
@@ -334,5 +334,6 @@
 
   :global(regular-table thead th) {
     height: var(--row-height);
+    user-select: none;
   }
 </style>

--- a/web-common/src/features/dashboards/pivot/Pivot.svelte
+++ b/web-common/src/features/dashboards/pivot/Pivot.svelte
@@ -179,8 +179,6 @@
       const maybeWidth = getColumnWidth(x);
       if (maybeWidth) {
         th.style.width = `${maybeWidth}px`;
-        th.style.minWidth = `${maybeWidth}px`;
-        th.style.maxWidth = `${maybeWidth}px`;
       }
     }
 
@@ -197,7 +195,8 @@
       value: meta.value,
       element: th,
     });
-    if (maybeVal) th.innerHTML = maybeVal;
+    if (maybeVal)
+      th.innerHTML = maybeVal + `<span class="rt-column-resize"></span>`;
   }
 
   function style_row_corner(th: HTMLTableCellElement) {
@@ -210,8 +209,6 @@
       const maybeWidth = getRowHeaderWidth(x);
       if (maybeWidth) {
         th.style.width = `${maybeWidth}px`;
-        th.style.minWidth = `${maybeWidth}px`;
-        th.style.maxWidth = `${maybeWidth}px`;
       }
     }
 
@@ -221,7 +218,11 @@
       value: meta.value,
       element: th,
     });
-    if (maybeVal) th.innerHTML = maybeVal;
+
+    console.log("called");
+
+    if (maybeVal)
+      th.innerHTML = maybeVal + `<span class="rt-column-resize"></span>`;
   }
 
   $: {

--- a/web-common/src/features/dashboards/time-dimension-details/TDDTable.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TDDTable.svelte
@@ -249,34 +249,11 @@
       </div>`;
   };
 
-  let containerWidth;
-
-  /**
-   * Compute available width for table columns by subtracting fixed widths
-   * from container width along with extra 50px for padding
-   */
-  $: colWidth = Math.floor(
-    (containerWidth - 250 - 130 - 50 - 50) / tableData?.columnCount
-  );
-
   const getColumnWidth = () => {
-    if (colWidth) {
-      if (colWidth < 75) return 75;
-      if (colWidth > 150) return 150;
-      else return colWidth;
-    }
     return 75;
   };
 
   const getRowHeaderWidth = (x: number) => {
-    if (colWidth > 160) {
-      if (x === 0) {
-        const dimWidth = 220 + tableData?.columnCount * (colWidth - 150);
-        return Math.min(dimWidth, 500);
-      } else if (x === 1) {
-        return 160;
-      }
-    }
     return [250, 130, 50][x];
   };
 
@@ -315,7 +292,7 @@
   const handleMouseHover = (evt, table) => {
     let newRowIdxHover;
     let newColIdxHover;
-    let newHoveringPin;
+    let newHoveringPin = hoveringPin;
     if (evt.type === "mouseout") {
       newRowIdxHover = undefined;
       newColIdxHover = undefined;
@@ -380,7 +357,6 @@
 </script>
 
 <div
-  bind:clientWidth={containerWidth}
   on:mouseleave={resetHighlight}
   style:height={comparing === "none" ? "80px" : "calc(100% - 50px)"}
   style={cssVarStyles}


### PR DESCRIPTION
Columns in Time Detailed Dimension table are now resizable.
This PR also removes custom width based on viewport size. It provides a fixed width for all columns. Users can resize these as per their convenience. 

https://www.notion.so/rilldata/Time-Dimension-Detail-Experience-Pass-1e2951a6d8f74adcaad70db50fc7607a?pvs=4#ae0af399741d4f6b9e76a6b0b13b65e0