### PR TITLE
Add typesafe context helper

### DIFF
--- a/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampDetail.svelte
+++ b/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampDetail.svelte
@@ -1,3 +1,19 @@
+<script context="module" lang="ts">
+  import { createContext } from "@rilldata/web-common/lib/context";
+
+  export const dataGraphicContext = {
+    x: createContext<Writable<ScaleLinear<number, number>>>(
+      "rill:data-graphic:X",
+    ),
+    y: createContext<Writable<ScaleLinear<number, number>>>(
+      "rill:data-graphic:Y",
+    ),
+    plotConfig: createContext<Writable<PlotConfig>>(
+      "rill:data-graphic:plot-config",
+    ),
+  };
+</script>
+
 <script lang="ts">
   /**
    * TimestampDetail.svelte
@@ -39,6 +55,7 @@
   import TimestampProfileSummary from "./TimestampProfileSummary.svelte";
   import TimestampTooltipContent from "./TimestampTooltipContent.svelte";
   import ZoomWindow from "./ZoomWindow.svelte";
+  import da from "date-fns/locale/da";
 
   const id = guidGenerator();
 
@@ -82,8 +99,9 @@
   const X: Writable<ScaleLinear<number, number>> = writable(undefined);
   const Y: Writable<ScaleLinear<number, number>> = writable(undefined);
   /** make them available to the children. */
-  setContext("rill:data-graphic:X", X);
-  setContext("rill:data-graphic:Y", Y);
+
+  dataGraphicContext.x.set(X);
+  dataGraphicContext.y.set(Y);
 
   const coordinates = writable(DEFAULT_COORDINATES);
 
@@ -105,7 +123,7 @@
     id,
   });
 
-  setContext("rill:data-graphic:plot-config", plotConfig);
+  dataGraphicContext.plotConfig.set(plotConfig);
 
   $: $plotConfig.devicePixelRatio = devicePixelRatio;
   $: $plotConfig.width = width;

--- a/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampDetail.svelte
+++ b/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampDetail.svelte
@@ -38,7 +38,7 @@
   import { bisector, extent, max, min } from "d3-array";
   import type { ScaleLinear } from "d3-scale";
   import { scaleLinear } from "d3-scale";
-  import { onMount, setContext } from "svelte";
+  import { onMount } from "svelte";
   import { cubicOut as easing } from "svelte/easing";
   import { spring } from "svelte/motion";
   import type { Writable } from "svelte/store";
@@ -55,7 +55,6 @@
   import TimestampProfileSummary from "./TimestampProfileSummary.svelte";
   import TimestampTooltipContent from "./TimestampTooltipContent.svelte";
   import ZoomWindow from "./ZoomWindow.svelte";
-  import da from "date-fns/locale/da";
 
   const id = guidGenerator();
 

--- a/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampDetail.svelte
+++ b/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampDetail.svelte
@@ -1,19 +1,3 @@
-<script context="module" lang="ts">
-  import { createContext } from "@rilldata/web-common/lib/context";
-
-  export const dataGraphicContext = {
-    x: createContext<Writable<ScaleLinear<number, number>>>(
-      "rill:data-graphic:X",
-    ),
-    y: createContext<Writable<ScaleLinear<number, number>>>(
-      "rill:data-graphic:Y",
-    ),
-    plotConfig: createContext<Writable<PlotConfig>>(
-      "rill:data-graphic:plot-config",
-    ),
-  };
-</script>
-
 <script lang="ts">
   /**
    * TimestampDetail.svelte
@@ -55,6 +39,7 @@
   import TimestampProfileSummary from "./TimestampProfileSummary.svelte";
   import TimestampTooltipContent from "./TimestampTooltipContent.svelte";
   import ZoomWindow from "./ZoomWindow.svelte";
+  import { dataGraphicContext } from "./context";
 
   const id = guidGenerator();
 

--- a/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampMouseoverAnnotation.svelte
+++ b/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampMouseoverAnnotation.svelte
@@ -7,7 +7,7 @@
   import { removeLocalTimezoneOffset } from "@rilldata/web-common/lib/time/timezone";
   import { fly } from "svelte/transition";
   import { outline } from "../../actions/outline";
-  import { dataGraphicContext } from "./TimestampDetail.svelte";
+  import { dataGraphicContext } from "./context";
 
   const X = dataGraphicContext.x.get();
   const Y = dataGraphicContext.y.get();

--- a/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampMouseoverAnnotation.svelte
+++ b/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampMouseoverAnnotation.svelte
@@ -4,27 +4,19 @@
     formatInteger,
     timePortion,
   } from "@rilldata/web-common/lib/formatters";
-  import type { ScaleLinear } from "d3-scale";
   import { removeLocalTimezoneOffset } from "@rilldata/web-common/lib/time/timezone";
-  import { getContext } from "svelte";
-  import type { Writable } from "svelte/store";
   import { fly } from "svelte/transition";
   import { outline } from "../../actions/outline";
-  import type { PlotConfig } from "../../utils";
+  import { dataGraphicContext } from "./TimestampDetail.svelte";
 
-  const X: Writable<ScaleLinear<number, number>> = getContext(
-    "rill:data-graphic:X",
-  );
-  const Y: Writable<ScaleLinear<number, number>> = getContext(
-    "rill:data-graphic:Y",
-  );
-  const config: Writable<PlotConfig> = getContext(
-    "rill:data-graphic:plot-config",
-  );
+  const X = dataGraphicContext.x.get();
+  const Y = dataGraphicContext.y.get();
+  const config = dataGraphicContext.plotConfig.get();
 
   export let point;
   export let xAccessor: string;
   export let yAccessor: string;
+
   $: xLabel = removeLocalTimezoneOffset(point[xAccessor]);
 </script>
 

--- a/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampPaths.svelte
+++ b/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampPaths.svelte
@@ -3,7 +3,7 @@
    *
    */
 
-  import { dataGraphicContext } from "./TimestampDetail.svelte";
+  import { dataGraphicContext } from "./context";
   import { areaFactory, lineFactory } from "../../utils";
 
   export let xAccessor: string;

--- a/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampPaths.svelte
+++ b/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampPaths.svelte
@@ -2,13 +2,9 @@
   /** the path elements used in the timestamp profiler.
    *
    */
-  import type { ScaleLinear } from "d3-scale";
 
-  import { getContext } from "svelte";
-  import type { Writable } from "svelte/store";
-
+  import { dataGraphicContext } from "./TimestampDetail.svelte";
   import { areaFactory, lineFactory } from "../../utils";
-  import type { PlotConfig } from "../../utils";
 
   export let xAccessor: string;
   export let yAccessor: string;
@@ -16,16 +12,9 @@
   export let smooth = false;
   export let data;
 
-  const X: Writable<ScaleLinear<number, number>> = getContext(
-    "rill:data-graphic:X",
-  );
-  const Y: Writable<ScaleLinear<number, number>> = getContext(
-    "rill:data-graphic:Y",
-  );
-
-  const plotConfig: Writable<PlotConfig> = getContext(
-    "rill:data-graphic:plot-config",
-  );
+  const X = dataGraphicContext.x.get();
+  const Y = dataGraphicContext.y.get();
+  const plotConfig = dataGraphicContext.plotConfig.get();
 
   $: lineFcn = lineFactory({
     xScale: $X,

--- a/web-common/src/components/data-graphic/compositions/timestamp-profile/ZoomWindow.svelte
+++ b/web-common/src/components/data-graphic/compositions/timestamp-profile/ZoomWindow.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { dataGraphicContext } from "./TimestampDetail.svelte";
+  import { dataGraphicContext } from "./context";
 
   /** the starting value, in range space */
   export let start: number;

--- a/web-common/src/components/data-graphic/compositions/timestamp-profile/ZoomWindow.svelte
+++ b/web-common/src/components/data-graphic/compositions/timestamp-profile/ZoomWindow.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
-  import { getContext } from "svelte";
-  import type { Writable } from "svelte/store";
-  import type { PlotConfig } from "../../utils";
+  import { dataGraphicContext } from "./TimestampDetail.svelte";
 
   /** the starting value, in range space */
   export let start: number;
@@ -9,9 +7,7 @@
   export let stop: number;
   export let color: string;
 
-  const plotConfig: Writable<PlotConfig> = getContext(
-    "rill:data-graphic:plot-config",
-  );
+  const plotConfig = dataGraphicContext.plotConfig.get();
 </script>
 
 <rect

--- a/web-common/src/components/data-graphic/compositions/timestamp-profile/context.ts
+++ b/web-common/src/components/data-graphic/compositions/timestamp-profile/context.ts
@@ -1,0 +1,17 @@
+import { createContext } from "@rilldata/web-common/lib/context";
+
+import type { Writable } from "svelte/store";
+import type { ScaleLinear } from "d3-scale";
+import type { PlotConfig } from "../../utils";
+
+export const dataGraphicContext = {
+  x: createContext<Writable<ScaleLinear<number, number>>>(
+    "rill:data-graphic:X",
+  ),
+  y: createContext<Writable<ScaleLinear<number, number>>>(
+    "rill:data-graphic:Y",
+  ),
+  plotConfig: createContext<Writable<PlotConfig>>(
+    "rill:data-graphic:plot-config",
+  ),
+};

--- a/web-common/src/features/dashboards/state-managers/StateManagersProvider.svelte
+++ b/web-common/src/features/dashboards/state-managers/StateManagersProvider.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import { page } from "$app/stores";
-  import { setContext } from "svelte";
   import { useQueryClient } from "@tanstack/svelte-query";
-  import { createStateManagers, DEFAULT_STORE_KEY } from "./state-managers";
+  import { createStateManagers, stateManagersContext } from "./state-managers";
 
   export let metricsViewName: string;
 
@@ -16,7 +15,8 @@
     extraKeyPrefix:
       orgName && projectName ? `__${orgName}__${projectName}` : "",
   });
-  setContext(DEFAULT_STORE_KEY, stateManagers);
+
+  stateManagersContext.set(stateManagers);
 
   $: {
     // update metrics view name

--- a/web-common/src/features/dashboards/state-managers/state-managers.ts
+++ b/web-common/src/features/dashboards/state-managers/state-managers.ts
@@ -34,6 +34,7 @@ import {
   StateManagerReadables,
   createStateManagerReadables,
 } from "./selectors";
+import { createContext } from "@rilldata/web-common/lib/context";
 
 export type StateManagers = {
   runtime: Writable<Runtime>;
@@ -65,9 +66,10 @@ export type StateManagers = {
 
 export const DEFAULT_STORE_KEY = Symbol("state-managers");
 
-export function getStateManagers(): StateManagers {
-  return getContext(DEFAULT_STORE_KEY);
-}
+export const stateManagersContext =
+  createContext<StateManagers>(DEFAULT_STORE_KEY);
+
+export const getStateManagers = stateManagersContext.get;
 
 export function createStateManagers({
   queryClient,

--- a/web-common/src/lib/actions/command-click-action.ts
+++ b/web-common/src/lib/actions/command-click-action.ts
@@ -1,9 +1,24 @@
 import { setContext } from "svelte";
 import { get, writable } from "svelte/store";
+import { createContext } from "../context";
+import type { Subscriber, Invalidator, Unsubscriber } from "svelte/store";
 
 interface CreateCommandClick {
   stopImmediatePropagation: boolean;
 }
+
+type Callbacks = {
+  subscribe: (
+    this: void,
+    run: Subscriber<never[]>,
+    invalidate?: Invalidator<never[]> | undefined,
+  ) => Unsubscriber;
+  addCallback(callback: unknown): void;
+};
+
+const commandClickContext = createContext<Callbacks>(
+  "rill:app:ui:command-click-action-callbacks",
+);
 
 export function createCommandClickAction(
   params: CreateCommandClick = { stopImmediatePropagation: true },
@@ -24,7 +39,7 @@ export function createCommandClickAction(
     },
   };
 
-  setContext("rill:app:ui:command-click-action-callbacks", callbacks);
+  commandClickContext.set(callbacks);
 
   return {
     // export the click switch callbacks added by children, in case that's needed.

--- a/web-common/src/lib/context.ts
+++ b/web-common/src/lib/context.ts
@@ -1,0 +1,8 @@
+import { getContext, setContext } from "svelte";
+
+export function createContext<T>(key: string = `rill:${crypto.randomUUID()}`) {
+  return {
+    get: () => getContext<T>(key),
+    set: (ctx: T) => setContext(key, ctx),
+  };
+}

--- a/web-common/src/lib/context.ts
+++ b/web-common/src/lib/context.ts
@@ -1,6 +1,8 @@
 import { getContext, setContext } from "svelte";
 
-export function createContext<T>(key: string = `rill:${crypto.randomUUID()}`) {
+export function createContext<T>(
+  key: string | symbol = `rill:${crypto.randomUUID()}`,
+) {
   return {
     get: () => getContext<T>(key),
     set: (ctx: T) => setContext(key, ctx),


### PR DESCRIPTION
This is a work in progress PR to add a wrapper function around our use of `setContext` and `getContext` that provides "type safety", reduces the need for namespaced context keys, and limits the number of imports required when getting context.