### PR TITLE
Fix Use With Proxy

### DIFF
--- a/runtime/server/server.go
+++ b/runtime/server/server.go
@@ -169,7 +169,7 @@ func (s *Server) HTTPHandler(ctx context.Context, registerAdditionalHandlers fun
 	// Create REST gateway
 	gwMux := gateway.NewServeMux(gateway.WithErrorHandler(HTTPErrorHandler))
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
-	grpcAddress := fmt.Sprintf(":%d", s.opts.GRPCPort)
+	grpcAddress := fmt.Sprintf("localhost:%d", s.opts.GRPCPort)
 	err := runtimev1.RegisterRuntimeServiceHandlerFromEndpoint(ctx, gwMux, grpcAddress, opts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Include a hostname, localhost, when connecting to the GRPC endpoint.

Fixes bug in which `rill start` fails to start up when a proxy server is configured because rill sends an invalid request to the proxy.  Using mitmproxy, for example, will log the following error when rill tries to connect to the GRPC endpoint using only the port:
Bad HTTP request line: b'CONNECT :49009 HTTP/1.1'