### PR TITLE
Fix Go coverage

### DIFF
--- a/.github/workflows/go-cover.yml
+++ b/.github/workflows/go-cover.yml
@@ -28,7 +28,8 @@ jobs:
         # Build list of packages to include in coverage, excluding generated code in 'proto/gen'
         PACKAGES=$(go list ./... | grep -v 'proto/gen/' | tr '\n' ',' | sed -e 's/,$//' | sed -e 's/github.com\/rilldata\/rill/./g')
         # Run tests with coverage output
-        go test ./... -short -v -race -covermode=atomic -coverprofile=coverage.out -coverpkg=$PACKAGES
+        # NOTE(2024-03-01): Coverage fails on the generated code in 'proto/gen' without GOEXPERIMENT=nocoverageredesign. See https://github.com/golang/go/issues/55953.
+        GOEXPERIMENT=nocoverageredesign go test ./... -short -v -race -covermode=atomic -coverprofile=coverage.out -coverpkg=$PACKAGES
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
       with:

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,10 @@ coverage.go:
 	rm -rf coverage/go.out
 	mkdir -p coverage
 	# Run tests with coverage output. First builds the list of packages to include in coverage, excluding generated code in 'proto/gen'.
+	# NOTE(2024-03-01): Coverage fails on the generated code in 'proto/gen' without GOEXPERIMENT=nocoverageredesign. See https://github.com/golang/go/issues/55953.
 	set -e ; \
 		PACKAGES=$$(go list ./... | grep -v 'proto/gen/' | tr '\n' ',' | sed -e 's/,$$//' | sed -e 's/github.com\/rilldata\/rill/./g') ;\
-		go test ./... -short -v -coverprofile ./coverage/go.out -coverpkg $$PACKAGES
+		GOEXPERIMENT=nocoverageredesign go test ./proto/gen... -short -v -coverprofile ./coverage/go.out -coverpkg $$PACKAGES
 	go tool cover -func coverage/go.out
 
 .PHONY: docs.generate

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ coverage.go:
 	# NOTE(2024-03-01): Coverage fails on the generated code in 'proto/gen' without GOEXPERIMENT=nocoverageredesign. See https://github.com/golang/go/issues/55953.
 	set -e ; \
 		PACKAGES=$$(go list ./... | grep -v 'proto/gen/' | tr '\n' ',' | sed -e 's/,$$//' | sed -e 's/github.com\/rilldata\/rill/./g') ;\
-		GOEXPERIMENT=nocoverageredesign go test ./proto/gen... -short -v -coverprofile ./coverage/go.out -coverpkg $$PACKAGES
+		GOEXPERIMENT=nocoverageredesign go test ./... -short -v -coverprofile ./coverage/go.out -coverpkg $$PACKAGES
 	go tool cover -func coverage/go.out
 
 .PHONY: docs.generate


### PR DESCRIPTION
The coverage test has been failing for some time with the following errors:
```
github.com/rilldata/rill/proto/gen/rill/admin/v1: open /tmp/go-build1717652986/b205/covmeta.efd544d54abd57024320e5b09e7fbb7333ec3c9e2c058a3d351094eaca3dd4d6: no such file or directory
github.com/rilldata/rill/proto/gen/rill/runtime/v1: open /tmp/go-build1717652986/b324/covmeta.067b3bf4a6ecbbbcd442d5d3dfcb816dbf6bc1aee18591e902bf98c6b115f2e7: no such file or directory
```

This appears to be a bug in Go that can be resolved by setting `GOEXPERIMENT=nocoverageredesign`.

This issue may provide guidance on when the change can be reverted: https://github.com/golang/go/issues/55953.