### PR TITLE
Runtime: drop table fix for external table storage

### DIFF
--- a/runtime/drivers/duckdb/olap_crud_test.go
+++ b/runtime/drivers/duckdb/olap_crud_test.go
@@ -154,7 +154,8 @@ func Test_connection_DropTable(t *testing.T) {
 	err = c.CreateTableAsSelect(context.Background(), "test-drop", false, "select 1")
 	require.NoError(t, err)
 
-	err = c.DropTable(context.Background(), "test-drop", false)
+	// Note: true since at lot of places we look at information_schema lookup on main db to determine whether tbl is a view or table
+	err = c.DropTable(context.Background(), "test-drop", true)
 	require.NoError(t, err)
 
 	_, err = os.ReadDir(filepath.Join(temp, "test-drop"))


### PR DESCRIPTION
The issue is that at lot of places we look at `information_schema` `lookup` on main db to determine whether tbl is a view or table. For external table storage, it will always resolve to view so in cases when external table storage is enabled we need to check if its a true view or a view on top of externally stored table.