### PR TITLE
Fix: Pivot row totals data inconsistency

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-data-store.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-data-store.ts
@@ -22,7 +22,7 @@ import { sliceColumnAxesDataForDef } from "./pivot-infinite-scroll";
 import {
   createPivotAggregationRowQuery,
   getAxisForDimensions,
-  getAxisQueryForOtherMeasures,
+  getAxisQueryForMeasureTotals,
   getTotalsRowQuery,
 } from "./pivot-queries";
 import {
@@ -334,6 +334,7 @@ function createPivotDataStore(ctx: StateManagers): PivotDataStore {
           }
         }
 
+        // Get sort order for the anchor dimension
         const rowDimensionAxisQuery = getAxisForDimensions(
           ctx,
           config,
@@ -410,7 +411,7 @@ function createPivotDataStore(ctx: StateManagers): PivotDataStore {
 
             const totalColumns = getTotalColumnCount(totalsRow);
 
-            const rowAxesQueryForOtherMeasures = getAxisQueryForOtherMeasures(
+            const rowAxesQueryForMeasureTotals = getAxisQueryForMeasureTotals(
               ctx,
               config,
               isMeasureSortAccessor,
@@ -457,9 +458,9 @@ function createPivotDataStore(ctx: StateManagers): PivotDataStore {
              * Derive a store from initial table cell data query
              */
             return derived(
-              [rowAxesQueryForOtherMeasures, initialTableCellQuery],
-              ([rowOtherMeasuresAxesQuery, initialTableCellData], cellSet) => {
-                if (rowOtherMeasuresAxesQuery?.isFetching) {
+              [rowAxesQueryForMeasureTotals, initialTableCellQuery],
+              ([rowMeasureTotalsAxesQuery, initialTableCellData], cellSet) => {
+                if (rowMeasureTotalsAxesQuery?.isFetching) {
                   return cellSet({
                     isFetching: true,
                     data: rowTotals,
@@ -472,8 +473,8 @@ function createPivotDataStore(ctx: StateManagers): PivotDataStore {
                 const mergedRowTotals = mergeRowTotals(
                   rowDimensionValues,
                   rowTotals,
-                  rowOtherMeasuresAxesQuery?.data?.[anchorDimension] || [],
-                  rowOtherMeasuresAxesQuery?.totals?.[anchorDimension] || [],
+                  rowMeasureTotalsAxesQuery?.data?.[anchorDimension] || [],
+                  rowMeasureTotalsAxesQuery?.totals?.[anchorDimension] || [],
                 );
 
                 let pivotData: PivotDataRow[] = [];

--- a/web-common/src/features/dashboards/pivot/pivot-queries.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-queries.ts
@@ -20,7 +20,7 @@ import type { CreateQueryResult } from "@tanstack/svelte-query";
 import { Readable, derived, readable } from "svelte/store";
 import { mergeFilters } from "./pivot-merge-filters";
 import {
-  getFilterForOtherMeasuresAxesQuery,
+  getFilterForMeasuresTotalsAxesQuery,
   getTimeGrainFromDimension,
   isTimeDimension,
 } from "./pivot-utils";
@@ -171,7 +171,7 @@ export function getAxisForDimensions(
   );
 }
 
-export function getAxisQueryForOtherMeasures(
+export function getAxisQueryForMeasureTotals(
   ctx: StateManagers,
   config: PivotDataStoreConfig,
   isMeasureSortAccessor: boolean,
@@ -179,31 +179,29 @@ export function getAxisQueryForOtherMeasures(
   rowDimensionValues: string[],
   timeRange: TimeRangeString,
 ) {
-  let rowAxesQueryForOtherMeasures: Readable<PivotAxesData | null> =
+  let rowAxesQueryForMeasureTotals: Readable<PivotAxesData | null> =
     readable(null);
 
   if (rowDimensionValues.length && isMeasureSortAccessor && sortAccessor) {
     const { measureNames, rowDimensionNames } = config;
-    const otherMeasuresBody = measureNames
-      .map((m) => ({ name: m }))
-      .filter((m) => m.name !== sortAccessor);
+    const measuresBody = measureNames.map((m) => ({ name: m }));
 
-    const sortedRowFilters = getFilterForOtherMeasuresAxesQuery(
+    const sortedRowFilters = getFilterForMeasuresTotalsAxesQuery(
       config,
       rowDimensionValues,
     );
-    rowAxesQueryForOtherMeasures = getAxisForDimensions(
+    rowAxesQueryForMeasureTotals = getAxisForDimensions(
       ctx,
       config,
       rowDimensionNames.slice(0, 1),
-      otherMeasuresBody,
+      measuresBody,
       sortedRowFilters,
       [],
       timeRange,
     );
   }
 
-  return rowAxesQueryForOtherMeasures;
+  return rowAxesQueryForMeasureTotals;
 }
 
 export function getTotalsRowQuery(

--- a/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
@@ -143,23 +143,21 @@ export function mergeRowTotals(
   sortedRowTotals: V1MetricsViewAggregationResponseDataItem[],
   unsortedRowValues: string[],
   unsortedRowTotals: V1MetricsViewAggregationResponseDataItem[],
-) {
+): V1MetricsViewAggregationResponseDataItem[] {
   if (unsortedRowValues.length === 0) {
     return sortedRowTotals;
   }
+
   const unsortedRowValuesMap = createIndexMap(unsortedRowValues);
 
-  const mergedRowTotals = sortedRowTotals.map((sortedRowTotal, i) => {
-    const unsortedRowIndex = unsortedRowValuesMap.get(rowValues[i]);
+  const orderedRowTotals = rowValues.map((rowValue) => {
+    const unsortedRowIndex = unsortedRowValuesMap.get(rowValue);
     if (unsortedRowIndex === undefined) {
-      return sortedRowTotal;
+      console.error("Row value not found in unsorted row values", rowValue);
     }
-    const unsortedRowTotal = unsortedRowTotals[i];
-    return {
-      ...unsortedRowTotal,
-      ...sortedRowTotal,
-    };
+    const rowTotal = unsortedRowTotals[unsortedRowIndex as number];
+    return rowTotal;
   });
 
-  return mergedRowTotals;
+  return orderedRowTotals;
 }

--- a/web-common/src/features/dashboards/pivot/pivot-utils.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-utils.ts
@@ -380,7 +380,7 @@ export function getSortForAccessor(
   };
 }
 
-export function getFilterForOtherMeasuresAxesQuery(
+export function getFilterForMeasuresTotalsAxesQuery(
   config: PivotDataStoreConfig,
   rowDimensionValues: string[],
 ): V1Expression {


### PR DESCRIPTION
Fixes #4338

The initial row query (rowDimensionAxisQuery) when called with measure filters would only return measure totals with the applied filter.

To fix this, we have another query through which we get the totals for all measures and place them in the order defined by the first row query.