### PR TITLE
Fix slow leaderboard loads

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/ContextColumnValue.svelte
+++ b/web-common/src/features/dashboards/leaderboard/ContextColumnValue.svelte
@@ -5,6 +5,7 @@
   import type { LeaderboardItemData } from "./leaderboard-utils";
   import { formatProperFractionAsPercent } from "@rilldata/web-common/lib/number-formatting/proper-fraction-formatter";
   import { formatMeasurePercentageDifference } from "@rilldata/web-common/lib/number-formatting/percentage-formatter";
+  import { CONTEXT_COL_MAX_WIDTH } from "../state-managers/actions/context-columns";
 
   export let itemData: LeaderboardItemData;
 
@@ -23,8 +24,13 @@
     actions: {
       contextCol: { observeContextColumnWidth },
     },
+    contextColumnWidths,
   } = getStateManagers();
 
+  // let widthPx = "0px";
+  // $: widthPx = $contextColumn
+  //   ? $contextColumnWidths[$contextColumn] + "px"
+  //   : "0px";
   $: negativeChange = itemData.deltaAbs !== null && itemData.deltaAbs < 0;
   $: noChangeData = itemData.deltaRel === null;
 
@@ -38,10 +44,38 @@
         // the element may be gone by the time we get here,
         // if so, don't try to observe it
         if (!element) return;
-        observeContextColumnWidth(
-          $contextColumn,
-          element.getBoundingClientRect().width,
-        );
+        const width = element.getBoundingClientRect().width;
+
+        // // Conditional, separate store for widths
+        // if (
+        //   width > $contextColumnWidths[$contextColumn] &&
+        //   width < CONTEXT_COL_MAX_WIDTH
+        // ) {
+        //   $contextColumnWidths[$contextColumn] = width;
+        // }
+
+        // NOT conditional, separate store for widths
+        // $contextColumnWidths[$contextColumn] = Math.min(
+        //   Math.max(width, $contextColumnWidths[$contextColumn]),
+        //   CONTEXT_COL_MAX_WIDTH,
+        // );
+
+        // conditional, current store implementation
+        if (
+          width > $contextColumnWidths[$contextColumn] &&
+          width < CONTEXT_COL_MAX_WIDTH
+        ) {
+          observeContextColumnWidth(
+            $contextColumn,
+            element.getBoundingClientRect().width,
+          );
+        }
+
+        // NOT conditional, current store implementation
+        // observeContextColumnWidth(
+        //   $contextColumn,
+        //   element.getBoundingClientRect().width,
+        // );
       }, 17);
     }
   }

--- a/web-common/src/features/dashboards/leaderboard/ContextColumnValue.svelte
+++ b/web-common/src/features/dashboards/leaderboard/ContextColumnValue.svelte
@@ -13,7 +13,7 @@
     selectors: {
       contextColumn: {
         contextColumn,
-        widthPx,
+        width,
         isDeltaAbsolute,
         isDeltaPercent,
         isPercentOfTotal,
@@ -24,13 +24,8 @@
     actions: {
       contextCol: { observeContextColumnWidth },
     },
-    contextColumnWidths,
   } = getStateManagers();
 
-  // let widthPx = "0px";
-  // $: widthPx = $contextColumn
-  //   ? $contextColumnWidths[$contextColumn] + "px"
-  //   : "0px";
   $: negativeChange = itemData.deltaAbs !== null && itemData.deltaAbs < 0;
   $: noChangeData = itemData.deltaRel === null;
 
@@ -44,27 +39,10 @@
         // the element may be gone by the time we get here,
         // if so, don't try to observe it
         if (!element) return;
-        const width = element.getBoundingClientRect().width;
-
-        // // Conditional, separate store for widths
-        // if (
-        //   width > $contextColumnWidths[$contextColumn] &&
-        //   width < CONTEXT_COL_MAX_WIDTH
-        // ) {
-        //   $contextColumnWidths[$contextColumn] = width;
-        // }
-
-        // NOT conditional, separate store for widths
-        // $contextColumnWidths[$contextColumn] = Math.min(
-        //   Math.max(width, $contextColumnWidths[$contextColumn]),
-        //   CONTEXT_COL_MAX_WIDTH,
-        // );
+        const this_width = element.getBoundingClientRect().width;
 
         // conditional, current store implementation
-        if (
-          width > $contextColumnWidths[$contextColumn] &&
-          width < CONTEXT_COL_MAX_WIDTH
-        ) {
+        if (this_width > $width && this_width < CONTEXT_COL_MAX_WIDTH) {
           observeContextColumnWidth(
             $contextColumn,
             element.getBoundingClientRect().width,
@@ -82,7 +60,7 @@
 </script>
 
 {#if !$isHidden}
-  <div style:width={$widthPx} class="overflow-hidden">
+  <div style:width={$width + "px"} class="overflow-hidden">
     <div class="inline-block" bind:this={element}>
       {#if $isPercentOfTotal}
         <PercentageChange

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
@@ -20,7 +20,7 @@
   const {
     selectors: {
       contextColumn: {
-        widthPx,
+        width,
         isDeltaAbsolute,
         isDeltaPercent,
         isPercentOfTotal,
@@ -124,7 +124,7 @@
           on:click={toggleSortByActiveContextColumn}
           class="shrink flex flex-row items-center justify-end"
           aria-label="Toggle sort leaderboards by context column"
-          style:width={$widthPx}
+          style:width={$width + "px"}
         >
           {#if $isDeltaPercent}
             <Delta /> %

--- a/web-common/src/features/dashboards/state-managers/actions/context-columns.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/context-columns.ts
@@ -6,7 +6,7 @@ import {
 } from "../../stores/metrics-explorer-entity";
 import type { DashboardMutables } from "./types";
 
-const CONTEXT_COL_MAX_WIDTH = 100;
+export const CONTEXT_COL_MAX_WIDTH = 100;
 
 export const setContextColumn = (
   { dashboard }: DashboardMutables,

--- a/web-common/src/features/dashboards/state-managers/selectors/context-column.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/context-column.ts
@@ -1,13 +1,13 @@
 import { LeaderboardContextColumn } from "../../leaderboard-context-column";
+
 import type { DashboardDataSources } from "./types";
 
-const contextColumnWidth = ({ dashboard }: DashboardDataSources): string => {
+const contextColumnWidth = ({ dashboard }: DashboardDataSources): number => {
   const contextType = dashboard.leaderboardContextColumn;
-  const width = dashboard.contextColumnWidths[contextType];
-  if (typeof width === "number") {
-    return width + "px";
+  if (contextType === LeaderboardContextColumn.HIDDEN) {
+    return 0;
   }
-  return "0px";
+  return dashboard.contextColumnWidths[contextType];
 };
 
 export const contextColSelectors = {
@@ -56,5 +56,5 @@ export const contextColSelectors = {
    * returns a css style string specifying the width of the context
    * column in the leaderboards.
    */
-  widthPx: contextColumnWidth,
+  width: contextColumnWidth,
 };

--- a/web-common/src/features/dashboards/state-managers/state-managers.ts
+++ b/web-common/src/features/dashboards/state-managers/state-managers.ts
@@ -1,8 +1,4 @@
-import {
-  contextColWidthDefaults,
-  type ContextColWidths,
-  type MetricsExplorerEntity,
-} from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import {
   V1MetricsViewTimeRangeResponse,
   createQueryServiceMetricsViewTimeRange,
@@ -50,6 +46,13 @@ export type StateManagers = {
    * A collection of functions that update the dashboard data model.
    */
   actions: StateManagerActions;
+  /**
+   * Store to track the width of the context columns in leaderboards.
+   * FIXME: this was implemented as a low-risk fix for in advance of
+   * the new branding release 2024-01-31, but should be revisted since
+   * it's a one-off solution that introduces another new pattern.
+   */
+  contextColumnWidths: Writable<ContextColWidths>;
 };
 
 export const DEFAULT_STORE_KEY = Symbol("state-managers");
@@ -112,11 +115,6 @@ export function createStateManagers({
     // TODO: Remove dependency on MetricsExplorerStore singleton and its exports
     updateMetricsExplorerByName(name, callback);
   };
-
-  //
-  const contextColumnWidths = writable<ContextColWidths>(
-    contextColWidthDefaults,
-  );
 
   return {
     runtime: runtime,

--- a/web-common/src/features/dashboards/state-managers/state-managers.ts
+++ b/web-common/src/features/dashboards/state-managers/state-managers.ts
@@ -50,13 +50,6 @@ export type StateManagers = {
    * A collection of functions that update the dashboard data model.
    */
   actions: StateManagerActions;
-  /**
-   * Store to track the width of the context columns in leaderboards.
-   * FIXME: this was implemented as a low-risk fix for in advance of
-   * the new branding release 2024-01-31, but should be revisted since
-   * it's a one-off solution that introduces another new pattern.
-   */
-  contextColumnWidths: Writable<ContextColWidths>;
 };
 
 export const DEFAULT_STORE_KEY = Symbol("state-managers");
@@ -154,6 +147,5 @@ export function createStateManagers({
         queryClient.cancelQueries();
       },
     }),
-    contextColumnWidths,
   };
 }

--- a/web-common/src/features/dashboards/state-managers/state-managers.ts
+++ b/web-common/src/features/dashboards/state-managers/state-managers.ts
@@ -46,13 +46,6 @@ export type StateManagers = {
    * A collection of functions that update the dashboard data model.
    */
   actions: StateManagerActions;
-  /**
-   * Store to track the width of the context columns in leaderboards.
-   * FIXME: this was implemented as a low-risk fix for in advance of
-   * the new branding release 2024-01-31, but should be revisted since
-   * it's a one-off solution that introduces another new pattern.
-   */
-  contextColumnWidths: Writable<ContextColWidths>;
 };
 
 export const DEFAULT_STORE_KEY = Symbol("state-managers");

--- a/web-common/src/features/dashboards/state-managers/state-managers.ts
+++ b/web-common/src/features/dashboards/state-managers/state-managers.ts
@@ -1,4 +1,8 @@
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import {
+  contextColWidthDefaults,
+  type ContextColWidths,
+  type MetricsExplorerEntity,
+} from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import {
   V1MetricsViewTimeRangeResponse,
   createQueryServiceMetricsViewTimeRange,
@@ -46,6 +50,13 @@ export type StateManagers = {
    * A collection of functions that update the dashboard data model.
    */
   actions: StateManagerActions;
+  /**
+   * Store to track the width of the context columns in leaderboards.
+   * FIXME: this was implemented as a low-risk fix for in advance of
+   * the new branding release 2024-01-31, but should be revisted since
+   * it's a one-off solution that introduces another new pattern.
+   */
+  contextColumnWidths: Writable<ContextColWidths>;
 };
 
 export const DEFAULT_STORE_KEY = Symbol("state-managers");
@@ -109,6 +120,11 @@ export function createStateManagers({
     updateMetricsExplorerByName(name, callback);
   };
 
+  //
+  const contextColumnWidths = writable<ContextColWidths>(
+    contextColWidthDefaults,
+  );
+
   return {
     runtime: runtime,
     metricsViewName: metricsViewNameStore,
@@ -138,5 +154,6 @@ export function createStateManagers({
         queryClient.cancelQueries();
       },
     }),
+    contextColumnWidths,
   };
 }


### PR DESCRIPTION
I think this fixes https://github.com/rilldata/rill-private-issues/issues/112, but not entirely sure about how to measure it. Subjectively, it seems much better.

What seems to have done the trick is wrapping the state update in a conditional, not adding a separate store.

But I'm now even less sure about what is going on, because this does not match the mental model we had developed, which was that
- the column size checker was updating `dashboardStore`
- query body objects that depend on dashboard store were therefore being updated
- because query body objects were updated, the reactive statements creating the `$: totalsQuery = ...` and ` $: sortedQuery = ...`  query service objects were being overwritten entirely rather than updated
- since the query service objects were being overwritten, the key/value store was being overwritten, and queries were being canceled a bunch of extra times

But it seems instead that by reducing the number of updates to the store (by only updating the column width if it is greater than the previously observed width), the problem is resolved. This indicates that there is something else going on that we still don't understand