### PR TITLE
Pin sveltekit to 1.30.0 temporarily

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7882,6 +7882,7 @@
       "integrity": "sha512-JSQIQT6XvdchCRQEm7BABxPC56WP5RYVONAi+09S8tmzeP43fBsRlr95bFmsTQM2RHBldfgQk+jgdnsKI75daA==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte": "^2.5.0",
         "@types/cookie": "^0.5.1",
@@ -7913,6 +7914,7 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.7.tgz",
       "integrity": "sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       },
@@ -30568,6 +30570,7 @@
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
       "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -32351,7 +32354,7 @@
         "@rgossiaux/svelte-headlessui": "^2.0.0",
         "@rilldata/svelte-query": "^4.29.20-0.0.3",
         "@sveltejs/adapter-static": "^1.0.0",
-        "@sveltejs/kit": "^1.20.4",
+        "@sveltejs/kit": "1.30.0",
         "@tanstack/svelte-query": "npm:@rilldata/svelte-query@4.29.20-0.0.3",
         "@tanstack/svelte-table": "^8.11.8",
         "autoprefixer": "^10.4.13",
@@ -32400,6 +32403,38 @@
         "@orval/core": "6.12.0"
       }
     },
+    "web-admin/node_modules/@sveltejs/kit": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.30.0.tgz",
+      "integrity": "sha512-HK7XE8ZAL7cGreRRxCCVEpcNA3x2KM0mfJlDv7geEyCElYjJsdBoANEb00HcYlvs/2ShNAsX8lY/A60s9Xdfew==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte": "^2.5.0",
+        "@types/cookie": "^0.5.1",
+        "cookie": "^0.5.0",
+        "devalue": "^4.3.1",
+        "esm-env": "^1.0.0",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.0",
+        "mrmime": "^1.0.1",
+        "sade": "^1.8.1",
+        "set-cookie-parser": "^2.6.0",
+        "sirv": "^2.0.2",
+        "tiny-glob": "^0.2.9",
+        "undici": "~5.26.2"
+      },
+      "bin": {
+        "svelte-kit": "svelte-kit.js"
+      },
+      "engines": {
+        "node": "^16.14 || >=18"
+      },
+      "peerDependencies": {
+        "svelte": "^3.54.0 || ^4.0.0-next.0 || ^5.0.0-next.0",
+        "vite": "^4.0.0"
+      }
+    },
     "web-admin/node_modules/ajv": {
       "version": "8.12.0",
       "dev": true,
@@ -32435,6 +32470,18 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
+    "web-admin/node_modules/magic-string": {
+      "version": "0.30.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.7.tgz",
+      "integrity": "sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "web-admin/node_modules/orval": {
       "version": "6.12.0",
       "dev": true,
@@ -32464,6 +32511,18 @@
         "orval": "dist/bin/orval.js"
       }
     },
+    "web-admin/node_modules/undici": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.26.5.tgz",
+      "integrity": "sha512-cSb4bPFd5qgR7qr2jYAi0hlX9n5YKK2ONKkLFkxl+v/9BvC0sOpZjBHDBSXc5lWAf5ty9oZdRXytBIHzgUcerw==",
+      "dev": true,
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "web-auth": {
       "version": "0.0.1",
       "devDependencies": {
@@ -32474,7 +32533,7 @@
         "@rollup/plugin-terser": "^0.4.0",
         "@sveltejs/adapter-auto": "^2.0.0",
         "@sveltejs/adapter-static": "^2.0.2",
-        "@sveltejs/kit": "^1.20.4",
+        "@sveltejs/kit": "1.30.0",
         "@types/auth0-js": "^9.14.7",
         "auth0-js": "^9.20.2",
         "autoprefixer": "^10.4.13",
@@ -32495,6 +32554,62 @@
       "license": "MIT",
       "peerDependencies": {
         "@sveltejs/kit": "^1.5.0"
+      }
+    },
+    "web-auth/node_modules/@sveltejs/kit": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.30.0.tgz",
+      "integrity": "sha512-HK7XE8ZAL7cGreRRxCCVEpcNA3x2KM0mfJlDv7geEyCElYjJsdBoANEb00HcYlvs/2ShNAsX8lY/A60s9Xdfew==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte": "^2.5.0",
+        "@types/cookie": "^0.5.1",
+        "cookie": "^0.5.0",
+        "devalue": "^4.3.1",
+        "esm-env": "^1.0.0",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.0",
+        "mrmime": "^1.0.1",
+        "sade": "^1.8.1",
+        "set-cookie-parser": "^2.6.0",
+        "sirv": "^2.0.2",
+        "tiny-glob": "^0.2.9",
+        "undici": "~5.26.2"
+      },
+      "bin": {
+        "svelte-kit": "svelte-kit.js"
+      },
+      "engines": {
+        "node": "^16.14 || >=18"
+      },
+      "peerDependencies": {
+        "svelte": "^3.54.0 || ^4.0.0-next.0 || ^5.0.0-next.0",
+        "vite": "^4.0.0"
+      }
+    },
+    "web-auth/node_modules/magic-string": {
+      "version": "0.30.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.7.tgz",
+      "integrity": "sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "web-auth/node_modules/undici": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.26.5.tgz",
+      "integrity": "sha512-cSb4bPFd5qgR7qr2jYAi0hlX9n5YKK2ONKkLFkxl+v/9BvC0sOpZjBHDBSXc5lWAf5ty9oZdRXytBIHzgUcerw==",
+      "dev": true,
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "web-common": {
@@ -32677,7 +32792,7 @@
         "@playwright/test": "^1.33.0",
         "@rilldata/svelte-query": "^4.29.20-0.0.3",
         "@sveltejs/adapter-static": "^1.0.0",
-        "@sveltejs/kit": "^1.20.4",
+        "@sveltejs/kit": "1.30.0",
         "@tanstack/svelte-query": "npm:@rilldata/svelte-query@4.29.20-0.0.3",
         "autoprefixer": "^10.4.4",
         "axios": "^0.27.2",
@@ -32688,6 +32803,62 @@
         "svelte-preprocess": "^5.0.3",
         "tree-kill": "^1.2.2",
         "web-common": "*"
+      }
+    },
+    "web-local/node_modules/@sveltejs/kit": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.30.0.tgz",
+      "integrity": "sha512-HK7XE8ZAL7cGreRRxCCVEpcNA3x2KM0mfJlDv7geEyCElYjJsdBoANEb00HcYlvs/2ShNAsX8lY/A60s9Xdfew==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@sveltejs/vite-plugin-svelte": "^2.5.0",
+        "@types/cookie": "^0.5.1",
+        "cookie": "^0.5.0",
+        "devalue": "^4.3.1",
+        "esm-env": "^1.0.0",
+        "kleur": "^4.1.5",
+        "magic-string": "^0.30.0",
+        "mrmime": "^1.0.1",
+        "sade": "^1.8.1",
+        "set-cookie-parser": "^2.6.0",
+        "sirv": "^2.0.2",
+        "tiny-glob": "^0.2.9",
+        "undici": "~5.26.2"
+      },
+      "bin": {
+        "svelte-kit": "svelte-kit.js"
+      },
+      "engines": {
+        "node": "^16.14 || >=18"
+      },
+      "peerDependencies": {
+        "svelte": "^3.54.0 || ^4.0.0-next.0 || ^5.0.0-next.0",
+        "vite": "^4.0.0"
+      }
+    },
+    "web-local/node_modules/magic-string": {
+      "version": "0.30.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.7.tgz",
+      "integrity": "sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "web-local/node_modules/undici": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.26.5.tgz",
+      "integrity": "sha512-cSb4bPFd5qgR7qr2jYAi0hlX9n5YKK2ONKkLFkxl+v/9BvC0sOpZjBHDBSXc5lWAf5ty9oZdRXytBIHzgUcerw==",
+      "dev": true,
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     }
   }

--- a/web-admin/package.json
+++ b/web-admin/package.json
@@ -18,7 +18,7 @@
     "@rgossiaux/svelte-headlessui": "^2.0.0",
     "@rilldata/svelte-query": "^4.29.20-0.0.3",
     "@sveltejs/adapter-static": "^1.0.0",
-    "@sveltejs/kit": "^1.20.4",
+    "@sveltejs/kit": "1.30.0",
     "@tanstack/svelte-query": "npm:@rilldata/svelte-query@4.29.20-0.0.3",
     "@tanstack/svelte-table": "^8.11.8",
     "autoprefixer": "^10.4.13",

--- a/web-auth/package.json
+++ b/web-auth/package.json
@@ -20,7 +20,7 @@
 		"@rollup/plugin-terser": "^0.4.0",
 		"@sveltejs/adapter-auto": "^2.0.0",
 		"@sveltejs/adapter-static": "^2.0.2",
-		"@sveltejs/kit": "^1.20.4",
+		"@sveltejs/kit": "1.30.0",
 		"@types/auth0-js": "^9.14.7",
 		"auth0-js": "^9.20.2",
 		"autoprefixer": "^10.4.13",

--- a/web-local/package.json
+++ b/web-local/package.json
@@ -18,7 +18,7 @@
     "@playwright/test": "^1.33.0",
     "@rilldata/svelte-query": "^4.29.20-0.0.3",
     "@sveltejs/adapter-static": "^1.0.0",
-    "@sveltejs/kit": "^1.20.4",
+    "@sveltejs/kit": "1.30.0",
     "@tanstack/svelte-query": "npm:@rilldata/svelte-query@4.29.20-0.0.3",
     "autoprefixer": "^10.4.4",
     "axios": "^0.27.2",


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
Visiting either dev or cloud UIs would add an additional forward slash. This lead to issues in dashboard where state url was not getting applied. Also caused in certain redirects like alerts.

#### Details:
This was caused by a bug in sveltekit. We should ideally upgrade to 2.0.1 to get this fixed. But for now pinning to the last version where this is not broken, 1.30.0.

## Steps to Verify
1. After starting either dev or cloud UIs, visit the page from `http://localhost:3000`
2. Navigating to different page shouldnt add the forward slash.
3. In dashboard the stateful url should get populated.