### PR TITLE
fix: clarify model CTA button copy

### DIFF
--- a/web-common/src/features/models/workspace/CreateDashboardButton.svelte
+++ b/web-common/src/features/models/workspace/CreateDashboardButton.svelte
@@ -50,7 +50,7 @@
     {#if hasError}
       Fix the errors in your model to autogenerate dashboard
     {:else}
-      Create a dashboard from this model
+      Autogenerate a dashboard from this model
     {/if}
   </TooltipContent>
 </Tooltip>

--- a/web-common/src/features/models/workspace/CreateDashboardButton.svelte
+++ b/web-common/src/features/models/workspace/CreateDashboardButton.svelte
@@ -44,7 +44,9 @@
     <IconSpaceFixer pullLeft pullRight={collapse}>
       <Add />
     </IconSpaceFixer>
-    <ResponsiveButtonText {collapse}>Autogenerate Dashboard</ResponsiveButtonText>
+    <ResponsiveButtonText {collapse}>
+      Autogenerate Dashboard
+    </ResponsiveButtonText>
   </Button>
   <TooltipContent slot="tooltip-content">
     {#if hasError}

--- a/web-common/src/features/models/workspace/CreateDashboardButton.svelte
+++ b/web-common/src/features/models/workspace/CreateDashboardButton.svelte
@@ -44,7 +44,7 @@
     <IconSpaceFixer pullLeft pullRight={collapse}>
       <Add />
     </IconSpaceFixer>
-    <ResponsiveButtonText {collapse}>Create Dashboard</ResponsiveButtonText>
+    <ResponsiveButtonText {collapse}>Autogenerate Dashboard</ResponsiveButtonText>
   </Button>
   <TooltipContent slot="tooltip-content">
     {#if hasError}


### PR DESCRIPTION
Changes `Create Dashboard` to `Autogenerate Dashboard` from user feedback