### PR TITLE
Fix aggregation on dimenison with timezone

### DIFF
--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -20,7 +20,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/marcboeker/go-duckdb"
 	"github.com/rilldata/rill/runtime/drivers"
-	"github.com/rilldata/rill/runtime/pkg/activity"
+	activity "github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/rilldata/rill/runtime/pkg/duckdbsql"
 	"github.com/rilldata/rill/runtime/pkg/observability"
 	"github.com/rilldata/rill/runtime/pkg/priorityqueue"
@@ -422,7 +422,6 @@ func (c *connection) reopenDB() error {
 		"LOAD 'sqlite'",
 		"SET max_expression_depth TO 250",
 		"SET timezone='UTC'",
-		"SET log_query_path = '~/duckdb-logs/out.log'",
 	)
 
 	// We want to set preserve_insertion_order=false in hosted environments only (where source data is never viewed directly). Setting it reduces batch data ingestion time by ~40%.

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -20,7 +20,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/marcboeker/go-duckdb"
 	"github.com/rilldata/rill/runtime/drivers"
-	activity "github.com/rilldata/rill/runtime/pkg/activity"
+	"github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/rilldata/rill/runtime/pkg/duckdbsql"
 	"github.com/rilldata/rill/runtime/pkg/observability"
 	"github.com/rilldata/rill/runtime/pkg/priorityqueue"
@@ -422,6 +422,7 @@ func (c *connection) reopenDB() error {
 		"LOAD 'sqlite'",
 		"SET max_expression_depth TO 250",
 		"SET timezone='UTC'",
+		"SET log_query_path = '~/duckdb-logs/out.log'",
 	)
 
 	// We want to set preserve_insertion_order=false in hosted environments only (where source data is never viewed directly). Setting it reduces batch data ingestion time by ~40%.

--- a/runtime/queries/metricsview_aggregation.go
+++ b/runtime/queries/metricsview_aggregation.go
@@ -437,6 +437,10 @@ func (q *MetricsViewAggregation) buildMetricsAggregationSQL(mv *runtimev1.Metric
 			return "", nil, err
 		}
 		selectCols = append(selectCols, fmt.Sprintf("%s as %s", expr, safeName(d.Name)))
+		// Using expr was causing issues with query arg expansion in duckdb.
+		// Using column name is not possible either since it will take the original column name instead of the aliased column name
+		// But using numbered group we can exactly target the correct selected column.
+		// Note that non-timestamp columns also use numbered group by for constancy.
 		groupCols = append(groupCols, fmt.Sprintf("%d", len(selectCols)))
 		args = append(args, exprArgs...)
 	}

--- a/runtime/queries/metricsview_aggregation.go
+++ b/runtime/queries/metricsview_aggregation.go
@@ -440,7 +440,7 @@ func (q *MetricsViewAggregation) buildMetricsAggregationSQL(mv *runtimev1.Metric
 		// Using expr was causing issues with query arg expansion in duckdb.
 		// Using column name is not possible either since it will take the original column name instead of the aliased column name
 		// But using numbered group we can exactly target the correct selected column.
-		// Note that non-timestamp columns also use numbered group by for constancy.
+		// Note that the non-timestamp columns also use the numbered group-by for constancy.
 		groupCols = append(groupCols, fmt.Sprintf("%d", len(selectCols)))
 		args = append(args, exprArgs...)
 	}

--- a/runtime/queries/metricsview_aggregation.go
+++ b/runtime/queries/metricsview_aggregation.go
@@ -103,7 +103,6 @@ func (q *MetricsViewAggregation) Resolve(ctx context.Context, rt *runtime.Runtim
 	if err != nil {
 		return fmt.Errorf("error building query: %w", err)
 	}
-	fmt.Println(sqlString, args)
 
 	if len(q.PivotOn) == 0 {
 		schema, data, err := olapQuery(ctx, olap, priority, sqlString, args)
@@ -416,10 +415,7 @@ func (q *MetricsViewAggregation) buildMetricsAggregationSQL(mv *runtimev1.Metric
 	groupCols := make([]string, 0, len(q.Dimensions))
 	unnestClauses := make([]string, 0)
 	var args []any
-	var groupArgs []any
 	for _, d := range q.Dimensions {
-		safeColName := safeName(d.Name)
-
 		// Handle regular dimensions
 		if d.TimeGrain == runtimev1.TimeGrain_TIME_GRAIN_UNSPECIFIED {
 			dim, err := metricsViewDimension(mv, d.Name)
@@ -431,7 +427,7 @@ func (q *MetricsViewAggregation) buildMetricsAggregationSQL(mv *runtimev1.Metric
 			if unnestClause != "" {
 				unnestClauses = append(unnestClauses, unnestClause)
 			}
-			groupCols = append(groupCols, safeColName)
+			groupCols = append(groupCols, fmt.Sprintf("%d", len(selectCols)))
 			continue
 		}
 
@@ -441,9 +437,8 @@ func (q *MetricsViewAggregation) buildMetricsAggregationSQL(mv *runtimev1.Metric
 			return "", nil, err
 		}
 		selectCols = append(selectCols, fmt.Sprintf("%s as %s", expr, safeName(d.Name)))
-		groupCols = append(groupCols, expr)
+		groupCols = append(groupCols, fmt.Sprintf("%d", len(selectCols)))
 		args = append(args, exprArgs...)
-		groupArgs = append(groupArgs, exprArgs...)
 	}
 
 	for _, m := range q.Measures {
@@ -471,6 +466,11 @@ func (q *MetricsViewAggregation) buildMetricsAggregationSQL(mv *runtimev1.Metric
 		}
 	}
 
+	groupClause := ""
+	if len(groupCols) > 0 {
+		groupClause = "GROUP BY " + strings.Join(groupCols, ", ")
+	}
+
 	whereClause := ""
 	if mv.TimeDimension != "" {
 		timeCol := safeName(mv.TimeDimension)
@@ -495,12 +495,6 @@ func (q *MetricsViewAggregation) buildMetricsAggregationSQL(mv *runtimev1.Metric
 	}
 	if len(whereClause) > 0 {
 		whereClause = "WHERE 1=1" + whereClause
-	}
-
-	groupClause := ""
-	if len(groupCols) > 0 {
-		groupClause = "GROUP BY " + strings.Join(groupCols, ", ")
-		args = append(args, groupArgs...)
 	}
 
 	havingClause := ""
@@ -601,7 +595,6 @@ func (q *MetricsViewAggregation) buildTimestampExpr(dim *runtimev1.MetricsViewAg
 		if dim.TimeZone == "" || dim.TimeZone == "UTC" {
 			return fmt.Sprintf("date_trunc('%s', %s)", convertToDateTruncSpecifier(dim.TimeGrain), col), nil, nil
 		}
-		//return fmt.Sprintf("timezone('%s', date_trunc('%s', timezone('%s', %s::TIMESTAMPTZ)))", dim.TimeZone, convertToDateTruncSpecifier(dim.TimeGrain), dim.TimeZone, col), nil, nil
 		return fmt.Sprintf("timezone(?, date_trunc('%s', timezone(?, %s::TIMESTAMPTZ)))", convertToDateTruncSpecifier(dim.TimeGrain), col), []any{dim.TimeZone, dim.TimeZone}, nil
 	case drivers.DialectDruid:
 		if dim.TimeZone == "" || dim.TimeZone == "UTC" {

--- a/runtime/queries/metricsview_aggregation_test.go
+++ b/runtime/queries/metricsview_aggregation_test.go
@@ -717,6 +717,79 @@ func TestMetricsViewAggregation_measure_filters(t *testing.T) {
 	require.NotEmpty(t, "instagram.com", q.Result.Data[2].AsMap()["dom"])
 }
 
+func TestMetricsViewsAggregation_timezone(t *testing.T) {
+	rt, instanceID := testruntime.NewInstanceForProject(t, "ad_bids")
+
+	ctrl, err := rt.Controller(context.Background(), instanceID)
+	require.NoError(t, err)
+	r, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}, false)
+	require.NoError(t, err)
+	mv := r.GetMetricsView().Spec
+
+	limit := int64(10)
+	q := &queries.MetricsViewAggregation{
+		MetricsViewName: "ad_bids_metrics",
+		Dimensions: []*runtimev1.MetricsViewAggregationDimension{
+			{
+				Name: "pub",
+			},
+			{
+				Name:      "timestamp",
+				TimeGrain: runtimev1.TimeGrain_TIME_GRAIN_MONTH,
+				TimeZone:  "America/New_York",
+			},
+		},
+		Measures: []*runtimev1.MetricsViewAggregationMeasure{
+			{
+				Name: "measure_1",
+			},
+		},
+		MetricsView: mv,
+		Sort: []*runtimev1.MetricsViewAggregationSort{
+			{
+				Name: "pub",
+			},
+			{
+				Name: "timestamp",
+			},
+		},
+
+		Limit: &limit,
+	}
+	err = q.Resolve(context.Background(), rt, instanceID, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, q.Result)
+	for i, row := range q.Result.Data {
+		for _, f := range row.Fields {
+			fmt.Printf("%v ", f.AsInterface())
+		}
+		fmt.Printf(" %d \n", i)
+
+	}
+	rows := q.Result.Data
+
+	i := 0
+	require.Equal(t, "Facebook,2021-12-01T05:00:00Z", fieldsToString(rows[i], "pub", "timestamp"))
+	i++
+	require.Equal(t, "Facebook,2022-02-01", fieldsToString(rows[i], "pub", "timestamp"))
+	i++
+	require.Equal(t, "Facebook,2022-03-01", fieldsToString(rows[i], "pub", "timestamp"))
+	i++
+	require.Equal(t, "Google,2022-01-01", fieldsToString(rows[i], "pub", "timestamp"))
+	i++
+	require.Equal(t, "Google,2022-02-01", fieldsToString(rows[i], "pub", "timestamp"))
+	i++
+	require.Equal(t, "Google,2022-03-01", fieldsToString(rows[i], "pub", "timestamp"))
+	i++
+	require.Equal(t, "Microsoft,2022-01-01", fieldsToString(rows[i], "pub", "timestamp"))
+	i++
+	require.Equal(t, "Microsoft,2022-02-01", fieldsToString(rows[i], "pub", "timestamp"))
+	i++
+	require.Equal(t, "Microsoft,2022-03-01", fieldsToString(rows[i], "pub", "timestamp"))
+	i++
+	require.Equal(t, "Yahoo,2022-01-01", fieldsToString(rows[i], "pub", "timestamp"))
+}
+
 func fieldsToString(row *structpb.Struct, args ...string) string {
 	s := make([]string, 0, len(args))
 	for _, arg := range args {

--- a/runtime/queries/metricsview_aggregation_test.go
+++ b/runtime/queries/metricsview_aggregation_test.go
@@ -759,35 +759,28 @@ func TestMetricsViewsAggregation_timezone(t *testing.T) {
 	err = q.Resolve(context.Background(), rt, instanceID, 0)
 	require.NoError(t, err)
 	require.NotEmpty(t, q.Result)
-	for i, row := range q.Result.Data {
-		for _, f := range row.Fields {
-			fmt.Printf("%v ", f.AsInterface())
-		}
-		fmt.Printf(" %d \n", i)
-
-	}
 	rows := q.Result.Data
 
 	i := 0
 	require.Equal(t, "Facebook,2021-12-01T05:00:00Z", fieldsToString(rows[i], "pub", "timestamp"))
 	i++
-	require.Equal(t, "Facebook,2022-02-01", fieldsToString(rows[i], "pub", "timestamp"))
+	require.Equal(t, "Facebook,2022-01-01T05:00:00Z", fieldsToString(rows[i], "pub", "timestamp"))
 	i++
-	require.Equal(t, "Facebook,2022-03-01", fieldsToString(rows[i], "pub", "timestamp"))
+	require.Equal(t, "Facebook,2022-02-01T05:00:00Z", fieldsToString(rows[i], "pub", "timestamp"))
 	i++
-	require.Equal(t, "Google,2022-01-01", fieldsToString(rows[i], "pub", "timestamp"))
+	require.Equal(t, "Facebook,2022-03-01T05:00:00Z", fieldsToString(rows[i], "pub", "timestamp"))
 	i++
-	require.Equal(t, "Google,2022-02-01", fieldsToString(rows[i], "pub", "timestamp"))
+	require.Equal(t, "Google,2021-12-01T05:00:00Z", fieldsToString(rows[i], "pub", "timestamp"))
 	i++
-	require.Equal(t, "Google,2022-03-01", fieldsToString(rows[i], "pub", "timestamp"))
+	require.Equal(t, "Google,2022-01-01T05:00:00Z", fieldsToString(rows[i], "pub", "timestamp"))
 	i++
-	require.Equal(t, "Microsoft,2022-01-01", fieldsToString(rows[i], "pub", "timestamp"))
+	require.Equal(t, "Google,2022-02-01T05:00:00Z", fieldsToString(rows[i], "pub", "timestamp"))
 	i++
-	require.Equal(t, "Microsoft,2022-02-01", fieldsToString(rows[i], "pub", "timestamp"))
+	require.Equal(t, "Google,2022-03-01T05:00:00Z", fieldsToString(rows[i], "pub", "timestamp"))
 	i++
-	require.Equal(t, "Microsoft,2022-03-01", fieldsToString(rows[i], "pub", "timestamp"))
+	require.Equal(t, "Microsoft,2021-12-01T05:00:00Z", fieldsToString(rows[i], "pub", "timestamp"))
 	i++
-	require.Equal(t, "Yahoo,2022-01-01", fieldsToString(rows[i], "pub", "timestamp"))
+	require.Equal(t, "Microsoft,2022-01-01T05:00:00Z", fieldsToString(rows[i], "pub", "timestamp"))
 }
 
 func fieldsToString(row *structpb.Struct, args ...string) string {


### PR DESCRIPTION
Adding timezone to dimension expression seems to break because it adds a query arg. This seems like a bug where `?` is not expanded properly, since manually using timezone instead of `?` works.

For now using numbered group by to fix the issue.