### PR TITLE
Send all relevant measures to dimension display query

### DIFF
--- a/web-common/src/features/dashboards/state-managers/selectors/dashboard-queries.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/dashboard-queries.ts
@@ -1,7 +1,6 @@
 import type { ResolvedMeasureFilter } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
 import { additionalMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measure-filters";
 import { sanitiseExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import type {
   QueryServiceMetricsViewComparisonBody,
   QueryServiceMetricsViewTotalsBody,

--- a/web-common/src/features/dashboards/state-managers/selectors/dashboard-queries.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/dashboard-queries.ts
@@ -1,6 +1,7 @@
 import type { ResolvedMeasureFilter } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
 import { additionalMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measure-filters";
 import { sanitiseExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
+import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import type {
   QueryServiceMetricsViewComparisonBody,
   QueryServiceMetricsViewTotalsBody,
@@ -43,7 +44,7 @@ export function dimensionTableSortedQueryBody(
 
     return prepareSortedQueryBody(
       dimensionName,
-      selectedMeasureNames(dashData),
+      measuresForDimensionTable(dashData),
       timeControlsState(dashData),
       sortingSelectors.sortMeasure(dashData),
       sortingSelectors.sortType(dashData),
@@ -52,6 +53,14 @@ export function dimensionTableSortedQueryBody(
       resolvedMeasureFilter.filter,
     );
   };
+}
+
+function measuresForDimensionTable(dashData: DashboardDataSources) {
+  const allMeasures = new Set([
+    ...selectedMeasureNames(dashData),
+    ...additionalMeasures(dashData),
+  ]);
+  return [...allMeasures];
 }
 
 export function dimensionTableTotalQueryBody(


### PR DESCRIPTION
Not a 100% sure when this broke, but if we have a measure hidden but it is selected as the leaderboard measure dimension display breaks. This is because we call sort on the selected leaderboard measure without actually selecting it in the query.

Sending all relevant measures to the query so that the app doesnt crash.