### PR TITLE
enable outlines for filter pills

### DIFF
--- a/web-common/src/components/chip/chip-types.ts
+++ b/web-common/src/components/chip/chip-types.ts
@@ -25,8 +25,8 @@ export const excludeChipColors = {
   bgHoverClass: "hover:bg-gray-100 hover:dark:bg-gray-600",
   textClass: "text-gray-600",
   bgActiveClass: "bg-gray-100 dark:bg-gray-600",
-  outlineClass: "",
-  outlineActiveClass: "",
+  outlineClass: "outline outline-1 outline-gray-200",
+  outlineActiveClass: "!outline-gray-400",
 };
 
 export const subrangeChipColors = {

--- a/web-common/src/components/chip/removable-list-chip/RemovableListChip.svelte
+++ b/web-common/src/components/chip/removable-list-chip/RemovableListChip.svelte
@@ -76,6 +76,7 @@ are details left to the consumer of the component; this component should remain 
       {active}
       {...colors}
       {label}
+      outline
     >
       <!-- remove button tooltip -->
       <svelte:fragment slot="remove-tooltip">


### PR DESCRIPTION
This PR enables the outlines for filter pills via the RemovableListChip component, bringing the UI in line with the design system.