### PR TITLE
Handle API error for timeseries

### DIFF
--- a/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDisplay.svelte
@@ -201,9 +201,7 @@
       </div>
     </div>
   </div>
-{/if}
-
-{#if formattedData && comparisonCopy}
+{:else if formattedData && comparisonCopy}
   <TDDTable
     {excludeMode}
     {dimensionLabel}

--- a/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDisplay.svelte
@@ -75,7 +75,6 @@
     timeDimensionDataCopy = $timeDimensionDataStore.data;
   }
   $: formattedData = timeDimensionDataCopy;
-
   $: excludeMode =
     $dashboardStore?.dimensionFilterExcludeMode.get(dimensionName) ?? false;
 
@@ -182,6 +181,27 @@
   }}
   on:toggle-all-search-items={() => toggleAllSearchItems()}
 />
+
+{#if $timeDimensionDataStore?.isError}
+  <div
+    style:height="calc(100% - 200px)"
+    class="w-full flex items-center justify-center text-sm"
+  >
+    <div class="text-center">
+      <div class="text-red-600 mt-1 text-lg">
+        We encountered an error while loading the data. Please try refreshing
+        the page.
+      </div>
+      <div class="text-gray-600">
+        If the issue persists, please contact us on <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href="http://bit.ly/3jg4IsF">Discord</a
+        >.
+      </div>
+    </div>
+  </div>
+{/if}
 
 {#if formattedData && comparisonCopy}
   <TDDTable

--- a/web-common/src/features/dashboards/time-dimension-details/time-dimension-data-store.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/time-dimension-data-store.ts
@@ -38,6 +38,7 @@ type MeasureValue = number | null | undefined;
 
 export type TimeDimensionDataState = {
   isFetching: boolean;
+  isError?: boolean;
   comparing?: TDDComparison;
   data?: TableData;
 };
@@ -391,6 +392,7 @@ export function createTimeDimensionDataStore(
       timeSeries,
       tableDimensionData,
     ]) => {
+      if (timeSeries?.isError) return { isFetching: false, isError: true };
       if (
         !timeControls.ready ||
         timeControls?.isFetching ||

--- a/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
+++ b/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
@@ -199,7 +199,7 @@ export function createTimeSeriesDataStore(
 
           return {
             isFetching: !primary?.data && !primaryTotal?.data,
-            isError: false, // FIXME Handle errors
+            isError: primary?.isError || primaryTotal?.isError,
             timeSeriesData: preparedTimeSeriesData,
             total: primaryTotal?.data?.data?.[0],
             unfilteredTotal: unfilteredTotal?.data?.data?.[0],


### PR DESCRIPTION
Partially fixes #4188
This checks for error in the timeseries data store and propagates that to the TDD table. 

We do not currently check for error on the individual timeseries API which is called for each row of the TDD table. Since we are planning to move away from individual timeseries API to a batch aggregation API, will add the error handling directly there.