### PR TITLE
Type cleanups

### DIFF
--- a/.github/workflows/web-test-code-quality.yml
+++ b/.github/workflows/web-test-code-quality.yml
@@ -44,7 +44,7 @@ jobs:
         if: steps.filter.outputs.common == 'true'
         run: |-
           npx eslint web-common --quiet
-          npx svelte-check --workspace web-common --no-tsconfig --ignore "src/features/dashboards/time-series/(MetricsTimeSeriesCharts.svelte|MeasureValueMouseover.svelte|ChartBody.svelte|MeasureChart.svelte|MeasureScrub.svelte|MeasureZoom.svelte|BackToOverview.svelte),src/features/dashboards/time-controls/(TimeRangeSelector.svelte|TimeControls.svelte),src/components/data-graphic/elements/GraphicContext.svelte"
+          npx svelte-check --workspace web-common --no-tsconfig --ignore "src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte,src/features/dashboards/time-controls/(TimeRangeSelector.svelte|TimeControls.svelte),src/components/data-graphic/elements/GraphicContext.svelte"
 
       - name: lint and type checks for web local
         if: steps.filter.outputs.local == 'true'

--- a/web-admin/src/features/scheduled-reports/get-dashboard-state-for-report.ts
+++ b/web-admin/src/features/scheduled-reports/get-dashboard-state-for-report.ts
@@ -235,7 +235,7 @@ function getDashboardFromComparisonRequest({
   }
 
   if (req.timeRange?.timeZone) {
-    dashboard.selectedTimezone = req.timeRange?.timeZone;
+    dashboard.selectedTimezone = req.timeRange?.timeZone || "UTC";
   }
 
   if (req.comparisonTimeRange) {

--- a/web-common/src/components/column-profile/column-types/details/NumericPlot.svelte
+++ b/web-common/src/components/column-profile/column-types/details/NumericPlot.svelte
@@ -36,7 +36,7 @@ Otherwise, the page will jump around as the data is fetched.
   import SummaryNumberPlot from "./SummaryNumberPlot.svelte";
   import TopK from "./TopK.svelte";
   import type { NumericPlotPoint } from "@rilldata/web-common/components/data-graphic/functional-components/types";
-  import { ScaleType } from "@rilldata/web-common/components/data-graphic/state/types";
+  import { ScaleType } from "@rilldata/web-common/components/data-graphic/state";
 
   export let data: NumericHistogramBinsBin[];
   export let rug: NumericOutliersOutlier[];
@@ -107,8 +107,8 @@ Otherwise, the page will jump around as the data is fetched.
       bottom={0}
       bodyBuffer={0}
       marginBuffer={0}
-      xType={ScaleType.number}
-      yType={ScaleType.number}
+      xType={ScaleType.NUMBER}
+      yType={ScaleType.NUMBER}
     >
       <SimpleDataGraphic let:config let:xScale let:yScale let:mouseoverValue>
         <WithBisector

--- a/web-common/src/components/column-profile/column-types/details/NumericPlot.svelte
+++ b/web-common/src/components/column-profile/column-types/details/NumericPlot.svelte
@@ -36,6 +36,7 @@ Otherwise, the page will jump around as the data is fetched.
   import SummaryNumberPlot from "./SummaryNumberPlot.svelte";
   import TopK from "./TopK.svelte";
   import type { NumericPlotPoint } from "@rilldata/web-common/components/data-graphic/functional-components/types";
+  import { ScaleType } from "@rilldata/web-common/components/data-graphic/state/types";
 
   export let data: NumericHistogramBinsBin[];
   export let rug: NumericOutliersOutlier[];
@@ -106,8 +107,8 @@ Otherwise, the page will jump around as the data is fetched.
       bottom={0}
       bodyBuffer={0}
       marginBuffer={0}
-      xType="number"
-      yType="number"
+      xType={ScaleType.number}
+      yType={ScaleType.number}
     >
       <SimpleDataGraphic let:config let:xScale let:yScale let:mouseoverValue>
         <WithBisector

--- a/web-common/src/components/column-profile/column-types/sparks/NumericSpark.svelte
+++ b/web-common/src/components/column-profile/column-types/sparks/NumericSpark.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import SimpleDataGraphic from "@rilldata/web-common/components/data-graphic/elements/SimpleDataGraphic.svelte";
   import { HistogramPrimitive } from "@rilldata/web-common/components/data-graphic/marks";
-  import { ScaleType } from "@rilldata/web-common/components/data-graphic/state/types";
+  import { ScaleType } from "@rilldata/web-common/components/data-graphic/state";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { COLUMN_PROFILE_CONFIG } from "@rilldata/web-common/layout/config";
@@ -19,8 +19,8 @@
 {#if data}
   <Tooltip location="right" alignment="center" distance={8}>
     <SimpleDataGraphic
-      xType={ScaleType.number}
-      yType={ScaleType.number}
+      xType={ScaleType.NUMBER}
+      yType={ScaleType.NUMBER}
       yMin={0}
       width={summaryWidthSize}
       height={18}

--- a/web-common/src/components/column-profile/column-types/sparks/NumericSpark.svelte
+++ b/web-common/src/components/column-profile/column-types/sparks/NumericSpark.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import SimpleDataGraphic from "@rilldata/web-common/components/data-graphic/elements/SimpleDataGraphic.svelte";
   import { HistogramPrimitive } from "@rilldata/web-common/components/data-graphic/marks";
+  import { ScaleType } from "@rilldata/web-common/components/data-graphic/state/types";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { COLUMN_PROFILE_CONFIG } from "@rilldata/web-common/layout/config";
@@ -18,8 +19,8 @@
 {#if data}
   <Tooltip location="right" alignment="center" distance={8}>
     <SimpleDataGraphic
-      xType="number"
-      yType="number"
+      xType={ScaleType.number}
+      yType={ScaleType.number}
       yMin={0}
       width={summaryWidthSize}
       height={18}

--- a/web-common/src/components/column-profile/column-types/sparks/TimestampSpark.svelte
+++ b/web-common/src/components/column-profile/column-types/sparks/TimestampSpark.svelte
@@ -13,7 +13,7 @@
     Area,
     Line,
   } from "@rilldata/web-common/components/data-graphic/marks";
-  import { ScaleType } from "@rilldata/web-common/components/data-graphic/state/types";
+  import { ScaleType } from "@rilldata/web-common/components/data-graphic/state";
 
   export let width = undefined;
   export let height = undefined;
@@ -31,8 +31,8 @@
 {#if data?.length}
   <WithParentClientRect let:rect>
     <SimpleDataGraphic
-      xType={ScaleType.date}
-      yType={ScaleType.number}
+      xType={ScaleType.DATE}
+      yType={ScaleType.NUMBER}
       width={width || rect?.width || 400}
       height={height || rect?.height}
       {bottom}

--- a/web-common/src/components/column-profile/column-types/sparks/TimestampSpark.svelte
+++ b/web-common/src/components/column-profile/column-types/sparks/TimestampSpark.svelte
@@ -13,6 +13,7 @@
     Area,
     Line,
   } from "@rilldata/web-common/components/data-graphic/marks";
+  import { ScaleType } from "@rilldata/web-common/components/data-graphic/state/types";
 
   export let width = undefined;
   export let height = undefined;
@@ -30,8 +31,8 @@
 {#if data?.length}
   <WithParentClientRect let:rect>
     <SimpleDataGraphic
-      xType="date"
-      yType="number"
+      xType={ScaleType.date}
+      yType={ScaleType.number}
       width={width || rect?.width || 400}
       height={height || rect?.height}
       {bottom}

--- a/web-common/src/components/data-graphic/actions/scrub-action-factory.ts
+++ b/web-common/src/components/data-graphic/actions/scrub-action-factory.ts
@@ -17,7 +17,7 @@
  */
 
 import { get, writable } from "svelte/store";
-import { DEFAULT_COORDINATES } from "../constants";
+import { DEFAULT_NUMBER_COORDINATES } from "../constants";
 
 /** converts an event to a simplified object
  * with only the needed properties
@@ -111,8 +111,8 @@ export function createScrubAction({
   moveEventName = undefined,
 }: ScrubActionFactoryArguments) {
   const coordinates = writable({
-    start: DEFAULT_COORDINATES,
-    stop: DEFAULT_COORDINATES,
+    start: DEFAULT_NUMBER_COORDINATES,
+    stop: DEFAULT_NUMBER_COORDINATES,
   });
 
   /** local plot bound state */
@@ -148,8 +148,8 @@ export function createScrubAction({
     scrubAction(node: Node): ScrubAction {
       function reset() {
         coordinates.set({
-          start: DEFAULT_COORDINATES,
-          stop: DEFAULT_COORDINATES,
+          start: DEFAULT_NUMBER_COORDINATES,
+          stop: DEFAULT_NUMBER_COORDINATES,
         });
         isScrubbing.set(false);
       }
@@ -163,7 +163,7 @@ export function createScrubAction({
         node.addEventListener(moveEvent, onScrub);
         coordinates.set({
           start: setCoordinateBounds(event),
-          stop: DEFAULT_COORDINATES,
+          stop: DEFAULT_NUMBER_COORDINATES,
         });
         isScrubbing.set(true);
         if (startEventName) {

--- a/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampSpark.svelte
+++ b/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampSpark.svelte
@@ -11,7 +11,7 @@
    */
   import { SimpleDataGraphic } from "../../elements";
   import { Area, Line } from "../../marks";
-  import { ScaleType } from "../../state/types";
+  import { ScaleType } from "../../state";
 
   export let data;
 
@@ -71,8 +71,8 @@
 
 {#if data.length}
   <SimpleDataGraphic
-    xType={ScaleType.date}
-    yType={ScaleType.number}
+    xType={ScaleType.DATE}
+    yType={ScaleType.NUMBER}
     {width}
     {height}
     yMin={0}

--- a/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampSpark.svelte
+++ b/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampSpark.svelte
@@ -11,6 +11,7 @@
    */
   import { SimpleDataGraphic } from "../../elements";
   import { Area, Line } from "../../marks";
+  import { ScaleType } from "../../state/types";
 
   export let data;
 
@@ -70,8 +71,8 @@
 
 {#if data.length}
   <SimpleDataGraphic
-    xType="date"
-    yType="number"
+    xType={ScaleType.date}
+    yType={ScaleType.number}
     {width}
     {height}
     yMin={0}

--- a/web-common/src/components/data-graphic/constants/index.ts
+++ b/web-common/src/components/data-graphic/constants/index.ts
@@ -5,6 +5,11 @@ export const DEFAULT_COORDINATES: DomainCoordinates = {
   y: undefined,
 };
 
+export const DEFAULT_NUMBER_COORDINATES: DomainCoordinates<number> = {
+  x: undefined,
+  y: undefined,
+};
+
 export const contexts = {
   config: "rill:data-graphic:plot-config",
   scale(namespace: string) {

--- a/web-common/src/components/data-graphic/constants/types.d.ts
+++ b/web-common/src/components/data-graphic/constants/types.d.ts
@@ -1,4 +1,4 @@
 export interface DomainCoordinates {
-  x?: number;
+  x?: number | Date;
   y?: number;
 }

--- a/web-common/src/components/data-graphic/constants/types.d.ts
+++ b/web-common/src/components/data-graphic/constants/types.d.ts
@@ -1,4 +1,4 @@
-export interface DomainCoordinates {
-  x?: number | Date;
+export interface DomainCoordinates<T extends number | Date = number | Date> {
+  x?: T;
   y?: number;
 }

--- a/web-common/src/components/data-graphic/elements/GraphicContext.svelte
+++ b/web-common/src/components/data-graphic/elements/GraphicContext.svelte
@@ -10,17 +10,17 @@ for any of its children.
   import { getContext, hasContext, onMount } from "svelte";
   import { contexts } from "../constants";
   import {
+    ScaleType,
     cascadingContextStore,
     initializeMaxMinStores,
     initializeScale,
     pruneProps,
   } from "../state";
-  import {
+  import type {
     ExtremumResolutionStore,
-    ScaleType,
     SimpleDataGraphicConfiguration,
     SimpleDataGraphicConfigurationArguments,
-  } from "../state/types";
+  } from "@rilldata/web-common/components/data-graphic/state/types";
 
   export let width: number | undefined = undefined;
   export let height: number | undefined = undefined;
@@ -35,8 +35,8 @@ for any of its children.
   export let bodyBuffer: number | undefined = undefined;
   export let marginBuffer: number | undefined = undefined;
 
-  export let xType: ScaleType = ScaleType.date;
-  export let yType: ScaleType = ScaleType.number;
+  export let xType: ScaleType = ScaleType.DATE;
+  export let yType: ScaleType = ScaleType.NUMBER;
 
   export let xMin: number | undefined | Date = undefined;
   export let xMax: number | undefined | Date = undefined;

--- a/web-common/src/components/data-graphic/elements/GraphicContext.svelte
+++ b/web-common/src/components/data-graphic/elements/GraphicContext.svelte
@@ -15,8 +15,9 @@ for any of its children.
     initializeScale,
     pruneProps,
   } from "../state";
-  import type {
+  import {
     ExtremumResolutionStore,
+    ScaleType,
     SimpleDataGraphicConfiguration,
     SimpleDataGraphicConfigurationArguments,
   } from "../state/types";
@@ -34,8 +35,8 @@ for any of its children.
   export let bodyBuffer: number | undefined = undefined;
   export let marginBuffer: number | undefined = undefined;
 
-  export let xType: "number" | "date" = "date";
-  export let yType: "number" | "date" = "number";
+  export let xType: ScaleType = ScaleType.date;
+  export let yType: ScaleType = ScaleType.number;
 
   export let xMin: number | undefined | Date = undefined;
   export let xMax: number | undefined | Date = undefined;

--- a/web-common/src/components/data-graphic/elements/GraphicContext.svelte
+++ b/web-common/src/components/data-graphic/elements/GraphicContext.svelte
@@ -34,8 +34,8 @@ for any of its children.
   export let bodyBuffer: number | undefined = undefined;
   export let marginBuffer: number | undefined = undefined;
 
-  export let xType: string | undefined = undefined;
-  export let yType: string | undefined = undefined;
+  export let xType: "number" | "date" = "date";
+  export let yType: "number" | "date" = "number";
 
   export let xMin: number | undefined | Date = undefined;
   export let xMax: number | undefined | Date = undefined;
@@ -94,7 +94,12 @@ for any of its children.
       marginBuffer,
       id,
     }),
-  };
+    // FIXME: this cast is not provably safe,
+    // but we've been treating this as if it's true
+    // for at least 19 months, so hopefully it's safe enough.
+    // In any case, this cascading context store approach is
+    // ridiculously over engineered and needs to be rethought
+  } as SimpleDataGraphicConfigurationArguments;
 
   $: parameters = {
     ...DEFAULTS,
@@ -118,7 +123,12 @@ for any of its children.
       id,
       devicePixelRatio,
     }),
-  };
+    // FIXME: this cast is not provably safe,
+    // but we've been treating this as if it's true
+    // for at least 19 months, so hopefully it's safe enough.
+    // In any case, this cascading context store approach is
+    // ridiculously over engineered and needs to be rethought
+  } as SimpleDataGraphicConfigurationArguments;
 
   const config = cascadingContextStore<
     SimpleDataGraphicConfigurationArguments,

--- a/web-common/src/components/data-graphic/elements/GraphicContext.svelte
+++ b/web-common/src/components/data-graphic/elements/GraphicContext.svelte
@@ -73,6 +73,7 @@ for any of its children.
         marginBuffer: 4,
         devicePixelRatio,
       };
+
   let parameters = {
     ...DEFAULTS,
     ...pruneProps({
@@ -95,12 +96,7 @@ for any of its children.
       marginBuffer,
       id,
     }),
-    // FIXME: this cast is not provably safe,
-    // but we've been treating this as if it's true
-    // for at least 19 months, so hopefully it's safe enough.
-    // In any case, this cascading context store approach is
-    // ridiculously over engineered and needs to be rethought
-  } as SimpleDataGraphicConfigurationArguments;
+  };
 
   $: parameters = {
     ...DEFAULTS,
@@ -124,12 +120,7 @@ for any of its children.
       id,
       devicePixelRatio,
     }),
-    // FIXME: this cast is not provably safe,
-    // but we've been treating this as if it's true
-    // for at least 19 months, so hopefully it's safe enough.
-    // In any case, this cascading context store approach is
-    // ridiculously over engineered and needs to be rethought
-  } as SimpleDataGraphicConfigurationArguments;
+  };
 
   const config = cascadingContextStore<
     SimpleDataGraphicConfigurationArguments,

--- a/web-common/src/components/data-graphic/elements/SimpleDataGraphic.svelte
+++ b/web-common/src/components/data-graphic/elements/SimpleDataGraphic.svelte
@@ -15,15 +15,15 @@ A simple composable container for SVG-based data graphics.
   export let height: number | undefined = undefined;
   export let fontSize: number | undefined = undefined;
   export let textGap: number | undefined = undefined;
-  export let xType: string | undefined = undefined;
-  export let yType: string | undefined = undefined;
+  export let xType: "number" | "date" = "date";
+  export let yType: "number" | "date" = "number";
 
   export let overflowHidden = true;
 
-  export let xMin: number | undefined = undefined;
-  export let xMax: number | undefined = undefined;
-  export let yMin: number | undefined = undefined;
-  export let yMax: number | undefined = undefined;
+  export let xMin: number | Date | undefined = undefined;
+  export let xMax: number | Date | undefined = undefined;
+  export let yMin: number | Date | undefined = undefined;
+  export let yMax: number | Date | undefined = undefined;
 
   export let xMinTweenProps = { duration: 0 };
   export let xMaxTweenProps = { duration: 0 };
@@ -34,7 +34,7 @@ A simple composable container for SVG-based data graphics.
   export let shareYScale = true;
 
   export let mouseoverValue: DomainCoordinates | undefined = undefined;
-  export let hovered = undefined;
+  export let hovered = false;
 
   /** this makes a wide variety of normal events, such as on:click, available
    * to the consumer

--- a/web-common/src/components/data-graphic/elements/SimpleDataGraphic.svelte
+++ b/web-common/src/components/data-graphic/elements/SimpleDataGraphic.svelte
@@ -3,7 +3,7 @@ A simple composable container for SVG-based data graphics.
 -->
 <script lang="ts">
   import type { DomainCoordinates } from "../constants/types";
-  import { ScaleType } from "../state/types";
+  import { ScaleType } from "../state";
   import { GraphicContext, SimpleSVGContainer } from "./index";
 
   export let top: number | undefined = undefined;
@@ -16,8 +16,8 @@ A simple composable container for SVG-based data graphics.
   export let height: number | undefined = undefined;
   export let fontSize: number | undefined = undefined;
   export let textGap: number | undefined = undefined;
-  export let xType: ScaleType = ScaleType.date;
-  export let yType: ScaleType = ScaleType.number;
+  export let xType: ScaleType = ScaleType.DATE;
+  export let yType: ScaleType = ScaleType.NUMBER;
 
   export let overflowHidden = true;
 

--- a/web-common/src/components/data-graphic/elements/SimpleDataGraphic.svelte
+++ b/web-common/src/components/data-graphic/elements/SimpleDataGraphic.svelte
@@ -3,6 +3,7 @@ A simple composable container for SVG-based data graphics.
 -->
 <script lang="ts">
   import type { DomainCoordinates } from "../constants/types";
+  import { ScaleType } from "../state/types";
   import { GraphicContext, SimpleSVGContainer } from "./index";
 
   export let top: number | undefined = undefined;
@@ -15,8 +16,8 @@ A simple composable container for SVG-based data graphics.
   export let height: number | undefined = undefined;
   export let fontSize: number | undefined = undefined;
   export let textGap: number | undefined = undefined;
-  export let xType: "number" | "date" = "date";
-  export let yType: "number" | "date" = "number";
+  export let xType: ScaleType = ScaleType.date;
+  export let yType: ScaleType = ScaleType.number;
 
   export let overflowHidden = true;
 

--- a/web-common/src/components/data-graphic/elements/SimpleSVGContainer.svelte
+++ b/web-common/src/components/data-graphic/elements/SimpleSVGContainer.svelte
@@ -40,7 +40,7 @@ to the props.
   });
 
   export let mouseoverValue: DomainCoordinates | undefined = undefined;
-  export let hovered: boolean | undefined = undefined;
+  export let hovered: boolean = false;
   export let overflowHidden = true;
 
   $: mouseoverValue = $coordinates;

--- a/web-common/src/components/data-graphic/guides/Axis.svelte
+++ b/web-common/src/components/data-graphic/guides/Axis.svelte
@@ -143,12 +143,7 @@ This component will draw an axis on the specified side.
     if (xOrY === "x") axisLength = $plotConfig.graphicWidth;
     else axisLength = $plotConfig.graphicHeight;
 
-    ticks = getTicks(
-      xOrY,
-      scale,
-      axisLength,
-      $plotConfig[`${xOrY}Type`] === "date",
-    );
+    ticks = getTicks(xOrY, scale, axisLength, $plotConfig[`${xOrY}Type`]);
   }
 
   let formatterFunction;

--- a/web-common/src/components/data-graphic/guides/Grid.svelte
+++ b/web-common/src/components/data-graphic/guides/Grid.svelte
@@ -6,11 +6,7 @@
   import { contexts } from "../constants";
   import { getTicks } from "../utils";
 
-  import {
-    ScaleType,
-    type ScaleStore,
-    type SimpleConfigurationStore,
-  } from "../state/types";
+  import type { ScaleStore, SimpleConfigurationStore } from "../state/types";
 
   const xScale = getContext(contexts.scale("x")) as ScaleStore;
   const yScale = getContext(contexts.scale("y")) as ScaleStore;
@@ -32,19 +28,9 @@
   let yTicks = [];
 
   $: if ($config) {
-    xTicks = getTicks(
-      "x",
-      $xScale,
-      $config.graphicWidth,
-      $config[`xType`] === ScaleType.date,
-    );
+    xTicks = getTicks("x", $xScale, $config.graphicWidth, $config[`xType`]);
 
-    yTicks = getTicks(
-      "y",
-      $yScale,
-      $config.graphicHeight,
-      $config[`yType`] === ScaleType.date,
-    );
+    yTicks = getTicks("y", $yScale, $config.graphicHeight, $config[`yType`]);
   }
 </script>
 

--- a/web-common/src/components/data-graphic/guides/Grid.svelte
+++ b/web-common/src/components/data-graphic/guides/Grid.svelte
@@ -6,7 +6,11 @@
   import { contexts } from "../constants";
   import { getTicks } from "../utils";
 
-  import type { ScaleStore, SimpleConfigurationStore } from "../state/types";
+  import {
+    ScaleType,
+    type ScaleStore,
+    type SimpleConfigurationStore,
+  } from "../state/types";
 
   const xScale = getContext(contexts.scale("x")) as ScaleStore;
   const yScale = getContext(contexts.scale("y")) as ScaleStore;
@@ -32,14 +36,14 @@
       "x",
       $xScale,
       $config.graphicWidth,
-      $config[`xType`] === "date",
+      $config[`xType`] === ScaleType.date,
     );
 
     yTicks = getTicks(
       "y",
       $yScale,
       $config.graphicHeight,
-      $config[`yType`] === "date",
+      $config[`yType`] === ScaleType.date,
     );
   }
 </script>

--- a/web-common/src/components/data-graphic/marks/DelayedLabel.svelte
+++ b/web-common/src/components/data-graphic/marks/DelayedLabel.svelte
@@ -1,9 +1,9 @@
-<script>
+<script lang="ts">
   import { previousValueStore } from "@rilldata/web-common/lib/store-utils";
   import { onMount, onDestroy } from "svelte";
   import { writable } from "svelte/store";
 
-  export let value;
+  export let value: number;
   export let duration = 300;
   export let isDimension = false;
 

--- a/web-common/src/components/data-graphic/marks/types.ts
+++ b/web-common/src/components/data-graphic/marks/types.ts
@@ -1,7 +1,7 @@
 export interface Point {
   x: number;
   y: number;
-  value: string;
+  value?: string;
   label: string;
   key: string;
   valueColorClass?: string;

--- a/web-common/src/components/data-graphic/state/index.ts
+++ b/web-common/src/components/data-graphic/state/index.ts
@@ -1,2 +1,7 @@
 export { initializeMaxMinStores, initializeScale } from "./scale-stores";
 export { cascadingContextStore, pruneProps } from "./cascading-context-store";
+
+export enum ScaleType {
+  NUMBER = "number",
+  DATE = "date",
+}

--- a/web-common/src/components/data-graphic/state/types.d.ts
+++ b/web-common/src/components/data-graphic/state/types.d.ts
@@ -31,8 +31,8 @@ export interface SimpleDataGraphicConfigurationArguments {
   bottom: number;
   fontSize: number;
   textGap: number;
-  xType: string; // FIXME: we should have an enum here
-  yType: string; // FIXME: we should have an enum here
+  xType: "number" | "date";
+  yType: "number" | "date";
   xMin: number | Date;
   xMax: number | Date;
   yMin: number | Date;

--- a/web-common/src/components/data-graphic/state/types.d.ts
+++ b/web-common/src/components/data-graphic/state/types.d.ts
@@ -21,6 +21,11 @@ export interface ScaleStore extends Readable<GraphicScale> {
   type: string;
 }
 
+export enum ScaleType {
+  "number" = "number",
+  "date" = "date",
+}
+
 export interface SimpleDataGraphicConfigurationArguments {
   id: string;
   width: number;
@@ -31,8 +36,8 @@ export interface SimpleDataGraphicConfigurationArguments {
   bottom: number;
   fontSize: number;
   textGap: number;
-  xType: "number" | "date";
-  yType: "number" | "date";
+  xType: ScaleType;
+  yType: ScaleType;
   xMin: number | Date;
   xMax: number | Date;
   yMin: number | Date;

--- a/web-common/src/components/data-graphic/state/types.d.ts
+++ b/web-common/src/components/data-graphic/state/types.d.ts
@@ -21,11 +21,6 @@ export interface ScaleStore extends Readable<GraphicScale> {
   type: string;
 }
 
-export enum ScaleType {
-  "number" = "number",
-  "date" = "date",
-}
-
 export interface SimpleDataGraphicConfigurationArguments {
   id: string;
   width: number;

--- a/web-common/src/components/data-graphic/utils.ts
+++ b/web-common/src/components/data-graphic/utils.ts
@@ -11,6 +11,7 @@ import type {
   ScaleStore,
   SimpleConfigurationStore,
 } from "./state/types";
+import { ScaleType } from "./state";
 
 /**
  * Creates a string to be fed into the d attribute of a path,
@@ -123,8 +124,9 @@ export function getTicks(
   xOrY: string,
   scale: GraphicScale,
   axisLength: number,
-  isDate: boolean,
+  scaleType: ScaleType,
 ) {
+  const isDate = scaleType === ScaleType.DATE;
   const tickCount = Math.trunc(axisLength / (xOrY === "x" ? 100 : 50));
 
   let ticks = scale.ticks(tickCount);

--- a/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
@@ -10,7 +10,10 @@
   import { FormatPreset } from "@rilldata/web-common/lib/number-formatting/humanizer-types";
   import { formatMeasurePercentageDifference } from "@rilldata/web-common/lib/number-formatting/percentage-formatter";
   import { numberPartsToString } from "@rilldata/web-common/lib/number-formatting/utils/number-parts-utils";
-  import type { TimeComparisonOption } from "@rilldata/web-common/lib/time/types";
+  import type {
+    TimeComparisonOption,
+    TimeRangePreset,
+  } from "@rilldata/web-common/lib/time/types";
   import type { MetricsViewSpecMeasureV2 } from "@rilldata/web-common/runtime-client";
   import { createEventDispatcher } from "svelte";
   import {
@@ -24,13 +27,20 @@
 
   export let measure: MetricsViewSpecMeasureV2;
   export let value: number | null;
-  export let comparisonOption: TimeComparisonOption | undefined = undefined;
+  export let comparisonOption:
+    | TimeComparisonOption
+    | TimeRangePreset
+    | undefined = undefined;
   export let comparisonValue: number | undefined = undefined;
-  export let comparisonPercChange: number | undefined = undefined;
   export let showComparison = false;
   export let status: EntityStatus;
   export let withTimeseries = true;
   export let isMeasureExpanded = false;
+
+  $: comparisonPercChange =
+    comparisonValue && value !== undefined && value !== null
+      ? (value - comparisonValue) / comparisonValue
+      : undefined;
 
   const dispatch = createEventDispatcher();
 

--- a/web-common/src/features/dashboards/proto-state/fromProto.ts
+++ b/web-common/src/features/dashboards/proto-state/fromProto.ts
@@ -151,9 +151,8 @@ export function getDashboardStateFromProto(
   if (dashboard.pinIndex !== undefined) {
     entity.pinIndex = dashboard.pinIndex;
   }
-  if (dashboard.selectedTimezone) {
-    entity.selectedTimezone = dashboard.selectedTimezone;
-  }
+
+  entity.selectedTimezone = dashboard.selectedTimezone ?? "UTC";
 
   if (dashboard.allMeasuresVisible) {
     entity.allMeasuresVisible = true;

--- a/web-common/src/features/dashboards/proto-state/toProto.ts
+++ b/web-common/src/features/dashboards/proto-state/toProto.ts
@@ -91,9 +91,9 @@ export function getProtoFromDashboardState(
   if (metrics.selectedComparisonDimension) {
     state.comparisonDimension = metrics.selectedComparisonDimension;
   }
-  if (metrics.selectedTimezone) {
-    state.selectedTimezone = metrics.selectedTimezone;
-  }
+
+  state.selectedTimezone = metrics.selectedTimezone;
+
   if (metrics.leaderboardMeasureName) {
     state.leaderboardMeasure = metrics.leaderboardMeasureName;
   }

--- a/web-common/src/features/dashboards/stores/dashboard-store-defaults.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-store-defaults.ts
@@ -146,6 +146,7 @@ export function getDefaultMetricsExplorerEntity(
     leaderboardContextColumn: LeaderboardContextColumn.HIDDEN,
     dashboardSortType: SortType.VALUE,
     sortDirection: SortDirection.DESCENDING,
+    selectedTimezone: "UTC",
 
     showTimeComparison: false,
     dimensionSearchText: "",

--- a/web-common/src/features/dashboards/stores/dashboard-store-defaults.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-store-defaults.ts
@@ -43,7 +43,7 @@ export function setDefaultTimeRange(
     ...timeRange,
     interval: timeGrain.grain,
   };
-  metricsExplorer.selectedTimezone = timeZone;
+  metricsExplorer.selectedTimezone = timeZone ?? "UTC";
   // TODO: refactor all sub methods and call setSelectedScrubRange here
   metricsExplorer.selectedScrubRange = undefined;
   metricsExplorer.lastDefinedScrubRange = undefined;

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -333,7 +333,7 @@ const metricViewReducers = {
     });
   },
 
-  setExpandedMeasureName(name: string, measureName: string) {
+  setExpandedMeasureName(name: string, measureName: string | undefined) {
     updateMetricsExplorerByName(name, (metricsExplorer) => {
       metricsExplorer.expandedMeasureName = measureName;
 
@@ -402,7 +402,7 @@ const metricViewReducers = {
     });
   },
 
-  setSelectedScrubRange(name: string, scrubRange: ScrubRange) {
+  setSelectedScrubRange(name: string, scrubRange: ScrubRange | undefined) {
     updateMetricsExplorerByName(name, (metricsExplorer) => {
       setSelectedScrubRange(metricsExplorer, scrubRange);
     });
@@ -602,7 +602,7 @@ export function sortTypeForContextColumnType(
 
 function setSelectedScrubRange(
   metricsExplorer: MetricsExplorerEntity,
-  scrubRange: ScrubRange,
+  scrubRange: ScrubRange | undefined,
 ) {
   if (scrubRange === undefined) {
     metricsExplorer.lastDefinedScrubRange = undefined;

--- a/web-common/src/features/dashboards/stores/metrics-explorer-entity.ts
+++ b/web-common/src/features/dashboards/stores/metrics-explorer-entity.ts
@@ -114,11 +114,9 @@ export interface MetricsExplorerEntity {
   selectedComparisonDimension?: string;
 
   /**
-   * user selected timezone
-   *
-   * if this is undefined, use "UTC" as default
+   * user selected timezone, should default to "UTC" if no other value is set
    */
-  selectedTimezone?: string;
+  selectedTimezone: string;
 
   /**
    * Search text state for dimension tables. This search text state

--- a/web-common/src/features/dashboards/stores/metrics-explorer-entity.ts
+++ b/web-common/src/features/dashboards/stores/metrics-explorer-entity.ts
@@ -115,6 +115,8 @@ export interface MetricsExplorerEntity {
 
   /**
    * user selected timezone
+   *
+   * if this is undefined, use "UTC" as default
    */
   selectedTimezone?: string;
 

--- a/web-common/src/features/dashboards/time-controls/TimeControls.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeControls.svelte
@@ -71,10 +71,10 @@
      */
     if (
       !availableTimeZones?.length &&
-      $dashboardStore?.selectedTimezone !== "Etc/UTC"
+      $dashboardStore?.selectedTimezone !== "UTC"
     ) {
-      metricsExplorerStore.setTimeZone(metricViewName, "Etc/UTC");
-      localUserPreferences.set({ timeZone: "Etc/UTC" });
+      metricsExplorerStore.setTimeZone(metricViewName, "UTC");
+      localUserPreferences.set({ timeZone: "UTC" });
     }
 
     baseTimeRange ??= {

--- a/web-common/src/features/dashboards/time-controls/TimeControls.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeControls.svelte
@@ -203,7 +203,7 @@
         boundaryEnd={allTimeRange.end}
         showComparison={$timeControlsStore?.showComparison}
         selectedComparison={$timeControlsStore?.selectedComparisonTimeRange}
-        zone={$dashboardStore?.selectedTimezone || "UTC"}
+        zone={$dashboardStore.selectedTimezone}
       />
     {/if}
     <TimeGrainSelector

--- a/web-common/src/features/dashboards/time-controls/TimeControls.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeControls.svelte
@@ -203,7 +203,7 @@
         boundaryEnd={allTimeRange.end}
         showComparison={$timeControlsStore?.showComparison}
         selectedComparison={$timeControlsStore?.selectedComparisonTimeRange}
-        zone={$dashboardStore?.selectedTimezone}
+        zone={$dashboardStore?.selectedTimezone || "UTC"}
       />
     {/if}
     <TimeGrainSelector

--- a/web-common/src/features/dashboards/time-controls/TimeZoneSelector.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeZoneSelector.svelte
@@ -27,7 +27,7 @@
 
   const dispatch = createEventDispatcher();
   const userLocalIANA = getLocalIANA();
-  const UTCIana = "Etc/UTC";
+  const UTCIana = "UTC";
 
   $: dashboardStore = useDashboardStore(metricViewName);
   $: activeTimeZone = $dashboardStore?.selectedTimezone;

--- a/web-common/src/features/dashboards/time-dimension-details/TDDTable.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TDDTable.svelte
@@ -26,8 +26,8 @@
   export let excludeMode: boolean;
   export let sortDirection: boolean;
   export let sortType: SortType;
-  export let highlightedCol: number;
-  export let scrubPos: { start: number; end: number };
+  export let highlightedCol: number | undefined;
+  export let scrubPos: { start?: number; end?: number };
   export let pinIndex: number;
   export let comparing: TDDComparison;
   export let tableData: TableData;
@@ -83,6 +83,7 @@
 
     const isScrubbed =
       scrubPos?.start !== undefined &&
+      scrubPos?.end !== undefined &&
       data.x >= scrubPos.start &&
       data.x <= scrubPos.end - 1;
 

--- a/web-common/src/features/dashboards/time-dimension-details/types.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/types.ts
@@ -14,9 +14,9 @@ export interface HighlightedCell {
 }
 
 export interface ChartInteractionColumns {
-  hover: number;
-  scrubStart: number;
-  scrubEnd: number;
+  hover: number | undefined;
+  scrubStart: number | undefined;
+  scrubEnd: number | undefined;
 }
 
 export type TDDComparison = "time" | "none" | "dimension";

--- a/web-common/src/features/dashboards/time-series/ChartBody.svelte
+++ b/web-common/src/features/dashboards/time-series/ChartBody.svelte
@@ -20,7 +20,7 @@
   export let xMax: Date | undefined = undefined;
   export let yExtentMax: number | undefined = undefined;
   export let showComparison: boolean;
-  export let dimensionValue: string;
+  export let dimensionValue: string | undefined;
   export let isHovering: boolean;
   export let data;
   export let dimensionData: DimensionDataItem[] = [];
@@ -52,7 +52,7 @@
   let yMaxStore = writable(yExtentMax);
   let previousYMax = previousValueStore(yMaxStore);
 
-  $: yMaxStore.set(yExtentMax);
+  $: if (typeof yExtentMax === "number") yMaxStore.set(yExtentMax);
   const timeRangeKey = writable(`${xMin}-${xMax}`);
 
   const previousTimeRangeKey = previousValueStore(timeRangeKey);
@@ -71,7 +71,9 @@
   }
 
   $: delay =
-    $previousTimeRangeKey === $timeRangeKey && $previousYMax < yExtentMax
+    $previousTimeRangeKey === $timeRangeKey &&
+    yExtentMax &&
+    $previousYMax < yExtentMax
       ? 100
       : 0;
 </script>

--- a/web-common/src/features/dashboards/time-series/DimensionValueMouseover.svelte
+++ b/web-common/src/features/dashboards/time-series/DimensionValueMouseover.svelte
@@ -11,11 +11,11 @@
   export let dimensionData: DimensionDataItem[];
   export let dimensionValue: string | undefined;
   export let validPercTotal: number | null;
-  export let hovered: boolean | undefined;
+  export let hovered = false;
 
   $: x = point?.[xAccessor];
 
-  function truncate(str) {
+  function truncate(str: string) {
     if (!str?.length) return str;
 
     const truncateLength = 34;

--- a/web-common/src/features/dashboards/time-series/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureChart.svelte
@@ -26,10 +26,7 @@
   } from "../../../lib/time/types";
   import { getContext } from "svelte";
   import { contexts } from "@rilldata/web-common/components/data-graphic/constants";
-  import {
-    ScaleType,
-    type ScaleStore,
-  } from "@rilldata/web-common/components/data-graphic/state/types";
+  import type { ScaleStore } from "@rilldata/web-common/components/data-graphic/state/types";
   import { TIME_GRAIN } from "@rilldata/web-common/lib/time/config";
   import MeasureScrub from "./MeasureScrub.svelte";
   import ChartBody from "./ChartBody.svelte";
@@ -40,6 +37,7 @@
   import { createMeasureValueFormatter } from "@rilldata/web-common/lib/number-formatting/format-measure-value";
   import { numberKindForMeasure } from "@rilldata/web-common/lib/number-formatting/humanizer-types";
   import type { DomainCoordinates } from "@rilldata/web-common/components/data-graphic/constants/types";
+  import { ScaleType } from "@rilldata/web-common/components/data-graphic/state";
 
   export let measure: MetricsViewSpecMeasureV2;
   export let metricViewName: string;
@@ -230,8 +228,8 @@
     {width}
     xMaxTweenProps={tweenProps}
     xMinTweenProps={tweenProps}
-    xType={ScaleType.date}
-    yType={ScaleType.number}
+    xType={ScaleType.DATE}
+    yType={ScaleType.NUMBER}
     yMax={internalYMax}
     yMaxTweenProps={tweenProps}
     yMin={internalYMin}

--- a/web-common/src/features/dashboards/time-series/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureChart.svelte
@@ -36,15 +36,16 @@
   import type { DimensionDataItem } from "@rilldata/web-common/features/dashboards/time-series/multiple-dimension-queries";
   import { createMeasureValueFormatter } from "@rilldata/web-common/lib/number-formatting/format-measure-value";
   import { numberKindForMeasure } from "@rilldata/web-common/lib/number-formatting/humanizer-types";
+  import type { DomainCoordinates } from "@rilldata/web-common/components/data-graphic/constants/types";
 
   export let measure: MetricsViewSpecMeasureV2;
   export let metricViewName: string;
-  export let width: number = undefined;
-  export let height: number = undefined;
-  export let xMin: Date = undefined;
-  export let xMax: Date = undefined;
-  export let yMin: number = undefined;
-  export let yMax: number = undefined;
+  export let width: number | undefined = undefined;
+  export let height: number | undefined = undefined;
+  export let xMin: Date | undefined = undefined;
+  export let xMax: Date | undefined = undefined;
+  export let yMin: number | undefined = undefined;
+  export let yMax: number | undefined = undefined;
 
   export let timeGrain: V1TimeGrain;
   export let zone: string;
@@ -55,7 +56,7 @@
   export let xAccessor = "ts";
   export let labelAccessor = "label";
   export let yAccessor = "value";
-  export let mouseoverValue;
+  export let mouseoverValue: DomainCoordinates | undefined = undefined;
   export let validPercTotal: number | null = null;
 
   // control point for scrub functionality.
@@ -72,12 +73,14 @@
   const tweenProps = { duration: 400, easing: cubicOut };
   const xScale = getContext(contexts.scale("x")) as ScaleStore;
 
-  let hovered: boolean | undefined = false;
+  let hovered: boolean = false;
   let scrub;
   let cursorClass;
   let preventScrubReset;
 
-  $: hoveredTime = mouseoverValue?.x || $tableInteractionStore.time;
+  $: hoveredTime =
+    (mouseoverValue?.x instanceof Date && mouseoverValue?.x) ||
+    $tableInteractionStore.time;
 
   $: hasSubrangeSelected = Boolean(scrubStart && scrubEnd);
 
@@ -195,7 +198,13 @@
     if (!hasSubrangeSelected) return;
 
     const { start, end } = getOrderedStartEnd(scrubStart, scrubEnd);
-    if (mouseoverValue?.x < start || mouseoverValue?.x > end) resetScrub();
+
+    if (
+      mouseoverValue?.x &&
+      (mouseoverValue?.x < start || mouseoverValue?.x > end)
+    ) {
+      resetScrub();
+    }
   }
 </script>
 
@@ -232,7 +241,7 @@
         {data}
         {dimensionData}
         dimensionValue={$tableInteractionStore?.dimensionValue}
-        isHovering={hoveredTime}
+        isHovering={Boolean(hoveredTime)}
         {scrubEnd}
         {scrubStart}
         {showComparison}

--- a/web-common/src/features/dashboards/time-series/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureChart.svelte
@@ -26,7 +26,10 @@
   } from "../../../lib/time/types";
   import { getContext } from "svelte";
   import { contexts } from "@rilldata/web-common/components/data-graphic/constants";
-  import type { ScaleStore } from "@rilldata/web-common/components/data-graphic/state/types";
+  import {
+    ScaleType,
+    type ScaleStore,
+  } from "@rilldata/web-common/components/data-graphic/state/types";
   import { TIME_GRAIN } from "@rilldata/web-common/lib/time/config";
   import MeasureScrub from "./MeasureScrub.svelte";
   import ChartBody from "./ChartBody.svelte";
@@ -227,12 +230,12 @@
     {width}
     xMaxTweenProps={tweenProps}
     xMinTweenProps={tweenProps}
-    xType="date"
+    xType={ScaleType.date}
+    yType={ScaleType.number}
     yMax={internalYMax}
     yMaxTweenProps={tweenProps}
     yMin={internalYMin}
     yMinTweenProps={tweenProps}
-    yType="number"
   >
     <Axis {numberKind} side="right" />
     <Grid />

--- a/web-common/src/features/dashboards/time-series/MeasureScrub.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureScrub.svelte
@@ -31,7 +31,7 @@
   let justCreatedScrub = false;
   let moveStartDelta = 0;
   let moveEndDelta = 0;
-  let isResizing: "start" | "end" = undefined;
+  let isResizing: "start" | "end" | undefined = undefined;
   let isMovingScrub = false;
 
   const dispatch = createEventDispatcher();

--- a/web-common/src/features/dashboards/time-series/MeasureZoom.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureZoom.svelte
@@ -30,15 +30,20 @@
   }
 
   function zoomScrub() {
-    const { start, end } = getOrderedStartEnd(
-      $dashboardStore?.selectedScrubRange?.start,
-      $dashboardStore?.selectedScrubRange?.end,
-    );
-    metricsExplorerStore.setSelectedTimeRange(metricViewName, {
-      name: TimeRangePreset.CUSTOM,
-      start,
-      end,
-    });
+    if (
+      $dashboardStore?.selectedScrubRange?.start instanceof Date &&
+      $dashboardStore?.selectedScrubRange?.end instanceof Date
+    ) {
+      const { start, end } = getOrderedStartEnd(
+        $dashboardStore.selectedScrubRange.start,
+        $dashboardStore.selectedScrubRange.end,
+      );
+      metricsExplorerStore.setSelectedTimeRange(metricViewName, {
+        name: TimeRangePreset.CUSTOM,
+        start,
+        end,
+      });
+    }
   }
 </script>
 

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -280,7 +280,7 @@
             {metricViewName}
             data={formattedData}
             {dimensionData}
-            zone={$dashboardStore?.selectedTimezone}
+            zone={$dashboardStore.selectedTimezone}
             xAccessor="ts_position"
             labelAccessor="ts"
             timeGrain={interval}

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -29,6 +29,7 @@
   import MeasureZoom from "./MeasureZoom.svelte";
   import TimeSeriesChartContainer from "./TimeSeriesChartContainer.svelte";
   import type { DimensionDataItem } from "./multiple-dimension-queries";
+  import type { DomainCoordinates } from "@rilldata/web-common/components/data-graphic/constants/types";
 
   export let metricViewName;
   export let workspaceWidth: number;
@@ -70,18 +71,11 @@
   );
 
   // List of measures which will be shown on the dashboard
-  let renderedMeasures = [];
-  $: {
-    if (expandedMeasureName) {
-      renderedMeasures = $metricsView.data?.measures.filter(
-        (measure) => measure.name === expandedMeasureName,
-      );
-    } else {
-      renderedMeasures = $metricsView.data?.measures.filter(
-        (_, i) => $showHideMeasures.selectedItems[i],
-      );
-    }
-  }
+  $: renderedMeasures = $metricsView.data?.measures?.filter(
+    expandedMeasureName
+      ? (measure) => measure.name === expandedMeasureName
+      : (_, i) => $showHideMeasures.selectedItems[i],
+  );
 
   $: totals = $timeSeriesDataStore.total;
   $: totalsComparisons = $timeSeriesDataStore.comparisonTotal;
@@ -89,7 +83,7 @@
   let scrubStart;
   let scrubEnd;
 
-  let mouseoverValue = undefined;
+  let mouseoverValue: DomainCoordinates | undefined = undefined;
   let startValue: Date;
   let endValue: Date;
 
@@ -120,11 +114,11 @@
     // adjust scrub values for Javascript's timezone changes
     scrubStart = adjustOffsetForZone(
       $dashboardStore?.selectedScrubRange?.start,
-      $dashboardStore?.selectedTimezone,
+      $dashboardStore.selectedTimezone,
     );
     scrubEnd = adjustOffsetForZone(
       $dashboardStore?.selectedScrubRange?.end,
-      $dashboardStore?.selectedTimezone,
+      $dashboardStore.selectedTimezone,
     );
 
     const slicedData =
@@ -156,7 +150,7 @@
       $dashboardStore?.selectedTimezone,
       interval,
       $timeControlsStore.selectedTimeRange?.name,
-      $metricsView.data.defaultTimeRange,
+      $metricsView?.data?.defaultTimeRange,
     );
 
     startValue = adjustedChartValue?.start;
@@ -169,7 +163,7 @@
     $timeControlsStore.selectedTimeRange &&
     !isScrubbing
   ) {
-    if (!mouseoverValue?.x) {
+    if (!mouseoverValue?.x || !(mouseoverValue.x instanceof Date)) {
       chartInteractionColumn.update((state) => ({
         ...state,
         hover: undefined,
@@ -243,18 +237,18 @@
     {/if}
   </div>
   <!-- bignumbers and line charts -->
-  {#if renderedMeasures.length}
+  {#if renderedMeasures}
     <!-- FIXME: this is pending the remaining state work for show/hide measures and dimensions -->
     {#each renderedMeasures as measure (measure.name)}
       <!-- FIXME: I can't select the big number by the measure id. -->
       <!-- for bigNum, catch nulls and convert to undefined.  -->
+
       {@const bigNum = totals?.[measure.name] ?? undefined}
       {@const comparisonValue = totalsComparisons?.[measure.name]}
-      {@const isValidPercTotal = $isMeasureValidPercentOfTotal(measure.name)}
-      {@const comparisonPercChange =
-        comparisonValue && bigNum !== undefined && bigNum !== null
-          ? (bigNum - comparisonValue) / comparisonValue
-          : undefined}
+      {@const isValidPercTotal = measure.name
+        ? $isMeasureValidPercentOfTotal(measure.name)
+        : false}
+
       <MeasureBigNumber
         {measure}
         value={bigNum}
@@ -262,7 +256,6 @@
         {showComparison}
         comparisonOption={$timeControlsStore?.selectedComparisonTimeRange?.name}
         {comparisonValue}
-        {comparisonPercChange}
         status={$timeSeriesDataStore?.isFetching
           ? EntityStatus.Running
           : EntityStatus.Idle}

--- a/web-common/src/features/dashboards/time-series/TimeSeriesChartContainer.svelte
+++ b/web-common/src/features/dashboards/time-series/TimeSeriesChartContainer.svelte
@@ -4,6 +4,7 @@ A container GraphicContext for the time series in a metrics dashboard.
 <script lang="ts">
   import { GraphicContext } from "@rilldata/web-common/components/data-graphic/elements";
   import { MEASURE_CONFIG } from "../config";
+  import { ScaleType } from "@rilldata/web-common/components/data-graphic/state/types";
   export let start: Date;
   export let end: Date;
   export let workspaceWidth: number;
@@ -38,9 +39,9 @@ A container GraphicContext for the time series in a metrics dashboard.
     xMaxTweenProps={{ duration: 400 }}
     xMin={start}
     xMinTweenProps={{ duration: 400 }}
-    xType="date"
+    xType={ScaleType.date}
+    yType={ScaleType.number}
     yMin={0}
-    yType="number"
   >
     <slot />
   </GraphicContext>

--- a/web-common/src/features/dashboards/time-series/TimeSeriesChartContainer.svelte
+++ b/web-common/src/features/dashboards/time-series/TimeSeriesChartContainer.svelte
@@ -4,7 +4,7 @@ A container GraphicContext for the time series in a metrics dashboard.
 <script lang="ts">
   import { GraphicContext } from "@rilldata/web-common/components/data-graphic/elements";
   import { MEASURE_CONFIG } from "../config";
-  import { ScaleType } from "@rilldata/web-common/components/data-graphic/state/types";
+  import { ScaleType } from "@rilldata/web-common/components/data-graphic/state";
   export let start: Date;
   export let end: Date;
   export let workspaceWidth: number;
@@ -39,8 +39,8 @@ A container GraphicContext for the time series in a metrics dashboard.
     xMaxTweenProps={{ duration: 400 }}
     xMin={start}
     xMinTweenProps={{ duration: 400 }}
-    xType={ScaleType.date}
-    yType={ScaleType.number}
+    xType={ScaleType.DATE}
+    yType={ScaleType.NUMBER}
     yMin={0}
   >
     <slot />

--- a/web-common/src/features/dashboards/time-series/multiple-dimension-queries.ts
+++ b/web-common/src/features/dashboards/time-series/multiple-dimension-queries.ts
@@ -219,7 +219,7 @@ export function getDimensionValueTimeSeries(
       const end = timeStore?.adjustedEnd;
       const interval =
         timeStore?.selectedTimeRange?.interval ?? timeStore?.minTimeGrain;
-      const zone = dashboardStore?.selectedTimezone;
+      const zone = dashboardStore.selectedTimezone;
 
       const isValidMeasureList =
         measures?.length > 0 && measures?.every((m) => m !== undefined);

--- a/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
+++ b/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
@@ -182,7 +182,7 @@ export function createTimeSeriesDataStore(ctx: StateManagers) {
               primary?.data?.data,
               comparison?.data?.data,
               TIME_GRAIN[interval]?.duration,
-              dashboardStore.selectedTimezone || "Etc/UTC",
+              dashboardStore.selectedTimezone || "UTC",
             );
           }
           return {

--- a/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
+++ b/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
@@ -75,7 +75,7 @@ function createMetricsViewTimeSeries(
           timeGranularity:
             timeControls.selectedTimeRange?.interval ??
             timeControls.minTimeGrain,
-          timeZone: dashboardStore?.selectedTimezone,
+          timeZone: dashboardStore.selectedTimezone,
         },
         {
           query: {
@@ -182,7 +182,7 @@ export function createTimeSeriesDataStore(ctx: StateManagers) {
               primary?.data?.data,
               comparison?.data?.data,
               TIME_GRAIN[interval]?.duration,
-              dashboardStore.selectedTimezone || "UTC",
+              dashboardStore.selectedTimezone,
             );
           }
           return {

--- a/web-common/src/features/metrics-views/metrics-internal-store.ts
+++ b/web-common/src/features/metrics-views/metrics-internal-store.ts
@@ -57,7 +57,7 @@ dimensions:
     column: dimension1
     description: ""
 available_time_zones:
-  - "Etc/UTC"
+  - "UTC"
   - "America/Los_Angeles"
   - "America/New_York"
 `;

--- a/web-common/src/lib/store-utils/previous-value-store.ts
+++ b/web-common/src/lib/store-utils/previous-value-store.ts
@@ -1,20 +1,13 @@
-import { get, writable } from "svelte/store";
+import { Writable, get, writable } from "svelte/store";
 
-export function previousValueStore(anotherStore) {
+export function previousValueStore<T extends number | string>(
+  anotherStore: Writable<T>,
+): Writable<T> {
   let previousValue = get(anotherStore);
   const store = writable(previousValue);
   anotherStore.subscribe(($currentValue) => {
-    if (Array.isArray(previousValue)) {
-      store.set([...previousValue]);
-    } else if (typeof previousValue === "object" && previousValue !== null) {
-      store.set({ ...previousValue });
-    } else {
-      store.set(previousValue);
-    }
+    store.set(previousValue);
     previousValue = $currentValue;
   });
-  return {
-    subscribe: store.subscribe,
-    set: store.set,
-  };
+  return store;
 }

--- a/web-common/src/lib/time/ranges/index.spec.ts
+++ b/web-common/src/lib/time/ranges/index.spec.ts
@@ -7,7 +7,7 @@ const getAdjustedFetchTimeTestCases = [
     test: "should return adjusted dates for a complete period",
     start: new Date("2020-01-04T00:00:00.000Z"),
     end: new Date("2020-01-06T00:00:00.000Z"),
-    zone: "Etc/UTC",
+    zone: "UTC",
     interval: V1TimeGrain.TIME_GRAIN_DAY,
     expected: {
       start: "2020-01-03T00:00:00.000Z",
@@ -18,7 +18,7 @@ const getAdjustedFetchTimeTestCases = [
     test: "should return adjusted dates for an incomplete period",
     start: new Date("2020-01-10T00:00:00.000Z"),
     end: new Date("2020-02-08T00:00:00.000Z"),
-    zone: "Etc/UTC",
+    zone: "UTC",
     interval: V1TimeGrain.TIME_GRAIN_WEEK,
     expected: {
       start: "2019-12-30T00:00:00.000Z",

--- a/web-common/src/lib/time/ranges/index.ts
+++ b/web-common/src/lib/time/ranges/index.ts
@@ -369,8 +369,8 @@ export function getAdjustedFetchTime(
  * time series charts
  */
 export function getAdjustedChartTime(
-  start: Date,
-  end: Date,
+  start: Date | undefined,
+  end: Date | undefined,
   zone: string,
   interval: V1TimeGrain,
   timePreset: TimeRangePreset,

--- a/web-common/src/lib/time/ranges/iso-ranges.ts
+++ b/web-common/src/lib/time/ranges/iso-ranges.ts
@@ -25,7 +25,7 @@ import { Duration } from "luxon";
 export function isoDurationToTimeRange(
   isoDuration: string,
   anchor: Date,
-  zone = "Etc/UTC",
+  zone = "UTC",
 ) {
   const startTime = transformDate(
     anchor,
@@ -55,7 +55,7 @@ export function isoDurationToFullTimeRange(
   isoDuration: string | undefined,
   start: Date,
   end: Date,
-  zone = "Etc/UTC",
+  zone = "UTC",
 ): TimeRange {
   if (!isoDuration) {
     return convertTimeRangePreset(TimeRangePreset.ALL_TIME, start, end, zone);

--- a/web-common/src/lib/time/timezone/index.ts
+++ b/web-common/src/lib/time/timezone/index.ts
@@ -24,7 +24,7 @@ export function getLocalIANA(): string {
 }
 
 export function getUTCIANA(): string {
-  return "Etc/UTC";
+  return "UTC";
 }
 
 export function getTimeZoneNameFromIANA(now: Date, iana: string): string {

--- a/web-common/src/lib/time/transforms/index.ts
+++ b/web-common/src/lib/time/transforms/index.ts
@@ -27,7 +27,7 @@ export function getPresentTime() {
 export function getStartOfPeriod(
   referenceTime: Date,
   period: Period,
-  zone = "Etc/UTC",
+  zone = "UTC",
 ) {
   const date = DateTime.fromJSDate(referenceTime, { zone });
   return date.startOf(TimeUnit[period]).toJSDate();
@@ -37,7 +37,7 @@ export function getStartOfPeriod(
 export function getEndOfPeriod(
   referenceTime: Date,
   period: Period,
-  zone = "Etc/UTC",
+  zone = "UTC",
 ) {
   const date = DateTime.fromJSDate(referenceTime, { zone });
   return date.endOf(TimeUnit[period]).toJSDate();
@@ -48,7 +48,7 @@ export function getOffset(
   referenceTime: Date,
   duration: string,
   direction: TimeOffsetType,
-  zone = "Etc/UTC",
+  zone = "UTC",
 ) {
   const durationObj = Duration.fromISO(duration);
   return DateTime.fromJSDate(referenceTime, { zone })
@@ -69,7 +69,7 @@ export function getTimeWidth(start: Date, end: Date) {
 export function transformDate(
   referenceTime: Date,
   transformations: RelativeTimeTransformation[],
-  zone = "Etc/UTC",
+  zone = "UTC",
 ) {
   let absoluteTime = referenceTime;
   for (const transformation of transformations) {

--- a/web-common/vite.config.ts
+++ b/web-common/vite.config.ts
@@ -31,6 +31,11 @@ export default defineConfig(({ mode }) => {
   }
 
   return {
+    server: {
+      fs: {
+        cachedChecks: false,
+      },
+    },
     resolve: {
       alias,
     },

--- a/web-common/vite.config.ts
+++ b/web-common/vite.config.ts
@@ -31,11 +31,6 @@ export default defineConfig(({ mode }) => {
   }
 
   return {
-    server: {
-      fs: {
-        cachedChecks: false,
-      },
-    },
     resolve: {
       alias,
     },

--- a/web-local/src/routes/dev/data-graphic/components.svelte
+++ b/web-local/src/routes/dev/data-graphic/components.svelte
@@ -2,7 +2,6 @@
   import { SimpleDataGraphic } from "@rilldata/web-common/components/data-graphic/elements";
   import { Axis } from "@rilldata/web-common/components/data-graphic/guides";
   import type { AxisSide } from "@rilldata/web-common/components/data-graphic/guides/types";
-  import { ScaleType } from "@rilldata/web-common/components/data-graphic/state/types";
   const width = 132;
   const height = 132;
   const leftRight = 36;
@@ -19,8 +18,8 @@
       side=<i>"{axis}"</i>
       <div class="border border-gray-200 rounded">
         <SimpleDataGraphic
-          xType={ScaleType.date}
-          yType={ScaleType.date}
+          xType="number"
+          yType="number"
           {width}
           {height}
           left={leftRight}

--- a/web-local/src/routes/dev/data-graphic/components.svelte
+++ b/web-local/src/routes/dev/data-graphic/components.svelte
@@ -2,6 +2,7 @@
   import { SimpleDataGraphic } from "@rilldata/web-common/components/data-graphic/elements";
   import { Axis } from "@rilldata/web-common/components/data-graphic/guides";
   import type { AxisSide } from "@rilldata/web-common/components/data-graphic/guides/types";
+  import { ScaleType } from "@rilldata/web-common/components/data-graphic/state/types";
   const width = 132;
   const height = 132;
   const leftRight = 36;
@@ -18,8 +19,8 @@
       side=<i>"{axis}"</i>
       <div class="border border-gray-200 rounded">
         <SimpleDataGraphic
-          xType="number"
-          yType="number"
+          xType={ScaleType.date}
+          yType={ScaleType.date}
           {width}
           {height}
           left={leftRight}

--- a/web-local/tests/dashboards/dashboards.spec.ts
+++ b/web-local/tests/dashboards/dashboards.spec.ts
@@ -133,12 +133,10 @@ test.describe("dashboard", () => {
 
     // Change time zone to UTC
     await page.getByLabel("Timezone selector").click();
-    await page
-      .getByRole("menuitem", { name: "UTC GMT +00:00 Etc/UTC" })
-      .click();
+    await page.getByRole("menuitem", { name: "UTC GMT +00:00 UTC" }).click();
     // Wait for menu to close
     await expect(
-      page.getByRole("menuitem", { name: "UTC GMT +00:00 Etc/UTC" }),
+      page.getByRole("menuitem", { name: "UTC GMT +00:00 UTC" }),
     ).not.toBeVisible();
 
     await interactWithComparisonMenu(page, "No comparison", (l) =>


### PR DESCRIPTION
part of #3424, hopefully helps with #3989, but it's not clear what exactly is causing that error.

Note that per conversation with @djbarnwal we're updating `MetricsExplorerEntity.selectedTimezone` to
(a) be required, not optional)
(b) default to "UTC" if not specified, 
(c) use the value "UTC" in preference to "Etc/UTC" in all cases