### PR TITLE
Fix scroll on embedded dashboards

### DIFF
--- a/web-admin/src/features/navigation/nav-utils.ts
+++ b/web-admin/src/features/navigation/nav-utils.ts
@@ -13,7 +13,10 @@ export function isProjectPage(page: Page): boolean {
   );
 }
 export function isDashboardPage(page: Page): boolean {
-  return page.route.id === "/[organization]/[project]/[dashboard]";
+  return (
+    page.route.id === "/[organization]/[project]/[dashboard]" ||
+    page.route.id === "/-/embed"
+  );
 }
 
 export function isReportPage(page: Page): boolean {


### PR DESCRIPTION
The scroll logic in `web-admin/src/routes/+layout.svelte` checks to see if the user is on a dashboard page. Previously, we only checked dashboards at the route `/{org}/{project}/{dashboard}`. With this PR, we additionally check embedded dashboards served from `/-/embed`.