### PR TITLE
Add compression and use gob encoding for download tokens

### DIFF
--- a/runtime/pkg/securetoken/securetoken.go
+++ b/runtime/pkg/securetoken/securetoken.go
@@ -2,9 +2,12 @@ package securetoken
 
 import "github.com/gorilla/securecookie"
 
-// Codec provides a means of encoding and decoding values to URL-friendly opaque tokens that clients cannot decode or tamper with.
-// It encodes values using JSON before encrypting them, and uses base64 URL encoding for serializing the encrypted bytes to the token string.
+// Codec provides a means of encoding and decoding values to URL-friendly opaque tokens that clients cannot tamper with.
+// It encodes values using encoding/gob before encrypting them, and uses base64 URL encoding for serializing the encrypted bytes to the token string.
 // It's implemented as a thin wrapper around gorilla/securecookie, which already provides the necessary functionality.
+//
+// TODO: securecookie redundantly applies two iterations of base64 encoding, increasing the output size (see https://github.com/gorilla/securecookie/issues/36).
+// Since there's not that much code, we should consider modifying/implementing the encoding directly in this package.
 type Codec struct {
 	codecs []securecookie.Codec
 }
@@ -14,13 +17,13 @@ func NewCodec(keyPairs [][]byte) *Codec {
 	for _, c := range codecs {
 		sc := c.(*securecookie.SecureCookie)
 		sc.MaxLength(0)
-		sc.SetSerializer(securecookie.JSONEncoder{})
+		sc.SetSerializer(securecookie.GobEncoder{})
 	}
 	return &Codec{codecs: codecs}
 }
 
 func NewRandom() *Codec {
-	keyPairs := [][]byte{securecookie.GenerateRandomKey(32)}
+	keyPairs := [][]byte{securecookie.GenerateRandomKey(32), securecookie.GenerateRandomKey(32)}
 	return NewCodec(keyPairs)
 }
 

--- a/runtime/server/downloads.go
+++ b/runtime/server/downloads.go
@@ -46,13 +46,14 @@ func UnbakeQuery(bakedQry string) (*runtimev1.Query, error) {
 		return nil, err
 	}
 
-	data, err = gzipDecompress(data)
+	uncompressed, err := gzipDecompress(data)
 	if err != nil {
-		return nil, err
+		// NOTE (2023-11-29): Backwards compatibility for when we didn't gzip baked queries. We can remove this in a few months.
+		uncompressed = data
 	}
 
 	qry := &runtimev1.Query{}
-	if err := proto.Unmarshal(data, qry); err != nil {
+	if err := proto.Unmarshal(uncompressed, qry); err != nil {
 		return nil, err
 	}
 

--- a/runtime/server/downloads.go
+++ b/runtime/server/downloads.go
@@ -32,11 +32,21 @@ func BakeQuery(qry *runtimev1.Query) (string, error) {
 		return "", err
 	}
 
+	data, err = gzipCompress(data)
+	if err != nil {
+		return "", err
+	}
+
 	return base64.URLEncoding.EncodeToString(data), nil
 }
 
 func UnbakeQuery(bakedQry string) (*runtimev1.Query, error) {
 	data, err := base64.URLEncoding.DecodeString(bakedQry)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err = gzipDecompress(data)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/server/downloads.go
+++ b/runtime/server/downloads.go
@@ -1,10 +1,14 @@
 package server
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/base64"
+	"encoding/gob"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"reflect"
 	"time"
@@ -355,11 +359,16 @@ func (s *Server) resolveExportLimit(base, override int64) int64 {
 // downloadTokenTTL determines how long a download token is valid.
 const downloadTokenTTL = 1 * time.Hour
 
-// downloadTokenJSON is the non-encrypted JSON representation of a download token.
-type downloadTokenJSON struct {
+// downloadToken is the non-encrypted representation of a download token.
+type downloadToken struct {
 	Request    []byte         `json:"req"`
 	Attributes map[string]any `json:"attrs"`
 	ExpiresOn  time.Time      `json:"exp"`
+}
+
+// register downloadToken for gob encoding
+func init() {
+	gob.Register(downloadToken{})
 }
 
 // generateDownloadToken generates and encrypts a download token for the given request and attributes.
@@ -369,13 +378,18 @@ func (s *Server) generateDownloadToken(req *runtimev1.ExportRequest, attrs map[s
 		return "", err
 	}
 
-	tknJSON := downloadTokenJSON{
+	r, err = gzipCompress(r)
+	if err != nil {
+		return "", err
+	}
+
+	tkn := downloadToken{
 		Request:    r,
 		Attributes: attrs,
 		ExpiresOn:  time.Now().Add(downloadTokenTTL),
 	}
 
-	res, err := s.codec.Encode(tknJSON)
+	res, err := s.codec.Encode(tkn)
 	if err != nil {
 		return "", err
 	}
@@ -384,22 +398,52 @@ func (s *Server) generateDownloadToken(req *runtimev1.ExportRequest, attrs map[s
 }
 
 // parseDownloadToken decrypts and parses a download token and returns the request and attributes.
-func (s *Server) parseDownloadToken(tkn string) (*runtimev1.ExportRequest, map[string]any, error) {
-	tknJSON := downloadTokenJSON{}
-	err := s.codec.Decode(tkn, &tknJSON)
+func (s *Server) parseDownloadToken(tknStr string) (*runtimev1.ExportRequest, map[string]any, error) {
+	tkn := downloadToken{}
+	err := s.codec.Decode(tknStr, &tkn)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	if tknJSON.ExpiresOn.Before(time.Now()) {
+	if tkn.ExpiresOn.Before(time.Now()) {
 		return nil, nil, fmt.Errorf("download token expired")
 	}
 
-	req := &runtimev1.ExportRequest{}
-	err = proto.Unmarshal(tknJSON.Request, req)
+	r, err := gzipDecompress(tkn.Request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return req, tknJSON.Attributes, nil
+	req := &runtimev1.ExportRequest{}
+	err = proto.Unmarshal(r, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return req, tkn.Attributes, nil
+}
+
+// gzipCompress compress the input bytes using gzip.
+func gzipCompress(v []byte) ([]byte, error) {
+	var b bytes.Buffer
+	w := gzip.NewWriter(&b)
+	_, err := w.Write(v)
+	if err != nil {
+		return nil, err
+	}
+	err = w.Close()
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+// gzipDecompress decompresses the input bytes using gzip.
+func gzipDecompress(v []byte) ([]byte, error) {
+	r, err := gzip.NewReader(bytes.NewReader(v))
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	return io.ReadAll(r)
 }

--- a/runtime/server/downloads.go
+++ b/runtime/server/downloads.go
@@ -440,6 +440,7 @@ func gzipCompress(v []byte) ([]byte, error) {
 	w := gzip.NewWriter(&b)
 	_, err := w.Write(v)
 	if err != nil {
+		_ = w.Close()
 		return nil, err
 	}
 	err = w.Close()

--- a/runtime/server/server_test.go
+++ b/runtime/server/server_test.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/rilldata/rill/runtime/pkg/ratelimit"
 	"github.com/rilldata/rill/runtime/server"
-
-	"github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/rilldata/rill/runtime/server/auth"
 	"github.com/rilldata/rill/runtime/testruntime"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Makes the following changes to reduce download token size:

- Apply GZIP compression to baked queries and download tokens
- Use gob instead of json for serialization in `pkg/securetoken`

Testing with a filter of 500 website URLs:

- Protobuf size: 26091
- Token length before this PR: 62136
- Token length after this PR: 10088

Other observations:

- Removing encryption does not change the token size
- I identified a further possibility for a ~30% size reduction, but it would require a few more hours of work. Added details in a comment in `pkg/securetoken`.