### PR TITLE
Enable custom themes for embedded dashboards

### DIFF
--- a/web-admin/src/routes/-/embed/+page.svelte
+++ b/web-admin/src/routes/-/embed/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { page } from "$app/stores";
   import { Dashboard } from "@rilldata/web-common/features/dashboards";
+  import DashboardThemeProvider from "@rilldata/web-common/features/dashboards/DashboardThemeProvider.svelte";
   import DashboardURLStateProvider from "@rilldata/web-common/features/dashboards/proto-state/DashboardURLStateProvider.svelte";
   import { useDashboard } from "@rilldata/web-common/features/dashboards/selectors";
   import StateManagersProvider from "@rilldata/web-common/features/dashboards/state-managers/StateManagersProvider.svelte";
@@ -41,7 +42,9 @@
       <StateManagersProvider metricsViewName={dashboardName}>
         <DashboardStateProvider metricViewName={dashboardName}>
           <DashboardURLStateProvider metricViewName={dashboardName}>
-            <Dashboard metricViewName={dashboardName} leftMargin={"48px"} />
+            <DashboardThemeProvider>
+              <Dashboard metricViewName={dashboardName} leftMargin={"48px"} />
+            </DashboardThemeProvider>
           </DashboardURLStateProvider>
         </DashboardStateProvider>
       </StateManagersProvider>


### PR DESCRIPTION
This PR makes it possible to add a custom theme to an embedded dashboard. Now, adding the `theme` query parameter to to an iframe URL will correctly propagate the custom theme to your embed.

Example iframe URL: `https://ui.rilldata.com/-/embed?access_token=<access_token>&instance_id=<instance_id>&kind=rill.runtime.v1.MetricsView&resource=<dashboard_name>&runtime_host=<runtime_host>&theme=<my_theme>`
