### PR TITLE
limit `--ignore` in web-local to only dev route!

### DIFF
--- a/.github/workflows/web-test.yml
+++ b/.github/workflows/web-test.yml
@@ -82,7 +82,7 @@ jobs:
         run: |-
           npx prettier --check "web-local/**/*"
           npx eslint web-local --quiet
-          npx svelte-check --workspace web-local --no-tsconfig --ignore "src/routes/dev,src/routes/\(application\)/dashboard/[name]"
+          npx svelte-check --workspace web-local --no-tsconfig --ignore "src/routes/dev"
 
       - name: Prettier checks and lint for web admin
         if: steps.filter.outputs.admin == 'true'

--- a/web-common/src/features/entity-management/resource-status-utils.ts
+++ b/web-common/src/features/entity-management/resource-status-utils.ts
@@ -12,6 +12,7 @@ import {
   V1ReconcileStatus,
   V1Resource,
 } from "@rilldata/web-common/runtime-client";
+import type { ErrorType } from "@rilldata/web-common/runtime-client/http-client";
 import type { QueryClient } from "@tanstack/svelte-query";
 import { derived, Readable, Unsubscriber } from "svelte/store";
 
@@ -23,7 +24,7 @@ export enum ResourceStatus {
 
 export type ResourceStatusState = {
   status: ResourceStatus;
-  error?: unknown;
+  error?: ErrorType<unknown>;
   resource?: V1Resource;
 };
 

--- a/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
@@ -61,7 +61,7 @@
       // When a mock user doesn't have access to the dashboard, stay on the page to show a message
       if (
         $selectedMockUserStore === null ||
-        $resourceStatusStore.error.response?.status !== 404
+        $resourceStatusStore?.error?.response?.status !== 404
       ) {
         // On all other errors, redirect to the `/edit` page
         goto(`/dashboard/${metricViewName}/edit`);


### PR DESCRIPTION
We can declare victory in `web-local`: the `src/routes/dev` folder can stay ignored since it's not user facing. After this pr we won't be ignoring any user facing type errors in that subfolder of the repo.


part of  #3424