### PR TITLE
fixes issue where leaderboard could not be fully scrolled when viewing model data on the dashboard

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -41,13 +41,10 @@
 <!-- container for the metrics leaderboard components and controls -->
 <div
   bind:this={leaderboardContainer}
-  class="flex flex-col overflow-hidden"
-  style:height="calc(100vh - 130px - 4rem)"
+  class="flex flex-col overflow-hidden h-full"
   style:min-width="365px"
 >
-  <div
-    class="grid grid-auto-cols justify-between grid-flow-col items-center pl-1 pb-3 flex-grow-0"
-  >
+  <div class="pl-1 pb-3">
     <LeaderboardControls metricViewName={$metricsViewName} />
   </div>
   <div class="grow overflow-hidden">


### PR DESCRIPTION
The `LeaderboardDisplay` component, unlike others rendered in the `Dashboard`'s right pane, was determining its height from a fixed calculation. When viewing model data, this meant that the Leaderboards could not all be scrolled into view. This PR fixes that issue by using `h-full` instead.