### PR TITLE
Remove Pivot expanded state from proto

### DIFF
--- a/web-common/src/features/dashboards/proto-state/toProto.ts
+++ b/web-common/src/features/dashboards/proto-state/toProto.ts
@@ -275,7 +275,7 @@ function toPivotProto(pivotState: PivotState): PartialMessage<DashboardState> {
       .map((d) => d.id),
     pivotColumnMeasures: pivotState.columns.measure.map((m) => m.id),
 
-    pivotExpanded: pivotState.expanded, // TODO
+    // pivotExpanded: pivotState.expanded,
     pivotSort: pivotState.sorting,
     pivotColumnPage: pivotState.columnPage,
     pivotRowJoinType: ToProtoPivotRowJoinTypeMap[pivotState.rowJoinType],


### PR DESCRIPTION
Removes expanded state from proto. A number of bugs were coming up because we don't yet support recursive, asynchronous, derived store based API calls yet. Once we have that it, we can revert this back. 