### PR TITLE
Alerts time range refactor

### DIFF
--- a/web-admin/src/features/alerts/metadata/utils.ts
+++ b/web-admin/src/features/alerts/metadata/utils.ts
@@ -1,4 +1,4 @@
-import { AlertIntervalOptions } from "@rilldata/web-common/features/alerts/data-tab/intervals";
+import { AlertIntervalOptions } from "@rilldata/web-common/features/alerts/delivery-tab/intervals";
 import { humaniseISODuration } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
 import { SnoozeOptions } from "@rilldata/web-common/features/alerts/delivery-tab/snooze";
 import type { V1AlertSpec } from "@rilldata/web-common/runtime-client";

--- a/web-common/src/components/forms/FormSection.svelte
+++ b/web-common/src/components/forms/FormSection.svelte
@@ -1,11 +1,28 @@
 <script lang="ts">
+  import InfoCircle from "@rilldata/web-common/components/icons/InfoCircle.svelte";
+  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
+  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
+
   export let title: string;
   export let description: string = "";
+  export let tooltip: boolean = false;
 </script>
 
 <div class="flex flex-col bg-white p-3 gap-y-3 rounded">
   <div class="flex flex-col">
-    <span class="text-base text-medium text-slate-900">{title}</span>
+    <span
+      class="flex flex-row items-center gap-1 text-base text-medium text-slate-900"
+    >
+      <div>{title}</div>
+      {#if tooltip}
+        <Tooltip>
+          <InfoCircle />
+          <TooltipContent slot="tooltip-content" maxWidth="600px">
+            <slot name="tooltip-content" />
+          </TooltipContent>
+        </Tooltip>
+      {/if}
+    </span>
     {#if description}
       <span class="text-sm text-slate-600">{description}</span>
     {/if}

--- a/web-common/src/features/alerts/CreateAlertDialog.svelte
+++ b/web-common/src/features/alerts/CreateAlertDialog.svelte
@@ -66,6 +66,7 @@
       metricsViewName: $metricsViewName,
       whereFilter: $dashboardStore.whereFilter,
       timeRange: {
+        isoDuration: timeControls.selectedTimeRange?.name,
         start: timeControls.timeStart,
         end: timeControls.timeEnd,
       },

--- a/web-common/src/features/alerts/EditAlertDialog.svelte
+++ b/web-common/src/features/alerts/EditAlertDialog.svelte
@@ -45,6 +45,7 @@
       name: alertSpec.title as string,
       snooze: getSnoozeValueFromAlertSpec(alertSpec),
       recipients: alertSpec?.emailRecipients?.map((r) => ({ email: r })) ?? [],
+      splitByTimeGrain: alertSpec.intervalsIsoDuration ?? "",
       ...extractAlertFormValues(queryArgsJson, metricsViewSpec),
     },
     validationSchema: alertFormValidationSchema,
@@ -99,5 +100,5 @@
   <DialogOverlay
     class="fixed inset-0 bg-gray-400 transition-opacity opacity-40"
   />
-  <BaseAlertForm isEditForm={true} {formState} on:close />
+  <BaseAlertForm {formState} isEditForm={true} on:close />
 </Dialog>

--- a/web-common/src/features/alerts/criteria-tab/AlertDialogCriteriaTab.svelte
+++ b/web-common/src/features/alerts/criteria-tab/AlertDialogCriteriaTab.svelte
@@ -22,7 +22,6 @@
       measure={$form["measure"]}
       metricsViewName={$form["metricsViewName"]}
       splitByDimension={$form["splitByDimension"]}
-      splitByTimeGrain={$form["splitByTimeGrain"]}
       timeRange={$form["timeRange"]}
       whereFilter={$form["whereFilter"]}
     />

--- a/web-common/src/features/alerts/criteria-tab/AlertPreview.svelte
+++ b/web-common/src/features/alerts/criteria-tab/AlertPreview.svelte
@@ -11,7 +11,6 @@
   export let metricsViewName: string;
   export let measure: string;
   export let splitByDimension: string;
-  export let splitByTimeGrain: string;
   export let whereFilter: V1Expression;
   export let criteria: V1Expression;
   export let timeRange: V1TimeRange;
@@ -22,7 +21,6 @@
     metricsViewName,
     measure,
     splitByDimension,
-    splitByTimeGrain,
     whereFilter,
     criteria,
     timeRange,

--- a/web-common/src/features/alerts/data-tab/AlertDialogDataTab.svelte
+++ b/web-common/src/features/alerts/data-tab/AlertDialogDataTab.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   import DataPreview from "@rilldata/web-common/features/alerts/data-tab/DataPreview.svelte";
-  import { AlertIntervalOptions } from "@rilldata/web-common/features/alerts/data-tab/intervals";
+  import { AlertIntervalOptions } from "@rilldata/web-common/features/alerts/delivery-tab/intervals";
   import FormSection from "../../../components/forms/FormSection.svelte";
   import InputV2 from "../../../components/forms/InputV2.svelte";
   import Select from "../../../components/forms/Select.svelte";
   import { runtime } from "../../../runtime-client/runtime-store";
   import FilterChipsReadOnly from "../../dashboards/filters/FilterChipsReadOnly.svelte";
   import { useMetricsView } from "../../dashboards/selectors";
-  import NoFiltersSelected from "./NoFiltersSelected.svelte";
 
   export let formState: any; // svelte-forms-lib's FormState
   export let isEditForm: boolean;
@@ -32,8 +31,6 @@
       label: d.label?.length ? d.label : d.expression,
     })) ?? []),
   ];
-
-  $: hasAtLeastOneFilter = $form.whereFilter.cond.exprs.length > 0;
 </script>
 
 <div class="flex flex-col gap-y-3">
@@ -48,19 +45,14 @@
     />
   </FormSection>
   <FormSection
-    description={hasAtLeastOneFilter
-      ? "These are inherited from the underlying dashboard view."
-      : ""}
+    description="These are inherited from the underlying dashboard view."
     title="Filters"
   >
-    {#if hasAtLeastOneFilter}
-      <FilterChipsReadOnly
-        metricsViewName={$form["metricsViewName"]}
-        filters={$form["whereFilter"]}
-      />
-    {:else}
-      <NoFiltersSelected {isEditForm} />
-    {/if}
+    <FilterChipsReadOnly
+      filters={$form["whereFilter"]}
+      metricsViewName={$form["metricsViewName"]}
+      timeRange={$form["timeRange"]}
+    />
   </FormSection>
   <FormSection
     description="Select the measures you want to monitor."
@@ -81,21 +73,12 @@
       options={dimensionOptions}
       placeholder="Select a dimension"
     />
-    <Select
-      bind:value={$form["splitByTimeGrain"]}
-      id="splitByTimeGrain"
-      label="Split by time grain"
-      optional
-      options={AlertIntervalOptions}
-      placeholder="Select a time grain"
-    />
   </FormSection>
   <FormSection title="Data preview">
     <DataPreview
       measure={$form["measure"]}
       metricsViewName={$form["metricsViewName"]}
       splitByDimension={$form["splitByDimension"]}
-      splitByTimeGrain={$form["splitByTimeGrain"]}
       timeRange={$form["timeRange"]}
       whereFilter={$form["whereFilter"]}
     />

--- a/web-common/src/features/alerts/data-tab/DataPreview.svelte
+++ b/web-common/src/features/alerts/data-tab/DataPreview.svelte
@@ -11,7 +11,6 @@
   export let metricsViewName: string;
   export let measure: string;
   export let splitByDimension: string;
-  export let splitByTimeGrain: string;
   export let whereFilter: V1Expression;
   export let timeRange: V1TimeRange;
 
@@ -21,7 +20,6 @@
     metricsViewName,
     measure,
     splitByDimension,
-    splitByTimeGrain,
     whereFilter,
     criteria: undefined,
     timeRange,

--- a/web-common/src/features/alerts/delivery-tab/AlertDialogDeliveryTab.svelte
+++ b/web-common/src/features/alerts/delivery-tab/AlertDialogDeliveryTab.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import FormSection from "@rilldata/web-common/components/forms/FormSection.svelte";
   import Select from "@rilldata/web-common/components/forms/Select.svelte";
+  import { AlertIntervalOptions } from "@rilldata/web-common/features/alerts/delivery-tab/intervals";
   import { SnoozeOptions } from "@rilldata/web-common/features/alerts/delivery-tab/snooze";
   import RecipientsInputArray from "@rilldata/web-common/features/scheduled-reports/RecipientsInputArray.svelte";
 
@@ -14,6 +15,36 @@
     description="We'll check for this alert whenever the data refreshes"
     title="Schedule"
   />
+  <FormSection
+    description="Choose the interval at which the alert is evaluated since the prior data refresh."
+    title="Evaluation interval"
+    tooltip
+  >
+    <Select
+      bind:value={$form["splitByTimeGrain"]}
+      id="splitByTimeGrain"
+      label=""
+      options={AlertIntervalOptions}
+      placeholder="None / Hourly / Daily / Weekly"
+    />
+    <ul class="list-disc ml-4" slot="tooltip-content">
+      <li>
+        Select ‘None’ to evaluate the alert only at the time of data refresh.
+      </li>
+      <li>
+        Select 'Hourly' to evaluate the alert for every hour that has passed
+        since the last refresh.
+      </li>
+      <li>
+        Select 'Daily' to evaluate the alert for every day that has passed since
+        the last refresh.
+      </li>
+      <li>
+        Select 'Weekly' to evaluate the alert for every week that has passed
+        since the last refresh.
+      </li>
+    </ul>
+  </FormSection>
   <FormSection
     description="Set a snooze period to silence repeat notifications for the same alert."
     title="Snooze"

--- a/web-common/src/features/alerts/delivery-tab/intervals.ts
+++ b/web-common/src/features/alerts/delivery-tab/intervals.ts
@@ -15,9 +15,4 @@ export const AlertIntervalOptions = [
     label: "Week",
     value: "P1W",
   },
-  {
-    label: "Month",
-    value: "P1M",
-    // TODO: add more
-  },
 ];

--- a/web-common/src/features/alerts/extract-alert-form-values.ts
+++ b/web-common/src/features/alerts/extract-alert-form-values.ts
@@ -17,7 +17,6 @@ export type AlertFormValuesSubset = Pick<
   | "timeRange"
   | "measure"
   | "splitByDimension"
-  | "splitByTimeGrain"
   | "criteria"
   | "criteriaOperation"
 >;
@@ -29,25 +28,12 @@ export function extractAlertFormValues(
   if (!queryArgs) return {} as AlertFormValuesSubset;
 
   const measures = queryArgs.measures as V1MetricsViewAggregationMeasure[];
-
-  const dimensions: string[] = [];
-  const timeDimension: V1MetricsViewAggregationDimension[] = [];
-  queryArgs.dimensions?.forEach((dim) => {
-    if (
-      (metricsViewSpec.dimensions?.findIndex(
-        (dimSpec) => dimSpec.name === dim.name,
-      ) ?? -1) >= 0
-    ) {
-      dimensions.push(dim.name as string);
-    } else if (dim.name === metricsViewSpec.timeDimension) {
-      timeDimension.push(dim);
-    }
-  });
+  const dimensions =
+    queryArgs.dimensions as V1MetricsViewAggregationDimension[];
 
   return {
-    measure: measures[0].name as string,
-    splitByDimension: dimensions[0] ?? "",
-    splitByTimeGrain: queryArgs.timeRange?.isoDuration ?? "",
+    measure: measures[0]?.name ?? "",
+    splitByDimension: dimensions[0]?.name ?? "",
 
     criteria:
       queryArgs.having?.cond?.exprs?.map((e) => ({

--- a/web-common/src/features/alerts/form-utils.ts
+++ b/web-common/src/features/alerts/form-utils.ts
@@ -53,13 +53,9 @@ export function getAlertQueryArgsFromFormValues(
         ),
       ),
     ),
-    ...(formValues.splitByTimeGrain
-      ? {
-          timeRange: {
-            isoDuration: formValues.splitByTimeGrain,
-          },
-        }
-      : {}),
+    timeRange: {
+      isoDuration: formValues.timeRange.isoDuration,
+    },
   };
 }
 

--- a/web-common/src/features/dashboards/filters/FilterChipsReadOnly.svelte
+++ b/web-common/src/features/dashboards/filters/FilterChipsReadOnly.svelte
@@ -2,8 +2,12 @@
 The main feature-set component for dashboard filters
  -->
 <script lang="ts">
+  import ReadOnlyTimeRange from "@rilldata/web-common/features/dashboards/filters/ReadOnlyTimeRange.svelte";
   import { getMapFromArray } from "@rilldata/web-common/lib/arrayUtils";
-  import type { V1Expression } from "@rilldata/web-common/runtime-client";
+  import type {
+    V1Expression,
+    V1TimeRange,
+  } from "@rilldata/web-common/runtime-client";
   import { flip } from "svelte/animate";
   import { runtime } from "../../../runtime-client/runtime-store";
   import { useDashboard } from "../selectors";
@@ -14,6 +18,7 @@ The main feature-set component for dashboard filters
 
   export let metricsViewName: string;
   export let filters: V1Expression | undefined;
+  export let timeRange: V1TimeRange | undefined;
 
   $: dashboard = useDashboard($runtime.instanceId, metricsViewName);
 
@@ -36,6 +41,9 @@ The main feature-set component for dashboard filters
 </script>
 
 <div class="relative flex flex-row flex-wrap gap-x-2 gap-y-2 items-center">
+  {#if timeRange}
+    <ReadOnlyTimeRange {timeRange} />
+  {/if}
   {#if dimensionFilters.length > 0}
     {#each dimensionFilters as { name, label, selectedValues } (name)}
       {@const dimension = dimensions.find((d) => d.name === name)}

--- a/web-common/src/features/dashboards/filters/ReadOnlyTimeRange.svelte
+++ b/web-common/src/features/dashboards/filters/ReadOnlyTimeRange.svelte
@@ -11,7 +11,7 @@
 
 <Chip {...timeChipColors} outline readOnly>
   <svelte:fragment slot="body">
-    <div class="font-bold text-xs text-slate-800">
+    <div class="font-bold text-xs text-slate-800 px-2">
       {#if timeRange.isoDuration && timeRange.isoDuration !== TimeRangePreset.CUSTOM}
         {#if timeRange.isoDuration === TimeRangePreset.ALL_TIME}
           All Time

--- a/web-common/src/features/dashboards/filters/ReadOnlyTimeRange.svelte
+++ b/web-common/src/features/dashboards/filters/ReadOnlyTimeRange.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { Chip } from "@rilldata/web-common/components/chip";
+  import { timeChipColors } from "@rilldata/web-common/components/chip/chip-types";
+  import { prettyFormatTimeRange } from "@rilldata/web-common/lib/time/ranges";
+  import { humaniseISODuration } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
+  import { TimeRangePreset } from "@rilldata/web-common/lib/time/types";
+  import type { V1TimeRange } from "@rilldata/web-common/runtime-client";
+
+  export let timeRange: V1TimeRange;
+</script>
+
+<Chip {...timeChipColors} outline readOnly>
+  <svelte:fragment slot="body">
+    <div class="font-bold text-xs text-slate-800">
+      {#if timeRange.isoDuration && timeRange.isoDuration !== TimeRangePreset.CUSTOM}
+        {#if timeRange.isoDuration === TimeRangePreset.ALL_TIME}
+          All Time
+        {:else}
+          Last {humaniseISODuration(timeRange.isoDuration)}
+        {/if}
+      {:else if timeRange.start && timeRange.end}
+        {prettyFormatTimeRange(
+          new Date(timeRange.start),
+          new Date(timeRange.end),
+          TimeRangePreset.CUSTOM,
+          "UTC", // TODO
+        )}
+      {/if}
+    </div>
+  </svelte:fragment>
+</Chip>

--- a/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilterReadOnlyChip.svelte
+++ b/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilterReadOnlyChip.svelte
@@ -15,7 +15,7 @@
 
 <Chip {...defaultChipColors} {label} outline readOnly>
   <svelte:fragment slot="body">
-    <div class="flex gap-x-2">
+    <div class="flex gap-x-2 mx-2">
       <div
         class="font-bold text-ellipsis overflow-hidden whitespace-nowrap"
         style:max-width={labelMaxWidth}

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterReadOnlyChip.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterReadOnlyChip.svelte
@@ -14,5 +14,7 @@
 </script>
 
 <Chip {...colors} extraRounded={false} {label} outline readOnly>
-  <MeasureFilterBody {dimensionName} {expr} {label} readOnly slot="body" />
+  <div class="mx-2" slot="body">
+    <MeasureFilterBody {dimensionName} {expr} {label} readOnly />
+  </div>
 </Chip>


### PR DESCRIPTION
This PR updates how we handle time range in alerts.
- [x] Use the dashboard time range as the query time range.
- [x] Use splitByGrain for only the alert run interval.
- [x] Add the time range from dashboard to the the filters section.