### PR TITLE
Add ShadCN's Data Table component set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24323,6 +24323,20 @@
         "dequal": "^2.0.2"
       }
     },
+    "node_modules/svelte-headless-table": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/svelte-headless-table/-/svelte-headless-table-0.18.1.tgz",
+      "integrity": "sha512-pcZIi36u8RV9B3m0oG6000az7tvT6CCK+c8qBUuNUQSChsfJySC5ryGdJSTFlAYBVRGUgZlqYOKGUgSbOfIrnA==",
+      "dev": true,
+      "dependencies": {
+        "svelte-keyed": "^2.0.0",
+        "svelte-render": "^2.0.0",
+        "svelte-subscribe": "^2.0.1"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0"
+      }
+    },
     "node_modules/svelte-hmr": {
       "version": "0.15.3",
       "dev": true,
@@ -24332,6 +24346,15 @@
       },
       "peerDependencies": {
         "svelte": "^3.19.0 || ^4.0.0"
+      }
+    },
+    "node_modules/svelte-keyed": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/svelte-keyed/-/svelte-keyed-2.0.0.tgz",
+      "integrity": "sha512-7TeEn+QbJC2OJrHiuM0T8vMBkms3DNpTE+Ir+NtnVBnBMA78aL4f1ft9t0Hn/pBbD/TnIXi4YfjFRAgtN+DZ5g==",
+      "dev": true,
+      "peerDependencies": {
+        "svelte": "^4.0.0"
       }
     },
     "node_modules/svelte-popperjs": {
@@ -24413,6 +24436,27 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/svelte-render": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/svelte-render/-/svelte-render-2.0.0.tgz",
+      "integrity": "sha512-YWMwXGlUlnlb8QhEd138Kmay2KfU6sE7jj3epoYZuHe3M2voGdXfgqYJY7gGizW55N0zDWtuRaY3Rh6PGcGQyQ==",
+      "dev": true,
+      "dependencies": {
+        "svelte-subscribe": "^2.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0"
+      }
+    },
+    "node_modules/svelte-subscribe": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/svelte-subscribe/-/svelte-subscribe-2.0.1.tgz",
+      "integrity": "sha512-eKXIjLxB4C7eQWPqKEdxcGfNXm2g/qJ67zmEZK/GigCZMfrTR3m7DPY93R6MX+5uoqM1FRYxl8LZ1oy4URWi2A==",
+      "dev": true,
+      "peerDependencies": {
+        "svelte": "^4.0.0"
       }
     },
     "node_modules/sveltedoc-parser": {
@@ -27934,6 +27978,7 @@
         "storybook": "^7.0.18",
         "svelte": "^4.0.0",
         "svelte-forms-lib": "^2.0.1",
+        "svelte-headless-table": "^0.18.1",
         "svelte-preprocess": "^5.0.4",
         "tailwind-merge": "^2.1.0",
         "tailwind-variants": "^0.1.19",

--- a/web-common/package.json
+++ b/web-common/package.json
@@ -59,6 +59,7 @@
     "storybook": "^7.0.18",
     "svelte": "^4.0.0",
     "svelte-forms-lib": "^2.0.1",
+    "svelte-headless-table": "^0.18.1",
     "svelte-preprocess": "^5.0.4",
     "tailwind-merge": "^2.1.0",
     "tailwind-variants": "^0.1.19",

--- a/web-common/src/components/table-shadcn/Table.svelte
+++ b/web-common/src/components/table-shadcn/Table.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { cn } from "@rilldata/web-common/lib/shadcn";
+  import type { HTMLTableAttributes } from "svelte/elements";
+
+  type $$Props = HTMLTableAttributes;
+
+  let className: $$Props["class"] = undefined;
+  export { className as class };
+</script>
+
+<div class="w-full overflow-auto">
+  <table
+    class={cn("w-full caption-bottom text-sm", className)}
+    {...$$restProps}
+  >
+    <slot />
+  </table>
+</div>

--- a/web-common/src/components/table-shadcn/TableBody.svelte
+++ b/web-common/src/components/table-shadcn/TableBody.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { cn } from "@rilldata/web-common/lib/shadcn";
+  import type { HTMLAttributes } from "svelte/elements";
+
+  type $$Props = HTMLAttributes<HTMLTableSectionElement>;
+
+  let className: $$Props["class"] = undefined;
+  export { className as class };
+</script>
+
+<tbody class={cn("[&_tr:last-child]:border-0", className)} {...$$restProps}>
+  <slot />
+</tbody>

--- a/web-common/src/components/table-shadcn/TableCaption.svelte
+++ b/web-common/src/components/table-shadcn/TableCaption.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { cn } from "@rilldata/web-common/lib/shadcn";
+  import type { HTMLAttributes } from "svelte/elements";
+
+  type $$Props = HTMLAttributes<HTMLTableCaptionElement>;
+
+  let className: $$Props["class"] = undefined;
+  export { className as class };
+</script>
+
+<caption
+  class={cn("mt-4 text-sm text-muted-foreground", className)}
+  {...$$restProps}
+>
+  <slot />
+</caption>

--- a/web-common/src/components/table-shadcn/TableCell.svelte
+++ b/web-common/src/components/table-shadcn/TableCell.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { cn } from "@rilldata/web-common/lib/shadcn";
+  import type { HTMLTdAttributes } from "svelte/elements";
+
+  type $$Props = HTMLTdAttributes;
+
+  let className: $$Props["class"] = undefined;
+  export { className as class };
+</script>
+
+<td
+  class={cn(
+    "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+    className,
+  )}
+  {...$$restProps}
+  on:click
+  on:keydown
+>
+  <slot />
+</td>

--- a/web-common/src/components/table-shadcn/TableFooter.svelte
+++ b/web-common/src/components/table-shadcn/TableFooter.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { cn } from "@rilldata/web-common/lib/shadcn";
+  import type { HTMLAttributes } from "svelte/elements";
+
+  type $$Props = HTMLAttributes<HTMLTableSectionElement>;
+
+  let className: $$Props["class"] = undefined;
+  export { className as class };
+</script>
+
+<tfoot
+  class={cn("bg-primary font-medium text-primary-foreground", className)}
+  {...$$restProps}
+>
+  <slot />
+</tfoot>

--- a/web-common/src/components/table-shadcn/TableHead.svelte
+++ b/web-common/src/components/table-shadcn/TableHead.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { cn } from "@rilldata/web-common/lib/shadcn";
+  import type { HTMLThAttributes } from "svelte/elements";
+
+  type $$Props = HTMLThAttributes;
+
+  let className: $$Props["class"] = undefined;
+  export { className as class };
+</script>
+
+<th
+  class={cn(
+    "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+    className,
+  )}
+  {...$$restProps}
+>
+  <slot />
+</th>

--- a/web-common/src/components/table-shadcn/TableHeader.svelte
+++ b/web-common/src/components/table-shadcn/TableHeader.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { cn } from "@rilldata/web-common/lib/shadcn";
+  import type { HTMLAttributes } from "svelte/elements";
+
+  type $$Props = HTMLAttributes<HTMLTableSectionElement>;
+
+  let className: $$Props["class"] = undefined;
+  export { className as class };
+</script>
+
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+<thead
+  class={cn("[&_tr]:border-b", className)}
+  {...$$restProps}
+  on:click
+  on:keydown
+>
+  <slot />
+</thead>

--- a/web-common/src/components/table-shadcn/TableRow.svelte
+++ b/web-common/src/components/table-shadcn/TableRow.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { cn } from "@rilldata/web-common/lib/shadcn";
+  import type { HTMLAttributes } from "svelte/elements";
+
+  type $$Props = HTMLAttributes<HTMLTableRowElement> & {
+    "data-state"?: unknown;
+  };
+
+  let className: $$Props["class"] = undefined;
+  export { className as class };
+</script>
+
+<tr
+  class={cn(
+    "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+    className,
+  )}
+  {...$$restProps}
+  on:click
+  on:keydown
+>
+  <slot />
+</tr>

--- a/web-common/src/components/table-shadcn/__stories__/Table.stories.svelte
+++ b/web-common/src/components/table-shadcn/__stories__/Table.stories.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  import { Meta, Story } from "@storybook/addon-svelte-csf";
+  import {
+    Render,
+    Subscribe,
+    createRender,
+    createTable,
+  } from "svelte-headless-table";
+  import { readable } from "svelte/store";
+  import * as Table from "..";
+  import { Tag } from "../../tag";
+  import { todos } from "./data";
+
+  const table = createTable(readable(todos));
+
+  const columns = table.createColumns([
+    table.column({
+      accessor: (todo) => todo.id,
+      header: "ID",
+    }),
+    table.column({
+      accessor: (todo) => todo.title,
+      header: "Title",
+    }),
+    // Example of how to use a custom cell renderer to render a component
+    table.column({
+      accessor: (todo) => todo.completed,
+      header: "Complete",
+      cell: ({ value }) => {
+        const color = value ? "blue" : "red";
+        return createRender(Tag, {
+          color,
+        }).slot(value ? "Completed" : "Not completed");
+      },
+    }),
+    // Example of how to use a custom cell renderer to format the data
+    table.column({
+      accessor: (todo) => todo.completedOn,
+      header: "Completed on",
+      cell: ({ value }) => {
+        if (!value) {
+          return "-";
+        }
+        return new Date(value).toLocaleString(undefined, {
+          month: "short",
+          day: "numeric",
+          hour: "numeric",
+          minute: "numeric",
+        });
+      },
+    }),
+  ]);
+
+  const { headerRows, pageRows, tableAttrs, tableBodyAttrs } =
+    table.createViewModel(columns);
+</script>
+
+<Meta title="Components/Table" />
+
+<Story name="Basic">
+  <div class="rounded-md border">
+    <Table.Root {...$tableAttrs}>
+      <Table.Header>
+        {#each $headerRows as headerRow}
+          <Subscribe rowAttrs={headerRow.attrs()}>
+            <Table.Row>
+              {#each headerRow.cells as cell (cell.id)}
+                <Subscribe attrs={cell.attrs()} let:attrs props={cell.props()}>
+                  <Table.Head {...attrs}>
+                    <Render of={cell.render()} />
+                  </Table.Head>
+                </Subscribe>
+              {/each}
+            </Table.Row>
+          </Subscribe>
+        {/each}
+      </Table.Header>
+      <Table.Body {...$tableBodyAttrs}>
+        {#each $pageRows as row (row.id)}
+          <Subscribe rowAttrs={row.attrs()} let:rowAttrs>
+            <Table.Row {...rowAttrs}>
+              {#each row.cells as cell (cell.id)}
+                <Subscribe attrs={cell.attrs()} let:attrs>
+                  <Table.Cell {...attrs}>
+                    <Render of={cell.render()} />
+                  </Table.Cell>
+                </Subscribe>
+              {/each}
+            </Table.Row>
+          </Subscribe>
+        {/each}
+      </Table.Body>
+    </Table.Root>
+  </div></Story
+>

--- a/web-common/src/components/table-shadcn/__stories__/data.ts
+++ b/web-common/src/components/table-shadcn/__stories__/data.ts
@@ -1,0 +1,35 @@
+export interface Todo {
+  id: number;
+  title: string;
+  completed: boolean;
+  completedOn?: string;
+}
+
+export const todos: Todo[] = [
+  {
+    id: 1,
+    title: "delectus aut autem",
+    completed: false,
+  },
+  {
+    id: 2,
+    title: "quis ut nam facilis et officia qui",
+    completed: false,
+  },
+  {
+    id: 3,
+    title: "fugiat veniam minus",
+    completed: false,
+  },
+  {
+    id: 4,
+    title: "et porro tempora",
+    completed: true,
+    completedOn: "2021-01-01",
+  },
+  {
+    id: 5,
+    title: "laboriosam mollitia et enim quasi adipisci quia provident illum",
+    completed: false,
+  },
+];

--- a/web-common/src/components/table-shadcn/index.ts
+++ b/web-common/src/components/table-shadcn/index.ts
@@ -1,0 +1,28 @@
+import Root from "./Table.svelte";
+import Body from "./TableBody.svelte";
+import Caption from "./TableCaption.svelte";
+import Cell from "./TableCell.svelte";
+import Footer from "./TableFooter.svelte";
+import Head from "./TableHead.svelte";
+import Header from "./TableHeader.svelte";
+import Row from "./TableRow.svelte";
+
+export {
+  Body,
+  Caption,
+  Cell,
+  Footer,
+  Head,
+  Header,
+  Root,
+  Row,
+  //
+  Root as Table,
+  Body as TableBody,
+  Caption as TableCaption,
+  Cell as TableCell,
+  Footer as TableFooter,
+  Head as TableHead,
+  Header as TableHeader,
+  Row as TableRow,
+};


### PR DESCRIPTION
This PR adds [ShadCN Svelte's "Data Table"](https://www.shadcn-svelte.com/docs/components/data-table) component set to `web-common/components/table-shadcn`. The PR includes a basic Storybook story to show it in action.

This PR will be followed by another that uses this component on the Cloud UI project status page.