### PR TITLE
Support toggle click in leaderboards to exclusively select a dimension value

### DIFF
--- a/web-common/src/components/tooltip/MetaKey.svelte
+++ b/web-common/src/components/tooltip/MetaKey.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  function isMac() {
+    return window.navigator.userAgent.includes("Macintosh");
+  }
+</script>
+
+{#if isMac()}
+  <span style="font-family: var(--system);">⌘</span>
+{:else}ctrl{/if} + Click

--- a/web-common/src/components/virtualized-table/core/Cell.svelte
+++ b/web-common/src/components/virtualized-table/core/Cell.svelte
@@ -8,6 +8,7 @@
   import TooltipShortcutContainer from "@rilldata/web-common/components/tooltip/TooltipShortcutContainer.svelte";
   import TooltipTitle from "@rilldata/web-common/components/tooltip/TooltipTitle.svelte";
   import { TOOLTIP_STRING_LIMIT } from "@rilldata/web-common/layout/config";
+  import { createCommandClickAction } from "@rilldata/web-common/lib/actions/command-click-action";
   import {
     createShiftClickAction,
     isClipboardApiSupported,
@@ -47,8 +48,8 @@
     cellActive = true;
   }
 
-  function onSelectItem() {
-    dispatch("select-item", row.index);
+  function onSelectItem(e: MouseEvent) {
+    dispatch("select-item", { index: row.index, meta: e.ctrlKey || e.metaKey });
   }
 
   function onBlur() {
@@ -110,19 +111,11 @@
 </script>
 
 <Tooltip
-  location="top"
   distance={16}
+  location="top"
   suppress={suppressTooltip || !isClipboardApiSupported()}
 >
   <div
-    role="gridcell"
-    tabindex="0"
-    on:mouseover={onFocus}
-    on:mouseout={onBlur}
-    on:focus={onFocus}
-    on:blur={onBlur}
-    on:click={onSelectItem}
-    on:keydown
     class="
       {positionStatic ? 'static' : 'absolute'}
       z-9
@@ -131,41 +124,50 @@
       {isDimensionTable ? 'pr-5' : 'border-r border-b'}
       {activityStatus}
       "
+    on:blur={onBlur}
+    on:click={onSelectItem}
+    on:focus={onFocus}
+    on:keydown
+    on:mouseout={onBlur}
+    on:mouseover={onFocus}
+    role="gridcell"
+    style:height="{row.size}px"
     style:left="{column.start}px"
     style:top="{row.start}px"
     style:width="{column.size}px"
-    style:height="{row.size}px"
+    tabindex="0"
   >
     <BarAndLabel
-      customBackgroundColor="rgba(0,0,0,0)"
-      showBackground={false}
-      justify="left"
-      value={barValue}
       color={barColor}
+      customBackgroundColor="rgba(0,0,0,0)"
+      justify="left"
+      showBackground={false}
+      value={barValue}
     >
       <button
+        aria-label={label}
         class="
           {isDimensionTable ? '' : 'px-4'}
           text-left w-full text-ellipsis overflow-x-hidden whitespace-nowrap
           "
-        use:shiftClickAction
+        on:command-click
         on:shift-click={shiftClick}
-        aria-label={label}
         style:height="{row.size}px"
+        use:shiftClickAction
       >
         <FormattedDataType
-          value={formattedValue || value}
-          isNull={value === null || value === undefined}
-          {type}
           customStyle={formattedDataTypeStyle}
           inTable
+          isNull={value === null || value === undefined}
+          {type}
+          value={formattedValue || value}
         />
       </button>
     </BarAndLabel>
   </div>
-  <TooltipContent slot="tooltip-content" maxWidth="360px">
+  <TooltipContent maxWidth="360px" slot="tooltip-content">
     <TooltipTitle>
-      <FormattedDataType slot="name" value={tooltipValue} {type} dark />
+      <FormattedDataType dark slot="name" {type} value={tooltipValue} />
     </TooltipTitle>
     <TooltipShortcutContainer>
       <div>

--- a/web-common/src/components/virtualized-table/core/Cell.svelte
+++ b/web-common/src/components/virtualized-table/core/Cell.svelte
@@ -8,7 +8,6 @@
   import TooltipShortcutContainer from "@rilldata/web-common/components/tooltip/TooltipShortcutContainer.svelte";
   import TooltipTitle from "@rilldata/web-common/components/tooltip/TooltipTitle.svelte";
   import { TOOLTIP_STRING_LIMIT } from "@rilldata/web-common/layout/config";
-  import { createCommandClickAction } from "@rilldata/web-common/lib/actions/command-click-action";
   import {
     createShiftClickAction,
     isClipboardApiSupported,
@@ -150,7 +149,6 @@
           {isDimensionTable ? '' : 'px-4'}
           text-left w-full text-ellipsis overflow-x-hidden whitespace-nowrap
           "
-        on:command-click
         on:shift-click={shiftClick}
         style:height="{row.size}px"
         use:shiftClickAction

--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -96,8 +96,13 @@
   );
 
   function onSelectItem(event) {
-    const label = tableRows[event.detail][dimensionColumnName] as string;
-    toggleDimensionValueSelection(dimensionName, label);
+    const label = tableRows[event.detail.index][dimensionColumnName] as string;
+    toggleDimensionValueSelection(
+      dimensionName,
+      label,
+      false,
+      event.detail.meta,
+    );
   }
 
   function toggleComparisonDimension(dimensionName, isBeingCompared) {

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardListItem.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardListItem.svelte
@@ -184,6 +184,7 @@
     {excluded}
     {filterExcludeMode}
     {label}
+    {selected}
     slot="tooltip-content"
   />
 </Tooltip>

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardListItem.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardListItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { FormattedDataType } from "@rilldata/web-common/components/data-types";
+  import { createCommandClickAction } from "@rilldata/web-common/lib/actions/command-click-action";
   import { fly, slide } from "svelte/transition";
   import BarAndLabel from "../../../components/BarAndLabel.svelte";
 
@@ -98,7 +99,12 @@
     on:blur={onLeave}
     on:click={(e) => {
       if (e.shiftKey) return;
-      toggleDimensionValueSelection(dimensionName, label);
+      toggleDimensionValueSelection(
+        dimensionName,
+        label,
+        false,
+        e.ctrlKey || e.metaKey,
+      );
     }}
     on:focus={onHover}
     on:keydown
@@ -109,8 +115,8 @@
     use:shiftClickAction
   >
     <LeaderboardItemFilterIcon
-      {isBeingCompared}
       {excluded}
+      {isBeingCompared}
       selectionIndex={itemData?.selectedIndex}
     />
     <BarAndLabel

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardListItem.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardListItem.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { FormattedDataType } from "@rilldata/web-common/components/data-types";
-  import { createCommandClickAction } from "@rilldata/web-common/lib/actions/command-click-action";
   import { fly, slide } from "svelte/transition";
   import BarAndLabel from "../../../components/BarAndLabel.svelte";
 

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardTooltipContent.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardTooltipContent.svelte
@@ -8,6 +8,7 @@ divider
 see more button
 -->
 <script lang="ts">
+  import MetaKey from "@rilldata/web-common/components/tooltip/MetaKey.svelte";
   import Shortcut from "@rilldata/web-common/components/tooltip/Shortcut.svelte";
   import StackingWord from "@rilldata/web-common/components/tooltip/StackingWord.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
@@ -16,6 +17,7 @@ see more button
   import { isClipboardApiSupported } from "../../../lib/actions/shift-click-action";
 
   export let label: string | number;
+  export let selected: boolean;
   export let excluded: boolean;
   // false = include, true = exclude
   export let filterExcludeMode: boolean;
@@ -51,6 +53,14 @@ see more button
       </div>
       <Shortcut>
         <span style="font-family: var(--system);">⇧</span> + Click
+      </Shortcut>
+    </TooltipShortcutContainer>
+  {/if}
+  {#if !selected && atLeastOneActive}
+    <TooltipShortcutContainer>
+      <div>Exclusively select this dimension value</div>
+      <Shortcut>
+        <MetaKey />
       </Shortcut>
     </TooltipShortcutContainer>
   {/if}

--- a/web-common/src/features/dashboards/state-managers/actions/dimension-filters.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/dimension-filters.ts
@@ -11,6 +11,7 @@ export function toggleDimensionValueSelection(
   dimensionName: string,
   dimensionValue: string,
   keepPillVisible?: boolean,
+  uniqueValue?: boolean,
 ) {
   // if we are able to update the filters, we must cancel any queries
   // that are currently running.
@@ -37,7 +38,13 @@ export function toggleDimensionValueSelection(
 
   const inIdx = getValueIndexInExpression(expr, dimensionValue) as number;
   if (inIdx === -1) {
-    expr.cond.exprs.push({ val: dimensionValue });
+    if (uniqueValue) {
+      expr.cond.exprs.splice(1, expr.cond.exprs.length - 1, {
+        val: dimensionValue,
+      });
+    } else {
+      expr.cond.exprs.push({ val: dimensionValue });
+    }
   } else {
     expr.cond.exprs.splice(inIdx, 1);
     // Only decrement pinIndex if the removed value was before the pinned value

--- a/web-common/src/features/dashboards/state-managers/actions/dimension-filters.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/dimension-filters.ts
@@ -11,7 +11,10 @@ export function toggleDimensionValueSelection(
   dimensionName: string,
   dimensionValue: string,
   keepPillVisible?: boolean,
-  uniqueValue?: boolean,
+  /**
+   * This marks the value as being exclusive. All other selected values will be unselected.
+   */
+  isExclusiveFilter?: boolean,
 ) {
   // if we are able to update the filters, we must cancel any queries
   // that are currently running.
@@ -38,7 +41,7 @@ export function toggleDimensionValueSelection(
 
   const inIdx = getValueIndexInExpression(expr, dimensionValue) as number;
   if (inIdx === -1) {
-    if (uniqueValue) {
+    if (isExclusiveFilter) {
       expr.cond.exprs.splice(1, expr.cond.exprs.length - 1, {
         val: dimensionValue,
       });


### PR DESCRIPTION
closes #3848

This adds a simple cmd/ctrl + click handler to leaderboard and dimension table. Doing this on an unselected value will select just that value and deselect everything else. Doing this on a selected value will just deselect it similar to a normal click.