### PR TITLE
removed WithTween wrapper around clipPath to prevent fickering when charts are updated

### DIFF
--- a/web-common/src/components/data-graphic/marks/ChunkedLine.svelte
+++ b/web-common/src/components/data-graphic/marks/ChunkedLine.svelte
@@ -170,28 +170,7 @@ Over time, we'll make this the default Line implementation, but it's not quite t
           {@const x = $xScale(segment[0][xAccessor])}
           {@const width =
             $xScale(segment.at(-1)[xAccessor]) - $xScale(segment[0][xAccessor])}
-          <WithTween
-            initialValue={{
-              x: x - width / 2,
-              width: width * 2,
-            }}
-            value={{
-              x,
-              width,
-            }}
-            tweenProps={{
-              duration,
-              easing: cubicOut,
-            }}
-            let:output
-          >
-            <rect
-              x={output.x}
-              y={0}
-              height={$yScale.range()[0]}
-              width={output.width}
-            />
-          </WithTween>
+          <rect {x} y={0} height={$yScale.range()[0]} {width} />
         {/each}
       </clipPath>
     </defs>


### PR DESCRIPTION
Closes #3524

Lines that do not extend to the right edge of the graph are clipped using a clipPath. Wrapping clipPath in WithTween delays the appearance of the clipping by a fraction of a second, causing unintended flickering when sorting or updating data.

This PR removes the wrapping of the clipPath element with no immediately apparent change in functionality. However, there may be a good reason that I am not yet aware of for why the tweening is necessary on the clipPath.