### PR TITLE
Adding steps for specific version install

### DIFF
--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -27,7 +27,24 @@ On both macOS and Linux, you can install the latest nightly build using the inst
 curl https://rill.sh | sh -s -- --nightly
 ```
 
-Note for macOS users: If you previously installed Rill using `brew`, the brew-managed binary will take precedent. You can remove it by running `brew uninstall rill`.
+:::warning MacOS users
+
+If you previously installed Rill using `brew`, *the brew-managed binary will take precedent*. You can remove it by running `brew uninstall rill`.
+
+:::
+
+## Installing a specific version of Rill
+
+Rather than installing the latest version of Rill automatically, you can also install a specific version through the installation script by using the following command (e.g. `v0.40.1`):
+```bash
+curl https://rill.sh | sh -s -- --version <insert_version_number>
+```
+
+:::info Checking the Rill version
+
+To check the precise version of available releases, you can navigate to the [**Releases**](https://github.com/rilldata/rill/releases) page of our [Rill repo](https://github.com/rilldata/rill). Note that if an invalid or incorrect version is passed to the install script, you will get prompted with an error to specify a correct version.
+
+:::
 
 ## Rill on Windows using WSL
 


### PR DESCRIPTION
We should also call out how the install script can be used to install a specific version of Rill