### PR TITLE
Runtime: Support OLAP connector overrides in analytical APIs

### DIFF
--- a/runtime/connections.go
+++ b/runtime/connections.go
@@ -111,13 +111,19 @@ func (r *Runtime) AI(ctx context.Context, instanceID string) (drivers.AIService,
 	return ai, release, nil
 }
 
-func (r *Runtime) OLAP(ctx context.Context, instanceID string) (drivers.OLAPStore, func(), error) {
+// OLAP returns a handle for an OLAP data store.
+// The connector argument is optional. If not provided, the instance's default OLAP connector is used.
+func (r *Runtime) OLAP(ctx context.Context, instanceID string, connector string) (drivers.OLAPStore, func(), error) {
 	inst, err := r.Instance(ctx, instanceID)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	conn, release, err := r.AcquireHandle(ctx, instanceID, inst.ResolveOLAPConnector())
+	if connector == "" {
+		connector = inst.ResolveOLAPConnector()
+	}
+
+	conn, release, err := r.AcquireHandle(ctx, instanceID, connector)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -125,7 +131,7 @@ func (r *Runtime) OLAP(ctx context.Context, instanceID string) (drivers.OLAPStor
 	olap, ok := conn.AsOLAP(instanceID)
 	if !ok {
 		release()
-		return nil, nil, fmt.Errorf("connector %q is not a valid OLAP data store", inst.ResolveOLAPConnector())
+		return nil, nil, fmt.Errorf("connector %q is not a valid OLAP data store", connector)
 	}
 
 	return olap, release, nil

--- a/runtime/connections.go
+++ b/runtime/connections.go
@@ -113,7 +113,7 @@ func (r *Runtime) AI(ctx context.Context, instanceID string) (drivers.AIService,
 
 // OLAP returns a handle for an OLAP data store.
 // The connector argument is optional. If not provided, the instance's default OLAP connector is used.
-func (r *Runtime) OLAP(ctx context.Context, instanceID string, connector string) (drivers.OLAPStore, func(), error) {
+func (r *Runtime) OLAP(ctx context.Context, instanceID, connector string) (drivers.OLAPStore, func(), error) {
 	inst, err := r.Instance(ctx, instanceID)
 	if err != nil {
 		return nil, nil, err

--- a/runtime/controller_test.go
+++ b/runtime/controller_test.go
@@ -231,7 +231,7 @@ path: data/foo.csv
 	testruntime.RequireOLAPTableCount(t, rt, id, "foo", 1)
 
 	// Delete the underlying table
-	olap, release, err := rt.OLAP(context.Background(), id)
+	olap, release, err := rt.OLAP(context.Background(), id, "")
 	require.NoError(t, err)
 	err = olap.Exec(context.Background(), &drivers.Statement{Query: "DROP TABLE foo;"})
 	require.NoError(t, err)
@@ -462,7 +462,7 @@ select 1
 	testruntime.ReconcileParserAndWait(t, rt, id)
 	testruntime.RequireReconcileState(t, rt, id, 2, 0, 0)
 
-	olap, done, err := rt.OLAP(context.Background(), id)
+	olap, done, err := rt.OLAP(context.Background(), id, "")
 	require.NoError(t, err)
 	defer done()
 

--- a/runtime/queries/column_cardinality.go
+++ b/runtime/queries/column_cardinality.go
@@ -13,6 +13,7 @@ import (
 )
 
 type ColumnCardinality struct {
+	Connector  string
 	TableName  string
 	ColumnName string
 	Result     float64
@@ -48,7 +49,7 @@ func (q *ColumnCardinality) UnmarshalResult(v any) error {
 }
 
 func (q *ColumnCardinality) Resolve(ctx context.Context, rt *runtime.Runtime, instanceID string, priority int) error {
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.Connector)
 	if err != nil {
 		return err
 	}

--- a/runtime/queries/column_desc_stats.go
+++ b/runtime/queries/column_desc_stats.go
@@ -11,6 +11,7 @@ import (
 )
 
 type ColumnDescriptiveStatistics struct {
+	Connector  string
 	TableName  string
 	ColumnName string
 	Result     *runtimev1.NumericStatistics
@@ -46,7 +47,7 @@ func (q *ColumnDescriptiveStatistics) UnmarshalResult(v any) error {
 }
 
 func (q *ColumnDescriptiveStatistics) Resolve(ctx context.Context, rt *runtime.Runtime, instanceID string, priority int) error {
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.Connector)
 	if err != nil {
 		return err
 	}

--- a/runtime/queries/column_null_count.go
+++ b/runtime/queries/column_null_count.go
@@ -12,6 +12,7 @@ import (
 )
 
 type ColumnNullCount struct {
+	Connector  string
 	TableName  string
 	ColumnName string
 	Result     float64
@@ -47,7 +48,7 @@ func (q *ColumnNullCount) UnmarshalResult(v any) error {
 }
 
 func (q *ColumnNullCount) Resolve(ctx context.Context, rt *runtime.Runtime, instanceID string, priority int) error {
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.Connector)
 	if err != nil {
 		return err
 	}

--- a/runtime/queries/column_numeric_histogram.go
+++ b/runtime/queries/column_numeric_histogram.go
@@ -12,6 +12,7 @@ import (
 )
 
 type ColumnNumericHistogram struct {
+	Connector  string
 	TableName  string
 	ColumnName string
 	Method     runtimev1.HistogramMethod
@@ -136,7 +137,7 @@ func (q *ColumnNumericHistogram) calculateBucketSize(ctx context.Context, olap d
 }
 
 func (q *ColumnNumericHistogram) calculateFDMethod(ctx context.Context, rt *runtime.Runtime, instanceID string, priority int) error {
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.Connector)
 	if err != nil {
 		return err
 	}
@@ -254,7 +255,7 @@ func (q *ColumnNumericHistogram) calculateFDMethod(ctx context.Context, rt *runt
 }
 
 func (q *ColumnNumericHistogram) calculateDiagnosticMethod(ctx context.Context, rt *runtime.Runtime, instanceID string, priority int) error {
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.Connector)
 	if err != nil {
 		return err
 	}

--- a/runtime/queries/column_rug_histogram.go
+++ b/runtime/queries/column_rug_histogram.go
@@ -11,6 +11,7 @@ import (
 )
 
 type ColumnRugHistogram struct {
+	Connector  string
 	TableName  string
 	ColumnName string
 	Result     []*runtimev1.NumericOutliers_Outlier
@@ -51,7 +52,7 @@ func (q *ColumnRugHistogram) UnmarshalResult(v any) error {
 }
 
 func (q *ColumnRugHistogram) Resolve(ctx context.Context, rt *runtime.Runtime, instanceID string, priority int) error {
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.Connector)
 	if err != nil {
 		return err
 	}

--- a/runtime/queries/column_time_grain.go
+++ b/runtime/queries/column_time_grain.go
@@ -12,6 +12,7 @@ import (
 )
 
 type ColumnTimeGrain struct {
+	Connector  string
 	TableName  string
 	ColumnName string
 	Result     runtimev1.TimeGrain
@@ -56,7 +57,7 @@ func (q *ColumnTimeGrain) Resolve(ctx context.Context, rt *runtime.Runtime, inst
 		return err
 	}
 
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.Connector)
 	if err != nil {
 		return err
 	}

--- a/runtime/queries/column_time_range.go
+++ b/runtime/queries/column_time_range.go
@@ -20,6 +20,7 @@ const hourInDay = 24
 var microsInDay = hourInDay * time.Hour.Microseconds()
 
 type ColumnTimeRange struct {
+	Connector  string
 	TableName  string
 	ColumnName string
 	Result     *runtimev1.TimeRangeSummary
@@ -55,7 +56,7 @@ func (q *ColumnTimeRange) UnmarshalResult(v any) error {
 }
 
 func (q *ColumnTimeRange) Resolve(ctx context.Context, rt *runtime.Runtime, instanceID string, priority int) error {
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.Connector)
 	if err != nil {
 		return err
 	}

--- a/runtime/queries/column_timeseries.go
+++ b/runtime/queries/column_timeseries.go
@@ -34,6 +34,7 @@ type ColumnTimeseriesResult struct {
 }
 
 type ColumnTimeseries struct {
+	Connector           string                                            `json:"connector"`
 	TableName           string                                            `json:"table_name"`
 	Measures            []*runtimev1.ColumnTimeSeriesRequest_BasicMeasure `json:"measures"`
 	TimestampColumnName string                                            `json:"timestamp_column_name"`
@@ -85,7 +86,7 @@ func (q *ColumnTimeseries) UnmarshalResult(v any) error {
 }
 
 func (q *ColumnTimeseries) Resolve(ctx context.Context, rt *runtime.Runtime, instanceID string, priority int) error {
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.Connector)
 	if err != nil {
 		return err
 	}

--- a/runtime/queries/column_timeseries_test.go
+++ b/runtime/queries/column_timeseries_test.go
@@ -191,7 +191,7 @@ func TestTimeseries_SparkOnly_same_timestamp(t *testing.T) {
 		Pixels:              2.0,
 	}
 	ctx := context.Background()
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.Connector)
 	require.NoError(t, err)
 	defer release()
 	values, err := q.CreateTimestampRollupReduction(context.Background(), rt, olap, instanceID, 0, "test", "time", "clicks")
@@ -214,7 +214,7 @@ func TestTimeseries_SparkOnly(t *testing.T) {
 		Pixels: 2.0,
 	}
 	ctx := context.Background()
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.Connector)
 	require.NoError(t, err)
 	defer release()
 	values, err := q.CreateTimestampRollupReduction(context.Background(), rt, olap, instanceID, 0, "test", "time", "clicks")

--- a/runtime/queries/column_topk.go
+++ b/runtime/queries/column_topk.go
@@ -12,6 +12,7 @@ import (
 )
 
 type ColumnTopK struct {
+	Connector  string
 	TableName  string
 	ColumnName string
 	Agg        string
@@ -50,7 +51,7 @@ func (q *ColumnTopK) UnmarshalResult(v any) error {
 
 func (q *ColumnTopK) Resolve(ctx context.Context, rt *runtime.Runtime, instanceID string, priority int) error {
 	// Get OLAP connection
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.Connector)
 	if err != nil {
 		return err
 	}

--- a/runtime/queries/metricsview_rows.go
+++ b/runtime/queries/metricsview_rows.go
@@ -66,7 +66,7 @@ func (q *MetricsViewRows) UnmarshalResult(v any) error {
 }
 
 func (q *MetricsViewRows) Resolve(ctx context.Context, rt *runtime.Runtime, instanceID string, priority int) error {
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.MetricsView.Connector)
 	if err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func (q *MetricsViewRows) Resolve(ctx context.Context, rt *runtime.Runtime, inst
 }
 
 func (q *MetricsViewRows) Export(ctx context.Context, rt *runtime.Runtime, instanceID string, w io.Writer, opts *runtime.ExportOptions) error {
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.MetricsView.Connector)
 	if err != nil {
 		return err
 	}

--- a/runtime/queries/metricsview_time_range.go
+++ b/runtime/queries/metricsview_time_range.go
@@ -65,7 +65,7 @@ func (q *MetricsViewTimeRange) Resolve(ctx context.Context, rt *runtime.Runtime,
 		return fmt.Errorf("metrics view '%s' does not have a time dimension", q.MetricsViewName)
 	}
 
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.MetricsView.Connector)
 	if err != nil {
 		return err
 	}

--- a/runtime/queries/metricsview_timeseries.go
+++ b/runtime/queries/metricsview_timeseries.go
@@ -78,7 +78,7 @@ func (q *MetricsViewTimeSeries) Resolve(ctx context.Context, rt *runtime.Runtime
 		return fmt.Errorf("metrics view '%s' does not have a time dimension", q.MetricsViewName)
 	}
 
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.MetricsView.Connector)
 	if err != nil {
 		return err
 	}

--- a/runtime/queries/metricsview_toplist.go
+++ b/runtime/queries/metricsview_toplist.go
@@ -67,7 +67,7 @@ func (q *MetricsViewToplist) UnmarshalResult(v any) error {
 }
 
 func (q *MetricsViewToplist) Resolve(ctx context.Context, rt *runtime.Runtime, instanceID string, priority int) error {
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.MetricsView.Connector)
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func (q *MetricsViewToplist) Resolve(ctx context.Context, rt *runtime.Runtime, i
 }
 
 func (q *MetricsViewToplist) Export(ctx context.Context, rt *runtime.Runtime, instanceID string, w io.Writer, opts *runtime.ExportOptions) error {
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.MetricsView.Connector)
 	if err != nil {
 		return err
 	}

--- a/runtime/queries/metricsview_totals.go
+++ b/runtime/queries/metricsview_totals.go
@@ -63,7 +63,7 @@ func (q *MetricsViewTotals) UnmarshalResult(v any) error {
 }
 
 func (q *MetricsViewTotals) Resolve(ctx context.Context, rt *runtime.Runtime, instanceID string, priority int) error {
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.MetricsView.Connector)
 	if err != nil {
 		return err
 	}

--- a/runtime/queries/resource_watermark.go
+++ b/runtime/queries/resource_watermark.go
@@ -90,7 +90,7 @@ func (q *ResourceWatermark) resolveMetricsView(ctx context.Context, rt *runtime.
 		return nil
 	}
 
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, spec.Connector)
 	if err != nil {
 		return err
 	}

--- a/runtime/queries/table_cardinality.go
+++ b/runtime/queries/table_cardinality.go
@@ -12,6 +12,7 @@ import (
 )
 
 type TableCardinality struct {
+	Connector string
 	TableName string
 	Result    int64
 }
@@ -50,7 +51,7 @@ func (q *TableCardinality) Resolve(ctx context.Context, rt *runtime.Runtime, ins
 		safeName(q.TableName),
 	)
 
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.Connector)
 	if err != nil {
 		return err
 	}

--- a/runtime/queries/table_columns.go
+++ b/runtime/queries/table_columns.go
@@ -13,6 +13,7 @@ import (
 )
 
 type TableColumns struct {
+	Connector string
 	TableName string
 	Result    []*runtimev1.ProfileColumn
 }
@@ -52,7 +53,7 @@ func (q *TableColumns) UnmarshalResult(v any) error {
 }
 
 func (q *TableColumns) Resolve(ctx context.Context, rt *runtime.Runtime, instanceID string, priority int) error {
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.Connector)
 	if err != nil {
 		return err
 	}

--- a/runtime/queries/table_head.go
+++ b/runtime/queries/table_head.go
@@ -12,6 +12,7 @@ import (
 )
 
 type TableHead struct {
+	Connector string
 	TableName string
 	Limit     int
 	Result    []*structpb.Struct
@@ -54,7 +55,7 @@ func (q *TableHead) UnmarshalResult(v any) error {
 }
 
 func (q *TableHead) Resolve(ctx context.Context, rt *runtime.Runtime, instanceID string, priority int) error {
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.Connector)
 	if err != nil {
 		return err
 	}
@@ -86,7 +87,7 @@ func (q *TableHead) Resolve(ctx context.Context, rt *runtime.Runtime, instanceID
 }
 
 func (q *TableHead) Export(ctx context.Context, rt *runtime.Runtime, instanceID string, w io.Writer, opts *runtime.ExportOptions) error {
-	olap, release, err := rt.OLAP(ctx, instanceID)
+	olap, release, err := rt.OLAP(ctx, instanceID, q.Connector)
 	if err != nil {
 		return err
 	}

--- a/runtime/query.go
+++ b/runtime/query.go
@@ -62,32 +62,32 @@ func (r *Runtime) Query(ctx context.Context, instanceID string, query Query, pri
 		return query.Resolve(ctx, r, instanceID, priority)
 	}
 
-	// Skip caching for specific named drivers.
-	// TODO: Make this configurable with a default provided by the driver.
-	olap, release, err := r.OLAP(ctx, instanceID)
-	if err != nil {
-		return err
-	}
-	// TODO :: check enabling caching at clickhouse level
-	if olap.Dialect() == drivers.DialectDruid || olap.Dialect() == drivers.DialectClickHouse {
-		release()
-		return query.Resolve(ctx, r, instanceID, priority)
-	}
-	release()
-
-	// Get dependency cache keys
+	// Get dependency cache keys and optionally the underlying OLAP connector
 	ctrl, err := r.Controller(ctx, instanceID)
 	if err != nil {
 		return err
 	}
 	deps := query.Deps()
 	depKeys := make([]string, 0, len(deps))
+	olapConnector := ""
 	for _, dep := range deps {
+		// Get the dependency resource
 		res, err := ctrl.Get(ctx, dep, false)
 		if err != nil {
 			// Deps are approximate, not exact (see docstring for Deps()), so they may not all exist
 			continue
 		}
+
+		// Infer OLAP connector for common resource types used in a query
+		if mv := res.GetMetricsView(); mv != nil {
+			olapConnector = mv.Spec.Connector
+		} else if mdl := res.GetModel(); mdl != nil {
+			olapConnector = mdl.Spec.Connector
+		} else if src := res.GetSource(); src != nil {
+			olapConnector = src.Spec.SinkConnector
+		}
+
+		// Add to cache key.
 		// Using StateUpdatedOn instead of StateVersion because the state version is reset when the resource is deleted and recreated.
 		key := fmt.Sprintf("%s:%s:%d:%d", res.Meta.Name.Kind, res.Meta.Name.Name, res.Meta.StateUpdatedOn.Seconds, res.Meta.StateUpdatedOn.Nanos/int32(time.Millisecond))
 		depKeys = append(depKeys, key)
@@ -95,6 +95,18 @@ func (r *Runtime) Query(ctx context.Context, instanceID string, query Query, pri
 
 	// If there were no known dependencies, skip caching
 	if len(depKeys) == 0 {
+		return query.Resolve(ctx, r, instanceID, priority)
+	}
+
+	// Skip caching if the OLAP connector is not DuckDB.
+	// NOTE: This hack is removed in the new resolvers by letting the resolver itself decide whether to cache or not.
+	olap, release, err := r.OLAP(ctx, instanceID, olapConnector)
+	if err != nil {
+		return err
+	}
+	dialect := olap.Dialect()
+	release()
+	if dialect != drivers.DialectDuckDB {
 		return query.Resolve(ctx, r, instanceID, priority)
 	}
 

--- a/runtime/registry_test.go
+++ b/runtime/registry_test.go
@@ -330,7 +330,7 @@ func TestRuntime_EditInstance(t *testing.T) {
 			require.NoError(t, err)
 
 			// Acquire OLAP (to make sure it's opened)
-			firstOlap, release, err := rt.OLAP(ctx, inst.ID)
+			firstOlap, release, err := rt.OLAP(ctx, inst.ID, "")
 			require.NoError(t, err)
 			release()
 
@@ -364,7 +364,7 @@ func TestRuntime_EditInstance(t *testing.T) {
 			require.Equal(t, tt.savedInst.Variables, newInst.Variables)
 
 			// Verify new olap connection is opened
-			olap, release, err := rt.OLAP(ctx, inst.ID)
+			olap, release, err := rt.OLAP(ctx, inst.ID, "")
 			require.NoError(t, err)
 			defer release()
 			err = olap.Exec(context.Background(), &drivers.Statement{Query: "SELECT COUNT(*) FROM rill.migration_version"})
@@ -417,7 +417,7 @@ func TestRuntime_DeleteInstance(t *testing.T) {
 			require.NoError(t, err)
 
 			// Acquire OLAP
-			olap, release, err := rt.OLAP(ctx, inst.ID)
+			olap, release, err := rt.OLAP(ctx, inst.ID, "")
 			require.NoError(t, err)
 			defer release()
 
@@ -484,7 +484,7 @@ func TestRuntime_DeleteInstance_DropCorrupted(t *testing.T) {
 	require.NoError(t, err)
 
 	// Put some data into it to create a .db file on disk
-	olap, release, err := rt.OLAP(ctx, inst.ID)
+	olap, release, err := rt.OLAP(ctx, inst.ID, "")
 	require.NoError(t, err)
 	defer release()
 	err = olap.Exec(ctx, &drivers.Statement{Query: "CREATE TABLE data(id INTEGER, name VARCHAR)"})
@@ -498,7 +498,7 @@ func TestRuntime_DeleteInstance_DropCorrupted(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check we can't open it anymore
-	_, _, err = rt.OLAP(ctx, inst.ID)
+	_, _, err = rt.OLAP(ctx, inst.ID, "")
 	require.Error(t, err)
 	require.FileExists(t, dbpath)
 

--- a/runtime/resolvers/metrics_sql_test.go
+++ b/runtime/resolvers/metrics_sql_test.go
@@ -9,7 +9,6 @@ import (
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
-	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/testruntime"
 	"github.com/stretchr/testify/require"
 )
@@ -59,7 +58,6 @@ func TestCompiler(t *testing.T) {
 				instanceID: instanceID,
 				ctrl:       ctrl,
 				sql:        tt.sql,
-				dialect:    drivers.DialectDuckDB,
 			}
 
 			got, _, deps, err := c.compile(context.Background())

--- a/runtime/resolvers/sql.go
+++ b/runtime/resolvers/sql.go
@@ -60,7 +60,7 @@ func newSQLWithRefs(ctx context.Context, opts *runtime.ResolverOptions, extraRef
 		return nil, err
 	}
 
-	olap, release, err := opts.Runtime.OLAP(ctx, opts.InstanceID)
+	olap, release, err := opts.Runtime.OLAP(ctx, opts.InstanceID, props.Connector)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/server/catalog.go
+++ b/runtime/server/catalog.go
@@ -409,7 +409,7 @@ func (s *Server) resourceToEntry(ctx context.Context, instanceID string, r *runt
 		RefreshedOn: r.Meta.StateUpdatedOn,
 	}
 
-	olap, release, err := s.runtime.OLAP(ctx, instanceID)
+	olap, release, err := s.runtime.OLAP(ctx, instanceID, "")
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/server/connectors.go
+++ b/runtime/server/connectors.go
@@ -222,13 +222,12 @@ func (s *Server) GCSGetCredentialsInfo(ctx context.Context, req *runtimev1.GCSGe
 }
 
 func (s *Server) OLAPListTables(ctx context.Context, req *runtimev1.OLAPListTablesRequest) (*runtimev1.OLAPListTablesResponse, error) {
-	conn, release, err := s.runtime.AcquireHandle(ctx, req.InstanceId, req.Connector)
+	olap, release, err := s.runtime.OLAP(ctx, req.InstanceId, req.Connector)
 	if err != nil {
 		return nil, err
 	}
 	defer release()
 
-	olap, _ := conn.AsOLAP(req.InstanceId)
 	tables, err := olap.InformationSchema().All(ctx)
 	if err != nil {
 		return nil, err
@@ -247,16 +246,11 @@ func (s *Server) OLAPListTables(ctx context.Context, req *runtimev1.OLAPListTabl
 }
 
 func (s *Server) OLAPGetTable(ctx context.Context, req *runtimev1.OLAPGetTableRequest) (*runtimev1.OLAPGetTableResponse, error) {
-	conn, release, err := s.runtime.AcquireHandle(ctx, req.InstanceId, req.Connector)
+	olap, release, err := s.runtime.OLAP(ctx, req.InstanceId, req.Connector)
 	if err != nil {
 		return nil, err
 	}
 	defer release()
-
-	olap, ok := conn.AsOLAP(req.InstanceId)
-	if !ok {
-		return nil, fmt.Errorf("connector %q is not an OLAP data store", req.Connector)
-	}
 
 	table, err := olap.InformationSchema().Lookup(ctx, req.Table)
 	if err != nil {

--- a/runtime/server/generate_metrics_view.go
+++ b/runtime/server/generate_metrics_view.go
@@ -51,8 +51,11 @@ func (s *Server) GenerateMetricsViewFile(ctx context.Context, req *runtimev1.Gen
 		return nil, err
 	}
 
-	// Determine if we're using the default OLAP connector
-	isDefaultConnector := req.Connector == "" || req.Connector == inst.ResolveOLAPConnector()
+	// If a connector is not provided, default to the instance's OLAP connector
+	if req.Connector == "" {
+		req.Connector = inst.ResolveOLAPConnector()
+	}
+	isDefaultConnector := req.Connector == inst.ResolveOLAPConnector()
 
 	// Connect to connector and check it's an OLAP db
 	olap, release, err := s.runtime.OLAP(ctx, req.InstanceId, req.Connector)

--- a/runtime/server/queries.go
+++ b/runtime/server/queries.go
@@ -36,7 +36,7 @@ func (s *Server) Query(ctx context.Context, req *runtimev1.QueryRequest) (*runti
 		args[i] = arg.AsInterface()
 	}
 
-	olap, release, err := s.runtime.OLAP(ctx, req.InstanceId)
+	olap, release, err := s.runtime.OLAP(ctx, req.InstanceId, "")
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/server/queries_columns_test.go
+++ b/runtime/server/queries_columns_test.go
@@ -609,7 +609,7 @@ func getColumnTestServerWithModel(t *testing.T, sql string, expectation int) (*s
 	server, err := server.NewServer(context.Background(), &server.Options{}, rt, nil, ratelimit.NewNoop(), activity.NewNoopClient())
 	require.NoError(t, err)
 
-	olap, release, err := rt.OLAP(testCtx(), instanceID)
+	olap, release, err := rt.OLAP(testCtx(), instanceID, "")
 	require.NoError(t, err)
 	defer release()
 	res, err := olap.Execute(testCtx(), &drivers.Statement{Query: "SELECT count(*) FROM test"})

--- a/runtime/server/queries_metrics.go
+++ b/runtime/server/queries_metrics.go
@@ -408,18 +408,11 @@ func (s *Server) MetricsViewSchema(ctx context.Context, req *runtimev1.MetricsVi
 		return nil, ErrForbidden
 	}
 
-	mv, _, err := resolveMVAndSecurity(ctx, s.runtime, req.InstanceId, req.MetricsViewName)
-	if err != nil {
-		return nil, err
-	}
-
 	q := &queries.MetricsViewSchema{
-		MetricsViewName: req.MetricsViewName,
-		TableName:       mv.Table,
-		Measures:        mv.Measures,
-		Dimensions:      mv.Dimensions,
+		MetricsViewName:    req.MetricsViewName,
+		SecurityAttributes: auth.GetClaims(ctx).Attributes(),
 	}
-	err = s.runtime.Query(ctx, req.InstanceId, q, int(req.Priority))
+	err := s.runtime.Query(ctx, req.InstanceId, q, int(req.Priority))
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/testruntime/olap.go
+++ b/runtime/testruntime/olap.go
@@ -11,7 +11,7 @@ import (
 )
 
 func RequireOLAPTable(t testing.TB, rt *runtime.Runtime, id, name string) {
-	olap, release, err := rt.OLAP(context.Background(), id)
+	olap, release, err := rt.OLAP(context.Background(), id, "")
 	require.NoError(t, err)
 	defer release()
 
@@ -20,7 +20,7 @@ func RequireOLAPTable(t testing.TB, rt *runtime.Runtime, id, name string) {
 }
 
 func RequireNoOLAPTable(t testing.TB, rt *runtime.Runtime, id, name string) {
-	olap, release, err := rt.OLAP(context.Background(), id)
+	olap, release, err := rt.OLAP(context.Background(), id, "")
 	require.NoError(t, err)
 	defer release()
 
@@ -29,7 +29,7 @@ func RequireNoOLAPTable(t testing.TB, rt *runtime.Runtime, id, name string) {
 }
 
 func RequireOLAPTableCount(t testing.TB, rt *runtime.Runtime, id, name string, count int) {
-	olap, release, err := rt.OLAP(context.Background(), id)
+	olap, release, err := rt.OLAP(context.Background(), id, "")
 	require.NoError(t, err)
 	defer release()
 


### PR DESCRIPTION
This PR enables a single Rill project to serve dashboards backed by different OLAP databases.

For some time, we have supported overriding the OLAP connector in model and dashboard YAML files. However, those overrides were not used in the analytical APIs, making the resulting resources broken in the UI. This PR fixes that.

Note that due to the UI locking down modeling when the default OLAP database is not DuckDB, to leverage multi-OLAP support, you must set DuckDB as the default OLAP connector (and then specify a different connector in the YAML for those dashboards that should not use DuckDB).

Closes https://github.com/rilldata/rill-private-issues/issues/194.