### PR TITLE
Runtime: fix failing race condition test

### DIFF
--- a/runtime/registry_test.go
+++ b/runtime/registry_test.go
@@ -289,6 +289,7 @@ func TestRuntime_EditInstance(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			rt := newTestRuntime(t)
 			ctx := context.Background()


### PR DESCRIPTION
Fixes the race condition that repeatedly causes race condition tests to fail on merge to main (e.g. [this one](https://github.com/rilldata/rill/actions/runs/7462333741/job/20304396670))