### PR TITLE
Style: Increase code editor font weight

### DIFF
--- a/web-common/src/components/editor/theme.ts
+++ b/web-common/src/components/editor/theme.ts
@@ -5,6 +5,7 @@ export const editorTheme = () =>
       overflowX: "hidden",
       width: "100%",
       height: "100%",
+      fontWeight: "500",
       "&.cm-focused": {
         outline: "none",
       },


### PR DESCRIPTION
Increase the code editor font-weight from default(400) to 500

More - https://rilldata.slack.com/archives/C04JP568RR6/p1710153070240849