### PR TITLE
Disable svelte check for a few files

### DIFF
--- a/.github/workflows/web-test-code-quality.yml
+++ b/.github/workflows/web-test-code-quality.yml
@@ -44,7 +44,7 @@ jobs:
         if: steps.filter.outputs.common == 'true'
         run: |-
           npx eslint web-common --quiet
-          npx svelte-check --workspace web-common --no-tsconfig --ignore "src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte,src/features/dashboards/time-controls/TimeControls.svelte,src/components/data-graphic/elements/GraphicContext.svelte"
+          npx svelte-check --workspace web-common --no-tsconfig --ignore "src/features/dashboards/time-series/(MetricsTimeSeriesCharts.svelte|MeasureChart.svelte),src/features/dashboards/time-controls/TimeControls.svelte,src/components/data-graphic/elements/GraphicContext.svelte,src/components/data-graphic/guides/(Axis.svelte|DynamicallyPlacedLabel.svelte|Grid.svelte),src/components/data-graphic/compositions/timestamp-profile/TimestampDetail.svelte,src/components/data-graphic/marks/(ChunkedLine.svelte|HistogramPrimitive.svelte|Line.svelte|MultiMetricMouseoverLabel.svelte),src/components/column-profile/column-types/details/SummaryNumberPlot.svelte"
 
 
       - name: lint and type checks for web local


### PR DESCRIPTION
svelte-check was updated recently and a lot more files that havent changed recently are failing. This disabled it for now to unblock other devs.