### PR TITLE
Begelundmuller/fix racy runtime test

### DIFF
--- a/runtime/reconcilers/project_parser.go
+++ b/runtime/reconcilers/project_parser.go
@@ -184,7 +184,7 @@ func (r *ProjectParserReconciler) Reconcile(ctx context.Context, n *runtimev1.Re
 			if e.Dir {
 				continue
 			}
-			if strings.HasSuffix(e.Path, ".db") || strings.HasSuffix(e.Path, ".wal") {
+			if strings.HasSuffix(e.Path, ".db") || strings.HasSuffix(e.Path, ".db-journal") || strings.HasSuffix(e.Path, ".wal") {
 				continue
 			}
 			changedPaths = append(changedPaths, e.Path)
@@ -249,7 +249,9 @@ func (r *ProjectParserReconciler) reconcileParser(ctx context.Context, inst *dri
 			r.C.Logger.Warn("Parser error", slog.String("path", e.FilePath), slog.String("err", e.Message))
 		}
 	} else if diff.Skipped {
-		r.C.Logger.Warn("Not parsing changed paths due to broken rill.yaml")
+		if diff.ParsedPathsCount != 0 { // Otherwise, a non-rill file was changed, which we don't want to log
+			r.C.Logger.Warn("Not parsing changed paths due to missing or broken rill.yaml")
+		}
 	} else {
 		for _, e := range parser.Errors {
 			if slices.Contains(changedPaths, e.FilePath) {

--- a/runtime/registry_test.go
+++ b/runtime/registry_test.go
@@ -289,6 +289,7 @@ func TestRuntime_EditInstance(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			rt := newTestRuntime(t)
 			ctx := context.Background()


### PR DESCRIPTION
Fixes the race condition that repeatedly causes race condition tests to fail on merge to main (e.g. [this one](https://github.com/rilldata/rill/actions/runs/7462333741/job/20304396670))