### PR TITLE
Fix time zone bug in "Edit report" form

### DIFF
--- a/web-common/src/features/scheduled-reports/EditScheduledReportDialog.svelte
+++ b/web-common/src/features/scheduled-reports/EditScheduledReportDialog.svelte
@@ -51,7 +51,7 @@
       timeOfDay: getTimeOfDayFromCronExpression(
         reportSpec.refreshSchedule?.cron as string
       ),
-      timeZone: reportSpec.refreshSchedule?.timeZone ?? "",
+      timeZone: reportSpec.refreshSchedule?.timeZone as string, // all UI-created reports have a timeZone
       exportFormat:
         reportSpec.exportFormat ?? V1ExportFormat.EXPORT_FORMAT_UNSPECIFIED,
       exportLimit: reportSpec.exportLimit === "0" ? "" : reportSpec.exportLimit,

--- a/web-common/src/features/scheduled-reports/EditScheduledReportDialog.svelte
+++ b/web-common/src/features/scheduled-reports/EditScheduledReportDialog.svelte
@@ -8,7 +8,6 @@
   import * as yup from "yup";
   import { Button } from "../../components/button";
   import { notifications } from "../../components/notifications";
-  import { getAbbreviationForIANA } from "../../lib/time/timezone";
   import {
     getRuntimeServiceGetResourceQueryKey,
     getRuntimeServiceListResourcesQueryKey,
@@ -52,12 +51,7 @@
       timeOfDay: getTimeOfDayFromCronExpression(
         reportSpec.refreshSchedule?.cron as string
       ),
-      timeZone: reportSpec.refreshSchedule?.timeZone
-        ? getAbbreviationForIANA(
-            new Date(),
-            reportSpec.refreshSchedule.timeZone
-          )
-        : "",
+      timeZone: reportSpec.refreshSchedule?.timeZone ?? "",
       exportFormat:
         reportSpec.exportFormat ?? V1ExportFormat.EXPORT_FORMAT_UNSPECIFIED,
       exportLimit: reportSpec.exportLimit === "0" ? "" : reportSpec.exportLimit,


### PR DESCRIPTION
Before this PR, editing a scheduled report and clicking "Save" sometimes led the user to a 404 page. This happened because:
1. We instantiated the "Edit report" form with the time zone abbreviation, not with the underlying IANA time zone.
2. When the form was submitted with this time zone abbreviation, it resulted in  an "invalid time zone" error in the virtual report file.
3. The presence of this error caused the report resource to be torn down.
4. Because the report resource no longer existed, a 404 page resulted.

This PR fixes this.