### PR TITLE
Add reference for missing tailwind color

### DIFF
--- a/web-common/src/features/dashboards/config.ts
+++ b/web-common/src/features/dashboards/config.ts
@@ -18,11 +18,11 @@ export const MEASURE_CONFIG = {
 };
 
 // Colors for Tailwind
-// fill-pink-400 fill-cyan-400 fill-green-500 fill-orange-400 fill-purple-500 fill-red-600 fill-primary-500 fill-gray-600
+// fill-blue-500 fill-pink-400 fill-cyan-400 fill-green-500 fill-orange-400 fill-purple-500 fill-red-600 fill-primary-500 fill-gray-600
 // fill-slate-500 fill-yellow-500 fill-lime-500 fill-violet-300 fill-gray-500 fill-gray-300
-// bg-pink-400 bg-cyan-400 bg-green-500 bg-orange-400 bg-purple-500 bg-red-600 bg-primary-500 bg-gray-600
+// bg-blue-500 bg-pink-400 bg-cyan-400 bg-green-500 bg-orange-400 bg-purple-500 bg-red-600 bg-primary-500 bg-gray-600
 // bg-slate-500 bg-yellow-500 bg-lime-500 bg-violet-300 bg-gray-500
-// stroke-pink-400 stroke-cyan-400 stroke-green-500 stroke-orange-400 stroke-purple-500 stroke-red-600 stroke-primary-500 stroke-gray-500
+// stroke-blue-500 stroke-pink-400 stroke-cyan-400 stroke-green-500 stroke-orange-400 stroke-purple-500 stroke-red-600 stroke-primary-500 stroke-gray-500
 // stroke-slate-500 stroke-yellow-500 stroke-lime-500 stroke-violet-300 stroke-gray-500
 export const CHECKMARK_COLORS = [
   "blue-500",


### PR DESCRIPTION
With some references of old `blue-500` gone, TDD table was showing black lines for the the first selected color. This PR fixes it.