### PR TITLE
Use `esnext` (as does SvelteKit's `tsconfig.json`)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,13 @@
   // "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
     "moduleResolution": "node",
-    "module": "es2020",
-    "lib": ["es2020", "DOM"],
-    "target": "es2020",
+    "module": "esnext",
+    "lib": [
+			"esnext",
+			"DOM",
+			"DOM.Iterable"
+		],
+    "target": "esnext",
     /**
       svelte-preprocess cannot figure out whether you have a value or a type, so tell TypeScript
       to enforce using \`import type\` instead of \`import\` for Types.


### PR DESCRIPTION
Upon upgrading some dependencies in #3999, I started to get these errors:

![image](https://github.com/rilldata/rill/assets/14206386/53958daf-7511-44a7-a504-b9883fd03155)

This PR updates the root `.tsconfig`'s `lib`, `module`, and `target` to use `esnext`. FWIW, this is the same configuration as in SvelteKit's `.tsconfig`, and it'd be nice to converge.