### PR TITLE
Fix invalid fetching state

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-data-store.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-data-store.ts
@@ -242,7 +242,8 @@ function createPivotDataStore(ctx: StateManagers): PivotDataStore {
     ) {
       const isFetching =
         config.pivot.columns.measure.length > 0 ||
-        config.pivot.rows.dimension.length > 0;
+        (config.pivot.rows.dimension.length > 0 &&
+          !config.pivot.columns.dimension.length);
       return configSet({
         isFetching: isFetching,
         data: [],


### PR DESCRIPTION
For cases where we have column dimensions and row dimension without any measures, the table view shows a fetching spinner. We should instead show the empty state for now