### PR TITLE
Improve Alert History table

### DIFF
--- a/runtime/queries/metricsview.go
+++ b/runtime/queries/metricsview.go
@@ -473,7 +473,7 @@ func buildInExpression(mv *runtimev1.MetricsViewSpec, cond *runtimev1.Condition,
 
 func buildAndOrExpressions(mv *runtimev1.MetricsViewSpec, cond *runtimev1.Condition, aliases []*runtimev1.MetricsViewComparisonMeasureAlias, dialect drivers.Dialect, joiner string) (string, []any, error) {
 	if len(cond.Exprs) == 0 {
-		return "", nil, fmt.Errorf("or/and expression should have at least 1 sub expressions")
+		return "", nil, fmt.Errorf("or/and expression should have at least 1 sub expression")
 	}
 
 	clauses := make([]string, 0)

--- a/runtime/queries/metricsview.go
+++ b/runtime/queries/metricsview.go
@@ -400,7 +400,7 @@ func buildLikeExpression(mv *runtimev1.MetricsViewSpec, cond *runtimev1.Conditio
 
 func buildInExpression(mv *runtimev1.MetricsViewSpec, cond *runtimev1.Condition, aliases []*runtimev1.MetricsViewComparisonMeasureAlias, dialect drivers.Dialect) (string, []any, error) {
 	if len(cond.Exprs) <= 1 {
-		return "", nil, fmt.Errorf("in/not in expression should have atleast 2 sub expressions")
+		return "", nil, fmt.Errorf("in/not in expression should have at least 2 sub expressions")
 	}
 
 	leftExpr, args, err := buildExpression(mv, cond.Exprs[0], aliases, dialect)
@@ -473,7 +473,7 @@ func buildInExpression(mv *runtimev1.MetricsViewSpec, cond *runtimev1.Condition,
 
 func buildAndOrExpressions(mv *runtimev1.MetricsViewSpec, cond *runtimev1.Condition, aliases []*runtimev1.MetricsViewComparisonMeasureAlias, dialect drivers.Dialect, joiner string) (string, []any, error) {
 	if len(cond.Exprs) == 0 {
-		return "", nil, fmt.Errorf("or/and expression should have atleast 1 sub expressions")
+		return "", nil, fmt.Errorf("or/and expression should have at least 1 sub expressions")
 	}
 
 	clauses := make([]string, 0)

--- a/web-admin/src/features/alerts/history/AlertHistoryStatusChip.svelte
+++ b/web-admin/src/features/alerts/history/AlertHistoryStatusChip.svelte
@@ -1,45 +1,49 @@
 <script lang="ts">
+  import { Tag } from "@rilldata/web-common/components/tag";
+  import type { Color } from "@rilldata/web-common/components/tag/Tag.svelte";
   import {
+    V1AlertExecution,
     V1AssertionStatus,
     type V1AssertionResult,
   } from "@rilldata/web-common/runtime-client";
 
+  export let currentExecution: V1AlertExecution;
   export let result: V1AssertionResult;
 
-  type StatusDisplay = {
+  type AssertionResultDisplay = {
     text: string;
-    textClass: string;
-    borderClass: string;
+    color: Color;
   };
-  const statusDisplays: Record<V1AssertionStatus, StatusDisplay> = {
-    [V1AssertionStatus.ASSERTION_STATUS_UNSPECIFIED]: {
-      // This should never happen
-      text: "Status unknown",
-      textClass: "text-yellow-600",
-      borderClass: "bg-yellow-50 border-yellow-300",
-    },
+  const assertionResultDisplays: Record<
+    V1AssertionStatus,
+    AssertionResultDisplay
+  > = {
     [V1AssertionStatus.ASSERTION_STATUS_PASS]: {
       text: "Not triggered",
-      textClass: "text-gray-600",
-      borderClass: "bg-gray-50 border-gray-300",
+      color: "gray",
     },
     [V1AssertionStatus.ASSERTION_STATUS_FAIL]: {
       text: "Triggered",
-      textClass: "text-blue-600",
-      borderClass: "bg-blue-50 border-blue-300",
+      color: "blue",
     },
     [V1AssertionStatus.ASSERTION_STATUS_ERROR]: {
       text: "Failed",
-      textClass: "text-red-600",
-      borderClass: "bg-red-50 border-red-300",
+      color: "red",
+    },
+    // This should never happen
+    [V1AssertionStatus.ASSERTION_STATUS_UNSPECIFIED]: {
+      text: "Status unknown",
+      color: "amber",
     },
   };
-  $: currentStatusDisplay = statusDisplays[result.status];
+
+  $: assertionResultDisplay = assertionResultDisplays[result.status];
 </script>
 
-<div
-  class="flex space-x-1 items-center px-2 border rounded-full w-fit {currentStatusDisplay.borderClass}"
->
-  <span class={currentStatusDisplay.textClass}>{currentStatusDisplay.text}</span
-  >
-</div>
+{#if currentExecution}
+  <Tag color="green">Running</Tag>
+{:else}
+  <Tag color={assertionResultDisplay.color}>
+    {assertionResultDisplay.text}
+  </Tag>
+{/if}

--- a/web-admin/src/features/alerts/history/AlertHistoryStatusChip.svelte
+++ b/web-admin/src/features/alerts/history/AlertHistoryStatusChip.svelte
@@ -38,7 +38,7 @@
 </script>
 
 <div
-  class="flex space-x-1 items-center px-2 border rounded rounded-[20px] w-fit {currentStatusDisplay.borderClass}"
+  class="flex space-x-1 items-center px-2 border rounded-full w-fit {currentStatusDisplay.borderClass}"
 >
   <span class={currentStatusDisplay.textClass}>{currentStatusDisplay.text}</span
   >

--- a/web-admin/src/features/alerts/history/AlertHistoryStatusChip.svelte
+++ b/web-admin/src/features/alerts/history/AlertHistoryStatusChip.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import {
-    type V1AssertionResult,
     V1AssertionStatus,
+    type V1AssertionResult,
   } from "@rilldata/web-common/runtime-client";
 
   export let result: V1AssertionResult;
@@ -13,21 +13,22 @@
   };
   const statusDisplays: Record<V1AssertionStatus, StatusDisplay> = {
     [V1AssertionStatus.ASSERTION_STATUS_UNSPECIFIED]: {
-      text: "Pending",
-      textClass: "text-purple-600",
-      borderClass: "bg-purple-50 border-purple-300",
+      // This should never happen
+      text: "Status unknown",
+      textClass: "text-yellow-600",
+      borderClass: "bg-yellow-50 border-yellow-300",
     },
     [V1AssertionStatus.ASSERTION_STATUS_PASS]: {
-      text: "Pass",
-      textClass: "text-green-600",
-      borderClass: "bg-green-50 border-green-300",
-    },
-    [V1AssertionStatus.ASSERTION_STATUS_ERROR]: {
-      text: "Errored",
-      textClass: "text-red-600",
-      borderClass: "bg-red-50 border-red-300",
+      text: "Not triggered",
+      textClass: "text-gray-600",
+      borderClass: "bg-gray-50 border-gray-300",
     },
     [V1AssertionStatus.ASSERTION_STATUS_FAIL]: {
+      text: "Triggered",
+      textClass: "text-blue-600",
+      borderClass: "bg-blue-50 border-blue-300",
+    },
+    [V1AssertionStatus.ASSERTION_STATUS_ERROR]: {
       text: "Failed",
       textClass: "text-red-600",
       borderClass: "bg-red-50 border-red-300",

--- a/web-admin/src/features/alerts/history/AlertHistoryTable.svelte
+++ b/web-admin/src/features/alerts/history/AlertHistoryTable.svelte
@@ -26,6 +26,8 @@
           alertTime: info.row.original.executionTime,
           timeZone:
             $alertQuery.data.resource.alert.spec.refreshSchedule.timeZone,
+          currentExecution:
+            $alertQuery.data.resource.alert.state.currentExecution,
           result: info.row.original.result,
         }),
     },

--- a/web-admin/src/features/alerts/history/AlertHistoryTableCompositeCell.svelte
+++ b/web-admin/src/features/alerts/history/AlertHistoryTableCompositeCell.svelte
@@ -1,22 +1,21 @@
 <script lang="ts">
   import AlertHistoryStatusChip from "@rilldata/web-admin/features/alerts/history/AlertHistoryStatusChip.svelte";
   import { formatRunDate } from "@rilldata/web-admin/features/scheduled-reports/tableUtils";
-  import {
-    type V1AssertionResult,
-    V1AssertionStatus,
+  import type {
+    V1AlertExecution,
+    V1AssertionResult,
   } from "@rilldata/web-common/runtime-client";
 
   export let alertTime: string;
   export let timeZone: string;
+  export let currentExecution: V1AlertExecution | null;
   export let result: V1AssertionResult;
 </script>
 
 <div class="flex gap-x-2 items-center px-4 py-[10px]">
-  <div class="text-gray-700 text-sm">
-    {result.status === V1AssertionStatus.ASSERTION_STATUS_UNSPECIFIED
-      ? "Checking"
-      : "Checked"}
+  <div class="text-gray-700 text-sm flex-shrink-0">
+    {currentExecution ? "Checking" : "Checked"}
     {formatRunDate(alertTime, timeZone)}
   </div>
-  <AlertHistoryStatusChip {result} />
+  <AlertHistoryStatusChip {currentExecution} {result} />
 </div>

--- a/web-admin/src/features/alerts/history/AlertHistoryTableCompositeCell.svelte
+++ b/web-admin/src/features/alerts/history/AlertHistoryTableCompositeCell.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import AlertHistoryStatusChip from "@rilldata/web-admin/features/alerts/history/AlertHistoryStatusChip.svelte";
   import { formatRunDate } from "@rilldata/web-admin/features/scheduled-reports/tableUtils";
-  import type {
-    V1AlertExecution,
-    V1AssertionResult,
+  import {
+    V1AssertionStatus,
+    type V1AlertExecution,
+    type V1AssertionResult,
   } from "@rilldata/web-common/runtime-client";
 
   export let alertTime: string;
@@ -18,4 +19,7 @@
     {formatRunDate(alertTime, timeZone)}
   </div>
   <AlertHistoryStatusChip {currentExecution} {result} />
+  {#if result.status === V1AssertionStatus.ASSERTION_STATUS_ERROR}
+    <span class="text-red-600">({result.errorMessage})</span>
+  {/if}
 </div>

--- a/web-admin/src/features/alerts/history/AlertHistoryTableCompositeCell.svelte
+++ b/web-admin/src/features/alerts/history/AlertHistoryTableCompositeCell.svelte
@@ -11,6 +11,7 @@
   export let timeZone: string;
   export let currentExecution: V1AlertExecution | null;
   export let result: V1AssertionResult;
+  $: console.log("result", result);
 </script>
 
 <div class="flex gap-x-2 items-center px-4 py-[10px]">
@@ -20,6 +21,6 @@
   </div>
   <AlertHistoryStatusChip {currentExecution} {result} />
   {#if result.status === V1AssertionStatus.ASSERTION_STATUS_ERROR}
-    <span class="text-red-600">({result.errorMessage})</span>
+    <span class="text-red-600">{result.errorMessage}</span>
   {/if}
 </div>

--- a/web-common/src/components/tag/Tag.svelte
+++ b/web-common/src/components/tag/Tag.svelte
@@ -1,5 +1,5 @@
-<script lang="ts">
-  type Color =
+<script context="module" lang="ts">
+  export type Color =
     | "gray"
     | "magenta"
     | "green"
@@ -9,7 +9,9 @@
     | "amber"
     | "blue"
     | "purple";
+</script>
 
+<script lang="ts">
   export let color: Color = "gray";
   export let height = 21;
 


### PR DESCRIPTION
Improvements:
- Updated chip copy to match mocks
- Added error text in case of a Failed execution
- Refactored the `AlertHistoryStatusChip` to use our `Tag` component

Some examples:

![image](https://github.com/rilldata/rill/assets/14206386/e8ad71f0-8a82-46a1-9db2-b4d1b352c7f1)
![image](https://github.com/rilldata/rill/assets/14206386/ac13c5e5-faba-46bc-97ef-ccdfccee0d3f)
![image](https://github.com/rilldata/rill/assets/14206386/39687093-770a-41e4-b28f-f68ddab7cf29)
