### PR TITLE
Fix 3568

### DIFF
--- a/web-common/src/layout/workspace/WorkspaceContainer.svelte
+++ b/web-common/src/layout/workspace/WorkspaceContainer.svelte
@@ -18,10 +18,6 @@
   export let bgClass = "bg-gray-100";
   export let top = "var(--header-height)";
 
-  window.addEventListener("popstate", () => {
-    console.log("------------------------ POPSTATE");
-  });
-
   const inspectorLayout = localStorageStore<LayoutElement>(assetID, {
     value: inspector ? DEFAULT_INSPECTOR_WIDTH : 0,
     visible: true,


### PR DESCRIPTION
Fixes #3568 (gnarly tooltip bug). This was another devastatingly annoying Svelte bug that took hours to track down and was a one line fix. :-|

(PR also includes incidental cleanup of unused event dispatches)

* [Applications](?expand=1&template=applications_template.md)
* [Others](?expand=1&template=fallback_template.md)