### PR TITLE
Fixing the sort type in export calls

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/dimension-table-export-utils.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-export-utils.ts
@@ -54,7 +54,7 @@ export function getDimensionTableExportArgs(
           {
             name: dashboardState.leaderboardMeasureName,
             desc: dashboardState.sortDirection === SortDirection.DESCENDING,
-            type: getQuerySortType(dashboardState.dashboardSortType),
+            sortType: getQuerySortType(dashboardState.dashboardSortType),
           },
         ],
         filter: dashboardState.filters,

--- a/web-common/src/features/dashboards/dimension-table/export-toplist.ts
+++ b/web-common/src/features/dashboards/dimension-table/export-toplist.ts
@@ -56,7 +56,7 @@ export default async function exportToplist({
             {
               name: dashboard.leaderboardMeasureName,
               desc: dashboard.sortDirection === SortDirection.DESCENDING,
-              type: getQuerySortType(dashboard.dashboardSortType),
+              sortType: getQuerySortType(dashboard.dashboardSortType),
             },
           ],
           filter: dashboard.filters,


### PR DESCRIPTION
`sortType` is the correct type for sorting. This was changed when we changed the API but missed changing these places in UI.