### PR TITLE
Runtime: Add log_queries config key to DuckDB driver

### DIFF
--- a/runtime/drivers/duckdb/config.go
+++ b/runtime/drivers/duckdb/config.go
@@ -46,6 +46,8 @@ type config struct {
 	DBFilePath string `mapstructure:"-"`
 	// ExtStoragePath is the path where the database files are stored in case external_table_storage is true. It is inferred from the DSN (can't be provided by user).
 	ExtStoragePath string `mapstructure:"-"`
+	// LogQueries controls whether to log the raw SQL passed to OLAP.Execute. (Internal queries will not be logged.)
+	LogQueries bool `mapstructure:"log_queries"`
 }
 
 func newConfig(cfgMap map[string]any) (*config, error) {

--- a/runtime/drivers/duckdb/olap.go
+++ b/runtime/drivers/duckdb/olap.go
@@ -69,6 +69,11 @@ func (c *connection) Exec(ctx context.Context, stmt *drivers.Statement) error {
 }
 
 func (c *connection) Execute(ctx context.Context, stmt *drivers.Statement) (res *drivers.Result, outErr error) {
+	// Log query if enabled (usually disabled)
+	if c.config.LogQueries {
+		c.logger.Info("duckdb query", zap.String("sql", stmt.Query), zap.Any("args", stmt.Args))
+	}
+
 	// We use the meta conn for dry run queries
 	if stmt.DryRun {
 		conn, release, err := c.acquireMetaConn(ctx)

--- a/runtime/drivers/duckdb/olap_crud_test.go
+++ b/runtime/drivers/duckdb/olap_crud_test.go
@@ -525,6 +525,6 @@ func verifyCount(t *testing.T, c *connection, table string, expected int) {
 	require.True(t, res.Next())
 	var count int
 	require.NoError(t, res.Scan(&count))
-	require.Equal(t, 1, count)
+	require.Equal(t, expected, count)
 	require.NoError(t, res.Close())
 }


### PR DESCRIPTION
Usage:

```bash
rill start dev-project --var connector.duckdb.log_queries=true
```

Note that it will only log queries passed to the OLAP interface. Internal queries (such as migrations and information schema queries) will not be logged.