### PR TITLE
fix: editor error dialog max height

### DIFF
--- a/web-common/src/features/metrics-views/workspace/editor/MetricsEditorContainer.svelte
+++ b/web-common/src/features/metrics-views/workspace/editor/MetricsEditorContainer.svelte
@@ -28,7 +28,7 @@ It will show an error message if passed in.
     <div
       role="status"
       transition:slide|local={{ duration: LIST_SLIDE_DURATION }}
-      class="editor-error ui-editor-text-error ui-editor-bg-error border border-red-500 border-l-4 px-2 py-5"
+      class="editor-error ui-editor-text-error ui-editor-bg-error border border-red-500 border-l-4 px-2 py-5 max-h-72	overflow-auto"
     >
       <div class="flex gap-x-2 items-center">
         <CancelCircle />{error.message}


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
Long editor errors won't take up the entire screen anymore.

#### Details:
<!-- PROVIDE DETAILS ON WHAT THE CHANGE IS, WHY, AND HOW IF APPLICABLE -->
