### PR TITLE
Pass through measure filters to pivot queries

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-expansion.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-expansion.ts
@@ -100,6 +100,7 @@ export function createSubTableCellQuery(
     config.measureNames,
     dimensionBody,
     filterForSubTable,
+    config.measureFilter,
     sortBy,
     "10000",
     "0",

--- a/web-common/src/features/dashboards/pivot/pivot-queries.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-queries.ts
@@ -1,3 +1,4 @@
+import type { ResolvedMeasureFilter } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
 import type {
   PivotAxesData,
   PivotDataStoreConfig,
@@ -25,6 +26,7 @@ export function createPivotAggregationRowQuery(
   measures: string[],
   dimensions: V1MetricsViewAggregationDimension[],
   whereFilter: V1Expression,
+  measureFilter: ResolvedMeasureFilter | undefined,
   sort: V1MetricsViewAggregationSort[] = [],
   limit = "100",
   offset = "0",
@@ -48,8 +50,7 @@ export function createPivotAggregationRowQuery(
         {
           measures: measures.map((measure) => ({ name: measure })),
           dimensions,
-          where: sanitiseExpression(whereFilter, undefined),
-          // TODO: having filter
+          where: sanitiseExpression(whereFilter, measureFilter?.filter),
           timeRange: {
             start: timeRange?.start ? timeRange.start : timeControls.timeStart,
             end: timeRange?.end ? timeRange.end : timeControls.timeEnd,
@@ -126,6 +127,7 @@ export function getAxisForDimensions(
         measures,
         [dimension],
         whereFilter,
+        config.measureFilter,
         sortByForDimension,
         "100",
         "0",

--- a/web-common/src/features/dashboards/pivot/types.ts
+++ b/web-common/src/features/dashboards/pivot/types.ts
@@ -1,3 +1,4 @@
+import type { ResolvedMeasureFilter } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
 import type { AvailableTimeGrain } from "@rilldata/web-common/lib/time/types";
 import type {
   MetricsViewSpecDimensionV2,
@@ -43,8 +44,9 @@ export type PivotRows = {
 };
 
 export interface PivotDataRow {
-  [key: string]: string | number | PivotDataRow[] | undefined;
   subRows?: PivotDataRow[];
+
+  [key: string]: string | number | PivotDataRow[] | undefined;
 }
 
 export interface TimeFilters {
@@ -70,6 +72,7 @@ export interface PivotDataStoreConfig {
   allMeasures: MetricsViewSpecMeasureV2[];
   allDimensions: MetricsViewSpecDimensionV2[];
   whereFilter: V1Expression;
+  measureFilter: ResolvedMeasureFilter;
   pivot: PivotState;
   time: PivotTimeConfig;
 }


### PR DESCRIPTION
Treating aggregation as timeseries and sending in `ResolvedMeasureFilter` to all the queries fired in pivot queries.