### PR TITLE
tweak filter clearing behavior

### DIFF
--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -155,10 +155,7 @@ The main feature-set component for dashboard filters
               }
             }}
             on:apply={(event) => {
-              if ($potentialFilterName) {
-                $potentialFilterName = null;
-              }
-              toggleDimensionValueSelection(name, event.detail);
+              toggleDimensionValueSelection(name, event.detail, true);
             }}
             on:search={(event) => {
               setActiveDimension(name, event.detail);

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardListItem.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardListItem.svelte
@@ -20,7 +20,6 @@
   import LeaderboardItemFilterIcon from "./LeaderboardItemFilterIcon.svelte";
   import LongBarZigZag from "./LongBarZigZag.svelte";
   import type { LeaderboardItemData } from "./leaderboard-utils";
-  import { potentialFilterName } from "../filters/Filters.svelte";
 
   export let dimensionName: string;
 

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardListItem.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardListItem.svelte
@@ -20,6 +20,7 @@
   import LeaderboardItemFilterIcon from "./LeaderboardItemFilterIcon.svelte";
   import LongBarZigZag from "./LongBarZigZag.svelte";
   import type { LeaderboardItemData } from "./leaderboard-utils";
+  import { potentialFilterName } from "../filters/Filters.svelte";
 
   export let dimensionName: string;
 

--- a/web-common/src/features/dashboards/state-managers/actions/dimension-filters.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/dimension-filters.ts
@@ -6,7 +6,8 @@ import { potentialFilterName } from "../../filters/Filters.svelte";
 export function toggleDimensionValueSelection(
   { dashboard, cancelQueries }: DashboardMutables,
   dimensionName: string,
-  dimensionValue: string
+  dimensionValue: string,
+  keepPillVisible?: boolean
 ) {
   const filters = filtersForCurrentExcludeMode({ dashboard })(dimensionName);
   // if there are no filters at this point we cannot update anything.
@@ -27,12 +28,14 @@ export function toggleDimensionValueSelection(
     if (removeIfExists(filtersIn, (value) => value === dimensionValue)) {
       if (filtersIn.length === 0) {
         filters.splice(dimensionEntryIndex, 1);
-        potentialFilterName.set(dimensionName);
+        if (keepPillVisible) potentialFilterName.set(dimensionName);
       }
       return;
     }
     filtersIn.push(dimensionValue);
   } else {
+    potentialFilterName.set(null);
+
     filters.push({
       name: dimensionName,
       in: [dimensionValue],


### PR DESCRIPTION
This PR changes the filter clearing behavior so that the "temporary" filter pill is only maintained when interacting with filters through the dropdown menu.