### PR TITLE
Only apply `overscroll-behavior: none` to Rill Developer

### DIFF
--- a/web-common/src/app.css
+++ b/web-common/src/app.css
@@ -160,8 +160,6 @@ body {
   --error-bg: hsl(1, 60%, 90%);
   --error-text: hsl(1, 60%, 30%);
 
-  overscroll-behavior: none;
-
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/web-common/src/layout/RillDeveloperLayout.svelte
+++ b/web-common/src/layout/RillDeveloperLayout.svelte
@@ -103,3 +103,10 @@
 </div>
 
 <NotificationCenter />
+
+<style>
+  /* Prevent trackpad navigation (like other code editors, like vscode.dev). */
+  :global(body) {
+    overscroll-behavior: none;
+  }
+</style>


### PR DESCRIPTION
`overscroll-behavior: none` is CSS that prevents trackpad gesture navigation (given it's enabled at your OS level). Previously, this CSS lived in our `app.css` file, which applies to both Rill Cloud and Rill Developer. This PR move the CSS so that it only applies to Rill Developer.

Code editors, or at least vscode.dev, tend to restrict this sort of trackpad navigation so that horizontally scrolling your code file does not accidentally trigger navigation.

Closes #3574 