### PR TITLE
Remove pivot field filtering based on dashboard visibility

### DIFF
--- a/web-common/src/features/dashboards/state-managers/selectors/pivot.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/pivot.ts
@@ -6,10 +6,7 @@ export const pivotSelectors = {
   rows: ({ dashboard }: DashboardDataSources) => dashboard.pivot.rows,
   columns: ({ dashboard }: DashboardDataSources) => dashboard.pivot.columns,
   measures: ({ metricsSpecQueryResult, dashboard }: DashboardDataSources) => {
-    const measures =
-      metricsSpecQueryResult.data?.measures?.filter(
-        (d) => d.name && dashboard.visibleMeasureKeys.has(d.name),
-      ) ?? [];
+    const measures = metricsSpecQueryResult.data?.measures ?? [];
     const columns = dashboard.pivot.columns;
 
     return measures
@@ -22,10 +19,8 @@ export const pivotSelectors = {
   },
   dimensions: ({ metricsSpecQueryResult, dashboard }: DashboardDataSources) => {
     {
-      const dimensions =
-        metricsSpecQueryResult.data?.dimensions?.filter(
-          (d) => d.name && dashboard.visibleDimensionKeys.has(d.name),
-        ) ?? [];
+      const dimensions = metricsSpecQueryResult.data?.dimensions ?? [];
+
       const columns = dashboard.pivot.columns;
       const rows = dashboard.pivot.rows;
 


### PR DESCRIPTION
This PR removes the filtering of the measures and dimensions based on the visibility in the dashboard.