### PR TITLE
[Alert Create/Edit] Show the dashboard time range and send it in queryArgs

### DIFF
--- a/web-common/src/features/alerts/CreateAlertDialog.svelte
+++ b/web-common/src/features/alerts/CreateAlertDialog.svelte
@@ -11,6 +11,7 @@
     alertFormValidationSchema,
     getAlertQueryArgsFromFormValues,
   } from "@rilldata/web-common/features/alerts/form-utils";
+  import { useMetricsView } from "@rilldata/web-common/features/dashboards/selectors/index";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import {
     V1Operation,
@@ -33,14 +34,16 @@
   const queryClient = useQueryClient();
   const dispatch = createEventDispatcher();
 
+  const ctx = getStateManagers();
   const {
     metricsViewName,
     dashboardStore,
     selectors: {
       timeRangeSelectors: { timeControlsState },
     },
-  } = getStateManagers();
+  } = ctx;
   const timeControls = get(timeControlsState);
+  const metricsView = useMetricsView(ctx);
 
   const formState = createForm({
     initialValues: {
@@ -66,6 +69,7 @@
       metricsViewName: $metricsViewName,
       whereFilter: $dashboardStore.whereFilter,
       timeRange: {
+        isoDuration: timeControls.selectedTimeRange?.name,
         start: timeControls.timeStart,
         end: timeControls.timeEnd,
       },
@@ -82,7 +86,10 @@
               intervalDuration: values.splitByTimeGrain,
               queryName: "MetricsViewAggregation",
               queryArgsJson: JSON.stringify(
-                getAlertQueryArgsFromFormValues(values),
+                getAlertQueryArgsFromFormValues(
+                  values,
+                  $metricsView.data ?? {},
+                ),
               ),
               metricsViewName: values.metricsViewName,
               recipients: values.recipients.map((r) => r.email).filter(Boolean),
@@ -121,5 +128,5 @@
   <DialogOverlay
     class="fixed inset-0 bg-gray-400 transition-opacity opacity-40"
   />
-  <BaseAlertForm isEditForm={false} {formState} on:close />
+  <BaseAlertForm {formState} isEditForm={false} on:close />
 </Dialog>

--- a/web-common/src/features/alerts/EditAlertDialog.svelte
+++ b/web-common/src/features/alerts/EditAlertDialog.svelte
@@ -60,7 +60,7 @@
               intervalDuration: values.splitByTimeGrain,
               queryName: "MetricsViewAggregation",
               queryArgsJson: JSON.stringify(
-                getAlertQueryArgsFromFormValues(values),
+                getAlertQueryArgsFromFormValues(values, metricsViewSpec),
               ),
               metricsViewName: values.metricsViewName,
               recipients: values.recipients.map((r) => r.email).filter(Boolean),
@@ -99,5 +99,5 @@
   <DialogOverlay
     class="fixed inset-0 bg-gray-400 transition-opacity opacity-40"
   />
-  <BaseAlertForm isEditForm={true} {formState} on:close />
+  <BaseAlertForm {formState} isEditForm={true} on:close />
 </Dialog>

--- a/web-common/src/features/alerts/data-tab/AlertDialogDataTab.svelte
+++ b/web-common/src/features/alerts/data-tab/AlertDialogDataTab.svelte
@@ -31,7 +31,8 @@
       label: d.label?.length ? d.label : d.expression,
     })) ?? [];
 
-  $: hasAtLeastOneFilter = $form.whereFilter.cond.exprs.length > 0;
+  $: hasAtLeastOneFilter =
+    $form.whereFilter.cond.exprs.length > 0 || $form["timeRange"];
 </script>
 
 <div class="flex flex-col gap-y-3">
@@ -54,6 +55,7 @@
       <FilterChipsReadOnly
         metricsViewName={$form["metricsViewName"]}
         filters={$form["whereFilter"]}
+        timeRange={$form["timeRange"]}
       />
     {:else}
       <NoFiltersSelected {isEditForm} />

--- a/web-common/src/features/alerts/form-utils.ts
+++ b/web-common/src/features/alerts/form-utils.ts
@@ -1,3 +1,4 @@
+import { getAlertPreviewQueryRequest } from "@rilldata/web-common/features/alerts/alert-preview-data";
 import {
   createAndExpression,
   createBinaryExpression,
@@ -5,6 +6,7 @@ import {
 import type {
   V1Expression,
   V1MetricsViewAggregationRequest,
+  V1MetricsViewSpec,
   V1Operation,
   V1TimeRange,
 } from "@rilldata/web-common/runtime-client";
@@ -32,31 +34,28 @@ export type AlertFormValues = {
 
 export function getAlertQueryArgsFromFormValues(
   formValues: AlertFormValues,
+  metricsViewSpec: V1MetricsViewSpec,
 ): V1MetricsViewAggregationRequest {
-  return {
-    metricsView: formValues.metricsViewName,
-    measures: [{ name: formValues.measure }],
-    dimensions: formValues.splitByDimension
-      ? [{ name: formValues.splitByDimension }]
-      : [],
-    where: formValues.whereFilter,
-    having: createAndExpression(
-      formValues.criteria.map((c) =>
-        createBinaryExpression(
-          c.field,
-          c.operation as V1Operation,
-          Number(c.value),
+  return getAlertPreviewQueryRequest(
+    {
+      metricsViewName: formValues.metricsViewName,
+      measure: formValues.measure,
+      splitByDimension: formValues.splitByDimension,
+      splitByTimeGrain: formValues.splitByTimeGrain,
+      timeRange: formValues.timeRange,
+      whereFilter: formValues.whereFilter,
+      criteria: createAndExpression(
+        formValues.criteria.map((c) =>
+          createBinaryExpression(
+            c.field,
+            c.operation as V1Operation,
+            Number(c.value),
+          ),
         ),
       ),
-    ),
-    ...(formValues.splitByTimeGrain
-      ? {
-          timeRange: {
-            isoDuration: formValues.splitByTimeGrain,
-          },
-        }
-      : {}),
-  };
+    },
+    metricsViewSpec,
+  );
 }
 
 export const alertFormValidationSchema = yup.object({

--- a/web-common/src/features/dashboards/filters/FilterChipsReadOnly.svelte
+++ b/web-common/src/features/dashboards/filters/FilterChipsReadOnly.svelte
@@ -2,8 +2,12 @@
 The main feature-set component for dashboard filters
  -->
 <script lang="ts">
+  import ReadonlyTimeRange from "@rilldata/web-common/features/dashboards/filters/ReadonlyTimeRange.svelte";
   import { getMapFromArray } from "@rilldata/web-common/lib/arrayUtils";
-  import type { V1Expression } from "@rilldata/web-common/runtime-client";
+  import type {
+    V1Expression,
+    V1TimeRange,
+  } from "@rilldata/web-common/runtime-client";
   import { flip } from "svelte/animate";
   import { runtime } from "../../../runtime-client/runtime-store";
   import { useDashboard } from "../selectors";
@@ -14,6 +18,7 @@ The main feature-set component for dashboard filters
 
   export let metricsViewName: string;
   export let filters: V1Expression | undefined;
+  export let timeRange: V1TimeRange | undefined;
 
   $: dashboard = useDashboard($runtime.instanceId, metricsViewName);
 
@@ -36,6 +41,9 @@ The main feature-set component for dashboard filters
 </script>
 
 <div class="relative flex flex-row flex-wrap gap-x-2 gap-y-2 items-center">
+  {#if timeRange}
+    <ReadonlyTimeRange {timeRange} />
+  {/if}
   {#if dimensionFilters.length > 0}
     {#each dimensionFilters as { name, label, selectedValues } (name)}
       {@const dimension = dimensions.find((d) => d.name === name)}

--- a/web-common/src/features/dashboards/filters/ReadonlyTimeRange.svelte
+++ b/web-common/src/features/dashboards/filters/ReadonlyTimeRange.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { Chip } from "@rilldata/web-common/components/chip";
+  import { timeChipColors } from "@rilldata/web-common/components/chip/chip-types";
+  import { prettyFormatTimeRange } from "@rilldata/web-common/lib/time/ranges";
+  import { humaniseISODuration } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
+  import { TimeRangePreset } from "@rilldata/web-common/lib/time/types";
+  import type { V1TimeRange } from "@rilldata/web-common/runtime-client";
+
+  export let timeRange: V1TimeRange;
+  $: console.log(timeRange);
+</script>
+
+<Chip {...timeChipColors} outline readOnly>
+  <svelte:fragment slot="body">
+    <div class="font-bold text-xs text-slate-800">
+      {#if timeRange.isoDuration && timeRange.isoDuration !== TimeRangePreset.CUSTOM}
+        {#if timeRange.isoDuration === TimeRangePreset.ALL_TIME}
+          All Time
+        {:else}
+          Last {humaniseISODuration(timeRange.isoDuration)}
+        {/if}
+      {:else if timeRange.start && timeRange.end}
+        {prettyFormatTimeRange(
+          new Date(timeRange.start),
+          new Date(timeRange.end),
+          TimeRangePreset.CUSTOM,
+          "UTC", // TODO
+        )}
+      {/if}
+    </div>
+  </svelte:fragment>
+</Chip>

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterBody.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterBody.svelte
@@ -45,7 +45,8 @@
     class="font-bold text-ellipsis overflow-hidden whitespace-nowrap"
     style:max-width={labelMaxWidth}
   >
-    {label} for {dimensionName}
+    {label}
+    {#if dimensionName}for {dimensionName}{/if}
   </div>
   <div class="flex flex-wrap flex-row items-baseline gap-y-1">
     {#if shortLabel}


### PR DESCRIPTION
Updates the way we handle time range.
- [x] Show the time range selected in the dashboard in the filters section.
- [x] Use the time range instead of split by grain in creating the alert.
- [x] Update the measure filter to not show `for` if dimension is not specified.