### PR TITLE
remove whitespace pre-wrap in MultiMetricMouseoverLabel

### DIFF
--- a/web-common/src/components/data-graphic/marks/MultiMetricMouseoverLabel.svelte
+++ b/web-common/src/components/data-graphic/marks/MultiMetricMouseoverLabel.svelte
@@ -294,7 +294,7 @@ It is probably not the most up to date code; but it works very well in practice.
     paint-order: stroke;
     stroke: white;
     stroke-width: 3px;
-    white-space: pre-wrap;
+
     /* Make all characters and numbers of equal width for easy scanibility */
     font-feature-settings:
       "case" 0,


### PR DESCRIPTION
In Safari, the inclusion of `whitespace: pre-wrap` appears to cause an issue where the value is placed incorrectly (see below). Removing this appears to maintain the intended placement in all browsers. However, it may have been added to address another visual issue.

<img width="192" alt="Screenshot 2024-01-11 at 3 47 05 PM" src="https://github.com/rilldata/rill/assets/120223836/69702e0b-545c-4e6e-b17b-361e90842f2a">
