### PR TITLE
Fix CTA layout bug

### DIFF
--- a/web-admin/src/features/navigation/nav-utils.ts
+++ b/web-admin/src/features/navigation/nav-utils.ts
@@ -13,10 +13,7 @@ export function isProjectPage(page: Page): boolean {
   );
 }
 export function isDashboardPage(page: Page): boolean {
-  return (
-    page.route.id === "/[organization]/[project]/[dashboard]" ||
-    page.route.id === "/-/embed"
-  );
+  return page.route.id === "/[organization]/[project]/[dashboard]";
 }
 
 export function isReportPage(page: Page): boolean {

--- a/web-admin/src/features/navigation/nav-utils.ts
+++ b/web-admin/src/features/navigation/nav-utils.ts
@@ -13,7 +13,10 @@ export function isProjectPage(page: Page): boolean {
   );
 }
 export function isDashboardPage(page: Page): boolean {
-  return page.route.id === "/[organization]/[project]/[dashboard]";
+  return (
+    page.route.id === "/[organization]/[project]/[dashboard]" ||
+    page.route.id === "/-/embed"
+  );
 }
 
 export function isReportPage(page: Page): boolean {

--- a/web-admin/src/routes/+layout.svelte
+++ b/web-admin/src/routes/+layout.svelte
@@ -60,19 +60,13 @@
 
 <RillTheme>
   <QueryClientProvider client={queryClient}>
-    <main class="flex flex-col {onDashboardPage && 'h-screen'}">
+    <main class="flex flex-col min-h-screen {onDashboardPage && 'h-screen'}">
       {#if !isEmbed}
         <TopNavigationBar />
       {/if}
-      <div
-        class="flex-grow {onDashboardPage
-          ? 'overflow-hidden'
-          : 'overflow-auto'}"
-      >
-        <ErrorBoundary>
-          <slot />
-        </ErrorBoundary>
-      </div>
+      <ErrorBoundary>
+        <slot />
+      </ErrorBoundary>
     </main>
   </QueryClientProvider>
 

--- a/web-common/src/components/calls-to-action/CTALayoutContainer.svelte
+++ b/web-common/src/components/calls-to-action/CTALayoutContainer.svelte
@@ -1,8 +1,3 @@
-<script lang="ts">
-  // Components with tall content might want h-4/5
-  export let height = "h-3/5";
-</script>
-
-<div class="flex flex-col justify-center items-center {height} m-auto">
+<div class="flex flex-col justify-center items-center my-16 sm:my-32 md:my-64">
   <slot />
 </div>


### PR DESCRIPTION
A [previous PR](https://github.com/rilldata/rill/pull/3843) caused us to lose the top margin on CTA pages. This PR further cleans up the Cloud layout to ensure aesthetic CTA pages.

Before:
![image](https://github.com/rilldata/rill/assets/14206386/564cfdac-4239-475d-92ec-b9f3967c4de0)

After:
![image](https://github.com/rilldata/rill/assets/14206386/a8bc56ee-085b-4aac-b901-8f1e818db8d7)
