### PR TITLE
Fix: Pivot arrow direction

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotTable.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTable.svelte
@@ -135,7 +135,7 @@
                       {#if sortDirection}
                         <span
                           class="transition-transform -mr-1"
-                          class:-rotate-180={sortDirection === "desc"}
+                          class:-rotate-180={sortDirection === "asc"}
                         >
                           <ArrowDown />
                         </span>


### PR DESCRIPTION
https://rilldata.slack.com/archives/C02T907FEUB/p1709162281494139

Fixes the direction of the arrow in the pivot table. Descending order should have a downward facing arrow.