### PR TITLE
Fix "View As" functionality in Cloud UI 

### DIFF
--- a/web-admin/src/features/view-as-user/setViewedAsUser.ts
+++ b/web-admin/src/features/view-as-user/setViewedAsUser.ts
@@ -32,7 +32,7 @@ export async function setViewedAsUser(
           userId: user.id,
         }),
     });
-  const jwt = jwtResp.jwt;
+  const jwt = jwtResp.accessToken;
 
   runtime.update((runtimeState) => {
     runtimeState.jwt = jwt;


### PR DESCRIPTION
PR #3590 changed the API response of `GetDeploymentCredentials`, renaming `jwt` to `accessToken`.  This PR accounts for this change client-side.

Closes #3739 