### PR TITLE
Alerts: Remove "Evaluation interval" from the UI

### DIFF
--- a/web-admin/src/features/alerts/metadata/AlertMetadata.svelte
+++ b/web-admin/src/features/alerts/metadata/AlertMetadata.svelte
@@ -4,10 +4,7 @@
   import AlertFilterCriteria from "@rilldata/web-admin/features/alerts/metadata/AlertFilterCriteria.svelte";
   import AlertFilters from "@rilldata/web-admin/features/alerts/metadata/AlertFilters.svelte";
   import AlertOwnerBlock from "@rilldata/web-admin/features/alerts/metadata/AlertOwnerBlock.svelte";
-  import {
-    humaniseAlertRunDuration,
-    humaniseAlertSnoozeOption,
-  } from "@rilldata/web-admin/features/alerts/metadata/utils";
+  import { humaniseAlertSnoozeOption } from "@rilldata/web-admin/features/alerts/metadata/utils";
   import {
     useAlert,
     useAlertDashboardName,
@@ -47,9 +44,6 @@
     $alertQuery.data?.resource?.alert?.spec?.queryArgsJson ?? "{}",
   ) as V1MetricsViewAggregationRequest;
 
-  $: runInterval = humaniseAlertRunDuration(
-    $alertQuery.data?.resource?.alert?.spec,
-  );
   $: snoozeLabel = humaniseAlertSnoozeOption(
     $alertQuery.data?.resource?.alert?.spec,
   );
@@ -144,12 +138,6 @@
       <div class="flex flex-col gap-y-3">
         <MetadataLabel>Schedule</MetadataLabel>
         <MetadataValue>Whenever your data refreshes</MetadataValue>
-      </div>
-
-      <!-- Split by time grain -->
-      <div class="flex flex-col gap-y-3">
-        <MetadataLabel>Evaluation interval</MetadataLabel>
-        <MetadataValue>{runInterval}</MetadataValue>
       </div>
 
       <!-- Snooze -->

--- a/web-common/src/features/alerts/CreateAlertDialog.svelte
+++ b/web-common/src/features/alerts/CreateAlertDialog.svelte
@@ -80,7 +80,6 @@
           data: {
             options: {
               title: values.name,
-              intervalDuration: values.evaluationInterval,
               queryName: "MetricsViewAggregation",
               queryArgsJson: JSON.stringify(
                 getAlertQueryArgsFromFormValues(values),

--- a/web-common/src/features/alerts/EditAlertDialog.svelte
+++ b/web-common/src/features/alerts/EditAlertDialog.svelte
@@ -70,7 +70,6 @@
           data: {
             options: {
               title: values.name,
-              intervalDuration: values.evaluationInterval,
               queryName: "MetricsViewAggregation",
               queryArgsJson: JSON.stringify(
                 getAlertQueryArgsFromFormValues(values),

--- a/web-common/src/features/alerts/delivery-tab/AlertDialogDeliveryTab.svelte
+++ b/web-common/src/features/alerts/delivery-tab/AlertDialogDeliveryTab.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import FormSection from "@rilldata/web-common/components/forms/FormSection.svelte";
   import Select from "@rilldata/web-common/components/forms/Select.svelte";
-  import { AlertIntervalOptions } from "@rilldata/web-common/features/alerts/delivery-tab/intervals";
   import { SnoozeOptions } from "@rilldata/web-common/features/alerts/delivery-tab/snooze";
   import RecipientsInputArray from "@rilldata/web-common/features/scheduled-reports/RecipientsInputArray.svelte";
 
@@ -15,34 +14,6 @@
     description="We'll check for this alert whenever the data refreshes"
     title="Schedule"
   />
-  <FormSection
-    description="Choose the interval at which the alert is evaluated since the prior data refresh."
-    title="Evaluation interval"
-  >
-    <Select
-      bind:value={$form["evaluationInterval"]}
-      id="evaluationInterval"
-      label=""
-      options={AlertIntervalOptions}
-    />
-    <ul class="list-disc ml-4" slot="tooltip-content">
-      <li>
-        Select ‘None’ to evaluate the alert only at the time of data refresh.
-      </li>
-      <li>
-        Select 'Hourly' to evaluate the alert for every hour that has passed
-        since the last refresh.
-      </li>
-      <li>
-        Select 'Daily' to evaluate the alert for every day that has passed since
-        the last refresh.
-      </li>
-      <li>
-        Select 'Weekly' to evaluate the alert for every week that has passed
-        since the last refresh.
-      </li>
-    </ul>
-  </FormSection>
   <FormSection
     description="Set a snooze period to silence repeat notifications for the same alert."
     title="Snooze"


### PR DESCRIPTION
The "Evaluation interval" is an advanced feature that accommodates late-arriving data. Given this feature applies to maybe 5% of use cases, it was discussed that we should remove it from the UI to not confuse the 95% of users who do not need it. The feature remains available through the Alert code artifact.

[Slack thread](https://rilldata.slack.com/archives/CTZ8XBQ85/p1710178949750839)