### PR TITLE
Encode dashboard url state only once

### DIFF
--- a/web-common/src/features/dashboards/proto-state/dashboard-url-state.ts
+++ b/web-common/src/features/dashboards/proto-state/dashboard-url-state.ts
@@ -123,7 +123,7 @@ function gotoNewDashboardUrl(url: URL, newState: string, defaultState: string) {
   const newUrl = getUrlForPath(url.pathname, ["features", "theme"]);
 
   if (newState !== defaultState) {
-    newStateInUrl = encodeURIComponent(newState);
+    newStateInUrl = newState;
     newUrl.searchParams.set("state", newStateInUrl);
   }
 

--- a/web-common/src/features/entity-management/resource-invalidations.ts
+++ b/web-common/src/features/entity-management/resource-invalidations.ts
@@ -83,8 +83,6 @@ async function invalidateResource(
 ) {
   refreshResource(queryClient, instanceId, resource);
 
-  console.log(resource.meta?.name, resource.meta?.reconcileError);
-
   const lastStateUpdatedOn = getLastStateUpdatedOn(resource);
   if (
     resource.meta.reconcileStatus !== V1ReconcileStatus.RECONCILE_STATUS_IDLE &&

--- a/web-common/src/features/entity-management/resource-invalidations.ts
+++ b/web-common/src/features/entity-management/resource-invalidations.ts
@@ -83,6 +83,8 @@ async function invalidateResource(
 ) {
   refreshResource(queryClient, instanceId, resource);
 
+  console.log(resource.meta?.name, resource.meta?.reconcileError);
+
   const lastStateUpdatedOn = getLastStateUpdatedOn(resource);
   if (
     resource.meta.reconcileStatus !== V1ReconcileStatus.RECONCILE_STATUS_IDLE &&


### PR DESCRIPTION
closes #3955

Using `URL::searchParams` and `URL::toString` does the encoding for us. So an additional encoding is not necessary.