### PR TITLE
Fix: timeseries chart container spacing

### DIFF
--- a/web-common/src/features/dashboards/time-series/TimeSeriesChartContainer.svelte
+++ b/web-common/src/features/dashboards/time-series/TimeSeriesChartContainer.svelte
@@ -13,7 +13,7 @@ A container GraphicContext for the time series in a metrics dashboard.
   const paddingForFullWidth = 80;
 </script>
 
-<div class="w-full h-fit pr-2 flex flex-col max-h-full pb-4">
+<div class="w-fit max-w-full h-fit pr-2 flex flex-col max-h-full pb-4">
   <GraphicContext
     bottom={4}
     height={enableFullWidth


### PR DESCRIPTION
TimeSeries chart container was taking up the available space rather than limiting itself to the width of its children.