### PR TITLE
Revert Leaderboard/BigNumber header color to slate-600

### DIFF
--- a/web-common/src/app.css
+++ b/web-common/src/app.css
@@ -36,8 +36,8 @@
     @apply text-gray-600 dark:text-gray-200;
   }
 
-  .ui-copy-primary {
-    @apply text-primary-700 dark:text-primary-200;
+  .ui-header-primary {
+    @apply text-slate-600 dark:text-slate-100;
   }
 
   .ui-copy-strong {

--- a/web-common/src/app.css
+++ b/web-common/src/app.css
@@ -34,10 +34,12 @@
 
   .ui-copy-muted {
     @apply text-gray-600 dark:text-gray-200;
+   
   }
 
   .ui-header-primary {
     @apply text-slate-600 dark:text-slate-100;
+    @apply hover:text-primary-700 group-hover:text-primary-700;
   }
 
   .ui-copy-strong {

--- a/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
@@ -116,7 +116,7 @@
     >
       <h2
         style:overflow-wrap="anywhere"
-        class="line-clamp-2 ui-copy-primary font-semibold"
+        class="line-clamp-2 ui-header-primary font-semibold"
         style:font-size={withTimeseries ? "" : "0.8rem"}
       >
         {name}

--- a/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
@@ -101,7 +101,7 @@
     use:shiftClickAction
     on:shift-click={() => shiftClickHandler(hoveredValue)}
     class:big-number={!isMeasureExpanded}
-    class="big-number m-0.5 rounded flex items-start {isMeasureExpanded
+    class="group big-number m-0.5 rounded flex items-start {isMeasureExpanded
       ? 'cursor-default'
       : 'cursor-pointer'}"
     on:click={(e) => {

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
@@ -84,7 +84,7 @@
       <Tooltip distance={16} location="top">
         <button
           on:click={() => setPrimaryDimension(dimensionName)}
-          class="ui-copy-primary pl-2 truncate flex justify-start"
+          class="ui-header-primary pl-2 truncate flex justify-start"
           style="max-width: calc(315px - 60px);"
           style:width="100%"
           aria-label="Open dimension details"


### PR DESCRIPTION
This PR reverts the default header color of the BigNumber and Leaderboard components to `slate-600`, displaying the UI primary color only on hover.