### PR TITLE
Fix race condition for expired JWTs

### DIFF
--- a/web-admin/src/features/projects/selectors.ts
+++ b/web-admin/src/features/projects/selectors.ts
@@ -2,6 +2,7 @@ import {
   createAdminServiceGetProject,
   createAdminServiceListProjectMembers,
 } from "@rilldata/web-admin/client";
+import { RUNTIME_ACCESS_TOKEN_DEFAULT_TTL } from "@rilldata/web-common/runtime-client/constants";
 
 export function getProjectPermissions(orgName: string, projName: string) {
   return createAdminServiceGetProject(orgName, projName, {
@@ -10,9 +11,6 @@ export function getProjectPermissions(orgName: string, projName: string) {
     },
   });
 }
-
-// The TTL is actually set in the Admin server – we just use the value for some frontend logic
-export const RUNTIME_ACCESS_TOKEN_DEFAULT_TTL = 30 * 60 * 1000; // 30 minutes
 
 export function useProjectRuntime(orgName: string, projName: string) {
   return createAdminServiceGetProject(orgName, projName, {

--- a/web-admin/src/features/projects/selectors.ts
+++ b/web-admin/src/features/projects/selectors.ts
@@ -11,11 +11,14 @@ export function getProjectPermissions(orgName: string, projName: string) {
   });
 }
 
+// The TTL is actually set in the Admin server – we just use the value for some frontend logic
+export const RUNTIME_ACCESS_TOKEN_DEFAULT_TTL = 30 * 60 * 1000; // 30 minutes
+
 export function useProjectRuntime(orgName: string, projName: string) {
   return createAdminServiceGetProject(orgName, projName, {
     query: {
-      // Proactively refetch the JWT because it's only valid for 1 hour
-      refetchInterval: 1000 * 60 * 30, // 30 minutes
+      // Proactively refetch the JWT before it expires
+      refetchInterval: RUNTIME_ACCESS_TOKEN_DEFAULT_TTL / 2,
       select: (data) => {
         // There may not be a prodDeployment if the project was hibernated
         if (!data.prodDeployment) {

--- a/web-admin/src/features/view-as-user/clearViewedAsUser.ts
+++ b/web-admin/src/features/view-as-user/clearViewedAsUser.ts
@@ -52,7 +52,10 @@ export async function clearViewedAsUserWithinProject(
   const jwt = projResp.jwt;
 
   runtime.update((runtimeState) => {
-    runtimeState.jwt = jwt;
+    runtimeState.jwt = {
+      token: jwt,
+      receivedAt: Date.now(),
+    };
     return runtimeState;
   });
 

--- a/web-admin/src/features/view-as-user/setViewedAsUser.ts
+++ b/web-admin/src/features/view-as-user/setViewedAsUser.ts
@@ -35,7 +35,10 @@ export async function setViewedAsUser(
   const jwt = jwtResp.accessToken;
 
   runtime.update((runtimeState) => {
-    runtimeState.jwt = jwt;
+    runtimeState.jwt = {
+      token: jwt,
+      receivedAt: Date.now(),
+    };
     return runtimeState;
   });
 

--- a/web-common/src/features/dashboards/granular-access-policies/updateDevJWT.ts
+++ b/web-common/src/features/dashboards/granular-access-policies/updateDevJWT.ts
@@ -32,7 +32,10 @@ export async function updateDevJWT(
 
   selectedMockUserJWT.set(jwt);
   runtime.update((runtimeState) => {
-    runtimeState.jwt = jwt;
+    runtimeState.jwt = {
+      token: jwt,
+      receivedAt: Date.now(),
+    };
     return runtimeState;
   });
   return invalidateAllMetricsViews(queryClient, get(runtime).instanceId);

--- a/web-common/src/features/dashboards/stores/dashboard-stores.spec.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.spec.ts
@@ -46,7 +46,6 @@ describe("dashboard-stores", () => {
     initPersistentDashboardStore(AD_BIDS_NAME);
     runtime.set({
       instanceId: "",
-      jwt: "",
       host: "",
     });
   });

--- a/web-common/src/runtime-client/RuntimeProvider.svelte
+++ b/web-common/src/runtime-client/RuntimeProvider.svelte
@@ -8,7 +8,12 @@
   $: runtime.set({
     host: host,
     instanceId: instanceId,
-    jwt: jwt,
+    jwt: jwt
+      ? {
+          token: jwt,
+          receivedAt: Date.now(),
+        }
+      : undefined,
   });
 </script>
 

--- a/web-common/src/runtime-client/constants.ts
+++ b/web-common/src/runtime-client/constants.ts
@@ -1,0 +1,2 @@
+// The TTL is actually set in the Admin server – we just use the value for some frontend logic
+export const RUNTIME_ACCESS_TOKEN_DEFAULT_TTL = 30 * 60 * 1000; // 30 minutes

--- a/web-common/src/runtime-client/http-client.ts
+++ b/web-common/src/runtime-client/http-client.ts
@@ -60,7 +60,7 @@ async function maybeWaitForFreshJWT(jwt: JWT): Promise<JWT> {
 
   // If the JWT has expired, or is close to expiring, wait for a fresh one.
   // Note: It could be even better to immediately fetch a new token here. However, in practice, the request
-  // for new token is already in flight (see comment for `maybeWaitForFreshJWT`). So, to keep the code simpler, we just wait.
+  // for new token is already in flight. So, to keep the code simpler, we just wait.
   while (Date.now() + JWT_EXPIRY_WARNING_WINDOW > jwtExpiresAt) {
     await new Promise((resolve) =>
       setTimeout(resolve, CHECK_RUNTIME_STORE_FOR_JWT_INTERVAL),

--- a/web-common/src/runtime-client/http-client.ts
+++ b/web-common/src/runtime-client/http-client.ts
@@ -44,24 +44,16 @@ const JWT_EXPIRY_WARNING_WINDOW = 2 * 1000; // Extra time to ensure that the JWT
 const CHECK_RUNTIME_STORE_FOR_JWT_INTERVAL = 50; // Interval to recheck JWT freshness in milliseconds
 
 /**
- * When a user returns to the app after an extended period, their JWT may have expired. At the moment the user returns,
- * TanStack Query will automatically refetch stale queries.
- *
- * Without intervention, simultaneously:
- * - the `GetProject` query would be sent to the Admin server to get a fresh JWT
- * - dashboard queries would be sent to the Runtime server, but with the stale JWT! This would result in 401 errors.
- *
- * So, this function waits for a fresh JWT to be set in the runtime store before sending requests to the runtime.
+ * If the JWT has expired, or is close to expiring, wait for a fresh one.
  */
 async function maybeWaitForFreshJWT(jwt: JWT): Promise<JWT> {
-  // This is the approximate time at which the JWT will expire.
-  // We could parse the JWT to get the exact expiration time, but it's better to treat the JWT as opaque.
+  // This is the approximate time at which the JWT will expire. We could parse the JWT to get the exact
+  // expiration time, but it's better to treat tokens as opaque.
   let jwtExpiresAt = jwt.receivedAt + RUNTIME_ACCESS_TOKEN_DEFAULT_TTL;
 
-  // If the JWT has expired, or is close to expiring, wait for a fresh one.
-  // Note: It could be even better to immediately fetch a new token here. However, in practice, the request
-  // for new token is already in flight. So, to keep the code simpler, we just wait.
   while (Date.now() + JWT_EXPIRY_WARNING_WINDOW > jwtExpiresAt) {
+    // Note: Rather than waiting, it could be even better to immediately fetch a new token here. However, in
+    // practice, the request for new token is already in flight. So to keep the code simpler, we just wait.
     await new Promise((resolve) =>
       setTimeout(resolve, CHECK_RUNTIME_STORE_FOR_JWT_INTERVAL),
     );

--- a/web-common/src/runtime-client/http-client.ts
+++ b/web-common/src/runtime-client/http-client.ts
@@ -52,8 +52,8 @@ async function maybeWaitForFreshJWT(jwt: JWT): Promise<JWT> {
   let jwtExpiresAt = jwt.receivedAt + RUNTIME_ACCESS_TOKEN_DEFAULT_TTL;
 
   while (Date.now() + JWT_EXPIRY_WARNING_WINDOW > jwtExpiresAt) {
-    // Note: Rather than waiting, it could be even better to immediately fetch a new token here. However, in
-    // practice, the request for new token is already in flight. So to keep the code simpler, we just wait.
+    // Note: Rather than waiting, it could be even better to immediately fetch a new token here. Anyways, in
+    // practice, a request for new token is already in flight. So to start simpler, we just wait.
     await new Promise((resolve) =>
       setTimeout(resolve, CHECK_RUNTIME_STORE_FOR_JWT_INTERVAL),
     );

--- a/web-common/src/runtime-client/http-client.ts
+++ b/web-common/src/runtime-client/http-client.ts
@@ -1,10 +1,11 @@
+import { RUNTIME_ACCESS_TOKEN_DEFAULT_TTL } from "@rilldata/web-admin/features/projects/selectors";
 import type {
   FetchWrapperOptions,
   HTTPError,
 } from "@rilldata/web-common/runtime-client/fetchWrapper";
 import { get } from "svelte/store";
 import { HttpRequestQueue } from "./http-request-queue/HttpRequestQueue";
-import { runtime } from "./runtime-store";
+import { JWT, runtime } from "./runtime-store";
 
 /**
  * Runtime base URL
@@ -20,23 +21,56 @@ export const httpRequestQueue = new HttpRequestQueue();
 export const httpClient = async <T>(
   config: FetchWrapperOptions,
 ): Promise<T> => {
-  // naive request interceptors
+  // Naive request interceptors
 
-  // set host
+  // Set host
   const host = get(runtime).host;
   const interceptedConfig = { ...config, baseUrl: host };
 
-  // set jwt
-  const jwt = get(runtime).jwt;
+  // Set JWT
+  let jwt = get(runtime).jwt;
   if (jwt) {
+    jwt = await maybeWaitForFreshJWT(jwt);
     interceptedConfig.headers = {
       ...interceptedConfig.headers,
-      Authorization: `Bearer ${jwt}`,
+      Authorization: `Bearer ${jwt.token}`,
     };
   }
 
   return (await httpRequestQueue.add(interceptedConfig)) as Promise<T>;
 };
+
+const JWT_EXPIRY_WARNING_WINDOW = 2 * 1000; // Extra time to ensure that the JWT is not expired when it ultimately reaches the server
+const CHECK_RUNTIME_STORE_FOR_JWT_INTERVAL = 50; // Interval to recheck JWT freshness in milliseconds
+
+/**
+ * When a user returns to the app after an extended period, their JWT may have expired. At the moment the user returns,
+ * TanStack Query will automatically refetch stale queries.
+ *
+ * Without intervention, simultaneously:
+ * - the `GetProject` query would be sent to the Admin server to get a fresh JWT
+ * - dashboard queries would be sent to the Runtime server, but with the stale JWT! This would result in 401 errors.
+ *
+ * So, this function waits for a fresh JWT to be set in the runtime store before sending requests to the runtime.
+ */
+async function maybeWaitForFreshJWT(jwt: JWT): Promise<JWT> {
+  // This is the approximate time at which the JWT will expire.
+  // We could parse the JWT to get the exact expiration time, but it's better to treat the JWT as opaque.
+  let jwtExpiresAt = jwt.receivedAt + RUNTIME_ACCESS_TOKEN_DEFAULT_TTL;
+
+  // If the JWT has expired, or is close to expiring, wait for a fresh one.
+  // Note: It could be even better to immediately fetch a new token here. However, in practice, the request
+  // for new token is already in flight (see comment for `maybeWaitForFreshJWT`). So, to keep the code simpler, we just wait.
+  while (Date.now() + JWT_EXPIRY_WARNING_WINDOW > jwtExpiresAt) {
+    await new Promise((resolve) =>
+      setTimeout(resolve, CHECK_RUNTIME_STORE_FOR_JWT_INTERVAL),
+    );
+    jwt = get(runtime).jwt as JWT;
+    jwtExpiresAt = jwt.receivedAt + RUNTIME_ACCESS_TOKEN_DEFAULT_TTL;
+  }
+
+  return jwt;
+}
 
 export default httpClient;
 

--- a/web-common/src/runtime-client/http-client.ts
+++ b/web-common/src/runtime-client/http-client.ts
@@ -1,9 +1,9 @@
-import { RUNTIME_ACCESS_TOKEN_DEFAULT_TTL } from "@rilldata/web-admin/features/projects/selectors";
 import type {
   FetchWrapperOptions,
   HTTPError,
 } from "@rilldata/web-common/runtime-client/fetchWrapper";
 import { get } from "svelte/store";
+import { RUNTIME_ACCESS_TOKEN_DEFAULT_TTL } from "./constants";
 import { HttpRequestQueue } from "./http-request-queue/HttpRequestQueue";
 import { JWT, runtime } from "./runtime-store";
 

--- a/web-common/src/runtime-client/runtime-store.ts
+++ b/web-common/src/runtime-client/runtime-store.ts
@@ -2,8 +2,8 @@ import { writable } from "svelte/store";
 
 export interface JWT {
   token: string;
-  // The time at which the JWT was received. We use this to calcualte the JWT's expiration time.
-  // We could parse the JWT to get the exact expiration time, but it's better to treat the JWT as opaque.
+  // The time at which the JWT was received. We use this to calculate the JWT's expiration time.
+  // We *could* parse the JWT to get the exact expiration time, but it's better to treat tokens as opaque.
   receivedAt: number;
 }
 

--- a/web-common/src/runtime-client/runtime-store.ts
+++ b/web-common/src/runtime-client/runtime-store.ts
@@ -1,9 +1,16 @@
 import { writable } from "svelte/store";
 
+export interface JWT {
+  token: string;
+  // The time at which the JWT was received. We use this to calcualte the JWT's expiration time.
+  // We could parse the JWT to get the exact expiration time, but it's better to treat the JWT as opaque.
+  receivedAt: number;
+}
+
 export interface Runtime {
   host: string;
   instanceId: string;
-  jwt?: string;
+  jwt?: JWT;
 }
 
 export const runtime = writable<Runtime>();

--- a/web-common/src/runtime-client/watch-request-client.ts
+++ b/web-common/src/runtime-client/watch-request-client.ts
@@ -119,7 +119,7 @@ export class WatchRequestClient<Res extends WatchResponse> {
     const headers = { "Content-Type": "application/json" };
     const jwt = get(runtime).jwt;
     if (jwt) {
-      headers["Authorization"] = `Bearer ${jwt}`;
+      headers["Authorization"] = `Bearer ${jwt.token}`;
     }
 
     return streamingFetchWrapper<StreamingFetchResponse<Res>>(


### PR DESCRIPTION
Closes #3876

This PR ensures a fresh JWT before firing requests to a Runtime server. This helps avoid the race condition mentioned in the above issue.

This PR assumes a runtime access token TTL of 30 minutes. So when this PR is merged, we'll be ready to merge https://github.com/rilldata/rill/pull/4058.