### PR TITLE
Dashboard: Replace `ColumnTimeRange` request with `MetricsViewTimeRange` request

### DIFF
--- a/web-common/src/features/dashboards/dashboard-fetch-mocks.ts
+++ b/web-common/src/features/dashboards/dashboard-fetch-mocks.ts
@@ -43,12 +43,11 @@ export class DashboardFetchMocks {
   }
 
   public mockTimeRangeSummary(
-    tableName: string,
-    columnName: string,
+    metricsViewName: string,
     resp: V1TimeRangeSummary,
   ) {
     this.responses.set(
-      `queries__time-range-summary__${tableName}__${columnName}`,
+      `queries__metrics-views__time-range-summary__${metricsViewName}`,
       {
         timeRangeSummary: resp,
       },
@@ -70,14 +69,7 @@ export class DashboardFetchMocks {
         break;
 
       case "queries":
-        key =
-          type +
-          "__" +
-          parts[0] +
-          "__" +
-          parts[2] +
-          "__" +
-          (u.searchParams.get("columnName") ?? "");
+        key = type + "__" + parts[0] + "__" + parts[2] + "__" + parts[1];
         break;
 
       case "metrics-views":

--- a/web-common/src/features/dashboards/proto-state/dashboard-url-state.spec.ts
+++ b/web-common/src/features/dashboards/proto-state/dashboard-url-state.spec.ts
@@ -17,7 +17,6 @@ import {
   AD_BIDS_MIRROR_NAME,
   AD_BIDS_NAME,
   AD_BIDS_PUBLISHER_DIMENSION,
-  AD_BIDS_SOURCE_NAME,
   AD_BIDS_TIMESTAMP_DIMENSION,
   AD_BIDS_WITH_DELETED_MEASURE,
   assertMetricsView,
@@ -259,14 +258,10 @@ describe("useDashboardUrlSync", () => {
       dashboardFetchMocks,
       AD_BIDS_INIT_WITH_TIME,
     );
-    dashboardFetchMocks.mockTimeRangeSummary(
-      AD_BIDS_SOURCE_NAME,
-      AD_BIDS_TIMESTAMP_DIMENSION,
-      {
-        min: TestTimeConstants.LAST_DAY.toISOString(),
-        max: TestTimeConstants.NOW.toISOString(),
-      },
-    );
+    dashboardFetchMocks.mockTimeRangeSummary(AD_BIDS_NAME, {
+      min: TestTimeConstants.LAST_DAY.toISOString(),
+      max: TestTimeConstants.NOW.toISOString(),
+    });
 
     const { unmount } = render(DashboardTestComponent, {
       ctx: stateManagers,

--- a/web-common/src/features/dashboards/selectors/index.ts
+++ b/web-common/src/features/dashboards/selectors/index.ts
@@ -101,20 +101,14 @@ export const getFilterSearchList = (
 export function createTimeRangeSummary(
   ctx: StateManagers,
 ): CreateQueryResult<V1MetricsViewTimeRangeResponse> {
-  return derived(
-    [ctx.runtime, useMetaQuery(ctx)],
-    ([runtime, metricsView], set) => {
-      return createQueryServiceMetricsViewTimeRange(
-        runtime.instanceId,
-        get(ctx.metricsViewName),
-        { priority: undefined },
-        {
-          query: {
-            enabled: !!metricsView.data?.timeDimension,
-            queryClient: ctx.queryClient,
-          },
-        },
-      ).subscribe(set);
+  return createQueryServiceMetricsViewTimeRange(
+    get(ctx.runtime).instanceId,
+    get(ctx.metricsViewName),
+    {},
+    {
+      query: {
+        queryClient: ctx.queryClient,
+      },
     },
   );
 }

--- a/web-common/src/features/dashboards/selectors/index.ts
+++ b/web-common/src/features/dashboards/selectors/index.ts
@@ -4,18 +4,18 @@ import {
   useResource,
 } from "@rilldata/web-common/features/entity-management/resource-selectors";
 import {
-  createQueryServiceColumnTimeRange,
-  createQueryServiceMetricsViewToplist,
   RpcStatus,
-  V1ColumnTimeRangeResponse,
   V1MetricsViewSpec,
+  V1MetricsViewTimeRangeResponse,
   V1MetricsViewToplistResponse,
+  createQueryServiceMetricsViewTimeRange,
+  createQueryServiceMetricsViewToplist,
 } from "@rilldata/web-common/runtime-client";
 import type {
   CreateQueryResult,
   QueryObserverResult,
 } from "@tanstack/svelte-query";
-import { derived, Readable } from "svelte/store";
+import { Readable, derived, get } from "svelte/store";
 import type { StateManagers } from "../state-managers/state-managers";
 
 export const useMetaQuery = <T = V1MetricsViewSpec>(
@@ -100,16 +100,14 @@ export const getFilterSearchList = (
 
 export function createTimeRangeSummary(
   ctx: StateManagers,
-): CreateQueryResult<V1ColumnTimeRangeResponse> {
+): CreateQueryResult<V1MetricsViewTimeRangeResponse> {
   return derived(
     [ctx.runtime, useMetaQuery(ctx)],
     ([runtime, metricsView], set) => {
-      return createQueryServiceColumnTimeRange(
+      return createQueryServiceMetricsViewTimeRange(
         runtime.instanceId,
-        metricsView.data?.table,
-        {
-          columnName: metricsView.data?.timeDimension,
-        },
+        get(ctx.metricsViewName),
+        { priority: undefined },
         {
           query: {
             enabled: !!metricsView.data?.timeDimension,

--- a/web-common/src/features/dashboards/state-managers/selectors/index.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/index.ts
@@ -1,23 +1,23 @@
-import { sortingSelectors } from "./sorting";
-import { derived, type Readable } from "svelte/store";
-import type { MetricsExplorerEntity } from "../../stores/metrics-explorer-entity";
-import type { ReadablesObj, SelectorFnsObj } from "./types";
-import type { QueryObserverResult } from "@tanstack/svelte-query";
 import type {
   RpcStatus,
-  V1ColumnTimeRangeResponse,
   V1MetricsViewSpec,
+  V1MetricsViewTimeRangeResponse,
 } from "@rilldata/web-common/runtime-client";
-import { formattingSelectors } from "./data-formatting";
-import { contextColSelectors } from "./context-column";
+import type { QueryObserverResult } from "@tanstack/svelte-query";
+import { derived, type Readable } from "svelte/store";
+import type { MetricsExplorerEntity } from "../../stores/metrics-explorer-entity";
 import { activeMeasureSelectors } from "./active-measure";
-import { dimensionSelectors } from "./dimensions";
-import { dimensionFilterSelectors } from "./dimension-filters";
-import { timeRangeSelectors } from "./time-range";
-import { leaderboardQuerySelectors } from "./dashboard-queries";
 import { comparisonSelectors } from "./comparisons";
+import { contextColSelectors } from "./context-column";
+import { leaderboardQuerySelectors } from "./dashboard-queries";
+import { formattingSelectors } from "./data-formatting";
+import { dimensionFilterSelectors } from "./dimension-filters";
 import { dimensionTableSelectors } from "./dimension-table";
+import { dimensionSelectors } from "./dimensions";
 import { measureSelectors } from "./measures";
+import { sortingSelectors } from "./sorting";
+import { timeRangeSelectors } from "./time-range";
+import type { ReadablesObj, SelectorFnsObj } from "./types";
 
 export type DashboardDataReadables = {
   dashboardStore: Readable<MetricsExplorerEntity>;
@@ -25,7 +25,7 @@ export type DashboardDataReadables = {
     QueryObserverResult<V1MetricsViewSpec, RpcStatus>
   >;
   timeRangeSummaryStore: Readable<
-    QueryObserverResult<V1ColumnTimeRangeResponse, unknown>
+    QueryObserverResult<V1MetricsViewTimeRangeResponse, unknown>
   >;
 };
 

--- a/web-common/src/features/dashboards/state-managers/selectors/types.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/types.ts
@@ -1,11 +1,11 @@
-import type { Readable } from "svelte/store";
-import type { MetricsExplorerEntity } from "../../stores/metrics-explorer-entity";
-import type { QueryObserverResult } from "@tanstack/svelte-query";
 import type {
   RpcStatus,
-  V1ColumnTimeRangeResponse,
   V1MetricsViewSpec,
+  V1MetricsViewTimeRangeResponse,
 } from "@rilldata/web-common/runtime-client";
+import type { QueryObserverResult } from "@tanstack/svelte-query";
+import type { Readable } from "svelte/store";
+import type { MetricsExplorerEntity } from "../../stores/metrics-explorer-entity";
 import type { Expand } from "../types";
 
 /**
@@ -24,7 +24,10 @@ import type { Expand } from "../types";
 export type DashboardDataSources = {
   dashboard: MetricsExplorerEntity;
   metricsSpecQueryResult: QueryObserverResult<V1MetricsViewSpec, RpcStatus>;
-  timeRangeSummary: QueryObserverResult<V1ColumnTimeRangeResponse, unknown>;
+  timeRangeSummary: QueryObserverResult<
+    V1MetricsViewTimeRangeResponse,
+    unknown
+  >;
 };
 
 /**

--- a/web-common/src/features/dashboards/state-managers/state-managers.ts
+++ b/web-common/src/features/dashboards/state-managers/state-managers.ts
@@ -1,31 +1,31 @@
 import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
-import { writable, Writable, Readable, derived, get } from "svelte/store";
-import { getContext } from "svelte";
-import type { QueryClient, QueryObserverResult } from "@tanstack/svelte-query";
+import {
+  V1MetricsViewTimeRangeResponse,
+  createQueryServiceMetricsViewTimeRange,
+  type RpcStatus,
+  type V1MetricsViewSpec,
+} from "@rilldata/web-common/runtime-client";
 import type { Runtime } from "@rilldata/web-common/runtime-client/runtime-store";
+import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
+import type { QueryClient, QueryObserverResult } from "@tanstack/svelte-query";
+import { getContext } from "svelte";
+import { Readable, Writable, derived, get, writable } from "svelte/store";
 import {
   MetricsExplorerStoreType,
   metricsExplorerStore,
   updateMetricsExplorerByName,
   useDashboardStore,
 } from "web-common/src/features/dashboards/stores/dashboard-stores";
-import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
-import {
-  StateManagerReadables,
-  createStateManagerReadables,
-} from "./selectors";
-import { createStateManagerActions, type StateManagerActions } from "./actions";
-import type { DashboardCallbackExecutor } from "./actions/types";
 import {
   ResourceKind,
   useResource,
 } from "../../entity-management/resource-selectors";
+import { createStateManagerActions, type StateManagerActions } from "./actions";
+import type { DashboardCallbackExecutor } from "./actions/types";
 import {
-  createQueryServiceColumnTimeRange,
-  V1ColumnTimeRangeResponse,
-  type RpcStatus,
-  type V1MetricsViewSpec,
-} from "@rilldata/web-common/runtime-client";
+  StateManagerReadables,
+  createStateManagerReadables,
+} from "./selectors";
 
 export type StateManagers = {
   runtime: Writable<Runtime>;
@@ -33,7 +33,7 @@ export type StateManagers = {
   metricsStore: Readable<MetricsExplorerStoreType>;
   dashboardStore: Readable<MetricsExplorerEntity>;
   timeRangeSummaryStore: Readable<
-    QueryObserverResult<V1ColumnTimeRangeResponse, unknown>
+    QueryObserverResult<V1MetricsViewTimeRangeResponse, unknown>
   >;
   queryClient: QueryClient;
   setMetricsViewName: (s: string) => void;
@@ -84,13 +84,13 @@ export function createStateManagers({
   });
 
   const timeRangeSummaryStore: Readable<
-    QueryObserverResult<V1ColumnTimeRangeResponse, unknown>
+    QueryObserverResult<V1MetricsViewTimeRangeResponse, unknown>
   > = derived([runtime, metricsSpecStore], ([runtime, metricsView], set) =>
-    createQueryServiceColumnTimeRange(
+    createQueryServiceMetricsViewTimeRange(
       runtime.instanceId,
-      metricsView.data?.table ?? "",
+      metricsViewName,
       {
-        columnName: metricsView.data?.timeDimension,
+        priority: undefined,
       },
       {
         query: {

--- a/web-common/src/features/dashboards/state-managers/state-managers.ts
+++ b/web-common/src/features/dashboards/state-managers/state-managers.ts
@@ -85,20 +85,15 @@ export function createStateManagers({
 
   const timeRangeSummaryStore: Readable<
     QueryObserverResult<V1MetricsViewTimeRangeResponse, unknown>
-  > = derived([runtime, metricsSpecStore], ([runtime, metricsView], set) =>
-    createQueryServiceMetricsViewTimeRange(
-      runtime.instanceId,
-      metricsViewName,
-      {
-        priority: undefined,
+  > = createQueryServiceMetricsViewTimeRange(
+    get(runtime).instanceId,
+    metricsViewName,
+    {},
+    {
+      query: {
+        queryClient: queryClient,
       },
-      {
-        query: {
-          enabled: !!metricsView.data?.timeDimension,
-          queryClient: queryClient,
-        },
-      },
-    ).subscribe(set),
+    },
   );
 
   const updateDashboard = (

--- a/web-common/src/features/dashboards/stores/dashboard-store-defaults.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-store-defaults.ts
@@ -15,8 +15,8 @@ import { ISODurationToTimePreset } from "@rilldata/web-common/lib/time/ranges";
 import { isoDurationToFullTimeRange } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
 import type { TimeComparisonOption } from "@rilldata/web-common/lib/time/types";
 import type {
-  V1ColumnTimeRangeResponse,
   V1MetricsViewSpec,
+  V1MetricsViewTimeRangeResponse,
 } from "@rilldata/web-common/runtime-client";
 import { MetricsViewSpecComparisonMode } from "@rilldata/web-common/runtime-client";
 import { get } from "svelte/store";
@@ -24,7 +24,7 @@ import { get } from "svelte/store";
 export function setDefaultTimeRange(
   metricsView: V1MetricsViewSpec,
   metricsExplorer: MetricsExplorerEntity,
-  fullTimeRange: V1ColumnTimeRangeResponse | undefined,
+  fullTimeRange: V1MetricsViewTimeRangeResponse | undefined,
 ) {
   // This function implementation mirrors some code in the metricsExplorer.init() function
   if (!fullTimeRange) return;
@@ -51,7 +51,7 @@ export function setDefaultTimeRange(
 function setDefaultComparison(
   metricsView: V1MetricsViewSpec,
   metricsExplorer: MetricsExplorerEntity,
-  fullTimeRange: V1ColumnTimeRangeResponse | undefined,
+  fullTimeRange: V1MetricsViewTimeRangeResponse | undefined,
 ) {
   switch (metricsView.defaultComparisonMode) {
     case MetricsViewSpecComparisonMode.COMPARISON_MODE_DIMENSION:
@@ -75,7 +75,7 @@ function setDefaultComparison(
 function setDefaultComparisonTimeRange(
   metricsView: V1MetricsViewSpec,
   metricsExplorer: MetricsExplorerEntity,
-  fullTimeRange: V1ColumnTimeRangeResponse | undefined,
+  fullTimeRange: V1MetricsViewTimeRangeResponse | undefined,
 ) {
   if (!fullTimeRange) return;
 
@@ -108,7 +108,7 @@ function setDefaultComparisonTimeRange(
 export function getDefaultMetricsExplorerEntity(
   name: string,
   metricsView: V1MetricsViewSpec,
-  fullTimeRange: V1ColumnTimeRangeResponse | undefined,
+  fullTimeRange: V1MetricsViewTimeRangeResponse | undefined,
 ): MetricsExplorerEntity {
   // CAST SAFETY: safe b/c (1) measure.name is a string if defined,
   // and (2) we filter out undefined values

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -13,13 +13,13 @@ import type {
   TimeRange,
 } from "@rilldata/web-common/lib/time/types";
 import type {
-  V1ColumnTimeRangeResponse,
   V1MetricsView,
   V1MetricsViewFilter,
   V1MetricsViewSpec,
+  V1MetricsViewTimeRangeResponse,
   V1TimeGrain,
 } from "@rilldata/web-common/runtime-client";
-import { derived, Readable, writable } from "svelte/store";
+import { Readable, derived, writable } from "svelte/store";
 import {
   SortDirection,
   SortType,
@@ -158,7 +158,7 @@ const metricViewReducers = {
   init(
     name: string,
     metricsView: V1MetricsViewSpec,
-    fullTimeRange: V1ColumnTimeRangeResponse | undefined,
+    fullTimeRange: V1MetricsViewTimeRangeResponse | undefined,
   ) {
     update((state) => {
       if (state.entities[name]) return state;
@@ -514,9 +514,7 @@ const metricViewReducers = {
         const filtersIn = filters[dimensionEntryIndex].in;
         if (filtersIn === undefined) return;
 
-        const index = filtersIn?.findIndex(
-          (value) => value === dimensionValue,
-        ) as number;
+        const index = filtersIn?.findIndex((value) => value === dimensionValue);
         if (index >= 0) {
           filtersIn?.splice(index, 1);
           if (filtersIn.length === 0) {

--- a/web-common/src/features/dashboards/time-controls/time-control-store.spec.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.spec.ts
@@ -4,8 +4,6 @@ import {
   AD_BIDS_INIT,
   AD_BIDS_INIT_WITH_TIME,
   AD_BIDS_NAME,
-  AD_BIDS_SOURCE_NAME,
-  AD_BIDS_TIMESTAMP_DIMENSION,
   initStateManagers,
 } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores-test-data";
 import TimeControlsStoreTest from "@rilldata/web-common/features/dashboards/time-controls/TimeControlsStoreTest.svelte";
@@ -59,14 +57,10 @@ describe("time-control-store", () => {
     assertStartAndEnd(state, undefined, undefined, undefined, undefined);
 
     dashboardFetchMocks.mockMetricsView(AD_BIDS_NAME, AD_BIDS_INIT_WITH_TIME);
-    dashboardFetchMocks.mockTimeRangeSummary(
-      AD_BIDS_SOURCE_NAME,
-      AD_BIDS_TIMESTAMP_DIMENSION,
-      {
-        min: "2022-01-01",
-        max: "2022-03-31",
-      },
-    );
+    dashboardFetchMocks.mockTimeRangeSummary(AD_BIDS_NAME, {
+      min: "2022-01-01",
+      max: "2022-03-31",
+    });
     await queryClient.refetchQueries({
       type: "active",
     });
@@ -80,14 +74,10 @@ describe("time-control-store", () => {
       "2022-04-01T00:00:00.000Z",
     );
 
-    dashboardFetchMocks.mockTimeRangeSummary(
-      AD_BIDS_SOURCE_NAME,
-      AD_BIDS_TIMESTAMP_DIMENSION,
-      {
-        min: "2023-01-01",
-        max: "2023-03-31",
-      },
-    );
+    dashboardFetchMocks.mockTimeRangeSummary(AD_BIDS_NAME, {
+      min: "2023-01-01",
+      max: "2023-03-31",
+    });
     await queryClient.refetchQueries({
       type: "active",
     });
@@ -106,14 +96,10 @@ describe("time-control-store", () => {
   });
 
   it("Switching selected time range", async () => {
-    dashboardFetchMocks.mockTimeRangeSummary(
-      AD_BIDS_SOURCE_NAME,
-      AD_BIDS_TIMESTAMP_DIMENSION,
-      {
-        min: "2022-01-01",
-        max: "2022-03-31",
-      },
-    );
+    dashboardFetchMocks.mockTimeRangeSummary(AD_BIDS_NAME, {
+      min: "2022-01-01",
+      max: "2022-03-31",
+    });
     const { unmount, timeControlsStore } = initTimeControlStoreTest(
       AD_BIDS_INIT_WITH_TIME,
     );
@@ -176,14 +162,10 @@ describe("time-control-store", () => {
   });
 
   it("Switching selected comparison time range", async () => {
-    dashboardFetchMocks.mockTimeRangeSummary(
-      AD_BIDS_SOURCE_NAME,
-      AD_BIDS_TIMESTAMP_DIMENSION,
-      {
-        min: "2022-01-01",
-        max: "2022-03-31",
-      },
-    );
+    dashboardFetchMocks.mockTimeRangeSummary(AD_BIDS_NAME, {
+      min: "2022-01-01",
+      max: "2022-03-31",
+    });
     const { unmount, timeControlsStore } = initTimeControlStoreTest(
       AD_BIDS_INIT_WITH_TIME,
     );
@@ -237,14 +219,10 @@ describe("time-control-store", () => {
   });
 
   it("Switching time zones", async () => {
-    dashboardFetchMocks.mockTimeRangeSummary(
-      AD_BIDS_SOURCE_NAME,
-      AD_BIDS_TIMESTAMP_DIMENSION,
-      {
-        min: "2022-01-01",
-        max: "2022-03-31",
-      },
-    );
+    dashboardFetchMocks.mockTimeRangeSummary(AD_BIDS_NAME, {
+      min: "2022-01-01",
+      max: "2022-03-31",
+    });
     const { unmount, timeControlsStore } = initTimeControlStoreTest(
       AD_BIDS_INIT_WITH_TIME,
     );
@@ -288,14 +266,10 @@ describe("time-control-store", () => {
   });
 
   it("Scrubbing to zoom", async () => {
-    dashboardFetchMocks.mockTimeRangeSummary(
-      AD_BIDS_SOURCE_NAME,
-      AD_BIDS_TIMESTAMP_DIMENSION,
-      {
-        min: "2022-01-01",
-        max: "2022-03-31",
-      },
-    );
+    dashboardFetchMocks.mockTimeRangeSummary(AD_BIDS_NAME, {
+      min: "2022-01-01",
+      max: "2022-03-31",
+    });
     const { unmount, timeControlsStore } = initTimeControlStoreTest(
       AD_BIDS_INIT_WITH_TIME,
     );
@@ -355,14 +329,10 @@ describe("time-control-store", () => {
   });
 
   it("Default time ranges", async () => {
-    dashboardFetchMocks.mockTimeRangeSummary(
-      AD_BIDS_SOURCE_NAME,
-      AD_BIDS_TIMESTAMP_DIMENSION,
-      {
-        min: "2022-01-01",
-        max: "2022-03-31",
-      },
-    );
+    dashboardFetchMocks.mockTimeRangeSummary(AD_BIDS_NAME, {
+      min: "2022-01-01",
+      max: "2022-03-31",
+    });
     const { unmount, timeControlsStore, queryClient } =
       initTimeControlStoreTest(AD_BIDS_INIT_WITH_TIME);
     await waitForUpdate(timeControlsStore, "2022-01-01T00:00:00.000Z");

--- a/web-common/src/features/dashboards/time-controls/time-control-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.ts
@@ -1,4 +1,7 @@
-import { useMetaQuery } from "@rilldata/web-common/features/dashboards/selectors/index";
+import {
+  createTimeRangeSummary,
+  useMetaQuery,
+} from "@rilldata/web-common/features/dashboards/selectors/index";
 import type { StateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
 import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import { getOrderedStartEnd } from "@rilldata/web-common/features/dashboards/time-series/utils";
@@ -30,14 +33,10 @@ import {
   V1MetricsViewSpec,
   V1MetricsViewTimeRangeResponse,
   V1TimeGrain,
-  createQueryServiceMetricsViewTimeRange,
 } from "@rilldata/web-common/runtime-client";
-import type {
-  CreateQueryResult,
-  QueryObserverResult,
-} from "@tanstack/svelte-query";
+import type { QueryObserverResult } from "@tanstack/svelte-query";
 import type { Readable } from "svelte/store";
-import { derived, get } from "svelte/store";
+import { derived } from "svelte/store";
 import { memoizeMetricsStore } from "../state-managers/memoize-metrics-store";
 
 export type TimeRangeState = {
@@ -70,28 +69,6 @@ export type TimeControlState = {
 } & TimeRangeState &
   ComparisonTimeRangeState;
 export type TimeControlStore = Readable<TimeControlState>;
-
-function createTimeRangeSummary(
-  ctx: StateManagers,
-): CreateQueryResult<V1MetricsViewTimeRangeResponse> {
-  return derived(
-    [ctx.runtime, useMetaQuery(ctx)],
-    ([runtime, metricsView], set) =>
-      createQueryServiceMetricsViewTimeRange(
-        runtime.instanceId,
-        get(ctx.metricsViewName),
-        {
-          priority: undefined,
-        },
-        {
-          query: {
-            enabled: !!metricsView.data?.timeDimension,
-            queryClient: ctx.queryClient,
-          },
-        },
-      ).subscribe(set),
-  );
-}
 
 export const timeControlStateSelector = ([
   metricsView,

--- a/web-common/src/features/dashboards/time-controls/time-range-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-range-store.ts
@@ -23,8 +23,8 @@ import {
 } from "@rilldata/web-common/lib/time/types";
 import {
   RpcStatus,
-  V1ColumnTimeRangeResponse,
   V1MetricsViewSpec,
+  V1MetricsViewTimeRangeResponse,
   V1TimeGrain,
 } from "@rilldata/web-common/runtime-client";
 import type { QueryObserverResult } from "@tanstack/svelte-query";
@@ -41,7 +41,7 @@ export function timeRangeSelectionsSelector([
   explorer,
 ]: [
   QueryObserverResult<V1MetricsViewSpec, RpcStatus>,
-  QueryObserverResult<V1ColumnTimeRangeResponse, unknown>,
+  QueryObserverResult<V1MetricsViewTimeRangeResponse, unknown>,
   MetricsExplorerEntity,
 ]): TimeRangeControlsState {
   if (!metricsView.data || !timeRangeResponse?.data?.timeRangeSummary)
@@ -119,7 +119,7 @@ export function timeComparisonOptionsSelector([
   selectedTimeRange,
 ]: [
   QueryObserverResult<V1MetricsViewSpec, RpcStatus>,
-  QueryObserverResult<V1ColumnTimeRangeResponse, unknown>,
+  QueryObserverResult<V1MetricsViewTimeRangeResponse, unknown>,
   MetricsExplorerEntity,
   DashboardTimeControls | undefined,
 ]): Array<{


### PR DESCRIPTION
Addresses the first bullet here: https://github.com/rilldata/rill/issues/3803