### PR TITLE
Disable chart pan on cmd/alt + arrow key

### DIFF
--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -43,10 +43,6 @@ const { update, subscribe } = writable({
   entities: {},
 } as MetricsExplorerStoreType);
 
-function updateMetricsExplorerProto(metricsExplorer: MetricsExplorerEntity) {
-  metricsExplorer.proto = getProtoFromDashboardState(metricsExplorer);
-}
-
 export const updateMetricsExplorerByName = (
   name: string,
   callback: (metricsExplorer: MetricsExplorerEntity) => void,
@@ -57,8 +53,6 @@ export const updateMetricsExplorerByName = (
     }
 
     callback(state.entities[name]);
-    // every change triggers a proto update
-    updateMetricsExplorerProto(state.entities[name]);
     return state;
   });
 };
@@ -187,8 +181,6 @@ const metricViewReducers = {
       state.entities[name] = restorePersistedDashboardState(
         state.entities[name],
       );
-
-      updateMetricsExplorerProto(state.entities[name]);
 
       return state;
     });

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -43,6 +43,10 @@ const { update, subscribe } = writable({
   entities: {},
 } as MetricsExplorerStoreType);
 
+function updateMetricsExplorerProto(metricsExplorer: MetricsExplorerEntity) {
+  metricsExplorer.proto = getProtoFromDashboardState(metricsExplorer);
+}
+
 export const updateMetricsExplorerByName = (
   name: string,
   callback: (metricsExplorer: MetricsExplorerEntity) => void,
@@ -53,6 +57,8 @@ export const updateMetricsExplorerByName = (
     }
 
     callback(state.entities[name]);
+    // every change triggers a proto update
+    updateMetricsExplorerProto(state.entities[name]);
     return state;
   });
 };
@@ -181,6 +187,8 @@ const metricViewReducers = {
       state.entities[name] = restorePersistedDashboardState(
         state.entities[name],
       );
+
+      updateMetricsExplorerProto(state.entities[name]);
 
       return state;
     });

--- a/web-common/src/features/dashboards/time-series/ChartInteractions.svelte
+++ b/web-common/src/features/dashboards/time-series/ChartInteractions.svelte
@@ -28,12 +28,12 @@
     if (["INPUT", "TEXTAREA", "SELECT"].includes(targetTagName)) {
       return;
     }
-    if (e.key === "ArrowLeft") {
+    if (e.key === "ArrowLeft" && !e.metaKey && !e.altKey) {
       if ($canPanLeft) {
         const panRange = $getNewPanRange("left");
         if (panRange) updatePanRange(panRange.start, panRange.end);
       }
-    } else if (e.key === "ArrowRight") {
+    } else if (e.key === "ArrowRight" && !e.metaKey && !e.altKey) {
       if ($canPanRight) {
         const panRange = $getNewPanRange("right");
         if (panRange) updatePanRange(panRange.start, panRange.end);


### PR DESCRIPTION
Pressing cmd/alt + left/right keys for navigation also updates time range because of chart panning. This interferes with history navigation of the browser and url state restoring.

This PR disables chart pan when cmd/alt key is pressed.