### PR TITLE
remove artificial time series chart delay

### DIFF
--- a/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
+++ b/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
@@ -159,16 +159,6 @@ export function createTimeSeriesDataStore(ctx: StateManagers) {
         ]) => {
           let timeSeriesData = primary?.data?.data;
 
-          if (!primary?.data || !primaryTotal?.data || !unfilteredTotal?.data) {
-            return {
-              isFetching:
-                metricsView.isFetching ||
-                primary?.isFetching ||
-                primaryTotal?.isFetching ||
-                unfilteredTotal?.isFetching,
-            };
-          }
-
           if (!primary.isFetching && interval) {
             timeSeriesData = prepareTimeSeries(
               primary?.data?.data,
@@ -178,7 +168,7 @@ export function createTimeSeriesDataStore(ctx: StateManagers) {
             );
           }
           return {
-            isFetching: primaryTotal?.isFetching || metricsView?.isFetching,
+            isFetching: !primary?.data && !primaryTotal?.data,
             isError: false, // FIXME Handle errors
             timeSeriesData,
             total: primaryTotal?.data?.data?.[0],

--- a/web-common/src/runtime-client/http-request-queue/priorities.ts
+++ b/web-common/src/runtime-client/http-request-queue/priorities.ts
@@ -16,6 +16,7 @@ export const QueryPriorities = {
   topk: 10,
   "rug-histogram": 10,
   "descriptive-statistics": 10,
+  totals: 30,
 };
 
 export function getPriority(type: string): number {


### PR DESCRIPTION
Closes #3381 

Note: I did not have access to the dataset being used in the referenced Notion doc, so had to artificially recreate this situation while debugging.

The issue seems to be that TimeSeriesDataStore was artificially holding back data and returning `isFetching` as `true` until both the totals and primary queries were available.

During exploration, I saw no obvious UI issues related to rendering either of those pieces of data independently. As such, my proposed fix is to simply change the boolean logic of the `isFetching` property and remove the stricter "gate". This appears to solve the issue.

This PR also updates the `totals` query to a priority of 30.