### PR TITLE
place pivot feature behind flag

### DIFF
--- a/web-common/src/features/dashboards/tab-bar/Tab.svelte
+++ b/web-common/src/features/dashboards/tab-bar/Tab.svelte
@@ -2,9 +2,11 @@
   import { Tab } from "@rgossiaux/svelte-headlessui";
 
   const baseClasses = "font-semibold py-2 px-1 items-center";
+  export let disabled = false;
 </script>
 
 <Tab
+  {disabled}
   class={({ selected }) => {
     return `${baseClasses} ${
       selected ? "text-blue-600 border-b-2 border-blue-500" : "text-gray-500"

--- a/web-common/src/features/dashboards/tab-bar/TabBar.svelte
+++ b/web-common/src/features/dashboards/tab-bar/TabBar.svelte
@@ -5,6 +5,11 @@
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
   import Tab from "./Tab.svelte";
+  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
+  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
+  import { featureFlags } from "../../feature-flags";
+
+  const { pivot: pivotAllowed } = featureFlags;
 
   const StateManagers = getStateManagers();
 
@@ -31,6 +36,8 @@
   function handleTabChange(event: CustomEvent) {
     const selectedTab = tabs[event.detail];
 
+    if (selectedTab.label === "Pivot" && !$pivotAllowed) return;
+
     metricsExplorerStore.setPivotMode(
       $metricsViewName,
       selectedTab.label === "Pivot",
@@ -42,12 +49,16 @@
   <TabGroup defaultIndex={currentTabIndex} on:change={handleTabChange}>
     <TabList class="flex gap-x-4">
       {#each tabs as tab}
-        <Tab>
-          <div class="flex gap-2 items-center">
-            <svelte:component this={tab.icon} />
-            {tab.label}
-          </div>
-        </Tab>
+        {@const disabled = tab.label === "Pivot" && !$pivotAllowed}
+        <Tooltip suppress={!disabled}>
+          <Tab {disabled}>
+            <div class="flex gap-2 items-center">
+              <svelte:component this={tab.icon} />
+              {tab.label}
+            </div>
+          </Tab>
+          <TooltipContent slot="tooltip-content">Coming Soon</TooltipContent>
+        </Tooltip>
       {/each}
     </TabList>
   </TabGroup>


### PR DESCRIPTION
This PR puts the pivot table functionality behind a feature flag, initially controllable via a URL Search Param.

To set this flag, add `?features=pivot` to the URL. The `features` key expects a comma separated list of values.