### PR TITLE
Update workspace container

### DIFF
--- a/web-common/src/features/onboarding/OnboardingWorkspace.svelte
+++ b/web-common/src/features/onboarding/OnboardingWorkspace.svelte
@@ -76,7 +76,7 @@
   }
 </script>
 
-<WorkspaceContainer top="0px" assetID="onboarding" inspector={false}>
+<WorkspaceContainer assetID="onboarding" inspector={false}>
   <div class="pt-20 px-8 flex flex-col gap-y-6 items-center" slot="body">
     <div class="text-center">
       <div class="font-bold">Getting started</div>

--- a/web-common/src/layout/workspace/Inspector.svelte
+++ b/web-common/src/layout/workspace/Inspector.svelte
@@ -7,17 +7,17 @@
   import type { LayoutElement } from "./types";
 
   /** the core inspector width element is stored in localStorage. */
-  const inspectorLayout = getContext(
+  const inspectorLayout = getContext<Writable<LayoutElement>>(
     "rill:app:inspector-layout",
-  ) as Writable<LayoutElement>;
+  );
 
-  const inspectorWidth = getContext(
+  const inspectorWidth = getContext<Writable<number>>(
     "rill:app:inspector-width-tween",
-  ) as Writable<number>;
+  );
 
-  const visibilityTween = getContext(
+  const visibilityTween = getContext<Writable<number>>(
     "rill:app:inspector-visibility-tween",
-  ) as Writable<number>;
+  );
 </script>
 
 <div

--- a/web-common/src/layout/workspace/WorkspaceContainer.svelte
+++ b/web-common/src/layout/workspace/WorkspaceContainer.svelte
@@ -13,10 +13,9 @@
   import Inspector from "./Inspector.svelte";
   import type { LayoutElement } from "./types";
 
-  export let assetID;
+  export let assetID: string;
   export let inspector = true;
   export let bgClass = "bg-gray-100";
-  export let top = "var(--header-height)";
 
   const inspectorLayout = localStorageStore<LayoutElement>(assetID, {
     value: inspector ? DEFAULT_INSPECTOR_WIDTH : 0,
@@ -78,40 +77,40 @@
   setContext("rill:app:output-height-tween", outputHeight);
   setContext("rill:app:output-visibility-tween", outputVisibilityTween);
 
-  const navigationWidth = getContext(
+  const navigationWidth = getContext<Writable<number>>(
     "rill:app:navigation-width-tween",
-  ) as Writable<number>;
-  const navVisibilityTween = getContext(
+  );
+  const navVisibilityTween = getContext<Writable<number>>(
     "rill:app:navigation-visibility-tween",
-  ) as Writable<number>;
+  );
 
+  // Unclear on usage of this variable
+  // Holding off on removing it for now
   let hasNoError = 1;
-  let hasInspector = true;
 </script>
 
 <div
-  class="fixed bg-white"
-  style:left="{($navigationWidth || 0) * (1 - $navVisibilityTween)}px"
-  style:right="0px"
->
-  <slot name="header" />
-</div>
-<div
-  class="box-border fixed {bgClass}"
-  style:height="100%"
-  style:top
+  class="flex flex-col h-screen overflow-hidden absolute"
   style:left="{($navigationWidth || 0) * (1 - $navVisibilityTween)}px"
   style:padding-left="{$navVisibilityTween * SIDE_PAD}px"
-  style:padding-right="{(1 - $visibilityTween) *
-    SIDE_PAD *
-    hasNoError *
-    (hasInspector ? 1 : 0)}px"
-  style:right="{hasInspector && hasNoError
-    ? $inspectorWidth * $visibilityTween
-    : 0}px"
+  style:right="0px"
 >
-  <slot name="body" />
+  {#if $$slots.header}
+    <header class="bg-white w-full h-fit z-10">
+      <slot name="header" />
+    </header>
+  {/if}
+
+  <div
+    class="h-full {bgClass}"
+    style:padding-right="{inspector && hasNoError
+      ? $inspectorWidth * $visibilityTween
+      : 0}px"
+  >
+    <slot name="body" />
+  </div>
 </div>
+
 {#if inspector}
   <Inspector>
     <slot name="inspector" />

--- a/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
@@ -91,7 +91,6 @@
 
 {#if ($fileQuery.data && $resourceStatusStore.status === ResourceStatus.Idle) || showErrorPage}
   <WorkspaceContainer
-    top="0px"
     assetID={metricViewName}
     bgClass="bg-white"
     inspector={false}
@@ -112,7 +111,6 @@
   </WorkspaceContainer>
 {:else if $resourceStatusStore.status === ResourceStatus.Busy}
   <WorkspaceContainer
-    top="0px"
     assetID={metricViewName}
     bgClass="bg-white"
     inspector={false}


### PR DESCRIPTION
This PR is an intermediary step on the way to removing the manual tween and layout calculations used across the application, but also solves some UI issues along the way.

In essence, this changes the WorkspaceContainer so that elements/components passed via the "body" slot behave as expected w/r/t flex layout and scroll behavior without needing to accommodate for the header height. It also alters some type annotations and properly connects the `inspector` prop to element rendering by removing the `hasInspector` variable.