### PR TITLE
Enable fetching state for larger dashboards

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-data-store.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-data-store.ts
@@ -240,8 +240,11 @@ function createPivotDataStore(ctx: StateManagers): PivotDataStore {
       (!rowDimensionNames.length && !measureNames.length) ||
       (colDimensionNames.length && !measureNames.length)
     ) {
+      const isFetching =
+        config.pivot.columns.measure.length > 0 ||
+        config.pivot.rows.dimension.length > 0;
       return configSet({
-        isFetching: false,
+        isFetching: isFetching,
         data: [],
         columnDef: [],
         assembled: false,


### PR DESCRIPTION
For dashboards of larger size, it might be a few seconds until we have data from `metricsView` query. `getPivotConfig` returns an empty config until then.

For those cases, we want to show a spinner as well.