### PR TITLE
[WIP] Prototype to leverage immer to create isolated derived stores

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29008,6 +29008,7 @@
         "d3-shape": "^3.1.0",
         "d3-time-format": "^4.1.0",
         "date-fns": "^2.30.0",
+        "immer": "^10.0.3",
         "jsdom": "^23.0.1",
         "litepicker": "^2.0.12",
         "lucide-svelte": "^0.298.0",
@@ -29442,6 +29443,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "web-common/node_modules/immer": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
+      "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "web-common/node_modules/json-schema-traverse": {

--- a/web-common/package.json
+++ b/web-common/package.json
@@ -52,6 +52,7 @@
     "d3-shape": "^3.1.0",
     "d3-time-format": "^4.1.0",
     "date-fns": "^2.30.0",
+    "immer": "^10.0.3",
     "jsdom": "^23.0.1",
     "litepicker": "^2.0.12",
     "lucide-svelte": "^0.298.0",

--- a/web-common/src/features/dashboards/state-managers/actions/index.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/index.ts
@@ -1,5 +1,6 @@
 import { filterActions } from "@rilldata/web-common/features/dashboards/state-managers/actions/filters";
 import { measureFilterActions } from "@rilldata/web-common/features/dashboards/state-managers/actions/measure-filters";
+import type { ImmerLayer } from "@rilldata/web-common/features/dashboards/state-managers/immer-layer";
 import { sortActions } from "./sorting";
 import { contextColActions } from "./context-columns";
 import type { MetricsExplorerEntity } from "../../stores/metrics-explorer-entity";

--- a/web-common/src/features/dashboards/state-managers/immer-layer.ts
+++ b/web-common/src/features/dashboards/state-managers/immer-layer.ts
@@ -1,0 +1,96 @@
+import { getProtoFromDashboardState } from "@rilldata/web-common/features/dashboards/proto-state/toProto";
+import type { MetricsExplorerStoreType } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
+import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import {
+  enablePatches,
+  applyPatches,
+  type Patch,
+  produce,
+  enableMapSet,
+} from "immer";
+import { get, type Readable, type Updater, writable } from "svelte/store";
+
+enablePatches();
+enableMapSet();
+
+export class ImmerLayer {
+  private updaters: ((patches: Patch[]) => void)[] = [];
+  private name: string;
+
+  public constructor(
+    private readonly updater: (
+      this: void,
+      updater: Updater<MetricsExplorerStoreType>,
+    ) => void,
+  ) {}
+
+  public setName(name: string) {
+    this.name = name;
+    this.updaters = [];
+  }
+
+  public wrapAction(
+    name: string,
+    callback: (metricsExplorer: MetricsExplorerEntity) => void,
+  ) {
+    this.updater((state) => {
+      if (!state.entities[name]) {
+        return state;
+      }
+
+      return produce(
+        state,
+        (d) => {
+          callback(d.entities[name]);
+          d.entities[name].proto = getProtoFromDashboardState(d.entities[name]);
+        },
+        (patches) => this.broadcast(patches),
+      );
+    });
+  }
+
+  public adhoc(
+    state: MetricsExplorerStoreType,
+    callback: (metricsExplorerStore: MetricsExplorerStoreType) => void,
+  ) {
+    return produce(
+      state,
+      (d) => {
+        callback(d);
+      },
+      (patches) => this.broadcast(patches),
+    );
+  }
+
+  public wrapStore(
+    dashboard: Readable<MetricsExplorerEntity>,
+    keys: Array<keyof MetricsExplorerEntity>,
+  ): Readable<{ root: MetricsExplorerEntity }> {
+    const state = get(dashboard);
+    const keysLookup = new Set(keys);
+
+    const { update, subscribe } = writable({ root: state });
+    this.updaters.push((patches: Patch[]) => {
+      const filteredPatches = patches.filter(
+        (p) =>
+          p.path.length === 1 ||
+          keysLookup.has(p.path[1] as keyof MetricsExplorerEntity),
+      );
+      if (!filteredPatches.length) return;
+      update((s) => applyPatches(s, filteredPatches));
+    });
+
+    return { subscribe };
+  }
+
+  private broadcast(patches: Patch[]) {
+    patches = patches
+      .filter((p) => p.path[1] == this.name)
+      .map((p) => ({
+        ...p,
+        path: ["root", ...p.path.slice(2)],
+      }));
+
+    this.updaters.forEach((u) => u(patches));
+  }
+}

--- a/web-common/src/features/dashboards/state-managers/selectors/active-measure.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/active-measure.ts
@@ -1,3 +1,4 @@
+import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import type { MetricsViewSpecMeasureV2 } from "@rilldata/web-common/runtime-client";
 import type { DashboardDataSources } from "./types";
 import { isSummableMeasure } from "../../dashboard-utils";
@@ -21,7 +22,9 @@ export const activeMeasureName = (dashData: DashboardDataSources): string => {
 };
 
 export const selectedMeasureNames = (
-  dashData: DashboardDataSources,
+  dashData: DashboardDataSources<
+    Pick<MetricsExplorerEntity, "visibleMeasureKeys">
+  >,
 ): string[] => {
   return [...dashData.dashboard.visibleMeasureKeys];
 };

--- a/web-common/src/features/dashboards/state-managers/selectors/dashboard-queries.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/dashboard-queries.ts
@@ -1,6 +1,11 @@
 import type { ResolvedMeasureFilter } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
 import { additionalMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measure-filters";
 import { sanitiseExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
+import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import {
+  DashboardKeysInTimeStore,
+  type TimeStoreDerivedDashboard,
+} from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import type {
   QueryServiceMetricsViewComparisonBody,
   QueryServiceMetricsViewTotalsBody,
@@ -12,11 +17,34 @@ import {
   isAnyMeasureSelected,
   selectedMeasureNames,
 } from "./active-measure";
-import { sortingSelectors } from "./sorting";
+import {
+  DashboardKeysInSorting,
+  type SortingDashboard,
+  sortingSelectors,
+} from "./sorting";
 import { isTimeControlReady, timeControlsState } from "./time-range";
 import { getFiltersForOtherDimensions } from "./dimension-filters";
 import { updateFilterOnSearch } from "../../dimension-table/dimension-table-utils";
 import { dimensionTableSearchString } from "./dimension-table";
+
+export const DashboardKeysInDimensionTable: Array<keyof MetricsExplorerEntity> =
+  [
+    "whereFilter",
+    "dimensionSearchText",
+    "selectedDimensionName",
+    "visibleMeasureKeys",
+    ...DashboardKeysInTimeStore,
+    ...DashboardKeysInSorting,
+  ];
+export type DimensionTableDerivedDashboard = Pick<
+  MetricsExplorerEntity,
+  | "whereFilter"
+  | "dimensionSearchText"
+  | "selectedDimensionName"
+  | "visibleMeasureKeys"
+> &
+  TimeStoreDerivedDashboard &
+  SortingDashboard;
 
 /**
  * Returns the sorted query body for the dimension table for the
@@ -26,7 +54,7 @@ import { dimensionTableSearchString } from "./dimension-table";
  * is not undefined, ie then the dimension table is visible.
  */
 export function dimensionTableSortedQueryBody(
-  dashData: DashboardDataSources,
+  dashData: DashboardDataSources<DimensionTableDerivedDashboard>,
 ): (
   resolvedMeasureFilter: ResolvedMeasureFilter,
 ) => QueryServiceMetricsViewComparisonBody {

--- a/web-common/src/features/dashboards/state-managers/selectors/index.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/index.ts
@@ -1,18 +1,20 @@
 import type { ImmerLayer } from "@rilldata/web-common/features/dashboards/state-managers/immer-layer";
 import { measureFilterSelectors } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measure-filters";
-import { DashboardKeysUsedInTimeStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import type {
   RpcStatus,
   V1MetricsViewSpec,
   V1MetricsViewTimeRangeResponse,
 } from "@rilldata/web-common/runtime-client";
 import type { QueryClient, QueryObserverResult } from "@tanstack/svelte-query";
-import { derived, get, type Readable } from "svelte/store";
+import { derived, type Readable } from "svelte/store";
 import type { MetricsExplorerEntity } from "../../stores/metrics-explorer-entity";
 import { activeMeasureSelectors } from "./active-measure";
 import { comparisonSelectors } from "./comparisons";
 import { contextColSelectors } from "./context-column";
-import { leaderboardQuerySelectors } from "./dashboard-queries";
+import {
+  DashboardKeysInDimensionTable,
+  leaderboardQuerySelectors,
+} from "./dashboard-queries";
 import { formattingSelectors } from "./data-formatting";
 import { dimensionFilterSelectors } from "./dimension-filters";
 import { dimensionTableSelectors } from "./dimension-table";
@@ -142,15 +144,7 @@ export const createStateManagerReadables = (
     dashboardQueries: createDerivedReadablesFromSelectors(
       leaderboardQuerySelectors,
       dashboardDataReadables,
-      [
-        "whereFilter",
-        "dimensionSearchText",
-        "selectedDimensionName",
-        "visibleMeasureKeys",
-        ...DashboardKeysUsedInTimeStore,
-        "dashboardSortType",
-        "sortDirection",
-      ],
+      DashboardKeysInDimensionTable,
     ),
 
     /**

--- a/web-common/src/features/dashboards/state-managers/selectors/sorting.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/sorting.ts
@@ -1,24 +1,35 @@
+import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import { SortDirection, SortType } from "../../proto-state/derived-types";
 import type { DashboardDataSources } from "./types";
+
+export const DashboardKeysInSorting: Array<keyof MetricsExplorerEntity> = [
+  "dashboardSortType",
+  "sortDirection",
+  "leaderboardMeasureName",
+];
+export type SortingDashboard = Pick<
+  MetricsExplorerEntity,
+  "dashboardSortType" | "sortDirection" | "leaderboardMeasureName"
+>;
 
 export const sortingSelectors = {
   /**
    * Gets the sort type for the dash (value, percent, delta, etc.)
    */
-  sortType: ({ dashboard }: DashboardDataSources) =>
+  sortType: ({ dashboard }: DashboardDataSources<SortingDashboard>) =>
     dashboard.dashboardSortType,
 
   /**
    * true if the dashboard is sorted ascending, false otherwise.
    */
-  sortedAscending: ({ dashboard }: DashboardDataSources) =>
+  sortedAscending: ({ dashboard }: DashboardDataSources<SortingDashboard>) =>
     dashboard.sortDirection === SortDirection.ASCENDING,
 
   /**
    * Returns the measure name that the dashboard is sorted by,
    * or null if the dashboard is sorted by dimension value.
    */
-  sortMeasure: ({ dashboard }: DashboardDataSources) =>
+  sortMeasure: ({ dashboard }: DashboardDataSources<SortingDashboard>) =>
     dashboard.dashboardSortType !== SortType.DIMENSION &&
     dashboard.dashboardSortType !== SortType.UNSPECIFIED
       ? dashboard.leaderboardMeasureName
@@ -27,6 +38,8 @@ export const sortingSelectors = {
   /**
    * Returns true if the dashboard is sorted by a dimension, false otherwise.
    */
-  sortedByDimensionValue: ({ dashboard }: DashboardDataSources) =>
+  sortedByDimensionValue: ({
+    dashboard,
+  }: DashboardDataSources<SortingDashboard>) =>
     dashboard.dashboardSortType === SortType.DIMENSION,
 };

--- a/web-common/src/features/dashboards/state-managers/selectors/time-range.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/time-range.ts
@@ -6,9 +6,12 @@ import type { DashboardDataSources } from "./types";
 import {
   selectedTimeRangeSelector,
   timeControlStateSelector,
+  type TimeStoreDerivedDashboard,
 } from "../../time-controls/time-control-store";
 
-export const timeControlsState = (dashData: DashboardDataSources) =>
+export const timeControlsState = (
+  dashData: DashboardDataSources<TimeStoreDerivedDashboard>,
+) =>
   timeControlStateSelector([
     dashData.metricsSpecQueryResult,
     dashData.timeRangeSummary,

--- a/web-common/src/features/dashboards/state-managers/selectors/types.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/types.ts
@@ -21,8 +21,11 @@ import type { Expand } from "../types";
  * outside of component code,
  * and utimately wrapped in Readables for use in components.
  */
-export type DashboardDataSources = {
-  dashboard: MetricsExplorerEntity;
+export type DashboardDataSources<
+  DerivedDashboard extends
+    Partial<MetricsExplorerEntity> = MetricsExplorerEntity,
+> = {
+  dashboard: DerivedDashboard;
   metricsSpecQueryResult: QueryObserverResult<V1MetricsViewSpec, RpcStatus>;
   timeRangeSummary: QueryObserverResult<
     V1MetricsViewTimeRangeResponse,

--- a/web-common/src/features/dashboards/state-managers/state-managers.ts
+++ b/web-common/src/features/dashboards/state-managers/state-managers.ts
@@ -17,8 +17,9 @@ import { Readable, Writable, derived, get, writable } from "svelte/store";
 import {
   MetricsExplorerStoreType,
   metricsExplorerStore,
-  updateMetricsExplorerByName,
   useDashboardStore,
+  immerLayer,
+  updateMetricsExplorerByName,
 } from "web-common/src/features/dashboards/stores/dashboard-stores";
 import {
   ResourceKind,
@@ -124,6 +125,7 @@ export function createStateManagers({
     contextColWidthDefaults,
   );
 
+  immerLayer.setName(metricsViewName);
   return {
     runtime: runtime,
     metricsViewName: metricsViewNameStore,
@@ -143,6 +145,7 @@ export function createStateManagers({
       metricsSpecQueryResultStore: metricsSpecStore,
       timeRangeSummaryStore,
       queryClient,
+      immerLayer: immerLayer,
     }),
     /**
      * A collection of functions that update the dashboard data model.

--- a/web-common/src/features/dashboards/time-controls/time-control-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.ts
@@ -70,6 +70,15 @@ export type TimeControlState = {
   ComparisonTimeRangeState;
 export type TimeControlStore = Readable<TimeControlState>;
 
+export const DashboardKeysUsedInTimeStore: Array<keyof MetricsExplorerEntity> =
+  [
+    "selectedTimezone",
+    "selectedTimeRange",
+    "showTimeComparison",
+    "selectedComparisonTimeRange",
+    "lastDefinedScrubRange",
+  ];
+
 export const timeControlStateSelector = ([
   metricsView,
   timeRangeResponse,

--- a/web-common/src/features/dashboards/time-controls/time-control-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.ts
@@ -70,14 +70,21 @@ export type TimeControlState = {
   ComparisonTimeRangeState;
 export type TimeControlStore = Readable<TimeControlState>;
 
-export const DashboardKeysUsedInTimeStore: Array<keyof MetricsExplorerEntity> =
-  [
-    "selectedTimezone",
-    "selectedTimeRange",
-    "showTimeComparison",
-    "selectedComparisonTimeRange",
-    "lastDefinedScrubRange",
-  ];
+export const DashboardKeysInTimeStore: Array<keyof MetricsExplorerEntity> = [
+  "selectedTimezone",
+  "selectedTimeRange",
+  "showTimeComparison",
+  "selectedComparisonTimeRange",
+  "lastDefinedScrubRange",
+];
+export type TimeStoreDerivedDashboard = Pick<
+  MetricsExplorerEntity,
+  | "selectedTimezone"
+  | "selectedTimeRange"
+  | "showTimeComparison"
+  | "selectedComparisonTimeRange"
+  | "lastDefinedScrubRange"
+>;
 
 export const timeControlStateSelector = ([
   metricsView,
@@ -86,7 +93,7 @@ export const timeControlStateSelector = ([
 ]: [
   QueryObserverResult<V1MetricsViewSpec, RpcStatus>,
   QueryObserverResult<V1MetricsViewTimeRangeResponse, unknown>,
-  MetricsExplorerEntity,
+  TimeStoreDerivedDashboard,
 ]): TimeControlState => {
   const hasTimeSeries = Boolean(metricsView.data?.timeDimension);
   if (
@@ -131,7 +138,7 @@ export const timeControlStateSelector = ([
   }
 
   const comparisonTimeRangeState = calculateComparisonTimeRangePartial(
-    metricsView,
+    metricsView.data,
     metricsExplorer,
     allTimeRange,
     timeRangeState,
@@ -169,7 +176,7 @@ export const useTimeControlStore = memoizeMetricsStore<TimeControlStore>(
  * Also adds start, end and their adjusted counterparts as strings ready to use in requests.
  */
 function calculateTimeRangePartial(
-  metricsExplorer: MetricsExplorerEntity,
+  metricsExplorer: TimeStoreDerivedDashboard,
   allTimeRange: DashboardTimeControls,
   defaultTimeRange: DashboardTimeControls,
   minTimeGrain: V1TimeGrain,
@@ -221,7 +228,7 @@ function calculateTimeRangePartial(
  */
 function calculateComparisonTimeRangePartial(
   metricsView: V1MetricsViewSpec,
-  metricsExplorer: MetricsExplorerEntity,
+  metricsExplorer: TimeStoreDerivedDashboard,
   allTimeRange: DashboardTimeControls,
   timeRangeState: TimeRangeState,
 ): ComparisonTimeRangeState {
@@ -279,7 +286,7 @@ function calculateComparisonTimeRangePartial(
 }
 
 function getTimeRange(
-  metricsExplorer: MetricsExplorerEntity,
+  metricsExplorer: TimeStoreDerivedDashboard,
   allTimeRange: DashboardTimeControls,
   defaultTimeRange: DashboardTimeControls,
 ) {
@@ -324,7 +331,7 @@ function getTimeRange(
 }
 
 function getTimeGrain(
-  metricsExplorer: MetricsExplorerEntity,
+  metricsExplorer: TimeStoreDerivedDashboard,
   timeRange: DashboardTimeControls,
   minTimeGrain: V1TimeGrain,
 ) {
@@ -355,7 +362,7 @@ function getTimeGrain(
 
 function getComparisonTimeRange(
   metricsView: V1MetricsViewSpec,
-  metricsExplorer: MetricsExplorerEntity,
+  metricsExplorer: TimeStoreDerivedDashboard,
   allTimeRange: DashboardTimeControls,
   timeRange: DashboardTimeControls,
   comparisonTimeRange: DashboardTimeControls,


### PR DESCRIPTION
## Checklist
- [ ] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [ ] Needs manual QA?

## Summary
#### Issue addressed: 
<!-- INSERT ISSUE # / LINK HERE IF APPLICABLE -->

#### Details:
TODO (these cannot be done without complete adoption of state-managers):
- [ ] Create new store for each dashboard instead of the global `metricsExplorerStore`.
- [ ] Move the init and sync functions to state managers.
- [ ] Create an instance of `ImmerLayer` for each dashboard.
- [ ] Get rid of manually adding `root` key.
- [ ] Add safeguards to make sure all fields used in selectors are actually derived.

## Steps to Verify
<!-- PROVIDE INFORMATION ON HOW TO CHECK THIS ADDITION
For example, given a new button "Foo" in the dashboard:
1. Run `npm run dev`
2. Open localhost:3000 and navigate to a dashboard
3. Click the "Foo" button in corner
4. Observe the side effect
 -->