### PR TITLE
Add state managers under the key by dash name

### DIFF
--- a/web-admin/src/routes/-/embed/+page.svelte
+++ b/web-admin/src/routes/-/embed/+page.svelte
@@ -37,14 +37,14 @@
   {#if isDashboardErrored}
     <br /> Dashboard Error <br />
   {:else}
-    <StateManagersProvider metricsViewName={dashboardName}>
-      {#key dashboardName}
+    {#key dashboardName}
+      <StateManagersProvider metricsViewName={dashboardName}>
         <DashboardStateProvider metricViewName={dashboardName}>
           <DashboardURLStateProvider metricViewName={dashboardName}>
             <Dashboard metricViewName={dashboardName} leftMargin={"48px"} />
           </DashboardURLStateProvider>
         </DashboardStateProvider>
-      {/key}
-    </StateManagersProvider>
+      </StateManagersProvider>
+    {/key}
   {/if}
 {/if}

--- a/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
@@ -100,8 +100,8 @@
   {#if isDashboardErrored}
     <ProjectErrored organization={orgName} project={projectName} />
   {:else}
-    <StateManagersProvider metricsViewName={dashboardName}>
-      {#key dashboardName}
+    {#key dashboardName}
+      <StateManagersProvider metricsViewName={dashboardName}>
         <DashboardStateProvider metricViewName={dashboardName}>
           <DashboardURLStateProvider metricViewName={dashboardName}>
             <DashboardThemeProvider>
@@ -109,7 +109,7 @@
             </DashboardThemeProvider>
           </DashboardURLStateProvider>
         </DashboardStateProvider>
-      {/key}
-    </StateManagersProvider>
+      </StateManagersProvider>
+    {/key}
   {/if}
 {/if}

--- a/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
@@ -94,17 +94,19 @@
     bgClass="bg-white"
     inspector={false}
   >
-    <StateManagersProvider metricsViewName={metricViewName} slot="body">
+    <svelte:fragment slot="body">
       {#key metricViewName}
-        <DashboardStateProvider {metricViewName}>
-          <DashboardURLStateProvider {metricViewName}>
-            <DashboardThemeProvider>
-              <Dashboard {metricViewName} />
-            </DashboardThemeProvider>
-          </DashboardURLStateProvider>
-        </DashboardStateProvider>
+        <StateManagersProvider metricsViewName={metricViewName}>
+          <DashboardStateProvider {metricViewName}>
+            <DashboardURLStateProvider {metricViewName}>
+              <DashboardThemeProvider>
+                <Dashboard {metricViewName} />
+              </DashboardThemeProvider>
+            </DashboardURLStateProvider>
+          </DashboardStateProvider>
+        </StateManagersProvider>
       {/key}
-    </StateManagersProvider>
+    </svelte:fragment>
   </WorkspaceContainer>
 {:else if $resourceStatusStore.status === ResourceStatus.Busy}
   <WorkspaceContainer


### PR DESCRIPTION
We are seeing issues with stale data from a previously selected dashbaord. This happens when we switch between 2 dashboards that are already opened (this caches data and updates are immediate). Since `StateManagersProvider` is outside the key the `stateManagers.setMetricsViewName` is run before the update in `metricsViewName` propagates to the key and the underlying dashboard components are swapped. There is a brief moment when components will have newer data in state managers but local data is stale. This can be seen in `Filters.svelte` where we have `activeDimensionName`.

One quick fix is to add the state managers under the key. Another way is to add safeguard everywhere queries are made using data inside a component, but this is not scalable. We should come up with a good fix in the long run.