### PR TITLE
Filter time grain options in pivot sidebar based on table state

### DIFF
--- a/web-common/src/features/dashboards/pivot/DragList.svelte
+++ b/web-common/src/features/dashboards/pivot/DragList.svelte
@@ -29,7 +29,7 @@
 </script>
 
 <div
-  class="flex flex-col gap-y-2 py-2 rounded-sm text-gray-500 w-full"
+  class="flex flex-col gap-y-2 py-2 rounded-sm text-gray-500 w-full max-w-full"
   class:horizontal
   use:dndzone={{ items, flipDurationMs }}
   on:consider={handleConsider}
@@ -61,7 +61,7 @@
   }
 
   .horizontal {
-    @apply flex flex-row bg-slate-50 w-full p-2 gap-x-2 h-10;
+    @apply flex flex-row flex-wrap bg-slate-50 w-full p-2 gap-x-2 h-fit;
     @apply items-center;
   }
 

--- a/web-common/src/features/dashboards/pivot/PivotDrag.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotDrag.svelte
@@ -13,6 +13,8 @@
 
   $: visible = showMore ? items.length : 3;
 
+  $: visibleItems = items.slice(0, visible);
+
   function toggleCollapse() {
     collapsed = !collapsed;
   }
@@ -31,7 +33,11 @@
   </button>
 
   {#if !collapsed}
-    <DragList items={items.slice(0, visible)} />
+    {#if visibleItems.length}
+      <DragList items={visibleItems} />
+    {:else}
+      <p class="text-gray-500 my-1">No available fields</p>
+    {/if}
 
     {#if !collapsed && items.length > 3}
       <button class="see-more" on:click={toggleShowMore}>

--- a/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
@@ -4,17 +4,18 @@
   import PivotDrag from "./PivotDrag.svelte";
   import { getAllowedTimeGrains } from "@rilldata/web-common/lib/time/grains";
   import { PivotChipType } from "./types";
+  import { use } from "chai";
 
   const stateManagers = getStateManagers();
   const {
     selectors: {
-      pivot: { measures, dimensions },
+      pivot: { measures, dimensions, columns, rows },
     },
   } = stateManagers;
 
   const timeControlsStore = useTimeControlStore(getStateManagers());
 
-  $: timeGrainOptions = getAllowedTimeGrains(
+  $: allTimeGrains = getAllowedTimeGrains(
     new Date($timeControlsStore.timeStart!),
     new Date($timeControlsStore.timeEnd!),
   ).map((tgo) => {
@@ -24,6 +25,15 @@
       type: PivotChipType.Time,
     };
   });
+
+  $: usedTimeGrains = $columns.dimension
+    .filter((m) => m.type === PivotChipType.Time)
+    .concat($rows.dimension.filter((d) => d.type === PivotChipType.Time));
+
+  $: console.log(usedTimeGrains);
+  $: timeGrainOptions = allTimeGrains.filter(
+    (tgo) => !usedTimeGrains.some((utg) => utg.id === tgo.id),
+  );
 </script>
 
 <div class="sidebar">

--- a/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
@@ -4,7 +4,6 @@
   import PivotDrag from "./PivotDrag.svelte";
   import { getAllowedTimeGrains } from "@rilldata/web-common/lib/time/grains";
   import { PivotChipType } from "./types";
-  import { use } from "chai";
 
   const stateManagers = getStateManagers();
   const {
@@ -30,7 +29,6 @@
     .filter((m) => m.type === PivotChipType.Time)
     .concat($rows.dimension.filter((d) => d.type === PivotChipType.Time));
 
-  $: console.log(usedTimeGrains);
   $: timeGrainOptions = allTimeGrains.filter(
     (tgo) => !usedTimeGrains.some((utg) => utg.id === tgo.id),
   );


### PR DESCRIPTION
This PR filters out available time grain options from the pivot sidebar as they are added to the table. It also adds some placeholder text when no fields are available and resolves a layout issue when there are more pills in the column/row component than can fit in the browser width.