### PR TITLE
Add installation instructions for conda

### DIFF
--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -20,6 +20,14 @@ Verify that the installation succeeded:
 rill --help
 ```
 
+## Install via Conda
+
+You can also install `rill` via `conda`:
+
+```
+conda install --channel conda-forge rill
+```
+
 ## Nightly Releases
 
 On both macOS and Linux, you can install the latest nightly build using the installation script:


### PR DESCRIPTION
Rill is now available on [Conda-Forge](https://conda-forge.org/): https://prefix.dev/channels/conda-forge/packages/rill

This PR extends the documentation to add Conda installation instructions.

Also, if any of the Rill maintainers would like to help maintain the [Rill Conda-Forge feedstock](https://github.com/conda-forge/rill-feedstock), please add yourself as recipe maintainer [here](https://github.com/conda-forge/rill-feedstock/blob/0888cb2fb5da2645e1c241f1d5ed99ce4ff8ba8b/recipe/meta.yaml#L55-L56). 