### PR TITLE
Refactor workspace layout

### DIFF
--- a/web-common/src/features/generic-yaml-editor/YamlWorkspace.svelte
+++ b/web-common/src/features/generic-yaml-editor/YamlWorkspace.svelte
@@ -6,7 +6,7 @@
   export let fileName: string;
 </script>
 
-<WorkspaceContainer assetID={fileName} inspector={false}>
+<WorkspaceContainer inspector={false}>
   <YamlWorkspaceHeader slot="header" {fileName} />
   <YamlWorkspaceBody slot="body" {fileName} />
 </WorkspaceContainer>

--- a/web-common/src/features/generic-yaml-editor/YamlWorkspaceHeader.svelte
+++ b/web-common/src/features/generic-yaml-editor/YamlWorkspaceHeader.svelte
@@ -7,7 +7,6 @@
 <div class="grid items-center" style:grid-template-columns="auto max-content">
   <WorkspaceHeader
     titleInput={fileName}
-    onChangeCallback={undefined}
     editable={false}
     showInspectorToggle={false}
   />

--- a/web-common/src/features/metrics-views/workspace/MetricsWorkspace.svelte
+++ b/web-common/src/features/metrics-views/workspace/MetricsWorkspace.svelte
@@ -7,7 +7,7 @@
   export let metricsDefName: string;
 </script>
 
-<WorkspaceContainer inspector={true} assetID={`${metricsDefName}-config`}>
+<WorkspaceContainer>
   <MetricsWorkspaceHeader slot="header" {metricsDefName} />
   <MetricsEditor slot="body" {metricsDefName} />
   <MetricsInspector slot="inspector" {metricsDefName} />

--- a/web-common/src/features/models/workspace/ModelBody.svelte
+++ b/web-common/src/features/models/workspace/ModelBody.svelte
@@ -129,14 +129,12 @@
 <div class="editor-pane h-full overflow-hidden w-full flex flex-col">
   {#if hasModelSql}
     <WorkspaceEditorContainer>
-      {#key modelName}
-        <Editor
-          content={modelSql}
-          {selections}
-          focusOnMount={focusEditorOnMount}
-          on:write={debounceUpdateModelContent}
-        />
-      {/key}
+      <Editor
+        content={modelSql}
+        {selections}
+        focusOnMount={focusEditorOnMount}
+        on:write={debounceUpdateModelContent}
+      />
     </WorkspaceEditorContainer>
   {/if}
 

--- a/web-common/src/features/models/workspace/ModelWorkspace.svelte
+++ b/web-common/src/features/models/workspace/ModelWorkspace.svelte
@@ -9,7 +9,7 @@
 </script>
 
 {#key modelName}
-  <WorkspaceContainer assetID={modelName}>
+  <WorkspaceContainer>
     <ModelWorkspaceHeader slot="header" {modelName} />
     <ModelBody slot="body" {modelName} {focusEditorOnMount} />
     <ModelInspector {modelName} slot="inspector" />

--- a/web-common/src/features/onboarding/OnboardingWorkspace.svelte
+++ b/web-common/src/features/onboarding/OnboardingWorkspace.svelte
@@ -76,7 +76,7 @@
   }
 </script>
 
-<WorkspaceContainer assetID="onboarding" inspector={false}>
+<WorkspaceContainer inspector={false}>
   <div class="pt-20 px-8 flex flex-col gap-y-6 items-center" slot="body">
     <div class="text-center">
       <div class="font-bold">Getting started</div>

--- a/web-common/src/features/sources/workspace/SourceWorkspace.svelte
+++ b/web-common/src/features/sources/workspace/SourceWorkspace.svelte
@@ -10,7 +10,7 @@
 
 {#key sourceName}
   <BeforeLeavingUnsavedSource {sourceName}>
-    <WorkspaceContainer assetID={sourceName}>
+    <WorkspaceContainer>
       <SourceWorkspaceHeader {sourceName} slot="header" />
       <SourceWorkspaceBody {sourceName} slot="body" />
       <SourceInspector {sourceName} slot="inspector" />

--- a/web-common/src/features/sources/workspace/SourceWorkspaceBody.svelte
+++ b/web-common/src/features/sources/workspace/SourceWorkspaceBody.svelte
@@ -53,12 +53,10 @@
 
   <WorkspaceTableContainer fade={isSourceUnsaved}>
     {#if !$allErrors?.length}
-      {#key sourceName}
-        <ConnectedPreviewTable
-          objectName={$sourceQuery?.data?.source?.state?.table}
-          loading={resourceIsLoading($sourceQuery?.data)}
-        />
-      {/key}
+      <ConnectedPreviewTable
+        objectName={$sourceQuery?.data?.source?.state?.table}
+        loading={resourceIsLoading($sourceQuery?.data)}
+      />
     {:else if $allErrors[0].message}
       <ErrorPane {sourceName} errorMessage={$allErrors[0].message} />
     {/if}

--- a/web-common/src/features/sources/workspace/SourceWorkspaceBody.svelte
+++ b/web-common/src/features/sources/workspace/SourceWorkspaceBody.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+  import WorkspaceTableContainer from "@rilldata/web-common/layout/workspace/WorkspaceTableContainer.svelte";
+  import WorkspaceEditorContainer from "@rilldata/web-common/layout/workspace/WorkspaceEditorContainer.svelte";
   import { ConnectedPreviewTable } from "@rilldata/web-common/components/preview-table";
   import { resourceIsLoading } from "@rilldata/web-common/features/entity-management/resource-selectors.js";
   import { getAllErrorsForFile } from "@rilldata/web-common/features/entity-management/resources-store";
   import { useQueryClient } from "@tanstack/svelte-query";
-  import HorizontalSplitter from "../../../layout/workspace/HorizontalSplitter.svelte";
   import { createRuntimeServiceGetFile } from "../../../runtime-client";
   import { runtime } from "../../../runtime-client/runtime-store";
   import { getFilePathFromNameAndType } from "../../entity-management/entity-mappers";
@@ -12,10 +13,6 @@
   import ErrorPane from "../errors/ErrorPane.svelte";
   import { useIsSourceUnsaved, useSource } from "../selectors";
   import { useSourceStore } from "../sources-store";
-  import Resizer from "@rilldata/web-common/layout/Resizer.svelte";
-  import { workspaces } from "@rilldata/web-common/layout/workspace/workspace-stores";
-  import { slide } from "svelte/transition";
-  import { quintOut } from "svelte/easing";
 
   export let sourceName: string;
 
@@ -41,10 +38,6 @@
 
   $: sourceQuery = useSource($runtime.instanceId, sourceName);
 
-  $: workspaceLayout = $workspaces;
-
-  $: tableHeight = workspaceLayout.table.height;
-
   $: isSourceUnsavedQuery = useIsSourceUnsaved(
     $runtime.instanceId,
     sourceName,
@@ -54,40 +47,20 @@
 </script>
 
 <div class="editor-pane h-full overflow-hidden w-full flex flex-col">
-  <div
-    class="p-5 size-full flex-shrink-1 overflow-hidden"
-    style:min-height="150px"
-  >
+  <WorkspaceEditorContainer>
     <SourceEditor {sourceName} {yaml} />
-  </div>
+  </WorkspaceEditorContainer>
 
-  <div
-    class="p-5 w-full relative flex flex-none flex-col gap-2"
-    style:height="{$tableHeight}px"
-    style:max-height="75%"
-    transition:slide={{ duration: 300, easing: quintOut }}
-  >
-    <Resizer max={600} direction="NS" side="top" bind:dimension={$tableHeight}>
-      <HorizontalSplitter />
-    </Resizer>
-    <div class="table-wrapper" class:brightness-90={isSourceUnsaved}>
-      {#if !$allErrors?.length}
-        {#key sourceName}
-          <ConnectedPreviewTable
-            objectName={$sourceQuery?.data?.source?.state?.table}
-            loading={resourceIsLoading($sourceQuery?.data)}
-          />
-        {/key}
-      {:else if $allErrors[0].message}
-        <ErrorPane {sourceName} errorMessage={$allErrors[0].message} />
-      {/if}
-    </div>
-  </div>
+  <WorkspaceTableContainer fade={isSourceUnsaved}>
+    {#if !$allErrors?.length}
+      {#key sourceName}
+        <ConnectedPreviewTable
+          objectName={$sourceQuery?.data?.source?.state?.table}
+          loading={resourceIsLoading($sourceQuery?.data)}
+        />
+      {/key}
+    {:else if $allErrors[0].message}
+      <ErrorPane {sourceName} errorMessage={$allErrors[0].message} />
+    {/if}
+  </WorkspaceTableContainer>
 </div>
-
-<style lang="postcss">
-  .table-wrapper {
-    transition: filter 200ms;
-    @apply rounded w-full overflow-hidden border-gray-200 border-2 h-full;
-  }
-</style>

--- a/web-common/src/features/tables/TableWorkspaceHeader.svelte
+++ b/web-common/src/features/tables/TableWorkspaceHeader.svelte
@@ -31,7 +31,6 @@
 <div class="grid items-center" style:grid-template-columns="auto max-content">
   <WorkspaceHeader
     editable={false}
-    onChangeCallback={undefined}
     showInspectorToggle={false}
     {...{ titleInput: fullyQualifiedTableName }}
   >

--- a/web-common/src/layout/Resizer.svelte
+++ b/web-common/src/layout/Resizer.svelte
@@ -40,7 +40,6 @@
         delta = event.clientX - start;
       }
     } else {
-      console.log("yeah");
       if (side === "top") {
         delta = start - event.clientY;
       } else {

--- a/web-common/src/layout/Resizer.svelte
+++ b/web-common/src/layout/Resizer.svelte
@@ -1,0 +1,103 @@
+<script lang="ts" context="module">
+  type Event = MouseEvent & {
+    currentTarget: EventTarget & HTMLButtonElement;
+  };
+</script>
+
+<script lang="ts">
+  export let dimension: number;
+  export let direction: "NS" | "EW" = "EW";
+  export let side: "left" | "right" | "top" | "bottom" =
+    direction === "EW" ? "left" : "top";
+  export let max = 440;
+  export let min = 200;
+  export let basis = 200;
+  export let resizing = false;
+
+  let start = 0;
+  let startingDimension = dimension;
+
+  function handleMousedown(e: Event) {
+    startingDimension = dimension;
+    resizing = true;
+
+    if (direction === "EW") {
+      start = e.clientX;
+    } else {
+      start = e.clientY;
+    }
+
+    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("mouseup", onMouseUp);
+  }
+
+  function onMouseMove(event: MouseEvent) {
+    let delta = 0;
+    if (direction === "EW") {
+      if (side === "left") {
+        delta = start - event.clientX;
+      } else {
+        delta = event.clientX - start;
+      }
+    } else {
+      console.log("yeah");
+      if (side === "top") {
+        delta = start - event.clientY;
+      } else {
+        delta = event.clientY - start;
+      }
+    }
+    dimension = Math.min(max, Math.max(min, startingDimension + delta));
+  }
+
+  function onMouseUp() {
+    resizing = false;
+    window.removeEventListener("mousemove", onMouseMove);
+    window.removeEventListener("mouseup", onMouseUp);
+  }
+
+  function handleDoubleClick() {
+    dimension = basis;
+  }
+</script>
+
+<button
+  class="{direction} {side}"
+  on:mousedown={handleMousedown}
+  on:dblclick={handleDoubleClick}
+>
+  <slot />
+</button>
+
+<style lang="postcss">
+  button {
+    @apply absolute z-[1000];
+    /* @apply bg-red-400; */
+  }
+
+  .NS {
+    @apply w-full h-2 pr-8;
+    @apply cursor-row-resize;
+  }
+
+  .EW {
+    @apply w-2 h-full;
+    @apply cursor-col-resize;
+  }
+
+  .left {
+    @apply -left-1;
+  }
+
+  .right {
+    @apply right-0;
+  }
+
+  .top {
+    @apply -top-1;
+  }
+
+  .bottom {
+    @apply -bottom-1;
+  }
+</style>

--- a/web-common/src/layout/Resizer.svelte
+++ b/web-common/src/layout/Resizer.svelte
@@ -70,7 +70,7 @@
 
 <style lang="postcss">
   button {
-    @apply absolute z-[1000];
+    @apply absolute z-10;
     /* @apply bg-red-400; */
   }
 

--- a/web-common/src/layout/workspace/HorizontalSplitter.svelte
+++ b/web-common/src/layout/workspace/HorizontalSplitter.svelte
@@ -1,54 +1,13 @@
-<script lang="ts">
-  import { getContext, onMount } from "svelte";
-  import type { Writable } from "svelte/store";
-  import type { LayoutElement } from "./types";
-
-  const outputLayout = getContext(
-    "rill:app:output-layout",
-  ) as Writable<LayoutElement>;
-
-  export let className = "";
-
-  onMount(() => {
-    parentElement = splitter.parentElement;
-  });
-
-  let parentElement: HTMLElement | null = null;
-  let splitter: HTMLButtonElement;
-
-  let parentHeight = 0;
-
-  function onMouseMove(e: MouseEvent) {
-    $outputLayout.value = Math.min(
-      parentHeight - 200,
-      Math.max(200, parentHeight - e.clientY),
-    );
-  }
-
-  function onMouseUp() {
-    window.removeEventListener("mousemove", onMouseMove);
-  }
-
-  function startDrag() {
-    if (!parentElement) return;
-
-    parentHeight = parentElement.clientHeight;
-
-    window.addEventListener("mousemove", onMouseMove);
-    window.addEventListener("mouseup", onMouseUp);
-  }
-</script>
-
-<button class={className} bind:this={splitter} on:mousedown={startDrag}>
+<div class="wrapper">
   <div class="line" />
   <span class="handle" />
-</button>
+</div>
 
 <style lang="postcss">
-  button {
-    @apply cursor-move;
+  .wrapper {
     @apply flex items-center justify-center;
-    @apply w-full h-2;
+    @apply w-full h-2 pr-2;
+    /* @apply border-2 border-red-400; */
   }
 
   .handle {

--- a/web-common/src/layout/workspace/WorkspaceContainer.svelte
+++ b/web-common/src/layout/workspace/WorkspaceContainer.svelte
@@ -1,81 +1,11 @@
 <script lang="ts">
-  import { localStorageStore } from "@rilldata/web-common/lib/store-utils";
-  import { getContext, setContext } from "svelte";
-  import { tweened } from "svelte/motion";
+  import { getContext } from "svelte";
   import type { Writable } from "svelte/store";
-  import {
-    DEFAULT_INSPECTOR_WIDTH,
-    DEFAULT_PREVIEW_TABLE_HEIGHT,
-    SIDE_PAD,
-    SURFACE_SLIDE_DURATION,
-    SURFACE_SLIDE_EASING,
-  } from "../config";
+  import { SIDE_PAD } from "../config";
   import Inspector from "./Inspector.svelte";
-  import type { LayoutElement } from "./types";
 
-  export let assetID: string;
   export let inspector = true;
   export let bgClass = "bg-gray-100";
-
-  const inspectorLayout = localStorageStore<LayoutElement>(assetID, {
-    value: inspector ? DEFAULT_INSPECTOR_WIDTH : 0,
-    visible: true,
-  });
-  const inspectorWidth = tweened(
-    inspector ? $inspectorLayout?.value || DEFAULT_INSPECTOR_WIDTH : 0,
-    {
-      duration: 50,
-    },
-  );
-  inspectorLayout.subscribe((state) => {
-    inspectorWidth.set(state.value);
-  });
-
-  export const visibilityTween = tweened($inspectorLayout?.visible ? 1 : 0, {
-    duration: SURFACE_SLIDE_DURATION,
-    easing: SURFACE_SLIDE_EASING,
-  });
-
-  /** when the inspector visibility changes, trigger the tween. */
-  inspectorLayout.subscribe((state) => {
-    visibilityTween.set(state.visible ? 1 : 0);
-  });
-
-  setContext("rill:app:inspector-layout", inspectorLayout);
-  setContext("rill:app:inspector-width-tween", inspectorWidth);
-  setContext("rill:app:inspector-visibility-tween", visibilityTween);
-
-  const outputLayout = localStorageStore<LayoutElement>(`${assetID}-output`, {
-    value: inspector ? DEFAULT_PREVIEW_TABLE_HEIGHT : 0,
-    visible: true,
-  });
-
-  const outputHeight = tweened(
-    inspector ? $outputLayout?.value || DEFAULT_PREVIEW_TABLE_HEIGHT : 0,
-    {
-      duration: 50,
-    },
-  );
-
-  outputLayout.subscribe((state) => {
-    outputHeight.set(state.value);
-  });
-
-  export const outputVisibilityTween = tweened(
-    $inspectorLayout?.visible ? 1 : 0,
-    {
-      duration: SURFACE_SLIDE_DURATION,
-      easing: SURFACE_SLIDE_EASING,
-    },
-  );
-
-  outputLayout.subscribe((state) => {
-    outputVisibilityTween.set(state.visible ? 1 : 0);
-  });
-
-  setContext("rill:app:output-layout", outputLayout);
-  setContext("rill:app:output-height-tween", outputHeight);
-  setContext("rill:app:output-visibility-tween", outputVisibilityTween);
 
   const navigationWidth = getContext<Writable<number>>(
     "rill:app:navigation-width-tween",
@@ -83,10 +13,6 @@
   const navVisibilityTween = getContext<Writable<number>>(
     "rill:app:navigation-visibility-tween",
   );
-
-  // Unclear on usage of this variable
-  // Holding off on removing it for now
-  let hasNoError = 1;
 </script>
 
 <div
@@ -101,18 +27,14 @@
     </header>
   {/if}
 
-  <div
-    class="h-full {bgClass}"
-    style:padding-right="{inspector && hasNoError
-      ? $inspectorWidth * $visibilityTween
-      : 0}px"
-  >
-    <slot name="body" />
+  <div class="h-full {bgClass} w-full flex overflow-hidden">
+    <div class="w-full h-full overflow-hidden">
+      <slot name="body" />
+    </div>
+    {#if inspector}
+      <Inspector>
+        <slot name="inspector" />
+      </Inspector>
+    {/if}
   </div>
 </div>
-
-{#if inspector}
-  <Inspector>
-    <slot name="inspector" />
-  </Inspector>
-{/if}

--- a/web-common/src/layout/workspace/WorkspaceEditorContainer.svelte
+++ b/web-common/src/layout/workspace/WorkspaceEditorContainer.svelte
@@ -1,0 +1,6 @@
+<div
+  class="p-5 size-full flex-shrink-1 overflow-hidden"
+  style:min-height="150px"
+>
+  <slot />
+</div>

--- a/web-common/src/layout/workspace/WorkspaceHeader.svelte
+++ b/web-common/src/layout/workspace/WorkspaceHeader.svelte
@@ -15,7 +15,7 @@
     e: Event & {
       currentTarget: EventTarget & HTMLInputElement;
     },
-  ) => void;
+  ) => void = () => {};
   export let titleInput: string;
   export let editable = true;
   export let showInspectorToggle = true;

--- a/web-common/src/layout/workspace/WorkspaceHeader.svelte
+++ b/web-common/src/layout/workspace/WorkspaceHeader.svelte
@@ -8,31 +8,36 @@
   import { dynamicTextInputWidth } from "@rilldata/web-common/lib/actions/dynamic-text-input-width";
   import { getContext } from "svelte";
   import type { Tweened } from "svelte/motion";
-  import type { Writable } from "svelte/store";
   import SourceUnsavedIndicator from "../../features/sources/editor/SourceUnsavedIndicator.svelte";
-  import type { LayoutElement } from "./types";
+  import { workspaces } from "./workspace-stores";
 
-  export let onChangeCallback;
-  export let titleInput;
+  export let onChangeCallback: (
+    e: Event & {
+      currentTarget: EventTarget & HTMLInputElement;
+    },
+  ) => void;
+  export let titleInput: string;
   export let editable = true;
   export let showInspectorToggle = true;
 
-  let titleInputElement;
+  let titleInputElement: HTMLInputElement;
   let editingTitle = false;
-
-  let tooltipActive;
-
+  let tooltipActive: boolean;
   let width: number;
 
-  const inspectorLayout = getContext(
-    "rill:app:inspector-layout",
-  ) as Writable<LayoutElement>;
+  $: workspaceLayout = $workspaces;
 
-  const navigationVisibilityTween = getContext(
+  $: visible = workspaceLayout.inspector.visible;
+
+  const navigationVisibilityTween = getContext<Tweened<number>>(
     "rill:app:navigation-visibility-tween",
-  ) as Tweened<number>;
+  );
 
-  function onKeydown(event) {
+  function onKeydown(
+    event: KeyboardEvent & {
+      currentTarget: EventTarget & Window;
+    },
+  ) {
     if (editingTitle && event.key === "Enter") {
       titleInputElement.blur();
     }
@@ -46,6 +51,7 @@
 </script>
 
 <svelte:window on:keydown={onKeydown} />
+
 <header
   class="grid items-center content-stretch justify-between pl-4 border-b border-gray-300"
   style:grid-template-columns="[title] minmax(0, 1fr) [controls] auto"
@@ -68,21 +74,20 @@
             autocomplete="off"
             disabled={!editable}
             id="model-title-input"
-            bind:this={titleInputElement}
+            class="bg-transparent border-transparent border-2 rounded pl-2 pr-2"
+            class:editable
+            class:font-bold={editingTitle === false}
+            value={titleInput}
+            on:input={onInput}
+            on:change={onChangeCallback}
             on:focus={() => {
               editingTitle = true;
             }}
-            on:input={onInput}
-            class="bg-transparent border border-transparent border-2 {editable
-              ? 'hover:border-gray-400 cursor-pointer'
-              : ''} rounded pl-2 pr-2"
-            class:font-bold={editingTitle === false}
             on:blur={() => {
               editingTitle = false;
             }}
-            value={titleInput}
             use:dynamicTextInputWidth
-            on:change={onChangeCallback}
+            bind:this={titleInputElement}
           />
           <TooltipContent slot="tooltip-content">
             <div class="flex items-center gap-x-2">Edit</div>
@@ -99,22 +104,13 @@
   <div class="flex items-center mr-4">
     <slot name="workspace-controls" {width} />
     {#if showInspectorToggle}
-      <IconButton
-        on:click={() => {
-          inspectorLayout.update((state) => {
-            state.visible = !state.visible;
-            return state;
-          });
-        }}
-      >
+      <IconButton on:click={workspaceLayout.inspector.toggle}>
         <span class="text-gray-500">
           <HideRightSidebar size="18px" />
         </span>
         <svelte:fragment slot="tooltip-content">
-          <SlidingWords
-            active={$inspectorLayout?.visible}
-            direction="horizontal"
-            reverse>inspector</SlidingWords
+          <SlidingWords active={$visible} direction="horizontal" reverse
+            >inspector</SlidingWords
           >
         </svelte:fragment>
       </IconButton>
@@ -125,3 +121,13 @@
     </div>
   </div>
 </header>
+
+<style lang="postcss">
+  .editable {
+    @apply cursor-pointer;
+  }
+
+  .editable:hover {
+    @apply border-gray-400;
+  }
+</style>

--- a/web-common/src/layout/workspace/WorkspaceTableContainer.svelte
+++ b/web-common/src/layout/workspace/WorkspaceTableContainer.svelte
@@ -15,7 +15,7 @@
   class="p-5 w-full relative flex flex-none flex-col gap-2"
   style:height="{$tableHeight}px"
   style:max-height="75%"
-  transition:slide={{ duration: 300, easing: quintOut }}
+  out:slide={{ duration: 300, easing: quintOut }}
 >
   <Resizer max={600} direction="NS" side="top" bind:dimension={$tableHeight}>
     <HorizontalSplitter />

--- a/web-common/src/layout/workspace/WorkspaceTableContainer.svelte
+++ b/web-common/src/layout/workspace/WorkspaceTableContainer.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import Resizer from "@rilldata/web-common/layout/Resizer.svelte";
+  import { workspaces } from "@rilldata/web-common/layout/workspace/workspace-stores";
+  import { slide } from "svelte/transition";
+  import { quintOut } from "svelte/easing";
+  import HorizontalSplitter from "@rilldata/web-common/layout/workspace/HorizontalSplitter.svelte";
+
+  export let fade = false;
+
+  $: workspaceLayout = $workspaces;
+  $: tableHeight = workspaceLayout.table.height;
+</script>
+
+<div
+  class="p-5 w-full relative flex flex-none flex-col gap-2"
+  style:height="{$tableHeight}px"
+  style:max-height="75%"
+  transition:slide={{ duration: 300, easing: quintOut }}
+>
+  <Resizer max={600} direction="NS" side="top" bind:dimension={$tableHeight}>
+    <HorizontalSplitter />
+  </Resizer>
+
+  <div class="table-wrapper" class:brightness-90={fade}>
+    <slot />
+  </div>
+
+  <slot name="error" />
+</div>
+
+<style lang="postcss">
+  .table-wrapper {
+    transition: filter 200ms;
+    @apply relative rounded w-full overflow-hidden border-gray-200 border-2 h-full;
+  }
+</style>

--- a/web-common/src/layout/workspace/workspace-stores.ts
+++ b/web-common/src/layout/workspace/workspace-stores.ts
@@ -29,10 +29,14 @@ class WorkspaceLayoutStore {
 
     if (history) {
       const parsed = JSON.parse(history) as WorkspaceLayout;
-      this.inspectorVisible.set(parsed.inspector.visible);
-      this.inspectorWidth.set(parsed.inspector.width);
-      this.tableHeight.set(parsed.table.height);
-      this.tableVisible.set(parsed.table.visible);
+      this.inspectorVisible.set(parsed?.inspector?.visible ?? true);
+      this.inspectorWidth.set(
+        parsed?.inspector?.width ?? DEFAULT_INSPECTOR_WIDTH,
+      );
+      this.tableHeight.set(
+        parsed?.table?.height ?? DEFAULT_PREVIEW_TABLE_HEIGHT,
+      );
+      this.tableVisible.set(parsed?.table?.visible ?? true);
     }
 
     const debouncer = debounce(

--- a/web-common/src/layout/workspace/workspace-stores.ts
+++ b/web-common/src/layout/workspace/workspace-stores.ts
@@ -1,0 +1,112 @@
+import { writable } from "svelte/store";
+import {
+  DEFAULT_INSPECTOR_WIDTH,
+  DEFAULT_PREVIEW_TABLE_HEIGHT,
+} from "../config";
+import { page } from "$app/stores";
+import { derived } from "svelte/store";
+import { debounce } from "@rilldata/web-common/lib/create-debouncer";
+
+type WorkspaceLayout = {
+  inspector: {
+    width: number;
+    visible: boolean;
+  };
+  table: {
+    height: number;
+    visible: boolean;
+  };
+};
+
+class WorkspaceLayoutStore {
+  private inspectorVisible = writable<boolean>(true);
+  private inspectorWidth = writable<number>(DEFAULT_INSPECTOR_WIDTH);
+  private tableHeight = writable<number>(DEFAULT_PREVIEW_TABLE_HEIGHT);
+  private tableVisible = writable<boolean>(true);
+
+  constructor(key: string) {
+    const history = localStorage.getItem(key);
+
+    if (history) {
+      const parsed = JSON.parse(history) as WorkspaceLayout;
+      this.inspectorVisible.set(parsed.inspector.visible);
+      this.inspectorWidth.set(parsed.inspector.width);
+      this.tableHeight.set(parsed.table.height);
+      this.tableVisible.set(parsed.table.visible);
+    }
+
+    const debouncer = debounce(
+      (v: WorkspaceLayout) => localStorage.setItem(key, JSON.stringify(v)),
+      750,
+    );
+
+    this.subscribe((v) => {
+      debouncer(v);
+    });
+  }
+
+  subscribe = derived(
+    [
+      this.inspectorVisible,
+      this.inspectorWidth,
+      this.tableHeight,
+      this.tableVisible,
+    ],
+    ([$inspectorVisible, $inspectorWidth, $tableHeight, $tableVisible]) => {
+      const layout: WorkspaceLayout = {
+        inspector: {
+          visible: $inspectorVisible,
+          width: $inspectorWidth,
+        },
+        table: {
+          height: $tableHeight,
+          visible: $tableVisible,
+        },
+      };
+      return layout;
+    },
+  ).subscribe;
+
+  get inspector() {
+    return {
+      visible: this.inspectorVisible,
+      width: this.inspectorWidth,
+      open: () => this.inspectorVisible.set(true),
+      close: () => this.inspectorVisible.set(false),
+      toggle: () => this.inspectorVisible.update((v) => !v),
+    };
+  }
+
+  get table() {
+    return {
+      height: this.tableHeight,
+      visible: this.tableVisible,
+      open: () => this.tableVisible.set(true),
+      close: () => this.tableVisible.set(false),
+      toggle: () => this.tableVisible.update((v) => !v),
+    };
+  }
+}
+
+class Workspaces {
+  private workspaces = writable(new Map<string, WorkspaceLayoutStore>());
+
+  subscribe = derived([page, this.workspaces], ([$page, $inspectors]) => {
+    const context = $page.route.id ?? crypto.randomUUID();
+    const assetId = $page.params.name;
+
+    const key = `${context}:${assetId}`;
+
+    let store = $inspectors.get(key);
+    if (!store) {
+      store = new WorkspaceLayoutStore(key);
+      $inspectors.set(key, store);
+    }
+    return store;
+  }).subscribe;
+
+  set = this.workspaces.set;
+  update = this.workspaces.update;
+}
+
+export const workspaces = new Workspaces();

--- a/web-common/src/layout/workspace/workspace-stores.ts
+++ b/web-common/src/layout/workspace/workspace-stores.ts
@@ -21,8 +21,8 @@ type WorkspaceLayout = {
 class WorkspaceLayoutStore {
   private inspectorVisible = writable<boolean>(true);
   private inspectorWidth = writable<number>(DEFAULT_INSPECTOR_WIDTH);
-  private tableHeight = writable<number>(DEFAULT_PREVIEW_TABLE_HEIGHT);
   private tableVisible = writable<boolean>(true);
+  private tableHeight = writable<number>(DEFAULT_PREVIEW_TABLE_HEIGHT);
 
   constructor(key: string) {
     const history = localStorage.getItem(key);
@@ -44,9 +44,7 @@ class WorkspaceLayoutStore {
       750,
     );
 
-    this.subscribe((v) => {
-      debouncer(v);
-    });
+    this.subscribe((v) => debouncer(v));
   }
 
   subscribe = derived(
@@ -93,24 +91,22 @@ class WorkspaceLayoutStore {
 }
 
 class Workspaces {
-  private workspaces = writable(new Map<string, WorkspaceLayoutStore>());
+  private workspaces = new Map<string, WorkspaceLayoutStore>();
 
-  subscribe = derived([page, this.workspaces], ([$page, $inspectors]) => {
+  subscribe = derived([page], ([$page]) => {
     const context = $page.route.id ?? crypto.randomUUID();
     const assetId = $page.params.name;
 
     const key = `${context}:${assetId}`;
 
-    let store = $inspectors.get(key);
+    let store = this.workspaces.get(key);
+
     if (!store) {
       store = new WorkspaceLayoutStore(key);
-      $inspectors.set(key, store);
+      this.workspaces.set(key, store);
     }
     return store;
   }).subscribe;
-
-  set = this.workspaces.set;
-  update = this.workspaces.update;
 }
 
 export const workspaces = new Workspaces();

--- a/web-local/src/routes/(application)/chart/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/chart/[name]/+page.svelte
@@ -37,7 +37,7 @@
 </svelte:head>
 
 {#if $fileQuery.data && yaml !== undefined}
-  <WorkspaceContainer inspector={false} assetID={`${chartName}`}>
+  <WorkspaceContainer inspector={false}>
     <ChartsHeader slot="header" {chartName} />
     <Charts slot="body" {chartName} />
   </WorkspaceContainer>

--- a/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/+page.svelte
@@ -90,11 +90,7 @@
 </svelte:head>
 
 {#if ($fileQuery.data && $resourceStatusStore.status === ResourceStatus.Idle) || showErrorPage}
-  <WorkspaceContainer
-    assetID={metricViewName}
-    bgClass="bg-white"
-    inspector={false}
-  >
+  <WorkspaceContainer bgClass="bg-white" inspector={false}>
     <svelte:fragment slot="body">
       {#key metricViewName}
         <StateManagersProvider metricsViewName={metricViewName}>
@@ -110,11 +106,7 @@
     </svelte:fragment>
   </WorkspaceContainer>
 {:else if $resourceStatusStore.status === ResourceStatus.Busy}
-  <WorkspaceContainer
-    assetID={metricViewName}
-    bgClass="bg-white"
-    inspector={false}
-  >
+  <WorkspaceContainer bgClass="bg-white" inspector={false}>
     <div class="grid h-screen place-content-center" slot="body">
       <ReconcilingSpinner />
     </div>

--- a/web-local/src/routes/(application)/table/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/table/[name]/+page.svelte
@@ -23,7 +23,7 @@
   <title>Rill Developer | {fullyQualifiedTableName}</title>
 </svelte:head>
 
-<WorkspaceContainer assetID={fullyQualifiedTableName} inspector={false}>
+<WorkspaceContainer inspector={false}>
   <TableWorkspaceHeader {fullyQualifiedTableName} slot="header" />
   <ConnectedPreviewTable objectName={table} loading={false} slot="body" />
 </WorkspaceContainer>


### PR DESCRIPTION
This PR refactors the process by which we store, update and render the various layout parameters associated with a workspace to improve rendering performance and, hopefully, simplify the DX around how all of this works.

To that end, the following changes were made:

-Remove the use of context to pass around layout parameters
-Create new `WorkspaceLayout` and `Workspaces` stores using our new state management model
-Rely on CSS/Svelte transitions to animate in/out panel sliding rather than manual tween calculations
-Add a new `Resizer` component
-Collect the table and inspector state into a single localStorage item
-Debounce updating localStorage when state changes

This should solve a variety of UI responsiveness issues when interacting with these surfaces (e.g. toggling the panels should no longer experience frame drops). Additional performance improvements will come once the `PreviewTable` has been refactored.