### PR TITLE
filter out dimension names that do not have dimension values

### DIFF
--- a/runtime/queries/metricsview.go
+++ b/runtime/queries/metricsview.go
@@ -631,7 +631,6 @@ func convertDimensionFilterToExpression(cond *runtimev1.MetricsViewFilter_Cond, 
 	} else if likeExpr != nil {
 		return likeExpr
 	}
-	
 
 	return nil
 }

--- a/runtime/queries/metricsview.go
+++ b/runtime/queries/metricsview.go
@@ -594,7 +594,7 @@ func convertDimensionFilterToExpression(cond *runtimev1.MetricsViewFilter_Cond, 
 		} else {
 			inExpr = expressionpb.In(expressionpb.Identifier(cond.Name), inExprs)
 		}
-	
+	}
 
 	var likeExpr *runtimev1.Expression
 	if len(cond.Like) == 1 {
@@ -631,7 +631,7 @@ func convertDimensionFilterToExpression(cond *runtimev1.MetricsViewFilter_Cond, 
 	} else if likeExpr != nil {
 		return likeExpr
 	}
-	}
+	
 
 	return nil
 }

--- a/runtime/queries/metricsview.go
+++ b/runtime/queries/metricsview.go
@@ -551,19 +551,25 @@ func convertFilterToExpression(filter *runtimev1.MetricsViewFilter) *runtimev1.E
 	if len(filter.Include) > 0 {
 		var includeExprs []*runtimev1.Expression
 		for _, cond := range filter.Include {
-			domExpr := convertDimensionFilterToExpression(cond, false)
-			if domExpr != nil {
-				includeExprs = append(includeExprs, domExpr)
+			if len(cond.In) > 0 {
+				domExpr := convertDimensionFilterToExpression(cond, false)
+				if domExpr != nil {
+					includeExprs = append(includeExprs, domExpr)
+				}
 			}
 		}
-		exprs = append(exprs, expressionpb.Or(includeExprs))
+		if len(includeExprs) > 0 {
+			exprs = append(exprs, expressionpb.Or(includeExprs))
+		}
 	}
 
 	if len(filter.Exclude) > 0 {
 		for _, cond := range filter.Exclude {
-			domExpr := convertDimensionFilterToExpression(cond, true)
-			if domExpr != nil {
-				exprs = append(exprs, domExpr)
+			if len(cond.In) > 0 {
+				domExpr := convertDimensionFilterToExpression(cond, true)
+				if domExpr != nil {
+					exprs = append(exprs, domExpr)
+				}
 			}
 		}
 	}
@@ -588,7 +594,7 @@ func convertDimensionFilterToExpression(cond *runtimev1.MetricsViewFilter_Cond, 
 		} else {
 			inExpr = expressionpb.In(expressionpb.Identifier(cond.Name), inExprs)
 		}
-	}
+	
 
 	var likeExpr *runtimev1.Expression
 	if len(cond.Like) == 1 {
@@ -624,6 +630,7 @@ func convertDimensionFilterToExpression(cond *runtimev1.MetricsViewFilter_Cond, 
 		return inExpr
 	} else if likeExpr != nil {
 		return likeExpr
+	}
 	}
 
 	return nil

--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -1,20 +1,6 @@
 <!-- @component
 The main feature-set component for dashboard filters
  -->
-<script context="module" lang="ts">
-  import { writable } from "svelte/store";
-  import type { Writable } from "svelte/store";
-
-  export const temporaryFilters: Writable<
-    {
-      name: string;
-      label: string;
-      selectedValues: any[];
-      filterType: string;
-    }[]
-  > = writable([]);
-</script>
-
 <script lang="ts">
   import {
     Chip,
@@ -133,31 +119,13 @@ The main feature-set component for dashboard filters
           };
         }) ?? [];
 
-    const currentTemporaryFilters =
-      $temporaryFilters
-        .filter((dimensionValues) => dimensionValues.name !== undefined)
-        .map((dimensionValues) => {
-          const name = dimensionValues.name as string;
-          return {
-            name,
-            label: getDisplayName(
-              dimensionIdMap.get(name) as MetricsViewSpecDimensionV2
-            ),
-            selectedValues: [],
-            filterType: "exclude",
-          };
-        }) ?? [];
-
     currentDimensionFilters = [
       ...currentDimensionIncludeFilters,
       ...currentDimensionExcludeFilters,
-      ...currentTemporaryFilters,
     ];
     // sort based on name to make sure toggling include/exclude is not jarring
     currentDimensionFilters.sort((a, b) => (a.name > b.name ? 1 : -1));
   }
-
-  $: console.log($temporaryFilters);
 
   function setActiveDimension(name, value = "") {
     activeDimensionName = name;

--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -1,6 +1,20 @@
 <!-- @component
 The main feature-set component for dashboard filters
  -->
+<script context="module" lang="ts">
+  import { writable } from "svelte/store";
+  import type { Writable } from "svelte/store";
+
+  export const temporaryFilters: Writable<
+    {
+      name: string;
+      label: string;
+      selectedValues: any[];
+      filterType: string;
+    }[]
+  > = writable([]);
+</script>
+
 <script lang="ts">
   import {
     Chip,
@@ -119,13 +133,31 @@ The main feature-set component for dashboard filters
           };
         }) ?? [];
 
+    const currentTemporaryFilters =
+      $temporaryFilters
+        .filter((dimensionValues) => dimensionValues.name !== undefined)
+        .map((dimensionValues) => {
+          const name = dimensionValues.name as string;
+          return {
+            name,
+            label: getDisplayName(
+              dimensionIdMap.get(name) as MetricsViewSpecDimensionV2
+            ),
+            selectedValues: [],
+            filterType: "exclude",
+          };
+        }) ?? [];
+
     currentDimensionFilters = [
       ...currentDimensionIncludeFilters,
       ...currentDimensionExcludeFilters,
+      ...currentTemporaryFilters,
     ];
     // sort based on name to make sure toggling include/exclude is not jarring
     currentDimensionFilters.sort((a, b) => (a.name > b.name ? 1 : -1));
   }
+
+  $: console.log($temporaryFilters);
 
   function setActiveDimension(name, value = "") {
     activeDimensionName = name;

--- a/web-common/src/features/dashboards/rows-viewer/RowsViewerAccordion.svelte
+++ b/web-common/src/features/dashboards/rows-viewer/RowsViewerAccordion.svelte
@@ -63,7 +63,10 @@
       ],
       timeStart: $timeControlsStore.timeStart,
       timeEnd,
-      filter: $dashboardStore?.filters,
+      filter: {
+        exclude: $dashboardStore.filters.exclude?.filter((f) => f.in?.length),
+        include: $dashboardStore.filters.include?.filter((f) => f.in?.length),
+      },
     },
     {
       query: {

--- a/web-common/src/features/dashboards/selectors.ts
+++ b/web-common/src/features/dashboards/selectors.ts
@@ -119,14 +119,22 @@ export const getFiltersForOtherDimensions = (
   const filter: V1MetricsViewFilter = {
     include:
       filters.include
-        ?.filter((dimensionValues) => dimensionName !== dimensionValues.name)
+        ?.filter((dimensionValues) => {
+          return (
+            dimensionName !== dimensionValues.name && dimensionValues.in?.length
+          );
+        })
         .map((dimensionValues) => ({
           name: dimensionValues.name,
           in: dimensionValues.in,
         })) ?? [],
     exclude:
       filters.exclude
-        ?.filter((dimensionValues) => dimensionName !== dimensionValues.name)
+        ?.filter((dimensionValues) => {
+          return (
+            dimensionName !== dimensionValues.name && dimensionValues.in?.length
+          );
+        })
         .map((dimensionValues) => ({
           name: dimensionValues.name,
           in: dimensionValues.in,

--- a/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
+++ b/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
@@ -50,7 +50,14 @@ function createMetricsViewTimeSeries(
         metricViewName,
         {
           measureNames: measures,
-          filter: dashboardStore?.filters,
+          filter: {
+            exclude: dashboardStore.filters.exclude?.filter(
+              (f) => f.in?.length
+            ),
+            include: dashboardStore.filters.include?.filter(
+              (f) => f.in?.length
+            ),
+          },
           timeStart: isComparison
             ? timeControls.comparisonAdjustedStart
             : timeControls.adjustedStart,

--- a/web-common/src/features/dashboards/time-series/totals-data-store.ts
+++ b/web-common/src/features/dashboards/time-series/totals-data-store.ts
@@ -26,7 +26,12 @@ export function createTotalsForMeasure(
         metricsViewName,
         {
           measures: measures.map((measure) => ({ name: measure })),
-          filter: noFilter ? { include: [], exclude: [] } : dashboard?.filters,
+          filter: noFilter
+            ? { include: [], exclude: [] }
+            : {
+                exclude: dashboard.filters.exclude?.filter((f) => f.in?.length),
+                include: dashboard.filters.include?.filter((f) => f.in?.length),
+              },
           timeStart: isComparison
             ? timeControls?.comparisonTimeStart
             : timeControls.timeStart,


### PR DESCRIPTION
When adding a temporary "filter" without an associated dimension value (a necessary part of the new filter button flow), the runtime throws an error.

There are three ways to solve this, in my opinion:

1) Create a new piece of state on the FE to hold "temporary" filters that have no dimension values and render those out in addition to filters actually included in the dashboard state and queries. This PR does not do this as I believe it would add some unnecessary complexity.
2) Filter out, on the frontend, the filters whose `in` property has no length before sending the query. This PR does this, but not in a centralized way. I would consider this a stopgap solution as adding a "filter" without a dimension value still triggers a new query, which is unnecessary. Changing this behavior would require additional thought.
3) Allow for the runtime to receive filters with no dimension values, something that was possible, I believe, prior to #3624. This PR makes a small change that achieves this, but I have spent limited time looking at the runtime code and there may be a better approach.

2 and 3 both solve the issue independently, but I see no reason not to include both. I would likely separate them out into separate PRs. This is just to consolidate discussion.