### PR TITLE
Docs: Adding clarification to using cron syntax for source refreshes

### DIFF
--- a/docs/docs/deploy/source-refresh.md
+++ b/docs/docs/deploy/source-refresh.md
@@ -42,7 +42,7 @@ sources:
     every: 24h
 ```
 
-Similarly, the following would use cron syntax to set a project-wide default of refreshings ources every 15 minutes:
+Similarly, the following would use cron syntax to set a project-wide configuration of refreshing sources by default every 15 minutes (unless overridden at the individual source level):
 ```yaml
 sources:
   refresh:

--- a/docs/docs/deploy/source-refresh.md
+++ b/docs/docs/deploy/source-refresh.md
@@ -18,6 +18,13 @@ refresh:
   every: 24h
 ```
 
+Similarly, if you would like to utilize cron syntax, the following example would update a source every 15 minutes:
+
+```yaml
+refresh:
+  cron: '*/15 * * * *'
+```
+
 :::tip Source settings
 
 For more details about available source configurations and properties, check our [Source YAML](../reference/project-files/sources) reference page.
@@ -28,11 +35,18 @@ For more details about available source configurations and properties, check our
 
 You can also specify a project-wide refresh schedule that will apply to all sources by default. This can be done through the `rill.yaml` file. More details can be found [here](../reference/project-files/rill-yaml.md#project-wide-defaults).
 
-Using the same example as above:
+Using the same example as above, the following sets a project-wide default of refreshing sources every 24 hours:
 ```yaml
 sources:
   refresh:
     every: 24h
+```
+
+Similarly, the following would use cron syntax to set a project-wide default of refreshings ources every 15 minutes:
+```yaml
+sources:
+  refresh:
+    cron: '*/15 * * * *'
 ```
 
 :::info Did you know?

--- a/docs/docs/reference/project-files/sources.md
+++ b/docs/docs/reference/project-files/sources.md
@@ -67,7 +67,7 @@ In your Rill project directory, create a `<source_name>.yaml` file in the `sourc
  — The maximum time to wait for souce ingestion.
 
 **`refresh`** - Optionally specify a schedule after which Rill should re-ingest the source
-  - **`cron`** - a cron schedule expression (optional)
+  - **`cron`** - a cron schedule expression, which should be encapsulated in single quotes e.g. `'* * * * *'` (optional)
   - **`every`** - a Go duration string, such as `24h` ([docs](https://pkg.go.dev/time#ParseDuration)) (optional)
 
 **`extract`** - Optionally limit the data ingested from remote sources (S3/GCS only)


### PR DESCRIPTION
Adding examples of cron syntax in source refreshes (and that it should be wrapped in single quotes for the yaml parser)