### PR TITLE
Fix compatibility discrepancy between metrics filter and new expressions

### DIFF
--- a/runtime/queries/metricsview.go
+++ b/runtime/queries/metricsview.go
@@ -418,14 +418,12 @@ func convertFilterToExpression(filter *runtimev1.MetricsViewFilter) *runtimev1.E
 	var exprs []*runtimev1.Expression
 
 	if len(filter.Include) > 0 {
-		var includeExprs []*runtimev1.Expression
 		for _, cond := range filter.Include {
 			domExpr := convertDimensionFilterToExpression(cond, false)
 			if domExpr != nil {
-				includeExprs = append(includeExprs, domExpr)
+				exprs = append(exprs, domExpr)
 			}
 		}
-		exprs = append(exprs, expressionpb.Or(includeExprs))
 	}
 
 	if len(filter.Exclude) > 0 {


### PR DESCRIPTION
Fixes issue reported by @djbarnwal [here](https://www.notion.so/rilldata/Pivot-Table-implementation-notes-19dac24bafaa4c018c87298523f25898?pvs=4#cd1faaa19dce4df2a66a045d295a8aaa).

The issue is not in the latest release, only in nightly/staging.