### PR TITLE
fix header title overlap on smaller screen sizes

### DIFF
--- a/web-common/src/features/dashboards/workspace/DashboardCTAs.svelte
+++ b/web-common/src/features/dashboards/workspace/DashboardCTAs.svelte
@@ -48,7 +48,7 @@
   let showDeployDashboardModal = false;
 </script>
 
-<PanelCTA side="right">
+<div class="flex gap-2 flex-shrink-0">
   {#if $dashboardPolicyCheck.data}
     <ViewAsButton />
   {/if}
@@ -78,7 +78,7 @@
       </TooltipContent>
     </Tooltip>
   {/if}
-</PanelCTA>
+</div>
 
 <DeployDashboardCta
   on:close={() => (showDeployDashboardModal = false)}

--- a/web-common/src/features/dashboards/workspace/DashboardCTAs.svelte
+++ b/web-common/src/features/dashboards/workspace/DashboardCTAs.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import MetricsIcon from "@rilldata/web-common/components/icons/Metrics.svelte";
-  import PanelCTA from "@rilldata/web-common/components/panel/PanelCTA.svelte";
   import { useDashboard } from "@rilldata/web-common/features/dashboards/selectors";
   import { V1ReconcileStatus } from "@rilldata/web-common/runtime-client";
   import { Button } from "../../../components/button";

--- a/web-common/src/features/dashboards/workspace/DashboardTitle.svelte
+++ b/web-common/src/features/dashboards/workspace/DashboardTitle.svelte
@@ -8,8 +8,13 @@
   $: displayName = $metaQuery.data?.title;
 </script>
 
-<h1 style:line-height="1.1" style:margin-top="-1px">
-  <div class="ui-copy-dashboard-header">
-    {displayName || metricViewName}
-  </div>
+<h1 class="ui-copy-dashboard-header">
+  {displayName || metricViewName}
 </h1>
+
+<style lang="postcss">
+  h1 {
+    @apply overflow-hidden whitespace-nowrap text-ellipsis;
+    @apply mr-2 mt-[-1px] leading-5;
+  }
+</style>


### PR DESCRIPTION
This PR fixes an issue where longer project title names overlap onto the call to action buttons (which are also pushed off the left edge) in the Dashboard header. See below.

Before:

<img width="544" alt="Screenshot 2024-01-10 at 11 39 14 PM" src="https://github.com/rilldata/rill/assets/120223836/739528ac-cf95-472b-9e7f-a61c7d34f6f7">

After:

<img width="547" alt="Screenshot 2024-01-10 at 11 38 41 PM" src="https://github.com/rilldata/rill/assets/120223836/b8618fed-453b-4a22-bfd7-35a1058c332c">
