### PR TITLE
Fix delayed dashboard url state load

### DIFF
--- a/web-common/src/features/dashboards/stores/DashboardStateProvider.svelte
+++ b/web-common/src/features/dashboards/stores/DashboardStateProvider.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { page } from "$app/stores";
   import {
     createTimeRangeSummary,
     useMetricsView,
@@ -7,6 +8,8 @@
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
   import { initLocalUserPreferenceStore } from "@rilldata/web-common/features/dashboards/user-preferences";
+  import { createQueryServiceMetricsViewSchema } from "@rilldata/web-common/runtime-client";
+  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import Spinner from "../../entity-management/Spinner.svelte";
   import { EntityStatus } from "../../entity-management/types";
 
@@ -17,9 +20,13 @@
   const metricsView = useMetricsView(stateManagers);
   const hasTimeSeries = useModelHasTimeSeries(stateManagers);
   const timeRangeQuery = createTimeRangeSummary(stateManagers);
+  const metricsViewSchema = createQueryServiceMetricsViewSchema(
+    $runtime.instanceId,
+    metricViewName,
+  );
 
   function syncDashboardState() {
-    if (!$metricsView.data) return;
+    if (!$metricsView.data || !$metricsViewSchema.data?.schema) return;
     if (metricViewName in $metricsExplorerStore.entities) {
       metricsExplorerStore.sync(metricViewName, $metricsView.data);
     } else {
@@ -28,10 +35,23 @@
         $metricsView.data,
         $timeRangeQuery.data,
       );
+      const urlState = $page.url.searchParams.get("state");
+      if (urlState) {
+        metricsExplorerStore.syncFromUrl(
+          metricViewName,
+          urlState,
+          $metricsView.data,
+          $metricsViewSchema.data.schema,
+        );
+      }
     }
   }
 
-  $: if ($metricsView.data && ($timeRangeQuery.data || !$hasTimeSeries.data)) {
+  $: if (
+    $metricsView.data &&
+    $metricsViewSchema.data &&
+    ($timeRangeQuery.data || !$hasTimeSeries.data)
+  ) {
     syncDashboardState();
   }
 


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Just after opening a dashboard with a url state that has non-default time range selected, changing the time grain for the 1st time will reset the time range to the default time range.

#### Details:
This is because there is a delay in url state applying to the dashboard store. This PR makes sure that the url state is loaded as soon as the store is created.

## Steps to Verify
1. Go to a dashboard.
2. Select a different time range.
3. Refresh the page.
4. Change the time grain.
5. Time range should not be reset.