### PR TITLE
update to leaderboard test to account for inconsistent Playwright behavior

### DIFF
--- a/web-local/test/ui/dashboard-flows/leaderboard-and-dim-table-sort.spec.ts
+++ b/web-local/test/ui/dashboard-flows/leaderboard-and-dim-table-sort.spec.ts
@@ -18,7 +18,7 @@ test.describe("leaderboard and dimension table sorting", () => {
   startRuntimeForEachTest();
 
   test("leaderboard and dimension table sorting", async ({ page }) => {
-    test.setTimeout(60000);
+    test.setTimeout(30000);
     await page.goto("/");
     // disable animations
     await page.addStyleTag({
@@ -93,9 +93,14 @@ test.describe("leaderboard and dimension table sorting", () => {
     await page.getByRole("button", { name: "Select a context column" }).click();
     await page.getByRole("menuitem", { name: "Percent change" }).click();
 
+    // need a slight delay for the rankings to update
+    await page.waitForTimeout(1000);
+
+    // Broader selectors using RegEx to account for some Playwright runs triggering the display
+    // of the starting value on hover
     await assertAAboveB(
-      page.getByRole("button", { name: "Google 116 4%" }),
-      page.getByRole("button", { name: "Facebook 283 -4%" })
+      page.getByRole("button", { name: /^Google/ }),
+      page.getByRole("button", { name: /^Facebook/ })
     );
 
     // toggle sort by pct change


### PR DESCRIPTION
This PR fixes an issue that occurs when running tests locally (and sometimes in CI).

Re: `leaderboard-and-dim-table-sort.spec.ts`

1. Adds a page timeout after selecting the `Percentage change` sorting option to allow for the Leaderboard rankings to update
2. Broadens the subsequent selectors by using RegEx rather than a specific string. The reason for this is that some Playwright runs trigger the hover effect on the element, which means that the "name" selector may sometimes include an additional number (see below)

<img width="729" alt="Screenshot 2023-12-12 at 6 35 39 PM" src="https://github.com/rilldata/rill/assets/120223836/7ea21122-d967-4f50-a26a-7b39b2acde5c">

If similar issues arise in the future, I think the other selectors could be broadened without issue. Also, if these are too broad, for whatever reason, this PR could be updated with a slightly more complex RegEx to capture both hover and not hovered states.