### PR TITLE
Let the Dashboard handle 400 errors

### DIFF
--- a/web-common/src/runtime-client/is-runtime-query.ts
+++ b/web-common/src/runtime-client/is-runtime-query.ts
@@ -1,0 +1,6 @@
+import type { Query } from "@tanstack/svelte-query";
+
+export function isRuntimeQuery(query: Query): boolean {
+  const [apiPath] = query.queryKey as string[];
+  return apiPath.startsWith("/v1/instances/");
+}


### PR DESCRIPTION
[Requested on Slack.](https://rilldata.slack.com/archives/CTZ8XBQ85/p1704812898068369?thread_ts=1704760656.823219&cid=CTZ8XBQ85)

When a dashboard query returns a 400 error:
- Before this PR, we showed a full-screen error page.
- After this PR, the Dashboard component is responsible for handling the error. Specific components, like a Time Series Chart or a Leaderboard, should now display a localized error.

In the future, we can apply the same behavior to more error cases, like 500-level errors. This PR does not include 500-level errors because that'd require more UX thought. When a 500-level error occurs, it's perhaps likely that all queries will fail. When all queries fail, we _should_ show a full-screen error page.