### PR TITLE
Cloud UI: Don't block dashboards on 429 errors

### DIFF
--- a/web-admin/src/features/errors/error-utils.ts
+++ b/web-admin/src/features/errors/error-utils.ts
@@ -68,7 +68,10 @@ export function createGlobalErrorCallback(queryClient: QueryClient) {
       // Let the Dashboard page handle errors for runtime queries.
       // Individual components (e.g. a specific line chart or leaderboard) should display a localised error message.
       // NOTE: let's start with 400 errors, but we may want to include 500-level errors too.
-      if (isRuntimeQuery(query) && error.response?.status === 400) {
+      if (
+        isRuntimeQuery(query) &&
+        (error.response?.status === 400 || error.response?.status === 429)
+      ) {
         return;
       }
 


### PR DESCRIPTION
In testing https://github.com/rilldata/rill/pull/4227, I found that the rows viewer can trigger a 429 error. We should not block Cloud dashboards with this error.

![image](https://github.com/rilldata/rill/assets/14206386/de4a354a-d840-4631-8c7a-d3298029868d)
