### PR TITLE
Cloud UI: add a tooltip to show full error messages on the Status page

### DIFF
--- a/web-admin/src/features/projects/status/ResourceErrorMessage.svelte
+++ b/web-admin/src/features/projects/status/ResourceErrorMessage.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
+  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
+  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
+
   export let message: string;
 </script>
 
 {#if message}
-  <span class="text-red-600 max-w-xs line-clamp-2">
-    {message}
-  </span>
+  <Tooltip distance={8}>
+    <span class="text-red-600 max-w-xs line-clamp-2">
+      {message}
+    </span>
+    <TooltipContent slot="tooltip-content">
+      {message}
+    </TooltipContent>
+  </Tooltip>
 {:else}
   <span>-</span>
 {/if}


### PR DESCRIPTION
Error messages on the status page are truncated after two lines:

![image](https://github.com/rilldata/rill/assets/14206386/9efa6a6e-7310-4be8-8fea-d9a6611b70f8)

This PR adds a tooltip that contains the full error message:

![image](https://github.com/rilldata/rill/assets/14206386/8d001779-9b20-43ca-b908-d795b8d840f5)
