### PR TITLE
use brand colors for bignum and leaderboard names

### DIFF
--- a/web-common/src/app.css
+++ b/web-common/src/app.css
@@ -36,6 +36,10 @@
     @apply text-gray-600 dark:text-gray-200;
   }
 
+  .ui-copy-primary {
+    @apply text-primary-700 dark:text-primary-200;
+  }
+
   .ui-copy-strong {
     @apply text-gray-900 dark:text-white font-semibold;
   }

--- a/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
@@ -106,7 +106,7 @@
     >
       <h2
         style:overflow-wrap="anywhere"
-        class="line-clamp-2"
+        class="line-clamp-2 ui-copy-primary font-semibold"
         style:font-size={withTimeseries ? "" : "0.8rem"}
       >
         {name}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
@@ -84,7 +84,7 @@
       <Tooltip distance={16} location="top">
         <button
           on:click={() => setPrimaryDimension(dimensionName)}
-          class="pl-2 truncate flex justify-start"
+          class="ui-copy-primary pl-2 truncate flex justify-start"
           style="max-width: calc(315px - 60px);"
           style:width="100%"
           aria-label="Open dimension details"


### PR DESCRIPTION
partial fix of #3907, teeny tweak to colors in a couple places

![image](https://github.com/rilldata/rill/assets/2380975/49fbbc5d-6cc2-4680-8469-e51bb50dc6e0)
