### PR TITLE
Runtime: Add support for dimension expressions in metrics_sql

### DIFF
--- a/runtime/reconcilers/util.go
+++ b/runtime/reconcilers/util.go
@@ -152,14 +152,14 @@ func olapForceRenameTable(ctx context.Context, c *runtime.Controller, connector,
 func logTableNameAndType(ctx context.Context, c *runtime.Controller, connector, name string) {
 	olap, release, err := c.AcquireOLAP(ctx, connector)
 	if err != nil {
-		c.Logger.Error("LogTableNameAndType: failed to acquire OLAP", zap.Error(err))
+		c.Logger.Warn("LogTableNameAndType: failed to acquire OLAP", zap.Error(err))
 		return
 	}
 	defer release()
 
 	res, err := olap.Execute(context.Background(), &drivers.Statement{Query: "SELECT column_name, data_type FROM information_schema.columns WHERE table_name=? ORDER BY column_name ASC", Args: []any{name}})
 	if err != nil {
-		c.Logger.Error("LogTableNameAndType: failed information_schema.columns", zap.Error(err))
+		c.Logger.Warn("LogTableNameAndType: failed information_schema.columns", zap.Error(err))
 		return
 	}
 	defer res.Close()
@@ -169,7 +169,7 @@ func logTableNameAndType(ctx context.Context, c *runtime.Controller, connector, 
 	for res.Next() {
 		err = res.Scan(&col, &typ)
 		if err != nil {
-			c.Logger.Error("LogTableNameAndType: failed scan", zap.Error(err))
+			c.Logger.Warn("LogTableNameAndType: failed scan", zap.Error(err))
 			return
 		}
 		colTyp = append(colTyp, fmt.Sprintf("%s:%s", col, typ))

--- a/runtime/resolvers/metrics_sql.go
+++ b/runtime/resolvers/metrics_sql.go
@@ -162,6 +162,9 @@ func (c *metricsSQLCompiler) compile(ctx context.Context) (string, string, []*ru
 
 func (c *metricsSQLCompiler) fromQueryForMetricsView(mv *runtimev1.Resource) (string, map[string]string, map[string]string, error) {
 	spec := mv.GetMetricsView().State.ValidSpec
+	if spec == nil {
+		return "", nil, nil, fmt.Errorf("metrics view %q is not ready for querying, reconcile status: %q", mv.Meta.GetName(), mv.Meta.ReconcileStatus)
+	}
 
 	security, err := c.ctrl.Runtime.ResolveMetricsViewSecurity(c.userAttributes, c.instanceID, spec, mv.Meta.StateUpdatedOn.AsTime())
 	if err != nil {

--- a/runtime/resolvers/metrics_sql.go
+++ b/runtime/resolvers/metrics_sql.go
@@ -12,7 +12,6 @@ import (
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/drivers"
-	"golang.org/x/exp/maps"
 )
 
 func init() {
@@ -83,21 +82,20 @@ var (
 	sqlIdentifier = `[a-zA-z_][a-zA-Z0-9_]*|"(?:[^"]|"")*"`
 
 	// aggregateRegex is regex pattern to identify an AGGREGATE function in SQL.
-	aggregateRegex = regexp.MustCompile(fmt.Sprintf(`(?i)AGGREGATE\((?:(%s)\.)?(%s)\)`, sqlIdentifier, sqlIdentifier))
+	aggregateRegex = regexp.MustCompile(fmt.Sprintf(`(?i)AGGREGATE\(\s*(%s)\s*\)`, sqlIdentifier))
 
-	// fromRegex is regex pattern to identify a FROM clause in SQL.
-	fromRegex = regexp.MustCompile(fmt.Sprintf(`(?i)FROM\s+(%s)`, sqlIdentifier))
+	sqlRegex = regexp.MustCompile(fmt.Sprintf(`(?i)SELECT\s+((?:.|\n)*)\s+FROM\s+(%s)((?:.|\n)*)`, sqlIdentifier))
 )
 
 // metricsSQLCompiler parses a metrics SQL query and compiles it to a regular SQL query.
 // Metrics SQL is a superset of SQL that supports querying Rill's metrics views.
-// The syntax is inspired by Calcite's measure columns: https://issues.apache.org/jira/browse/CALCITE-4496.
 //
 // This is a simple implementation that uses regular expressions. It does not support all SQL features.
 // It works by:
 //
-// 1. Expanding AGGREGATE(measure) into actual aggregate expressions from the metrics view definition.
-// 2. Converting "FROM metrics_view" clauses to nested SELECTs on the underlying table with filters based on the metrics view's security policy.
+// 1. Expanding measure into actual aggregate expressions from the metrics view definition.
+// 2. Expanding dimension into dimension expression or underlying column name.
+// 3. Converting "FROM metrics_view" clauses to nested SELECTs on the underlying table with filters based on the metrics view's security policy.
 //
 // TODO: This implementation does not resolve dimension names to underlying columns/expressions. Here is an example of the desired transformation:
 // - Input: SELECT dim1, AGGREGATE(measure1) FROM metrics_view GROUP BY dim1
@@ -115,84 +113,57 @@ type metricsSQLCompiler struct {
 // It returns the compiled SQL, the connector to use, and the refs to metrics views.
 // It does not return other refs (like sources or models). The regular SQL resolver will handle those.
 func (c *metricsSQLCompiler) compile(ctx context.Context) (string, string, []*runtimev1.ResourceName, error) {
-	// Expand "FROM metrics_view".
-	// For each match, match[1] will contain the metrics_view identifier.
-	sql := c.sql
-	matches := fromRegex.FindAllStringSubmatch(sql, -1)
-	mvToMeasureExprMap := make(map[string]map[string]string)
-	var mvConnector string
-	var refs []*runtimev1.ResourceName
-	for _, match := range matches {
-		metricView := unquote(match[1])
-		if _, ok := mvToMeasureExprMap[metricView]; ok {
-			continue
-		}
-
-		resource, err := c.ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: metricView}, false)
-		if err != nil {
-			if errors.Is(err, drivers.ErrResourceNotFound) {
-				continue
-			}
-			return "", "", nil, fmt.Errorf("error fetching resource %v: %w", metricView, err)
-		}
-
-		refs = append(refs, &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: metricView})
-
-		if mvConnector != "" && resource.GetMetricsView().Spec.Connector != mvConnector {
-			return "", "", nil, fmt.Errorf("all referenced metrics views must use the same connector")
-		}
-		mvConnector = resource.GetMetricsView().Spec.Connector
-
-		// Replace "FROM metric_view" with a query to the underlying table
-		fromQry, measureToExprMap, err := c.fromQueryForMetricsView(resource)
-		if err != nil {
-			return "", "", nil, err
-		}
-		mvToMeasureExprMap[metricView] = measureToExprMap
-		sql = strings.ReplaceAll(sql, match[0], fromQry)
+	sql := strings.TrimSpace(c.sql)
+	matches := sqlRegex.FindAllStringSubmatch(sql, -1)
+	if len(matches) != 1 {
+		return "", "", nil, fmt.Errorf("invalid metrics_sql: %q", sql)
 	}
 
-	// Expand AGGREGATE expressions
-	if len(mvToMeasureExprMap) > 0 {
-		// Example: SELECT dim1, AGGREGATE(mv."my measure") FROM mv
-		// The regex captures [AGGREGATE("mv name"."my measure"), mv name, measure]
-		aggMatches := aggregateRegex.FindAllStringSubmatch(sql, -1)
-		for _, aggMatch := range aggMatches {
-			metricView := unquote(aggMatch[1])
-			var expr string
-			var found bool
-			if metricView == "" {
-				if len(mvToMeasureExprMap) > 1 {
-					return "", "", nil, fmt.Errorf("ambiguous reference to measure %q: use a fully qualified name such as \"metrics_view.measure\"", unquote(aggMatch[2]))
-				}
+	metricView := unquote(strings.TrimSpace(matches[0][2]))
+	resource, err := c.ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: metricView}, false)
+	if err != nil {
+		if errors.Is(err, drivers.ErrResourceNotFound) {
+			return "", "", nil, fmt.Errorf("metrics_view %q not found. Metric SQL can only target metrics_view, use SQL for other user cases", metricView)
+		}
+		return "", "", nil, fmt.Errorf("error fetching resource %v: %w", metricView, err)
+	}
 
-				expr, found = maps.Values(mvToMeasureExprMap)[0][unquote(aggMatch[2])]
-			} else {
-				measureToExprMap, ok := mvToMeasureExprMap[metricView]
-				if !ok {
-					return "", "", nil, fmt.Errorf("metric_view %q not found", metricView)
-				}
-				expr, found = measureToExprMap[unquote(aggMatch[2])]
+	fromSQL, dimensions, measures, err := c.fromQueryForMetricsView(resource)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	selectList := strings.Split(matches[0][1], ",")
+	resolvedSelectList := make([]string, len(selectList))
+	for i, col := range selectList {
+		col = strings.Trim(strings.TrimSpace(col), "\n\t")
+		aggMatch := aggregateRegex.FindAllStringSubmatch(col, -1)
+		if len(aggMatch) > 0 {
+			col = strings.TrimSpace(aggMatch[0][1])
+			expr, ok := measures[unquote(col)]
+			if !ok {
+				return "", "", nil, fmt.Errorf("aggregate column %q must be a measure in metrics_view %q", col, metricView)
 			}
-
-			if !found {
-				return "", "", nil, fmt.Errorf("MetricsViewSQL: measure %q not found", aggMatch[2])
+			resolvedSelectList[i] = fmt.Sprintf("%s AS %s", expr, col)
+		} else {
+			expr, ok := dimensions[unquote(col)]
+			if !ok {
+				return "", "", nil, fmt.Errorf("non aggregate column %q must be a dimension in metrics_view %q", col, metricView)
 			}
-
-			// TODO handle case when two different tables have same column name in the measure expression
-			sql = strings.ReplaceAll(sql, aggMatch[0], expr)
+			resolvedSelectList[i] = fmt.Sprintf("%s AS %s", expr, col)
 		}
 	}
 
-	return sql, mvConnector, normalizeRefs(refs), nil
+	sql = fmt.Sprintf("SELECT %s FROM %s %s", strings.Join(resolvedSelectList, ", "), fromSQL, matches[0][3])
+	return sql, resource.GetMetricsView().State.ValidSpec.Connector, []*runtimev1.ResourceName{{Kind: runtime.ResourceKindMetricsView, Name: metricView}}, nil
 }
 
-func (c *metricsSQLCompiler) fromQueryForMetricsView(mv *runtimev1.Resource) (string, map[string]string, error) {
+func (c *metricsSQLCompiler) fromQueryForMetricsView(mv *runtimev1.Resource) (string, map[string]string, map[string]string, error) {
 	spec := mv.GetMetricsView().State.ValidSpec
 
 	security, err := c.ctrl.Runtime.ResolveMetricsViewSecurity(c.userAttributes, c.instanceID, spec, mv.Meta.StateUpdatedOn.AsTime())
 	if err != nil {
-		return "", nil, err
+		return "", nil, nil, err
 	}
 
 	measures := make(map[string]string, len(spec.Measures))
@@ -200,47 +171,47 @@ func (c *metricsSQLCompiler) fromQueryForMetricsView(mv *runtimev1.Resource) (st
 		measures[measure.Name] = measure.Expression
 	}
 
+	dimensions := make(map[string]string, len(spec.Dimensions))
+	for _, dim := range spec.Dimensions {
+		if dim.Expression != "" {
+			dimensions[dim.Name] = dim.Expression
+		} else {
+			dimensions[dim.Name] = c.dialect.EscapeIdentifier(dim.Column)
+		}
+	}
+
 	if security == nil {
-		return fmt.Sprintf("FROM %s", c.dialect.EscapeIdentifier(spec.Table)), measures, nil
+		return c.dialect.EscapeIdentifier(spec.Table), dimensions, measures, nil
 	}
 
 	if !security.Access || security.ExcludeAll {
-		return "", nil, fmt.Errorf("access to metrics view %q forbidden", mv.Meta.Name)
+		return "", nil, nil, fmt.Errorf("access to metrics view %q forbidden", mv.Meta.Name)
 	}
 
-	dims := make(map[string]any, len(spec.Dimensions))
-	for _, dim := range spec.Dimensions {
-		dims[dim.Column] = nil
-	}
-
-	finalMeasures := maps.Clone(measures)
 	if len(security.Include) != 0 {
-		for measure := range finalMeasures {
+		for measure := range measures {
 			if !slices.Contains(security.Include, measure) { // measures not part of include clause should not be accessible
-				finalMeasures[measure] = "null"
+				measures[measure] = "null"
+			}
+		}
+
+		for dimension := range dimensions {
+			if !slices.Contains(security.Include, dimension) { // dimensions not part of include clause should not be accessible
+				dimensions[dimension] = "null"
 			}
 		}
 	}
 
-	for _, include := range security.Include {
-		if _, ok := dims[include]; ok {
-			return "", nil, fmt.Errorf("metrics SQL does not support metrics views with an include/exclude security policy that applies to dimensions")
-		}
-		finalMeasures[include] = measures[include]
-	}
-
 	for _, exclude := range security.Exclude {
-		if _, ok := dims[exclude]; ok {
-			return "", nil, fmt.Errorf("metrics SQL does not support metrics views with an include/exclude security policy that applies to dimensions")
-		}
-		finalMeasures[exclude] = "null"
+		dimensions[exclude] = "null"
+		measures[exclude] = "null"
 	}
 
 	sql := "SELECT * FROM " + c.dialect.EscapeIdentifier(spec.Table)
 	if security.RowFilter != "" {
 		sql += " WHERE " + security.RowFilter
 	}
-	return fmt.Sprintf("FROM (%s)", sql), finalMeasures, nil
+	return fmt.Sprintf("(%s)", sql), dimensions, measures, nil
 }
 
 func unquote(input string) string {

--- a/runtime/testruntime/testdata/ad_bids/apis/mv_sql_policy_api.yaml
+++ b/runtime/testruntime/testdata/ad_bids/apis/mv_sql_policy_api.yaml
@@ -2,9 +2,8 @@ kind : api
 
 metrics_sql: | 
   select 
-  publisher, 
-  domain, 
-  AGGREGATE("total impressions") AS total_imp, 
-  AGGREGATE("total volume") as total_vol 
+  publisher,	domain, 
+  AGGREGATE("total impressions"), 
+  AGGREGATE("total volume") 
   FROM ad_bids_mini_metrics_with_policy 
   GROUP BY ALL

--- a/runtime/testruntime/testdata/ad_bids/apis/simple_mv_sql_api.yaml
+++ b/runtime/testruntime/testdata/ad_bids/apis/simple_mv_sql_api.yaml
@@ -1,3 +1,3 @@
 kind : api
 
-metrics_sql: select timestamp, publisher, domain from ad_bids_metrics LIMIT 5
+metrics_sql: select pub, dom from ad_bids_metrics LIMIT 5

--- a/runtime/testruntime/testdata/ad_bids/apis/templated_mv_sql_api.yaml
+++ b/runtime/testruntime/testdata/ad_bids/apis/templated_mv_sql_api.yaml
@@ -1,3 +1,3 @@
 kind : api
 
-metrics_sql: select publisher, domain, AGGREGATE("measure_2") as total_imp from ad_bids_mini_metrics where domain = '{{ .args.domain }}' GROUP BY ALL
+metrics_sql: select publisher, domain, AGGREGATE("measure_2") from ad_bids_mini_metrics where domain = '{{ .args.domain }}' GROUP BY ALL

--- a/runtime/testruntime/testdata/ad_bids/dashboards/ad_bids_mini_metrics_with_policy.yaml
+++ b/runtime/testruntime/testdata/ad_bids/dashboards/ad_bids_mini_metrics_with_policy.yaml
@@ -7,7 +7,8 @@ smallest_time_grain: ""
 
 dimensions:
   - label: Publisher
-    property: publisher
+    name: publisher
+    expression: upper(publisher)
     description: ""
   - label: Domain
     property: domain


### PR DESCRIPTION
1. Adds support for dimension expressions in metrics_sql
2. Joins are not supported
3. User defined aliases or shorthand notations are not supported. The rewritten sql will have the alias same as the dimension and measure.
4. Alias for dimension and measure is not supported but can be added if required.