### PR TITLE
Fix: Remove tooltip from Pivot chips

### DIFF
--- a/web-common/src/components/chip/core/Chip.svelte
+++ b/web-common/src/components/chip/core/Chip.svelte
@@ -28,6 +28,7 @@
   export let outlineActiveClass = defaultChipColors.outlineActiveClass;
 
   /** if removable is true, these props control the tooltip positioning */
+  export let supressTooltip = false;
   export let removeButtonTooltipLocation = "bottom";
   export let removeButtonTooltipAlignment = "start";
   export let removeButtonTooltipDistance = 12;
@@ -92,6 +93,7 @@
           tooltipLocation={removeButtonTooltipLocation}
           tooltipAlignment={removeButtonTooltipAlignment}
           tooltipDistance={removeButtonTooltipDistance}
+          {supressTooltip}
           on:remove
         >
           <svelte:fragment slot="remove-tooltip">

--- a/web-common/src/components/chip/core/RemoveChipButton.svelte
+++ b/web-common/src/components/chip/core/RemoveChipButton.svelte
@@ -11,6 +11,7 @@
   export let tooltipAlignment = "start";
   export let tooltipDistance = 12;
   export let textClass = defaultChipColors.textClass;
+  export let supressTooltip = false;
 
   const tooltipSuppression = getContext(
     "rill:app:childRequestedTooltipSuppression",
@@ -29,6 +30,7 @@
   location={tooltipLocation}
   alignment={tooltipAlignment}
   distance={tooltipDistance}
+  suppress={supressTooltip}
 >
   <button
     class={textClass}

--- a/web-common/src/features/dashboards/pivot/PivotChip.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotChip.svelte
@@ -1,12 +1,12 @@
 <script context="module" lang="ts">
   import { Chip } from "@rilldata/web-common/components/chip";
+  import type { ChipColors } from "@rilldata/web-common/components/chip/chip-types";
   import {
+    defaultChipColors,
     measureChipColors,
     timeChipColors,
-    defaultChipColors,
   } from "@rilldata/web-common/components/chip/chip-types";
   import { createEventDispatcher } from "svelte";
-  import type { ChipColors } from "@rilldata/web-common/components/chip/chip-types";
   import type { PivotChipData } from "./types";
   import { PivotChipType } from "./types";
 
@@ -26,6 +26,7 @@
 
 <Chip
   outline
+  supressTooltip
   {removable}
   {...colors[item.type]}
   extraPadding={false}


### PR DESCRIPTION
Removes tooltip from Pivot chips and adds a prop to suppress tooltips in chip component.