### PR TITLE
Runtime: shorthands for configuring "dev" and "prod" envs

### DIFF
--- a/runtime/compilers/rillv1/parse_node.go
+++ b/runtime/compilers/rillv1/parse_node.go
@@ -75,6 +75,10 @@ type commonYAML struct {
 	SQL string `yaml:"sql"`
 	// Environment-specific overrides
 	Env map[string]yaml.Node `yaml:"env"`
+	// Shorthand for setting "env:dev:"
+	Dev yaml.Node `yaml:"dev"`
+	// Shorthand for setting "env:prod:"
+	Prod yaml.Node `yaml:"prod"`
 }
 
 // parseStem parses a pair of YAML and SQL files with the same path stem (e.g. "/path/to/file.yaml" for "/path/to/file.sql").
@@ -109,6 +113,20 @@ func (p *Parser) parseStem(paths []string, ymlPath, yml, sqlPath, sql string) (*
 		res.Connector = cfg.Connector
 		res.SQL = cfg.SQL
 		res.SQLPath = ymlPath
+
+		// Handle "dev:" and "prod:" shorthands (copy to to cfg.Env)
+		if !cfg.Dev.IsZero() {
+			if cfg.Env == nil {
+				cfg.Env = make(map[string]yaml.Node)
+			}
+			cfg.Env["dev"] = cfg.Dev
+		}
+		if !cfg.Prod.IsZero() {
+			if cfg.Env == nil {
+				cfg.Env = make(map[string]yaml.Node)
+			}
+			cfg.Env["prod"] = cfg.Prod
+		}
 
 		// Set environment-specific override
 		if envOverride := cfg.Env[p.Environment]; !envOverride.IsZero() {

--- a/runtime/compilers/rillv1/parse_rillyaml.go
+++ b/runtime/compilers/rillv1/parse_rillyaml.go
@@ -38,7 +38,7 @@ type rillYAML struct {
 	Title string `yaml:"title"`
 	// Description of the project
 	Description string `yaml:"description"`
-	// The project's default OLAP connector to use (can be overriden in the individual resources)
+	// The project's default OLAP connector to use (can be overridden in the individual resources)
 	OLAPConnector string `yaml:"olap_connector"`
 	// Connectors required by the project
 	Connectors []struct {

--- a/runtime/compilers/rillv1/parse_rillyaml.go
+++ b/runtime/compilers/rillv1/parse_rillyaml.go
@@ -34,20 +34,34 @@ type VariableDef struct {
 
 // rillYAML is the raw YAML structure of rill.yaml
 type rillYAML struct {
-	Title         string `yaml:"title"`
-	Description   string `yaml:"description"`
+	// Title of the project
+	Title string `yaml:"title"`
+	// Description of the project
+	Description string `yaml:"description"`
+	// The project's default OLAP connector to use (can be overriden in the individual resources)
 	OLAPConnector string `yaml:"olap_connector"`
-	Connectors    []struct {
+	// Connectors required by the project
+	Connectors []struct {
 		Type     string            `yaml:"type"`
 		Name     string            `yaml:"name"`
 		Defaults map[string]string `yaml:"defaults"`
 	} `yaml:"connectors"`
-	Vars       map[string]string    `yaml:"vars"`
-	Env        map[string]yaml.Node `yaml:"env"`
-	Sources    yaml.Node            `yaml:"sources"`
-	Models     yaml.Node            `yaml:"models"`
-	Dashboards yaml.Node            `yaml:"dashboards"`
-	Migrations yaml.Node            `yaml:"migrations"`
+	// Variables required by the project and their default values
+	Vars map[string]string `yaml:"vars"`
+	// Environment-specific overrides for rill.yaml
+	Env map[string]yaml.Node `yaml:"env"`
+	// Shorthand for setting "env:dev:"
+	Dev yaml.Node `yaml:"dev"`
+	// Shorthand for setting "env:prod:"
+	Prod yaml.Node `yaml:"prod"`
+	// Default YAML values for sources
+	Sources yaml.Node `yaml:"sources"`
+	// Default YAML values for models
+	Models yaml.Node `yaml:"models"`
+	// Default YAML values for metric views
+	Dashboards yaml.Node `yaml:"dashboards"`
+	// Default YAML values for migrations
+	Migrations yaml.Node `yaml:"migrations"`
 }
 
 // parseRillYAML parses rill.yaml
@@ -73,6 +87,20 @@ func (p *Parser) parseRillYAML(ctx context.Context, path string) error {
 			tmp.Vars[k] = v.Value
 			delete(tmp.Env, k)
 		}
+	}
+
+	// Handle "dev:" and "prod:" shorthands (copy to to tmp.Env)
+	if !tmp.Dev.IsZero() {
+		if tmp.Env == nil {
+			tmp.Env = make(map[string]yaml.Node)
+		}
+		tmp.Env["dev"] = tmp.Dev
+	}
+	if !tmp.Prod.IsZero() {
+		if tmp.Env == nil {
+			tmp.Env = make(map[string]yaml.Node)
+		}
+		tmp.Env["prod"] = tmp.Prod
 	}
 
 	// Apply environment-specific overrides


### PR DESCRIPTION
- This PR adds shorthands for configuring environment-specific overrides for the `dev` and `prod` environments.
- This saves one level of nesting for configuring our two primary environments.
- The shorthands work in both individual YAML files and for `rill.yaml`.
- We still support the current `env:environment_name:` syntax. This keeps environment-specific overrides available for custom environments.

Examples:
```yaml
# sources/my-source.yaml
connector: s3
path: s3://bucket/**/*.parquet
dev:
  path: s3://bucket/year=2024/month=01/**/*.parquet

# rill.yaml
prod:
  models:
    materialize: true
```