### PR TITLE
Fix: Add label for empty string in column header

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotExpandableCell.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotExpandableCell.svelte
@@ -26,7 +26,7 @@
   {#if value === "LOADING_CELL"}
     {""}
   {:else if value === ""}
-    {"<empty string>"}
+    {"\u00A0"}
   {:else}
     {value}
   {/if}

--- a/web-common/src/features/dashboards/pivot/PivotExpandableCell.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotExpandableCell.svelte
@@ -22,7 +22,14 @@
       </div>
     </button>
   {/if}
-  {value === "LOADING_CELL" ? "" : value}
+
+  {#if value === "LOADING_CELL"}
+    {""}
+  {:else if value === ""}
+    {"<empty string>"}
+  {:else}
+    {value}
+  {/if}
 </div>
 
 <style lang="postcss">

--- a/web-common/src/features/dashboards/pivot/pivot-column-definition.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-column-definition.ts
@@ -96,6 +96,10 @@ function createColumnDefinitionForDimensions(
           [dimensionNames[level]]: value,
         });
 
+        if (displayValue === "") {
+          displayValue = "<empty string>";
+        }
+
         return {
           header: displayValue,
           columns: nestedColumns,

--- a/web-common/src/features/dashboards/pivot/pivot-column-definition.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-column-definition.ts
@@ -97,7 +97,7 @@ function createColumnDefinitionForDimensions(
         });
 
         if (displayValue === "") {
-          displayValue = "<empty string>";
+          displayValue = "\u00A0";
         }
 
         return {


### PR DESCRIPTION
If one of the values of a dimension is "" (empty string), the app would crash. This PR adds a label `<empty string>` for such cases. 