### PR TITLE
Make a couple items in the Alert form optional

### DIFF
--- a/web-common/src/components/forms/Select.svelte
+++ b/web-common/src/components/forms/Select.svelte
@@ -11,6 +11,7 @@
   export let label: string;
   export let options: { value: string; label?: string }[];
   export let placeholder: string = "";
+  export let optional: boolean = false;
 
   // temporary till we figure out the menus
   export let detach = false;
@@ -30,7 +31,14 @@
 
 <div class="flex flex-col gap-y-2">
   {#if label?.length}
-    <label for={id} class="text-gray-800 text-sm font-medium">{label}</label>
+    <label for={id} class="text-sm flex gap-x-1">
+      <span class="text-gray-800 font-medium">
+        {label}
+      </span>
+      {#if optional}
+        <span class="text-gray-500">(optional)</span>
+      {/if}
+    </label>
   {/if}
   <Menu {detach}>
     <MenuButton

--- a/web-common/src/features/alerts/data-tab/AlertDialogDataTab.svelte
+++ b/web-common/src/features/alerts/data-tab/AlertDialogDataTab.svelte
@@ -76,13 +76,15 @@
       label="Split by dimension"
       options={dimensionOptions}
       placeholder="Select a dimension"
+      optional
     />
     <Select
       bind:value={$form["splitByTimeGrain"]}
       id="splitByTimeGrain"
-      label="Split By Time Grain"
+      label="Split by time grain"
       options={AlertIntervalOptions}
       placeholder="Select a time grain"
+      optional
     />
   </FormSection>
   <FormSection title="Data preview">


### PR DESCRIPTION
This PR:
- Adds an `optional` prop to our `Select` form element
- Uses this `optional` prop for two elements in the Alert form: "Split by dimension" and "Split by time grain"