### PR TITLE
Fix Welcome page navigation bugs

### DIFF
--- a/web-common/src/features/welcome/ProjectCards.svelte
+++ b/web-common/src/features/welcome/ProjectCards.svelte
@@ -28,7 +28,7 @@
       title: "OpenRTB Programmatic Ads",
       description: "Real-time Bidding (RTB) advertising",
       image: "bg-[url('$img/welcome-bg-openrtb.png')] bg-no-repeat bg-cover",
-      firstPage: "dashboard/auction",
+      firstPage: "/dashboard/auction",
     },
     {
       name: "rill-github-analytics",
@@ -36,7 +36,7 @@
       description: "A Git project's commit activity",
       image:
         "bg-[url('$img/welcome-bg-github-analytics.png')] bg-no-repeat bg-cover",
-      firstPage: "dashboard/duckdb_commits",
+      firstPage: "/dashboard/duckdb_commits",
     },
   ];
 

--- a/web-common/src/layout/BasicLayout.svelte
+++ b/web-common/src/layout/BasicLayout.svelte
@@ -41,7 +41,7 @@ BasicLayout is the backbone of the Rill application.
   setContext("rill:app:navigation-width-tween", navigationWidth);
   setContext("rill:app:navigation-visibility-tween", navVisibilityTween);
 
-  $: showNavigation = $page.url.pathname !== "/welcome";
+  $: showNavigation = $page.route.id !== "/(application)/welcome";
 </script>
 
 <main>


### PR DESCRIPTION
A recent PR caused navigation to `/welcome/` rather than `/welcome`. It's unclear why navigation to this route now includes the trailing slash (especially given [SvelteKit's default](https://kit.svelte.dev/docs/page-options#trailingslash) is to never include trailing slashes). However, this PR protects against the trailing slash in two places:
- Logic to show/hide the left-hand sidebar
- Links to example project dashboards