### PR TITLE
Runtime: Reduce chance and impact of deadlocked DuckDB calls

### DIFF
--- a/runtime/controller.go
+++ b/runtime/controller.go
@@ -26,6 +26,9 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// reconcileCancelationTimeout sets a timeout for how long to wait for a reconcile to cancel before stopping the controller with a critical error.
+const reconcileCancelationTimeout = 10 * time.Minute
+
 // errCyclicDependency is set as the error on resources that can't be reconciled due to a cyclic dependency
 var errCyclicDependency = errors.New("cannot be reconciled due to cyclic dependency")
 
@@ -151,6 +154,10 @@ func (c *Controller) Run(ctx context.Context) error {
 	flushTicker := time.NewTicker(10 * time.Second)
 	defer flushTicker.Stop()
 
+	// Ticker for periodically checking for hanging reconciles that don't respond to cancelation
+	hangingTicker := time.NewTicker(time.Minute)
+	defer hangingTicker.Stop()
+
 	// Timer for scheduling resources added to c.timeline.
 	// Call resetTimelineTimer whenever the timeline may have been changed (must hold mu).
 	timelineTimer := time.NewTimer(time.Second)
@@ -225,6 +232,22 @@ func (c *Controller) Run(ctx context.Context) error {
 			if err != nil {
 				loopErr = err
 				stop = true
+			}
+		case <-hangingTicker.C: // It's time to check for hanging canceled reconciles
+			var hangingName *runtimev1.ResourceName
+			c.mu.RLock()
+			for _, inv := range c.invocations {
+				if !inv.cancelledOn.IsZero() && time.Since(inv.cancelledOn) > reconcileCancelationTimeout {
+					hangingName = inv.name
+					break
+				}
+			}
+			c.mu.RUnlock()
+
+			if hangingName != nil {
+				loopErr = fmt.Errorf("reconcile for resource \"%s/%s\" has hung for more than %v after cancelation", hangingName.Kind, hangingName.Name, reconcileCancelationTimeout)
+				stop = true
+				break
 			}
 		case <-c.catalog.hasEventsCh: // The catalog has events to process
 			// Need a write lock to call resetEvents.
@@ -1272,6 +1295,7 @@ func (c *Controller) invoke(r *runtimev1.Resource) error {
 			// Send invocation to event loop for post-processing
 			c.completed <- inv
 		}()
+
 		// Start tracing span
 		tracerAttrs := []attribute.KeyValue{
 			attribute.String("instance_id", c.InstanceID),
@@ -1318,8 +1342,8 @@ func (c *Controller) processCompletedInvocation(inv *invocation) error {
 	if !inv.result.Retrigger.IsZero() {
 		logArgs = append(logArgs, slog.String("retrigger_on", inv.result.Retrigger.Format(time.RFC3339)))
 	}
-	if inv.cancelled {
-		logArgs = append(logArgs, slog.Bool("cancelled", inv.cancelled))
+	if !inv.cancelledOn.IsZero() {
+		logArgs = append(logArgs, slog.Bool("cancelled", true))
 	}
 	errorLevel := false
 	if inv.result.Err != nil && !errors.Is(inv.result.Err, context.Canceled) {
@@ -1343,7 +1367,7 @@ func (c *Controller) processCompletedInvocation(inv *invocation) error {
 
 	if inv.isDelete {
 		// Extra checks in case item was re-created during deletion, or deleted during a normal reconciling (in which case this is just a cancellation of the normal reconcile, not the result of deletion)
-		if r != nil && r.Meta.DeletedOn != nil && !inv.cancelled {
+		if r != nil && r.Meta.DeletedOn != nil && inv.cancelledOn.IsZero() {
 			if inv.result.Err != nil {
 				c.Logger.Error("got error while deleting resource", slog.String("name", nameStr(r.Meta.Name)), slog.Any("error", inv.result.Err))
 			}
@@ -1365,7 +1389,7 @@ func (c *Controller) processCompletedInvocation(inv *invocation) error {
 
 	if inv.isRename {
 		// Extra checks in case item was cancelled during renaming
-		if r != nil && r.Meta.RenamedFrom != nil && !inv.cancelled {
+		if r != nil && r.Meta.RenamedFrom != nil && inv.cancelledOn.IsZero() {
 			err = c.catalog.clearRenamedFrom(r.Meta.Name)
 			if err != nil {
 				return err
@@ -1452,7 +1476,7 @@ type invocation struct {
 	isRename    bool
 	startedOn   time.Time
 	cancelFn    context.CancelFunc
-	cancelled   bool
+	cancelledOn time.Time
 	reschedule  bool
 	holdsLock   bool
 	deletedSelf bool
@@ -1470,8 +1494,8 @@ type waitlistEntry struct {
 // It can be called multiple times with different reschedule values, and will be rescheduled if any of the calls ask for it.
 // It's not thread-safe (must be called while the controller's mutex is held).
 func (i *invocation) cancel(reschedule bool) {
-	if !i.cancelled {
-		i.cancelled = true
+	if i.cancelledOn.IsZero() {
+		i.cancelledOn = time.Now()
 		i.cancelFn()
 	}
 	i.reschedule = i.reschedule || reschedule

--- a/runtime/drivers/duckdb/config_test.go
+++ b/runtime/drivers/duckdb/config_test.go
@@ -120,6 +120,7 @@ func TestOverrides(t *testing.T) {
 	require.True(t, res.Next())
 	var mem string
 	require.NoError(t, res.Scan(&mem))
+	require.NoError(t, res.Close())
 
 	require.Equal(t, "2.0GB", mem)
 }

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -811,6 +811,7 @@ func (c *connection) periodicallyCheckConnDurations(d time.Duration) {
 					c.logger.Error("duckdb: a connection has been held for more longer than the maximum allowed duration", zap.Int("conn_id", connID), zap.Duration("duration", time.Since(connTime)))
 				}
 			}
+			c.connTimesMu.Unlock()
 		}
 	}
 }

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -770,11 +770,13 @@ func (c *connection) detachAllDBs() {
 	if !c.config.ExtTableStorage {
 		return
 	}
+
 	entries, err := os.ReadDir(c.config.ExtStoragePath)
 	if err != nil {
 		c.logger.Error("unable to read ExtStoragePath", zap.String("path", c.config.ExtStoragePath), zap.Error(err))
 		return
 	}
+
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -318,20 +318,14 @@ func (c *connection) Config() map[string]any {
 
 // Close implements drivers.Connection.
 func (c *connection) Close() error {
-	c.cancel()
-	_ = c.registration.Unregister()
-
-	// Set a 1 minute timeout for closing the DB.
-	// This is likely excessive, but some DuckDB checkpoint cases  can take a while.
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-
 	// Gracefully detach all databases (otherwise DuckDB may leak memory)
-	_ = c.WithConnection(ctx, 9000, true, false, func(ctx, ensuredCtx context.Context, conn *databasesql.Conn) error {
+	_ = c.WithConnection(context.Background(), 9000, true, false, func(ctx, ensuredCtx context.Context, conn *databasesql.Conn) error {
 		c.detachAllDBs(ctx, conn)
 		return nil
 	})
 
+	c.cancel()
+	_ = c.registration.Unregister()
 	return c.db.Close()
 }
 

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -136,6 +136,7 @@ func (d Driver) Open(cfgMap map[string]any, shared bool, ac activity.Client, log
 		driverConfig:   cfgMap,
 		driverName:     d.name,
 		shared:         shared,
+		connTimes:      make(map[int]time.Time),
 		ctx:            ctx,
 		cancel:         cancel,
 	}

--- a/runtime/drivers/duckdb/olap.go
+++ b/runtime/drivers/duckdb/olap.go
@@ -652,7 +652,6 @@ func (c *connection) convertToEnum(ctx context.Context, table, col string) error
 	dbName := dbName(table, version)
 	enum := fmt.Sprintf("%s_enum", col)
 
-	var switchErr error
 	err = c.WithConnection(ctx, 100, true, false, func(ctx, ensuredCtx context.Context, _ *dbsql.Conn) error {
 		// check that atleast one non nil value exists in the column
 		res, err := c.Execute(ctx, &drivers.Statement{Query: fmt.Sprintf("SELECT (SELECT count(%s) FROM %s.default WHERE %s IS NOT NULL) > 0 AS cnt", safeSQLName(col), safeSQLName(dbName), safeSQLName(col))})
@@ -697,7 +696,11 @@ func (c *connection) convertToEnum(ctx context.Context, table, col string) error
 		defer func() {
 			// switch to original db, notice `db.schema` just doing USE db switches context to `main` schema in the current db if doing `USE main`
 			// we want to switch to original db and schema
-			switchErr = c.Exec(ensuredCtx, &drivers.Statement{Query: fmt.Sprintf("USE %s.%s", safeSQLName(currentDB), safeSQLName(currentSchema))})
+			err = c.Exec(ensuredCtx, &drivers.Statement{Query: fmt.Sprintf("USE %s.%s", safeSQLName(currentDB), safeSQLName(currentSchema))})
+			if err != nil {
+				// This should NEVER happen
+				c.fatalInternalError(fmt.Errorf("failed to switch back from db %q: %w", dbName, err))
+			}
 		}()
 
 		err = c.Exec(ensuredCtx, &drivers.Statement{Query: fmt.Sprintf("CREATE TYPE %s AS ENUM (SELECT DISTINCT %s FROM \"default\" WHERE %s IS NOT NULL)", safeSQLName(enum), safeSQLName(col), safeSQLName(col))})
@@ -714,12 +717,6 @@ func (c *connection) convertToEnum(ctx context.Context, table, col string) error
 		// NOTE :: db name need to be appened in the view query else query fails when switching to main db
 		return c.Exec(ensuredCtx, &drivers.Statement{Query: fmt.Sprintf("CREATE OR REPLACE VIEW %s.%s.%s AS SELECT * FROM %s.default", safeSQLName(currentDB), safeSQLName(currentSchema), safeSQLName(table), safeSQLName(dbName))})
 	})
-	if switchErr != nil {
-		c.logger.Error("failed switch db to main, reopening db", zap.Error(switchErr))
-		// if switching to main fails all subsequent queries would fail so we reopen db
-		_ = c.reopenDB() // TODO: NOT SAFE!
-	}
-
 	if err != nil {
 		return err
 	}

--- a/runtime/drivers/duckdb/olap_crud_test.go
+++ b/runtime/drivers/duckdb/olap_crud_test.go
@@ -410,6 +410,7 @@ func Test_connection_CastEnum(t *testing.T) {
 	require.True(t, res.Next())
 	require.NoError(t, res.Scan(&typ))
 	require.Equal(t, "ENUM('hello', 'world')", typ)
+	require.NoError(t, res.Close())
 }
 
 func Test_connection_CreateTableAsSelectWithComments(t *testing.T) {

--- a/runtime/drivers/duckdb/transporter_motherduck_to_duckDB.go
+++ b/runtime/drivers/duckdb/transporter_motherduck_to_duckDB.go
@@ -45,7 +45,12 @@ func (t *motherduckToDuckDB) Transfer(ctx context.Context, srcProps, sinkProps m
 	tmpTable := fmt.Sprintf("__%s_tmp_postgres", sinkCfg.Table)
 	defer func() {
 		// ensure temporary table is cleaned
-		if err := t.to.Exec(context.Background(), &drivers.Statement{Query: fmt.Sprintf("DROP TABLE IF EXISTS %s", tmpTable), Priority: 100}); err != nil {
+		err := t.to.Exec(context.Background(), &drivers.Statement{
+			Query:       fmt.Sprintf("DROP TABLE IF EXISTS %s", tmpTable),
+			Priority:    100,
+			LongRunning: true,
+		})
+		if err != nil {
 			t.logger.Error("failed to drop temp table", zap.String("table", tmpTable), zap.Error(err))
 		}
 	}()

--- a/runtime/drivers/duckdb/transporter_postgres_to_duckDB_test.go
+++ b/runtime/drivers/duckdb/transporter_postgres_to_duckDB_test.go
@@ -86,5 +86,6 @@ func allDataTypesTest(t *testing.T, db *sql.DB, dbURL string) {
 		require.NoError(t, err)
 		require.Equal(t, count, 1)
 	}
+	require.NoError(t, res.Close())
 	require.NoError(t, to.Close())
 }

--- a/runtime/drivers/duckdb/transporter_sqlite_to_duckDB_test.go
+++ b/runtime/drivers/duckdb/transporter_sqlite_to_duckDB_test.go
@@ -47,5 +47,6 @@ func Test_sqliteToDuckDB_Transfer(t *testing.T) {
 	var count int
 	err = res.Scan(&count)
 	require.NoError(t, err)
+	require.NoError(t, res.Close())
 	require.Equal(t, 2, count)
 }

--- a/runtime/drivers/duckdb/transporter_sqlstore_to_duckDB.go
+++ b/runtime/drivers/duckdb/transporter_sqlstore_to_duckDB.go
@@ -132,13 +132,19 @@ func (s *sqlStoreToDuckDB) transferFromRowIterator(ctx context.Context, iter dri
 	}
 
 	// create table
-	if err := s.to.Exec(ctx, &drivers.Statement{Query: qry, Priority: 1}); err != nil {
+	err = s.to.Exec(ctx, &drivers.Statement{Query: qry, Priority: 1, LongRunning: true})
+	if err != nil {
 		return err
 	}
 
 	defer func() {
 		// ensure temporary table is cleaned
-		if err := s.to.Exec(context.Background(), &drivers.Statement{Query: fmt.Sprintf("DROP TABLE IF EXISTS %s", tmpTable), Priority: 100}); err != nil {
+		err := s.to.Exec(context.Background(), &drivers.Statement{
+			Query:       fmt.Sprintf("DROP TABLE IF EXISTS %s", tmpTable),
+			Priority:    100,
+			LongRunning: true,
+		})
+		if err != nil {
 			s.logger.Error("failed to drop temp table", zap.String("table", tmpTable), zap.Error(err))
 		}
 	}()

--- a/runtime/drivers/duckdb/transporter_test.go
+++ b/runtime/drivers/duckdb/transporter_test.go
@@ -190,6 +190,7 @@ mum,8.2`)
 			for rows.Next() {
 				colCount++
 			}
+			require.NoError(t, rows.Close())
 			require.Equal(t, test.colCount, colCount)
 		})
 	}
@@ -432,6 +433,7 @@ func TestIterativeParquetIngestionWithVariableSchema(t *testing.T) {
 			for rows.Next() {
 				colCount++
 			}
+			require.NoError(t, rows.Close())
 			require.Equal(t, test.colCount, colCount)
 		})
 	}
@@ -579,6 +581,7 @@ func TestIterativeJSONIngestionWithVariableSchema(t *testing.T) {
 			for rows.Next() {
 				colCount++
 			}
+			require.NoError(t, rows.Close())
 			require.Equal(t, test.colCount, colCount)
 		})
 	}

--- a/runtime/registry_test.go
+++ b/runtime/registry_test.go
@@ -353,7 +353,7 @@ func TestRuntime_EditInstance(t *testing.T) {
 			olap, release, err := rt.OLAP(ctx, inst.ID)
 			require.NoError(t, err)
 			defer release()
-			_, err = olap.Execute(context.Background(), &drivers.Statement{Query: "SELECT COUNT(*) FROM rill.migration_version"})
+			err = olap.Exec(context.Background(), &drivers.Statement{Query: "SELECT COUNT(*) FROM rill.migration_version"})
 			require.NoError(t, err)
 
 			// Verify new olap is not the old one
@@ -426,7 +426,7 @@ func TestRuntime_DeleteInstance(t *testing.T) {
 			// verify older olap connection is closed and cache updated
 			require.False(t, rt.connCache.lru.Contains(inst.ID+"duckdb"+fmt.Sprintf("dsn:%s ", dbFile)))
 			require.False(t, rt.connCache.lru.Contains(inst.ID+"file"+fmt.Sprintf("dsn:%s ", repodsn)))
-			_, err = olap.Execute(context.Background(), &drivers.Statement{Query: "SELECT COUNT(*) FROM rill.migration_version"})
+			err = olap.Exec(context.Background(), &drivers.Statement{Query: "SELECT COUNT(*) FROM rill.migration_version"})
 			require.True(t, err != nil)
 
 			// verify db file is dropped if requested


### PR DESCRIPTION
- Ensures `LongRunning=true` for all mutation queries
- Stop the reconcile controller and log an error if a cancelled reconcile does not finish within 10 minutes
- Log an error from DuckDB driver if a connection has been held for more than one hour
- Avoid implicit connection creation in `detachAllDBs`
- Correct usage of `reopenDB`

Contributes to https://github.com/rilldata/rill-private-issues/issues/17