### PR TITLE
Fix: Select correct accessor for measures

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-column-definition.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-column-definition.ts
@@ -196,7 +196,7 @@ export function getColumnDefForPivot(
 
   const leafColumns: ColumnDef<PivotDataRow>[] = measures.map((m) => {
     return {
-      accessorFn: (row) => row[m.name],
+      accessorKey: m.name,
       header: m.label || m.name,
       cell: (info) => {
         const value = m.formatter(info.getValue() as number | null | undefined);


### PR DESCRIPTION
The accessor for measures in the pivot table right now are broken. Use `accessorKey` instead of `accessorFn` for measures.