### PR TITLE
Fix: Placement of environment variable declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev-web": "npm run dev -w web-local",
     "dev-runtime": "go run cli/main.go start dev-project --no-ui",
     "clean": "rm -rf dev-project",
-    "test": "npm run test -w web-common & npm run test -w web-auth & make cli && npm run test -w web-local"
+    "test": "npm run test -w web-common & npm run test -w web-auth & PLAYWRIGHT_TEST=true make cli && npm run test -w web-local"
   },
   "overrides": {
     "@rgossiaux/svelte-headlessui": {

--- a/web-local/package.json
+++ b/web-local/package.json
@@ -10,7 +10,7 @@
     "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "eslint --ignore-path .gitignore .",
     "format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. .",
-    "test": "PLAYWRIGHT_TEST=true npx playwright test",
+    "test": "npx playwright test",
     "test:watch": "npm run test -- --watch",
     "manual-publish": "./build-tools/npm_publish.sh"
   },


### PR DESCRIPTION
The declaration of the `PLAYWRIGHT_TEST` environment variable was not being captured during the test-invoked CLI build process, preventing AI features from being disabled during local testing.