### PR TITLE
Fix issues with non string dimension filters

### DIFF
--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -39,6 +39,9 @@ The main feature-set component for dashboard filters
         toggleDimensionValueSelection,
       },
     },
+    selectors: {
+      dimensionFilters: { atLeastOneSelection },
+    },
   } = StateManagers;
 
   /** the height of a row of chips */
@@ -114,6 +117,17 @@ The main feature-set component for dashboard filters
     if (!filters || !filters.include || !filters.exclude) return false;
     return filters.include.length > 0 || filters.exclude.length > 0;
   }
+
+  function handleDimensionValueToggle(name: string, value: string) {
+    toggleDimensionValueSelection(name, value);
+    if ($atLeastOneSelection(name)) {
+      $potentialFilterName = null;
+    } else {
+      // since this toggle is only from the filter pill dropdown,
+      // set potentialFilterName to keep the dropdown open when there are no values selected
+      $potentialFilterName = name;
+    }
+  }
 </script>
 
 <section
@@ -155,10 +169,7 @@ The main feature-set component for dashboard filters
               }
             }}
             on:apply={(event) => {
-              if ($potentialFilterName) {
-                $potentialFilterName = null;
-              }
-              toggleDimensionValueSelection(name, event.detail);
+              handleDimensionValueToggle(name, event.detail);
             }}
             on:search={(event) => {
               setActiveDimension(name, event.detail);

--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -78,7 +78,7 @@ The main feature-set component for dashboard filters
 
   $: dimensionIdMap = getMapFromArray(
     dimensions,
-    (dimension) => dimension.name
+    (dimension) => dimension.name as string
   );
 
   $: currentFormattedFilters = formatFilters(

--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -39,9 +39,6 @@ The main feature-set component for dashboard filters
         toggleDimensionValueSelection,
       },
     },
-    selectors: {
-      dimensionFilters: { atLeastOneSelection },
-    },
   } = StateManagers;
 
   /** the height of a row of chips */
@@ -116,17 +113,6 @@ The main feature-set component for dashboard filters
   function isFiltered(filters: V1MetricsViewFilter): boolean {
     if (!filters || !filters.include || !filters.exclude) return false;
     return filters.include.length > 0 || filters.exclude.length > 0;
-  }
-
-  function handleDimensionValueToggle(name: string, value: string) {
-    toggleDimensionValueSelection(name, value);
-    if ($atLeastOneSelection(name)) {
-      $potentialFilterName = null;
-    } else {
-      // since this toggle is only from the filter pill dropdown,
-      // set potentialFilterName to keep the dropdown open when there are no values selected
-      $potentialFilterName = name;
-    }
   }
 </script>
 

--- a/web-common/src/features/dashboards/leaderboard/leaderboard-utils.ts
+++ b/web-common/src/features/dashboards/leaderboard/leaderboard-utils.ts
@@ -141,16 +141,16 @@ export function prepareLeaderboardItemData(
   // selected values that _are_ in the API results.
   //
   // We also need to retain the original selection indices
-  const selectedButNotInAPIResults = new Map<string, number>();
-  selectedValues.map((v, i) => selectedButNotInAPIResults.set(v, i));
+  const selectedButNotInAPIResults = new Set<number>();
+  selectedValues.map((v, i) => selectedButNotInAPIResults.add(i));
 
   values.forEach((v, i) => {
-    const selectedIndex = selectedValues.findIndex(
-      (value) => value === v.dimensionValue
+    const selectedIndex = selectedValues.findIndex((value) =>
+      leaderboardValuesCompare(value, v.dimensionValue)
     );
     // if we have found this selected value in the API results,
     // remove it from the selectedButNotInAPIResults array
-    if (selectedIndex > -1) selectedButNotInAPIResults.delete(v.dimensionValue);
+    if (selectedIndex > -1) selectedButNotInAPIResults.delete(selectedIndex);
 
     const cleanValue = cleanUpComparisonValue(v, total, selectedIndex);
 
@@ -169,9 +169,9 @@ export function prepareLeaderboardItemData(
   // that pushes it out of the top N. In that case, we will follow
   // the previous strategy, and just push a dummy value with only
   // the dimension value and nulls for all measure values.
-  for (const [dimensionValue, selectedIndex] of selectedButNotInAPIResults) {
+  for (const selectedIndex of selectedButNotInAPIResults) {
     selectedBelowTheFold.push({
-      dimensionValue,
+      dimensionValue: selectedValues[selectedIndex],
       selectedIndex,
       value: null,
       pctOfTotal: null,
@@ -255,4 +255,24 @@ export function getQuerySortType(sortType: SortType) {
         ApiSortType.METRICS_VIEW_COMPARISON_MEASURE_TYPE_BASE_VALUE,
     }[sortType] || ApiSortType.METRICS_VIEW_COMPARISON_MEASURE_TYPE_BASE_VALUE
   );
+}
+
+// Backwards compatibility fix for older filters that converted all non-null values to string
+export function leaderboardValuesCompare(selected: string, value: any) {
+  if (selected === null || value === null) {
+    return selected === value;
+  }
+  if (typeof selected === typeof value) {
+    return selected === value;
+  }
+  switch (typeof value) {
+    case "boolean":
+      return (selected.toLowerCase() === "true") === value;
+
+    case "number":
+      return Number(selected) === value;
+
+    default:
+      return selected === value;
+  }
 }

--- a/web-common/src/features/dashboards/leaderboard/leaderboard-utils.ts
+++ b/web-common/src/features/dashboards/leaderboard/leaderboard-utils.ts
@@ -146,7 +146,7 @@ export function prepareLeaderboardItemData(
 
   values.forEach((v, i) => {
     const selectedIndex = selectedValues.findIndex((value) =>
-      leaderboardValuesCompare(value, v.dimensionValue)
+      compareLeaderboardValues(value, v.dimensionValue)
     );
     // if we have found this selected value in the API results,
     // remove it from the selectedButNotInAPIResults array
@@ -258,7 +258,7 @@ export function getQuerySortType(sortType: SortType) {
 }
 
 // Backwards compatibility fix for older filters that converted all non-null values to string
-export function leaderboardValuesCompare(selected: string, value: any) {
+export function compareLeaderboardValues(selected: string, value: any) {
   if (selected === null || value === null) {
     return selected === value;
   }

--- a/web-common/src/features/dashboards/state-managers/actions/dimension-filters.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/dimension-filters.ts
@@ -1,3 +1,4 @@
+import { leaderboardValuesCompare } from "@rilldata/web-common/features/dashboards/leaderboard/leaderboard-utils";
 import { removeIfExists } from "@rilldata/web-common/lib/arrayUtils";
 import type { DashboardMutables } from "./types";
 import { filtersForCurrentExcludeMode } from "../selectors/dimension-filters";
@@ -24,10 +25,13 @@ export function toggleDimensionValueSelection(
   if (dimensionEntryIndex >= 0) {
     const filtersIn = filters[dimensionEntryIndex].in;
     if (filtersIn === undefined) return;
-    if (removeIfExists(filtersIn, (value) => value === dimensionValue)) {
+    if (
+      removeIfExists(filtersIn, (value) =>
+        leaderboardValuesCompare(value as string, dimensionValue)
+      )
+    ) {
       if (filtersIn.length === 0) {
         filters.splice(dimensionEntryIndex, 1);
-        potentialFilterName.set(dimensionName);
       }
       return;
     }

--- a/web-common/src/features/dashboards/state-managers/actions/dimension-filters.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/dimension-filters.ts
@@ -1,4 +1,4 @@
-import { leaderboardValuesCompare } from "@rilldata/web-common/features/dashboards/leaderboard/leaderboard-utils";
+import { compareLeaderboardValues } from "@rilldata/web-common/features/dashboards/leaderboard/leaderboard-utils";
 import { removeIfExists } from "@rilldata/web-common/lib/arrayUtils";
 import type { DashboardMutables } from "./types";
 import { filtersForCurrentExcludeMode } from "../selectors/dimension-filters";
@@ -28,7 +28,7 @@ export function toggleDimensionValueSelection(
     if (filtersIn === undefined) return;
     if (
       removeIfExists(filtersIn, (value) =>
-        leaderboardValuesCompare(value as string, dimensionValue)
+        compareLeaderboardValues(value as string, dimensionValue)
       )
     ) {
       if (filtersIn.length === 0) {

--- a/web-common/src/lib/arrayUtils.ts
+++ b/web-common/src/lib/arrayUtils.ts
@@ -7,10 +7,10 @@ export function removeIfExists<T>(array: Array<T>, checker: (e: T) => boolean) {
   return false;
 }
 
-export function getMapFromArray<T>(
+export function getMapFromArray<T, K>(
   array: Array<T>,
-  keyGetter: (entity: T) => string | number | undefined
-): Map<string | number, T> {
+  keyGetter: (entity: T) => K
+): Map<K, T> {
   const map = new Map();
   for (const entity of array) {
     map.set(keyGetter(entity), entity);


### PR DESCRIPTION
Older filter objects stored all non-null filters as strings. This is a temporary fix for this use case. In the new filters we should retain the original type.