### PR TITLE
Move telemetry failure logs to debug

### DIFF
--- a/cli/pkg/local/app.go
+++ b/cli/pkg/local/app.go
@@ -491,7 +491,7 @@ func (a *App) trackingHandler(info *localInfo) http.Handler {
 			// Send proxied request
 			resp, err := http.DefaultClient.Do(proxyReq)
 			if err != nil {
-				a.BaseLogger.Info("failed to send telemetry", zap.Error(err))
+				a.BaseLogger.Debug("failed to send telemetry", zap.Error(err))
 				w.WriteHeader(http.StatusOK)
 				return
 			}


### PR DESCRIPTION
When rill-dev is run in offline mode, we get lot of failure info logs.
```
{"level":"info","ts":1708516890.8632698,"msg":"failed to send telemetry{error 26 0  Post \"https://intake.rilldata.io/events/data-modeler-metrics\": d
ial tcp: lookup intake.rilldata.io: no such host}"}
```

