### PR TITLE
fix: export dialog visible with feature flag

### DIFF
--- a/web-common/src/features/dashboards/rows-viewer/RowsViewerAccordion.svelte
+++ b/web-common/src/features/dashboards/rows-viewer/RowsViewerAccordion.svelte
@@ -11,7 +11,6 @@
   import { useDashboardStore } from "web-common/src/features/dashboards/stores/dashboard-stores";
   import { drag } from "../../../layout/drag";
   import type { LayoutElement } from "../../../layout/workspace/types";
-  import { featureFlags } from "../../feature-flags";
   import ExportModelDataButton from "./ExportModelDataButton.svelte";
   import RowsViewer from "./RowsViewer.svelte";
 
@@ -100,8 +99,6 @@
     }
   }
 
-  $: isLocal = $featureFlags.readOnly === false;
-
   const rowsViewerLayout = writable<LayoutElement>({
     value: INITIAL_HEIGHT_EXPANDED,
     visible: true,
@@ -135,7 +132,7 @@
       {label}
     </button>
     <div class="ml-auto">
-      {#if isLocal}<ExportModelDataButton />{/if}
+      <ExportModelDataButton />
     </div>
   </div>
 


### PR DESCRIPTION
We enabled the data viewer via feature flags via https://github.com/rilldata/rill/pull/4158
However the export option still checked for local, removed that so the entire component is toggled via feature flags.