### PR TITLE
Materialize models by default in deployed projects

### DIFF
--- a/admin/deployments.go
+++ b/admin/deployments.go
@@ -368,17 +368,19 @@ func (da *deploymentAnnotations) toMap() map[string]string {
 	return res
 }
 
+// defaultModelMaterialize determines whether to materialize models by default for deployed projects.
+// It defaults to true, but can be overridden with the __materialize_default variable.
 func defaultModelMaterialize(vars map[string]string) (bool, error) {
 	// Temporary hack to enable configuring ModelDefaultMaterialize using a variable.
 	// Remove when we have a way to conditionally configure it using code files.
 
 	if vars == nil {
-		return false, nil
+		return true, nil
 	}
 
 	s, ok := vars["__materialize_default"]
 	if !ok {
-		return false, nil
+		return true, nil
 	}
 
 	val, err := strconv.ParseBool(s)


### PR DESCRIPTION
This PR sets models to be materialized by default on cloud. This has successfully improved performance in several deployed projects already.

This is a short term change pending separation of ETL and serving (work ongoing), which will enable smart materialization of only those models that are referenced by a metrics view.

Closes https://github.com/rilldata/rill-private-issues/issues/142