### PR TITLE
Fix accessor with dot in name

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-column-definition.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-column-definition.ts
@@ -179,7 +179,7 @@ export function getColumnDefForPivot(
   const rowDefinitions: ColumnDef<PivotDataRow>[] =
     rowDimensionsForColumnDef.map((d) => {
       return {
-        accessorKey: d.name,
+        accessorFn: (row) => row[d.name],
         header: nestedLabel,
         cell: ({ row, getValue }) =>
           cellComponent(PivotExpandableCell, {
@@ -196,7 +196,7 @@ export function getColumnDefForPivot(
 
   const leafColumns: ColumnDef<PivotDataRow>[] = measures.map((m) => {
     return {
-      accessorKey: m.name,
+      accessorFn: (row) => row[m.name],
       header: m.label || m.name,
       cell: (info) => {
         const value = m.formatter(info.getValue() as number | null | undefined);


### PR DESCRIPTION
If measure name or dimension name had a dot in it ex - `dimension.property.extensions`, tanstack table would interpret as accessing a nested structure. This PR fixes it so that dot can be present in name.

Example of failed case - 
<img width="204" alt="image" src="https://github.com/rilldata/rill/assets/4402679/2fd63267-cbb6-4904-a115-7609c6e219ba">

Reproduction steps -

- Edit yaml spec and add dot in the name of a dimension
- Create pivot using that dimension