### PR TITLE
Fix filter not applying in dimension table

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
@@ -72,8 +72,8 @@ export function updateFilterOnSearch(
       filterExpressions(
         filterForDimension,
         (e) =>
-          e.cond?.op === V1Operation.OPERATION_LIKE ||
-          e.cond?.op === V1Operation.OPERATION_NLIKE,
+          e.cond?.op !== V1Operation.OPERATION_LIKE &&
+          e.cond?.op !== V1Operation.OPERATION_NLIKE,
       ) ?? createAndExpression([]);
   }
   return filterForDimension;


### PR DESCRIPTION
In the previous cleanup PR, dimension table got missed for QA and had incorrect filter applied to it.