### PR TITLE
Fix: Scroll to previous position in the table on expansion

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotTable.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTable.svelte
@@ -9,13 +9,13 @@
     getCoreRowModel,
     getExpandedRowModel,
   } from "@tanstack/svelte-table";
-  import type { Readable } from "svelte/motion";
-  import { derived } from "svelte/store";
-  import type { PivotDataRow, PivotDataStore } from "./types";
   import {
     createVirtualizer,
     defaultRangeExtractor,
   } from "@tanstack/svelte-virtual";
+  import type { Readable } from "svelte/motion";
+  import { derived } from "svelte/store";
+  import type { PivotDataRow, PivotDataStore } from "./types";
 
   export let pivotDataStore: PivotDataStore;
 
@@ -68,6 +68,7 @@
     getScrollElement: () => containerRefElement,
     estimateSize: () => ROW_HEIGHT,
     overscan: OVERSCAN,
+    initialOffset: rowScrollOffset,
     rangeExtractor: (range) => {
       const next = new Set([...stickyRows, ...defaultRangeExtractor(range)]);
 
@@ -77,6 +78,9 @@
 
   $: virtualRows = $virtualizer.getVirtualItems();
   $: totalRowSize = $virtualizer.getTotalSize();
+
+  let rowScrollOffset = 0;
+  $: rowScrollOffset = $virtualizer?.scrollOffset || 0;
 
   // In this virtualization model, we create buffer rows before and after our real data
   // This maintains the "correct" scroll position when the user scrolls


### PR DESCRIPTION
The table scroll position would reset to 0 when expanding a row item after scrolling a bit further down the table. This PR adds `scrollOffset` to the `virtualizer` to avoid such cases during a state change.