### PR TITLE
Fix meaningless "broken rill.yaml" warnings for empty projects

### DIFF
--- a/runtime/compilers/rillv1/parser.go
+++ b/runtime/compilers/rillv1/parser.go
@@ -217,7 +217,7 @@ func (p *Parser) Reparse(ctx context.Context, paths []string) (*Diff, error) {
 // IsIgnored returns true if the path will be ignored by Reparse.
 // It's useful for callers to avoid triggering a reparse when they know the path is not relevant.
 func (p *Parser) IsIgnored(path string) bool {
-	return !pathIsYAML(path) && !pathIsSQL(path) && !pathIsRillYAML(path) && !pathIsDotEnv(path)
+	return !pathIsYAML(path) && !pathIsSQL(path) && !pathIsDotEnv(path)
 }
 
 // reload resets the parser's state and then parses the entire project.

--- a/runtime/compilers/rillv1/parser.go
+++ b/runtime/compilers/rillv1/parser.go
@@ -353,11 +353,6 @@ func (p *Parser) reparseExceptRillYAML(ctx context.Context, paths []string) (*Di
 		}
 	}
 
-	// If we did not identify any paths to (re)parse, exit early.
-	if len(parsePaths) == 0 {
-		return &Diff{}, nil
-	}
-
 	// Phase 2: Parse (or reparse) the related paths, adding back resources
 	err := p.parsePaths(ctx, parsePaths)
 	if err != nil {

--- a/runtime/reconcilers/project_parser.go
+++ b/runtime/reconcilers/project_parser.go
@@ -184,7 +184,7 @@ func (r *ProjectParserReconciler) Reconcile(ctx context.Context, n *runtimev1.Re
 			if e.Dir {
 				continue
 			}
-			if strings.HasSuffix(e.Path, ".db") || strings.HasSuffix(e.Path, ".wal") {
+			if strings.HasSuffix(e.Path, ".db") || strings.HasSuffix(e.Path, ".db-journal") || strings.HasSuffix(e.Path, ".wal") {
 				continue
 			}
 			changedPaths = append(changedPaths, e.Path)
@@ -249,7 +249,9 @@ func (r *ProjectParserReconciler) reconcileParser(ctx context.Context, inst *dri
 			r.C.Logger.Warn("Parser error", slog.String("path", e.FilePath), slog.String("err", e.Message))
 		}
 	} else if diff.Skipped {
-		r.C.Logger.Warn("Not parsing changed paths due to broken rill.yaml")
+		if diff.ParsedPathsCount != 0 { // Otherwise, a non-rill file was changed, which we don't want to log
+			r.C.Logger.Warn("Not parsing changed paths due to missing or broken rill.yaml")
+		}
 	} else {
 		for _, e := range parser.Errors {
 			if slices.Contains(changedPaths, e.FilePath) {

--- a/runtime/reconcilers/project_parser.go
+++ b/runtime/reconcilers/project_parser.go
@@ -184,7 +184,7 @@ func (r *ProjectParserReconciler) Reconcile(ctx context.Context, n *runtimev1.Re
 			if e.Dir {
 				continue
 			}
-			if strings.HasSuffix(e.Path, ".db") || strings.HasSuffix(e.Path, ".db-journal") || strings.HasSuffix(e.Path, ".wal") {
+			if parser.IsIgnored(e.Path) {
 				continue
 			}
 			changedPaths = append(changedPaths, e.Path)
@@ -249,9 +249,7 @@ func (r *ProjectParserReconciler) reconcileParser(ctx context.Context, inst *dri
 			r.C.Logger.Warn("Parser error", slog.String("path", e.FilePath), slog.String("err", e.Message))
 		}
 	} else if diff.Skipped {
-		if diff.ParsedPathsCount != 0 { // Otherwise, a non-rill file was changed, which we don't want to log
-			r.C.Logger.Warn("Not parsing changed paths due to missing or broken rill.yaml")
-		}
+		r.C.Logger.Warn("Not parsing changed paths due to missing or broken rill.yaml")
 	} else {
 		for _, e := range parser.Errors {
 			if slices.Contains(changedPaths, e.FilePath) {


### PR DESCRIPTION
- When the application is started in a new directory, a sqlite file is created immediately in `tmp/meta.db`
- This causes file watch events to be triggered before `rill.yaml` has been initialized
- This PR fixes the issue by not printing warnings about missing/broken `rill.yaml` files for non-YAML and non-SQL file events

Contributes to https://github.com/rilldata/rill/issues/3551