### PR TITLE
Wrap project names with underscores

### DIFF
--- a/web-admin/src/features/projects/ProjectCard.svelte
+++ b/web-admin/src/features/projects/ProjectCard.svelte
@@ -14,6 +14,10 @@
 
   // Check whether project is public or private
   $: proj = createAdminServiceGetProject(organization, project);
+
+  function doesProjectNameIncludeUnderscores(project: string) {
+    return project.includes("_");
+  }
 </script>
 
 {#if $proj.data}
@@ -22,7 +26,13 @@
     bgClasses="bg-gradient-to-b from-white to-slate-50"
   >
     <!-- Project name -->
-    <h2 class="text-gray-700 font-medium text-lg break-words text-center px-4">
+    <h2
+      class="text-gray-700 font-medium text-lg text-center px-4 {doesProjectNameIncludeUnderscores(
+        project
+      )
+        ? 'break-all'
+        : 'break-words'}"
+    >
       {project}
     </h2>
     <!-- Permissions tag -->


### PR DESCRIPTION
Closes #3650 

Tailwind's `break-words` does not break words with underscores. `break-all` does. Because `break-words` is more aesthetic than `break-all`, this PR only uses `break-all` for project names that have underscores.