### PR TITLE
Fixing rill start without project path argument

### DIFF
--- a/cli/cmd/start/start.go
+++ b/cli/cmd/start/start.go
@@ -156,6 +156,9 @@ func countFilesInDirectory(path string) (int, error) {
 		return nil
 	})
 	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
 		return 0, err
 	}
 

--- a/cli/cmd/start/start.go
+++ b/cli/cmd/start/start.go
@@ -142,6 +142,10 @@ func StartCmd(ch *cmdutil.Helper) *cobra.Command {
 func countFilesInDirectory(path string) (int, error) {
 	var fileCount int
 
+	if path == "" {
+		path = "."
+	}
+
 	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err


### PR DESCRIPTION
Found this issue while debugging main for margin_metering project. The check for "too many files" uses project path argument as is. No argument should instead use `.` to denote current directory.