### PR TITLE
Revert "Integrate measure row filters to pivot  (#4062)"

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-expansion.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-expansion.ts
@@ -86,7 +86,6 @@ export function createSubTableCellQuery(
       };
     } else return { name: dimension };
   });
-  const measureBody = config.measureNames.map((m) => ({ name: m }));
 
   const { filters: filterForSubTable, timeFilters: colTimeFilters } =
     getFilterForPivotTable(config, columnDimensionAxesData, totalsRow);
@@ -106,7 +105,7 @@ export function createSubTableCellQuery(
   ];
   return createPivotAggregationRowQuery(
     ctx,
-    measureBody,
+    config.measureNames,
     dimensionBody,
     filterForSubTable,
     config.measureFilter,
@@ -141,7 +140,6 @@ export function queryExpandedRowMeasureValues(
   const expanded = config.pivot.expanded;
   if (!tableData || Object.keys(expanded).length == 0) return writable(null);
 
-  const measureBody = config.measureNames.map((m) => ({ name: m }));
   return derived(
     Object.keys(expanded)?.map((expandIndex) => {
       const nestLevel = expandIndex?.split(".")?.length;
@@ -227,7 +225,6 @@ export function queryExpandedRowMeasureValues(
             ctx,
             config,
             [anchorDimension],
-            measureBody,
             allMergedFilters,
             sortPivotBy,
             timeRange,


### PR DESCRIPTION
This reverts commit 68c52899ea2aadfece8747f7a4464e25cd25409c.

Removes integration of measure filters and reverts back to two queries approach.