### PR TITLE
Disable invalid request when changing to no comparison

### DIFF
--- a/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
+++ b/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
@@ -64,7 +64,11 @@ function createMetricsViewTimeSeries(
         },
         {
           query: {
-            enabled: !!timeControls.ready && !!ctx.dashboardStore,
+            enabled:
+              !!timeControls.ready &&
+              !!ctx.dashboardStore &&
+              // in case of comparison, we need to wait for the comparison start time to be available
+              (!isComparison || !!timeControls.comparisonAdjustedStart),
             queryClient: ctx.queryClient,
             keepPreviousData: true,
           },


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
rill-private-issues#7 
Cloud dashboard sometimes crashes when changing to no comparison mode.

#### Details:
We were sending an additional request to `timeseries` API when comparison was changed to no comparison. The `timeStart` and `timeEnd` were undefined leading to the error.

