### PR TITLE
Admin: do not treat duplicate invite as an internal error

### DIFF
--- a/admin/server/organizations.go
+++ b/admin/server/organizations.go
@@ -338,6 +338,9 @@ func (s *Server) AddOrganizationMember(ctx context.Context, req *adminv1.AddOrga
 			RoleID:    role.ID,
 		})
 		if err != nil {
+			if errors.Is(err, database.ErrNotUnique) {
+				return nil, status.Error(codes.AlreadyExists, err.Error())
+			}
 			return nil, status.Error(codes.Internal, err.Error())
 		}
 


### PR DESCRIPTION
Prevents [this Datadog alert](https://rill.datadoghq.com/logs?query=service%3Arill-cloud%20%40error%3A%2A%20%40level%3Aerror&agg_m=count&agg_q=kube_namespace%2Chost%2C%40env&agg_t=count&cols=host%2Cservice&event=AgAAAY0xsMWIkPhWLQAAAAAAAAAYAAAAAEFZMHhzTmJ0QUFESV9uY2lvVUNYYlFBQgAAACQAAAAAMDE4ZDMxYjMtOTRkNC00ODRlLWEzYTMtZmViY2NjMmMxNThk&index=main&messageDisplay=inline&refresh_mode=sliding&sort=time&source=monitor_notif&spanID=18289623261313601859&stream_sort=desc&view=spans&viz=stream&from_ts=1705935422000&to_ts=1705935722000&live=false)