### PR TITLE
No need in additional context for timestamps of Snowflake

### DIFF
--- a/runtime/drivers/snowflake/sql_store.go
+++ b/runtime/drivers/snowflake/sql_store.go
@@ -54,7 +54,7 @@ func (c *connection) QueryAsFiles(ctx context.Context, props map[string]any, opt
 		return nil, err
 	}
 
-	ctx = sf.WithOriginalTimestamp(sf.WithArrowAllocator(sf.WithArrowBatches(ctx), memory.DefaultAllocator))
+	ctx = sf.WithArrowAllocator(sf.WithArrowBatches(ctx), memory.DefaultAllocator)
 
 	conn, err := db.Conn(ctx)
 	if err != nil {


### PR DESCRIPTION
This should work correctly for most cases except timestamps with very high precision that cannot fit into `arrow.Timestamp`
Closes #4079