### PR TITLE
Integrating available_time_ranges in UI

### DIFF
--- a/web-common/src/features/dashboards/state-managers/selectors/time-range.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/time-range.ts
@@ -1,5 +1,12 @@
+import {
+  timeComparisonOptionsSelector,
+  timeRangeSelectionsSelector,
+} from "@rilldata/web-common/features/dashboards/time-controls/time-range-store";
 import type { DashboardDataSources } from "./types";
-import { timeControlStateSelector } from "../../time-controls/time-control-store";
+import {
+  selectedTimeRangeSelector,
+  timeControlStateSelector,
+} from "../../time-controls/time-control-store";
 
 export const timeControlsState = (dashData: DashboardDataSources) =>
   timeControlStateSelector([
@@ -14,6 +21,28 @@ export const isTimeControlReady = (dashData: DashboardDataSources): boolean =>
 export const isTimeComparisonActive = (
   dashData: DashboardDataSources
 ): boolean => timeControlsState(dashData).showComparison === true;
+
+export const timeRangeSelectorState = (dashData: DashboardDataSources) =>
+  timeRangeSelectionsSelector([
+    dashData.metricsSpecQueryResult,
+    dashData.timeRangeSummary,
+    dashData.dashboard,
+  ]);
+
+export const timeComparisonOptionsState = (dashData: DashboardDataSources) =>
+  timeComparisonOptionsSelector([
+    dashData.metricsSpecQueryResult,
+    dashData.timeRangeSummary,
+    dashData.dashboard,
+    selectedTimeRangeState(dashData),
+  ]);
+
+export const selectedTimeRangeState = (dashData: DashboardDataSources) =>
+  selectedTimeRangeSelector([
+    dashData.metricsSpecQueryResult,
+    dashData.timeRangeSummary,
+    dashData.dashboard,
+  ]);
 
 export const timeRangeSelectors = {
   /**
@@ -30,4 +59,19 @@ export const timeRangeSelectors = {
    * Is the time comparison active?
    */
   isTimeComparisonActive,
+
+  /**
+   * Selection options for the time range selector
+   */
+  timeRangeSelectorState,
+
+  /**
+   * Selection options for the time comparison selector
+   */
+  timeComparisonOptionsState,
+
+  /**
+   * Full {@link DashboardTimeControls} filled in based on selected time range.
+   */
+  selectedTimeRangeState,
 };

--- a/web-common/src/features/dashboards/state-managers/selectors/time-range.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/time-range.ts
@@ -37,6 +37,7 @@ export const timeComparisonOptionsState = (dashData: DashboardDataSources) =>
     selectedTimeRangeState(dashData),
   ]);
 
+// TODO: use this in place of timeControlStore
 export const selectedTimeRangeState = (dashData: DashboardDataSources) =>
   selectedTimeRangeSelector([
     dashData.metricsSpecQueryResult,

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -353,13 +353,11 @@ const metricViewReducers = {
     });
   },
 
-  // TODO: can the comparison validity be removed?
   selectTimeRange(
     name: string,
     timeRange: TimeRange,
     timeGrain: V1TimeGrain,
-    comparisonTimeRange: DashboardTimeControls | undefined,
-    allTimeRange: TimeRange
+    comparisonTimeRange: DashboardTimeControls | undefined
   ) {
     updateMetricsExplorerByName(name, (metricsExplorer) => {
       if (!timeRange.name) return;
@@ -372,31 +370,7 @@ const metricViewReducers = {
         interval: timeGrain,
       };
 
-      if (!comparisonTimeRange) {
-        // when switching time range we reset comparison time range
-        // get the default for the new time range and set it only if is valid
-        const comparisonOption = DEFAULT_TIME_RANGES[timeRange.name]
-          ?.defaultComparison as TimeComparisonOption;
-        const range = getTimeComparisonParametersForComponent(
-          comparisonOption,
-          allTimeRange.start,
-          allTimeRange.end,
-          timeRange.start,
-          timeRange.end
-        );
-
-        if (range.isComparisonRangeAvailable) {
-          metricsExplorer.selectedComparisonTimeRange = {
-            start: range.start,
-            end: range.end,
-            name: comparisonOption,
-          };
-        } else {
-          metricsExplorer.selectedComparisonTimeRange = undefined;
-        }
-      } else {
-        metricsExplorer.selectedComparisonTimeRange = comparisonTimeRange;
-      }
+      metricsExplorer.selectedComparisonTimeRange = comparisonTimeRange;
 
       setDisplayComparison(
         metricsExplorer,

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -7,12 +7,9 @@ import {
   getMapFromArray,
   removeIfExists,
 } from "@rilldata/web-common/lib/arrayUtils";
-import { getTimeComparisonParametersForComponent } from "@rilldata/web-common/lib/time/comparisons";
-import { DEFAULT_TIME_RANGES } from "@rilldata/web-common/lib/time/config";
 import type {
   DashboardTimeControls,
   ScrubRange,
-  TimeComparisonOption,
   TimeRange,
 } from "@rilldata/web-common/lib/time/types";
 import type {

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -353,6 +353,7 @@ const metricViewReducers = {
     });
   },
 
+  // TODO: can the comparison validity be removed?
   selectTimeRange(
     name: string,
     timeRange: TimeRange,

--- a/web-common/src/features/dashboards/time-controls/TimeComparisonSelector.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeComparisonSelector.svelte
@@ -115,6 +115,7 @@ This component needs to do the following:
   <Tooltip distance={8} suppress={active}>
     <SelectorButton
       {active}
+      label="Select time comparison option"
       on:click={() => {
         toggleFloatingElement();
       }}

--- a/web-common/src/features/dashboards/time-controls/TimeComparisonSelector.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeComparisonSelector.svelte
@@ -14,7 +14,6 @@ This component needs to do the following:
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
-  import { createTimeComparisonOptionsState } from "@rilldata/web-common/features/dashboards/time-controls/time-range-store";
   import { LIST_SLIDE_DURATION } from "@rilldata/web-common/layout/config";
   import { getComparisonRange } from "@rilldata/web-common/lib/time/comparisons";
   import {
@@ -47,30 +46,11 @@ This component needs to do the following:
 
   $: comparisonOption = selectedComparison?.name;
 
-  const comparisonOptionsStore = createTimeComparisonOptionsState(
-    getStateManagers()
-  );
-
-  /** compile the comparison options */
-  let options: {
-    name: TimeComparisonOption;
-    start: Date;
-    end: Date;
-  }[];
-  $: options =
-    Object.entries($comparisonOptionsStore)?.map(([key, value]) => {
-      const comparisonTimeRange = getComparisonRange(
-        currentStart,
-        currentEnd,
-        value
-      );
-      return {
-        name: value,
-        key,
-        start: comparisonTimeRange.start,
-        end: comparisonTimeRange.end,
-      };
-    }) ?? [];
+  const {
+    selectors: {
+      timeRangeSelectors: { timeComparisonOptionsState },
+    },
+  } = getStateManagers();
 
   function onSelectCustomComparisonRange(
     startDate: string,
@@ -157,7 +137,7 @@ This component needs to do the following:
     on:escape={toggleFloatingElement}
     slot="floating-element"
   >
-    {#each options as option}
+    {#each $timeComparisonOptionsState as option}
       {@const preset = TIME_COMPARISON[option.name]}
       <MenuItem
         selected={option.name === intermediateSelection}
@@ -173,11 +153,11 @@ This component needs to do the following:
           {preset?.label || option.name}
         </span>
       </MenuItem>
-      {#if option.name === TimeComparisonOption.CONTIGUOUS && options.length > 2}
+      {#if option.name === TimeComparisonOption.CONTIGUOUS && $timeComparisonOptionsState.length > 2}
         <Divider />
       {/if}
     {/each}
-    {#if options.length >= 1}
+    {#if $timeComparisonOptionsState.length >= 1}
       <Divider />
     {/if}
 

--- a/web-common/src/features/dashboards/time-controls/TimeControls.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeControls.svelte
@@ -210,7 +210,6 @@
         showComparison={$timeControlsStore?.showComparison}
         selectedComparison={$timeControlsStore?.selectedComparisonTimeRange}
         zone={$dashboardStore?.selectedTimezone}
-        comparisonOptions={availableComparisons}
       />
     {/if}
     <TimeGrainSelector

--- a/web-common/src/features/dashboards/time-controls/TimeControls.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeControls.svelte
@@ -155,8 +155,7 @@
       metricViewName,
       timeRange,
       timeGrain,
-      comparisonTimeRange,
-      $timeControlsStore.allTimeRange
+      comparisonTimeRange
     );
   }
 </script>

--- a/web-common/src/features/dashboards/time-controls/TimeControls.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeControls.svelte
@@ -6,12 +6,12 @@
   } from "@rilldata/web-common/features/dashboards/selectors";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
-  import { getAvailableComparisonsForTimeRange } from "@rilldata/web-common/lib/time/comparisons";
+  import { getValidComparisonOption } from "@rilldata/web-common/features/dashboards/time-controls/time-range-store";
   import {
     getDefaultTimeGrain,
     getAllowedTimeGrains,
   } from "@rilldata/web-common/lib/time/grains";
-  import {
+  import type {
     DashboardTimeControls,
     TimeComparisonOption,
     TimeGrain,
@@ -102,12 +102,17 @@
       baseTimeRange.end
     ).grain;
 
-    makeTimeSeriesTimeRangeAndUpdateAppState(
+    // Get valid option for the new time range
+    const validComparison = getValidComparisonOption(
+      $metaQuery.data,
       baseTimeRange,
-      defaultTimeGrain,
-      // reset the comparison range
-      undefined
+      $dashboardStore.selectedComparisonTimeRange?.name,
+      $timeControlsStore.allTimeRange
     );
+
+    makeTimeSeriesTimeRangeAndUpdateAppState(baseTimeRange, defaultTimeGrain, {
+      name: validComparison,
+    } as DashboardTimeControls);
   }
 
   function onSelectTimeGrain(timeGrain: V1TimeGrain) {
@@ -152,22 +157,6 @@
       timeGrain,
       comparisonTimeRange,
       $timeControlsStore.allTimeRange
-    );
-  }
-
-  let availableComparisons;
-
-  $: if (allTimeRange?.start && $timeControlsStore.ready) {
-    availableComparisons = getAvailableComparisonsForTimeRange(
-      allTimeRange.start,
-      allTimeRange.end,
-      $timeControlsStore.selectedTimeRange.start,
-      $timeControlsStore.selectedTimeRange.end,
-      [...Object.values(TimeComparisonOption)],
-      [
-        $timeControlsStore.selectedComparisonTimeRange
-          ?.name as TimeComparisonOption,
-      ]
     );
   }
 </script>

--- a/web-common/src/features/dashboards/time-controls/TimeRangeSelector.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeRangeSelector.svelte
@@ -52,10 +52,6 @@
   let isCustomRangeOpen = false;
   let isCalendarRecentlyClosed = false;
 
-  $: showDefaultItem =
-    $metaQuery.data?.defaultTimeRange &&
-    !($metaQuery.data?.defaultTimeRange in ISODurationToTimeRangePreset);
-
   $: hasSubRangeSelected = $dashboardStore?.selectedScrubRange?.end;
 
   function setIntermediateSelection(timeRangeName: string) {
@@ -224,7 +220,7 @@
         {allTime.label}
       </span>
     </MenuItem>
-    {#if showDefaultItem && $timeControlsStore.defaultTimeRange}
+    {#if $timeRangeStore.showDefaultItem}
       <DefaultTimeRangeMenuItem
         on:before-select={setIntermediateSelection(
           $metaQuery.data?.defaultTimeRange

--- a/web-common/src/features/dashboards/time-controls/TimeRangeSelector.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeRangeSelector.svelte
@@ -7,16 +7,12 @@
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import DefaultTimeRangeMenuItem from "@rilldata/web-common/features/dashboards/time-controls/DefaultTimeRangeMenuItem.svelte";
   import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
-  import { createTimeRangeStore } from "@rilldata/web-common/features/dashboards/time-controls/time-range-store";
   import {
     ALL_TIME,
     DEFAULT_TIME_RANGES,
   } from "@rilldata/web-common/lib/time/config";
   import { prettyFormatTimeRange } from "@rilldata/web-common/lib/time/ranges";
-  import {
-    humaniseISODuration,
-    ISODurationToTimeRangePreset,
-  } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
+  import { humaniseISODuration } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
   import {
     DashboardTimeControls,
     TimeRange,
@@ -47,7 +43,11 @@
   const ctx = getStateManagers();
   const timeControlsStore = useTimeControlStore(ctx);
   const metaQuery = useMetaQuery(ctx);
-  const timeRangeStore = createTimeRangeStore(ctx);
+  const {
+    selectors: {
+      timeRangeSelectors: { timeRangeSelectorState },
+    },
+  } = ctx;
 
   let isCustomRangeOpen = false;
   let isCalendarRecentlyClosed = false;
@@ -220,7 +220,7 @@
         {allTime.label}
       </span>
     </MenuItem>
-    {#if $timeRangeStore.showDefaultItem}
+    {#if $timeRangeSelectorState.showDefaultItem}
       <DefaultTimeRangeMenuItem
         on:before-select={setIntermediateSelection(
           $metaQuery.data?.defaultTimeRange
@@ -234,9 +234,9 @@
         isoDuration={$metaQuery.data?.defaultTimeRange}
       />
     {/if}
-    {#if $timeRangeStore.latestWindowTimeRanges?.length}
+    {#if $timeRangeSelectorState.latestWindowTimeRanges?.length}
       <Divider />
-      {#each $timeRangeStore.latestWindowTimeRanges as timeRange}
+      {#each $timeRangeSelectorState.latestWindowTimeRanges as timeRange}
         <MenuItem
           on:before-select={setIntermediateSelection(timeRange.name)}
           on:select={() =>
@@ -248,9 +248,9 @@
         </MenuItem>
       {/each}
     {/if}
-    {#if $timeRangeStore.periodToDateRanges?.length}
+    {#if $timeRangeSelectorState.periodToDateRanges?.length}
       <Divider />
-      {#each $timeRangeStore.periodToDateRanges as timeRange}
+      {#each $timeRangeSelectorState.periodToDateRanges as timeRange}
         <MenuItem
           on:before-select={setIntermediateSelection(timeRange.name)}
           on:select={() =>
@@ -261,8 +261,8 @@
           </span>
         </MenuItem>
       {/each}
-      <Divider />
     {/if}
+    <Divider />
     <CustomTimeRangeMenuItem
       on:select={() => {
         isCustomRangeOpen = !isCustomRangeOpen;

--- a/web-common/src/features/dashboards/time-controls/time-range-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-range-store.ts
@@ -93,7 +93,6 @@ export function timeRangeSelectionsSelector([
     periodToDateRanges = PERIOD_TO_DATE_RANGES;
   }
 
-  console.log(latestWindowTimeRanges, periodToDateRanges);
   return {
     latestWindowTimeRanges: getChildTimeRanges(
       allTimeRange.start,

--- a/web-common/src/features/dashboards/time-controls/time-range-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-range-store.ts
@@ -1,0 +1,115 @@
+import { useMetaQuery } from "@rilldata/web-common/features/dashboards/selectors/index";
+import type { StateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
+import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
+import { getAvailableComparisonsForTimeRange } from "@rilldata/web-common/lib/time/comparisons";
+import {
+  LATEST_WINDOW_TIME_RANGES,
+  PERIOD_TO_DATE_RANGES,
+} from "@rilldata/web-common/lib/time/config";
+import type { TimeRangeMetaSet } from "@rilldata/web-common/lib/time/config";
+import { getChildTimeRanges } from "@rilldata/web-common/lib/time/ranges";
+import { TimeComparisonOption } from "@rilldata/web-common/lib/time/types";
+import type { TimeRangeOption } from "@rilldata/web-common/lib/time/types";
+import { derived } from "svelte/store";
+import type { Readable } from "svelte/store";
+
+export type TimeRangeState = {
+  latestWindowTimeRanges: Array<TimeRangeOption>;
+  periodToDateRanges: Array<TimeRangeOption>;
+};
+
+export function createTimeRangeStore(ctx: StateManagers) {
+  return derived(
+    [useMetaQuery(ctx), useTimeControlStore(ctx), ctx.dashboardStore],
+    ([metricsView, timeControlsState, explorer]) => {
+      if (
+        !metricsView.data ||
+        !timeControlsState.ready ||
+        !timeControlsState.allTimeRange
+      )
+        return {
+          latestWindowTimeRanges: [],
+          periodToDateRanges: [],
+        };
+
+      let latestWindowTimeRanges: TimeRangeMetaSet = {};
+      let periodToDateRanges: TimeRangeMetaSet = {};
+
+      if (metricsView.data.availableTimeRanges?.length) {
+        for (const availableTimeRange of metricsView.data.availableTimeRanges) {
+          if (!availableTimeRange.range) continue;
+
+          if (availableTimeRange.range in LATEST_WINDOW_TIME_RANGES) {
+            latestWindowTimeRanges[availableTimeRange.range] =
+              LATEST_WINDOW_TIME_RANGES[availableTimeRange.range];
+          } else if (availableTimeRange.range in PERIOD_TO_DATE_RANGES) {
+            periodToDateRanges[availableTimeRange.range] =
+              PERIOD_TO_DATE_RANGES[availableTimeRange.range];
+          }
+        }
+      } else {
+        latestWindowTimeRanges = LATEST_WINDOW_TIME_RANGES;
+        periodToDateRanges = PERIOD_TO_DATE_RANGES;
+      }
+
+      return {
+        latestWindowTimeRanges: getChildTimeRanges(
+          timeControlsState.allTimeRange.start,
+          timeControlsState.allTimeRange.end,
+          latestWindowTimeRanges,
+          timeControlsState.minTimeGrain,
+          explorer.selectedTimezone
+        ),
+        periodToDateRanges: getChildTimeRanges(
+          timeControlsState.allTimeRange.start,
+          timeControlsState.allTimeRange.end,
+          periodToDateRanges,
+          timeControlsState.minTimeGrain,
+          explorer.selectedTimezone
+        ),
+      };
+    }
+  ) as Readable<TimeRangeState>;
+}
+
+export type TimeComparisonOptionsState = Array<TimeComparisonOption>;
+
+export function createTimeComparisonOptionsState(ctx: StateManagers) {
+  return derived(
+    [useMetaQuery(ctx), useTimeControlStore(ctx)],
+    ([metricsView, timeControlsState]) => {
+      if (
+        !metricsView.data ||
+        !timeControlsState.ready ||
+        !timeControlsState.allTimeRange ||
+        !timeControlsState.selectedTimeRange
+      )
+        return [];
+
+      let allOptions = [...Object.values(TimeComparisonOption)];
+      if (metricsView.data.availableTimeRanges?.length) {
+        const timeRange = metricsView.data.availableTimeRanges.find(
+          (tr) => tr.range === timeControlsState.selectedTimeRange?.name
+        );
+        if (timeRange?.comparisonOffsets) {
+          allOptions =
+            timeRange.comparisonOffsets?.map(
+              (co) => co.range as TimeComparisonOption
+            ) ?? [];
+        }
+      }
+
+      return getAvailableComparisonsForTimeRange(
+        timeControlsState.allTimeRange.start,
+        timeControlsState.allTimeRange.end,
+        timeControlsState.selectedTimeRange.start,
+        timeControlsState.selectedTimeRange.end,
+        allOptions,
+        [
+          timeControlsState.selectedComparisonTimeRange
+            ?.name as TimeComparisonOption,
+        ]
+      );
+    }
+  ) as Readable<TimeComparisonOptionsState>;
+}

--- a/web-common/src/features/dashboards/time-controls/time-range-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-range-store.ts
@@ -1,129 +1,219 @@
-import { useMetaQuery } from "@rilldata/web-common/features/dashboards/selectors/index";
-import type { StateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
-import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
-import { getAvailableComparisonsForTimeRange } from "@rilldata/web-common/lib/time/comparisons";
+import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import {
+  getAvailableComparisonsForTimeRange,
+  getComparisonRange,
+  getTimeComparisonParametersForComponent,
+} from "@rilldata/web-common/lib/time/comparisons";
 import type { TimeRangeMetaSet } from "@rilldata/web-common/lib/time/config";
 import {
+  DEFAULT_TIME_RANGES,
   LATEST_WINDOW_TIME_RANGES,
   PERIOD_TO_DATE_RANGES,
 } from "@rilldata/web-common/lib/time/config";
 import { getChildTimeRanges } from "@rilldata/web-common/lib/time/ranges";
 import { isoDurationToTimeRangeMeta } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
-import type { TimeRangeOption } from "@rilldata/web-common/lib/time/types";
-import { TimeComparisonOption } from "@rilldata/web-common/lib/time/types";
-import type { Readable } from "svelte/store";
-import { derived } from "svelte/store";
+import type {
+  DashboardTimeControls,
+  TimeRangeOption,
+} from "@rilldata/web-common/lib/time/types";
+import {
+  TimeComparisonOption,
+  TimeRange,
+  TimeRangePreset,
+} from "@rilldata/web-common/lib/time/types";
+import {
+  RpcStatus,
+  V1ColumnTimeRangeResponse,
+  V1MetricsViewSpec,
+  V1TimeGrain,
+} from "@rilldata/web-common/runtime-client";
+import type { QueryObserverResult } from "@tanstack/svelte-query";
 
-export type TimeRangeState = {
+export type TimeRangeControlsState = {
   latestWindowTimeRanges: Array<TimeRangeOption>;
   periodToDateRanges: Array<TimeRangeOption>;
   showDefaultItem: boolean;
 };
 
-export function createTimeRangeStore(ctx: StateManagers) {
-  return derived(
-    [useMetaQuery(ctx), useTimeControlStore(ctx), ctx.dashboardStore],
-    ([metricsView, timeControlsState, explorer]) => {
-      if (
-        !metricsView.data ||
-        !timeControlsState.ready ||
-        !timeControlsState.allTimeRange
-      )
-        return {
-          latestWindowTimeRanges: [],
-          periodToDateRanges: [],
-          showDefaultItem: false,
-        };
+export function timeRangeSelectionsSelector([
+  metricsView,
+  timeRangeResponse,
+  explorer,
+]: [
+  QueryObserverResult<V1MetricsViewSpec, RpcStatus>,
+  QueryObserverResult<V1ColumnTimeRangeResponse, unknown>,
+  MetricsExplorerEntity
+]): TimeRangeControlsState {
+  if (!metricsView.data || !timeRangeResponse?.data?.timeRangeSummary)
+    return {
+      latestWindowTimeRanges: [],
+      periodToDateRanges: [],
+      showDefaultItem: false,
+    };
 
-      let latestWindowTimeRanges: TimeRangeMetaSet = {};
-      let periodToDateRanges: TimeRangeMetaSet = {};
-      let hasDefaultInRanges = false;
+  const allTimeRange = {
+    name: TimeRangePreset.ALL_TIME,
+    start: new Date(timeRangeResponse.data.timeRangeSummary.min ?? 0),
+    end: new Date(timeRangeResponse.data.timeRangeSummary.max ?? 0),
+  };
+  const minTimeGrain =
+    (metricsView.data.smallestTimeGrain as V1TimeGrain) ||
+    V1TimeGrain.TIME_GRAIN_UNSPECIFIED;
 
-      if (metricsView.data.availableTimeRanges?.length) {
-        for (const availableTimeRange of metricsView.data.availableTimeRanges) {
-          if (!availableTimeRange.range) continue;
+  let latestWindowTimeRanges: TimeRangeMetaSet = {};
+  let periodToDateRanges: TimeRangeMetaSet = {};
+  let hasDefaultInRanges = false;
 
-          // default time range is part of availableTimeRanges.
-          // this is used to not show a separate selection for the default
-          if (metricsView.data.defaultTimeRange === availableTimeRange.range) {
-            hasDefaultInRanges = true;
-          }
-          if (availableTimeRange.range in LATEST_WINDOW_TIME_RANGES) {
-            latestWindowTimeRanges[availableTimeRange.range] =
-              LATEST_WINDOW_TIME_RANGES[availableTimeRange.range];
-          } else if (availableTimeRange.range in PERIOD_TO_DATE_RANGES) {
-            periodToDateRanges[availableTimeRange.range] =
-              PERIOD_TO_DATE_RANGES[availableTimeRange.range];
-          } else {
-            latestWindowTimeRanges[availableTimeRange.range] =
-              isoDurationToTimeRangeMeta(availableTimeRange.range);
-          }
-        }
-      } else {
-        latestWindowTimeRanges = LATEST_WINDOW_TIME_RANGES;
-        periodToDateRanges = PERIOD_TO_DATE_RANGES;
+  if (metricsView.data.availableTimeRanges?.length) {
+    for (const availableTimeRange of metricsView.data.availableTimeRanges) {
+      if (!availableTimeRange.range) continue;
+
+      // default time range is part of availableTimeRanges.
+      // this is used to not show a separate selection for the default
+      if (metricsView.data.defaultTimeRange === availableTimeRange.range) {
+        hasDefaultInRanges = true;
       }
-
-      return {
-        latestWindowTimeRanges: getChildTimeRanges(
-          timeControlsState.allTimeRange.start,
-          timeControlsState.allTimeRange.end,
-          latestWindowTimeRanges,
-          timeControlsState.minTimeGrain,
-          explorer.selectedTimezone
-        ),
-        periodToDateRanges: getChildTimeRanges(
-          timeControlsState.allTimeRange.start,
-          timeControlsState.allTimeRange.end,
-          periodToDateRanges,
-          timeControlsState.minTimeGrain,
-          explorer.selectedTimezone
-        ),
-        showDefaultItem:
-          metricsView.data.defaultTimeRange && !hasDefaultInRanges,
-      };
+      if (availableTimeRange.range in LATEST_WINDOW_TIME_RANGES) {
+        latestWindowTimeRanges[availableTimeRange.range] =
+          LATEST_WINDOW_TIME_RANGES[availableTimeRange.range];
+      } else if (availableTimeRange.range in PERIOD_TO_DATE_RANGES) {
+        periodToDateRanges[availableTimeRange.range] =
+          PERIOD_TO_DATE_RANGES[availableTimeRange.range];
+      } else {
+        latestWindowTimeRanges[availableTimeRange.range] =
+          isoDurationToTimeRangeMeta(
+            availableTimeRange.range,
+            availableTimeRange.comparisonOffsets?.[0]
+              ?.offset as TimeComparisonOption
+          );
+      }
     }
-  ) as Readable<TimeRangeState>;
+  } else {
+    latestWindowTimeRanges = LATEST_WINDOW_TIME_RANGES;
+    periodToDateRanges = PERIOD_TO_DATE_RANGES;
+  }
+
+  return {
+    latestWindowTimeRanges: getChildTimeRanges(
+      allTimeRange.start,
+      allTimeRange.end,
+      latestWindowTimeRanges,
+      minTimeGrain,
+      explorer.selectedTimezone
+    ),
+    periodToDateRanges: getChildTimeRanges(
+      allTimeRange.start,
+      allTimeRange.end,
+      periodToDateRanges,
+      minTimeGrain,
+      explorer.selectedTimezone
+    ),
+    showDefaultItem: !!metricsView.data.defaultTimeRange && !hasDefaultInRanges,
+  };
 }
 
-export type TimeComparisonOptionsState = Array<TimeComparisonOption>;
+export function timeComparisonOptionsSelector([
+  metricsView,
+  timeRangeResponse,
+  explorer,
+  selectedTimeRange,
+]: [
+  QueryObserverResult<V1MetricsViewSpec, RpcStatus>,
+  QueryObserverResult<V1ColumnTimeRangeResponse, unknown>,
+  MetricsExplorerEntity,
+  DashboardTimeControls | undefined
+]): Array<{
+  name: TimeComparisonOption;
+  key: number;
+  start: Date;
+  end: Date;
+}> {
+  if (
+    !metricsView.data ||
+    !timeRangeResponse?.data?.timeRangeSummary ||
+    !explorer.selectedTimeRange ||
+    !selectedTimeRange
+  )
+    return [];
 
-export function createTimeComparisonOptionsState(ctx: StateManagers) {
-  return derived(
-    [useMetaQuery(ctx), useTimeControlStore(ctx)],
-    ([metricsView, timeControlsState]) => {
-      if (
-        !metricsView.data ||
-        !timeControlsState.ready ||
-        !timeControlsState.allTimeRange ||
-        !timeControlsState.selectedTimeRange
-      )
-        return [];
+  const allTimeRange = {
+    name: TimeRangePreset.ALL_TIME,
+    start: new Date(timeRangeResponse.data.timeRangeSummary.min ?? 0),
+    end: new Date(timeRangeResponse.data.timeRangeSummary.max ?? 0),
+  };
 
-      let allOptions = [...Object.values(TimeComparisonOption)];
-      if (metricsView.data.availableTimeRanges?.length) {
-        const timeRange = metricsView.data.availableTimeRanges.find(
-          (tr) => tr.range === timeControlsState.selectedTimeRange?.name
-        );
-        if (timeRange?.comparisonOffsets) {
-          allOptions =
-            timeRange.comparisonOffsets?.map(
-              (co) => co.range as TimeComparisonOption
-            ) ?? [];
-        }
-      }
-
-      return getAvailableComparisonsForTimeRange(
-        timeControlsState.allTimeRange.start,
-        timeControlsState.allTimeRange.end,
-        timeControlsState.selectedTimeRange.start,
-        timeControlsState.selectedTimeRange.end,
-        allOptions,
-        [
-          timeControlsState.selectedComparisonTimeRange
-            ?.name as TimeComparisonOption,
-        ]
-      );
+  let allOptions = [...Object.values(TimeComparisonOption)];
+  if (metricsView.data.availableTimeRanges?.length) {
+    const timeRange = metricsView.data.availableTimeRanges.find(
+      (tr) => tr.range === explorer.selectedTimeRange?.name
+    );
+    if (timeRange?.comparisonOffsets?.length) {
+      allOptions =
+        timeRange.comparisonOffsets?.map(
+          (co) => co.offset as TimeComparisonOption
+        ) ?? [];
+      allOptions.push(TimeComparisonOption.CUSTOM);
     }
-  ) as Readable<TimeComparisonOptionsState>;
+  }
+
+  const timeComparisonOptions = getAvailableComparisonsForTimeRange(
+    allTimeRange.start,
+    allTimeRange.end,
+    explorer.selectedTimeRange.start,
+    explorer.selectedTimeRange.end,
+    allOptions,
+    [explorer.selectedComparisonTimeRange?.name as TimeComparisonOption]
+  );
+
+  return timeComparisonOptions.map((co, i) => {
+    const comparisonTimeRange = getComparisonRange(
+      selectedTimeRange.start,
+      selectedTimeRange.end,
+      co
+    );
+    return {
+      name: co,
+      key: i,
+      start: comparisonTimeRange.start,
+      end: comparisonTimeRange.end,
+    };
+  });
+}
+
+export function getValidComparisonOption(
+  metricsView: V1MetricsViewSpec,
+  selectedTimeRange: TimeRange,
+  prevComparisonOption: TimeComparisonOption | undefined,
+  allTimeRange: TimeRange
+) {
+  if (!metricsView.availableTimeRanges?.length) return undefined;
+
+  const timeRange = metricsView.availableTimeRanges.find(
+    (tr) => tr.range === selectedTimeRange.name
+  );
+  if (!timeRange) return undefined;
+
+  // If comparisonOffsets are not defined get default from presets.
+  if (!timeRange.comparisonOffsets?.length) {
+    return DEFAULT_TIME_RANGES[selectedTimeRange.name as TimeRangePreset]
+      ?.defaultComparison as TimeComparisonOption;
+  }
+
+  const existing = timeRange.comparisonOffsets?.find(
+    (co) => co.offset === prevComparisonOption
+  );
+  const existingComparison = getTimeComparisonParametersForComponent(
+    prevComparisonOption,
+    allTimeRange.start,
+    allTimeRange.end,
+    selectedTimeRange.start,
+    selectedTimeRange.end
+  );
+  console.log(prevComparisonOption, existing, existingComparison);
+  // if currently selected comparison option is in allowed list and is valid select it
+  if (existing && existingComparison.isComparisonRangeAvailable) {
+    return prevComparisonOption;
+  }
+
+  return timeRange.comparisonOffsets[0].offset as TimeComparisonOption;
 }

--- a/web-common/src/features/dashboards/time-controls/time-range-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-range-store.ts
@@ -93,6 +93,7 @@ export function timeRangeSelectionsSelector([
     periodToDateRanges = PERIOD_TO_DATE_RANGES;
   }
 
+  console.log(latestWindowTimeRanges, periodToDateRanges);
   return {
     latestWindowTimeRanges: getChildTimeRanges(
       allTimeRange.start,

--- a/web-common/src/features/dashboards/time-controls/time-range-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-range-store.ts
@@ -160,8 +160,8 @@ export function timeComparisonOptionsSelector([
   const timeComparisonOptions = getAvailableComparisonsForTimeRange(
     allTimeRange.start,
     allTimeRange.end,
-    explorer.selectedTimeRange.start,
-    explorer.selectedTimeRange.end,
+    selectedTimeRange.start,
+    selectedTimeRange.end,
     allOptions,
     [explorer.selectedComparisonTimeRange?.name as TimeComparisonOption]
   );
@@ -210,7 +210,6 @@ export function getValidComparisonOption(
     selectedTimeRange.start,
     selectedTimeRange.end
   );
-  console.log(prevComparisonOption, existing, existingComparison);
   // if currently selected comparison option is in allowed list and is valid select it
   if (existing && existingComparison.isComparisonRangeAvailable) {
     return prevComparisonOption;

--- a/web-common/src/lib/time/comparisons/index.ts
+++ b/web-common/src/lib/time/comparisons/index.ts
@@ -190,7 +190,7 @@ export function getAvailableComparisonsForTimeRange(
 
 /** A convenience function that gets comparison range and states whether it is within bounds. */
 export function getTimeComparisonParametersForComponent(
-  comparisonOption: TimeComparisonOption,
+  comparisonOption: TimeComparisonOption | undefined,
   boundStart,
   boundEnd,
   currentStart,

--- a/web-common/src/lib/time/config.ts
+++ b/web-common/src/lib/time/config.ts
@@ -19,6 +19,8 @@ import {
   TimeTruncationType,
 } from "./types";
 
+export type TimeRangeMetaSet = Partial<Record<TimeRangePreset, TimeRangeMeta>>;
+
 /**
  * The "latest" window time ranges are defined as a set of time ranges that are
  * anchored to the latest data point in the dataset with a conceptually-fixed
@@ -30,7 +32,7 @@ import {
  * may be during an incomplete period. For now, we are truncating to a reasonable
  * periodicity (e.g. to the start of the hour) and then applying the offset.
  */
-export const LATEST_WINDOW_TIME_RANGES: Record<string, TimeRangeMeta> = {
+export const LATEST_WINDOW_TIME_RANGES: TimeRangeMetaSet = {
   [TimeRangePreset.LAST_SIX_HOURS]: {
     label: "Last 6 Hours",
     rangePreset: RangePresetType.OFFSET_ANCHORED,
@@ -196,9 +198,7 @@ export const LATEST_WINDOW_TIME_RANGES: Record<string, TimeRangeMeta> = {
  * Like the latest window ranges, wetruncate the latest data point datetime to the
  * start of a reasonable period for now.
  */
-export const PERIOD_TO_DATE_RANGES: Partial<
-  Record<TimeRangePreset, TimeRangeMeta>
-> = {
+export const PERIOD_TO_DATE_RANGES: TimeRangeMetaSet = {
   [TimeRangePreset.TODAY]: {
     label: "Today",
     rangePreset: RangePresetType.PERIOD_ANCHORED,
@@ -317,9 +317,7 @@ export const DEFAULT = {
 };
 
 // TODO: get rid of Partial here
-export const DEFAULT_TIME_RANGES: Partial<
-  Record<TimeRangePreset, TimeRangeMeta>
-> = {
+export const DEFAULT_TIME_RANGES: TimeRangeMetaSet = {
   ...LATEST_WINDOW_TIME_RANGES,
   ...PERIOD_TO_DATE_RANGES,
   [TimeRangePreset.ALL_TIME]: ALL_TIME,

--- a/web-common/src/lib/time/ranges/index.ts
+++ b/web-common/src/lib/time/ranges/index.ts
@@ -396,11 +396,7 @@ export function getAdjustedChartTime(
     start = getStartOfPeriod(start, grainDuration, zone);
     start = getOffset(start, offsetDuration, TimeOffsetType.ADD);
     adjustedEnd = getEndOfPeriod(adjustedEnd, grainDuration, zone);
-  } else if (
-    timePreset &&
-    timePreset !== TimeRangePreset.CUSTOM &&
-    !(timePreset in ISODurationToTimeRangePreset)
-  ) {
+  } else if (timePreset && timePreset === TimeRangePreset.DEFAULT) {
     // For default presets the iso range can be mixed. There the offset added will be the smallest unit in the range.
     // But for the graph we need the offset based on selected grain.
     const smallestTimeGrain = getSmallestTimeGrain(defaultTimeRange);

--- a/web-common/src/lib/time/ranges/index.ts
+++ b/web-common/src/lib/time/ranges/index.ts
@@ -5,10 +5,7 @@
  * - there's some legacy stuff that needs to get deprecated out of this.
  * - we need tests for this.
  */
-import {
-  getSmallestTimeGrain,
-  ISODurationToTimeRangePreset,
-} from "@rilldata/web-common/lib/time/ranges/iso-ranges";
+import { getSmallestTimeGrain } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
 import {
   addZoneOffset,
   getDateMonthYearForTimezone,

--- a/web-common/src/lib/time/ranges/iso-ranges.ts
+++ b/web-common/src/lib/time/ranges/iso-ranges.ts
@@ -8,6 +8,7 @@ import {
   RangePresetType,
   ReferencePoint,
   RelativeTimeTransformation,
+  TimeComparisonOption,
   TimeOffsetType,
   TimeRange,
   TimeRangeMeta,
@@ -51,7 +52,7 @@ for (const preset in TimeRangePreset) {
 }
 
 export function isoDurationToFullTimeRange(
-  isoDuration: string,
+  isoDuration: string | undefined,
   start: Date,
   end: Date,
   zone = "Etc/UTC"
@@ -100,9 +101,13 @@ export function getSmallestTimeGrain(isoDuration: string) {
   return undefined;
 }
 
-export function isoDurationToTimeRangeMeta(isoDuration: string): TimeRangeMeta {
+export function isoDurationToTimeRangeMeta(
+  isoDuration: string,
+  defaultComparison: TimeComparisonOption
+): TimeRangeMeta {
   return {
     label: `Last ${humaniseISODuration(isoDuration)}`,
+    defaultComparison,
     rangePreset: RangePresetType.OFFSET_ANCHORED,
     start: {
       reference: ReferencePoint.LATEST_DATA,

--- a/web-common/src/lib/time/ranges/iso-ranges.ts
+++ b/web-common/src/lib/time/ranges/iso-ranges.ts
@@ -5,9 +5,12 @@ import {
   transformDate,
 } from "@rilldata/web-common/lib/time/transforms";
 import {
+  RangePresetType,
+  ReferencePoint,
   RelativeTimeTransformation,
   TimeOffsetType,
   TimeRange,
+  TimeRangeMeta,
   TimeRangePreset,
   TimeTruncationType,
 } from "@rilldata/web-common/lib/time/types";
@@ -95,6 +98,21 @@ export function getSmallestTimeGrain(isoDuration: string) {
   }
 
   return undefined;
+}
+
+export function isoDurationToTimeRangeMeta(isoDuration: string): TimeRangeMeta {
+  return {
+    label: `Last ${humaniseISODuration(isoDuration)}`,
+    rangePreset: RangePresetType.OFFSET_ANCHORED,
+    start: {
+      reference: ReferencePoint.LATEST_DATA,
+      transformation: getStartTimeTransformations(isoDuration),
+    },
+    end: {
+      reference: ReferencePoint.LATEST_DATA,
+      transformation: getEndTimeTransformations(isoDuration),
+    },
+  };
 }
 
 function getStartTimeTransformations(

--- a/web-local/test/ui/dashboard-flows/dashboard-flow-template.ts
+++ b/web-local/test/ui/dashboard-flows/dashboard-flow-template.ts
@@ -1,28 +1,15 @@
-import { createDashboardFromModel } from "../utils/dashboardHelpers";
-import { createAdBidsModel } from "../utils/dataSpecifcHelpers";
+import { useDashboardFlowTestSetup } from "web-local/test/ui/dashboard-flows/dashboard-flow-test-setup";
 import { test, expect } from "@playwright/test";
 import { startRuntimeForEachTest } from "../utils/startRuntimeForEachTest";
 
 test.describe("~~~~~~~~~~~~~~~~~~~~FIXME RENAME THIS~~~~~~~~~~~~~~~~~~~~~~~", () => {
   startRuntimeForEachTest();
+  // dashboard test setup
+  useDashboardFlowTestSetup();
 
   test("~~~~~~~~~~~~~~~~~~~~FIXME RENAME THIS~~~~~~~~~~~~~~~~~~~~~~~", async ({
     page,
   }) => {
-    test.setTimeout(60000);
-    await page.goto("/");
-    // disable animations
-    await page.addStyleTag({
-      content: `
-        *, *::before, *::after {
-          animation-duration: 0s !important;
-          transition-duration: 0s !important;
-        }
-      `,
-    });
-    await createAdBidsModel(page);
-    await createDashboardFromModel(page, "AdBids_model");
-
     // Delete this when your flow is ready.
     await page.pause();
 

--- a/web-local/test/ui/dashboard-flows/dashboard-flow-test-setup.ts
+++ b/web-local/test/ui/dashboard-flows/dashboard-flow-test-setup.ts
@@ -1,0 +1,21 @@
+import { test } from "@playwright/test";
+import { createDashboardFromModel } from "web-local/test/ui/utils/dashboardHelpers";
+import { createAdBidsModel } from "web-local/test/ui/utils/dataSpecifcHelpers";
+
+export function useDashboardFlowTestSetup() {
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(60000);
+    await page.goto("/");
+    // disable animations
+    await page.addStyleTag({
+      content: `
+        *, *::before, *::after {
+          animation-duration: 0s !important;
+          transition-duration: 0s !important;
+        }
+      `,
+    });
+    await createAdBidsModel(page);
+    await createDashboardFromModel(page, "AdBids_model");
+  });
+}

--- a/web-local/test/ui/dashboard-flows/dimension-and-measure-selection.spec.ts
+++ b/web-local/test/ui/dashboard-flows/dimension-and-measure-selection.spec.ts
@@ -1,26 +1,13 @@
-import { createDashboardFromModel } from "../utils/dashboardHelpers";
-import { createAdBidsModel } from "../utils/dataSpecifcHelpers";
+import { useDashboardFlowTestSetup } from "web-local/test/ui/dashboard-flows/dashboard-flow-test-setup";
 import { test, expect } from "@playwright/test";
 import { startRuntimeForEachTest } from "../utils/startRuntimeForEachTest";
 
 test.describe("dimension and measure selectors", () => {
   startRuntimeForEachTest();
+  // dashboard test setup
+  useDashboardFlowTestSetup();
 
   test("dimension and measure selectors flow", async ({ page }) => {
-    test.setTimeout(60000);
-    await page.goto("/");
-    // disable animations
-    await page.addStyleTag({
-      content: `
-        *, *::before, *::after {
-          animation-duration: 0s !important;
-          transition-duration: 0s !important;
-        }
-      `,
-    });
-    await createAdBidsModel(page);
-    await createDashboardFromModel(page, "AdBids_model");
-
     await page.getByRole("button", { name: "All Measures" }).click();
     await page.getByRole("menuitem", { name: "Total records" }).click();
     await page.getByRole("button", { name: "1 of 2 Measures" }).click();

--- a/web-local/test/ui/dashboard-flows/time-controls-from-config.spec.ts
+++ b/web-local/test/ui/dashboard-flows/time-controls-from-config.spec.ts
@@ -142,12 +142,18 @@ available_time_ranges:
     // Open the time range menu
     await page.getByLabel("Select time range").click();
     // Assert the options available
-    await expect(page.getByText("All Time")).toBeVisible();
-    await expect(page.getByText("Last 6 Hours")).toBeVisible();
-    await expect(page.getByText("Last 5 Days")).toBeVisible();
-    await expect(page.getByText("Last 4 Weeks")).toBeVisible();
-    await expect(page.getByText("Week To Date")).toBeVisible();
-    await expect(page.getByText("Month To Date")).toBeVisible();
+    await Promise.all(
+      [
+        "All Time",
+        "Last 6 Hours",
+        "Last 5 Days",
+        "Last 4 Weeks",
+        "Week To Date",
+        "Month To Date",
+      ].map((label) =>
+        expect(page.getByRole("menuitem", { name: label })).toBeVisible()
+      )
+    );
     // Select Last 6 hours
     await page.getByRole("menuitem", { name: "Last 6 Hours" }).click();
     // Wait for time range menu to close
@@ -155,39 +161,44 @@ available_time_ranges:
       page.getByRole("menu", { name: "Time range selector" })
     ).not.toBeVisible();
     // Assert data has changed
-    await expect(page.getByText("Total rows 251 -37 -12%")).toBeVisible();
-    await expect(page.getByText("Facebook 63 -14%")).toBeVisible();
+    await expect(page.getByText("Total rows 272 -23 -7%")).toBeVisible();
+    await expect(page.getByText("Facebook 68 -4%")).toBeVisible();
 
     // Open the time comparison
     await page.getByLabel("Select time comparison option").click();
     // Assert the options available
-    await expect(page.getByText("Last Period")).toBeVisible();
-    await expect(page.getByText("Previous day")).toBeVisible();
-    await expect(page.getByText("Previous week")).toBeVisible();
-    await expect(page.getByText("Previous month")).toBeVisible();
-    // Select Last 6 hours
+    await Promise.all(
+      ["Last Period", "Previous day", "Previous week", "Previous month"].map(
+        (label) =>
+          expect(page.getByRole("menuitem", { name: label })).toBeVisible()
+      )
+    );
+    // Select Previous week
     await page.getByRole("menuitem", { name: "Previous week" }).click();
     // Wait for time range menu to close
     await expect(
       page.getByRole("menu", { name: "Time comparison selector" })
     ).not.toBeVisible();
     // Assert data has changed
-    await expect(page.getByText("Total rows 251 -48 -16%")).toBeVisible();
-    await expect(page.getByText("Facebook 63 -30%")).toBeVisible();
+    await expect(page.getByText("Total rows 272 -18 -6%")).toBeVisible();
+    await expect(page.getByText("Facebook 68 -26%")).toBeVisible();
 
     // Select Last 5 days
     await interactWithTimeRangeMenu(page, async () => {
       await page.getByRole("menuitem", { name: "Last 5 Days" }).click();
     });
     // Assert data has changed
-    await expect(page.getByText("Total rows 4.8k -857 -15%")).toBeVisible();
-    await expect(page.getByText("Facebook 1.2k -17%")).toBeVisible();
+    await expect(page.getByText("Total rows 5.6k +16 ~0%")).toBeVisible();
+    await expect(page.getByText("Facebook 1.5k -1%")).toBeVisible();
 
     // Open the time comparison
     await page.getByLabel("Select time comparison option").click();
     // Assert the options available
-    await expect(page.getByText("Last Period")).toBeVisible();
-    await expect(page.getByText("Previous week")).toBeVisible();
+    await Promise.all(
+      ["Last Period", "Previous week"].map((label) =>
+        expect(page.getByRole("menuitem", { name: label })).toBeVisible()
+      )
+    );
     // Select Last 6 hours
     await page.getByRole("menuitem", { name: "Last Period" }).click();
     // Wait for time range menu to close
@@ -195,8 +206,8 @@ available_time_ranges:
       page.getByRole("menu", { name: "Time comparison selector" })
     ).not.toBeVisible();
     // Assert data has changed
-    await expect(page.getByText("Total rows 4.8k -829 -14%")).toBeVisible();
-    await expect(page.getByText("Facebook 1.2k -14%")).toBeVisible();
+    await expect(page.getByText("Total rows 5.6k -23 ~0%")).toBeVisible();
+    await expect(page.getByText("Facebook 1.5k ~0%")).toBeVisible();
   });
 });
 
@@ -206,7 +217,6 @@ function getDashboardYaml(defaults: string) {
 
 title: "AdBids_model_dashboard_rename"
 model: "AdBids_model"
-smallest_time_grain: "week"
 timeseries: "timestamp"
 ${defaults}
 measures:

--- a/web-local/test/ui/dashboard-flows/time-controls-from-config.spec.ts
+++ b/web-local/test/ui/dashboard-flows/time-controls-from-config.spec.ts
@@ -24,8 +24,8 @@ test.describe("time controls settings from dashboard config", () => {
     // Time range has changed
     await expect(page.getByText("Last 4 Weeks")).toBeVisible();
     // Data has changed as well
-    await expect(page.getByText("Total rows 26.7k")).toBeVisible();
-    await expect(page.getByText("Facebook 7.0k")).toBeVisible();
+    await expect(page.getByText("Total rows 26.7k -4.7k -15%")).toBeVisible();
+    await expect(page.getByText("Facebook 7.0k 66%")).toBeVisible();
     await page.getByRole("button", { name: "Edit metrics" }).click();
 
     // Set a time range that is one of the period to date preset
@@ -40,8 +40,8 @@ test.describe("time controls settings from dashboard config", () => {
     // Time range has changed
     await expect(page.getByText("Week to Date")).toBeVisible();
     // Data has changed as well
-    await expect(page.getByText("Total rows 3.7k")).toBeVisible();
-    await expect(page.getByText("Facebook 948")).toBeVisible();
+    await expect(page.getByText("Total rows 3.4k +156 4%")).toBeVisible();
+    await expect(page.getByText("Facebook 889 4%")).toBeVisible();
 
     // Select a different time range
     await interactWithTimeRangeMenu(page, async () => {
@@ -52,21 +52,9 @@ test.describe("time controls settings from dashboard config", () => {
       page.getByRole("menuitem", { name: "Last 7 Days" })
     ).not.toBeVisible();
     // Data has changed
-    await expect(page.getByText("Total rows 7.9k")).toBeVisible();
-    await expect(page.getByText("Facebook 2.0k")).toBeVisible();
-
-    // Last 2 weeks is still available in the menu
-    // Select a different time range
-    await interactWithTimeRangeMenu(page, async () => {
-      await page.getByRole("menuitem", { name: "Last 2 Weeks" }).click();
-    });
-    // Wait for menu to close
-    await expect(
-      page.getByRole("menuitem", { name: "Last 2 Weeks" })
-    ).not.toBeVisible();
-    // Data has changed
-    await expect(page.getByText("Total rows 11.2k")).toBeVisible();
-    await expect(page.getByText("Facebook 2.9k")).toBeVisible();
+    await expect(page.getByText("Total rows 7.9k -15 ~0%")).toBeVisible();
+    await expect(page.getByText("Facebook 2.0k -2%")).toBeVisible();
+    await page.getByRole("button", { name: "Edit metrics" }).click();
 
     // Set a time range that is not one of the supported presets
     await updateCodeEditor(page, getDashboardYaml(`default_time_range: "P2W"`));
@@ -77,8 +65,8 @@ test.describe("time controls settings from dashboard config", () => {
     // Time range has changed
     await expect(page.getByText("Last 2 Weeks")).toBeVisible();
     // Data has changed as well
-    await expect(page.getByText("Total rows 11.2k")).toBeVisible();
-    await expect(page.getByText("Facebook 2.9k")).toBeVisible();
+    await expect(page.getByText("Total rows 11.2k -4.4k -28%")).toBeVisible();
+    await expect(page.getByText("Facebook 2.9k -29%")).toBeVisible();
   });
 
   test("default_comparison", async ({ page }) => {
@@ -145,9 +133,70 @@ available_time_ranges:
       - rill-PW
   - P4W
   - rill-WTD
-  - rill-MTD
-`)
+  - rill-MTD`)
     );
+    await waitForDashboard(page);
+    // Go to dashboard
+    await page.getByRole("button", { name: "Go to dashboard" }).click();
+
+    // Open the time range menu
+    await page.getByLabel("Select time range").click();
+    // Assert the options available
+    await expect(page.getByText("All Time")).toBeVisible();
+    await expect(page.getByText("Last 6 Hours")).toBeVisible();
+    await expect(page.getByText("Last 5 Days")).toBeVisible();
+    await expect(page.getByText("Last 4 Weeks")).toBeVisible();
+    await expect(page.getByText("Week To Date")).toBeVisible();
+    await expect(page.getByText("Month To Date")).toBeVisible();
+    // Select Last 6 hours
+    await page.getByRole("menuitem", { name: "Last 6 Hours" }).click();
+    // Wait for time range menu to close
+    await expect(
+      page.getByRole("menu", { name: "Time range selector" })
+    ).not.toBeVisible();
+    // Assert data has changed
+    await expect(page.getByText("Total rows 251 -37 -12%")).toBeVisible();
+    await expect(page.getByText("Facebook 63 -14%")).toBeVisible();
+
+    // Open the time comparison
+    await page.getByLabel("Select time comparison option").click();
+    // Assert the options available
+    await expect(page.getByText("Last Period")).toBeVisible();
+    await expect(page.getByText("Previous day")).toBeVisible();
+    await expect(page.getByText("Previous week")).toBeVisible();
+    await expect(page.getByText("Previous month")).toBeVisible();
+    // Select Last 6 hours
+    await page.getByRole("menuitem", { name: "Previous week" }).click();
+    // Wait for time range menu to close
+    await expect(
+      page.getByRole("menu", { name: "Time comparison selector" })
+    ).not.toBeVisible();
+    // Assert data has changed
+    await expect(page.getByText("Total rows 251 -48 -16%")).toBeVisible();
+    await expect(page.getByText("Facebook 63 -30%")).toBeVisible();
+
+    // Select Last 5 days
+    await interactWithTimeRangeMenu(page, async () => {
+      await page.getByRole("menuitem", { name: "Last 5 Days" }).click();
+    });
+    // Assert data has changed
+    await expect(page.getByText("Total rows 4.8k -857 -15%")).toBeVisible();
+    await expect(page.getByText("Facebook 1.2k -17%")).toBeVisible();
+
+    // Open the time comparison
+    await page.getByLabel("Select time comparison option").click();
+    // Assert the options available
+    await expect(page.getByText("Last Period")).toBeVisible();
+    await expect(page.getByText("Previous week")).toBeVisible();
+    // Select Last 6 hours
+    await page.getByRole("menuitem", { name: "Last Period" }).click();
+    // Wait for time range menu to close
+    await expect(
+      page.getByRole("menu", { name: "Time comparison selector" })
+    ).not.toBeVisible();
+    // Assert data has changed
+    await expect(page.getByText("Total rows 4.8k -829 -14%")).toBeVisible();
+    await expect(page.getByText("Facebook 1.2k -14%")).toBeVisible();
   });
 });
 

--- a/web-local/test/ui/dashboard-flows/time-controls-from-config.spec.ts
+++ b/web-local/test/ui/dashboard-flows/time-controls-from-config.spec.ts
@@ -1,0 +1,178 @@
+import { expect, test } from "@playwright/test";
+import { useDashboardFlowTestSetup } from "web-local/test/ui/dashboard-flows/dashboard-flow-test-setup";
+import { updateCodeEditor } from "web-local/test/ui/utils/commonHelpers";
+import {
+  interactWithTimeRangeMenu,
+  waitForDashboard,
+} from "web-local/test/ui/utils/dashboardHelpers";
+import { startRuntimeForEachTest } from "web-local/test/ui/utils/startRuntimeForEachTest";
+
+test.describe("time controls settings from dashboard config", () => {
+  startRuntimeForEachTest();
+  // dashboard test setup
+  useDashboardFlowTestSetup();
+
+  test("default_time_range", async ({ page }) => {
+    await page.getByRole("button", { name: "Edit metrics" }).click();
+
+    // Set a time range that is one of the supported presets
+    await updateCodeEditor(page, getDashboardYaml(`default_time_range: "P4W"`));
+    await waitForDashboard(page);
+    // Go to dashboard
+    await page.getByRole("button", { name: "Go to dashboard" }).click();
+
+    // Time range has changed
+    await expect(page.getByText("Last 4 Weeks")).toBeVisible();
+    // Data has changed as well
+    await expect(page.getByText("Total rows 26.7k")).toBeVisible();
+    await expect(page.getByText("Facebook 7.0k")).toBeVisible();
+    await page.getByRole("button", { name: "Edit metrics" }).click();
+
+    // Set a time range that is one of the period to date preset
+    await updateCodeEditor(
+      page,
+      getDashboardYaml(`default_time_range: "rill-WTD"`)
+    );
+    await waitForDashboard(page);
+    // Go to dashboard
+    await page.getByRole("button", { name: "Go to dashboard" }).click();
+
+    // Time range has changed
+    await expect(page.getByText("Week to Date")).toBeVisible();
+    // Data has changed as well
+    await expect(page.getByText("Total rows 3.7k")).toBeVisible();
+    await expect(page.getByText("Facebook 948")).toBeVisible();
+
+    // Select a different time range
+    await interactWithTimeRangeMenu(page, async () => {
+      await page.getByRole("menuitem", { name: "Last 7 Days" }).click();
+    });
+    // Wait for menu to close
+    await expect(
+      page.getByRole("menuitem", { name: "Last 7 Days" })
+    ).not.toBeVisible();
+    // Data has changed
+    await expect(page.getByText("Total rows 7.9k")).toBeVisible();
+    await expect(page.getByText("Facebook 2.0k")).toBeVisible();
+
+    // Last 2 weeks is still available in the menu
+    // Select a different time range
+    await interactWithTimeRangeMenu(page, async () => {
+      await page.getByRole("menuitem", { name: "Last 2 Weeks" }).click();
+    });
+    // Wait for menu to close
+    await expect(
+      page.getByRole("menuitem", { name: "Last 2 Weeks" })
+    ).not.toBeVisible();
+    // Data has changed
+    await expect(page.getByText("Total rows 11.2k")).toBeVisible();
+    await expect(page.getByText("Facebook 2.9k")).toBeVisible();
+
+    // Set a time range that is not one of the supported presets
+    await updateCodeEditor(page, getDashboardYaml(`default_time_range: "P2W"`));
+    await waitForDashboard(page);
+    // Go to dashboard
+    await page.getByRole("button", { name: "Go to dashboard" }).click();
+
+    // Time range has changed
+    await expect(page.getByText("Last 2 Weeks")).toBeVisible();
+    // Data has changed as well
+    await expect(page.getByText("Total rows 11.2k")).toBeVisible();
+    await expect(page.getByText("Facebook 2.9k")).toBeVisible();
+  });
+
+  test("default_comparison", async ({ page }) => {
+    await page.getByRole("button", { name: "Edit metrics" }).click();
+
+    // Set comparison to time
+    await updateCodeEditor(
+      page,
+      getDashboardYaml(`default_time_range: "P4W"
+default_comparison:
+  mode: time
+`)
+    );
+    await waitForDashboard(page);
+    // Go to dashboard
+    await page.getByRole("button", { name: "Go to dashboard" }).click();
+    // Comparison is selected
+    await expect(page.getByText("Comparing by Time")).toBeVisible();
+    // Go back to metrics editor
+    await page.getByRole("button", { name: "Edit metrics" }).click();
+
+    // Set comparison to dimension
+    await updateCodeEditor(
+      page,
+      getDashboardYaml(`default_time_range: "P4W"
+default_comparison:
+  mode: dimension
+  dimension: publisher
+`)
+    );
+    await waitForDashboard(page);
+    // Go to dashboard
+    await page.getByRole("button", { name: "Go to dashboard" }).click();
+    // Comparison is selected
+    await expect(page.getByText("Comparing by Publisher")).toBeVisible();
+    // Go back to metrics editor
+    await page.getByRole("button", { name: "Edit metrics" }).click();
+
+    // Set comparison to none
+    await updateCodeEditor(
+      page,
+      getDashboardYaml(`default_time_range: "P4W"
+default_comparison:
+  mode: none
+`)
+    );
+    await waitForDashboard(page);
+    // Go to dashboard
+    await page.getByRole("button", { name: "Go to dashboard" }).click();
+    // No Comparison
+    await expect(page.getByText("No Comparison")).toBeVisible();
+  });
+
+  test("available_time_ranges", async ({ page }) => {
+    await page.getByRole("button", { name: "Edit metrics" }).click();
+    await updateCodeEditor(
+      page,
+      getDashboardYaml(`default_time_range: "P4W"
+available_time_ranges:
+  - PT6H
+  - range: P5D
+    comparison_offsets:
+      - rill-PP
+      - rill-PW
+  - P4W
+  - rill-WTD
+  - rill-MTD
+`)
+    );
+  });
+});
+
+function getDashboardYaml(defaults: string) {
+  return `
+# Visit https://docs.rilldata.com/reference/project-files to learn more about Rill project files.
+
+title: "AdBids_model_dashboard_rename"
+model: "AdBids_model"
+smallest_time_grain: "week"
+timeseries: "timestamp"
+${defaults}
+measures:
+  - label: Total rows
+    expression: count(*)
+    name: total_rows
+    description: Total number of records present
+dimensions:
+  - name: publisher
+    label: Publisher
+    column: publisher
+    description: ""
+  - name: domain
+    label: Domain Name
+    column: domain
+    description: ""
+  `;
+}

--- a/web-local/test/ui/utils/dashboardHelpers.ts
+++ b/web-local/test/ui/utils/dashboardHelpers.ts
@@ -4,6 +4,7 @@ import type {
   V1MetricsViewFilter,
 } from "@rilldata/web-common/runtime-client";
 import type { Page, Response } from "playwright";
+import { waitForValidResource } from "web-local/test/ui/utils/commonHelpers";
 import { clickMenuButton, openEntityMenu } from "./helpers";
 
 export async function createDashboardFromSource(page: Page, source: string) {
@@ -152,5 +153,28 @@ export function metricsViewRequestFilterMatcher(
           .get(label)
           ?.in.every((val) => values.indexOf(val) >= 0) ?? false
     )
+  );
+}
+
+// Helper that opens the time range menu, calls your interactions, and then waits until the menu closes
+export async function interactWithTimeRangeMenu(
+  page: Page,
+  cb: () => void | Promise<void>
+) {
+  // Open the menu
+  await page.getByLabel("Select time range").click();
+  // Run the defined interactions
+  await cb();
+  // Wait for menu to close
+  await expect(
+    page.getByRole("menu", { name: "Time range selector" })
+  ).not.toBeVisible();
+}
+
+export async function waitForDashboard(page: Page) {
+  return waitForValidResource(
+    page,
+    "AdBids_model_dashboard",
+    "rill.runtime.v1.MetricsView"
   );
 }


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [x] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
We added backend support for `available_time_ranges` but no UI support.

#### Details:
1. Refactor TimeRangeSelector to use a new selector that provides the list of available time ranges from `available_time_ranges` config.
2. Refactor TimeComparisonSelector to use a new selector that provides the list of available comparison options from `available_time_ranges` or the default.

## Steps to Verify
1. Create a dashboard with timestamp.
2. Add this setting to start testing,
```
available_time_ranges:
  - PT6H
  - range: P5D
    comparison_offsets:
      - rill-PP
      - rill-PW
  - P4W
  - rill-WTD
  - rill-MTD
```