### PR TITLE
Improve toast notification that shows on scheduled report creation

### DIFF
--- a/web-common/src/components/icons/Check.svelte
+++ b/web-common/src/components/icons/Check.svelte
@@ -1,6 +1,7 @@
 <script>
   export let size = "1em";
   export let color = "currentColor";
+  export let className = "";
 </script>
 
 <svg
@@ -8,6 +9,7 @@
   viewBox="0 0 24 24"
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
+  class={className}
 >
   <path
     fill-rule="evenodd"

--- a/web-common/src/components/notifications/NotificationCenter.svelte
+++ b/web-common/src/components/notifications/NotificationCenter.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import Notification from "./Notification.svelte";
-  import notificationStore from "./notificationStore";
+  import PersistedLinkNotification from "./PersistedLinkNotification.svelte";
   import PersistedNotification from "./PersistedNotification.svelte";
+  import notificationStore from "./notificationStore";
 </script>
 
 {#key $notificationStore.id}
@@ -11,6 +12,12 @@
         <div slot="title">{$notificationStore.message}</div>
         <div slot="body">{$notificationStore.detail}</div>
       </PersistedNotification>
+    {:else if $notificationStore.options.persistedLink}
+      <PersistedLinkNotification
+        message={$notificationStore.message}
+        link={$notificationStore.link}
+        on:clear={() => notificationStore.clear()}
+      />
     {:else}
       <Notification location="bottom" {...$notificationStore.options}>
         {$notificationStore.message}

--- a/web-common/src/components/notifications/PersistedLinkNotification.svelte
+++ b/web-common/src/components/notifications/PersistedLinkNotification.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte";
+  import { scale } from "svelte/transition";
+  import { IconButton } from "../button";
+  import Check from "../icons/Check.svelte";
+  import Close from "../icons/Close.svelte";
+  import type { Link } from "./notificationStore";
+
+  export let message: string;
+  export let link: Link;
+
+  const dispatch = createEventDispatcher();
+</script>
+
+<div
+  transition:scale={{ duration: 200, start: 0.98, opacity: 0 }}
+  class="fixed bottom-10 left-1/2 -translate-x-1/2 py-1.5 bg-gray-800 rounded-sm shadow flex items-center"
+>
+  <div class="flex px-4 gap-x-1.5">
+    <Check size="18px" className="text-white" />
+    <span class="text-gray-50">
+      {message}
+    </span>
+  </div>
+  <div class="px-4 border-l border-gray-600">
+    <a href={link.href} on:click={() => dispatch("clear")}>{link.text}</a>
+  </div>
+  <div class="px-2.5 border-l border-gray-600">
+    <IconButton on:click={() => dispatch("clear")} bgDark>
+      <Close size="18px" color="#fff" />
+    </IconButton>
+  </div>
+</div>

--- a/web-common/src/components/notifications/PersistedLinkNotification.svelte
+++ b/web-common/src/components/notifications/PersistedLinkNotification.svelte
@@ -14,18 +14,18 @@
 
 <div
   transition:scale={{ duration: 200, start: 0.98, opacity: 0 }}
-  class="fixed bottom-10 left-1/2 -translate-x-1/2 py-1.5 bg-gray-800 rounded-sm shadow flex items-center"
+  class="fixed bottom-10 left-1/2 -translate-x-1/2 py-0.5 bg-gray-800 rounded-sm shadow flex items-center"
 >
-  <div class="flex px-4 gap-x-1.5">
+  <div class="flex px-4 py-1.5 gap-x-1.5">
     <Check size="18px" className="text-white" />
-    <span class="text-gray-50">
+    <span class="text-gray-50 text-sm">
       {message}
     </span>
   </div>
-  <div class="px-4 border-l border-gray-600">
+  <div class="px-4 py-1.5 border-l border-gray-600 text-sm">
     <a href={link.href} on:click={() => dispatch("clear")}>{link.text}</a>
   </div>
-  <div class="px-2.5 border-l border-gray-600">
+  <div class="px-2.5 py-1.5 border-l border-gray-600">
     <IconButton on:click={() => dispatch("clear")} bgDark>
       <Close size="18px" color="#fff" />
     </IconButton>

--- a/web-common/src/components/notifications/notificationStore.ts
+++ b/web-common/src/components/notifications/notificationStore.ts
@@ -9,10 +9,16 @@ interface NotificationStore extends Readable<object> {
   clear: () => void;
 }
 
+export interface Link {
+  text: string;
+  href: string;
+}
+
 interface NotificationMessageArguments {
   message: string;
   type?: string;
   detail?: string;
+  link?: Link;
   options?: NotificationOptions;
 }
 
@@ -21,12 +27,14 @@ interface NotificationMessage {
   type?: string;
   message: string;
   detail?: string;
+  link?: Link;
   options?: NotificationOptions;
 }
 
 interface NotificationOptions {
   width?: number;
   persisted?: boolean;
+  persistedLink?: boolean;
 }
 
 function createNotificationStore(): NotificationStore {
@@ -37,6 +45,7 @@ function createNotificationStore(): NotificationStore {
     message,
     type = "default",
     detail,
+    link,
     options = {},
   }: NotificationMessageArguments): void {
     const notificationMessage: NotificationMessage = {
@@ -44,6 +53,7 @@ function createNotificationStore(): NotificationStore {
       message,
       type,
       detail,
+      link,
       options,
     };
     _notification.set(notificationMessage);
@@ -61,7 +71,11 @@ function createNotificationStore(): NotificationStore {
       clearTimeout(timeout);
       set($notification);
       // if this is not the reset message, set the timer.
-      if ($notification.id && !$notification.options?.persisted) {
+      if (
+        $notification.id &&
+        !$notification.options?.persisted &&
+        !$notification.options?.persistedLink
+      ) {
         timeout = setTimeout(clear, NOTIFICATION_TIMEOUT);
       }
     }

--- a/web-common/src/components/notifications/notificationStore.ts
+++ b/web-common/src/components/notifications/notificationStore.ts
@@ -24,8 +24,7 @@ interface NotificationMessage {
   options?: NotificationOptions;
 }
 
-// No need to export after we deprecate the Node backend
-export interface NotificationOptions {
+interface NotificationOptions {
   width?: number;
   persisted?: boolean;
 }

--- a/web-common/src/features/dashboards/dimension-table/ExportDimensionTableDataButton.svelte
+++ b/web-common/src/features/dashboards/dimension-table/ExportDimensionTableDataButton.svelte
@@ -5,10 +5,10 @@
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
   import {
-    createQueryServiceExport,
     V1ExportFormat,
+    createQueryServiceExport,
   } from "@rilldata/web-common/runtime-client";
-  import { onMount, SvelteComponent } from "svelte";
+  import { SvelteComponent, onMount } from "svelte";
   import CaretDownIcon from "../../../components/icons/CaretDownIcon.svelte";
   import exportToplist from "./export-toplist";
 
@@ -37,7 +37,9 @@
   onMount(async () => {
     if (includeScheduledReport) {
       CreateScheduledReportDialog = (
-        await import("../scheduled-reports/CreateScheduledReportDialog.svelte")
+        await import(
+          "../../scheduled-reports/CreateScheduledReportDialog.svelte"
+        )
       ).default;
     }
   });

--- a/web-common/src/features/scheduled-reports/BaseScheduledReportForm.svelte
+++ b/web-common/src/features/scheduled-reports/BaseScheduledReportForm.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import TimePicker from "@rilldata/web-common/components/forms/TimePicker.svelte";
   import { V1ExportFormat } from "@rilldata/web-common/runtime-client";
-  import InputArray from "../../../components/forms/InputArray.svelte";
-  import InputV2 from "../../../components/forms/InputV2.svelte";
-  import Select from "../../../components/forms/Select.svelte";
-  import { runtime } from "../../../runtime-client/runtime-store";
-  import { useDashboard } from "../selectors";
+  import InputArray from "../../components/forms/InputArray.svelte";
+  import InputV2 from "../../components/forms/InputV2.svelte";
+  import Select from "../../components/forms/Select.svelte";
+  import { runtime } from "../../runtime-client/runtime-store";
+  import { useDashboard } from "../dashboards/selectors";
   import { makeTimeZoneOptions } from "./time-utils";
 
   export let formId: string;

--- a/web-common/src/features/scheduled-reports/CreateScheduledReportDialog.svelte
+++ b/web-common/src/features/scheduled-reports/CreateScheduledReportDialog.svelte
@@ -89,7 +89,13 @@
         dispatch("close");
         notifications.send({
           message: "Report created",
-          type: "success",
+          link: {
+            href: `/${organization}/${project}/-/reports`,
+            text: "Go to scheduled reports",
+          },
+          options: {
+            persistedLink: true,
+          },
         });
       } catch (e) {
         // showing error below

--- a/web-common/src/features/scheduled-reports/CreateScheduledReportDialog.svelte
+++ b/web-common/src/features/scheduled-reports/CreateScheduledReportDialog.svelte
@@ -9,15 +9,14 @@
   import { createEventDispatcher } from "svelte";
   import { createForm } from "svelte-forms-lib";
   import * as yup from "yup";
-  import { Button } from "../../../components/button";
-  import { notifications } from "../../../components/notifications";
-  import { getLocalIANA } from "../../../lib/time/timezone";
+  import { Button } from "../../components/button";
+  import { notifications } from "../../components/notifications";
+  import { getLocalIANA } from "../../lib/time/timezone";
   import {
-    getRuntimeServiceListResourcesQueryKey,
     V1ExportFormat,
-  } from "../../../runtime-client";
-  import { runtime } from "../../../runtime-client/runtime-store";
-  import { getStateManagers } from "../state-managers/state-managers";
+    getRuntimeServiceListResourcesQueryKey,
+  } from "../../runtime-client";
+  import { runtime } from "../../runtime-client/runtime-store";
   import BaseScheduledReportForm from "./BaseScheduledReportForm.svelte";
   import {
     convertFormValuesToCronExpression,
@@ -99,10 +98,6 @@
   });
 
   const { isSubmitting, form } = formState;
-
-  const ctx = getStateManagers();
-  const dashboardStore = ctx.dashboardStore;
-  $: dashboardTimeZone = $dashboardStore?.selectedTimezone ?? "";
 </script>
 
 <Dialog {open}>

--- a/web-common/src/features/scheduled-reports/EditScheduledReportDialog.svelte
+++ b/web-common/src/features/scheduled-reports/EditScheduledReportDialog.svelte
@@ -6,18 +6,18 @@
   import { createEventDispatcher } from "svelte";
   import { createForm } from "svelte-forms-lib";
   import * as yup from "yup";
-  import { Button } from "../../../components/button";
-  import { notifications } from "../../../components/notifications";
-  import { getAbbreviationForIANA } from "../../../lib/time/timezone";
+  import { Button } from "../../components/button";
+  import { notifications } from "../../components/notifications";
+  import { getAbbreviationForIANA } from "../../lib/time/timezone";
   import {
     getRuntimeServiceGetResourceQueryKey,
     getRuntimeServiceListResourcesQueryKey,
     V1ExportFormat,
     V1ReportSpec,
     V1ReportSpecAnnotations,
-  } from "../../../runtime-client";
-  import { runtime } from "../../../runtime-client/runtime-store";
-  import { ResourceKind } from "../../entity-management/resource-selectors";
+  } from "../../runtime-client";
+  import { runtime } from "../../runtime-client/runtime-store";
+  import { ResourceKind } from "../entity-management/resource-selectors";
   import BaseScheduledReportForm from "./BaseScheduledReportForm.svelte";
   import {
     convertFormValuesToCronExpression,

--- a/web-common/src/features/scheduled-reports/time-utils.ts
+++ b/web-common/src/features/scheduled-reports/time-utils.ts
@@ -3,7 +3,7 @@ import {
   getAbbreviationForIANA,
   getLocalIANA,
   getUTCIANA,
-} from "../../../lib/time/timezone";
+} from "../../lib/time/timezone";
 
 export function getTodaysDayOfWeek(): string {
   return DateTime.now().toLocaleString({ weekday: "long" });


### PR DESCRIPTION
Addresses [this UXQA item in Notion](https://www.notion.so/rilldata/Match-design-of-success-notification-36c678ff28bb44eb8bda58cb7e76f285).

Note: The notifications/toasts code is quite hacky. At some point, we should review all our notifications, consider leveraging a third party library (like [Melt UI](https://www.melt-ui.com/docs/builders/toast)), and refactor accordingly.