### PR TITLE
Tests: locator and clarity tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev-web": "npm run dev -w web-local",
     "dev-runtime": "go run cli/main.go start dev-project --no-ui",
     "clean": "rm -rf dev-project",
-    "test": "npm run test -w web-common & npm run test -w web-auth & make cli && npm run test -w web-local"
+    "test": "npm run test -w web-common & npm run test -w web-auth & PLAYWRIGHT_TEST=true make cli && npm run test -w web-local"
   },
   "overrides": {
     "@rgossiaux/svelte-headlessui": {

--- a/web-common/src/components/searchable-filter-menu/SeachableFilterButton.svelte
+++ b/web-common/src/components/searchable-filter-menu/SeachableFilterButton.svelte
@@ -68,7 +68,7 @@ props as needed.
     location="bottom"
     suppress={active}
   >
-    <SelectButton {active} on:click={toggleFloatingElement}
+    <SelectButton label={tooltipText} {active} on:click={toggleFloatingElement}
       ><strong>{numShownString} {label}</strong></SelectButton
     >
     <div slot="tooltip-content" transition:fly={{ duration: 300, y: 4 }}>

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
@@ -136,15 +136,15 @@
         tooltipText="Choose dimensions to display"
       />
 
-      <div class="whitespace-nowrap">showing</div>
-
       <SelectMenu
+        fixedText="showing"
         paddingTop={2}
         paddingBottom={2}
         {options}
         {selection}
         alignment="end"
         on:select={handleMeasureUpdate}
+        ariaLabel="Select a measure to filter by"
       />
 
       <LeaderboardContextColumnMenu {validPercentOfTotal} />

--- a/web-local/package.json
+++ b/web-local/package.json
@@ -10,7 +10,7 @@
     "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "eslint --ignore-path .gitignore .",
     "format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. .",
-    "test": "PLAYWRIGHT_TEST=true npx playwright test",
+    "test": "npx playwright test",
     "test:watch": "npm run test -- --watch",
     "manual-publish": "./build-tools/npm_publish.sh"
   },

--- a/web-local/tests/dashboards/dashboards.spec.ts
+++ b/web-local/tests/dashboards/dashboards.spec.ts
@@ -462,7 +462,9 @@ dimensions:
     await expect(page.getByText("Avg Bid Price $3.01")).toBeVisible();
 
     // Change the leaderboard metric
-    await page.getByRole("button", { name: "Total rows", exact: true }).click();
+    await page
+      .getByRole("button", { name: "Select a measure to filter by" })
+      .click();
     await page.getByRole("menuitem", { name: "Avg Bid Price" }).click();
 
     // Check domain and sample value in leaderboard

--- a/web-local/tests/dashboards/dimension-and-measure-selection.spec.ts
+++ b/web-local/tests/dashboards/dimension-and-measure-selection.spec.ts
@@ -1,38 +1,59 @@
 import { expect } from "@playwright/test";
 import { useDashboardFlowTestSetup } from "web-local/tests/dashboards/dashboard-flow-test-setup";
 import { test } from "../utils/test";
+import { clickMenuButton } from "../utils/commonHelpers";
 
 test.describe("dimension and measure selectors", () => {
   // dashboard test setup
   useDashboardFlowTestSetup();
 
   test("dimension and measure selectors flow", async ({ page }) => {
-    await page.getByRole("button", { name: "All Measures" }).click();
-    await page.getByRole("menuitem", { name: "Total records" }).click();
-    await page.getByRole("button", { name: "1 of 2 Measures" }).click();
+    const measuresButton = page.getByRole("button", {
+      name: "Choose measures to display",
+    });
+    const dimensionsButton = page.getByRole("button", {
+      name: "Choose dimensions to display",
+    });
+
+    async function escape() {
+      await page.keyboard.press("Escape");
+      await page.getByRole("menu").waitFor({ state: "hidden" });
+    }
+
+    async function clickMenuItem(itemName: string) {
+      await clickMenuButton(page, itemName);
+    }
+
+    await measuresButton.click();
+    await clickMenuItem("Total records");
+    await escape();
+    await expect(measuresButton).toHaveText("1 of 2 Measures");
 
     await expect(page.getByText("Sum of Bid Price 300.6k")).toBeVisible();
     await expect(page.getByText("Total records 100.0k")).not.toBeVisible();
 
-    await page.getByRole("button", { name: "1 of 2 Measures" }).click();
-    await page.getByRole("menuitem", { name: "Total records" }).click();
-    await page.getByRole("menuitem", { name: "Sum of Bid Price" }).click();
-    await page.getByRole("button", { name: "1 of 2 Measures" }).click();
+    await measuresButton.click();
+    await clickMenuItem("Total records");
+    await clickMenuItem("Sum of Bid Price");
+    await expect(measuresButton).toHaveText("1 of 2 Measures");
+    await escape();
 
     await expect(page.getByText("Sum of Bid Price 300.6k")).not.toBeVisible();
     await expect(page.getByText("Total records 100.0k")).toBeVisible();
 
-    await page.getByRole("button", { name: "All Dimensions" }).click();
-    await page.getByRole("menuitem", { name: "Publisher" }).click();
-    await page.getByRole("button", { name: "1 of 2 Dimensions" }).click();
+    await dimensionsButton.click();
+    await clickMenuItem("Publisher");
+    await expect(dimensionsButton).toHaveText("1 of 2 Dimensions");
+    await escape();
 
     await expect(page.getByText("Publisher")).not.toBeVisible();
     await expect(page.getByText("Domain")).toBeVisible();
 
-    await page.getByRole("button", { name: "1 of 2 Dimensions" }).click();
-    await page.getByRole("menuitem", { name: "Publisher" }).click();
-    await page.getByRole("menuitem", { name: "Domain" }).click();
-    await page.getByRole("button", { name: "1 of 2 Dimensions" }).click();
+    await dimensionsButton.click();
+    await clickMenuItem("Publisher");
+    await clickMenuItem("Domain");
+    await expect(dimensionsButton).toHaveText("1 of 2 Dimensions");
+    await escape();
 
     await expect(page.getByText("Publisher")).toBeVisible();
     await expect(page.getByText("Domain")).not.toBeVisible();

--- a/web-local/tests/dashboards/leaderboard-and-dim-table-sort.spec.ts
+++ b/web-local/tests/dashboards/leaderboard-and-dim-table-sort.spec.ts
@@ -40,8 +40,25 @@ test.describe("leaderboard and dimension table sorting", () => {
       page.getByRole("button", { name: "null 32.9k" }),
     );
 
+    const timeRangeMenu = page.getByRole("button", {
+      name: "Select time range",
+    });
+    const contextColumnMenu = page.getByRole("button", {
+      name: "Select a context column",
+    });
+
+    async function openTimeRangeMenu() {
+      await timeRangeMenu.click();
+      await page.getByRole("menu").waitFor({ state: "visible" });
+    }
+
+    async function openContextColumnMenu() {
+      await contextColumnMenu.click();
+      await page.getByRole("menu").waitFor({ state: "visible" });
+    }
+
     // add pct of total context column
-    await page.getByRole("button", { name: "Select a context column" }).click();
+    await openContextColumnMenu();
     await page.getByRole("menuitem", { name: "Percent of total" }).click();
 
     await assertAAboveB(
@@ -70,7 +87,7 @@ test.describe("leaderboard and dimension table sorting", () => {
     await page.getByRole("button", { name: "No comparison" }).click();
     await page.getByRole("menuitem", { name: "Time" }).click();
 
-    await page.getByRole("button", { name: "Select time range" }).click();
+    await openTimeRangeMenu();
     await page.getByRole("menuitem", { name: "Last 24 Hours" }).click();
 
     // need a slight delay for the time range to update
@@ -78,7 +95,7 @@ test.describe("leaderboard and dimension table sorting", () => {
     // in the context column dropdown
     await page.waitForTimeout(1000);
 
-    await page.getByRole("button", { name: "Select a context column" }).click();
+    await openContextColumnMenu();
     await page.getByRole("menuitem", { name: "Percent change" }).click();
 
     // need a slight delay for the rankings to update
@@ -108,7 +125,7 @@ test.describe("leaderboard and dimension table sorting", () => {
     );
 
     // select absolute change
-    await page.getByRole("button", { name: "Select a context column" }).click();
+    await openContextColumnMenu();
     await page.getByRole("menuitem", { name: "Absolute change" }).click();
 
     await assertAAboveB(

--- a/web-local/tests/dashboards/leaderboard-context-column.spec.ts
+++ b/web-local/tests/dashboards/leaderboard-context-column.spec.ts
@@ -8,6 +8,7 @@ import {
 } from "../utils/dashboardHelpers";
 import { createAdBidsModel } from "../utils/dataSpecifcHelpers";
 import { test } from "../utils/test";
+import { clickMenuButton } from "../utils/commonHelpers";
 
 test.describe("leaderboard context column", () => {
   test.beforeEach(async ({ page }) => {
@@ -68,6 +69,28 @@ test.describe("leaderboard context column", () => {
     await updateCodeEditor(page, metricsWithValidPercentOfTotal);
     await waitForDashboard(page);
 
+    async function clickMenuItem(itemName: string, wait = true) {
+      await clickMenuButton(page, itemName);
+      if (wait) {
+        await page.getByRole("menu").waitFor({ state: "hidden" });
+      }
+    }
+
+    const contextColumnMenuTrigger = page.getByLabel("Select a context column");
+    const measuresButton = page.getByRole("button", {
+      name: "Select a measure to filter by",
+    });
+
+    async function openContextMenu() {
+      await contextColumnMenuTrigger.click();
+      await page.getByRole("menu").waitFor({ state: "visible" });
+    }
+
+    async function escape() {
+      await page.keyboard.press("Escape");
+      await page.getByRole("menu").waitFor({ state: "hidden" });
+    }
+
     // Go to dashboard
     await page.getByRole("button", { name: "Go to dashboard" }).click();
 
@@ -82,8 +105,7 @@ test.describe("leaderboard context column", () => {
      * when there is no time comparison
      */
 
-    // click to open the context column menu
-    await page.getByLabel("Select a context column").click();
+    await openContextMenu();
     // Check "percent change" menuitem disabled since there is no time comparison
     await expect(
       page.getByRole("menuitem", { name: "Percent change" }),
@@ -92,8 +114,8 @@ test.describe("leaderboard context column", () => {
     await expect(
       page.getByRole("menuitem", { name: "Percent of total" }),
     ).toBeDisabled();
-    // click to close the context column menu
-    await page.getByLabel("Select a context column").click();
+
+    await escape();
 
     /**
      * SUBFLOW: check correct behavior when a time comparison
@@ -126,8 +148,7 @@ test.describe("leaderboard context column", () => {
     // Check that time comparison context column is visible with correct value now that there is a time comparison
     await expect(page.getByText(comparisonColumnRegex)).toBeVisible();
 
-    // click to open the context column menu
-    await page.getByLabel("Select a context column").click();
+    await openContextMenu();
     // Check that the "percent change" menuitem is enabled
     await expect(
       page.getByRole("menuitem", { name: "Percent change" }),
@@ -136,8 +157,8 @@ test.describe("leaderboard context column", () => {
     await expect(
       page.getByRole("menuitem", { name: "Percent of total" }),
     ).toBeDisabled();
-    // click to close the context column menu
-    await page.getByLabel("Select a context column").click();
+
+    await escape();
 
     /**
      * SUBFLOW: check correct behavior when
@@ -146,9 +167,9 @@ test.describe("leaderboard context column", () => {
      * - and then the context column is turned off
      */
 
-    // turn off the context column
-    await page.getByLabel("Select a context column").click();
-    await page.getByRole("menuitem", { name: "No context column" }).click();
+    await openContextMenu();
+    await clickMenuItem("No context column");
+
     // Check that time comparison context column is hidden
     await expect(page.getByText(comparisonColumnRegex)).not.toBeVisible();
     await expect(page.getByText("Facebook 68")).toBeVisible();
@@ -160,9 +181,8 @@ test.describe("leaderboard context column", () => {
      * - and then time comparison is turned off
      */
 
-    // turn on the context column
-    await page.getByLabel("Select a context column").click();
-    await page.getByRole("menuitem", { name: "Percent change" }).click();
+    await openContextMenu();
+    await clickMenuItem("Percent change");
     await expect(page.getByText(comparisonColumnRegex)).toBeVisible();
 
     // click back to "All time" to clear the time comparison
@@ -176,11 +196,13 @@ test.describe("leaderboard context column", () => {
     // Check that time comparison context column is hidden
     await expect(page.getByText(comparisonColumnRegex)).not.toBeVisible();
     await expect(page.getByText("Facebook 19.3k")).toBeVisible();
+
     // Check that the "percent change" menuitem is disabled
-    await page.getByLabel("Select a context column").click();
+    await openContextMenu();
     await expect(
       page.getByRole("menuitem", { name: "Percent change" }),
     ).toBeDisabled();
+    await escape();
 
     /**
      * SUBFLOW: check correct behavior when
@@ -189,22 +211,22 @@ test.describe("leaderboard context column", () => {
      */
 
     // Switch to measure "total bid price"
-    await page.getByRole("button", { name: "Total rows", exact: true }).click();
-    await page.getByRole("menuitem", { name: "Total Bid Price" }).click();
-    await page.getByRole("button", { name: "Total Bid Price" }).isVisible();
+    await measuresButton.click();
+    await clickMenuItem("Total Bid Price", false);
+    await escape();
+    await expect(measuresButton).toHaveText("showing Total Bid Price");
 
-    // open the context column menu
-    await page.getByLabel("Select a context column").click();
-    // Check that the "0ercent of total" menuitem is enabled
+    await openContextMenu();
+    // Check that the "percent of total" menuitem is enabled
     await expect(
       page.getByRole("menuitem", { name: "Percent of total" }),
-    ).toBeDisabled();
+    ).toBeEnabled();
     // Check that the "percent change" menuitem is disabled
     await expect(
       page.getByRole("menuitem", { name: "Percent change" }),
     ).toBeDisabled();
-    // close the context column menu
-    await page.getByLabel("Select a context column").click();
+
+    await escape();
 
     // Check that the percent of total is hidden
     await expect(page.getByText(comparisonColumnRegex)).not.toBeVisible();
@@ -216,12 +238,9 @@ test.describe("leaderboard context column", () => {
      * - percent of total context column is turned on
      */
 
-    // open the context column menu
-    await page.getByLabel("Select a context column").click();
-    // click on "percent of total" menuitem
-    await page.getByRole("menuitem", { name: "Percent of total" }).click();
-    //close the context column menu
-    await page.getByLabel("Select a context column").click();
+    await openContextMenu();
+    await clickMenuItem("Percent of total");
+
     // check that the percent of total is visible
     await expect(page.getByText("Facebook $57.8k 19%")).toBeVisible();
 
@@ -256,21 +275,15 @@ test.describe("leaderboard context column", () => {
       l.getByRole("menuitem", { name: "Time" }).click(),
     );
 
-    // open the context column menu
-    await page.getByLabel("Select a context column").click();
-    // click on "percent change" menuitem
-    await page.getByRole("menuitem", { name: "Percent change" }).click();
-    //close the context column menu
-    await page.getByLabel("Select a context column").click();
+    await openContextMenu();
+    await clickMenuItem("Percent change");
+
     // check that the percent change is visible+correct
     await expect(page.getByText("Facebook $229.26 4%")).toBeVisible();
 
-    // open the context column menu
-    await page.getByLabel("Select a context column").click();
-    // click on "percent of total" menuitem
-    await page.getByRole("menuitem", { name: "Percent of total" }).click();
-    //close the context column menu
-    await page.getByLabel("Select a context column").click();
+    await openContextMenu();
+    await clickMenuItem("Percent of total");
+
     // check that the percent of total is visible+correct
     await expect(page.getByText("Facebook $229.26 29%")).toBeVisible();
 
@@ -282,14 +295,14 @@ test.describe("leaderboard context column", () => {
      */
 
     // Switch to measure "total rows" (no valid_percent_of_total)
-    await page
-      .getByRole("button", { name: "Total Bid Price", exact: true })
-      .click();
-    await page.getByRole("menuitem", { name: "Total rows" }).click();
+    await measuresButton.click();
+    await clickMenuItem("Total Rows");
+    await expect(measuresButton).toHaveText("showing Total rows");
     // check that the context column is hidden
     await expect(page.getByText(comparisonColumnRegex)).not.toBeVisible();
+
     // open the context column menu
-    await page.getByLabel("Select a context column").click();
+    await openContextMenu();
     // check that the "percent of total" menuitem is disabled
     await expect(
       page.getByRole("menuitem", { name: "Percent of total" }),

--- a/web-local/tests/dashboards/number-formatting.spec.ts
+++ b/web-local/tests/dashboards/number-formatting.spec.ts
@@ -74,7 +74,7 @@ dimensions:
     await waitForDashboard(page);
 
     // make the viewport big enough to see the whole dashboard
-    page.setViewportSize({ width: 1920, height: 1200 });
+    await page.setViewportSize({ width: 1920, height: 1200 });
 
     // Go to dashboard
     await page.getByRole("button", { name: "Go to dashboard" }).click();
@@ -116,11 +116,14 @@ dimensions:
      * but a few combinations of format and context column.
      *
      ******************/
+
+    const measuresButton = page.getByRole("button", {
+      name: "Select a measure to filter by",
+    });
     await page.getByRole("button", { name: "Select a context column" }).click();
-    await page
-      .getByRole("button", { name: "humanized default", exact: true })
-      .click();
+    await measuresButton.click();
     await page.getByRole("menuitem", { name: "USD" }).click();
+    await expect(measuresButton).toHaveText("showing USD");
     // turn on a context column to check the formatting there
     await page.getByRole("button", { name: "Select a context column" }).click();
     await page.getByRole("menuitem", { name: "Percent of total" }).click();
@@ -129,16 +132,18 @@ dimensions:
       page.getByRole("button", { name: "null $98.8k 33%" }),
     ).toBeVisible();
 
-    await page.getByRole("button", { name: "USD", exact: true }).click();
+    await measuresButton.click();
     await page.getByRole("menuitem", { name: "percentage" }).click();
+    await expect(measuresButton).toHaveText("showing percentage");
 
     await expect(
       page.getByRole("button", { name: "null 9.9M% 33%" }),
     ).toBeVisible();
 
     // try interval_ms...
-    await page.getByRole("button", { name: "percentage", exact: true }).click();
+    await measuresButton.click();
     await page.getByRole("menuitem", { name: "interval_ms" }).click();
+    await expect(measuresButton).toHaveText("showing interval_ms");
     // ...and add a time comparison to check absolute change
     await interactWithTimeRangeMenu(page, async () => {
       await page.getByRole("menuitem", { name: "Last 4 Weeks" }).click();
@@ -152,10 +157,9 @@ dimensions:
     ).toBeVisible();
 
     // try No Format...
-    await page
-      .getByRole("button", { name: "interval_ms", exact: true })
-      .click();
+    await measuresButton.click();
     await page.getByRole("menuitem", { name: "No Format" }).click();
+    await expect(measuresButton).toHaveText("showing No Format");
     // ...with percent change context column
     await page.getByRole("button", { name: "Select a context column" }).click();
     await page.getByRole("menuitem", { name: "Percent change" }).click();


### PR DESCRIPTION
See #4286 first

This PR makes a variety of related changes and improvements to our end-to-end dashboard tests.

- Adds more descriptive aria-labels to the dropdown menus and uses those to locate the elements
- Adds assertions that the text value of those elements has changed rather than attempting to locate them by the text value, which `getByRole` is not intended for
- Adds appropriate locator actions to wait for menu visibility to change (should improve test stability on different platforms)
- Adds wrapper helper functions for selecting menu items
- Closes menus explicitly via the escape key when necessary

Finally, the `leaderboard-context-column` test was repeatedly closing a menu that closed automatically, meaning it was actually re-opening the menu. Somehow, the test was still passing, but this test has been a given a slightly more thorough rework, including one line where an assertion that an element was disabled should have actually been an assertion that it was enabled.