### PR TITLE
Runtime: fix malformed SQL for security policies with 'OR'

### DIFF
--- a/runtime/queries/metricsview.go
+++ b/runtime/queries/metricsview.go
@@ -164,7 +164,7 @@ func buildFilterClauseForMetricsViewFilter(mv *runtimev1.MetricsViewSpec, filter
 	}
 
 	if policy != nil && policy.RowFilter != "" {
-		clauses = append(clauses, "AND "+policy.RowFilter)
+		clauses = append(clauses, fmt.Sprintf("AND (%s)", policy.RowFilter))
 	}
 
 	return strings.Join(clauses, " "), args, nil

--- a/runtime/queries/metricsview_aggregation.go
+++ b/runtime/queries/metricsview_aggregation.go
@@ -210,14 +210,12 @@ func (q *MetricsViewAggregation) buildMetricsAggregationSQL(mv *runtimev1.Metric
 		}
 		whereClause += clause
 	}
-	if q.Filter != nil {
-		clause, clauseArgs, err := buildFilterClauseForMetricsViewFilter(mv, q.Filter, dialect, policy)
-		if err != nil {
-			return "", nil, err
-		}
-		whereClause += " " + clause
-		args = append(args, clauseArgs...)
+	filterClause, filterClauseArgs, err := buildFilterClauseForMetricsViewFilter(mv, q.Filter, dialect, policy)
+	if err != nil {
+		return "", nil, err
 	}
+	whereClause += " " + filterClause
+	args = append(args, filterClauseArgs...)
 	if len(whereClause) > 0 {
 		whereClause = "WHERE 1=1" + whereClause
 	}

--- a/runtime/queries/metricsview_comparison_toplist.go
+++ b/runtime/queries/metricsview_comparison_toplist.go
@@ -291,15 +291,12 @@ func (q *MetricsViewComparison) buildMetricsTopListSQL(mv *runtimev1.MetricsView
 	}
 	baseWhereClause += trc
 
-	if q.Filter != nil {
-		clause, clauseArgs, err := buildFilterClauseForMetricsViewFilter(mv, q.Filter, dialect, policy)
-		if err != nil {
-			return "", nil, err
-		}
-		baseWhereClause += " " + clause
-
-		args = append(args, clauseArgs...)
+	filterClause, filterClauseArgs, err := buildFilterClauseForMetricsViewFilter(mv, q.Filter, dialect, policy)
+	if err != nil {
+		return "", nil, err
 	}
+	baseWhereClause += " " + filterClause
+	args = append(args, filterClauseArgs...)
 
 	var orderClauses []string
 	for _, s := range q.Sort {
@@ -490,31 +487,20 @@ func (q *MetricsViewComparison) buildMetricsComparisonTopListSQL(mv *runtimev1.M
 	}
 	baseWhereClause += trc
 
-	if q.Filter != nil {
-		clause, clauseArgs, err := buildFilterClauseForMetricsViewFilter(mv, q.Filter, dialect, policy)
-		if err != nil {
-			return "", nil, err
-		}
-		baseWhereClause += " " + clause
-
-		args = append(args, clauseArgs...)
-	}
-
 	trc, err = timeRangeClause(q.ComparisonTimeRange, mv, dialect, td, &args)
 	if err != nil {
 		return "", nil, err
 	}
 	comparisonWhereClause += trc
 
-	if q.Filter != nil {
-		clause, clauseArgs, err := buildFilterClauseForMetricsViewFilter(mv, q.Filter, dialect, policy)
-		if err != nil {
-			return "", nil, err
-		}
-		comparisonWhereClause += " " + clause
-
-		args = append(args, clauseArgs...)
+	filterClause, filterClauseArgs, err := buildFilterClauseForMetricsViewFilter(mv, q.Filter, dialect, policy)
+	if err != nil {
+		return "", nil, err
 	}
+	baseWhereClause += " " + filterClause
+	comparisonWhereClause += " " + filterClause
+	args = append(args, filterClauseArgs...)
+	args = append(args, filterClauseArgs...)
 
 	err = validateSort(q.Sort)
 	if err != nil {

--- a/runtime/queries/metricsview_rows.go
+++ b/runtime/queries/metricsview_rows.go
@@ -228,14 +228,12 @@ func (q *MetricsViewRows) buildMetricsRowsSQL(mv *runtimev1.MetricsViewSpec, dia
 		}
 	}
 
-	if q.Filter != nil {
-		clause, clauseArgs, err := buildFilterClauseForMetricsViewFilter(mv, q.Filter, dialect, policy)
-		if err != nil {
-			return "", nil, err
-		}
-		whereClause += " " + clause
-		args = append(args, clauseArgs...)
+	filterClause, filterClauseArgs, err := buildFilterClauseForMetricsViewFilter(mv, q.Filter, dialect, policy)
+	if err != nil {
+		return "", nil, err
 	}
+	whereClause += " " + filterClause
+	args = append(args, filterClauseArgs...)
 
 	sortingCriteria := make([]string, 0, len(q.Sort))
 	for _, s := range q.Sort {

--- a/runtime/queries/metricsview_timeseries.go
+++ b/runtime/queries/metricsview_timeseries.go
@@ -277,14 +277,12 @@ func (q *MetricsViewTimeSeries) buildMetricsTimeseriesSQL(olap drivers.OLAPStore
 		args = append(args, q.TimeEnd.AsTime())
 	}
 
-	if q.Filter != nil {
-		clause, clauseArgs, err := buildFilterClauseForMetricsViewFilter(mv, q.Filter, olap.Dialect(), policy)
-		if err != nil {
-			return "", "", nil, err
-		}
-		whereClause += " " + clause
-		args = append(args, clauseArgs...)
+	filterClause, filterClauseArgs, err := buildFilterClauseForMetricsViewFilter(mv, q.Filter, olap.Dialect(), policy)
+	if err != nil {
+		return "", "", nil, err
 	}
+	whereClause += " " + filterClause
+	args = append(args, filterClauseArgs...)
 
 	tsAlias := tempName("_ts_")
 	timezone := "UTC"

--- a/runtime/queries/metricsview_toplist.go
+++ b/runtime/queries/metricsview_toplist.go
@@ -214,14 +214,12 @@ func (q *MetricsViewToplist) buildMetricsTopListSQL(mv *runtimev1.MetricsViewSpe
 		}
 	}
 
-	if q.Filter != nil {
-		clause, clauseArgs, err := buildFilterClauseForMetricsViewFilter(mv, q.Filter, dialect, policy)
-		if err != nil {
-			return "", nil, err
-		}
-		whereClause += " " + clause
-		args = append(args, clauseArgs...)
+	filterClause, filterClauseArgs, err := buildFilterClauseForMetricsViewFilter(mv, q.Filter, dialect, policy)
+	if err != nil {
+		return "", nil, err
 	}
+	whereClause += " " + filterClause
+	args = append(args, filterClauseArgs...)
 
 	sortingCriteria := make([]string, 0, len(q.Sort))
 	for _, s := range q.Sort {

--- a/runtime/queries/metricsview_totals.go
+++ b/runtime/queries/metricsview_totals.go
@@ -124,14 +124,12 @@ func (q *MetricsViewTotals) buildMetricsTotalsSQL(mv *runtimev1.MetricsViewSpec,
 		}
 	}
 
-	if q.Filter != nil {
-		clause, clauseArgs, err := buildFilterClauseForMetricsViewFilter(mv, q.Filter, dialect, policy)
-		if err != nil {
-			return "", nil, err
-		}
-		whereClause += " " + clause
-		args = append(args, clauseArgs...)
+	filterClause, filterClauseArgs, err := buildFilterClauseForMetricsViewFilter(mv, q.Filter, dialect, policy)
+	if err != nil {
+		return "", nil, err
 	}
+	whereClause += " " + filterClause
+	args = append(args, filterClauseArgs...)
 
 	sql := fmt.Sprintf(
 		"SELECT %s FROM %q WHERE %s",


### PR DESCRIPTION
- Ensures correct precedence of filters when a security policy uses `OR`
- Ensures security policies are always applied even when a nil filter is passed (this closes a security loophole, but didn't impact the user experience since an empty non-nil filter is always passed)