### PR TITLE
Runtime: Support dots in YAML/SQL filenames

### DIFF
--- a/runtime/compilers/rillv1/parse_node.go
+++ b/runtime/compilers/rillv1/parse_node.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/rilldata/rill/runtime/pkg/fileutil"
 	"github.com/rilldata/rill/runtime/pkg/sqlparse"
 	"gopkg.in/yaml.v3"
 )
@@ -220,9 +220,9 @@ func (p *Parser) parseStem(ctx context.Context, paths []string, ymlPath, yml, sq
 	// If name is not set in YAML or SQL, infer it from path
 	if res.Name == "" {
 		if ymlPath != "" {
-			res.Name = fileutil.Stem(ymlPath)
+			res.Name = filepath.Base(pathStem(ymlPath))
 		} else if sqlPath != "" {
-			res.Name = fileutil.Stem(sqlPath)
+			res.Name = filepath.Base(pathStem(sqlPath))
 		}
 	}
 

--- a/runtime/compilers/rillv1/parser.go
+++ b/runtime/compilers/rillv1/parser.go
@@ -912,7 +912,7 @@ func normalizePath(path string) string {
 }
 
 // pathStem returns a slice of the path without the final file extension.
-// If the path does not contain a file extension, the entire path is returned.f
+// If the path does not contain a file extension, the entire path is returned
 func pathStem(path string) string {
 	i := strings.LastIndexByte(path, '.')
 	if i == -1 {


### PR DESCRIPTION
Closes issue reported [here](https://rilldata.slack.com/archives/CTZ8XBQ85/p1709530154230399?thread_ts=1708474022.726509&cid=CTZ8XBQ85)