### PR TITLE
Restrict width of the first column

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotExpandableCell.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotExpandableCell.svelte
@@ -23,13 +23,15 @@
     </button>
   {/if}
 
-  {#if value === "LOADING_CELL"}
-    {""}
-  {:else if value === ""}
-    {"\u00A0"}
-  {:else}
-    {value}
-  {/if}
+  <span class="truncate">
+    {#if value === "LOADING_CELL"}
+      {""}
+    {:else if value === ""}
+      {"\u00A0"}
+    {:else}
+      {value}
+    {/if}
+  </span>
 </div>
 
 <style lang="postcss">

--- a/web-common/src/features/dashboards/pivot/PivotTable.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTable.svelte
@@ -248,6 +248,9 @@
   tr > .with-row-dimension:first-of-type {
     @apply sticky left-0 z-0;
     @apply bg-white;
+    @apply truncate;
+    /* re-evaluate this when adding resizing and virtualization */
+    max-width: 500px;
   }
 
   tr > td:first-of-type:not(:last-of-type) > .cell {


### PR DESCRIPTION
Restricts the width of the first column in the pivot table. Previously, long strings would cover the whole screen. This PR adds a max width of `500px` for the first column.

Before
<img width="1180" alt="image" src="https://github.com/rilldata/rill/assets/4402679/46515aaa-ce94-4ba3-a759-df08d2318e08">

After
<img width="1028" alt="image" src="https://github.com/rilldata/rill/assets/4402679/41d7bbe7-857a-4de6-a69e-220545154bfe">
