### PR TITLE
Fix: Negative SVG values in Graphic Context

### DIFF
--- a/web-common/src/features/dashboards/time-series/TimeSeriesChartContainer.svelte
+++ b/web-common/src/features/dashboards/time-series/TimeSeriesChartContainer.svelte
@@ -26,12 +26,14 @@ A container GraphicContext for the time series in a metrics dashboard.
     right={50}
     fontSize={11}
     top={4}
-    width={(enableFullWidth
-      ? workspaceWidth - paddingForFullWidth
-      : workspaceWidth >= MEASURE_CONFIG.breakpoint
-      ? MEASURE_CONFIG.container.width.full
-      : MEASURE_CONFIG.container.width.breakpoint) -
-      MEASURE_CONFIG.bigNumber.widthWithChart}
+    width={Math.max(
+      enableFullWidth
+        ? workspaceWidth - paddingForFullWidth
+        : workspaceWidth >= MEASURE_CONFIG.breakpoint
+        ? MEASURE_CONFIG.container.width.full
+        : MEASURE_CONFIG.container.width.breakpoint,
+      400
+    ) - MEASURE_CONFIG.bigNumber.widthWithChart}
     xMax={end}
     xMaxTweenProps={{ duration: 400 }}
     xMin={start}


### PR DESCRIPTION
For some initial renders of the chart, we were seeing negative width value error in the console. 
This was one of those bugs which took hours to figure out but required a one line change. This occurs when `workspaceWidth` is still being computed and has a value of 0.

I tried pulling out the ternary operators out of the HTML block and into the scripts. Somehow that made the charts fixed a single smaller width. Not sure what is exactly going wrong and why reactivity is not working there properly. Nevertheless have made changes which fixes the bug/error.