### PR TITLE
Runtime: Handle clickhouse LowCardinality nullable types

### DIFF
--- a/runtime/drivers/clickhouse/information_schema.go
+++ b/runtime/drivers/clickhouse/information_schema.go
@@ -60,8 +60,7 @@ func (i informationSchema) Lookup(ctx context.Context, name string) (*drivers.Ta
 			T.TABLE_NAME AS NAME,
 			T.TABLE_TYPE AS TABLE_TYPE, 
 			C.COLUMN_NAME AS COLUMN_NAME,
-			C.DATA_TYPE AS COLUMN_TYPE,
-			C.IS_NULLABLE = '1' AS IS_NULLABLE
+			C.DATA_TYPE AS COLUMN_TYPE
 		FROM INFORMATION_SCHEMA.TABLES T 
 		JOIN INFORMATION_SCHEMA.COLUMNS C ON T.TABLE_SCHEMA = C.TABLE_SCHEMA AND T.TABLE_NAME = C.TABLE_NAME
 		WHERE T.TABLE_SCHEMA = 'default' AND T.TABLE_NAME = ?
@@ -102,9 +101,8 @@ func (i informationSchema) scanTables(rows *sqlx.Rows) ([]*drivers.Table, error)
 		var tableType string
 		var columnName string
 		var columnType string
-		var nullable bool
 
-		err := rows.Scan(&database, &schema, &name, &tableType, &columnName, &columnType, &nullable)
+		err := rows.Scan(&database, &schema, &name, &tableType, &columnName, &columnType)
 		if err != nil {
 			return nil, err
 		}
@@ -128,7 +126,7 @@ func (i informationSchema) scanTables(rows *sqlx.Rows) ([]*drivers.Table, error)
 		}
 
 		// parse column type
-		colType, err := databaseTypeToPB(columnType, nullable)
+		colType, err := databaseTypeToPB(columnType, false)
 		if err != nil {
 			return nil, err
 		}

--- a/runtime/drivers/clickhouse/olap.go
+++ b/runtime/drivers/clickhouse/olap.go
@@ -389,12 +389,13 @@ func databaseTypeToPB(dbt string, nullable bool) (*runtimev1.Type, error) {
 	// For nullable the datatype is Nullable(X)
 	if strings.HasPrefix(dbt, "NULLABLE(") {
 		dbt = dbt[9 : len(dbt)-1]
-		nullable = true
+		return databaseTypeToPB(dbt, true)
 	}
 
 	// For LowCardinality the datatype is LowCardinality(X)
 	if strings.HasPrefix(dbt, "LOWCARDINALITY(") {
 		dbt = dbt[15 : len(dbt)-1]
+		return databaseTypeToPB(dbt, nullable)
 	}
 
 	match := true


### PR DESCRIPTION
1. Although not clear from the clickhouse docs but underlying type in `LowCardinality` type can also nullable. 
2. We actually don't need `is_nullable` from `information_schema.columns` since any nullable type in clickhouse is expected to be of form `Nullable(x)` so removed its usage.
