### PR TITLE
Fix 'Add email' button

### DIFF
--- a/web-common/src/components/button/Button.svelte
+++ b/web-common/src/components/button/Button.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
   import { builderActions, getAttrs, type Builder } from "bits-ui";
+  import { createEventDispatcher } from "svelte";
 
   type ButtonType =
     | "primary"
@@ -63,7 +63,7 @@
     @apply text-xs leading-snug font-normal;
     @apply gap-x-2 min-w-fit;
     @apply rounded-[2px];
-    @apply px-3 h-7;
+    @apply px-3 h-7 min-h-[28px];
   }
 
   button:focus {

--- a/web-common/src/components/forms/InputArray.svelte
+++ b/web-common/src/components/forms/InputArray.svelte
@@ -74,7 +74,7 @@
         {/if}
       </div>
     {/each}
-    <Button on:click={() => dispatch("add-item")} dashed>
+    <Button on:click={() => dispatch("add-item")} type="secondary" dashed>
       <div class="flex gap-x-2">
         <Add className="text-gray-700" />
         {addItemLabel}


### PR DESCRIPTION
This PR fixes two issues with the "Add email" button for scheduled reports:
1. The color was dark blue (primary) not white (secondary)
2. The button was squished vertically when its container overflowed

Before:
![image](https://github.com/rilldata/rill/assets/14206386/10b88215-1f8e-4787-ab0e-2892f775fca9)

After:
![image](https://github.com/rilldata/rill/assets/14206386/4858e289-46c6-4483-befc-57faf257fbdf)
