### PR TITLE
update dashboard layout to match design system

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
@@ -76,7 +76,7 @@
     @apply font-semibold text-gray-700 pt-2;
   }
   .sidebar {
-    @apply bg-white p-2 border-r border-slate-200;
+    @apply bg-white p-2 border-r border-slate-200 pl-4;
     min-width: 250px;
     overflow-y: auto;
   }

--- a/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
@@ -76,7 +76,7 @@
     @apply font-semibold text-gray-700 pt-2;
   }
   .sidebar {
-    @apply bg-slate-50 p-2;
+    @apply bg-white p-2 border-r border-slate-200;
     min-width: 250px;
     overflow-y: auto;
   }

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -117,7 +117,7 @@
           <PivotDisplay />
         </div>
       {:else}
-        <div class="flex gap-x-1 pt-4">
+        <div class="flex gap-x-1 pt-4 w-full overflow-hidden flex-row">
           <div
             class:fixed-metric-height={expandedMeasureName}
             class="overflow-y-scroll pb-8 flex-none"

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -108,16 +108,15 @@
   {#if mockUserHasNoAccess}
     <MockUserHasNoAccess />
   {:else}
-    <div
-      class="flex w-full h-full overflow-hidden flex-{dashboardAlignment}"
-      style:padding-left={leftSide}
-    >
+    <div class="w-full h-full overflow-hidden" style:padding-left={leftSide}>
       {#if showPivot}
         <div class="overflow-y-hidden flex-1">
           <PivotDisplay />
         </div>
       {:else}
-        <div class="flex gap-x-1 pt-4 w-full overflow-hidden flex-row">
+        <div
+          class="flex gap-x-1 pt-4 w-full overflow-hidden flex-{dashboardAlignment}"
+        >
           <div
             class:fixed-metric-height={expandedMeasureName}
             class="overflow-y-scroll pb-8 flex-none"

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -108,14 +108,14 @@
   {#if mockUserHasNoAccess}
     <MockUserHasNoAccess />
   {:else}
-    <div class="w-full h-full overflow-hidden" style:padding-left={leftSide}>
+    <div class="w-full h-full" style:padding-left={leftSide}>
       {#if showPivot}
         <div class="overflow-y-hidden flex-1">
           <PivotDisplay />
         </div>
       {:else}
         <div
-          class="flex gap-x-1 pt-4 w-full overflow-hidden flex-{dashboardAlignment}"
+          class="flex gap-x-1 mt-3 h-full overflow-hidden flex-{dashboardAlignment}"
         >
           <div
             class:fixed-metric-height={expandedMeasureName}

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -69,11 +69,11 @@
 </script>
 
 <section
-  class="flex flex-col gap-y-1 h-full overflow-x-auto overflow-y-hidden dashboard-theme-boundary"
+  class="flex flex-col h-full overflow-x-auto overflow-y-hidden dashboard-theme-boundary"
   use:listenToNodeResize
 >
   <div
-    class="border-b mb-3 w-full flex flex-col"
+    class="border-b w-full flex flex-col"
     id="header"
     style:padding-left={leftSide}
   >
@@ -109,7 +109,7 @@
     <MockUserHasNoAccess />
   {:else}
     <div
-      class="flex gap-x-1 h-full overflow-hidden flex-{dashboardAlignment}"
+      class="flex w-full h-full overflow-hidden flex-{dashboardAlignment}"
       style:padding-left={leftSide}
     >
       {#if showPivot}
@@ -117,30 +117,34 @@
           <PivotDisplay />
         </div>
       {:else}
-        <div
-          class:fixed-metric-height={expandedMeasureName}
-          class="overflow-y-scroll pb-8 flex-none"
-        >
-          {#key metricViewName}
-            {#if hasTimeSeries}
-              <MetricsTimeSeriesCharts
-                {metricViewName}
-                workspaceWidth={exploreContainerWidth}
-              />
-            {:else}
-              <MeasuresContainer {exploreContainerWidth} {metricViewName} />
-            {/if}
-          {/key}
-        </div>
+        <div class="flex gap-x-1 pt-4">
+          <div
+            class:fixed-metric-height={expandedMeasureName}
+            class="overflow-y-scroll pb-8 flex-none"
+          >
+            {#key metricViewName}
+              {#if hasTimeSeries}
+                <MetricsTimeSeriesCharts
+                  {metricViewName}
+                  workspaceWidth={exploreContainerWidth}
+                />
+              {:else}
+                <MeasuresContainer {exploreContainerWidth} {metricViewName} />
+              {/if}
+            {/key}
+          </div>
 
-        <div class="overflow-y-hidden grow {expandedMeasureName ? '' : 'px-4'}">
-          {#if expandedMeasureName}
-            <TimeDimensionDisplay {metricViewName} />
-          {:else if selectedDimensionName}
-            <DimensionDisplay />
-          {:else}
-            <LeaderboardDisplay />
-          {/if}
+          <div
+            class="overflow-y-hidden grow {expandedMeasureName ? '' : 'px-4'}"
+          >
+            {#if expandedMeasureName}
+              <TimeDimensionDisplay {metricViewName} />
+            {:else if selectedDimensionName}
+              <DimensionDisplay />
+            {:else}
+              <LeaderboardDisplay />
+            {/if}
+          </div>
         </div>
       {/if}
     </div>

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -108,13 +108,14 @@
   {#if mockUserHasNoAccess}
     <MockUserHasNoAccess />
   {:else}
-    <div class="w-full h-full" style:padding-left={leftSide}>
+    <div class="flex h-full overflow-hidden">
       {#if showPivot}
         <div class="overflow-y-hidden flex-1">
           <PivotDisplay />
         </div>
       {:else}
         <div
+          style:padding-left={leftSide}
           class="flex gap-x-1 mt-3 h-full overflow-hidden flex-{dashboardAlignment}"
         >
           <div

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -116,7 +116,7 @@
       {:else}
         <div
           style:padding-left={leftSide}
-          class="flex gap-x-1 mt-3 h-full overflow-hidden flex-{dashboardAlignment}"
+          class="flex gap-x-1 mt-3 w-full h-full overflow-hidden flex-{dashboardAlignment}"
         >
           <div
             class:fixed-metric-height={expandedMeasureName}


### PR DESCRIPTION
This PR removes the bottom margin from the dashboard header to allow the pivot view to display full height. It also changes the sidebar background and border colors to match the latest designs.