### PR TITLE
Runtime: druid close fix

### DIFF
--- a/runtime/drivers/druid/olap.go
+++ b/runtime/drivers/druid/olap.go
@@ -101,6 +101,7 @@ func (c *connection) Execute(ctx context.Context, stmt *drivers.Statement) (*dri
 
 	schema, err := rowsToSchema(rows)
 	if err != nil {
+		rows.Close()
 		if cancelFunc != nil {
 			cancelFunc()
 		}


### PR DESCRIPTION
Although `rowsToSchema(rows)` should not return any error in current case but can lead to leaks in future.