### PR TITLE
Fix format of ducksql sample select query

### DIFF
--- a/runtime/pkg/duckdbsql/ast_test.go
+++ b/runtime/pkg/duckdbsql/ast_test.go
@@ -377,6 +377,11 @@ on publisher
 `,
 			`SELECT * FROM (SELECT * FROM AdBids WHERE (publisher IS NOT NULL)) UNPIVOT ("value" FOR "name" IN ('publisher'))`,
 		},
+		{
+			"percent sample",
+			`select * from read_parquet('data/sales_data_more_variability_aggregated.parquet') USING SAMPLE 10%`,
+			`SELECT * FROM sales_data_more_variability_aggregated USING SAMPLE 10% (System)`,
+		},
 	}
 
 	for _, tt := range sqlVariations {

--- a/runtime/pkg/duckdbsql/ast_traversal.go
+++ b/runtime/pkg/duckdbsql/ast_traversal.go
@@ -44,6 +44,7 @@ func (a *AST) traverseSelectQueryStatement(node astNode, isRoot bool) {
 		}
 		a.traverseCTEMap(toNode(node, astKeyCTE))
 		a.traverseFromTable(node, astKeyFromTable)
+		node[astKeySample] = a.correctSampleClause(toNode(node, astKeySample))
 
 	case "SET_OPERATION_NODE":
 		a.traverseCTEMap(toNode(node, astKeyCTE))

--- a/runtime/pkg/duckdbsql/ast_values.go
+++ b/runtime/pkg/duckdbsql/ast_values.go
@@ -26,6 +26,7 @@ const (
 	astKeyAlias            string = "alias"
 	astKeyID               string = "id"
 	astKeySample           string = "sample"
+	astKeySampleSize       string = "sample_size"
 	astKeyColumnNameAlias  string = "column_name_alias"
 	astKeyModifiers        string = "modifiers"
 	astKeyLimit            string = "limit"

--- a/runtime/pkg/duckdbsql/corrections.go
+++ b/runtime/pkg/duckdbsql/corrections.go
@@ -1,0 +1,17 @@
+package duckdbsql
+
+func (a *AST) correctSampleClause(node astNode) astNode {
+	if node == nil {
+		return nil
+	}
+	sampleSize := toNode(node, astKeySampleSize)
+	if sampleSize == nil {
+		return node
+	}
+	newSampleSize, err := createStandaloneValue(sampleSize[astKeyValue])
+	if err != nil {
+		return nil
+	}
+	node[astKeySampleSize] = newSampleSize
+	return node
+}

--- a/web-common/src/layout/RillDeveloperLayout.svelte
+++ b/web-common/src/layout/RillDeveloperLayout.svelte
@@ -34,7 +34,6 @@
     if (localStorage.getItem("customDashboards") === "true") {
       featureFlags.set(true, "customDashboards");
     }
-    // featureFlags
 
     appBuildMetaStore.set({
       version: config.version,
@@ -81,6 +80,7 @@
   <SourceImportedModal open={!!$sourceImportedName} />
 
   <div
+    role="application"
     class="index-body absolute w-screen h-screen"
     on:dragenter|preventDefault|stopPropagation
     on:dragleave|preventDefault|stopPropagation
@@ -89,7 +89,6 @@
     }}
     on:drag|preventDefault|stopPropagation
     on:drop|preventDefault|stopPropagation
-    role="application"
   >
     <WelcomePageRedirect>
       <BasicLayout>

--- a/web-common/src/layout/RillDeveloperLayout.svelte
+++ b/web-common/src/layout/RillDeveloperLayout.svelte
@@ -34,6 +34,7 @@
     if (localStorage.getItem("customDashboards") === "true") {
       featureFlags.set(true, "customDashboards");
     }
+    // featureFlags
 
     appBuildMetaStore.set({
       version: config.version,
@@ -80,7 +81,6 @@
   <SourceImportedModal open={!!$sourceImportedName} />
 
   <div
-    role="application"
     class="index-body absolute w-screen h-screen"
     on:dragenter|preventDefault|stopPropagation
     on:dragleave|preventDefault|stopPropagation
@@ -89,6 +89,7 @@
     }}
     on:drag|preventDefault|stopPropagation
     on:drop|preventDefault|stopPropagation
+    role="application"
   >
     <WelcomePageRedirect>
       <BasicLayout>


### PR DESCRIPTION
A query like this was erroring out,
```
select * from read_parquet('data/sales_data_more_variability_aggregated.parquet') USING SAMPLE 10%
```

This is because json format wont retain `.0`. This leads to a json like this,
```
"sample": {
  "sample_size": {
    "type": {
      "id": "DOUBLE",
      "type_info": null
    },
    "is_null": false,
    "value": 10 // Since this doesnt have a `.0` duckdb seem to assume it is uint
  },
  "is_percentage": true,
  "method": "System",
  "seed": -1
},
```

We need to change the `type.id` and match the type.