### PR TITLE
Fix auth redirect on the Dashboard page

### DIFF
--- a/web-admin/src/client/utils.ts
+++ b/web-admin/src/client/utils.ts
@@ -1,0 +1,18 @@
+import type { Query } from "@tanstack/svelte-query";
+
+export function isAdminServerQuery(query: Query): boolean {
+  const [apiPath] = query.queryKey as string[];
+  const adminApiEndpoints = [
+    "/v1/deployments",
+    "/v1/github",
+    "/v1/organizations",
+    "/v1/projects",
+    "/v1/services",
+    "/v1/superuser",
+    "/v1/telemetry",
+    "/v1/tokens",
+    "/v1/users",
+  ];
+
+  return adminApiEndpoints.some((endpoint) => apiPath.startsWith(endpoint));
+}

--- a/web-admin/src/features/errors/error-utils.ts
+++ b/web-admin/src/features/errors/error-utils.ts
@@ -1,5 +1,6 @@
 import { goto } from "$app/navigation";
 import { page } from "$app/stores";
+import { isAdminServerQuery } from "@rilldata/web-admin/client/utils";
 import {
   getScreenNameFromPage,
   isDashboardPage,
@@ -33,6 +34,12 @@ export function createGlobalErrorCallback(queryClient: QueryClient) {
         (error.response?.data as RpcStatus)?.message ?? error.message,
         screenName
       );
+    }
+
+    // If unauthorized to the admin server, redirect to login page
+    if (isAdminServerQuery(query) && error.response?.status === 401) {
+      goto(`${ADMIN_URL}/auth/login?redirect=${window.origin}`);
+      return;
     }
 
     // Special handling for some errors on the Project page
@@ -69,12 +76,6 @@ export function createGlobalErrorCallback(queryClient: QueryClient) {
       if (error.response?.status === 401) {
         return;
       }
-    }
-
-    // If Unauthorized, redirect to login page
-    if (error.response?.status === 401) {
-      goto(`${ADMIN_URL}/auth/login?redirect=${window.origin}`);
-      return;
     }
 
     // Create a pretty message for the error page

--- a/web-admin/src/features/errors/error-utils.ts
+++ b/web-admin/src/features/errors/error-utils.ts
@@ -38,7 +38,9 @@ export function createGlobalErrorCallback(queryClient: QueryClient) {
 
     // If unauthorized to the admin server, redirect to login page
     if (isAdminServerQuery(query) && error.response?.status === 401) {
-      goto(`${ADMIN_URL}/auth/login?redirect=${window.origin}`);
+      goto(
+        `${ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`
+      );
       return;
     }
 


### PR DESCRIPTION
Closes #3372 

When adding special handling for 401s from the Runtime server, we broke the auth redirect for 401s from the Admin server (when on the Dashboard page).

This PR:
- Redirects to the login page whenever a request to the admin server returns a 401
- Edits the login page redirect so that, after login, the user is returned to their intended page

Note: In the future we can consider using unique TanStack Query `QueryClients` for the Admin server and for different Runtimes. That isolation would've prevented this issue from happening in the first place.