### PR TITLE
Fix layout on `/-/auth/device` page

### DIFF
--- a/web-admin/src/routes/-/auth/device/+page.svelte
+++ b/web-admin/src/routes/-/auth/device/+page.svelte
@@ -3,6 +3,8 @@
   import { createAdminServiceGetCurrentUser } from "@rilldata/web-admin/client";
   import { ADMIN_URL } from "@rilldata/web-admin/client/http-client";
   import CtaButton from "@rilldata/web-common/components/calls-to-action/CTAButton.svelte";
+  import CtaContentContainer from "@rilldata/web-common/components/calls-to-action/CTAContentContainer.svelte";
+  import CtaLayoutContainer from "@rilldata/web-common/components/calls-to-action/CTALayoutContainer.svelte";
   import RillLogoSquareNegative from "@rilldata/web-common/components/icons/RillLogoSquareNegative.svelte";
 
   let actionTaken = false;
@@ -81,44 +83,46 @@
 </svelte:head>
 
 {#if $user.data && $user.data.user}
-  <div class="flex flex-col justify-center items-center h-4/5 gap-y-6">
-    <RillLogoSquareNegative size="84px" />
-    <h1 class="text-xl font-normal text-gray-800">Authorize Rill CLI</h1>
-    <p class="text-base text-gray-500 text-center">
-      You are authenticating into Rill as <span
-        class="font-medium text-gray-600">{$user.data.user.email}</span
-      >.<br />Please confirm this is the code displayed in the Rill CLI.
-    </p>
-    <div
-      class="px-2 py-1 rounded-sm text-4xl tracking-widest bg-gray-100 text-gray-700 mb-5 font-mono"
-    >
-      {userCode}
-    </div>
-
-    <div class="flex flex-col gap-y-4 w-[400px]">
-      <CtaButton
-        variant="primary"
-        on:click={() => {
-          actionTaken = true;
-          confirmUserCode();
-        }}
-        disabled={actionTaken}>Confirm code</CtaButton
+  <CtaLayoutContainer>
+    <CtaContentContainer>
+      <RillLogoSquareNegative size="84px" />
+      <h1 class="text-xl font-normal text-gray-800">Authorize Rill CLI</h1>
+      <p class="text-base text-gray-500 text-center">
+        You are authenticating into Rill as <span
+          class="font-medium text-gray-600">{$user.data.user.email}</span
+        >.<br />Please confirm this is the code displayed in the Rill CLI.
+      </p>
+      <div
+        class="px-2 py-1 rounded-sm text-4xl tracking-widest bg-gray-100 text-gray-700 mb-5 font-mono"
       >
-      <CtaButton
-        variant="secondary"
-        on:click={() => {
-          actionTaken = true;
-          rejectUserCode();
-        }}
-        disabled={actionTaken}>Cancel</CtaButton
-      >
-    </div>
+        {userCode}
+      </div>
 
-    {#if successMsg}
-      <p class="text-md text-green-700 font-bold mb-6">{successMsg}</p>
-    {/if}
-    {#if errorMsg}
-      <p class="text-md text-red-400 font-bold mb-6">{errorMsg}</p>
-    {/if}
-  </div>
+      <div class="flex flex-col gap-y-4 w-[400px]">
+        <CtaButton
+          variant="primary"
+          on:click={() => {
+            actionTaken = true;
+            confirmUserCode();
+          }}
+          disabled={actionTaken}>Confirm code</CtaButton
+        >
+        <CtaButton
+          variant="secondary"
+          on:click={() => {
+            actionTaken = true;
+            rejectUserCode();
+          }}
+          disabled={actionTaken}>Cancel</CtaButton
+        >
+      </div>
+
+      {#if successMsg}
+        <p class="text-md text-green-700 font-bold mb-6">{successMsg}</p>
+      {/if}
+      {#if errorMsg}
+        <p class="text-md text-red-400 font-bold mb-6">{errorMsg}</p>
+      {/if}
+    </CtaContentContainer>
+  </CtaLayoutContainer>
 {/if}


### PR DESCRIPTION
This page wasn't correctly wrapped in our "CTA" components.

Before:
![image](https://github.com/rilldata/rill/assets/14206386/3bce0ab7-5ece-479f-aff9-3e223469ffb6)

After:
![image](https://github.com/rilldata/rill/assets/14206386/82ef1ec4-ac84-4bfe-9488-eac3a3512009)
