### PR TITLE
Fix sorting for the first dimension column

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-column-definition.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-column-definition.ts
@@ -179,6 +179,7 @@ export function getColumnDefForPivot(
   const rowDefinitions: ColumnDef<PivotDataRow>[] =
     rowDimensionsForColumnDef.map((d) => {
       return {
+        id: d.name,
         accessorFn: (row) => row[d.name],
         header: nestedLabel,
         cell: ({ row, getValue }) =>


### PR DESCRIPTION
Sorting on the first dimension column crashes right now. This is regression from https://github.com/rilldata/rill/pull/4017 
We need to have and `id` for columns which use an `accessorFn`.
