### PR TITLE
add default tooltip max width to fix flicker noticed by Nishant

### DIFF
--- a/web-common/src/components/tooltip/TooltipContent.svelte
+++ b/web-common/src/components/tooltip/TooltipContent.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  export let maxWidth: string | undefined = undefined;
+  /**
+   * The maximum width of the tooltip content.
+   * Defaults to 400px, which is the most commonly
+   * used width for tooltips in the app.
+   */
+  export let maxWidth = "400px";
 </script>
 
 <div


### PR DESCRIPTION
Fixes flicker mentioned here https://rilldata.slack.com/archives/C02T907FEUB/p1701116172362659, add adds a default (overridable) max width to all tooltips