### PR TITLE
Update key for pivot table cache

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-utils.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-utils.ts
@@ -91,17 +91,19 @@ export function getPivotConfigKey(config: PivotDataStoreConfig) {
     rowDimensionNames,
     measureNames,
     whereFilter,
+    measureFilter,
     pivot,
   } = config;
 
   const { sorting } = pivot;
   const sortingKey = JSON.stringify(sorting);
   const filterKey = JSON.stringify(whereFilter);
+  const measureFilterKey = JSON.stringify(measureFilter);
   const dimsAndMeasures = rowDimensionNames
     .concat(measureNames, colDimensionNames)
     .join("_");
 
-  return `${dimsAndMeasures}_${sortingKey}_${filterKey}`;
+  return `${dimsAndMeasures}_${sortingKey}_${filterKey}_${measureFilterKey}`;
 }
 
 /**


### PR DESCRIPTION
Updates the cache map key. Included measure filter string in the key. 
Changing measure filter would now re-fetch table data instead of keeping stale data.