### PR TITLE
Fix: Disable chart keydown ops on input fields

### DIFF
--- a/web-common/src/features/dashboards/time-series/ChartInteractions.svelte
+++ b/web-common/src/features/dashboards/time-series/ChartInteractions.svelte
@@ -11,7 +11,7 @@
   } from "@rilldata/web-common/lib/time/types";
   import type { V1TimeGrain } from "@rilldata/web-common/runtime-client";
 
-  export let metricViewName;
+  export let metricViewName: string;
   export let showComparison = false;
   export let timeGrain: V1TimeGrain | undefined;
 
@@ -23,7 +23,11 @@
     },
   } = StateManagers;
 
-  function onKeyDown(e) {
+  function onKeyDown(e: KeyboardEvent) {
+    const targetTagName = (e.target as HTMLElement).tagName;
+    if (["INPUT", "TEXTAREA", "SELECT"].includes(targetTagName)) {
+      return;
+    }
     if (e.key === "ArrowLeft") {
       if ($canPanLeft) {
         const panRange = $getNewPanRange("left");


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Details:
Pressing left or right arrow while in an input field such as measure threshold, dimension search in comparison would pan the charts. We want to disable key event actions when on an input field.

## Steps to Verify
1. Add a measure filter
2. Use the left and right arrows while in the input field
3. The charts should not pan