### PR TITLE
fix formatter warnings

### DIFF
--- a/web-common/src/components/button-group/ButtonGroup.svelte
+++ b/web-common/src/components/button-group/ButtonGroup.svelte
@@ -70,7 +70,7 @@
     // Note: we pass the dispatch function here so that the subbutton
     // the subbutton can dispatch events "from" the parent button group.
     // Since the subbutton is slotted into the parent button group,
-    // the wrapper div in the parent button group does not recieve
+    // the wrapper div in the parent button group does not receive
     // the event normally and cannot forward it.
     dispatch,
   });

--- a/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
@@ -67,7 +67,8 @@
   $: hoveredValue = measureValueFormatterUnabridged(value);
 
   const { shiftClickAction } = createShiftClickAction();
-  async function shiftClickHandler(number: string) {
+  async function shiftClickHandler(number: string | undefined) {
+    if (number === undefined) return;
     await navigator.clipboard.writeText(number);
     notifications.send({
       message: `copied dimension value "${number}" to clipboard`,

--- a/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
@@ -23,7 +23,7 @@
   import { createShiftClickAction } from "@rilldata/web-common/lib/actions/shift-click-action";
 
   export let measure: MetricsViewSpecMeasureV2;
-  export let value: number;
+  export let value: number | null;
   export let comparisonOption: TimeComparisonOption | undefined = undefined;
   export let comparisonValue: number | undefined = undefined;
   export let comparisonPercChange: number | undefined = undefined;
@@ -34,16 +34,20 @@
 
   const dispatch = createEventDispatcher();
 
-  $: measureValueFormatter = createMeasureValueFormatter(measure);
+  $: measureValueFormatter = createMeasureValueFormatter<null>(measure);
 
-  $: measureValueFormatterUnabridged = createMeasureValueFormatter(
+  // this is used to show the full value in tooltips when the user hovers
+  // over the number. If not present, we'll use the string "no data"
+  $: measureValueFormatterUnabridged = createMeasureValueFormatter<null>(
     measure,
     true
   );
 
   $: name = measure?.label || measure?.expression;
 
-  $: valueIsPresent = value !== undefined && value !== null;
+  $: if (value === undefined) {
+    value = null;
+  }
 
   const [send, receive] = crossfade({
     fallback: (node: Element, params: CrossfadeParams) =>
@@ -51,7 +55,7 @@
   });
 
   $: diff =
-    valueIsPresent && comparisonValue !== undefined
+    value !== null && comparisonValue !== undefined
       ? value - comparisonValue
       : 0;
   $: noChange = !comparisonValue;
@@ -64,7 +68,7 @@
   /** when the measure is a percentage, we don't show a percentage change. */
   $: measureIsPercentage = measure?.formatPreset === FormatPreset.PERCENTAGE;
 
-  $: hoveredValue = measureValueFormatterUnabridged(value);
+  $: hoveredValue = measureValueFormatterUnabridged(value) ?? "no data";
 
   const { shiftClickAction } = createShiftClickAction();
   async function shiftClickHandler(number: string | undefined) {
@@ -113,7 +117,7 @@
         style:font-weight="light"
       >
         <div>
-          {#if valueIsPresent && status === EntityStatus.Idle}
+          {#if value !== null && status === EntityStatus.Idle}
             <div class="w-max">
               <WithTween {value} tweenProps={{ duration: 500 }} let:output>
                 {measureValueFormatter(output)}
@@ -124,9 +128,11 @@
                 {#if comparisonValue != null}
                   <div
                     on:mouseenter={() =>
-                      (hoveredValue = measureValueFormatterUnabridged(diff))}
+                      (hoveredValue =
+                        measureValueFormatterUnabridged(diff) ?? "no data")}
                     on:mouseleave={() =>
-                      (hoveredValue = measureValueFormatterUnabridged(value))}
+                      (hoveredValue =
+                        measureValueFormatterUnabridged(value) ?? "no data")}
                     class="w-max text-sm ui-copy-inactive"
                     class:font-semibold={isComparisonPositive}
                   >
@@ -149,7 +155,8 @@
                         )
                       ))}
                     on:mouseleave={() =>
-                      (hoveredValue = measureValueFormatterUnabridged(value))}
+                      (hoveredValue =
+                        measureValueFormatterUnabridged(value) ?? "no data")}
                     class="w-max text-sm
               {isComparisonPositive ? 'ui-copy-inactive' : 'text-red-500'}"
                   >
@@ -177,7 +184,7 @@
             >
               <Spinner status={EntityStatus.Running} />
             </div>
-          {:else if !valueIsPresent}
+          {:else if value === null}
             <span class="ui-copy-disabled-faint italic text-sm">no data</span>
           {/if}
         </div>

--- a/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
@@ -194,7 +194,8 @@
           <!-- FIXME: I can't select the big number by the measure id. -->
           <MeasureBigNumber
             {measure}
-            value={$totalsQuery?.data?.data?.[measure?.name ?? ""] ?? 0}
+            value={// catch nulls and pass only undefined to the component
+            $totalsQuery?.data?.data?.[measure?.name ?? ""] ?? undefined}
             withTimeseries={false}
             status={$totalsQuery?.isFetching
               ? EntityStatus.Running

--- a/web-common/src/features/dashboards/state-managers/selectors/data-formatting.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/data-formatting.ts
@@ -16,6 +16,12 @@ export const formattingSelectors = {
    * according to the active measure's format specification,
    * whether it's a d3 format string or a format preset.
    */
-  activeMeasureFormatter: (args: DashboardDataSources) =>
-    createMeasureValueFormatter(activeMeasure(args)),
+  activeMeasureFormatter: (args: DashboardDataSources) => {
+    const measure = activeMeasure(args);
+    if (measure === undefined) {
+      return (_value: number | undefined) => undefined;
+    }
+
+    return createMeasureValueFormatter(measure);
+  },
 };

--- a/web-common/src/features/dashboards/time-dimension-details/time-dimension-data-store.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/time-dimension-data-store.ts
@@ -5,7 +5,7 @@ import type { MetricsViewSpecMeasureV2 } from "@rilldata/web-common/runtime-clie
 import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import { useTimeSeriesDataStore } from "@rilldata/web-common/features/dashboards/time-series/timeseries-data-store";
 import { createSparkline } from "@rilldata/web-common/components/data-graphic/marks/sparkline";
-import { safeFormatter, transposeArray } from "./util";
+import { transposeArray } from "./util";
 import {
   DEFAULT_TIME_RANGES,
   TIME_COMPARISON,
@@ -81,7 +81,7 @@ function prepareDimensionData(
   if (!data || !totalsData || !measure || data?.length < selectedValues.length)
     return;
 
-  const formatter = safeFormatter(createMeasureValueFormatter(measure));
+  const formatter = createMeasureValueFormatter(measure);
   const measureName = measure?.name as string;
   const validPercentOfTotal = measure?.validPercentOfTotal as boolean;
 
@@ -198,7 +198,7 @@ function prepareTimeData(
 ): TableData {
   if (!data || !measure) return;
 
-  const formatter = safeFormatter(createMeasureValueFormatter(measure));
+  const formatter = createMeasureValueFormatter(measure);
   const measureName = measure?.name ?? "";
 
   /** Strip out data points out of chart view */

--- a/web-common/src/features/dashboards/time-dimension-details/time-dimension-data-store.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/time-dimension-data-store.ts
@@ -81,7 +81,7 @@ function prepareDimensionData(
   if (!data || !totalsData || !measure || data?.length < selectedValues.length)
     return;
 
-  const formatter = createMeasureValueFormatter(measure);
+  const formatter = createMeasureValueFormatter<null | undefined>(measure);
   const measureName = measure?.name as string;
   const validPercentOfTotal = measure?.validPercentOfTotal as boolean;
 
@@ -198,7 +198,7 @@ function prepareTimeData(
 ): TableData {
   if (!data || !measure) return;
 
-  const formatter = createMeasureValueFormatter(measure);
+  const formatter = createMeasureValueFormatter<null | undefined>(measure);
   const measureName = measure?.name ?? "";
 
   /** Strip out data points out of chart view */

--- a/web-common/src/features/dashboards/time-dimension-details/util.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/util.ts
@@ -12,22 +12,6 @@ export function transposeArray(arr, rowCount, columnCount) {
   return columnarBody;
 }
 
-/**
- * This formatter is less strict and
- * returns undefined if the input is undefined
- * */
-export function safeFormatter(formatter) {
-  return (value) => {
-    if (value === undefined) {
-      return undefined;
-    } else if (value === null) {
-      return null;
-    } else {
-      return formatter(value);
-    }
-  };
-}
-
 export function getClassForCell(
   palette: "fixed" | "scrubbed" | "default",
   highlightedRow,

--- a/web-common/src/features/dashboards/time-series/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureChart.svelte
@@ -66,7 +66,7 @@
   export let mouseoverTimeFormat: (d: number | Date | string) => string = (v) =>
     v.toString();
 
-  $: mouseoverFormat = createMeasureValueFormatter(measure);
+  $: mouseoverFormat = createMeasureValueFormatter<null | undefined>(measure);
   $: numberKind = numberKindForMeasure(measure);
 
   export let tweenProps = { duration: 400, easing: cubicOut };

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -235,7 +235,8 @@
     <!-- FIXME: this is pending the remaining state work for show/hide measures and dimensions -->
     {#each renderedMeasures as measure (measure.name)}
       <!-- FIXME: I can't select the big number by the measure id. -->
-      {@const bigNum = totals?.[measure.name]}
+      <!-- for bigNum, catch nulls and convert to undefined.  -->
+      {@const bigNum = totals?.[measure.name] ?? undefined}
       {@const comparisonValue = totalsComparisons?.[measure.name]}
       {@const comparisonPercChange =
         comparisonValue && bigNum !== undefined && bigNum !== null

--- a/web-common/src/lib/number-formatting/format-measure-value.ts
+++ b/web-common/src/lib/number-formatting/format-measure-value.ts
@@ -70,14 +70,13 @@ function humanizeDataTypeUnabridged(value: number, type: FormatPreset): string {
  * This higher-order function takes a measure spec and returns
  * a function appropriate for formatting values from that measure.
  *
- * As of October 2023, all measure values supplied to the client
- * are in the form of a number, so this formatting function will only
- * accept numeric inputs.
+ * As of Nov 2023, all measure values supplied to the client
+ * are in the form of a number or undefined for missing values.
  */
 export const createMeasureValueFormatter = (
   measureSpec: MetricsViewSpecMeasureV2,
   useUnabridged = false
-): ((value: number) => string) => {
+): ((value: number | undefined) => string | undefined) => {
   const humanizer = useUnabridged
     ? humanizeDataTypeUnabridged
     : humanizeDataType;
@@ -92,9 +91,14 @@ export const createMeasureValueFormatter = (
   // otherwise, use the humanize formatter.
   if (measureSpec.formatD3 !== undefined && measureSpec.formatD3 !== "") {
     try {
-      return d3format(measureSpec.formatD3);
+      const formatter = d3format(measureSpec.formatD3);
+      return (value: number | undefined) =>
+        value === undefined ? undefined : formatter(value);
     } catch (error) {
-      return (value: number) => humanizer(value, FormatPreset.HUMANIZE);
+      return (value: number | undefined) =>
+        value === undefined
+          ? undefined
+          : humanizer(value, FormatPreset.HUMANIZE);
     }
   }
 
@@ -103,5 +107,6 @@ export const createMeasureValueFormatter = (
     measureSpec.formatPreset && measureSpec.formatPreset !== ""
       ? (measureSpec.formatPreset as FormatPreset)
       : FormatPreset.HUMANIZE;
-  return (value: number) => humanizer(value, formatPreset);
+  return (value: number | undefined) =>
+    value === undefined ? undefined : humanizer(value, formatPreset);
 };

--- a/web-common/src/lib/number-formatting/strategies/IntTimesPowerOfTen.ts
+++ b/web-common/src/lib/number-formatting/strategies/IntTimesPowerOfTen.ts
@@ -95,7 +95,7 @@ export class IntTimesPowerOfTenFormatter implements Formatter {
         // valid inputs must already be close to a single digit
         //  integer multiple of a power of ten
         if (!closeToIntTimesPowerOfTen(x)) {
-          const msg = `recieved invalid input for IntTimesPowerOfTenFormatter: ${x}`;
+          const msg = `received invalid input for IntTimesPowerOfTenFormatter: ${x}`;
           if (onInvalidInput === "consoleWarn") {
             console.warn(msg);
           } else {


### PR DESCRIPTION
Fixes #3527. Tagging @djbarnwal, because I made the formatters accept `undefined` as you requested last week, and therefore removed the need for the `safeFormatter` function, so I took that out. Please confirm that this meets your needs! :-)

* [Applications](?expand=1&template=applications_template.md)