### PR TITLE
Util for better HTTP error handling

### DIFF
--- a/admin/server/auth/handlers.go
+++ b/admin/server/auth/handlers.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/rilldata/rill/admin/database"
+	"github.com/rilldata/rill/runtime/pkg/httputil"
 	"github.com/rilldata/rill/runtime/pkg/middleware"
 	"github.com/rilldata/rill/runtime/pkg/observability"
 	"github.com/rilldata/rill/runtime/pkg/ratelimit"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 )
@@ -30,30 +30,33 @@ const (
 // Note that these are not gRPC handlers, just regular HTTP endpoints that we mount on the gRPC-gateway mux.
 func (a *Authenticator) RegisterEndpoints(mux *http.ServeMux, limiter ratelimit.Limiter) {
 	// checkLimit needs access to limiter
-	checkLimit := func(route string, req *http.Request) error {
-		claims := GetClaims(req.Context())
-		if claims == nil || claims.OwnerType() == OwnerTypeAnon {
-			limitKey := ratelimit.AnonLimitKey(route, observability.HTTPPeer(req))
-			if err := limiter.Limit(req.Context(), limitKey, ratelimit.Sensitive); err != nil {
-				if errors.As(err, &ratelimit.QuotaExceededError{}) {
-					return middleware.NewHTTPError(http.StatusTooManyRequests, err.Error())
+	checkLimit := func(route string) middleware.CheckFunc {
+		return func(req *http.Request) error {
+			claims := GetClaims(req.Context())
+			if claims == nil || claims.OwnerType() == OwnerTypeAnon {
+				limitKey := ratelimit.AnonLimitKey(route, observability.HTTPPeer(req))
+				if err := limiter.Limit(req.Context(), limitKey, ratelimit.Sensitive); err != nil {
+					if errors.As(err, &ratelimit.QuotaExceededError{}) {
+						return httputil.Error(http.StatusTooManyRequests, err)
+					}
+					return err
 				}
-				return err
 			}
+			return nil
 		}
-		return nil
 	}
+
 	// TODO: Add helper utils to clean this up
 	inner := http.NewServeMux()
-	inner.Handle("/auth/signup", otelhttp.WithRouteTag("/auth/signup", middleware.RequestHTTPHandler("/auth/signup", checkLimit, http.HandlerFunc(a.authSignup))))
-	inner.Handle("/auth/login", otelhttp.WithRouteTag("/auth/login", middleware.RequestHTTPHandler("/auth/login", checkLimit, http.HandlerFunc(a.authLogin))))
-	inner.Handle("/auth/callback", otelhttp.WithRouteTag("/auth/callback", middleware.RequestHTTPHandler("/auth/callback", checkLimit, http.HandlerFunc(a.authLoginCallback))))
-	inner.Handle("/auth/with-token", otelhttp.WithRouteTag("/auth/with-token", middleware.RequestHTTPHandler("/auth/with-token", checkLimit, http.HandlerFunc(a.authWithToken))))
-	inner.Handle("/auth/logout", otelhttp.WithRouteTag("/auth/logout", middleware.RequestHTTPHandler("/auth/logout", checkLimit, http.HandlerFunc(a.authLogout))))
-	inner.Handle("/auth/logout/callback", otelhttp.WithRouteTag("/auth/logout/callback", middleware.RequestHTTPHandler("/auth/logout/callback", checkLimit, http.HandlerFunc(a.authLogoutCallback))))
-	inner.Handle("/auth/oauth/device_authorization", otelhttp.WithRouteTag("/auth/oauth/device_authorization", middleware.RequestHTTPHandler("/auth/oauth/device_authorization", checkLimit, http.HandlerFunc(a.handleDeviceCodeRequest))))
-	inner.Handle("/auth/oauth/device", otelhttp.WithRouteTag("/auth/oauth/device", a.HTTPMiddleware(middleware.RequestHTTPHandler("/auth/oauth/device", checkLimit, http.HandlerFunc(a.handleUserCodeConfirmation))))) // NOTE: Uses auth middleware
-	inner.Handle("/auth/oauth/token", otelhttp.WithRouteTag("/auth/oauth/token", middleware.RequestHTTPHandler("/auth/oauth/token", checkLimit, http.HandlerFunc(a.getAccessToken))))
+	observability.MuxHandle(inner, "/auth/signup", middleware.Check(checkLimit("/auth/signup"), http.HandlerFunc(a.authSignup)))
+	observability.MuxHandle(inner, "/auth/login", middleware.Check(checkLimit("/auth/login"), http.HandlerFunc(a.authLogin)))
+	observability.MuxHandle(inner, "/auth/callback", middleware.Check(checkLimit("/auth/callback"), http.HandlerFunc(a.authLoginCallback)))
+	observability.MuxHandle(inner, "/auth/with-token", middleware.Check(checkLimit("/auth/with-token"), http.HandlerFunc(a.authWithToken)))
+	observability.MuxHandle(inner, "/auth/logout", middleware.Check(checkLimit("/auth/logout"), http.HandlerFunc(a.authLogout)))
+	observability.MuxHandle(inner, "/auth/logout/callback", middleware.Check(checkLimit("/auth/logout/callback"), http.HandlerFunc(a.authLogoutCallback)))
+	observability.MuxHandle(inner, "/auth/oauth/device_authorization", middleware.Check(checkLimit("/auth/oauth/device_authorization"), http.HandlerFunc(a.handleDeviceCodeRequest)))
+	observability.MuxHandle(inner, "/auth/oauth/device", a.HTTPMiddleware(middleware.Check(checkLimit("/auth/oauth/device"), http.HandlerFunc(a.handleUserCodeConfirmation)))) // NOTE: Uses auth middleware
+	observability.MuxHandle(inner, "/auth/oauth/token", middleware.Check(checkLimit("/auth/oauth/token"), http.HandlerFunc(a.getAccessToken)))
 	mux.Handle("/auth/", observability.Middleware("admin", a.logger, inner))
 }
 

--- a/admin/server/deployment.go
+++ b/admin/server/deployment.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"errors"
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -75,38 +74,6 @@ func (s *Server) TriggerRefreshSources(ctx context.Context, req *adminv1.Trigger
 	}
 
 	return &adminv1.TriggerRefreshSourcesResponse{}, nil
-}
-
-func (s *Server) triggerRefreshSourcesInternal(w http.ResponseWriter, r *http.Request) {
-	orgName := r.URL.Query().Get("organization")
-	projectName := r.URL.Query().Get("project")
-	if orgName == "" || projectName == "" {
-		http.Error(w, "organization or project not specified", http.StatusBadRequest)
-		return
-	}
-
-	proj, err := s.admin.DB.FindProjectByName(r.Context(), orgName, projectName)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	if proj.ProdDeploymentID == nil {
-		http.Error(w, "project does not have a deployment", http.StatusBadRequest)
-		return
-	}
-
-	depl, err := s.admin.DB.FindDeployment(r.Context(), *proj.ProdDeploymentID)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	err = s.admin.TriggerRefreshSources(r.Context(), depl, nil)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
 }
 
 func (s *Server) TriggerRedeploy(ctx context.Context, req *adminv1.TriggerRedeployRequest) (*adminv1.TriggerRedeployResponse, error) {

--- a/admin/server/github.go
+++ b/admin/server/github.go
@@ -15,10 +15,10 @@ import (
 	"github.com/rilldata/rill/admin/pkg/urlutil"
 	"github.com/rilldata/rill/admin/server/auth"
 	adminv1 "github.com/rilldata/rill/proto/gen/rill/admin/v1"
+	"github.com/rilldata/rill/runtime/pkg/httputil"
 	"github.com/rilldata/rill/runtime/pkg/middleware"
 	"github.com/rilldata/rill/runtime/pkg/observability"
 	"github.com/rilldata/rill/runtime/pkg/ratelimit"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/oauth2"
 	githuboauth "golang.org/x/oauth2/github"
@@ -143,17 +143,12 @@ func (s *Server) GetGitCredentials(ctx context.Context, req *adminv1.GetGitCrede
 func (s *Server) registerGithubEndpoints(mux *http.ServeMux) {
 	// TODO: Add helper utils to clean this up
 	inner := http.NewServeMux()
-	inner.Handle("/github/webhook", otelhttp.WithRouteTag("/github/webhook", http.HandlerFunc(s.githubWebhook)))
-	inner.Handle("/github/connect", otelhttp.WithRouteTag("/github/connect", s.authenticator.HTTPMiddleware(
-		middleware.RequestHTTPHandler("/github/connect", s.checkGithubRateLimit, http.HandlerFunc(s.githubConnect)))))
-	inner.Handle("/github/connect/callback", otelhttp.WithRouteTag("/github/connect/callback", s.authenticator.HTTPMiddleware(
-		middleware.RequestHTTPHandler("/github/connect/callback", s.checkGithubRateLimit, http.HandlerFunc(s.githubConnectCallback)))))
-	inner.Handle("/github/auth/login", otelhttp.WithRouteTag("github/auth/login", s.authenticator.HTTPMiddleware(
-		middleware.RequestHTTPHandler("github/auth/login", s.checkGithubRateLimit, http.HandlerFunc(s.githubAuthLogin)))))
-	inner.Handle("/github/auth/callback", otelhttp.WithRouteTag("github/auth/callback", s.authenticator.HTTPMiddleware(
-		middleware.RequestHTTPHandler("github/auth/callback", s.checkGithubRateLimit, http.HandlerFunc(s.githubAuthCallback)))))
-	inner.Handle("/github/post-auth-redirect", otelhttp.WithRouteTag("github/post-auth-redirect", s.authenticator.HTTPMiddleware(
-		middleware.RequestHTTPHandler("github/post-auth-redirect", s.checkGithubRateLimit, http.HandlerFunc(s.githubRepoStatus)))))
+	observability.MuxHandle(inner, "/github/webhook", http.HandlerFunc(s.githubWebhook))
+	observability.MuxHandle(inner, "/github/connect", s.authenticator.HTTPMiddleware(middleware.Check(s.checkGithubRateLimit("/github/connect"), http.HandlerFunc(s.githubConnect))))
+	observability.MuxHandle(inner, "/github/connect/callback", s.authenticator.HTTPMiddleware(middleware.Check(s.checkGithubRateLimit("/github/connect/callback"), http.HandlerFunc(s.githubConnectCallback))))
+	observability.MuxHandle(inner, "/github/auth/login", s.authenticator.HTTPMiddleware(middleware.Check(s.checkGithubRateLimit("github/auth/login"), http.HandlerFunc(s.githubAuthLogin))))
+	observability.MuxHandle(inner, "/github/auth/callback", s.authenticator.HTTPMiddleware(middleware.Check(s.checkGithubRateLimit("github/auth/callback"), http.HandlerFunc(s.githubAuthCallback))))
+	observability.MuxHandle(inner, "/github/post-auth-redirect", s.authenticator.HTTPMiddleware(middleware.Check(s.checkGithubRateLimit("github/post-auth-redirect"), http.HandlerFunc(s.githubRepoStatus))))
 	mux.Handle("/github/", observability.Middleware("admin", s.logger, inner))
 }
 
@@ -595,16 +590,18 @@ func (s *Server) redirectLogin(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
 }
 
-func (s *Server) checkGithubRateLimit(route string, req *http.Request) error {
-	claims := auth.GetClaims(req.Context())
-	if claims == nil || claims.OwnerType() == auth.OwnerTypeAnon {
-		limitKey := ratelimit.AnonLimitKey(route, observability.HTTPPeer(req))
-		if err := s.limiter.Limit(req.Context(), limitKey, ratelimit.Sensitive); err != nil {
-			if errors.As(err, &ratelimit.QuotaExceededError{}) {
-				return middleware.NewHTTPError(http.StatusTooManyRequests, err.Error())
+func (s *Server) checkGithubRateLimit(route string) middleware.CheckFunc {
+	return func(req *http.Request) error {
+		claims := auth.GetClaims(req.Context())
+		if claims == nil || claims.OwnerType() == auth.OwnerTypeAnon {
+			limitKey := ratelimit.AnonLimitKey(route, observability.HTTPPeer(req))
+			if err := s.limiter.Limit(req.Context(), limitKey, ratelimit.Sensitive); err != nil {
+				if errors.As(err, &ratelimit.QuotaExceededError{}) {
+					return httputil.Error(http.StatusTooManyRequests, err)
+				}
+				return err
 			}
-			return err
 		}
+		return nil
 	}
-	return nil
 }

--- a/admin/server/runtime_proxy.go
+++ b/admin/server/runtime_proxy.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -9,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/rilldata/rill/admin/server/auth"
+	"github.com/rilldata/rill/runtime/pkg/httputil"
 	runtimeauth "github.com/rilldata/rill/runtime/server/auth"
 )
 
@@ -17,7 +17,7 @@ import (
 // If the request is made using an Authorization header or cookie recognized by the admin service,
 // the proxied request is made with a newly minted JWT similar to the one that could be obtained by calling GetProject.
 // If the Authorization header of the request is not recognized by the admin service, it is proxied through to the runtime service.
-func (s *Server) runtimeProxyForOrgAndProject(w http.ResponseWriter, r *http.Request) {
+func (s *Server) runtimeProxyForOrgAndProject(w http.ResponseWriter, r *http.Request) error {
 	// Get args from URL path components
 	org := r.PathValue("org")
 	project := r.PathValue("project")
@@ -26,17 +26,14 @@ func (s *Server) runtimeProxyForOrgAndProject(w http.ResponseWriter, r *http.Req
 	// Find the production deployment for the project we're proxying to
 	proj, err := s.admin.DB.FindProjectByName(r.Context(), org, project)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
+		return httputil.Error(http.StatusBadRequest, err)
 	}
 	if proj.ProdDeploymentID == nil {
-		http.Error(w, "no prod deployment for project", http.StatusBadRequest)
-		return
+		return httputil.Errorf(http.StatusBadRequest, "no prod deployment for project")
 	}
 	depl, err := s.admin.DB.FindDeployment(r.Context(), *proj.ProdDeploymentID)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
+		return httputil.Error(http.StatusBadRequest, err)
 	}
 
 	// Get or issue a JWT to use for the proxied request.
@@ -57,16 +54,14 @@ func (s *Server) runtimeProxyForOrgAndProject(w http.ResponseWriter, r *http.Req
 
 		permissions := claims.ProjectPermissions(r.Context(), proj.OrganizationID, depl.ProjectID)
 		if !permissions.ReadProd {
-			http.Error(w, "does not have permission to access the production deployment", http.StatusForbidden)
-			return
+			return httputil.Errorf(http.StatusForbidden, "does not have permission to access the production deployment")
 		}
 
 		var attr map[string]any
 		if claims.OwnerType() == auth.OwnerTypeUser {
 			attr, err = s.jwtAttributesForUser(r.Context(), claims.OwnerID(), proj.OrganizationID, permissions)
 			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
+				return httputil.Error(http.StatusInternalServerError, err)
 			}
 		}
 
@@ -86,12 +81,10 @@ func (s *Server) runtimeProxyForOrgAndProject(w http.ResponseWriter, r *http.Req
 			Attributes: attr,
 		})
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
+			return httputil.Error(http.StatusInternalServerError, err)
 		}
 	default:
-		http.Error(w, fmt.Sprintf("runtime proxy not available for owner type %q", claims.OwnerType()), http.StatusBadRequest)
-		return
+		return httputil.Errorf(http.StatusBadRequest, "runtime proxy not available for owner type %q", claims.OwnerType())
 	}
 
 	// Track usage of the deployment
@@ -112,15 +105,13 @@ func (s *Server) runtimeProxyForOrgAndProject(w http.ResponseWriter, r *http.Req
 	// Create the URL to proxy to by prepending `/v1/instances/{instanceID}` to the proxy path.
 	proxyURL, err := url.JoinPath(runtimeHost, "/v1/instances", depl.RuntimeInstanceID, proxyPath)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return httputil.Error(http.StatusInternalServerError, err)
 	}
 
 	// Create the proxied request.
 	req, err := http.NewRequestWithContext(r.Context(), r.Method, proxyURL, r.Body)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return httputil.Error(http.StatusInternalServerError, err)
 	}
 	for k, v := range r.Header {
 		req.Header.Add(k, v[0])
@@ -132,8 +123,7 @@ func (s *Server) runtimeProxyForOrgAndProject(w http.ResponseWriter, r *http.Req
 	// Send the proxied request using http.DefaultClient. The default client automatically handles caching/pooling of TCP connections.
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return httputil.Error(http.StatusInternalServerError, err)
 	}
 	defer res.Body.Close()
 
@@ -147,7 +137,8 @@ func (s *Server) runtimeProxyForOrgAndProject(w http.ResponseWriter, r *http.Req
 	w.WriteHeader(res.StatusCode)
 	_, err = io.Copy(w, res.Body)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return httputil.Error(http.StatusInternalServerError, err)
 	}
+
+	return nil
 }

--- a/admin/server/server.go
+++ b/admin/server/server.go
@@ -22,13 +22,13 @@ import (
 	adminv1 "github.com/rilldata/rill/proto/gen/rill/admin/v1"
 	"github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/rilldata/rill/runtime/pkg/graceful"
+	"github.com/rilldata/rill/runtime/pkg/httputil"
 	"github.com/rilldata/rill/runtime/pkg/middleware"
 	"github.com/rilldata/rill/runtime/pkg/observability"
 	"github.com/rilldata/rill/runtime/pkg/ratelimit"
 	runtimeauth "github.com/rilldata/rill/runtime/server/auth"
 	"github.com/rs/cors"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -208,7 +208,7 @@ func (s *Server) HTTPHandler(ctx context.Context) (http.Handler, error) {
 		observability.Middleware(
 			"runtime-proxy",
 			s.logger,
-			s.authenticator.HTTPMiddlewareLenient(http.HandlerFunc(s.runtimeProxyForOrgAndProject)),
+			s.authenticator.HTTPMiddlewareLenient(httputil.Handler(s.runtimeProxyForOrgAndProject)),
 		),
 	)
 
@@ -225,9 +225,6 @@ func (s *Server) HTTPHandler(ctx context.Context) (http.Handler, error) {
 
 	// Add Github-related endpoints (not gRPC handlers, just regular endpoints on /github/*)
 	s.registerGithubEndpoints(mux)
-
-	// Add temporary internal endpoint for refreshing sources
-	mux.Handle("/internal/projects/trigger-refresh", otelhttp.WithRouteTag("/internal/projects/trigger-refresh", http.HandlerFunc(s.triggerRefreshSourcesInternal)))
 
 	// Build CORS options for admin server
 

--- a/admin/server/server.go
+++ b/admin/server/server.go
@@ -206,7 +206,7 @@ func (s *Server) HTTPHandler(ctx context.Context) (http.Handler, error) {
 	mux.Handle("/v1/", gwMux)
 
 	// Add runtime proxy
-	mux.Handle("/v1/orgs/{org}/projects/{project}/runtime/{path...}",
+	observability.MuxHandle(mux, "/v1/orgs/{org}/projects/{project}/runtime/{path...}",
 		observability.Middleware(
 			"runtime-proxy",
 			s.logger,

--- a/runtime/pkg/httputil/httputil.go
+++ b/runtime/pkg/httputil/httputil.go
@@ -66,9 +66,9 @@ func WriteError(w http.ResponseWriter, err error) {
 
 	// Write error as JSON
 	obj := map[string]string{"error": err.Error()}
-	json, err := json.Marshal(obj)
+	data, err := json.Marshal(obj)
 	if err != nil {
 		panic(err)
 	}
-	w.Write(json)
+	_, _ = w.Write(data)
 }

--- a/runtime/pkg/httputil/httputil.go
+++ b/runtime/pkg/httputil/httputil.go
@@ -1,0 +1,74 @@
+package httputil
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+// Handler is similar to http.HandlerFunc with simple error handling built in.
+// If an error is returned, it will be written to the response as a JSON object (using WriteError).
+type Handler func(http.ResponseWriter, *http.Request) error
+
+func (fn Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	err := fn(w, r)
+	if err != nil {
+		WriteError(w, err)
+	}
+}
+
+// Error creates a new HTTP error with a status code from an existing error.
+func Error(statusCode int, err error) error {
+	return HTTPError{
+		StatusCode: statusCode,
+		Err:        err,
+	}
+}
+
+// Errorf creates a new HTTP error with a status code and formatted message message.
+func Errorf(statusCode int, format string, args ...interface{}) error {
+	return HTTPError{
+		StatusCode: statusCode,
+		Err:        fmt.Errorf(format, args...),
+	}
+}
+
+// HTTPError represents an error with a HTTP status code.
+type HTTPError struct {
+	StatusCode int
+	Err        error
+}
+
+func (e HTTPError) Error() string {
+	return e.Err.Error()
+}
+
+func (e HTTPError) Unwrap() error {
+	return e.Err
+}
+
+// WriteError writes an error to the response as a JSON object.
+// If the error is an instance of Error, the status code will be set to the error's code.
+// Otherwise, it will return a 400 status code.
+func WriteError(w http.ResponseWriter, err error) {
+	// Set content type to JSON
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
+	// Write the error code
+	code := http.StatusBadRequest
+	var httperr HTTPError
+	if errors.As(err, &httperr) {
+		code = httperr.StatusCode
+	}
+	w.WriteHeader(code)
+
+	// Write error as JSON
+	obj := map[string]string{"error": err.Error()}
+	json, err := json.Marshal(obj)
+	if err != nil {
+		panic(err)
+	}
+	w.Write(json)
+}

--- a/runtime/pkg/middleware/request.go
+++ b/runtime/pkg/middleware/request.go
@@ -1,36 +1,22 @@
 package middleware
 
 import (
-	"errors"
 	"net/http"
+
+	"github.com/rilldata/rill/runtime/pkg/httputil"
 )
 
-// RequestHTTPHandler calls fn on each request.
-func RequestHTTPHandler(route string, fn func(route string, req *http.Request) error, next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := fn(route, r); err != nil {
-			var httpError *HTTPError
-			if errors.As(err, &httpError) {
-				http.Error(w, err.Error(), httpError.Code)
-			} else {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-			return
+type CheckFunc func(req *http.Request) error
+
+// Check is a middleware that only calls the next handler if the checkFn succeeds.
+// If the checkFn fails, the error is written to the response as per the behavior of httputil.Handler.
+func Check(checkFn CheckFunc, next http.Handler) httputil.Handler {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		if err := checkFn(r); err != nil {
+			return err
 		}
 
 		next.ServeHTTP(w, r)
-	})
-}
-
-type HTTPError struct {
-	Code    int
-	Message string
-}
-
-func NewHTTPError(code int, msg string) *HTTPError {
-	return &HTTPError{code, msg}
-}
-
-func (e *HTTPError) Error() string {
-	return e.Message
+		return nil
+	}
 }

--- a/runtime/pkg/observability/httpmux.go
+++ b/runtime/pkg/observability/httpmux.go
@@ -1,0 +1,13 @@
+package observability
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+// MuxHandle is a wrapper around http.ServeMux.Handle that adds route tags to the handler.
+// It does NOT wrap the handler with observability.Middleware. The caller is expected to add that on the ServeMux itself.
+func MuxHandle(mux *http.ServeMux, pattern string, handler http.Handler) {
+	mux.Handle(pattern, otelhttp.WithRouteTag(pattern, handler))
+}

--- a/runtime/server/server.go
+++ b/runtime/server/server.go
@@ -202,7 +202,7 @@ func (s *Server) HTTPHandler(ctx context.Context, registerAdditionalHandlers fun
 	httpMux.Handle("/v1/", gwMux)
 
 	// Add HTTP handler for query export downloads
-	httpMux.Handle("/v1/download", auth.HTTPMiddleware(s.aud, http.HandlerFunc(s.downloadHandler)))
+	observability.MuxHandle(httpMux, "/v1/download", observability.Middleware("runtime", s.logger, auth.HTTPMiddleware(s.aud, http.HandlerFunc(s.downloadHandler))))
 
 	// Add Prometheus
 	if s.opts.ServePrometheus {


### PR DESCRIPTION
Example:
```go
// Can do this:
return httputil.Errorf(http.StatusBadRequest, "runtime proxy not available for owner type %q", claims.OwnerType())

// Instead of this:	
http.Error(w, fmt.Sprintf("runtime proxy not available for owner type %q", claims.OwnerType()), http.StatusBadRequest)
return
```

Also includes a few other minor cleanups.