### PR TITLE
Adding security policy when no include clauses match

### DIFF
--- a/runtime/security.go
+++ b/runtime/security.go
@@ -36,10 +36,11 @@ var openAccess = &ResolvedMetricsViewSecurity{
 }
 
 type ResolvedMetricsViewSecurity struct {
-	Access    bool
-	RowFilter string
-	Include   []string
-	Exclude   []string
+	Access     bool
+	RowFilter  string
+	Include    []string
+	Exclude    []string
+	ExcludeAll bool
 }
 
 func computeCacheKey(instanceID string, mv *runtimev1.MetricsViewSpec, lastUpdatedOn time.Time, attributes map[string]any) (string, error) {
@@ -146,6 +147,11 @@ func (p *securityEngine) resolveMetricsViewSecurity(attributes map[string]any, i
 				resolved.Include = append(resolved.Include, name)
 			}
 		}
+	}
+
+	// this is to handle the case where include filter was present but none of them evaluted to true
+	if len(mv.Security.Include) > 0 && len(resolved.Include) == 0 {
+		resolved.ExcludeAll = true
 	}
 
 	for _, exc := range mv.Security.Exclude {

--- a/runtime/security_test.go
+++ b/runtime/security_test.go
@@ -248,6 +248,43 @@ func TestResolveMetricsView(t *testing.T) {
 			errMsgContains: "cannot evaluate empty expression",
 		},
 		{
+			name: "test_no_include_matched",
+			args: args{
+				attr: map[string]any{
+					"name":   "test",
+					"email":  "test@gmail.com",
+					"domain": "gmail.com",
+					"groups": []interface{}{"test"},
+					"admin":  true,
+				},
+				mv: &runtimev1.MetricsViewSpec{
+					Security: &runtimev1.MetricsViewSpec_SecurityV2{
+						Access:    "('{{.user.domain}}' = 'rilldata.com' OR '{{.user.domain}}' = 'gmail.com') AND {{.user.admin}}",
+						RowFilter: "WHERE groups IN ('{{ .user.groups | join \"', '\" }}')",
+						Include: []*runtimev1.MetricsViewSpec_SecurityV2_FieldConditionV2{
+							{
+								Names:     []string{"col1"},
+								Condition: "'{{.user.domain}}' = 'test.com'",
+							},
+							{
+								Names:     []string{"col2"},
+								Condition: "'{{.user.domain}}' = 'rilldata.com'",
+							},
+						},
+						Exclude: nil,
+					},
+				},
+			},
+			want: &ResolvedMetricsViewSecurity{
+				Access:     true,
+				RowFilter:  "WHERE groups IN ('test')",
+				Include:    nil,
+				Exclude:    nil,
+				ExcludeAll: true,
+			},
+			wantErr: false,
+		},
+		{
 			name: "test_exclude",
 			args: args{
 				attr: map[string]any{
@@ -316,6 +353,43 @@ func TestResolveMetricsView(t *testing.T) {
 				RowFilter: "WHERE groups IN ('all')",
 				Include:   nil,
 				Exclude:   []string{"col2"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test_no_exclude_matched",
+			args: args{
+				attr: map[string]any{
+					"name":   "test",
+					"email":  "test@gmail.com",
+					"domain": "gmail.com",
+					"groups": []interface{}{"test"},
+					"admin":  true,
+				},
+				mv: &runtimev1.MetricsViewSpec{
+					Security: &runtimev1.MetricsViewSpec_SecurityV2{
+						Access:    "('{{.user.domain}}' = 'rilldata.com' OR '{{.user.domain}}' = 'gmail.com') AND {{.user.admin}}",
+						RowFilter: "WHERE groups IN ('{{ .user.groups | join \"', '\" }}')",
+						Include:   nil,
+						Exclude: []*runtimev1.MetricsViewSpec_SecurityV2_FieldConditionV2{
+							{
+								Names:     []string{"col1", "col2"},
+								Condition: "'{{.user.domain}}' = 'test.com'",
+							},
+							{
+								Names:     []string{"col2"},
+								Condition: "'{{.user.domain}}' = 'rilldata.com'",
+							},
+						},
+					},
+				},
+			},
+			want: &ResolvedMetricsViewSecurity{
+				Access:     true,
+				RowFilter:  "WHERE groups IN ('test')",
+				Include:    nil,
+				Exclude:    nil,
+				ExcludeAll: false,
 			},
 			wantErr: false,
 		},

--- a/runtime/server/controller.go
+++ b/runtime/server/controller.go
@@ -320,11 +320,20 @@ func (s *Server) applySecurityPolicyMetricsView(ctx context.Context, instID stri
 
 // applySecurityPolicyIncludesAndExcludes rewrites a metrics view based on the include/exclude conditions of a security policy.
 func (s *Server) applySecurityPolicyMetricsViewIncludesAndExcludes(mv *runtimev1.MetricsViewV2, policy *runtime.ResolvedMetricsViewSecurity) (*runtimev1.MetricsViewV2, bool) {
-	if policy == nil || (len(policy.Include) == 0 && len(policy.Exclude) == 0) {
+	if policy == nil {
 		return mv, false
 	}
-
 	mv = proto.Clone(mv).(*runtimev1.MetricsViewV2)
+
+	if policy.ExcludeAll {
+		mv.Spec.Measures = make([]*runtimev1.MetricsViewSpec_MeasureV2, 0)
+		mv.Spec.Dimensions = make([]*runtimev1.MetricsViewSpec_DimensionV2, 0)
+		if mv.State.ValidSpec != nil {
+			mv.State.ValidSpec.Measures = make([]*runtimev1.MetricsViewSpec_MeasureV2, 0)
+			mv.State.ValidSpec.Dimensions = make([]*runtimev1.MetricsViewSpec_DimensionV2, 0)
+		}
+		return mv, true
+	}
 
 	if len(policy.Include) > 0 {
 		allowed := make(map[string]bool)


### PR DESCRIPTION
When there are some include clauses and none of them match, we end up including all measures/dimensions.

Adding a boolean `ExcludeAll` that is set when some include conditions are present but non are met.