### PR TITLE
Hide UI controls for scheduled reports created through code

### DIFF
--- a/web-admin/src/features/scheduled-reports/metadata/ReportMetadata.svelte
+++ b/web-admin/src/features/scheduled-reports/metadata/ReportMetadata.svelte
@@ -15,7 +15,11 @@
   import cronstrue from "cronstrue";
   import { createAdminServiceDeleteReport } from "../../../client";
   import ProjectAccessControls from "../../projects/ProjectAccessControls.svelte";
-  import { useReport, useReportDashboardName } from "../selectors";
+  import {
+    useIsReportCreatedByCode,
+    useReport,
+    useReportDashboardName,
+  } from "../selectors";
   import MetadataLabel from "./MetadataLabel.svelte";
   import MetadataValue from "./MetadataValue.svelte";
   import ReportOwnerBlock from "./ReportOwnerBlock.svelte";
@@ -27,6 +31,10 @@
   export let report: string;
 
   $: reportQuery = useReport($runtime.instanceId, report);
+  $: isReportCreatedByCode = useIsReportCreatedByCode(
+    $runtime.instanceId,
+    report
+  );
 
   // Get dashboard
   $: dashboardName = useReportDashboardName($runtime.instanceId, report);
@@ -103,22 +111,24 @@
         </h1>
         <div class="grow" />
         <RunNowButton {organization} {project} {report} />
-        <Menu>
-          <MenuButton>
-            <IconButton>
-              <ThreeDot size="16px" />
-            </IconButton>
-          </MenuButton>
-          <MenuItems>
-            <MenuItem as="button" on:click={handleEditReport}
-              >Edit report</MenuItem
-            >
-            <!-- TODO: add an "are you sure?" confirmation dialog -->
-            <MenuItem as="button" on:click={handleDeleteReport}
-              >Delete report</MenuItem
-            >
-          </MenuItems>
-        </Menu>
+        {#if !$isReportCreatedByCode.data}
+          <Menu>
+            <MenuButton>
+              <IconButton>
+                <ThreeDot size="16px" />
+              </IconButton>
+            </MenuButton>
+            <MenuItems>
+              <MenuItem as="button" on:click={handleEditReport}
+                >Edit report</MenuItem
+              >
+              <!-- TODO: add an "are you sure?" confirmation dialog -->
+              <MenuItem as="button" on:click={handleDeleteReport}
+                >Delete report</MenuItem
+              >
+            </MenuItems>
+          </Menu>
+        {/if}
       </div>
     </div>
 

--- a/web-admin/src/features/scheduled-reports/metadata/ReportOwnerBlock.svelte
+++ b/web-admin/src/features/scheduled-reports/metadata/ReportOwnerBlock.svelte
@@ -5,7 +5,7 @@
   export let project: string;
   export let ownerId: string;
 
-  const ownerName = useReportOwnerName(organization, project, ownerId);
+  $: ownerName = useReportOwnerName(organization, project, ownerId);
 </script>
 
 {#if $ownerName.isSuccess}

--- a/web-admin/src/features/scheduled-reports/selectors.ts
+++ b/web-admin/src/features/scheduled-reports/selectors.ts
@@ -63,3 +63,19 @@ export function useReportOwnerName(
     }
   );
 }
+
+export function useIsReportCreatedByCode(instanceId: string, name: string) {
+  return createRuntimeServiceGetResource(
+    instanceId,
+    {
+      "name.name": name,
+      "name.kind": ResourceKind.Report,
+    },
+    {
+      query: {
+        select: (data) =>
+          !data.resource.report.spec.annotations["admin_owner_user_id"],
+      },
+    }
+  );
+}


### PR DESCRIPTION
For reports created through code, this PR hides the report page's three-dot menu that includes the "Edit report" and "Delete report" actions. For reports created through code, the admin should edit/delete reports by editing the code files directly.

Contributes to #3427