### PR TITLE
fix slow leaderboard loads

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/ContextColumnValue.svelte
+++ b/web-common/src/features/dashboards/leaderboard/ContextColumnValue.svelte
@@ -5,6 +5,7 @@
   import type { LeaderboardItemData } from "./leaderboard-utils";
   import { formatProperFractionAsPercent } from "@rilldata/web-common/lib/number-formatting/proper-fraction-formatter";
   import { formatMeasurePercentageDifference } from "@rilldata/web-common/lib/number-formatting/percentage-formatter";
+  import { CONTEXT_COL_MAX_WIDTH } from "../state-managers/actions/context-columns";
 
   export let itemData: LeaderboardItemData;
 
@@ -23,8 +24,13 @@
     actions: {
       contextCol: { observeContextColumnWidth },
     },
+    contextColumnWidths,
   } = getStateManagers();
 
+  // let widthPx = "0px";
+  // $: widthPx = $contextColumn
+  //   ? $contextColumnWidths[$contextColumn] + "px"
+  //   : "0px";
   $: negativeChange = itemData.deltaAbs !== null && itemData.deltaAbs < 0;
   $: noChangeData = itemData.deltaRel === null;
 
@@ -38,10 +44,38 @@
         // the element may be gone by the time we get here,
         // if so, don't try to observe it
         if (!element) return;
-        observeContextColumnWidth(
-          $contextColumn,
-          element.getBoundingClientRect().width,
-        );
+        const width = element.getBoundingClientRect().width;
+
+        // // Conditional, separate store for widths
+        // if (
+        //   width > $contextColumnWidths[$contextColumn] &&
+        //   width < CONTEXT_COL_MAX_WIDTH
+        // ) {
+        //   $contextColumnWidths[$contextColumn] = width;
+        // }
+
+        // NOT conditional, separate store for widths
+        // $contextColumnWidths[$contextColumn] = Math.min(
+        //   Math.max(width, $contextColumnWidths[$contextColumn]),
+        //   CONTEXT_COL_MAX_WIDTH,
+        // );
+
+        // conditional, current store implementation
+        if (
+          width > $contextColumnWidths[$contextColumn] &&
+          width < CONTEXT_COL_MAX_WIDTH
+        ) {
+          observeContextColumnWidth(
+            $contextColumn,
+            element.getBoundingClientRect().width,
+          );
+        }
+
+        // NOT conditional, current store implementation
+        // observeContextColumnWidth(
+        //   $contextColumn,
+        //   element.getBoundingClientRect().width,
+        // );
       }, 17);
     }
   }

--- a/web-common/src/features/dashboards/leaderboard/ContextColumnValue.svelte
+++ b/web-common/src/features/dashboards/leaderboard/ContextColumnValue.svelte
@@ -13,7 +13,6 @@
     selectors: {
       contextColumn: {
         contextColumn,
-        widthPx,
         isDeltaAbsolute,
         isDeltaPercent,
         isPercentOfTotal,
@@ -21,16 +20,13 @@
       },
       numberFormat: { activeMeasureFormatter },
     },
-    actions: {
-      contextCol: { observeContextColumnWidth },
-    },
     contextColumnWidths,
   } = getStateManagers();
 
-  // let widthPx = "0px";
-  // $: widthPx = $contextColumn
-  //   ? $contextColumnWidths[$contextColumn] + "px"
-  //   : "0px";
+  let widthPx = "0px";
+  $: widthPx = $contextColumn
+    ? $contextColumnWidths[$contextColumn] + "px"
+    : "0px";
   $: negativeChange = itemData.deltaAbs !== null && itemData.deltaAbs < 0;
   $: noChangeData = itemData.deltaRel === null;
 
@@ -47,34 +43,17 @@
         const width = element.getBoundingClientRect().width;
 
         // // Conditional, separate store for widths
-        // if (
-        //   width > $contextColumnWidths[$contextColumn] &&
-        //   width < CONTEXT_COL_MAX_WIDTH
-        // ) {
-        //   $contextColumnWidths[$contextColumn] = width;
-        // }
+        if (
+          width > $contextColumnWidths[$contextColumn] &&
+          width < CONTEXT_COL_MAX_WIDTH
+        ) {
+          $contextColumnWidths[$contextColumn] = width;
+        }
 
         // NOT conditional, separate store for widths
         // $contextColumnWidths[$contextColumn] = Math.min(
         //   Math.max(width, $contextColumnWidths[$contextColumn]),
         //   CONTEXT_COL_MAX_WIDTH,
-        // );
-
-        // conditional, current store implementation
-        if (
-          width > $contextColumnWidths[$contextColumn] &&
-          width < CONTEXT_COL_MAX_WIDTH
-        ) {
-          observeContextColumnWidth(
-            $contextColumn,
-            element.getBoundingClientRect().width,
-          );
-        }
-
-        // NOT conditional, current store implementation
-        // observeContextColumnWidth(
-        //   $contextColumn,
-        //   element.getBoundingClientRect().width,
         // );
       }, 17);
     }
@@ -82,7 +61,7 @@
 </script>
 
 {#if !$isHidden}
-  <div style:width={$widthPx} class="overflow-hidden">
+  <div style:width={widthPx} class="overflow-hidden">
     <div class="inline-block" bind:this={element}>
       {#if $isPercentOfTotal}
         <PercentageChange

--- a/web-common/src/features/dashboards/leaderboard/ContextColumnValue.svelte
+++ b/web-common/src/features/dashboards/leaderboard/ContextColumnValue.svelte
@@ -45,19 +45,12 @@
         if (!element) return;
         const width = element.getBoundingClientRect().width;
 
-        // // Conditional, separate store for widths
         if (
           width > $contextColumnWidths[$contextColumn] &&
           width < CONTEXT_COL_MAX_WIDTH
         ) {
           $contextColumnWidths[$contextColumn] = width;
         }
-
-        // NOT conditional, separate store for widths
-        // $contextColumnWidths[$contextColumn] = Math.min(
-        //   Math.max(width, $contextColumnWidths[$contextColumn]),
-        //   CONTEXT_COL_MAX_WIDTH,
-        // );
       }, 17);
     }
   }

--- a/web-common/src/features/dashboards/leaderboard/ContextColumnValue.svelte
+++ b/web-common/src/features/dashboards/leaderboard/ContextColumnValue.svelte
@@ -6,7 +6,6 @@
   import { formatProperFractionAsPercent } from "@rilldata/web-common/lib/number-formatting/proper-fraction-formatter";
   import { formatMeasurePercentageDifference } from "@rilldata/web-common/lib/number-formatting/percentage-formatter";
   import { CONTEXT_COL_MAX_WIDTH } from "../state-managers/actions/context-columns";
-
   import { LeaderboardContextColumn } from "../leaderboard-context-column";
 
   export let itemData: LeaderboardItemData;

--- a/web-common/src/features/dashboards/leaderboard/ContextColumnValue.svelte
+++ b/web-common/src/features/dashboards/leaderboard/ContextColumnValue.svelte
@@ -7,6 +7,8 @@
   import { formatMeasurePercentageDifference } from "@rilldata/web-common/lib/number-formatting/percentage-formatter";
   import { CONTEXT_COL_MAX_WIDTH } from "../state-managers/actions/context-columns";
 
+  import { LeaderboardContextColumn } from "../leaderboard-context-column";
+
   export let itemData: LeaderboardItemData;
 
   const {
@@ -24,9 +26,10 @@
   } = getStateManagers();
 
   let widthPx = "0px";
-  $: widthPx = $contextColumn
-    ? $contextColumnWidths[$contextColumn] + "px"
-    : "0px";
+  $: widthPx =
+    $contextColumn !== LeaderboardContextColumn.HIDDEN
+      ? $contextColumnWidths[$contextColumn] + "px"
+      : "0px";
   $: negativeChange = itemData.deltaAbs !== null && itemData.deltaAbs < 0;
   $: noChangeData = itemData.deltaRel === null;
 

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
@@ -20,7 +20,7 @@
   const {
     selectors: {
       contextColumn: {
-        widthPx,
+        contextColumn,
         isDeltaAbsolute,
         isDeltaPercent,
         isPercentOfTotal,
@@ -34,7 +34,13 @@
       sorting: { toggleSort, toggleSortByActiveContextColumn },
       dimensions: { setPrimaryDimension },
     },
+    contextColumnWidths,
   } = getStateManagers();
+
+  let widthPx = "0px";
+  $: widthPx = $contextColumn
+    ? $contextColumnWidths[$contextColumn] + "px"
+    : "0px";
 
   $: isBeingCompared = $isBeingComparedReadable(dimensionName);
   $: displayName = $getDimensionDisplayName(dimensionName);
@@ -124,7 +130,7 @@
           on:click={toggleSortByActiveContextColumn}
           class="shrink flex flex-row items-center justify-end"
           aria-label="Toggle sort leaderboards by context column"
-          style:width={$widthPx}
+          style:width={widthPx}
         >
           {#if $isDeltaPercent}
             <Delta /> %

--- a/web-common/src/features/dashboards/state-managers/actions/context-columns.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/context-columns.ts
@@ -6,7 +6,7 @@ import {
 } from "../../stores/metrics-explorer-entity";
 import type { DashboardMutables } from "./types";
 
-const CONTEXT_COL_MAX_WIDTH = 100;
+export const CONTEXT_COL_MAX_WIDTH = 100;
 
 export const setContextColumn = (
   { dashboard }: DashboardMutables,

--- a/web-common/src/features/dashboards/state-managers/state-managers.ts
+++ b/web-common/src/features/dashboards/state-managers/state-managers.ts
@@ -120,7 +120,6 @@ export function createStateManagers({
     updateMetricsExplorerByName(name, callback);
   };
 
-  //
   const contextColumnWidths = writable<ContextColWidths>(
     contextColWidthDefaults,
   );

--- a/web-common/src/features/dashboards/state-managers/state-managers.ts
+++ b/web-common/src/features/dashboards/state-managers/state-managers.ts
@@ -1,4 +1,8 @@
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import {
+  contextColWidthDefaults,
+  type ContextColWidths,
+  type MetricsExplorerEntity,
+} from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import {
   V1MetricsViewTimeRangeResponse,
   createQueryServiceMetricsViewTimeRange,
@@ -46,6 +50,13 @@ export type StateManagers = {
    * A collection of functions that update the dashboard data model.
    */
   actions: StateManagerActions;
+  /**
+   * Store to track the width of the context columns in leaderboards.
+   * FIXME: this was implemented as a low-risk fix for in advance of
+   * the new branding release 2024-01-31, but should be revisted since
+   * it's a one-off solution that introduces another new pattern.
+   */
+  contextColumnWidths: Writable<ContextColWidths>;
 };
 
 export const DEFAULT_STORE_KEY = Symbol("state-managers");
@@ -109,6 +120,11 @@ export function createStateManagers({
     updateMetricsExplorerByName(name, callback);
   };
 
+  //
+  const contextColumnWidths = writable<ContextColWidths>(
+    contextColWidthDefaults,
+  );
+
   return {
     runtime: runtime,
     metricsViewName: metricsViewNameStore,
@@ -138,5 +154,6 @@ export function createStateManagers({
         queryClient.cancelQueries();
       },
     }),
+    contextColumnWidths,
   };
 }


### PR DESCRIPTION
like https://github.com/rilldata/rill/pull/3946/files, I think this fixes https://github.com/rilldata/rill-private-issues/issues/112, though I don't have an objective measure.

This PR uses an additional store in `getStateManagers`, but what actually seems to be the thing that does the trick is wrapping the update to that store in a conditional.
