### PR TITLE
Add button for selecting pivot fields via dropdown

### DIFF
--- a/web-common/src/components/button/Button.svelte
+++ b/web-common/src/components/button/Button.svelte
@@ -8,7 +8,8 @@
     | "highlighted"
     | "text"
     | "link"
-    | "brand";
+    | "brand"
+    | "add";
 
   export let type: ButtonType = "primary";
   export let status: "info" | "error" = "info";
@@ -24,6 +25,7 @@
   export let small = false;
   export let noStroke = false;
   export let dashed = false;
+  export let rounded = false;
   export let builders: Builder[] = [];
 
   const dispatch = createEventDispatcher();
@@ -45,6 +47,7 @@
   class:small
   class:dashed
   class:compact
+  class:rounded
   class:danger={status === "error"}
   class:no-stroke={noStroke}
   type={submitForm ? "submit" : "button"}
@@ -63,11 +66,7 @@
     @apply text-xs leading-snug font-normal;
     @apply gap-x-2 min-w-fit;
     @apply rounded-[2px];
-    @apply px-3 h-7 min-h-[28px];
-  }
-
-  button:focus {
-    @apply outline-none ring-2 ring-slate-800;
+    @apply h-7 min-h-[28px];
   }
 
   button:disabled {
@@ -98,11 +97,15 @@
 
   .secondary:hover,
   .secondary:disabled,
-  .secondary.selected {
+  .secondary.selected,
+  .add:hover,
+  .add:disabled,
+  .add.selected {
     @apply bg-slate-100;
   }
 
-  .secondary:active {
+  .secondary:active,
+  .add:active {
     @apply bg-slate-200;
   }
 
@@ -150,6 +153,7 @@
     @apply text-ellipsis overflow-hidden whitespace-nowrap flex-grow-0 flex-shrink-0;
   }
 
+  .rounded,
   .circle {
     @apply rounded-full;
   }
@@ -220,5 +224,14 @@
 
   .dashed {
     @apply border border-dashed;
+  }
+
+  /* ADD BUTTON STYLES */
+
+  .add {
+    @apply w-[34px] h-[26px] rounded-2xl;
+    @apply flex items-center justify-center;
+    @apply border border-dashed border-slate-300;
+    @apply bg-white;
   }
 </style>

--- a/web-common/src/features/dashboards/pivot/AddField.svelte
+++ b/web-common/src/features/dashboards/pivot/AddField.svelte
@@ -1,0 +1,63 @@
+<script lang="ts" context="module">
+  import Add from "@rilldata/web-common/components/icons/Add.svelte";
+  import Button from "@rilldata/web-common/components/button/Button.svelte";
+  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu/";
+  import { getStateManagers } from "../state-managers/state-managers";
+  import { metricsExplorerStore } from "../stores/dashboard-stores";
+  import type { PivotChipData } from "./types";
+</script>
+
+<script lang="ts">
+  export let type: "rows" | "columns" | null = null;
+
+  const {
+    selectors: {
+      pivot: { dimensions, measures },
+    },
+    metricsViewName,
+  } = getStateManagers();
+
+  let open = false;
+
+  function handleSelectValue(data: PivotChipData) {
+    metricsExplorerStore.addPivotField($metricsViewName, data, type === "rows");
+  }
+</script>
+
+<DropdownMenu.Root bind:open>
+  <DropdownMenu.Trigger asChild let:builder>
+    <Button builders={[builder]} type="add" selected={open}>
+      <Add size="17px" />
+    </Button>
+  </DropdownMenu.Trigger>
+
+  <DropdownMenu.Content class="h-80 w-64 overflow-scroll" align="start">
+    {#if type === "columns"}
+      <DropdownMenu.Label>Measures</DropdownMenu.Label>
+      <DropdownMenu.Group>
+        {#each $measures as measure}
+          <DropdownMenu.Item
+            on:click={() => {
+              handleSelectValue(measure);
+            }}
+          >
+            {measure.title}
+          </DropdownMenu.Item>
+        {/each}
+      </DropdownMenu.Group>
+      <DropdownMenu.Separator />
+    {/if}
+    <DropdownMenu.Label>Dimensions</DropdownMenu.Label>
+    <DropdownMenu.Group>
+      {#each $dimensions as dimension}
+        <DropdownMenu.Item
+          on:click={() => {
+            handleSelectValue(dimension);
+          }}
+        >
+          {dimension.title}
+        </DropdownMenu.Item>
+      {/each}
+    </DropdownMenu.Group>
+  </DropdownMenu.Content>
+</DropdownMenu.Root>

--- a/web-common/src/features/dashboards/pivot/DragList.svelte
+++ b/web-common/src/features/dashboards/pivot/DragList.svelte
@@ -11,10 +11,11 @@
 
 <script lang="ts">
   export let items: PivotChipData[] = [];
-  export let style: "vertical" | "horizontal" = "vertical";
-  export let removable = false;
   export let placeholder: string | null = null;
   export let type: "rows" | "columns" | null = null;
+
+  const removable = Boolean(type);
+  const horizontal = Boolean(type);
 
   const dispatch = createEventDispatcher();
   const flipDurationMs = 200;
@@ -45,7 +46,7 @@
 
 <div
   class="container"
-  class:horizontal={style === "horizontal"}
+  class:horizontal
   use:dndzone={{ items, flipDurationMs }}
   on:consider={handleConsider}
   on:finalize={handleFinalize}
@@ -68,7 +69,7 @@
       />
     </div>
   {/each}
-  {#if style === "horizontal"}
+  {#if removable}
     <AddField {type} />
   {/if}
 </div>

--- a/web-common/src/features/dashboards/pivot/DragList.svelte
+++ b/web-common/src/features/dashboards/pivot/DragList.svelte
@@ -1,10 +1,11 @@
 <script context="module" lang="ts">
+  import AddField from "./AddField.svelte";
+  import PivotChip from "./PivotChip.svelte";
   import { dndzone } from "svelte-dnd-action";
   import { flip } from "svelte/animate";
   import { createEventDispatcher } from "svelte";
   import type { PivotChipData } from "./types";
   import { PivotChipType } from "./types";
-  import PivotChip from "./PivotChip.svelte";
   import type { TimeGrain } from "@rilldata/web-common/lib/time/types";
 </script>
 
@@ -12,17 +13,11 @@
   export let items: PivotChipData[] = [];
   export let style: "vertical" | "horizontal" = "vertical";
   export let removable = false;
+  export let placeholder: string | null = null;
+  export let type: "rows" | "columns" | null = null;
 
   const dispatch = createEventDispatcher();
   const flipDurationMs = 200;
-
-  let listClasses: string;
-
-  $: if (style === "horizontal") {
-    listClasses = "flex flex-row bg-slate-50 w-full p-2 gap-x-2 h-10";
-  } else {
-    listClasses = "flex flex-col gap-y-2 py-2";
-  }
 
   function handleConsider(e: CustomEvent<{ items: PivotChipData[] }>) {
     items = e.detail.items;
@@ -49,11 +44,15 @@
 </script>
 
 <div
-  class="{listClasses} rounded-sm"
+  class="container"
+  class:horizontal={style === "horizontal"}
   use:dndzone={{ items, flipDurationMs }}
   on:consider={handleConsider}
   on:finalize={handleFinalize}
 >
+  {#if !items.length && placeholder}
+    <p class="text-gray-500">{placeholder}</p>
+  {/if}
   {#each items as item (item.id)}
     <div class="item" animate:flip={{ duration: flipDurationMs }}>
       <PivotChip
@@ -69,11 +68,23 @@
       />
     </div>
   {/each}
+  {#if style === "horizontal"}
+    <AddField {type} />
+  {/if}
 </div>
 
 <style type="postcss">
   .item {
     @apply text-center h-6;
+  }
+
+  .container {
+    @apply flex flex-col gap-y-2 py-2 rounded-sm;
+  }
+
+  .horizontal {
+    @apply flex flex-row bg-slate-50 w-full p-2 gap-x-2 h-10;
+    @apply items-center;
   }
 
   div {

--- a/web-common/src/features/dashboards/pivot/PivotDrag.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotDrag.svelte
@@ -25,7 +25,6 @@
 <div class="flex flex-col gap-1 items-start">
   <button class="flex gap-1" on:click={toggleCollapse}>
     <span class="header">{title}</span>
-
     <div class="transition-transform" class:-rotate-180={!collapsed}>
       <CaretDownIcon size="12px" />
     </div>

--- a/web-common/src/features/dashboards/pivot/PivotHeader.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotHeader.svelte
@@ -31,17 +31,20 @@
   <div class="header-row">
     <span class="row-label"> <Column size="16px" /> Columns</span>
     <DragList
+      type="columns"
       removable
       items={$columns.dimension.concat($columns.measure)}
       style="horizontal"
+      placeholder="Drag dimensions here"
       on:update={updateColumn}
     />
   </div>
   <div class="header-row">
     <span class="row-label"> <Row size="16px" /> Rows</span>
-
     <DragList
+      type="rows"
       removable
+      placeholder="Drag dimensions or measures here"
       on:update={updateRows}
       items={$rows.dimension}
       style="horizontal"

--- a/web-common/src/features/dashboards/pivot/PivotHeader.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotHeader.svelte
@@ -32,9 +32,7 @@
     <span class="row-label"> <Column size="16px" /> Columns</span>
     <DragList
       type="columns"
-      removable
       items={$columns.dimension.concat($columns.measure)}
-      style="horizontal"
       placeholder="Drag dimensions here"
       on:update={updateColumn}
     />
@@ -43,11 +41,9 @@
     <span class="row-label"> <Row size="16px" /> Rows</span>
     <DragList
       type="rows"
-      removable
       placeholder="Drag dimensions or measures here"
       on:update={updateRows}
       items={$rows.dimension}
-      style="horizontal"
     />
   </div>
 </div>

--- a/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
@@ -8,35 +8,11 @@
   const stateManagers = getStateManagers();
   const {
     selectors: {
-      measures: { visibleMeasures },
-      dimensions: { visibleDimensions },
-      pivot: { columns, rows },
+      pivot: { measures, dimensions },
     },
   } = stateManagers;
 
   const timeControlsStore = useTimeControlStore(getStateManagers());
-
-  // Todo: Move to external selectors
-  $: measures = $visibleMeasures
-    .filter((m) => !$columns.measure.find((c) => c.id === m.name))
-    .map((measure) => ({
-      id: measure.name || "Unknown",
-      title: measure.label || measure.name || "Unknown",
-      type: PivotChipType.Measure,
-    }));
-
-  $: dimensions = $visibleDimensions
-    .filter((d) => {
-      return !(
-        $columns.dimension.find((c) => c.id === d.name) ||
-        $rows.dimension.find((r) => r.id === d.name)
-      );
-    })
-    .map((dimension) => ({
-      id: dimension.name || dimension.column || "Unknown",
-      title: dimension.label || dimension.name || dimension.column || "Unknown",
-      type: PivotChipType.Dimension,
-    }));
 
   $: timeGrainOptions = getAllowedTimeGrains(
     new Date($timeControlsStore.timeStart!),
@@ -53,8 +29,8 @@
 <div class="sidebar">
   <div class="container">
     <PivotDrag title="Time" items={timeGrainOptions} />
-    <PivotDrag title="Measures" items={measures} />
-    <PivotDrag title="Dimensions" items={dimensions} />
+    <PivotDrag title="Measures" items={$measures} />
+    <PivotDrag title="Dimensions" items={$dimensions} />
   </div>
 </div>
 

--- a/web-common/src/features/dashboards/state-managers/selectors/pivot.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/pivot.ts
@@ -1,7 +1,47 @@
 import type { DashboardDataSources } from "./types";
+import { PivotChipType } from "../../pivot/types";
 
 export const pivotSelectors = {
   showPivot: ({ dashboard }: DashboardDataSources) => dashboard.pivot.active,
   rows: ({ dashboard }: DashboardDataSources) => dashboard.pivot.rows,
   columns: ({ dashboard }: DashboardDataSources) => dashboard.pivot.columns,
+  measures: ({ metricsSpecQueryResult, dashboard }: DashboardDataSources) => {
+    const measures =
+      metricsSpecQueryResult.data?.measures?.filter(
+        (d) => d.name && dashboard.visibleMeasureKeys.has(d.name),
+      ) ?? [];
+    const columns = dashboard.pivot.columns;
+
+    return measures
+      .filter((m) => !columns.measure.find((c) => c.id === m.name))
+      .map((measure) => ({
+        id: measure.name || "Unknown",
+        title: measure.label || measure.name || "Unknown",
+        type: PivotChipType.Measure,
+      }));
+  },
+  dimensions: ({ metricsSpecQueryResult, dashboard }: DashboardDataSources) => {
+    {
+      const dimensions =
+        metricsSpecQueryResult.data?.dimensions?.filter(
+          (d) => d.name && dashboard.visibleDimensionKeys.has(d.name),
+        ) ?? [];
+      const columns = dashboard.pivot.columns;
+      const rows = dashboard.pivot.rows;
+
+      return dimensions
+        .filter((d) => {
+          return !(
+            columns.dimension.find((c) => c.id === d.name) ||
+            rows.dimension.find((r) => r.id === d.name)
+          );
+        })
+        .map((dimension) => ({
+          id: dimension.name || dimension.column || "Unknown",
+          title:
+            dimension.label || dimension.name || dimension.column || "Unknown",
+          type: PivotChipType.Dimension,
+        }));
+    }
+  },
 };

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -242,7 +242,6 @@ const metricViewReducers = {
       });
 
       metricsExplorer.pivot.rows = {
-        ...metricsExplorer.pivot.rows,
         dimension: dimensions,
       };
     });
@@ -262,10 +261,23 @@ const metricViewReducers = {
       });
 
       metricsExplorer.pivot.columns = {
-        ...metricsExplorer.pivot.columns,
         dimension: dimensions,
         measure: measures,
       };
+    });
+  },
+
+  addPivotField(name: string, value: PivotChipData, rows: boolean) {
+    updateMetricsExplorerByName(name, (metricsExplorer) => {
+      if (value.type === PivotChipType.Measure) {
+        metricsExplorer.pivot.columns.measure.push(value);
+      } else {
+        if (rows) {
+          metricsExplorer.pivot.rows.dimension.push(value);
+        } else {
+          metricsExplorer.pivot.columns.dimension.push(value);
+        }
+      }
     });
   },
 


### PR DESCRIPTION
This PR adds a button to the pivot columns and rows drag lists that allows the user to select pivot fields via dropdown. To support this, the dimension and measure aggregators have been moved to the pivot selectors.