### PR TITLE
Fixing all dimension values having the same measure value

### DIFF
--- a/web-common/src/features/dashboards/time-series/multiple-dimension-queries.ts
+++ b/web-common/src/features/dashboards/time-series/multiple-dimension-queries.ts
@@ -243,7 +243,6 @@ export function getDimensionValueTimeSeries(
             ([value, timeseries]) => {
               let prepData = timeseries?.data?.data;
               if (!timeseries?.isFetching) {
-                console.log(value, timeseries?.data);
                 prepData = prepareTimeSeries(
                   timeseries?.data?.data,
                   undefined,

--- a/web-common/src/features/dashboards/time-series/multiple-dimension-queries.ts
+++ b/web-common/src/features/dashboards/time-series/multiple-dimension-queries.ts
@@ -1,5 +1,6 @@
 import { selectedDimensionValues } from "@rilldata/web-common/features/dashboards/state-managers/selectors/dimension-filters";
 import {
+  createAndExpression,
   createInExpression,
   filterExpressions,
   sanitiseExpression,
@@ -209,12 +210,11 @@ export function getDimensionValueTimeSeries(
       return derived(
         dimensionValues?.values?.map((value, i) => {
           // create a copy
-          const updatedFilter = filterExpressions(
-            dimensionValues?.filter,
-            () => true,
-          );
+          const updatedFilter =
+            filterExpressions(dimensionValues?.filter, () => true) ??
+            createAndExpression([]);
           // add the value to "in" expression
-          updatedFilter?.cond?.exprs?.push(
+          updatedFilter.cond?.exprs?.push(
             createInExpression(dimensionName, [value]),
           );
 
@@ -243,6 +243,7 @@ export function getDimensionValueTimeSeries(
             ([value, timeseries]) => {
               let prepData = timeseries?.data?.data;
               if (!timeseries?.isFetching) {
+                console.log(value, timeseries?.data);
                 prepData = prepareTimeSeries(
                   timeseries?.data?.data,
                   undefined,


### PR DESCRIPTION
Selecting compare by dimension in the time dimensional table would result in all dimension values getting the same measure value. This was because the filter was getting sent properly.