### PR TITLE
Temporarily limit pivot UI to one time pill

### DIFF
--- a/web-common/src/features/dashboards/pivot/DragList.svelte
+++ b/web-common/src/features/dashboards/pivot/DragList.svelte
@@ -13,6 +13,7 @@
   export let items: PivotChipData[] = [];
   export let placeholder: string | null = null;
   export let type: "rows" | "columns" | null = null;
+  export let disabled = false;
 
   const removable = Boolean(type);
   const horizontal = Boolean(type);
@@ -47,7 +48,7 @@
 <div
   class="container"
   class:horizontal
-  use:dndzone={{ items, flipDurationMs }}
+  use:dndzone={{ items, flipDurationMs, dragDisabled: disabled }}
   on:consider={handleConsider}
   on:finalize={handleFinalize}
 >
@@ -55,7 +56,11 @@
     <p class="text-gray-500">{placeholder}</p>
   {/if}
   {#each items as item (item.id)}
-    <div class="item" animate:flip={{ duration: flipDurationMs }}>
+    <div
+      class="item"
+      class:disabled
+      animate:flip={{ duration: flipDurationMs }}
+    >
       <PivotChip
         {removable}
         {item}
@@ -90,5 +95,9 @@
 
   div {
     outline: none !important;
+  }
+
+  .disabled {
+    @apply cursor-not-allowed opacity-50 pointer-events-none;
   }
 </style>

--- a/web-common/src/features/dashboards/pivot/PivotDrag.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotDrag.svelte
@@ -8,6 +8,7 @@
   export let title: PivotSidebarSection;
   export let items: PivotChipData[];
   export let collapsed = false;
+  export let disabled = false;
 
   let showMore = false;
 
@@ -31,7 +32,7 @@
   </button>
 
   {#if !collapsed}
-    <DragList items={items.slice(0, visible)} />
+    <DragList {disabled} items={items.slice(0, visible)} />
 
     {#if !collapsed && items.length > 3}
       <button class="see-more" on:click={toggleShowMore}>

--- a/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
@@ -8,7 +8,7 @@
   const stateManagers = getStateManagers();
   const {
     selectors: {
-      pivot: { measures, dimensions },
+      pivot: { measures, dimensions, hasTimePill },
     },
   } = stateManagers;
 
@@ -28,7 +28,8 @@
 
 <div class="sidebar">
   <div class="container">
-    <PivotDrag title="Time" items={timeGrainOptions} />
+    <PivotDrag title="Time" items={timeGrainOptions} disabled={$hasTimePill} />
+
     <PivotDrag title="Measures" items={$measures} />
     <PivotDrag title="Dimensions" items={$dimensions} />
   </div>

--- a/web-common/src/features/dashboards/state-managers/selectors/pivot.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/pivot.ts
@@ -10,9 +10,9 @@ export const pivotSelectors = {
     const columns = dashboard.pivot.columns;
     const rows = dashboard.pivot.rows;
 
-    return (
+    return Boolean(
       columns.dimension.find((c) => c.type === PivotChipType.Time) ||
-      rows.dimension.find((r) => r.type === PivotChipType.Time)
+        rows.dimension.find((r) => r.type === PivotChipType.Time),
     );
   },
   measures: ({ metricsSpecQueryResult, dashboard }: DashboardDataSources) => {

--- a/web-common/src/features/dashboards/state-managers/selectors/pivot.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/pivot.ts
@@ -5,6 +5,16 @@ export const pivotSelectors = {
   showPivot: ({ dashboard }: DashboardDataSources) => dashboard.pivot.active,
   rows: ({ dashboard }: DashboardDataSources) => dashboard.pivot.rows,
   columns: ({ dashboard }: DashboardDataSources) => dashboard.pivot.columns,
+  // Temporary limit to have only 1 time pill
+  hasTimePill: ({ dashboard }: DashboardDataSources) => {
+    const columns = dashboard.pivot.columns;
+    const rows = dashboard.pivot.rows;
+
+    return (
+      columns.dimension.find((c) => c.type === PivotChipType.Time) ||
+      rows.dimension.find((r) => r.type === PivotChipType.Time)
+    );
+  },
   measures: ({ metricsSpecQueryResult, dashboard }: DashboardDataSources) => {
     const measures =
       metricsSpecQueryResult.data?.measures?.filter(


### PR DESCRIPTION
This PR puts in place a temporary UI limit of one time pill per pivot table. It does this by creating a piece of derived state called `hasTimePill`.