### PR TITLE
Docs: Adding primer about flexible project structure in our reference docs

### DIFF
--- a/docs/docs/reference/project-files/dashboards.md
+++ b/docs/docs/reference/project-files/dashboards.md
@@ -6,32 +6,38 @@ sidebar_position: 30
 
 In your Rill project directory, create a `<dashboard_name>.yaml` file in the `dashboards` directory. Rill will ingest the dashboard definition next time you run `rill start`.
 
+:::info Did you know?
+
+Files that are *nested at any level* under your `dashboards` directory will be assumed to be metric definitions.
+
+:::
+
 ## Properties
 
-_**`model`**_ — the model name powering the dashboard with no path _(required)_
+**`model`** — the model name powering the dashboard with no path _(required)_
 
-_**`title`**_ — the display name for the dashboard _(required)_
+**`title`** — the display name for the dashboard _(required)_
 
-_**`timeseries`**_ — the timestamp column from your model that will underlie x-axis data in the line charts _(optional)_. If not specified, the line charts will not appear.
+**`timeseries`** — the timestamp column from your model that will underlie x-axis data in the line charts _(optional)_. If not specified, the line charts will not appear.
 
-_**`default_time_range`**_ — the default time range shown when a user initially loads the dashboard _(optional)_. The value must be either a valid [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) (for example, `PT12H` for 12 hours, `P1M` for 1 month, or `P26W` for 26 weeks) or the constant value `inf` for all time (default). If not specified, defaults to the full time range of the `timeseries` column.
+**`default_time_range`** — the default time range shown when a user initially loads the dashboard _(optional)_. The value must be either a valid [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) (for example, `PT12H` for 12 hours, `P1M` for 1 month, or `P26W` for 26 weeks) or the constant value `inf` for all time (default). If not specified, defaults to the full time range of the `timeseries` column.
 
-_**`smallest_time_grain`**_ — the smallest time granularity the user is allowed to view in the dashboard _(optional)_. The valid values are: `millisecond`, `second`, `minute`, `hour`, `day`, `week`, `month`, `quarter`, `year`.
+**`smallest_time_grain`** — the smallest time granularity the user is allowed to view in the dashboard _(optional)_. The valid values are: `millisecond`, `second`, `minute`, `hour`, `day`, `week`, `month`, `quarter`, `year`.
 
-_**`first_day_of_week`**_ — the first day of the week for time grain aggregation (for example, Sunday instead of Monday). The valid values are 1 through 7 where Monday=1 and Sunday=7 _(optional)_
+**`first_day_of_week`** — the first day of the week for time grain aggregation (for example, Sunday instead of Monday). The valid values are 1 through 7 where Monday=1 and Sunday=7 _(optional)_
 
-_**`first_month_of_year`**_ — the first month of the year for time grain aggregation. The valid values are 1 through 12 where January=1 and December=12 _(optional)_
+**`first_month_of_year`** — the first month of the year for time grain aggregation. The valid values are 1 through 12 where January=1 and December=12 _(optional)_
 
-_**`available_time_zones`**_ — time zones that should be pinned to the top of the time zone selector _(optional)_. It should be a list of [IANA time zone identifiers](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). By adding one or more time zones will make the dashboard time zone aware and allow users to change current time zone within the dashboard.
+**`available_time_zones`** — time zones that should be pinned to the top of the time zone selector _(optional)_. It should be a list of [IANA time zone identifiers](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). By adding one or more time zones will make the dashboard time zone aware and allow users to change current time zone within the dashboard.
 
-_**`dimensions`**_ — for exploring [segments](../../develop/metrics-dashboard#dimensions) and filtering the dashboard _(required)_
+**`dimensions`** — for exploring [segments](../../develop/metrics-dashboard#dimensions) and filtering the dashboard _(required)_
   - _**`column`**_ — a categorical column _(required)_ 
   - _**`name`**_ — a stable identifier for the dimension _(optional)_
   - _**`label`**_ — a label for your dashboard dimension _(optional)_ 
   - _**`description`**_ — a freeform text description of the dimension for your dashboard _(optional)_ 
   - _**`ignore`**_ — hides the dimension _(optional)_ 
 
-_**`measures`**_ — numeric [aggregates](../../develop/metrics-dashboard#measures) of columns from your data model  _(required)_
+**`measures`** — numeric [aggregates](../../develop/metrics-dashboard#measures) of columns from your data model  _(required)_
   - _**`expression`**_ — a combination of operators and functions for aggregations _(required)_ 
   - _**`name`**_ — a stable identifier for the measure _(required)_
   - _**`label`**_ — a label for your dashboard measure _(optional)_ 
@@ -48,7 +54,7 @@ _**`measures`**_ — numeric [aggregates](../../develop/metrics-dashboard#measur
     - _`percentage`_ — output transformed from a rate to a percentage appended with a percentage sign
     - _`interval_ms`_ — time intervals given in milliseconds are transformed into human readable time units like hours (h), days (d), years (y), etc
 
-_**`security`**_ - define a [security policy](../../develop/security) for the dashboard _(optional)_
+**`security`** - define a [security policy](../../develop/security) for the dashboard _(optional)_
   - _**`access`**_ - Expression indicating if the user should be granted access to the dashboard. If not defined, it will resolve to `false` and the dashboard won't be accessible to anyone. Needs to be a valid SQL expression that evaluates to a boolean. _(optional)_
   - _**`row_filter`**_ - SQL expression to filter the underlying model by. Can leverage templated user attributes to customize the filter for the requesting user. Needs to be a valid SQL expression that can be injected into a `WHERE` clause. _(optional)_
   - _**`exclude`**_ - List of dimension or measure names to exclude from the dashboard. If `exclude` is defined all other dimensions and measures are included. _(optional)_
@@ -57,3 +63,6 @@ _**`security`**_ - define a [security policy](../../develop/security) for the da
   - _**`include`**_ - List of dimension or measure names to include in the dashboard. If `include` is defined all other dimensions and measures are excluded. _(optional)_
     - **`if`** - Expression to decide if the column should be included or not. It can leverage templated user attributes. Needs to be a valid SQL expression that evaluates to a boolean. _(required)_
     - **`names`** - List of fields to include. Should match the `name` of one of the dashboard's dimensions or measures. _(required)_
+
+**`kind`**
+ — This property is used by Rill to identify the resource kind. For dashboard YAML files that exist **outside** of the default location (i.e. `dashboards` directory), this value must be set and should be `dashboard`. Alternative values can include `source` and `model`. _(optional)_

--- a/docs/docs/reference/project-files/dashboards.md
+++ b/docs/docs/reference/project-files/dashboards.md
@@ -14,7 +14,9 @@ Files that are *nested at any level* under your `dashboards` directory will be a
 
 ## Properties
 
-**`model`** — the model name powering the dashboard with no path _(required)_
+**`model`** — the model/table name powering the dashboard with no path _(required)_
+
+**`table`** - alias for the model property and can be used interchangeably _(optional)_
 
 **`title`** — the display name for the dashboard _(required)_
 

--- a/docs/docs/reference/project-files/models.md
+++ b/docs/docs/reference/project-files/models.md
@@ -9,3 +9,9 @@ Data transformations in Rill Developer are powered by DuckDB and their dialect o
 Please visit the [DuckDB documentation](https://duckdb.org/docs/sql/introduction) for insight into how to write your models.
 
 In your Rill project directory, create a `<model_name>.sql` file in the `models` directory containing a DuckDB SQL `SELECT` statement. Rill will automatically detect and parse the model next time you run `rill start`.
+
+:::info Did you know?
+
+Files that are *nested at any level* under your `models` directory will be assumed to be model definitions.
+
+:::

--- a/docs/docs/reference/project-files/sources.md
+++ b/docs/docs/reference/project-files/sources.md
@@ -6,6 +6,12 @@ sidebar_position: 10
 
 In your Rill project directory, create a `<source_name>.yaml` file in the `sources` directory containing a `type` and location (`uri` or `path`). Rill will automatically detect and ingest the source next time you run `rill start`.
 
+:::info Did you know?
+
+Files that are *nested at any level* under your `sources` directory will be assumed to be source definitions.
+
+:::
+
 ## Properties
 
 **`type`**
@@ -93,3 +99,6 @@ duckdb:
   delim: "'|'"
   columns: "columns={'FlightDate': 'DATE', 'UniqueCarrier': 'VARCHAR', 'OriginCityName': 'VARCHAR', 'DestCityName': 'VARCHAR'}"
 ```
+
+**`kind`**
+ — This property is used by Rill to identify the resource kind. For source YAML files that exist **outside** of the default location (i.e. `sources` directory), this value must be set and should be `source`. Alternative values can include `model` and `dashboard`. _(optional)_


### PR DESCRIPTION
Splitting out the docs changes about the flexible project structure so we can merge once full support has been added:
- Calls out the flexible project structure in each resource reference page
- Documents the **kind** property that is needed for YAML files that exist outside their default directory
- Minor cleanup to align the formatting of our dashboard properties page with our source properties page