### PR TITLE
Add safeguard to time range summary calls to support dashboards without timestamp columns

### DIFF
--- a/web-common/src/features/dashboards/selectors/index.ts
+++ b/web-common/src/features/dashboards/selectors/index.ts
@@ -102,8 +102,8 @@ export function createTimeRangeSummary(
   ctx: StateManagers,
 ): CreateQueryResult<V1MetricsViewTimeRangeResponse> {
   return derived(
-    [ctx.runtime, ctx.metricsViewName],
-    ([runtime, metricsViewName], set) =>
+    [ctx.runtime, ctx.metricsViewName, useMetricsView(ctx)],
+    ([runtime, metricsViewName, metricsView], set) =>
       createQueryServiceMetricsViewTimeRange(
         runtime.instanceId,
         metricsViewName,
@@ -111,6 +111,7 @@ export function createTimeRangeSummary(
         {
           query: {
             queryClient: ctx.queryClient,
+            enabled: !!metricsView.data?.timeDimension,
           },
         },
       ).subscribe(set),

--- a/web-common/src/features/dashboards/state-managers/state-managers.ts
+++ b/web-common/src/features/dashboards/state-managers/state-managers.ts
@@ -85,17 +85,20 @@ export function createStateManagers({
 
   const timeRangeSummaryStore: Readable<
     QueryObserverResult<V1MetricsViewTimeRangeResponse, unknown>
-  > = derived([runtime, metricsViewNameStore], ([runtime, mvName], set) =>
-    createQueryServiceMetricsViewTimeRange(
-      runtime.instanceId,
-      mvName,
-      {},
-      {
-        query: {
-          queryClient: queryClient,
+  > = derived(
+    [runtime, metricsViewNameStore, metricsSpecStore],
+    ([runtime, mvName, metricsView], set) =>
+      createQueryServiceMetricsViewTimeRange(
+        runtime.instanceId,
+        mvName,
+        {},
+        {
+          query: {
+            queryClient: queryClient,
+            enabled: !!metricsView.data?.timeDimension,
+          },
         },
-      },
-    ).subscribe(set),
+      ).subscribe(set),
   );
 
   const updateDashboard = (


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Time range summary calls are missing no time dimension safeguard. This leads to a 400 call crashing the app in cloud.

#### Details:
Adding `enabled` field to the time range summary query.

## Steps to Verify
1. Create a dashboard without a `timestamp` defined.
2. On dev there shouldnt be any 400 calls when navigating to the dashboard.
3. On cloud the dashbaord shouldnt crash.