### PR TITLE
Cloud UI: fix `rill sudo user open`

### DIFF
--- a/web-admin/src/features/authentication/AuthRedirect.svelte
+++ b/web-admin/src/features/authentication/AuthRedirect.svelte
@@ -3,16 +3,12 @@
   import { createAdminServiceGetCurrentUser } from "../../client";
   import { ADMIN_URL } from "../../client/http-client";
 
+  const user = createAdminServiceGetCurrentUser();
+
   // redirect to login if not logged in
-  const user = createAdminServiceGetCurrentUser({
-    query: {
-      onSuccess: (data) => {
-        if (!data.user) {
-          goto(`${ADMIN_URL}/auth/login?redirect=${window.origin}`);
-        }
-      },
-    },
-  });
+  $: if ($user.isSuccess && !$user.data.user) {
+    goto(`${ADMIN_URL}/auth/login?redirect=${window.origin}`);
+  }
 </script>
 
 {#if $user.data && $user.data.user}

--- a/web-admin/src/features/authentication/AvatarButton.svelte
+++ b/web-admin/src/features/authentication/AvatarButton.svelte
@@ -3,7 +3,6 @@
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
   import { createAdminServiceGetCurrentUser } from "../../client";
   import { ADMIN_URL } from "../../client/http-client";
-  import { LOCAL_STORAGE_ACTIVE_ORG_KEY } from "../organizations/activeOrg";
   import ProjectAccessControls from "../projects/ProjectAccessControls.svelte";
   import ViewAsUserPopover from "../view-as-user/ViewAsUserPopover.svelte";
 
@@ -21,9 +20,6 @@
   }
 
   function handleLogOut() {
-    // Clear user-specific items from localStorage
-    localStorage.removeItem(LOCAL_STORAGE_ACTIVE_ORG_KEY);
-
     // Create a login URL that redirects back to the current page
     const loginWithRedirect = `${ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`;
 

--- a/web-admin/src/features/navigation/Breadcrumbs.svelte
+++ b/web-admin/src/features/navigation/Breadcrumbs.svelte
@@ -14,7 +14,7 @@
     createAdminServiceListProjectsForOrganization,
   } from "../../client";
   import { useDashboards } from "../dashboards/listing/selectors";
-  import { LOCAL_STORAGE_ACTIVE_ORG_KEY } from "../organizations/activeOrg";
+  import { getActiveOrgLocalStorageKey } from "../organizations/active-org/local-storage";
   import { useReports } from "../scheduled-reports/selectors";
   import BreadcrumbItem from "./BreadcrumbItem.svelte";
   import OrganizationAvatar from "./OrganizationAvatar.svelte";
@@ -39,7 +39,10 @@
   });
   $: onOrganizationPage = isOrganizationPage($page);
   async function onOrgChange(org: string) {
-    localStorage.setItem(LOCAL_STORAGE_ACTIVE_ORG_KEY, org);
+    const activeOrgLocalStorageKey = getActiveOrgLocalStorageKey(
+      $user.data?.user?.id,
+    );
+    localStorage.setItem(activeOrgLocalStorageKey, org);
     await goto(`/${org}`);
   }
 

--- a/web-admin/src/features/organizations/active-org/OrganizationRedirect.svelte
+++ b/web-admin/src/features/organizations/active-org/OrganizationRedirect.svelte
@@ -1,14 +1,21 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
-  import { adminServiceListOrganizations } from "@rilldata/web-admin/client";
+  import {
+    adminServiceGetCurrentUser,
+    adminServiceListOrganizations,
+  } from "@rilldata/web-admin/client";
   import { onMount } from "svelte";
-  import { LOCAL_STORAGE_ACTIVE_ORG_KEY } from "./activeOrg";
+  import { getActiveOrgLocalStorageKey } from "./local-storage";
 
   let showWelcomeMessage = false;
 
   onMount(async () => {
+    // Get the activeOrg local storage key for the current user
+    const userId = (await adminServiceGetCurrentUser())?.user?.id;
+    const activeOrgLocalStorageKey = getActiveOrgLocalStorageKey(userId);
+
     // Scenario 1: User has an activeOrg in localStorage
-    const activeOrg = localStorage.getItem(LOCAL_STORAGE_ACTIVE_ORG_KEY);
+    const activeOrg = localStorage.getItem(activeOrgLocalStorageKey);
     if (activeOrg) {
       await goto(`/${activeOrg}`);
       return;
@@ -18,7 +25,7 @@
 
     // Scenario 2: User has no activeOrg in localStorage, but does belong to an org
     if (orgs.length > 0) {
-      localStorage.setItem(LOCAL_STORAGE_ACTIVE_ORG_KEY, orgs[0].name);
+      localStorage.setItem(activeOrgLocalStorageKey, orgs[0].name);
       await goto(`/${orgs[0].name}`);
       return;
     }

--- a/web-admin/src/features/organizations/active-org/local-storage.ts
+++ b/web-admin/src/features/organizations/active-org/local-storage.ts
@@ -1,0 +1,5 @@
+const ACTIVE_ORG_LOCAL_STORAGE_KEY_PREFIX = "activeOrg";
+
+export function getActiveOrgLocalStorageKey(userId: string) {
+  return `${ACTIVE_ORG_LOCAL_STORAGE_KEY_PREFIX}_${userId}`;
+}

--- a/web-admin/src/features/organizations/activeOrg.ts
+++ b/web-admin/src/features/organizations/activeOrg.ts
@@ -1,1 +1,0 @@
-export const LOCAL_STORAGE_ACTIVE_ORG_KEY = "activeOrg";

--- a/web-admin/src/routes/+page.svelte
+++ b/web-admin/src/routes/+page.svelte
@@ -2,7 +2,7 @@
   import { createAdminServiceGetCurrentUser } from "../client";
   import AuthRedirect from "../features/authentication/AuthRedirect.svelte";
   import WelcomeMessage from "../features/home/WelcomeMessage.svelte";
-  import OrganizationRedirect from "../features/organizations/OrganizationRedirect.svelte";
+  import OrganizationRedirect from "../features/organizations/active-org/OrganizationRedirect.svelte";
 
   const user = createAdminServiceGetCurrentUser();
 


### PR DESCRIPTION
PR https://github.com/rilldata/rill/pull/3787 introduced the concept of an "active" org to the Cloud UI. Navigation to the homepage will redirect to the active `/{org}` page. The active org is stored in local storage.

This PR stores the "active org" on a per-user basis: `activeOrg_{userID}`. This accounts for a bug  where `rill sudo user open` navigated to the wrong organization.

Closes https://github.com/rilldata/rill-private-issues/issues/133