### PR TITLE
Add back reactivity to the metrics view time range summary calls

### DIFF
--- a/web-common/src/features/dashboards/selectors/index.ts
+++ b/web-common/src/features/dashboards/selectors/index.ts
@@ -15,7 +15,7 @@ import type {
   CreateQueryResult,
   QueryObserverResult,
 } from "@tanstack/svelte-query";
-import { Readable, derived, get } from "svelte/store";
+import { Readable, derived } from "svelte/store";
 import type { StateManagers } from "../state-managers/state-managers";
 
 export const useMetaQuery = <T = V1MetricsViewSpec>(

--- a/web-common/src/features/dashboards/selectors/index.ts
+++ b/web-common/src/features/dashboards/selectors/index.ts
@@ -101,14 +101,18 @@ export const getFilterSearchList = (
 export function createTimeRangeSummary(
   ctx: StateManagers,
 ): CreateQueryResult<V1MetricsViewTimeRangeResponse> {
-  return createQueryServiceMetricsViewTimeRange(
-    get(ctx.runtime).instanceId,
-    get(ctx.metricsViewName),
-    {},
-    {
-      query: {
-        queryClient: ctx.queryClient,
-      },
-    },
+  return derived(
+    [ctx.runtime, ctx.metricsViewName],
+    ([runtime, metricsViewName], set) =>
+      createQueryServiceMetricsViewTimeRange(
+        runtime.instanceId,
+        metricsViewName,
+        {},
+        {
+          query: {
+            queryClient: ctx.queryClient,
+          },
+        },
+      ).subscribe(set),
   );
 }

--- a/web-common/src/features/dashboards/state-managers/state-managers.ts
+++ b/web-common/src/features/dashboards/state-managers/state-managers.ts
@@ -85,15 +85,17 @@ export function createStateManagers({
 
   const timeRangeSummaryStore: Readable<
     QueryObserverResult<V1MetricsViewTimeRangeResponse, unknown>
-  > = createQueryServiceMetricsViewTimeRange(
-    get(runtime).instanceId,
-    metricsViewName,
-    {},
-    {
-      query: {
-        queryClient: queryClient,
+  > = derived([runtime, metricsViewNameStore], ([runtime, mvName], set) =>
+    createQueryServiceMetricsViewTimeRange(
+      runtime.instanceId,
+      mvName,
+      {},
+      {
+        query: {
+          queryClient: queryClient,
+        },
       },
-    },
+    ).subscribe(set),
   );
 
   const updateDashboard = (


### PR DESCRIPTION
When we moved to the metrics view query to fetch time range summary, reactivity on metrics view name was missing. This adds it back.