### PR TITLE
Runtime proxy on the admin service

### DIFF
--- a/admin/server/auth/middleware.go
+++ b/admin/server/auth/middleware.go
@@ -83,7 +83,7 @@ func (a *Authenticator) httpMiddleware(next http.Handler, lenient bool) http.Han
 		if authHeader != "" {
 			newCtx, err := a.parseClaimsFromBearer(r.Context(), authHeader)
 			if err != nil {
-				// In lenient model, we set anonClaims.
+				// In lenient mode, we set anonClaims.
 				if lenient {
 					newCtx := context.WithValue(r.Context(), claimsContextKey{}, anonClaims{})
 					next.ServeHTTP(w, r.WithContext(newCtx))

--- a/admin/server/runtime_proxy.go
+++ b/admin/server/runtime_proxy.go
@@ -14,8 +14,9 @@ import (
 
 // runtimeProxyForOrgAndProject proxies a request to the runtime service for a specific project.
 // This provides a way to directly query a project's runtime on a stable URL without needing to call GetProject or GetDeploymentCredentials to discover the runtime URL.
-// If the request is made using an Authorization header or cookie recognized by the admin service, the proxied request is made with a newly minted JWT similar to the one that could be obtained by calling GetProject.
-// If the Authorization header of the request is not recognized, it is proxied through to the runtime service.
+// If the request is made using an Authorization header or cookie recognized by the admin service,
+// the proxied request is made with a newly minted JWT similar to the one that could be obtained by calling GetProject.
+// If the Authorization header of the request is not recognized by the admin service, it is proxied through to the runtime service.
 func (s *Server) runtimeProxyForOrgAndProject(w http.ResponseWriter, r *http.Request) {
 	// Get args from URL path components
 	org := r.PathValue("org")
@@ -53,6 +54,7 @@ func (s *Server) runtimeProxyForOrgAndProject(w http.ResponseWriter, r *http.Req
 	case auth.OwnerTypeUser, auth.OwnerTypeService:
 		// If the client is authenticated with the admin service, we issue a new ephemeral runtime JWT.
 		// The JWT should have the same permissions/configuration as one they would get by calling AdminService.GetProject.
+
 		permissions := claims.ProjectPermissions(r.Context(), proj.OrganizationID, depl.ProjectID)
 		if !permissions.ReadProd {
 			http.Error(w, "does not have permission to access the production deployment", http.StatusForbidden)

--- a/admin/server/runtime_proxy.go
+++ b/admin/server/runtime_proxy.go
@@ -1,0 +1,134 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/rilldata/rill/admin/server/auth"
+	runtimeauth "github.com/rilldata/rill/runtime/server/auth"
+)
+
+func (s *Server) runtimeProxyForOrgAndProject(w http.ResponseWriter, r *http.Request) {
+	org := r.PathValue("org")
+	project := r.PathValue("project")
+	proxyPath := r.PathValue("path")
+
+	proj, err := s.admin.DB.FindProjectByName(r.Context(), org, project)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if proj.ProdDeploymentID == nil {
+		http.Error(w, "no prod deployment for project", http.StatusBadRequest)
+		return
+	}
+
+	depl, err := s.admin.DB.FindDeployment(r.Context(), *proj.ProdDeploymentID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	claims := auth.GetClaims(r.Context())
+	permissions := claims.ProjectPermissions(r.Context(), proj.OrganizationID, depl.ProjectID)
+	if proj.Public {
+		permissions.ReadProject = true
+		permissions.ReadProd = true
+	}
+
+	if !permissions.ReadProd {
+		http.Error(w, "does not have permission to access the production deployment", http.StatusForbidden)
+		return
+	}
+
+	s.admin.Used.Deployment(depl.ID)
+
+	// Get the JWT (if any) to use for the proxied request.
+	var jwt string
+	switch claims.OwnerType() {
+	// If the client is not authenticated with the admin service, we just proxy the contents of the Authorization header to the runtime (if any).
+	// Note that the authorization middleware for this handler is set to be "lenient",
+	// which means it will still invoke this handler even if the Authorization header contains a token that is not valid for the admin service.
+	case auth.OwnerTypeAnon:
+		authorizationHeader := r.Header.Get("Authorization")
+		if len(authorizationHeader) >= 6 && strings.EqualFold(authorizationHeader[0:6], "bearer") {
+			jwt = strings.TrimSpace(authorizationHeader[6:])
+		}
+	// If the client is authenticated with the admin service, we issue a new ephemeral runtime JWT.
+	// The JWT should have the same permissions/configuration as one they would get by calling AdminService.GetProject.
+	case auth.OwnerTypeUser, auth.OwnerTypeService:
+		var attr map[string]any
+		if claims.OwnerType() == auth.OwnerTypeUser {
+			attr, err = s.jwtAttributesForUser(r.Context(), claims.OwnerID(), proj.OrganizationID, permissions)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		jwt, err = s.issuer.NewToken(runtimeauth.TokenOptions{
+			AudienceURL: depl.RuntimeAudience,
+			Subject:     claims.OwnerID(),
+			TTL:         runtimeAccessTokenDefaultTTL,
+			InstancePermissions: map[string][]runtimeauth.Permission{
+				depl.RuntimeInstanceID: {
+					// TODO: Remove ReadProfiling and ReadRepo (may require frontend changes)
+					runtimeauth.ReadObjects,
+					runtimeauth.ReadMetrics,
+					runtimeauth.ReadProfiling,
+					runtimeauth.ReadRepo,
+				},
+			},
+			Attributes: attr,
+		})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	default:
+		http.Error(w, fmt.Sprintf("runtime proxy not available for owner type %q", claims.OwnerType()), http.StatusBadRequest)
+		return
+	}
+
+	// Create the URL to proxy to
+	proxyURL, err := url.JoinPath(depl.RuntimeHost, "/v1/instances", depl.RuntimeInstanceID, proxyPath)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Create the proxied request.
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, proxyURL, r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	for k, v := range r.Header {
+		req.Header.Add(k, v[0])
+	}
+
+	// Override the authorization header with the JWT.
+	req.Header.Set("Authorization", "Bearer "+jwt)
+
+	// Send the proxied request using http.DefaultClient. The default client automatically handles caching/pooling of TCP connections.
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer res.Body.Close()
+
+	// Copy the proxied response to the original response writer
+	outHeader := w.Header()
+	for k, v := range res.Header {
+		for _, vv := range v {
+			outHeader.Add(k, vv)
+		}
+	}
+	w.WriteHeader(res.StatusCode)
+	io.Copy(w, res.Body)
+}

--- a/admin/server/runtime_proxy.go
+++ b/admin/server/runtime_proxy.go
@@ -5,62 +5,60 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/rilldata/rill/admin/server/auth"
 	runtimeauth "github.com/rilldata/rill/runtime/server/auth"
 )
 
+// runtimeProxyForOrgAndProject proxies a request to the runtime service for a specific project.
+// This provides a way to directly query a project's runtime on a stable URL without needing to call GetProject or GetDeploymentCredentials to discover the runtime URL.
+// If the request is made using an Authorization header or cookie recognized by the admin service, the proxied request is made with a newly minted JWT similar to the one that could be obtained by calling GetProject.
+// If the Authorization header of the request is not recognized, it is proxied through to the runtime service.
 func (s *Server) runtimeProxyForOrgAndProject(w http.ResponseWriter, r *http.Request) {
+	// Get args from URL path components
 	org := r.PathValue("org")
 	project := r.PathValue("project")
 	proxyPath := r.PathValue("path")
 
+	// Find the production deployment for the project we're proxying to
 	proj, err := s.admin.DB.FindProjectByName(r.Context(), org, project)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-
 	if proj.ProdDeploymentID == nil {
 		http.Error(w, "no prod deployment for project", http.StatusBadRequest)
 		return
 	}
-
 	depl, err := s.admin.DB.FindDeployment(r.Context(), *proj.ProdDeploymentID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	claims := auth.GetClaims(r.Context())
-	permissions := claims.ProjectPermissions(r.Context(), proj.OrganizationID, depl.ProjectID)
-	if proj.Public {
-		permissions.ReadProject = true
-		permissions.ReadProd = true
-	}
-
-	if !permissions.ReadProd {
-		http.Error(w, "does not have permission to access the production deployment", http.StatusForbidden)
-		return
-	}
-
-	s.admin.Used.Deployment(depl.ID)
-
-	// Get the JWT (if any) to use for the proxied request.
+	// Get or issue a JWT to use for the proxied request.
 	var jwt string
+	claims := auth.GetClaims(r.Context())
 	switch claims.OwnerType() {
-	// If the client is not authenticated with the admin service, we just proxy the contents of the Authorization header to the runtime (if any).
-	// Note that the authorization middleware for this handler is set to be "lenient",
-	// which means it will still invoke this handler even if the Authorization header contains a token that is not valid for the admin service.
 	case auth.OwnerTypeAnon:
+		// If the client is not authenticated with the admin service, we just proxy the contents of the Authorization header to the runtime (if any).
+		// Note that the authorization middleware for this handler is set to be "lenient",
+		// which means it will still invoke this handler even if the Authorization header contains a token that is not valid for the admin service.
 		authorizationHeader := r.Header.Get("Authorization")
 		if len(authorizationHeader) >= 6 && strings.EqualFold(authorizationHeader[0:6], "bearer") {
 			jwt = strings.TrimSpace(authorizationHeader[6:])
 		}
-	// If the client is authenticated with the admin service, we issue a new ephemeral runtime JWT.
-	// The JWT should have the same permissions/configuration as one they would get by calling AdminService.GetProject.
 	case auth.OwnerTypeUser, auth.OwnerTypeService:
+		// If the client is authenticated with the admin service, we issue a new ephemeral runtime JWT.
+		// The JWT should have the same permissions/configuration as one they would get by calling AdminService.GetProject.
+		permissions := claims.ProjectPermissions(r.Context(), proj.OrganizationID, depl.ProjectID)
+		if !permissions.ReadProd {
+			http.Error(w, "does not have permission to access the production deployment", http.StatusForbidden)
+			return
+		}
+
 		var attr map[string]any
 		if claims.OwnerType() == auth.OwnerTypeUser {
 			attr, err = s.jwtAttributesForUser(r.Context(), claims.OwnerID(), proj.OrganizationID, permissions)
@@ -94,8 +92,23 @@ func (s *Server) runtimeProxyForOrgAndProject(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Create the URL to proxy to
-	proxyURL, err := url.JoinPath(depl.RuntimeHost, "/v1/instances", depl.RuntimeInstanceID, proxyPath)
+	// Track usage of the deployment
+	s.admin.Used.Deployment(depl.ID)
+
+	// Determine runtime host.
+	// NOTE: In production, the runtime host serves both the HTTP and gRPC servers.
+	// But in development, the two are presently on different ports, and depl.RuntimeHost is that of the gRPC server.
+	// Until we get both servers on the same port in development, this hack rewrites the runtime host to the HTTP server.
+	runtimeHost := depl.RuntimeHost
+	if strings.HasPrefix(runtimeHost, "http://localhost:") {
+		runtimeHost = os.Getenv("RILL_RUNTIME_AUTH_AUDIENCE_URL")
+		if runtimeHost == "" {
+			runtimeHost = "http://localhost:8081"
+		}
+	}
+
+	// Create the URL to proxy to by prepending `/v1/instances/{instanceID}` to the proxy path.
+	proxyURL, err := url.JoinPath(runtimeHost, "/v1/instances", depl.RuntimeInstanceID, proxyPath)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -111,7 +124,7 @@ func (s *Server) runtimeProxyForOrgAndProject(w http.ResponseWriter, r *http.Req
 		req.Header.Add(k, v[0])
 	}
 
-	// Override the authorization header with the JWT.
+	// Override the authorization header with the JWT (note use of Set instead of Add).
 	req.Header.Set("Authorization", "Bearer "+jwt)
 
 	// Send the proxied request using http.DefaultClient. The default client automatically handles caching/pooling of TCP connections.
@@ -130,5 +143,9 @@ func (s *Server) runtimeProxyForOrgAndProject(w http.ResponseWriter, r *http.Req
 		}
 	}
 	w.WriteHeader(res.StatusCode)
-	io.Copy(w, res.Body)
+	_, err = io.Copy(w, res.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 }

--- a/admin/server/server.go
+++ b/admin/server/server.go
@@ -205,14 +205,10 @@ func (s *Server) HTTPHandler(ctx context.Context) (http.Handler, error) {
 
 	// Add runtime proxy
 	mux.Handle("/v1/orgs/{org}/projects/{project}/runtime/{path...}",
-		observability.TracingMiddleware(
-			observability.LoggingMiddleware(
-				s.logger,
-				s.authenticator.HTTPMiddlewareLenient(
-					http.HandlerFunc(s.runtimeProxyForOrgAndProject),
-				),
-			),
+		observability.Middleware(
 			"runtime-proxy",
+			s.logger,
+			s.authenticator.HTTPMiddlewareLenient(http.HandlerFunc(s.runtimeProxyForOrgAndProject)),
 		),
 	)
 

--- a/runtime/pkg/observability/middleware.go
+++ b/runtime/pkg/observability/middleware.go
@@ -235,14 +235,14 @@ func LoggingMiddleware(logger *zap.Logger, next http.Handler) http.Handler {
 				zap.Int("http.status", httpStatus),
 				zap.Duration("duration", time.Since(start)),
 			)
-			logger.Debug("http request finished", fields...)
+			logger.Info("http request finished", fields...)
 		}()
 
 		// Add log fields to context
 		r = r.WithContext(contextWithLogFields(r.Context(), &fields))
 
 		// Print start message
-		logger.Debug("http request started", fields...)
+		logger.Info("http request started", fields...)
 
 		next.ServeHTTP(&wrapped, r)
 	})


### PR DESCRIPTION
- Adds a runtime proxy endpoint on the admin service
- Requests made to `{admin host}/v1/orgs/{org}/projects/{project}/runtime/{path...}` are proxied to `{runtime host}/v1/instances/{instanceID}/{path...}`
- Authentication logic:
  - If the request is made using an authentication mechanism recognized by the admin service (i.e. browser cookie or service bearer token), the admin service checks permissions and issues an ephemeral JWT similar to the one that could be obtained by calling `GetDeploymentCredentials`.
  - If the request is made using an `Authorization` header that the admin service doesn't recognize (e.g. a previously issued runtime JWT), the contents are directly proxied in the runtime request
  - If no authentication mechanism is used, the request is proxied without any authentication. This enables access to public endpoints on the runtime instance, such as `/openapi`.

