### PR TITLE
Temporary workaround for DragList quirk

### DIFF
--- a/web-common/src/components/button/Button.svelte
+++ b/web-common/src/components/button/Button.svelte
@@ -229,7 +229,7 @@
   /* ADD BUTTON STYLES */
 
   .add {
-    @apply w-[34px] h-[26px] rounded-2xl;
+    @apply w-[34px] h-[26px] rounded-2xl flex-shrink-0;
     @apply flex items-center justify-center;
     @apply border border-dashed border-slate-300;
     @apply bg-white px-0;

--- a/web-common/src/features/dashboards/pivot/DragList.svelte
+++ b/web-common/src/features/dashboards/pivot/DragList.svelte
@@ -45,15 +45,16 @@
 </script>
 
 <div
-  class="container"
+  class="container text-gray-500"
   class:horizontal
   use:dndzone={{ items, flipDurationMs }}
   on:consider={handleConsider}
   on:finalize={handleFinalize}
 >
   {#if !items.length && placeholder}
-    <p class="text-gray-500">{placeholder}</p>
+    {placeholder}
   {/if}
+
   {#each items as item (item.id)}
     <div class="item" animate:flip={{ duration: flipDurationMs }}>
       <PivotChip
@@ -69,10 +70,11 @@
       />
     </div>
   {/each}
-  {#if removable}
-    <AddField {type} />
-  {/if}
 </div>
+
+{#if removable}
+  <AddField {type} />
+{/if}
 
 <style type="postcss">
   .item {

--- a/web-common/src/features/dashboards/pivot/PivotHeader.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotHeader.svelte
@@ -58,6 +58,6 @@
     @apply flex items-center gap-x-2 px-2;
   }
   .row-label {
-    @apply flex items-center gap-x-1 w-20;
+    @apply flex items-center gap-x-1 w-20 flex-shrink-0;
   }
 </style>


### PR DESCRIPTION
This PR enables a temporary workaround for the pivot drag list to resolve a limitation with the chosen drag-and-drop library. A more permanent solution will be put in place after discussing with the team.

The limitation is that child elements of the designated drag area are automatically turned into draggable elements behind the scenes, meaning our AddField button cannot be a child of that element without presenting (somewhat non-obvious) cursor and UX issues.

As such, this PR moves the AddField button outside of the drag area temporarily.