### PR TITLE
fix: menu item focus contrast

### DIFF
--- a/web-common/src/app.css
+++ b/web-common/src/app.css
@@ -20,7 +20,7 @@
   }
 
   .surface-focus {
-    @apply bg-gray-200 dark:bg-gray-600;
+    @apply bg-gray-600 dark:bg-gray-600;
   }
 
   .surface-faint {


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
Contrast on menu item hover was too low. Flicker on click still works.

Before:
<img width="322" alt="Screenshot 2023-11-17 at 11 54 13" src="https://github.com/rilldata/rill/assets/1181922/d3db6487-76b6-4548-ab33-7e2f5303fd26">

After:
<img width="312" alt="Screenshot 2023-11-17 at 11 54 37" src="https://github.com/rilldata/rill/assets/1181922/6d4d851e-ba69-4ec1-96e8-db2b6ae9e596">

