### PR TITLE
Empty filters are now errors

### DIFF
--- a/runtime/queries/metricsview.go
+++ b/runtime/queries/metricsview.go
@@ -379,15 +379,16 @@ func buildInExpression(mv *runtimev1.MetricsViewSpec, cond *runtimev1.Condition,
 }
 
 func buildAndOrExpressions(mv *runtimev1.MetricsViewSpec, cond *runtimev1.Condition, aliases []*runtimev1.MetricsViewComparisonMeasureAlias, dialect drivers.Dialect, joiner string) (string, []any, error) {
+	if len(cond.Exprs) == 0 {
+		return "", nil, fmt.Errorf("or/and expression should have atleast 1 sub expressions")
+	}
+
 	clauses := make([]string, 0)
 	var args []any
 	for _, expr := range cond.Exprs {
 		clause, subArgs, err := buildExpression(mv, expr, aliases, dialect)
 		if err != nil {
 			return "", nil, err
-		}
-		if strings.TrimSpace(clause) == "" {
-			continue
 		}
 		args = append(args, subArgs...)
 		clauses = append(clauses, fmt.Sprintf("(%s)", clause))


### PR DESCRIPTION
In a previous PR (#3779) we handled empty and/or operations by allowing them. This PR adds the check for empty operations and returns an error.