### PR TITLE
initial time grain support for pivot table

### DIFF
--- a/web-common/src/components/chip/chip-types.ts
+++ b/web-common/src/components/chip/chip-types.ts
@@ -41,11 +41,11 @@ export const measureChipColors = {
 };
 
 export const timeChipColors = {
-  bgBaseClass: "bg-gray-50 dark:bg-gray-700",
+  bgBaseClass: "bg-white dark:bg-gray-700",
   bgHoverClass: "hover:bg-gray-100 hover:dark:bg-gray-600",
   textClass: "text-gray-600",
   bgActiveClass: "bg-gray-100 dark:bg-gray-600",
-  outlineClass: "",
+  outlineClass: "outline outline-1 outline-gray-200",
   outlineActiveClass: "",
 };
 

--- a/web-common/src/features/dashboards/pivot/PivotChip.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotChip.svelte
@@ -1,0 +1,87 @@
+<script context="module" lang="ts">
+  import { Chip } from "@rilldata/web-common/components/chip";
+  import {
+    measureChipColors,
+    timeChipColors,
+    defaultChipColors,
+  } from "@rilldata/web-common/components/chip/chip-types";
+  import { createEventDispatcher } from "svelte";
+  import type { ChipColors } from "@rilldata/web-common/components/chip/chip-types";
+  import type { PivotChipData } from "./types";
+  import { PivotChipType } from "./types";
+  import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
+  import TimeDropdown from "./TimeDropdown.svelte";
+  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu/";
+
+  const colors: Record<PivotChipType, ChipColors> = {
+    time: timeChipColors,
+    measure: measureChipColors,
+    dimension: defaultChipColors,
+  };
+</script>
+
+<script lang="ts">
+  export let item: PivotChipData;
+  export let removable = false;
+
+  const dispatch = createEventDispatcher();
+
+  let open = false;
+</script>
+
+{#if item.type === PivotChipType.Time && removable}
+  <DropdownMenu.Root bind:open>
+    <DropdownMenu.Trigger asChild let:builder>
+      <Chip
+        outline
+        builders={[builder]}
+        {removable}
+        {...colors[item.type]}
+        extraPadding={false}
+        extraRounded={true}
+        label={item.title}
+        on:remove={() => {
+          dispatch("remove", item);
+        }}
+      >
+        <div slot="body" class="flex gap-x-1 items-center">
+          <b>Time</b>
+          <p>{item.title}</p>
+          {#if removable}
+            <span class="transition-transform" class:-rotate-180={open}>
+              <CaretDownIcon size="12px" />
+            </span>
+          {/if}
+        </div>
+      </Chip>
+    </DropdownMenu.Trigger>
+    <TimeDropdown selected={item.id} on:select-time-grain />
+  </DropdownMenu.Root>
+{:else}
+  <Chip
+    outline
+    {removable}
+    {...colors[item.type]}
+    extraPadding={false}
+    extraRounded={item.type !== PivotChipType.Measure}
+    label={item.title}
+    on:remove={() => {
+      dispatch("remove", item);
+    }}
+  >
+    <div slot="body" class="flex gap-x-1 items-center">
+      {#if item.type === PivotChipType.Time}
+        <b>Time</b>
+        <p>{item.title}</p>
+      {:else}
+        <p class="font-semibold">{item.title}</p>
+      {/if}
+    </div>
+  </Chip>
+{/if}
+
+<style type="postcss">
+  div {
+    outline: none !important;
+  }
+</style>

--- a/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
@@ -1,46 +1,24 @@
 <script lang="ts">
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
-  import { sanitiseExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
   import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
-  import { createQueryServiceMetricsViewRows } from "@rilldata/web-common/runtime-client";
   import PivotDrag from "./PivotDrag.svelte";
+  import { getAllowedTimeGrains } from "@rilldata/web-common/lib/time/grains";
   import { PivotChipType } from "./types";
 
   const stateManagers = getStateManagers();
   const {
-    dashboardStore,
     selectors: {
       measures: { visibleMeasures },
       dimensions: { visibleDimensions },
+      pivot: { columns, rows },
     },
-    metricsViewName,
-    runtime,
   } = stateManagers;
 
   const timeControlsStore = useTimeControlStore(getStateManagers());
 
-  $: tableQuery = createQueryServiceMetricsViewRows(
-    $runtime?.instanceId,
-    $metricsViewName,
-    {
-      limit: 1,
-      where: sanitiseExpression($dashboardStore.whereFilter, undefined),
-      timeStart: $timeControlsStore.timeStart,
-      timeEnd: $timeControlsStore.timeEnd,
-    },
-    {
-      query: {
-        enabled: $timeControlsStore.ready && !!$dashboardStore?.whereFilter,
-      },
-    },
-  );
-
-  $: columnsInTable = $dashboardStore?.pivot?.columns;
-  $: rowsInTable = $dashboardStore?.pivot?.columns;
-
   // Todo: Move to external selectors
   $: measures = $visibleMeasures
-    .filter((m) => !columnsInTable.includes(m.name as string))
+    .filter((m) => !$columns.measure.find((c) => c.id === m.name))
     .map((measure) => ({
       id: measure.name || "Unknown",
       title: measure.label || measure.name || "Unknown",
@@ -48,25 +26,33 @@
     }));
 
   $: dimensions = $visibleDimensions
-    .filter((d) => !rowsInTable.includes((d.name ?? d.column) as string))
+    .filter((d) => {
+      return !(
+        $columns.dimension.find((c) => c.id === d.name) ||
+        $rows.dimension.find((r) => r.id === d.name)
+      );
+    })
     .map((dimension) => ({
       id: dimension.name || dimension.column || "Unknown",
       title: dimension.label || dimension.name || dimension.column || "Unknown",
       type: PivotChipType.Dimension,
     }));
 
-  $: timeDimesions = (
-    $tableQuery?.data?.meta?.filter((d) => d.type === "CODE_TIMESTAMP") ?? []
-  ).map((t) => ({
-    id: t.name ?? "Unknown",
-    title: t.name ?? "Unknown",
-    type: PivotChipType.Time,
-  }));
+  $: timeGrainOptions = getAllowedTimeGrains(
+    new Date($timeControlsStore.timeStart!),
+    new Date($timeControlsStore.timeEnd!),
+  ).map((tgo) => {
+    return {
+      id: tgo.grain,
+      title: tgo.label,
+      type: PivotChipType.Time,
+    };
+  });
 </script>
 
 <div class="sidebar">
   <div class="container">
-    <PivotDrag title="Time" items={timeDimesions} />
+    <PivotDrag title="Time" items={timeGrainOptions} />
     <PivotDrag title="Measures" items={measures} />
     <PivotDrag title="Dimensions" items={dimensions} />
   </div>

--- a/web-common/src/features/dashboards/pivot/PivotTable.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTable.svelte
@@ -12,18 +12,11 @@
   import { derived } from "svelte/store";
   import type { PivotDataRow, PivotDataStore } from "./types";
   import { ChevronDown } from "lucide-svelte";
-  import { getMeasureCountInColumn } from "./pivot-utils";
 
   export let pivotDataStore: PivotDataStore;
 
   const stateManagers = getStateManagers();
-  const {
-    dashboardStore,
-    metricsViewName,
-    selectors: {
-      measures: { visibleMeasures },
-    },
-  } = stateManagers;
+  const { dashboardStore, metricsViewName } = stateManagers;
 
   const pivotDashboardStore = derived(dashboardStore, (dashboard) => {
     return dashboard?.pivot;
@@ -59,10 +52,7 @@
   // $: totalColumns = $pivotDataStore.totalColumns;
 
   $: headerGroups = $table.getHeaderGroups();
-  $: measureCount = getMeasureCountInColumn(
-    $dashboardStore.pivot,
-    $visibleMeasures,
-  );
+  $: measureCount = $dashboardStore.pivot?.columns?.measure?.length ?? 0;
 
   function handleExpandedChange(updater) {
     expanded = updater(expanded);

--- a/web-common/src/features/dashboards/pivot/TimeDropdown.svelte
+++ b/web-common/src/features/dashboards/pivot/TimeDropdown.svelte
@@ -1,0 +1,40 @@
+<script context="module" lang="ts">
+  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu/";
+  import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
+  import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
+  import { getAllowedTimeGrains } from "@rilldata/web-common/lib/time/grains";
+  import Check from "@rilldata/web-common/components/icons/Check.svelte";
+  import { createEventDispatcher } from "svelte";
+</script>
+
+<script lang="ts">
+  export let selected: string;
+
+  const dispatch = createEventDispatcher();
+  const timeControlsStore = useTimeControlStore(getStateManagers());
+
+  $: timeGrainOptions = getAllowedTimeGrains(
+    new Date($timeControlsStore.timeStart!),
+    new Date($timeControlsStore.timeEnd!),
+  );
+</script>
+
+<DropdownMenu.Content align="start">
+  {#each timeGrainOptions as timeGrain (timeGrain.grain)}
+    {@const isSelected = timeGrain.grain === selected}
+    <DropdownMenu.Item
+      class="flex gap-x-2"
+      on:click={() => {
+        if (isSelected) return;
+        dispatch("select-time-grain", { timeGrain });
+      }}
+    >
+      <span class="w-3 aspect-square">
+        {#if isSelected}
+          <Check />
+        {/if}
+      </span>
+      {timeGrain.label}
+    </DropdownMenu.Item>
+  {/each}
+</DropdownMenu.Content>

--- a/web-common/src/features/dashboards/pivot/pivot-data-store.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-data-store.ts
@@ -223,7 +223,6 @@ function createPivotDataStore(ctx: StateManagers): PivotDataStore {
    */
   return derived(getPivotConfig(ctx), (config, configSet) => {
     const { rowDimensionNames, colDimensionNames, measureNames } = config;
-    console.log({ config });
 
     if (
       (!rowDimensionNames.length && !measureNames.length) ||

--- a/web-common/src/features/dashboards/pivot/pivot-data-store.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-data-store.ts
@@ -27,20 +27,18 @@ import {
   reduceTableCellDataIntoRows,
 } from "./pivot-table-transformations";
 import {
-  getDimensionsInPivotColumns,
-  getDimensionsInPivotRow,
   getFilterForPivotTable,
-  getMeasuresInPivotColumns,
   getPivotConfigKey,
   getSortForAccessor,
   getTotalColumnCount,
   reconcileMissingDimensionValues,
 } from "./pivot-utils";
-import type {
-  PivotDataRow,
-  PivotDataStore,
-  PivotDataStoreConfig,
-  PivotTimeConfig,
+import {
+  PivotChipType,
+  type PivotDataRow,
+  type PivotDataStore,
+  type PivotDataStoreConfig,
+  type PivotTimeConfig,
 } from "./types";
 
 /**
@@ -50,8 +48,6 @@ function getPivotConfig(ctx: StateManagers): Readable<PivotDataStoreConfig> {
   return derived(
     [useMetricsView(ctx), ctx.dashboardStore, useTimeControlStore(ctx)],
     ([metricsView, dashboardStore, timeControls]) => {
-      const { rows, columns } = dashboardStore.pivot;
-
       let interval: AvailableTimeGrain = "TIME_GRAIN_HOUR";
       const existingTimeGrain = timeControls?.selectedTimeRange?.interval;
 
@@ -73,7 +69,6 @@ function getPivotConfig(ctx: StateManagers): Readable<PivotDataStoreConfig> {
       };
 
       if (
-        (rows.length == 0 && columns.length == 0) ||
         !metricsView.data?.measures ||
         !metricsView.data?.dimensions ||
         !timeControls.ready
@@ -89,18 +84,24 @@ function getPivotConfig(ctx: StateManagers): Readable<PivotDataStoreConfig> {
           time,
         };
       }
-      const measureNames = getMeasuresInPivotColumns(
-        dashboardStore.pivot,
-        metricsView.data?.measures,
+
+      const measureNames = dashboardStore.pivot.columns.measure.map(
+        (m) => m.id,
       );
-      const rowDimensionNames = getDimensionsInPivotRow(
-        dashboardStore.pivot,
-        metricsView.data?.measures,
+      const rowDimensionNames = dashboardStore.pivot.rows.dimension.map(
+        (d) => d.id,
       );
 
-      const colDimensionNames = getDimensionsInPivotColumns(
-        dashboardStore.pivot,
-        metricsView.data?.measures,
+      // This is temporary until we have a better way to handle time grains
+      const colDimensionNames = dashboardStore.pivot.columns.dimension.map(
+        (d) => {
+          if (d.type === PivotChipType.Time) {
+            time.interval = d.id as AvailableTimeGrain;
+            return time.timeDimension;
+          }
+
+          return d.id;
+        },
       );
 
       return {
@@ -222,6 +223,7 @@ function createPivotDataStore(ctx: StateManagers): PivotDataStore {
    */
   return derived(getPivotConfig(ctx), (config, configSet) => {
     const { rowDimensionNames, colDimensionNames, measureNames } = config;
+    console.log({ config });
 
     if (
       (!rowDimensionNames.length && !measureNames.length) ||

--- a/web-common/src/features/dashboards/pivot/pivot-utils.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-utils.ts
@@ -11,153 +11,16 @@ import {
   TimeRangeString,
 } from "@rilldata/web-common/lib/time/types";
 import type {
-  MetricsViewSpecDimensionV2,
-  MetricsViewSpecMeasureV2,
   V1Expression,
   V1MetricsViewAggregationSort,
 } from "@rilldata/web-common/runtime-client";
 import { getColumnFiltersForPage } from "./pivot-infinite-scroll";
 import type {
   PivotAxesData,
-  PivotChipData,
   PivotDataStoreConfig,
-  PivotState,
   PivotTimeConfig,
   TimeFilters,
 } from "./types";
-import { PivotChipType } from "./types";
-
-export function getMeasuresInPivotColumns(
-  pivot: PivotState,
-  measures: MetricsViewSpecMeasureV2[],
-): string[] {
-  const { columns } = pivot;
-
-  return columns.filter(
-    (rowName) => measures.findIndex((m) => m?.name === rowName) > -1,
-  );
-}
-
-export function getDimensionsInPivotRow(
-  pivot: PivotState,
-  measures: MetricsViewSpecMeasureV2[],
-): string[] {
-  const { rows } = pivot;
-  return rows.filter(
-    (rowName) => measures.findIndex((m) => m?.name === rowName) === -1,
-  );
-}
-
-export function getDimensionsInPivotColumns(
-  pivot: PivotState,
-  measures: MetricsViewSpecMeasureV2[],
-): string[] {
-  const { columns } = pivot;
-  return columns.filter(
-    (colName) => measures.findIndex((m) => m?.name === colName) === -1,
-  );
-}
-
-export function getFormattedColumn(
-  pivot: PivotState,
-  allMeasures: MetricsViewSpecMeasureV2[],
-  alldimensions: MetricsViewSpecDimensionV2[],
-) {
-  const measures: PivotChipData[] = [];
-  const timeAndDimensions: PivotChipData[] = [];
-
-  const { columns } = pivot;
-
-  columns.forEach((colName) => {
-    let label = "";
-    let id = "";
-    let chipType = PivotChipType.Measure;
-
-    const measure = allMeasures.find((m) => m?.name === colName);
-
-    if (measure && measure.label && measure.name) {
-      chipType = PivotChipType.Measure;
-      label = measure.label;
-      id = measure.name;
-
-      measures.push({ id, title: label, type: chipType });
-
-      return;
-    }
-
-    const dimension = alldimensions.find((d) => d?.name === colName);
-
-    if (dimension && dimension.label && dimension.name) {
-      chipType = PivotChipType.Dimension;
-      label = dimension.label;
-      id = dimension.name;
-    } else {
-      chipType = PivotChipType.Time;
-      label = colName;
-      id = colName;
-    }
-
-    timeAndDimensions.push({ id, title: label, type: chipType });
-  });
-
-  return timeAndDimensions.concat(measures);
-}
-
-export function getFormattedRow(
-  pivot: PivotState,
-  allDimensions: MetricsViewSpecDimensionV2[],
-) {
-  const data: PivotChipData[] = [];
-
-  const { rows } = pivot;
-
-  rows.forEach((rowName) => {
-    let label = "";
-    let id = "";
-    let chipType = PivotChipType.Dimension;
-
-    const dimension = allDimensions.find((m) => m?.name === rowName);
-
-    if (dimension && dimension.label && dimension.name) {
-      chipType = PivotChipType.Dimension;
-      label = dimension.label;
-      id = dimension.name;
-    } else {
-      chipType = PivotChipType.Time;
-      label = rowName;
-      id = rowName;
-    }
-
-    data.push({ id, title: label, type: chipType });
-  });
-
-  return data;
-}
-
-export function getFormattedHeaderValues(
-  pivot: PivotState,
-  allMeasures: MetricsViewSpecMeasureV2[],
-  alldimensions: MetricsViewSpecDimensionV2[],
-) {
-  const rows = getFormattedRow(pivot, alldimensions);
-  const columns = getFormattedColumn(pivot, allMeasures, alldimensions);
-
-  return {
-    rows,
-    columns,
-  };
-}
-
-export function getMeasureCountInColumn(
-  pivot: PivotState,
-  allMeasures: MetricsViewSpecMeasureV2[],
-) {
-  const { columns } = pivot;
-
-  return columns.filter(
-    (rowName) => allMeasures.findIndex((m) => m?.name === rowName) > -1,
-  ).length;
-}
 
 /**
  * Returns a sorted data array by appending the missing values in

--- a/web-common/src/features/dashboards/pivot/types.ts
+++ b/web-common/src/features/dashboards/pivot/types.ts
@@ -25,13 +25,22 @@ export type PivotDataStore = Readable<PivotDataState>;
 
 export interface PivotState {
   active: boolean;
-  rows: string[];
-  columns: string[];
+  columns: PivotColumns;
+  rows: PivotRows;
   expanded: ExpandedState;
   sorting: SortingState;
   columnPage: number;
   rowJoinType: "flat" | "nest";
 }
+
+export type PivotColumns = {
+  measure: PivotChipData[];
+  dimension: PivotChipData[];
+};
+
+export type PivotRows = {
+  dimension: PivotChipData[];
+};
 
 export interface PivotDataRow {
   [key: string]: string | number | PivotDataRow[] | undefined;
@@ -122,7 +131,7 @@ export type PivotChipData = {
 };
 
 export enum PivotChipType {
-  Time = "Time",
-  Measure = "Measure",
-  Dimension = "Dimension",
+  Time = "time",
+  Measure = "measure",
+  Dimension = "dimension",
 }

--- a/web-common/src/features/dashboards/state-managers/selectors/pivot.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/pivot.ts
@@ -2,4 +2,6 @@ import type { DashboardDataSources } from "./types";
 
 export const pivotSelectors = {
   showPivot: ({ dashboard }: DashboardDataSources) => dashboard.pivot.active,
+  rows: ({ dashboard }: DashboardDataSources) => dashboard.pivot.rows,
+  columns: ({ dashboard }: DashboardDataSources) => dashboard.pivot.columns,
 };

--- a/web-common/src/features/dashboards/stores/dashboard-store-defaults.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-store-defaults.ts
@@ -153,8 +153,13 @@ export function getDefaultMetricsExplorerEntity(
     pinIndex: -1,
     pivot: {
       active: false,
-      rows: [],
-      columns: [],
+      rows: {
+        dimension: [],
+      },
+      columns: {
+        dimension: [],
+        measure: [],
+      },
       rowJoinType: "nest",
       expanded: {},
       sorting: [],

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -32,6 +32,7 @@ import {
   SortDirection,
   SortType,
 } from "web-common/src/features/dashboards/proto-state/derived-types";
+import { PivotChipType, type PivotChipData } from "../pivot/types";
 
 export interface MetricsExplorerStoreType {
   entities: Record<string, MetricsExplorerEntity>;
@@ -229,15 +230,41 @@ const metricViewReducers = {
     });
   },
 
-  setPivotRows(name: string, values: string[]) {
+  setPivotRows(name: string, value: PivotChipData[]) {
     updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.pivot = { ...metricsExplorer.pivot, rows: values };
+      const dimensions: PivotChipData[] = [];
+
+      value.forEach((val) => {
+        if (val.type !== PivotChipType.Measure) {
+          dimensions.push(val);
+        }
+      });
+
+      metricsExplorer.pivot.rows = {
+        ...metricsExplorer.pivot.rows,
+        dimension: dimensions,
+      };
     });
   },
 
-  setPivotColumns(name: string, values: string[]) {
+  setPivotColumns(name: string, value: PivotChipData[]) {
     updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.pivot = { ...metricsExplorer.pivot, columns: values };
+      const dimensions: PivotChipData[] = [];
+      const measures: PivotChipData[] = [];
+
+      value.forEach((val) => {
+        if (val.type === PivotChipType.Measure) {
+          measures.push(val);
+        } else {
+          dimensions.push(val);
+        }
+      });
+
+      metricsExplorer.pivot.columns = {
+        ...metricsExplorer.pivot.columns,
+        dimension: dimensions,
+        measure: measures,
+      };
     });
   },
 
@@ -267,8 +294,13 @@ const metricViewReducers = {
       metricsExplorer.pivot = {
         ...metricsExplorer.pivot,
         active: true,
-        rows,
-        columns,
+        rows: {
+          dimension: [],
+        },
+        columns: {
+          dimension: [],
+          measure: [],
+        },
         expanded: {},
         sorting: [],
         columnPage: 1,

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -33,6 +33,7 @@ import {
   SortType,
 } from "web-common/src/features/dashboards/proto-state/derived-types";
 import { PivotChipType, type PivotChipData } from "../pivot/types";
+import type { PivotRows, PivotColumns } from "../pivot/types";
 
 export interface MetricsExplorerStoreType {
   entities: Record<string, MetricsExplorerEntity>;
@@ -289,18 +290,13 @@ const metricViewReducers = {
     });
   },
 
-  createPivot(name: string, rows: string[], columns: string[]) {
+  createPivot(name: string, rows: PivotRows, columns: PivotColumns) {
     updateMetricsExplorerByName(name, (metricsExplorer) => {
       metricsExplorer.pivot = {
         ...metricsExplorer.pivot,
         active: true,
-        rows: {
-          dimension: [],
-        },
-        columns: {
-          dimension: [],
-          measure: [],
-        },
+        rows,
+        columns,
         expanded: {},
         sorting: [],
         columnPage: 1,

--- a/web-common/src/features/dashboards/time-dimension-details/TDDHeader.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TDDHeader.svelte
@@ -31,6 +31,7 @@
   import { featureFlags } from "../../feature-flags";
   import TDDExportButton from "./TDDExportButton.svelte";
   import type { TDDComparison } from "./types";
+  import { PivotChipType } from "../pivot/types";
 
   export let metricViewName: string;
   export let dimensionName: string;
@@ -112,21 +113,47 @@
   function startPivotForTDD() {
     const pivot = $dashboardStore?.pivot;
 
-    if (pivot.rows.length || pivot.columns.length) {
+    if (
+      pivot.rows.dimension.length ||
+      pivot.columns.measure.length ||
+      pivot.columns.dimension.length
+    ) {
       showReplacePivotModal = true;
     } else {
       createPivot();
     }
   }
+
+  // This needs to be reworked - bgh
   function createPivot() {
     showReplacePivotModal = false;
     const timeDimension = $metricsView?.data?.timeDimension;
     if (!timeDimension || !expandedMeasureName) return;
-    const rowDimensions = dimensionName ? [dimensionName] : [];
-    metricsExplorerStore.createPivot(metricViewName, rowDimensions, [
-      timeDimension,
-      expandedMeasureName,
-    ]);
+    const rowDimensions = dimensionName
+      ? [
+          {
+            id: dimensionName,
+            title: dimensionName,
+            type: PivotChipType.Dimension,
+          },
+        ]
+      : [];
+    metricsExplorerStore.createPivot(
+      metricViewName,
+      { dimension: rowDimensions },
+      {
+        dimension: [
+          { id: timeDimension, title: timeDimension, type: PivotChipType.Time },
+        ],
+        measure: [
+          {
+            id: expandedMeasureName,
+            title: expandedMeasureName,
+            type: PivotChipType.Measure,
+          },
+        ],
+      },
+    );
   }
 </script>
 


### PR DESCRIPTION
This PR adds the initial code necessary for supporting time granularity in the pivot table.

- Changes row/column data structure in the pivot store
- Removes related utils from pivot-utils
- Adds selectors for rows and columns
- Changes setPivotRows and setPivotColumns function to match new structure
- Adds a new PivotChip component to wrap Chip
- Displays a dropdown menu (not fully styled) for time pills in the pivot header
- Does not support adding multiple time pills (requires more API work)