### PR TITLE
Rework duplicate source modal

### DIFF
--- a/web-common/src/features/onboarding/OnboardingWorkspace.svelte
+++ b/web-common/src/features/onboarding/OnboardingWorkspace.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import AddSourceModal from "@rilldata/web-common/features/sources/modal/AddSourceModal.svelte";
   import { IconSpaceFixer } from "../../components/button";
   import Button from "../../components/button/Button.svelte";
   import Add from "../../components/icons/Add.svelte";
   import { WorkspaceContainer } from "../../layout/workspace";
   import { createRuntimeServiceGetInstance } from "../../runtime-client";
   import { runtime } from "../../runtime-client/runtime-store";
+  import { addSourceModal } from "../sources/modal/add-source-visibility";
 
   let steps: OnboardingStep[];
   $: instance = createRuntimeServiceGetInstance($runtime.instanceId);
@@ -69,11 +69,6 @@
         "Interactively explore line charts and leaderboards to uncover insights.",
     },
   ];
-
-  let showAddSourceModal = false;
-  function openAddSourceModal() {
-    showAddSourceModal = true;
-  }
 </script>
 
 <WorkspaceContainer assetID="onboarding" inspector={false}>
@@ -95,7 +90,7 @@
                 <p>{step.description}</p>
               </div>
               {#if step.id === "source"}
-                <Button type="secondary" on:click={openAddSourceModal}>
+                <Button type="secondary" on:click={addSourceModal.open}>
                   <IconSpaceFixer pullLeft><Add /></IconSpaceFixer>
                   <span>Add data</span>
                 </Button>
@@ -105,9 +100,5 @@
         {/each}
       {/if}
     </ol>
-    <AddSourceModal
-      open={showAddSourceModal}
-      on:close={() => (showAddSourceModal = false)}
-    />
   </div>
 </WorkspaceContainer>

--- a/web-common/src/features/sources/modal/AddSourceModal.svelte
+++ b/web-common/src/features/sources/modal/AddSourceModal.svelte
@@ -30,6 +30,8 @@
   import LocalSourceUpload from "./LocalSourceUpload.svelte";
   import RemoteSourceForm from "./RemoteSourceForm.svelte";
   import RequestConnectorForm from "./RequestConnectorForm.svelte";
+  import { duplicateSourceName } from "../sources-store";
+  import DuplicateSource from "./DuplicateSource.svelte";
 
   export let open: boolean;
 
@@ -137,7 +139,9 @@
     {:else if step === 2}
       <h2 class="flex gap-x-1 items-center">
         <span>
-          {#if selectedConnector}
+          {#if $duplicateSourceName !== null}
+            Duplicate source
+          {:else if selectedConnector}
             {selectedConnector?.displayName}
           {/if}
 
@@ -174,7 +178,12 @@
       </div>
     {:else if step === 2}
       {#if selectedConnector}
-        {#if selectedConnector.name === "local_file"}
+        {#if $duplicateSourceName !== null}
+          <DuplicateSource
+            on:cancel={onCompleteDialog}
+            on:complete={onCompleteDialog}
+          />
+        {:else if selectedConnector.name === "local_file"}
           <LocalSourceUpload on:close={onCompleteDialog} on:back={resetModal} />
         {:else if selectedConnector.name === "clickhouse"}
           <ClickHouseInstructions on:back={resetModal} />

--- a/web-common/src/features/sources/modal/DuplicateSource.svelte
+++ b/web-common/src/features/sources/modal/DuplicateSource.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { Dialog } from "@rilldata/web-common/components/modal/index";
-  import { createEventDispatcher } from "svelte";
+  import DialogFooter from "@rilldata/web-common/components/modal/dialog/DialogFooter.svelte";
+  import DialogCTA from "@rilldata/web-common/components/modal/dialog/DialogCTA.svelte";
+  import { createEventDispatcher, onDestroy } from "svelte";
   import {
     DuplicateActions,
     duplicateSourceAction,
@@ -8,34 +9,46 @@
   } from "../sources-store";
 
   const dispatch = createEventDispatcher();
+
   function onCancel() {
     $duplicateSourceName = null;
     $duplicateSourceAction = DuplicateActions.Cancel;
     dispatch("cancel");
   }
-</script>
 
-<Dialog
-  showCancel
-  size="md"
-  on:cancel={onCancel}
-  on:click-outside={onCancel}
-  on:primary-action={() => {
+  function onPrimaryAction() {
     $duplicateSourceName = null;
     $duplicateSourceAction = DuplicateActions.KeepBoth;
-  }}
-  on:secondary-action={() => {
+    dispatch("complete");
+  }
+
+  function onSecondaryAction() {
     $duplicateSourceName = null;
     $duplicateSourceAction = DuplicateActions.Overwrite;
-  }}
->
-  <svelte:fragment slot="title">Duplicate source name</svelte:fragment>
-  <svelte:fragment slot="body">
-    A source with the name <b>{$duplicateSourceName}</b> already exists.
-  </svelte:fragment>
+    dispatch("complete");
+  }
 
-  <svelte:fragment slot="secondary-action-body"
-    >Replace Existing Source</svelte:fragment
+  onDestroy(() => {
+    $duplicateSourceName = null;
+  });
+</script>
+
+<p class="py-2">
+  A source with the name <b>{$duplicateSourceName}</b> already exists.
+</p>
+
+<DialogFooter>
+  <DialogCTA
+    on:cancel={onCancel}
+    on:primary-action={onPrimaryAction}
+    on:secondary-action={onSecondaryAction}
+    showSecondary
   >
-  <svelte:fragment slot="primary-action-body">Keep Both</svelte:fragment>
-</Dialog>
+    <svelte:fragment slot="secondary-action-body"
+      ><slot name="secondary-action-body" />Replace Existing Source</svelte:fragment
+    >
+    <svelte:fragment slot="primary-action-body"
+      ><slot name="primary-action-body" />Keep Both</svelte:fragment
+    >
+  </DialogCTA>
+</DialogFooter>

--- a/web-common/src/features/sources/modal/add-source-visibility.ts
+++ b/web-common/src/features/sources/modal/add-source-visibility.ts
@@ -1,0 +1,12 @@
+import { writable } from "svelte/store";
+
+export const addSourceModal = (() => {
+  const { subscribe, set, update } = writable(false);
+
+  return {
+    subscribe,
+    open: () => set(true),
+    close: () => set(false),
+    toggle: () => update((state) => !state),
+  };
+})();

--- a/web-common/src/features/sources/navigation/SourceAssets.svelte
+++ b/web-common/src/features/sources/navigation/SourceAssets.svelte
@@ -20,27 +20,25 @@
   import AddAssetButton from "../../entity-management/AddAssetButton.svelte";
   import { EntityType } from "../../entity-management/types";
   import { createModelFromSource } from "../createModel";
-  import AddSourceModal from "../modal/AddSourceModal.svelte";
   import SourceMenuItems from "./SourceMenuItems.svelte";
   import SourceTooltip from "./SourceTooltip.svelte";
+  import { addSourceModal } from "../modal/add-source-visibility";
 
   $: sourceNames = useSourceFileNames($runtime.instanceId);
   $: modelNames = useModelFileNames($runtime.instanceId);
 
   let showTables = true;
 
-  let showAddSourceModal = false;
+  async function openShowAddSourceModal() {
+    addSourceModal.open();
 
-  const openShowAddSourceModal = () => {
-    showAddSourceModal = true;
-
-    behaviourEvent?.fireSourceTriggerEvent(
+    await behaviourEvent?.fireSourceTriggerEvent(
       BehaviourEventAction.SourceAdd,
       BehaviourEventMedium.Button,
       $appScreen,
       MetricsEventSpace.LeftPanel,
     );
-  };
+  }
 
   const queryHandler = async (tableName: string) => {
     await createModelFromSource(
@@ -113,10 +111,6 @@
   </div>
 {/if}
 
-<AddSourceModal
-  on:close={() => (showAddSourceModal = false)}
-  open={showAddSourceModal}
-/>
 {#if showRenameTableModal && renameTableName !== null}
   <RenameAssetModal
     entityType={EntityType.Table}

--- a/web-common/src/features/welcome/TitleContent.svelte
+++ b/web-common/src/features/welcome/TitleContent.svelte
@@ -3,23 +3,22 @@
   import RillLogoSquareNegative from "@rilldata/web-common/components/icons/RillLogoSquareNegative.svelte";
   import RadixH1 from "@rilldata/web-common/components/typography/RadixH1.svelte";
   import Subheading from "@rilldata/web-common/components/typography/Subheading.svelte";
-  import AddSourceModal from "@rilldata/web-common/features/sources/modal/AddSourceModal.svelte";
   import { behaviourEvent } from "../../metrics/initMetrics";
   import {
     BehaviourEventAction,
     BehaviourEventMedium,
   } from "../../metrics/service/BehaviourEventTypes";
   import { MetricsEventSpace } from "../../metrics/service/MetricsTypes";
+  import { addSourceModal } from "../sources/modal/add-source-visibility";
 
-  let showAddSourceModal = false;
-  const openShowAddSourceModal = () => {
-    showAddSourceModal = true;
-    behaviourEvent?.fireSplashEvent(
+  async function openShowAddSourceModal() {
+    addSourceModal.open();
+    await behaviourEvent?.fireSplashEvent(
       BehaviourEventAction.SourceModal,
       BehaviourEventMedium.Button,
       MetricsEventSpace.Workspace,
     );
-  };
+  }
 </script>
 
 <section class="flex flex-col gap-y-6 items-center text-center">
@@ -48,8 +47,4 @@
       Add data
     </div>
   </button>
-  <AddSourceModal
-    open={showAddSourceModal}
-    on:close={() => (showAddSourceModal = false)}
-  />
 </section>

--- a/web-common/src/layout/RillDeveloperLayout.svelte
+++ b/web-common/src/layout/RillDeveloperLayout.svelte
@@ -75,9 +75,6 @@
     </BlockingOverlayContainer>
   {/if}
 
-  {#if $duplicateSourceName !== null}
-    <DuplicateSource />
-  {/if}
   <SourceImportedModal open={!!$sourceImportedName} />
 
   <div

--- a/web-common/src/layout/RillDeveloperLayout.svelte
+++ b/web-common/src/layout/RillDeveloperLayout.svelte
@@ -2,13 +2,9 @@
   import NotificationCenter from "@rilldata/web-common/components/notifications/NotificationCenter.svelte";
   import { resourcesStore } from "@rilldata/web-common/features/entity-management/resources-store";
   import { featureFlags } from "@rilldata/web-common/features/feature-flags";
-  import DuplicateSource from "@rilldata/web-common/features/sources/modal/DuplicateSource.svelte";
   import FileDrop from "@rilldata/web-common/features/sources/modal/FileDrop.svelte";
   import SourceImportedModal from "@rilldata/web-common/features/sources/modal/SourceImportedModal.svelte";
-  import {
-    duplicateSourceName,
-    sourceImportedName,
-  } from "@rilldata/web-common/features/sources/sources-store";
+  import { sourceImportedName } from "@rilldata/web-common/features/sources/sources-store";
   import BlockingOverlayContainer from "@rilldata/web-common/layout/BlockingOverlayContainer.svelte";
   import type { ApplicationBuildMetadata } from "@rilldata/web-common/layout/build-metadata";
   import { initMetrics } from "@rilldata/web-common/metrics/initMetrics";

--- a/web-common/src/layout/RillDeveloperLayout.svelte
+++ b/web-common/src/layout/RillDeveloperLayout.svelte
@@ -15,6 +15,9 @@
   import { runtimeServiceGetConfig } from "../runtime-client/manual-clients";
   import BasicLayout from "./BasicLayout.svelte";
   import { importOverlayVisible, overlay } from "./overlay-store";
+  import AddSourceModal from "../features/sources/modal/AddSourceModal.svelte";
+  import { duplicateSourceName } from "@rilldata/web-common/features/sources/sources-store";
+  import { addSourceModal } from "../features/sources/modal/add-source-visibility";
 
   const appBuildMetaStore: Writable<ApplicationBuildMetadata> =
     getContext("rill:app:metadata");
@@ -71,6 +74,9 @@
     </BlockingOverlayContainer>
   {/if}
 
+  {#if $addSourceModal || $duplicateSourceName}
+    <AddSourceModal />
+  {/if}
   <SourceImportedModal open={!!$sourceImportedName} />
 
   <div


### PR DESCRIPTION
This PR moves the duplicate source modal flow from its own dedicated component into the `AddSourceModal` component.

Previously, these concerns were separated in a way that caused UI issues, as seen below.

Blocker for #4216 

Before:
<img width="1125" alt="Screenshot 2024-03-08 at 7 23 32 PM" src="https://github.com/rilldata/rill/assets/120223836/9e19dde9-19ad-48eb-90a1-ac456e52a57b">

After:
<img width="1039" alt="Screenshot 2024-03-08 at 7 24 05 PM" src="https://github.com/rilldata/rill/assets/120223836/f50aa414-cbfe-4efe-a735-7612a2660e17">
