### PR TITLE
Cloud UI: handle more than 20 orgs in the Org Breadcrumb's dropdown menu

### DIFF
--- a/web-admin/src/features/navigation/BreadcrumbItem.svelte
+++ b/web-admin/src/features/navigation/BreadcrumbItem.svelte
@@ -12,7 +12,7 @@
   export let isCurrentPage = false;
 </script>
 
-<li class="flex flex items-center gap-x-2 p-2">
+<li class="flex items-center gap-x-2 p-2">
   <slot name="icon" />
   <div class="flex flex-row gap-x-1 items-center">
     <a
@@ -30,7 +30,7 @@
         >
           <CaretDownIcon size="14px" />
         </DropdownMenu.Trigger>
-        <DropdownMenu.Content align="start">
+        <DropdownMenu.Content align="start" class="max-h-96 overflow-auto">
           {#each menuOptions as option}
             <DropdownMenu.Item on:click={() => onSelectMenuOption(option.key)}>
               {#if option.key === menuKey}

--- a/web-admin/src/features/navigation/Breadcrumbs.svelte
+++ b/web-admin/src/features/navigation/Breadcrumbs.svelte
@@ -34,11 +34,14 @@
   // Org breadcrumb
   $: orgName = $page.params.organization;
   $: organization = createAdminServiceGetOrganization(orgName);
-  $: organizations = createAdminServiceListOrganizations(undefined, {
-    query: {
-      enabled: !!$user.data?.user,
+  $: organizations = createAdminServiceListOrganizations(
+    { pageSize: 100 },
+    {
+      query: {
+        enabled: !!$user.data?.user,
+      },
     },
-  });
+  );
   $: onOrganizationPage = isOrganizationPage($page);
   async function onOrgChange(org: string) {
     const activeOrgLocalStorageKey = getActiveOrgLocalStorageKey(


### PR DESCRIPTION
In the Org Breadcrumb's call to `ListOrganizations`, we have not yet set a specific page size. The page size defaults to 20. This PR explicitly sets a page size of 100.

Further, to accommodate many results, this PR adds a maximum height and scrollbar to the Breadcrumb dropdown menus.

This is a quick fix. In the future, we can add a search box and/or lazy loading for large lists (including in the project and dashboard breadcrumbs).