### PR TITLE
Support multiple measures in pivot with sorting

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-queries.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-queries.ts
@@ -1,12 +1,4 @@
 import type { ResolvedMeasureFilter } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
-import {
-  getTimeGrainFromDimension,
-  isTimeDimension,
-} from "@rilldata/web-common/features/dashboards/pivot/pivot-utils";
-import type {
-  PivotAxesData,
-  PivotDataStoreConfig,
-} from "@rilldata/web-common/features/dashboards/pivot/types";
 import type { StateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
 import {
   createAndExpression,
@@ -27,6 +19,12 @@ import {
 import type { CreateQueryResult } from "@tanstack/svelte-query";
 import { Readable, derived, readable } from "svelte/store";
 import { mergeFilters } from "./pivot-merge-filters";
+import {
+  getFilterForOtherMeasuresAxesQuery,
+  getTimeGrainFromDimension,
+  isTimeDimension,
+} from "./pivot-utils";
+import type { PivotAxesData, PivotDataStoreConfig } from "./types";
 
 /**
  * Wrapper function for Aggregate Query API
@@ -171,6 +169,41 @@ export function getAxisForDimensions(
       };
     },
   );
+}
+
+export function getAxisQueryForOtherMeasures(
+  ctx: StateManagers,
+  config: PivotDataStoreConfig,
+  isMeasureSortAccessor: boolean,
+  sortAccessor: string | undefined,
+  rowDimensionValues: string[],
+  timeRange: TimeRangeString,
+) {
+  let rowAxesQueryForOtherMeasures: Readable<PivotAxesData | null> =
+    readable(null);
+
+  if (rowDimensionValues.length && isMeasureSortAccessor && sortAccessor) {
+    const { measureNames, rowDimensionNames } = config;
+    const otherMeasuresBody = measureNames
+      .map((m) => ({ name: m }))
+      .filter((m) => m.name !== sortAccessor);
+
+    const sortedRowFilters = getFilterForOtherMeasuresAxesQuery(
+      config,
+      rowDimensionValues,
+    );
+    rowAxesQueryForOtherMeasures = getAxisForDimensions(
+      ctx,
+      config,
+      rowDimensionNames.slice(0, 1),
+      otherMeasuresBody,
+      sortedRowFilters,
+      [],
+      timeRange,
+    );
+  }
+
+  return rowAxesQueryForOtherMeasures;
 }
 
 export function getTotalsRowQuery(

--- a/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
@@ -137,3 +137,29 @@ export function getTotalsRow(
 
   return totalsRow;
 }
+
+export function mergeRowTotals(
+  rowValues: string[],
+  sortedRowTotals: V1MetricsViewAggregationResponseDataItem[],
+  unsortedRowValues: string[],
+  unsortedRowTotals: V1MetricsViewAggregationResponseDataItem[],
+) {
+  if (unsortedRowValues.length === 0) {
+    return sortedRowTotals;
+  }
+  const unsortedRowValuesMap = createIndexMap(unsortedRowValues);
+
+  const mergedRowTotals = sortedRowTotals.map((sortedRowTotal, i) => {
+    const unsortedRowIndex = unsortedRowValuesMap.get(rowValues[i]);
+    if (unsortedRowIndex === undefined) {
+      return sortedRowTotal;
+    }
+    const unsortedRowTotal = unsortedRowTotals[i];
+    return {
+      ...unsortedRowTotal,
+      ...sortedRowTotal,
+    };
+  });
+
+  return mergedRowTotals;
+}

--- a/web-common/src/features/dashboards/pivot/pivot-utils.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-utils.ts
@@ -15,6 +15,7 @@ import type {
   V1MetricsViewAggregationSort,
 } from "@rilldata/web-common/runtime-client";
 import { getColumnFiltersForPage } from "./pivot-infinite-scroll";
+import { mergeFilters } from "./pivot-merge-filters";
 import type {
   PivotDataRow,
   PivotDataStoreConfig,
@@ -377,4 +378,21 @@ export function getSortForAccessor(
     sortPivotBy,
     timeRange,
   };
+}
+
+export function getFilterForOtherMeasuresAxesQuery(
+  config: PivotDataStoreConfig,
+  rowDimensionValues: string[],
+) {
+  const { rowDimensionNames } = config;
+  const anchorDimension = rowDimensionNames?.[0];
+
+  let rowFilters: V1Expression | undefined;
+  if (anchorDimension) {
+    rowFilters = createInExpression(anchorDimension, rowDimensionValues);
+  }
+
+  const mergedFilters = mergeFilters(config.whereFilter, rowFilters ?? {});
+
+  return mergedFilters;
 }


### PR DESCRIPTION
`filter` for measure supports only one measure. To get values for the other measures, we need to make an extra query. More https://rilldata.slack.com/archives/C05PTA6DK0S/p1708444432289219