### PR TITLE
convert measure filter dropdown to ShadCN components and resolve validation issues

### DIFF
--- a/web-common/src/components/chip/core/Chip.svelte
+++ b/web-common/src/components/chip/core/Chip.svelte
@@ -2,11 +2,12 @@
   = left (icon) – used primarily for icons, action buttons, and small images
   - center (text) – used primarily for label information
 -->
-<script>
+<script lang="ts">
   import { createEventDispatcher } from "svelte";
   import { slideRight } from "../../../lib/transitions";
   import { defaultChipColors } from "../chip-types";
   import RemoveChipButton from "./RemoveChipButton.svelte";
+  import { builderActions, getAttrs, type Builder } from "bits-ui";
 
   export let removable = false;
   export let active = false;
@@ -29,7 +30,9 @@
   export let removeButtonTooltipAlignment = "start";
   export let removeButtonTooltipDistance = 12;
 
-  export let label = undefined;
+  export let label: string | undefined = undefined;
+
+  export let builders: Builder[] = [];
 
   /** the maximum width for the tooltip of the main chip */
 
@@ -53,6 +56,8 @@
       : ""}
     {$$slots.body ? "max-content" : ""}"
     aria-label={label}
+    {...getAttrs(builders)}
+    use:builderActions={{ builders }}
   >
     <!-- a cancelable element, e.g. filter buttons -->
     {#if removable}

--- a/web-common/src/components/data-graphic/actions/scrub-action-factory.ts
+++ b/web-common/src/components/data-graphic/actions/scrub-action-factory.ts
@@ -155,12 +155,12 @@ export function createScrubAction({
       }
 
       function onScrubStart(event: MouseEvent) {
-        event.preventDefault();
         // Check for the main button press
         if (event.button !== 0) return;
         if (!(startPredicate === undefined || startPredicate(event))) {
           return;
         }
+        node.addEventListener(moveEvent, onScrub);
         coordinates.set({
           start: setCoordinateBounds(event),
           stop: DEFAULT_COORDINATES,
@@ -180,6 +180,7 @@ export function createScrubAction({
 
       function onScrub(event: MouseEvent) {
         event.preventDefault();
+
         const isCurrentlyScrubbing = get(isScrubbing);
         if (!isCurrentlyScrubbing) return;
         if (!(movePredicate === undefined || movePredicate(event))) {
@@ -208,6 +209,7 @@ export function createScrubAction({
 
       function onScrubEnd(event: MouseEvent) {
         event.preventDefault();
+        node.removeEventListener(moveEvent, onScrub);
         if (!(endPredicate === undefined || endPredicate(event))) {
           reset();
           return;
@@ -227,7 +229,6 @@ export function createScrubAction({
       }
 
       node.addEventListener(startEvent, onScrubStart);
-      node.addEventListener(moveEvent, onScrub);
       window.addEventListener(endEvent, onScrubEnd);
       window.addEventListener(endEvent, reset);
       return {

--- a/web-common/src/components/data-graphic/actions/scrub-action-factory.ts
+++ b/web-common/src/components/data-graphic/actions/scrub-action-factory.ts
@@ -181,8 +181,6 @@ export function createScrubAction({
       function onScrub(event: MouseEvent) {
         event.preventDefault();
 
-        const isCurrentlyScrubbing = get(isScrubbing);
-        if (!isCurrentlyScrubbing) return;
         if (!(movePredicate === undefined || movePredicate(event))) {
           reset();
           return;

--- a/web-common/src/components/data-graphic/elements/SimpleSVGContainer.svelte
+++ b/web-common/src/components/data-graphic/elements/SimpleSVGContainer.svelte
@@ -53,6 +53,7 @@ to the props.
   role="button"
   tabindex="0"
   style="overflow: {overflowHidden ? 'hidden' : 'visible'}"
+  style:outline="none"
   use:scrub
   on:scrub-start
   on:scrub-end

--- a/web-common/src/components/forms/InputV2.svelte
+++ b/web-common/src/components/forms/InputV2.svelte
@@ -66,7 +66,7 @@
     bind:this={inputElement}
     bind:value
   />
-  {#if error && value && !focus}
+  {#if error && !focus && value}
     <div in:slide={{ duration: 200 }} class="text-red-500 text-sm py-px">
       {error}
     </div>
@@ -77,7 +77,7 @@
   input {
     @apply w-full h-8 rounded-sm;
     @apply px-3 py-[5px];
-    @apply cursor-pointer text-xs;
+    @apply text-xs;
     @apply bg-white border border-gray-300;
   }
 

--- a/web-common/src/components/forms/InputV2.svelte
+++ b/web-common/src/components/forms/InputV2.svelte
@@ -16,7 +16,8 @@
 
   const dispatch = createEventDispatcher();
 
-  let inputElement;
+  let inputElement: HTMLInputElement;
+  let focus = false;
 
   if (claimFocusOnMount) {
     onMount(() => {
@@ -27,6 +28,7 @@
   function handleKeyDown(event: KeyboardEvent) {
     if (event.key === "Enter") {
       event.preventDefault();
+      inputElement.blur();
       dispatch("enter-pressed");
     }
   }
@@ -50,22 +52,39 @@
     {/if}
   </div>
   <input
-    autocomplete="off"
-    bind:this={inputElement}
-    bind:value
-    class="bg-white rounded-sm border border-gray-300 px-3 py-[5px] h-8 cursor-pointer focus:outline-primary-500 w-full text-xs {error &&
-      'border-red-500'}"
     {id}
+    type="text"
+    {placeholder}
     name={id}
+    autocomplete="off"
+    class:error={error && value}
     on:change
     on:input
     on:keydown={handleKeyDown}
-    {placeholder}
-    type="text"
+    on:focus={() => (focus = true)}
+    on:blur={() => (focus = false)}
+    bind:this={inputElement}
+    bind:value
   />
-  {#if error}
+  {#if error && value && !focus}
     <div in:slide={{ duration: 200 }} class="text-red-500 text-sm py-px">
       {error}
     </div>
   {/if}
 </div>
+
+<style lang="postcss">
+  input {
+    @apply w-full h-8 rounded-sm;
+    @apply px-3 py-[5px];
+    @apply cursor-pointer text-xs;
+    @apply bg-white border border-gray-300;
+  }
+
+  input:focus {
+    @apply outline-primary-500;
+  }
+  .error:not(:focus) {
+    @apply border-red-500;
+  }
+</style>

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilter.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilter.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
+  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu/";
   import { Chip } from "@rilldata/web-common/components/chip";
   import {
     ChipColors,
     measureChipColors,
   } from "@rilldata/web-common/components/chip/chip-types";
-  import WithTogglableFloatingElement from "@rilldata/web-common/components/floating-element/WithTogglableFloatingElement.svelte";
+
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import TooltipTitle from "@rilldata/web-common/components/tooltip/TooltipTitle.svelte";
@@ -18,10 +19,11 @@
   export let name: string;
   export let label: string | undefined = undefined;
   export let colors: ChipColors = measureChipColors;
-  export let expr: V1Expression | undefined;
+  export let expr: V1Expression | undefined = undefined;
+
+  const dispatch = createEventDispatcher();
 
   let active = !expr;
-  const dispatch = createEventDispatcher();
 
   function handleDismiss() {
     if (!expr) {
@@ -32,60 +34,59 @@
   }
 </script>
 
-<WithTogglableFloatingElement
-  alignment="start"
-  bind:active
-  distance={8}
-  let:toggleFloatingElement
+<DropdownMenu.Root
+  preventScroll
+  bind:open={active}
+  onOpenChange={(open) => {
+    if (!open) {
+      // Clicking outside a menu triggers a transition
+      // Wait for that transition to finish before dismissing the pill
+      setTimeout(() => {
+        handleDismiss();
+      }, 60);
+    }
+  }}
 >
-  <Tooltip
-    activeDelay={60}
-    alignment="start"
-    distance={8}
-    location="bottom"
-    suppress={active}
-  >
-    <Chip
-      {...colors}
-      {active}
-      extraRounded={false}
-      {label}
-      on:click={() => {
-        toggleFloatingElement();
-        dispatch("click");
-      }}
-      on:remove={() => dispatch("remove")}
-      outline
-      removable
+  <DropdownMenu.Trigger asChild let:builder>
+    <Tooltip
+      activeDelay={60}
+      alignment="start"
+      distance={8}
+      location="bottom"
+      suppress={active}
     >
-      <!-- remove button tooltip -->
-      <svelte:fragment slot="remove-tooltip">
-        <slot name="remove-tooltip-content">
-          remove {label}
-        </slot>
-      </svelte:fragment>
-      <!-- body -->
-      <MeasureFilterBody {dimensionName} {expr} {label} slot="body" />
-    </Chip>
-    <div slot="tooltip-content" transition:fly={{ duration: 100, y: 4 }}>
-      <TooltipContent maxWidth="400px">
-        <TooltipTitle>
-          <svelte:fragment slot="name">{name}</svelte:fragment>
-          <svelte:fragment slot="description">{label || ""}</svelte:fragment>
-        </TooltipTitle>
-        {#if $$slots["body-tooltip-content"]}
-          <slot name="body-tooltip-content">click to edit the values</slot>
-        {/if}
-      </TooltipContent>
-    </div>
-  </Tooltip>
-  <MeasureFilterMenu
-    {dimensionName}
-    {expr}
-    {name}
-    on:apply
-    on:click-outside={handleDismiss}
-    on:escape={handleDismiss}
-    slot="floating-element"
-  />
-</WithTogglableFloatingElement>
+      <Chip
+        {...colors}
+        {active}
+        extraRounded={false}
+        {label}
+        builders={[builder]}
+        on:remove={() => dispatch("remove")}
+        outline
+        removable
+      >
+        <!-- remove button tooltip -->
+        <svelte:fragment slot="remove-tooltip">
+          <slot name="remove-tooltip-content">
+            remove {label}
+          </slot>
+        </svelte:fragment>
+        <!-- body -->
+        <MeasureFilterBody {dimensionName} {expr} {label} slot="body" />
+      </Chip>
+      <div slot="tooltip-content" transition:fly={{ duration: 100, y: 4 }}>
+        <TooltipContent maxWidth="400px">
+          <TooltipTitle>
+            <svelte:fragment slot="name">{name}</svelte:fragment>
+            <svelte:fragment slot="description">{label || ""}</svelte:fragment>
+          </TooltipTitle>
+          {#if $$slots["body-tooltip-content"]}
+            <slot name="body-tooltip-content">click to edit the values</slot>
+          {/if}
+        </TooltipContent>
+      </div>
+    </Tooltip>
+  </DropdownMenu.Trigger>
+
+  <MeasureFilterMenu {dimensionName} {expr} {name} on:apply open={active} />
+</DropdownMenu.Root>

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilter.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilter.svelte
@@ -68,7 +68,7 @@
         <!-- remove button tooltip -->
         <svelte:fragment slot="remove-tooltip">
           <slot name="remove-tooltip-content">
-            remove {label}
+            Remove {label}
           </slot>
         </svelte:fragment>
         <!-- body -->
@@ -81,7 +81,7 @@
             <svelte:fragment slot="description">{label || ""}</svelte:fragment>
           </TooltipTitle>
           {#if $$slots["body-tooltip-content"]}
-            <slot name="body-tooltip-content">click to edit the values</slot>
+            <slot name="body-tooltip-content">Click to edit the values</slot>
           {/if}
         </TooltipContent>
       </div>

--- a/web-common/src/features/dashboards/filters/measure-filters/measure-filter-options.ts
+++ b/web-common/src/features/dashboards/filters/measure-filters/measure-filter-options.ts
@@ -1,6 +1,12 @@
 import { V1Operation } from "@rilldata/web-common/runtime-client";
 
-export const MeasureFilterOptions = [
+export type MeasureFilterOption = {
+  value: V1Operation;
+  label: string;
+  shortLabel: string;
+};
+
+export const MeasureFilterOptions: MeasureFilterOption[] = [
   {
     value: V1Operation.OPERATION_LT,
     label: "Less Than",
@@ -22,12 +28,12 @@ export const MeasureFilterOptions = [
     shortLabel: ">=",
   },
   {
-    value: "b",
+    value: V1Operation.OPERATION_AND,
     label: "Between",
     shortLabel: "",
   },
   {
-    value: "nb",
+    value: V1Operation.OPERATION_OR,
     label: "Not Between",
     shortLabel: "",
   },


### PR DESCRIPTION
The purpose of this PR is to convert the `MeasureFilterMenu` and `MeasureFilter` components to ShadCN and improve the UX around validation when adjusting measure filter parameters.

It also solves a bug where the `preventDefault` call on the MeasureChart function prevented the measure filter form from submitting when clicking outside.

Regarding validation UX, the new menu now restores the last previously valid state of the form on close.  If you change the threshold, for instance, from "Less Than" to "Between", the new form fields are no longer valid w/r/t the API. If you dismiss the menu in this state, the last valid state is restored, so you'll see "Less Than" when the menu is reopened. This is to bring consistency between what you see in the Chip (which is always valid w/r/t the API) and what is shown in the menu. This is true of other invalid states, like entering strings instead of numbers.

Additionally, this PR attempts to simplify the form code and provide more robust yup validation that accounts for different form states. To that end, this PR removes the "b" and "nb" notation that appeared to be local to this component and replaces it with `V1Operation` values, which is what was being sent to the API and stored in the serialized proto. This may be the wrong approach.

To achieve this, the following changes were made:

- Add the ShadCN builder pattern to the Chip so that it can be used as a menu trigger
- Remove the WithTogglableFloatingElement components and replace with ShadCN's DropdownMenu
- Move the conditional variable assignment in MeasureFilterMenu into the initialValue declaration
- Add a conditional to the schema for `value2`
- Change `InputV2` component to only display errors when a value is present and the input is not currently focused
- Remove preventDefault call in `onScrubStart` function
- Add the `onScrub` listener only when `onScrubStart` has fired
