### PR TITLE
Persist row time dimensions in url state

### DIFF
--- a/proto/rill/ui/v1/dashboard.proto
+++ b/proto/rill/ui/v1/dashboard.proto
@@ -107,21 +107,23 @@ message DashboardState {
    * Pivot related fields
    */
   optional bool pivot_is_active = 22;
+  // List of time dimensions selected for rows
+  repeated rill.runtime.v1.TimeGrain pivot_row_time_dimensions = 23;
   // List of dimensions selected for rows
-  repeated string pivot_row_dimensions = 23;
+  repeated string pivot_row_dimensions = 24;
   // List of time dimensions selected for columns
-  repeated rill.runtime.v1.TimeGrain pivot_column_time_dimensions = 24;
+  repeated rill.runtime.v1.TimeGrain pivot_column_time_dimensions = 25;
   // List of time dimensions selected for columns
-  repeated string pivot_column_dimensions = 25;
+  repeated string pivot_column_dimensions = 26;
   // List of time measures selected for columns
-  repeated string pivot_column_measures = 26;
+  repeated string pivot_column_measures = 27;
   // Map of dimensions that are expanded
-  map<string, bool> pivot_expanded = 27;
+  map<string, bool> pivot_expanded = 28;
   // Sort settings
-  repeated PivotColumnSort pivot_sort = 28;
+  repeated PivotColumnSort pivot_sort = 29;
   // Pagination data
-  optional int32 pivot_column_page = 29;
-  optional PivotRowJoinType pivot_row_join_type = 30;
+  optional int32 pivot_column_page = 30;
+  optional PivotRowJoinType pivot_row_join_type = 31;
 }
 
 message DashboardTimeRange {

--- a/web-common/src/features/dashboards/proto-state/fromProto.ts
+++ b/web-common/src/features/dashboards/proto-state/fromProto.ts
@@ -32,6 +32,7 @@ import {
   TimeRangePreset,
 } from "@rilldata/web-common/lib/time/types";
 import type { Expression } from "@rilldata/web-common/proto/gen/rill/runtime/v1/expression_pb";
+import type { TimeGrain } from "@rilldata/web-common/proto/gen/rill/runtime/v1/time_grain_pb";
 import {
   DashboardState,
   DashboardState_LeaderboardContextColumn,
@@ -309,6 +310,13 @@ function fromPivotProto(
     title: dimensionsMap.get(name)?.label || "Unknown",
     type: PivotChipType.Dimension,
   });
+  const mapTimeDimension: (grain: TimeGrain) => PivotChipData = (
+    grain: TimeGrain,
+  ) => ({
+    id: FromProtoTimeGrainMap[grain],
+    title: TIME_GRAIN[FromProtoTimeGrainMap[grain]].label,
+    type: PivotChipType.Time,
+  });
   const measuresMap = getMapFromArray(
     metricsView.measures ?? [],
     (m) => m.name,
@@ -322,15 +330,14 @@ function fromPivotProto(
   return {
     active: dashboard.pivotIsActive ?? false,
     rows: {
-      dimension: dashboard.pivotRowDimensions.map(mapDimension),
+      dimension: [
+        ...dashboard.pivotRowTimeDimensions.map(mapTimeDimension),
+        ...dashboard.pivotRowDimensions.map(mapDimension),
+      ],
     },
     columns: {
       dimension: [
-        ...dashboard.pivotColumnTimeDimensions.map((tg) => ({
-          id: FromProtoTimeGrainMap[tg],
-          title: TIME_GRAIN[FromProtoTimeGrainMap[tg]].label,
-          type: PivotChipType.Time,
-        })),
+        ...dashboard.pivotColumnTimeDimensions.map(mapTimeDimension),
         ...dashboard.pivotColumnDimensions.map(mapDimension),
       ],
       measure: dashboard.pivotColumnMeasures.map(mapMeasure),

--- a/web-common/src/features/dashboards/proto-state/toProto.ts
+++ b/web-common/src/features/dashboards/proto-state/toProto.ts
@@ -259,7 +259,14 @@ function toPivotProto(pivotState: PivotState): PartialMessage<DashboardState> {
     };
   return {
     pivotIsActive: true,
-    pivotRowDimensions: pivotState.rows.dimension.map((d) => d.id),
+
+    pivotRowTimeDimensions: pivotState.rows.dimension
+      .filter((d) => d.type === PivotChipType.Time)
+      .map((d) => ToProtoTimeGrainMap[d.id as V1TimeGrain]),
+    pivotRowDimensions: pivotState.rows.dimension
+      .filter((d) => d.type === PivotChipType.Dimension)
+      .map((d) => d.id),
+
     pivotColumnTimeDimensions: pivotState.columns.dimension
       .filter((d) => d.type === PivotChipType.Time)
       .map((d) => ToProtoTimeGrainMap[d.id as V1TimeGrain]),
@@ -267,6 +274,7 @@ function toPivotProto(pivotState: PivotState): PartialMessage<DashboardState> {
       .filter((d) => d.type === PivotChipType.Dimension)
       .map((d) => d.id),
     pivotColumnMeasures: pivotState.columns.measure.map((m) => m.id),
+
     pivotExpanded: pivotState.expanded, // TODO
     pivotSort: pivotState.sorting,
     pivotColumnPage: pivotState.columnPage,

--- a/web-common/src/proto/gen/rill/ui/v1/dashboard_pb.ts
+++ b/web-common/src/proto/gen/rill/ui/v1/dashboard_pb.ts
@@ -151,56 +151,63 @@ export class DashboardState extends Message<DashboardState> {
   pivotIsActive?: boolean;
 
   /**
+   * List of time dimensions selected for rows
+   *
+   * @generated from field: repeated rill.runtime.v1.TimeGrain pivot_row_time_dimensions = 23;
+   */
+  pivotRowTimeDimensions: TimeGrain[] = [];
+
+  /**
    * List of dimensions selected for rows
    *
-   * @generated from field: repeated string pivot_row_dimensions = 23;
+   * @generated from field: repeated string pivot_row_dimensions = 24;
    */
   pivotRowDimensions: string[] = [];
 
   /**
    * List of time dimensions selected for columns
    *
-   * @generated from field: repeated rill.runtime.v1.TimeGrain pivot_column_time_dimensions = 24;
+   * @generated from field: repeated rill.runtime.v1.TimeGrain pivot_column_time_dimensions = 25;
    */
   pivotColumnTimeDimensions: TimeGrain[] = [];
 
   /**
    * List of time dimensions selected for columns
    *
-   * @generated from field: repeated string pivot_column_dimensions = 25;
+   * @generated from field: repeated string pivot_column_dimensions = 26;
    */
   pivotColumnDimensions: string[] = [];
 
   /**
    * List of time measures selected for columns
    *
-   * @generated from field: repeated string pivot_column_measures = 26;
+   * @generated from field: repeated string pivot_column_measures = 27;
    */
   pivotColumnMeasures: string[] = [];
 
   /**
    * Map of dimensions that are expanded
    *
-   * @generated from field: map<string, bool> pivot_expanded = 27;
+   * @generated from field: map<string, bool> pivot_expanded = 28;
    */
   pivotExpanded: { [key: string]: boolean } = {};
 
   /**
    * Sort settings
    *
-   * @generated from field: repeated rill.ui.v1.PivotColumnSort pivot_sort = 28;
+   * @generated from field: repeated rill.ui.v1.PivotColumnSort pivot_sort = 29;
    */
   pivotSort: PivotColumnSort[] = [];
 
   /**
    * Pagination data
    *
-   * @generated from field: optional int32 pivot_column_page = 29;
+   * @generated from field: optional int32 pivot_column_page = 30;
    */
   pivotColumnPage?: number;
 
   /**
-   * @generated from field: optional rill.ui.v1.DashboardState.PivotRowJoinType pivot_row_join_type = 30;
+   * @generated from field: optional rill.ui.v1.DashboardState.PivotRowJoinType pivot_row_join_type = 31;
    */
   pivotRowJoinType?: DashboardState_PivotRowJoinType;
 
@@ -234,14 +241,15 @@ export class DashboardState extends Message<DashboardState> {
     { no: 18, name: "expanded_measure", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 19, name: "pin_index", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
     { no: 22, name: "pivot_is_active", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
-    { no: 23, name: "pivot_row_dimensions", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
-    { no: 24, name: "pivot_column_time_dimensions", kind: "enum", T: proto3.getEnumType(TimeGrain), repeated: true },
-    { no: 25, name: "pivot_column_dimensions", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
-    { no: 26, name: "pivot_column_measures", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
-    { no: 27, name: "pivot_expanded", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "scalar", T: 8 /* ScalarType.BOOL */} },
-    { no: 28, name: "pivot_sort", kind: "message", T: PivotColumnSort, repeated: true },
-    { no: 29, name: "pivot_column_page", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
-    { no: 30, name: "pivot_row_join_type", kind: "enum", T: proto3.getEnumType(DashboardState_PivotRowJoinType), opt: true },
+    { no: 23, name: "pivot_row_time_dimensions", kind: "enum", T: proto3.getEnumType(TimeGrain), repeated: true },
+    { no: 24, name: "pivot_row_dimensions", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+    { no: 25, name: "pivot_column_time_dimensions", kind: "enum", T: proto3.getEnumType(TimeGrain), repeated: true },
+    { no: 26, name: "pivot_column_dimensions", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+    { no: 27, name: "pivot_column_measures", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+    { no: 28, name: "pivot_expanded", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "scalar", T: 8 /* ScalarType.BOOL */} },
+    { no: 29, name: "pivot_sort", kind: "message", T: PivotColumnSort, repeated: true },
+    { no: 30, name: "pivot_column_page", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 31, name: "pivot_row_join_type", kind: "enum", T: proto3.getEnumType(DashboardState_PivotRowJoinType), opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DashboardState {


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Row time dimensions was missing from url state.

#### Details:
Adding a new field to the proto and code to serialise/deserialise row time dimensions.

## Steps to Verify
<!-- PROVIDE INFORMATION ON HOW TO CHECK THIS ADDITION
For example, given a new button "Foo" in the dashboard:
1. Run `npm run dev`
2. Open localhost:3000 and navigate to a dashboard
3. Click the "Foo" button in corner
4. Observe the side effect
 -->