### PR TITLE
split web tests

### DIFF
--- a/.github/workflows/web-test-code-quality.yml
+++ b/.github/workflows/web-test-code-quality.yml
@@ -21,22 +21,15 @@ jobs:
           filters: |
             admin:
               - ".github/workflows/web-test.yml"
-              - "admin/**"
-              - "cli/**"
-              - "runtime/**"
               - "web-admin/**"
             auth:
               - ".github/workflows/web-test.yml"
               - "web-auth/**"
             local:
               - ".github/workflows/web-test.yml"
-              - "cli/**"
-              - "runtime/**"
               - "web-local/**"
             common:
               - ".github/workflows/web-test.yml"
-              - "cli/**"
-              - "runtime/**"
               - "web-common/**"
 
       - name: Set up NodeJS

--- a/.github/workflows/web-test-code-quality.yml
+++ b/.github/workflows/web-test-code-quality.yml
@@ -1,11 +1,8 @@
-name: Build and Test web code
+name: Web code quality checks
 on:
   pull_request:
     paths:
       - ".github/workflows/web-test.yml"
-      - "admin/**"
-      - "cli/**"
-      - "runtime/**"
       - "web-admin/**"
       - "web-auth/**"
       - "web-common/**"
@@ -47,78 +44,30 @@ jobs:
         with:
           node-version: 18
 
-      - name: Set up go for E2E
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.21
-      - name: go build cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: NPM Install
         run: npm install
 
-      - name: Build and embed static UI
-        run: make cli
-
-      - name: Install browser for UI tests
-        run: npx playwright install
-
-      - name: Prettier checks and lint for web common
+      - name: lint and type checks for web common
         if: steps.filter.outputs.common == 'true'
         run: |-
-          npx prettier --check "web-common/**/*"
           npx eslint web-common --quiet
           npx svelte-check --threshold error --workspace web-common --no-tsconfig --ignore "src/components/data-graphic,src/features/dashboards/time-series,src/features/dashboards/time-controls/TimeRangeSelector.svelte,src/features/dashboards/time-controls/TimeControls.svelte"
 
-      - name: Prettier checks and lint for web local
+      - name: lint and type checks for web local
         if: steps.filter.outputs.local == 'true'
         run: |-
-          npx prettier --check "web-local/**/*"
           npx eslint web-local --quiet
           npx svelte-check --workspace web-local --no-tsconfig --ignore "src/routes/dev"
 
-      - name: Prettier checks and lint for web admin
+      - name: lint and type checks for web admin
         if: steps.filter.outputs.admin == 'true'
         run: |-
-          npx prettier --check "web-admin/**/*"
           npx eslint web-admin --quiet
           npx svelte-check --workspace web-admin --no-tsconfig
 
-      - name: Prettier checks and lint for web auth
+      - name: lint and type checks for web auth
         if: steps.filter.outputs.auth == 'true'
         run: |-
-          npx prettier --check "web-auth/**/*"
           npx eslint web-auth --quiet
           npx svelte-check --workspace web-auth --no-tsconfig
 
-      - name: Test web common
-        if: steps.filter.outputs.common == 'true'
-        run: npm run test -w web-common
-
-      - name: Test web local
-        if: ${{ steps.filter.outputs.local == 'true' || steps.filter.outputs.common == 'true' }}
-        run: npm run test -w web-local
-
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: playwright-report
-          path: web-local/playwright-report/
-          retention-days: 30
-
-      - name: Build & Test the web admin
-        if: ${{ steps.filter.outputs.admin == 'true' || steps.filter.outputs.common == 'true' }}
-        run: |-
-          npm run build -w web-admin
-          npm run test -w web-admin
-
-      - name: Build & Test storybook
-        run: |-
-          npm run storybook:smoketest -w web-common

--- a/.github/workflows/web-test-e2e.yml
+++ b/.github/workflows/web-test-e2e.yml
@@ -1,0 +1,88 @@
+name: Build and Test web code
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/web-test.yml"
+      - "admin/**"
+      - "cli/**"
+      - "runtime/**"
+      - "web-admin/**"
+      - "web-auth/**"
+      - "web-common/**"
+      - "web-local/**"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Filter modified codepaths
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            admin:
+              - ".github/workflows/web-test.yml"
+              - "admin/**"
+              - "cli/**"
+              - "runtime/**"
+              - "web-admin/**"
+            auth:
+              - ".github/workflows/web-test.yml"
+              - "web-auth/**"
+            local:
+              - ".github/workflows/web-test.yml"
+              - "cli/**"
+              - "runtime/**"
+              - "web-local/**"
+            common:
+              - ".github/workflows/web-test.yml"
+              - "cli/**"
+              - "runtime/**"
+              - "web-common/**"
+
+      - name: Set up NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Set up go for E2E
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.21
+      - name: go build cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: NPM Install
+        run: npm install
+
+      - name: Build and embed static UI
+        run: make cli
+
+      - name: Install browser for UI tests
+        run: npx playwright install
+
+      - name: Test web local
+        if: ${{ steps.filter.outputs.local == 'true' || steps.filter.outputs.common == 'true' }}
+        run: npm run test -w web-local
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: web-local/playwright-report/
+          retention-days: 30
+
+      - name: Build & Test the web admin
+        if: ${{ steps.filter.outputs.admin == 'true' || steps.filter.outputs.common == 'true' }}
+        run: |-
+          npm run build -w web-admin
+          npm run test -w web-admin

--- a/.github/workflows/web-test-e2e.yml
+++ b/.github/workflows/web-test-e2e.yml
@@ -1,4 +1,4 @@
-name: Build and Test web code
+name: End-to-end tests of web+runtime
 on:
   pull_request:
     paths:

--- a/.github/workflows/web-test-unit-tests.yml
+++ b/.github/workflows/web-test-unit-tests.yml
@@ -21,22 +21,15 @@ jobs:
           filters: |
             admin:
               - ".github/workflows/web-test.yml"
-              - "admin/**"
-              - "cli/**"
-              - "runtime/**"
               - "web-admin/**"
             auth:
               - ".github/workflows/web-test.yml"
               - "web-auth/**"
             local:
               - ".github/workflows/web-test.yml"
-              - "cli/**"
-              - "runtime/**"
               - "web-local/**"
             common:
               - ".github/workflows/web-test.yml"
-              - "cli/**"
-              - "runtime/**"
               - "web-common/**"
 
       - name: Set up NodeJS
@@ -47,14 +40,14 @@ jobs:
       - name: NPM Install
         run: npm install
 
-      - name: unit test web-common
+      - name: Run web-common unit tests
         if: steps.filter.outputs.common == 'true'
         run: npm run test -w web-common
 
-      - name: Test web-auth
+      - name: Run web-auth unit tests
         if: steps.filter.outputs.auth == 'true'
         run: npm run test -w web-auth
 
-      - name: Make sure storybook is working
+      - name: Run storybook smoke tests
         run: |-
           npm run storybook:smoketest -w web-common

--- a/.github/workflows/web-test-unit-tests.yml
+++ b/.github/workflows/web-test-unit-tests.yml
@@ -1,0 +1,60 @@
+name: Unit tests for web code
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/web-test.yml"
+      - "web-admin/**"
+      - "web-auth/**"
+      - "web-common/**"
+      - "web-local/**"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Filter modified codepaths
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            admin:
+              - ".github/workflows/web-test.yml"
+              - "admin/**"
+              - "cli/**"
+              - "runtime/**"
+              - "web-admin/**"
+            auth:
+              - ".github/workflows/web-test.yml"
+              - "web-auth/**"
+            local:
+              - ".github/workflows/web-test.yml"
+              - "cli/**"
+              - "runtime/**"
+              - "web-local/**"
+            common:
+              - ".github/workflows/web-test.yml"
+              - "cli/**"
+              - "runtime/**"
+              - "web-common/**"
+
+      - name: Set up NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: NPM Install
+        run: npm install
+
+      - name: unit test web-common
+        if: steps.filter.outputs.common == 'true'
+        run: npm run test -w web-common
+
+      - name: Test web-auth
+        if: steps.filter.outputs.auth == 'true'
+        run: npm run test -w web-auth
+
+      - name: Make sure storybook is working
+        run: |-
+          npm run storybook:smoketest -w web-common


### PR DESCRIPTION
Splits web tests up into:
- code quality (lint and type check)
- unit tests (we apparently only have unit tests in web-common and web-auth, though we have not been running the auth tests in CI, so those are added)
- e2e tests (only web-local and web-admin have this, though web-admin only seems to have a test stub for now)

Note that we have a separate GH action that runs prettier on the entire repo (prettier.yaml) so I thought it was redundant to have the prettier checks for each web folder. Easy to add back in if that is incorrect.

Looking to @himadrisingh for approval from the dev-ops perspective since I'm not super familiar with the ins-and-outs of GH actions. In particular, I don't know what the "dorny/paths-filter@v2" does, so I just copied that over as-is across the board. Please LMK if that need to be changed or can be simplified

But also fyi @ericpgreen2 @djbarnwal @AdityaHegde @briangregoryholmes to have extra eyes on this.

Partially addresses #3443, though we may want to look into parallelizing (or otherwise speeding up) the e2e at some point.

