### PR TITLE
move incomplete filters out of dashboard store and into a dedicated piece of state

### DIFF
--- a/web-common/src/components/chip/removable-list-chip/RemovableListChip.svelte
+++ b/web-common/src/components/chip/removable-list-chip/RemovableListChip.svelte
@@ -38,8 +38,6 @@ are details left to the consumer of the component; this component should remain 
 
   let active = !selectedValues.length;
 
-  $: console.log(name, excludeMode);
-
   const dispatch = createEventDispatcher();
 
   onMount(() => {

--- a/web-common/src/components/chip/removable-list-chip/RemovableListChip.svelte
+++ b/web-common/src/components/chip/removable-list-chip/RemovableListChip.svelte
@@ -38,6 +38,8 @@ are details left to the consumer of the component; this component should remain 
 
   let active = !selectedValues.length;
 
+  $: console.log(name, excludeMode);
+
   const dispatch = createEventDispatcher();
 
   onMount(() => {

--- a/web-common/src/components/menu/core/MenuItem.svelte
+++ b/web-common/src/components/menu/core/MenuItem.svelte
@@ -77,6 +77,7 @@
     if (!disabled) {
       hovered = true;
     }
+    dispatch("hover");
   }
 
   function onFocus() {
@@ -84,6 +85,7 @@
       $currentItem = itemID;
       hovered = true;
     }
+    dispatch("focus");
   }
 
   function onBlur() {

--- a/web-common/src/components/searchable-filter-menu/SearchableFilterDropdown.svelte
+++ b/web-common/src/components/searchable-filter-menu/SearchableFilterDropdown.svelte
@@ -7,7 +7,6 @@
   import Button from "../button/Button.svelte";
   import { createEventDispatcher } from "svelte";
   import { matchSorter } from "match-sorter";
-  import { hoverTooltip } from "@codemirror/view";
 
   const dispatch = createEventDispatcher();
 

--- a/web-common/src/components/searchable-filter-menu/SearchableFilterDropdown.svelte
+++ b/web-common/src/components/searchable-filter-menu/SearchableFilterDropdown.svelte
@@ -7,6 +7,7 @@
   import Button from "../button/Button.svelte";
   import { createEventDispatcher } from "svelte";
   import { matchSorter } from "match-sorter";
+  import { hoverTooltip } from "@codemirror/view";
 
   const dispatch = createEventDispatcher();
 
@@ -85,6 +86,12 @@
         icon
         animateSelect={false}
         focusOnMount={false}
+        on:hover={() => {
+          dispatch("hover", { index, name });
+        }}
+        on:focus={() => {
+          dispatch("focus", { index, name });
+        }}
         on:select={() => {
           if (singleSelection && selected) return;
           dispatch("item-clicked", { index, name });

--- a/web-common/src/features/dashboards/filters/FilterButton.svelte
+++ b/web-common/src/features/dashboards/filters/FilterButton.svelte
@@ -5,6 +5,7 @@
   import Add from "@rilldata/web-common/components/icons/Add.svelte";
   import SearchableFilterDropdown from "@rilldata/web-common/components/searchable-filter-menu/SearchableFilterDropdown.svelte";
   import WithTogglableFloatingElement from "@rilldata/web-common/components/floating-element/WithTogglableFloatingElement.svelte";
+  import { potentialFilterName } from "./Filters.svelte";
 </script>
 
 <script lang="ts">
@@ -12,9 +13,6 @@
     selectors: {
       dimensions: { allDimensions },
       dimensionFilters: { getAllFilters, isFilterExcludeMode },
-    },
-    actions: {
-      dimensionsFilter: { toggleDimensionNameSelection },
     },
   } = getStateManagers();
 
@@ -61,7 +59,7 @@
     on:click-outside={toggleFloatingElement}
     on:item-clicked={(e) => {
       toggleFloatingElement();
-      toggleDimensionNameSelection(e.detail.name);
+      $potentialFilterName = e.detail.name;
     }}
   />
 </WithTogglableFloatingElement>

--- a/web-common/src/features/dashboards/filters/FilterButton.svelte
+++ b/web-common/src/features/dashboards/filters/FilterButton.svelte
@@ -55,6 +55,8 @@
     selectedItems={[]}
     allowMultiSelect={false}
     {selectableItems}
+    on:hover
+    on:focus
     on:escape={toggleFloatingElement}
     on:click-outside={toggleFloatingElement}
     on:item-clicked={(e) => {

--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -50,7 +50,7 @@ The main feature-set component for dashboard filters
   $: dimensions = $metaQuery.data?.dimensions ?? [];
 
   let searchText = "";
-  let allValues: string[] | null = null;
+  let allValues: Record<string, string[]> = {};
   let activeDimensionName: string;
   let topListQuery: ReturnType<typeof getFilterSearchList> | undefined;
 
@@ -70,7 +70,8 @@ The main feature-set component for dashboard filters
 
   $: if (!$topListQuery?.isFetching) {
     const topListData = $topListQuery?.data?.data ?? [];
-    allValues = topListData.map((datum) => datum[activeColumn]) ?? [];
+    allValues[activeDimensionName] =
+      topListData.map((datum) => datum[activeColumn]) ?? [];
   }
 
   $: hasFilters = isFiltered($dashboardStore.filters);
@@ -174,7 +175,7 @@ The main feature-set component for dashboard filters
             colors={getColorForChip(isInclude)}
             label="View filter"
             {selectedValues}
-            {allValues}
+            allValues={allValues[activeDimensionName]}
           >
             <svelte:fragment slot="body-tooltip-content">
               Click to edit the the filters in this dimension
@@ -183,7 +184,14 @@ The main feature-set component for dashboard filters
         </div>
       {/each}
     {/if}
-    <FilterButton />
+    <FilterButton
+      on:focus={({ detail: { name } }) => {
+        activeDimensionName = name;
+      }}
+      on:hover={({ detail: { name } }) => {
+        activeDimensionName = name;
+      }}
+    />
     <!-- if filters are present, place a chip at the end of the flex container 
       that enables clearing all filters -->
     {#if hasFilters}

--- a/web-common/src/features/dashboards/filters/formatFilters.ts
+++ b/web-common/src/features/dashboards/filters/formatFilters.ts
@@ -1,0 +1,34 @@
+import type { MetricsViewFilterCond } from "@rilldata/web-common/runtime-client";
+import type { MetricsViewSpecDimensionV2 } from "@rilldata/web-common/runtime-client";
+import { getDisplayName } from "./getDisplayName";
+
+export type DimensionFilter = {
+  name: string;
+  label: string;
+  selectedValues: any[];
+  filterType: string;
+};
+
+export function formatFilters(
+  filters: MetricsViewFilterCond[] | undefined,
+  exclude: boolean,
+  dimensionIdMap: Map<string | number, MetricsViewSpecDimensionV2>
+): DimensionFilter[] {
+  if (!filters) return [];
+
+  const formatted: DimensionFilter[] = [];
+
+  filters.forEach(({ name, in: selectedValues }) => {
+    if (name === undefined) return;
+    formatted.push({
+      name,
+      label: getDisplayName(
+        dimensionIdMap.get(name) as MetricsViewSpecDimensionV2
+      ),
+      selectedValues: selectedValues as any[],
+      filterType: exclude ? "exclude" : "include",
+    });
+  });
+
+  return formatted;
+}

--- a/web-common/src/features/dashboards/filters/formatFilters.ts
+++ b/web-common/src/features/dashboards/filters/formatFilters.ts
@@ -5,30 +5,28 @@ import { getDisplayName } from "./getDisplayName";
 export type DimensionFilter = {
   name: string;
   label: string;
-  selectedValues: any[];
-  filterType: string;
+  selectedValues: string[];
 };
 
 export function formatFilters(
   filters: MetricsViewFilterCond[] | undefined,
-  exclude: boolean,
   dimensionIdMap: Map<string | number, MetricsViewSpecDimensionV2>
 ): DimensionFilter[] {
   if (!filters) return [];
 
-  const formatted: DimensionFilter[] = [];
+  const formattedFilters: DimensionFilter[] = [];
 
   filters.forEach(({ name, in: selectedValues }) => {
     if (name === undefined) return;
-    formatted.push({
+
+    const formatted = {
       name,
-      label: getDisplayName(
-        dimensionIdMap.get(name) as MetricsViewSpecDimensionV2
-      ),
-      selectedValues: selectedValues as any[],
-      filterType: exclude ? "exclude" : "include",
-    });
+      label: getDisplayName(dimensionIdMap.get(name)),
+      selectedValues: selectedValues as string[],
+    };
+
+    formattedFilters.push(formatted);
   });
 
-  return formatted;
+  return formattedFilters;
 }

--- a/web-common/src/features/dashboards/filters/getDisplayName.ts
+++ b/web-common/src/features/dashboards/filters/getDisplayName.ts
@@ -1,5 +1,7 @@
 import type { MetricsViewSpecDimensionV2 } from "@rilldata/web-common/runtime-client";
 
-export function getDisplayName(dimension: MetricsViewSpecDimensionV2): string {
+export function getDisplayName(
+  dimension: MetricsViewSpecDimensionV2 | undefined
+): string {
   return (dimension?.label?.length ? dimension?.label : dimension?.name) ?? "";
 }

--- a/web-common/src/features/dashboards/filters/getDisplayName.ts
+++ b/web-common/src/features/dashboards/filters/getDisplayName.ts
@@ -1,5 +1,5 @@
 import type { MetricsViewSpecDimensionV2 } from "@rilldata/web-common/runtime-client";
 
 export function getDisplayName(dimension: MetricsViewSpecDimensionV2): string {
-  return dimension?.label?.length ? dimension?.label : dimension?.name;
+  return (dimension?.label?.length ? dimension?.label : dimension?.name) ?? "";
 }

--- a/web-common/src/features/dashboards/state-managers/actions/dimension-filters.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/dimension-filters.ts
@@ -1,6 +1,7 @@
 import { removeIfExists } from "@rilldata/web-common/lib/arrayUtils";
 import type { DashboardMutables } from "./types";
 import { filtersForCurrentExcludeMode } from "../selectors/dimension-filters";
+import { potentialFilterName } from "../../filters/Filters.svelte";
 
 export function toggleDimensionValueSelection(
   { dashboard, cancelQueries }: DashboardMutables,
@@ -26,6 +27,7 @@ export function toggleDimensionValueSelection(
     if (removeIfExists(filtersIn, (value) => value === dimensionValue)) {
       if (filtersIn.length === 0) {
         filters.splice(dimensionEntryIndex, 1);
+        potentialFilterName.set(dimensionName);
       }
       return;
     }


### PR DESCRIPTION
This PR moves temporary/potential/incomplete filters (those that do not have dimension values) outside of the dashboard store.

This addresses a change in the runtime that happened in #3624  that requires the `in` field of a filter be a nonempty array.

