### PR TITLE
Add feature flag to enable the Data Viewer in Rill Cloud

### DIFF
--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -28,6 +28,8 @@
   export let metricViewName: string;
   export let leftMargin = undefined;
 
+  const { cloudDataViewer } = featureFlags;
+
   let exploreContainerWidth;
 
   $: metricsExplorer = useDashboardStore(metricViewName);
@@ -154,7 +156,7 @@
       {/if}
     </div>
 
-    {#if isRillDeveloper && !expandedMeasureName && !showPivot}
+    {#if (isRillDeveloper || $cloudDataViewer) && !expandedMeasureName && !showPivot}
       <RowsViewerAccordion {metricViewName} />
     {/if}
   {/if}

--- a/web-common/src/features/feature-flags.ts
+++ b/web-common/src/features/feature-flags.ts
@@ -16,6 +16,7 @@ const flags = {
   pivot: features?.includes("pivot") || false,
   alerts: features?.includes("alerts") || false,
   ai: true,
+  cloudDataViewer: features?.includes("data-viewer") || false,
 };
 
 export type FeatureFlags = typeof flags;


### PR DESCRIPTION
This PR enables the Data Viewer in Rill Cloud when a user appends their URL with `?features=data-viewer`.

![image](https://github.com/rilldata/rill/assets/14206386/cfb6501f-b323-4083-b763-ec94631b10ff)
