### PR TITLE
Docs: Describe generated CLI reference docs

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -27,3 +27,7 @@ go run ./cli
 # To run start:
 go run ./cli start --project dev-project
 ```
+
+## Generating CLI reference docs
+
+See `../docs/README.md` for details about the generated CLI reference docs.

--- a/cli/cmd/docs/generate.go
+++ b/cli/cmd/docs/generate.go
@@ -111,6 +111,7 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 		---
 	*/
 	buf.WriteString("---\n")
+	buf.WriteString("note: GENERATED. DO NOT EDIT.\n")
 	if cmd.Parent() == nil {
 		buf.WriteString("title: CLI usage\n")
 		buf.WriteString("sidebar_position: 15\n")

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,13 +3,15 @@
 
 This folder contains docs for Rill, generated using [Docusaurus](https://docusaurus.io/) and deployed to [https://docs.rilldata.com](https://docs.rilldata.com).
 
-## Install packages
+## Building the docs
+
+### Install packages
 
 ```
 npm install
 ```
 
-## Local development
+### Local development
 
 To start the docs server with hot reloading, run the following command from the _root/docs_ folder of the repo:
 
@@ -17,7 +19,7 @@ To start the docs server with hot reloading, run the following command from the 
 npm run dev
 ```
 
-## Preview production build
+### Preview production build
 
 To run a full build and production preview of the docs, run the following commands from the _root/docs_ folder of the repo:
 
@@ -29,3 +31,12 @@ npm run preview
 ## Deploying the docs
 
 The docs site is deployed via Netlify.
+
+## Generated docs
+
+### CLI reference
+
+The CLI reference docs in `docs/reference/cli` are auto-generated based on the CLI help text. To re-generate the docs, run the following command from the repository root:
+```bash
+make docs.generate
+```

--- a/docs/docs/reference/cli/cli.md
+++ b/docs/docs/reference/cli/cli.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: CLI usage
 sidebar_position: 15
 ---

--- a/docs/docs/reference/cli/deploy.md
+++ b/docs/docs/reference/cli/deploy.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill deploy
 ---
 ## rill deploy

--- a/docs/docs/reference/cli/docs/docs.md
+++ b/docs/docs/reference/cli/docs/docs.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill docs
 ---
 ## rill docs

--- a/docs/docs/reference/cli/env/configure.md
+++ b/docs/docs/reference/cli/env/configure.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill env configure
 ---
 ## rill env configure

--- a/docs/docs/reference/cli/env/env.md
+++ b/docs/docs/reference/cli/env/env.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill env
 ---
 ## rill env

--- a/docs/docs/reference/cli/env/rm.md
+++ b/docs/docs/reference/cli/env/rm.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill env rm
 ---
 ## rill env rm

--- a/docs/docs/reference/cli/env/set.md
+++ b/docs/docs/reference/cli/env/set.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill env set
 ---
 ## rill env set

--- a/docs/docs/reference/cli/env/show.md
+++ b/docs/docs/reference/cli/env/show.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill env show
 ---
 ## rill env show

--- a/docs/docs/reference/cli/login.md
+++ b/docs/docs/reference/cli/login.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill login
 ---
 ## rill login

--- a/docs/docs/reference/cli/logout.md
+++ b/docs/docs/reference/cli/logout.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill logout
 ---
 ## rill logout

--- a/docs/docs/reference/cli/org/create.md
+++ b/docs/docs/reference/cli/org/create.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill org create
 ---
 ## rill org create

--- a/docs/docs/reference/cli/org/delete.md
+++ b/docs/docs/reference/cli/org/delete.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill org delete
 ---
 ## rill org delete

--- a/docs/docs/reference/cli/org/edit.md
+++ b/docs/docs/reference/cli/org/edit.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill org edit
 ---
 ## rill org edit

--- a/docs/docs/reference/cli/org/list.md
+++ b/docs/docs/reference/cli/org/list.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill org list
 ---
 ## rill org list

--- a/docs/docs/reference/cli/org/org.md
+++ b/docs/docs/reference/cli/org/org.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill org
 ---
 ## rill org

--- a/docs/docs/reference/cli/org/rename.md
+++ b/docs/docs/reference/cli/org/rename.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill org rename
 ---
 ## rill org rename
@@ -14,6 +15,7 @@ rill org rename [flags]
 ```
       --org string        Current Org Name
       --new-name string   New Org Name
+      --force             Force rename org without confirmation prompt
 ```
 
 ### Global flags

--- a/docs/docs/reference/cli/org/switch.md
+++ b/docs/docs/reference/cli/org/switch.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill org switch
 ---
 ## rill org switch

--- a/docs/docs/reference/cli/project/delete.md
+++ b/docs/docs/reference/cli/project/delete.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill project delete
 ---
 ## rill project delete

--- a/docs/docs/reference/cli/project/describe.md
+++ b/docs/docs/reference/cli/project/describe.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill project describe
 ---
 ## rill project describe

--- a/docs/docs/reference/cli/project/edit.md
+++ b/docs/docs/reference/cli/project/edit.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill project edit
 ---
 ## rill project edit

--- a/docs/docs/reference/cli/project/list.md
+++ b/docs/docs/reference/cli/project/list.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill project list
 ---
 ## rill project list

--- a/docs/docs/reference/cli/project/logs.md
+++ b/docs/docs/reference/cli/project/logs.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill project logs
 ---
 ## rill project logs

--- a/docs/docs/reference/cli/project/project.md
+++ b/docs/docs/reference/cli/project/project.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill project
 ---
 ## rill project

--- a/docs/docs/reference/cli/project/refresh.md
+++ b/docs/docs/reference/cli/project/refresh.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill project refresh
 ---
 ## rill project refresh

--- a/docs/docs/reference/cli/project/rename.md
+++ b/docs/docs/reference/cli/project/rename.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill project rename
 ---
 ## rill project rename

--- a/docs/docs/reference/cli/project/reset.md
+++ b/docs/docs/reference/cli/project/reset.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill project reset
 ---
 ## rill project reset

--- a/docs/docs/reference/cli/project/show.md
+++ b/docs/docs/reference/cli/project/show.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill project show
 ---
 ## rill project show

--- a/docs/docs/reference/cli/project/status.md
+++ b/docs/docs/reference/cli/project/status.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill project status
 ---
 ## rill project status

--- a/docs/docs/reference/cli/start.md
+++ b/docs/docs/reference/cli/start.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill start
 ---
 ## rill start

--- a/docs/docs/reference/cli/upgrade.md
+++ b/docs/docs/reference/cli/upgrade.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill upgrade
 ---
 ## rill upgrade

--- a/docs/docs/reference/cli/user/add.md
+++ b/docs/docs/reference/cli/user/add.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill user add
 ---
 ## rill user add

--- a/docs/docs/reference/cli/user/list.md
+++ b/docs/docs/reference/cli/user/list.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill user list
 ---
 ## rill user list

--- a/docs/docs/reference/cli/user/remove.md
+++ b/docs/docs/reference/cli/user/remove.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill user remove
 ---
 ## rill user remove

--- a/docs/docs/reference/cli/user/set-role.md
+++ b/docs/docs/reference/cli/user/set-role.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill user set-role
 ---
 ## rill user set-role

--- a/docs/docs/reference/cli/user/user.md
+++ b/docs/docs/reference/cli/user/user.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill user
 ---
 ## rill user

--- a/docs/docs/reference/cli/user/whitelist/list.md
+++ b/docs/docs/reference/cli/user/whitelist/list.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill user whitelist list
 ---
 ## rill user whitelist list

--- a/docs/docs/reference/cli/user/whitelist/remove.md
+++ b/docs/docs/reference/cli/user/whitelist/remove.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill user whitelist remove
 ---
 ## rill user whitelist remove

--- a/docs/docs/reference/cli/user/whitelist/setup.md
+++ b/docs/docs/reference/cli/user/whitelist/setup.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill user whitelist setup
 ---
 ## rill user whitelist setup

--- a/docs/docs/reference/cli/user/whitelist/whitelist.md
+++ b/docs/docs/reference/cli/user/whitelist/whitelist.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill user whitelist
 ---
 ## rill user whitelist

--- a/docs/docs/reference/cli/version.md
+++ b/docs/docs/reference/cli/version.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill version
 ---
 ## rill version

--- a/docs/docs/reference/cli/whoami.md
+++ b/docs/docs/reference/cli/whoami.md
@@ -1,4 +1,5 @@
 ---
+note: GENERATED. DO NOT EDIT.
 title: rill whoami
 ---
 ## rill whoami


### PR DESCRIPTION
- Add notes about how to re-generate the CLI reference docs in the relevant READMEs
- Add a "DO NOT EDIT" warning in the front matter of the generated CLI docs files