### PR TITLE
Improve errors for expired JWTs and increase TTL to 24h

### DIFF
--- a/admin/server/deployment.go
+++ b/admin/server/deployment.go
@@ -233,7 +233,7 @@ func (s *Server) GetDeploymentCredentials(ctx context.Context, req *adminv1.GetD
 		}
 	}
 
-	ttlDuration := time.Hour
+	ttlDuration := runtimeAccessTokenTTL
 	if req.TtlSeconds > 0 {
 		ttlDuration = time.Duration(req.TtlSeconds) * time.Second
 	}
@@ -350,8 +350,7 @@ func (s *Server) GetIFrame(ctx context.Context, req *adminv1.GetIFrameRequest) (
 		}
 	}
 
-	// default here is higher than GetDeploymentCredentials as most embedders probably won't implement refresh and state management
-	ttlDuration := 24 * time.Hour
+	ttlDuration := runtimeAccessTokenTTL
 	if req.TtlSeconds > 0 {
 		ttlDuration = time.Duration(req.TtlSeconds) * time.Second
 	}

--- a/admin/server/projects.go
+++ b/admin/server/projects.go
@@ -22,6 +22,10 @@ import (
 
 const prodDeplTTL = 14 * 24 * time.Hour
 
+// runtimeAccessTokenTTL is the validity duration of JWTs issued for runtime access to users (not used for internal communication between the admin and runtime).
+// This TTL is also used for JWTs issued for embedding, and since most embedders probably won't implement refresh and state management, it can't be set to a very low value.
+const runtimeAccessTokenTTL = 24 * time.Hour
+
 func (s *Server) ListProjectsForOrganization(ctx context.Context, req *adminv1.ListProjectsForOrganizationRequest) (*adminv1.ListProjectsForOrganizationResponse, error) {
 	observability.AddRequestAttributes(ctx,
 		attribute.String("args.org", req.OrganizationName),
@@ -141,7 +145,7 @@ func (s *Server) GetProject(ctx context.Context, req *adminv1.GetProjectRequest)
 	jwt, err := s.issuer.NewToken(runtimeauth.TokenOptions{
 		AudienceURL: depl.RuntimeAudience,
 		Subject:     claims.OwnerID(),
-		TTL:         time.Hour,
+		TTL:         runtimeAccessTokenTTL,
 		InstancePermissions: map[string][]runtimeauth.Permission{
 			depl.RuntimeInstanceID: {
 				// TODO: Remove ReadProfiling and ReadRepo (may require frontend changes)

--- a/runtime/server/auth/interceptors.go
+++ b/runtime/server/auth/interceptors.go
@@ -137,6 +137,11 @@ func parseClaims(ctx context.Context, aud *Audience, authorizationHeader string)
 	// Parse, validate and set claims from JWT
 	claims, err := aud.ParseAndValidate(bearerToken)
 	if err != nil {
+		if errors.Is(err, jwt.ErrTokenExpired) {
+			// The JWT library appends the expiration duration to the error message, which looks messy/ungrouped in observability.
+			// This is a workaround to remove the expiration duration from the error message.
+			return nil, status.Error(codes.Unauthenticated, "jwt is expired")
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
To make JWT expiration errors less frequent and easier to aggregate in the observability dashboard