### PR TITLE
docs: hide content class

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,3 +40,8 @@ The CLI reference docs in `docs/reference/cli` are auto-generated based on the C
 ```bash
 make docs.generate
 ```
+
+## Hiding content
+
+Sometimes you want to merge documentation but hide it pending a future release, there are a few different short-hands available.  
+For individual pages add `sidebar_class_name: hidden` to the top of the page and to hide an entire category add `className: hidden` to the `_category_.yml` file. Note that the pages are only hidden but still generated so you can still link to them.

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -68,3 +68,7 @@
   border-radius: var(--ifm-global-radius);
   padding: 0px 20px 20px 20px;
 }
+
+.hidden {
+  display: none !important;
+}


### PR DESCRIPTION
Adds short-hand css classes to hide pages and categories from documentation.