### PR TITLE
Add debug log for weird file watcher error

### DIFF
--- a/runtime/drivers/file/file.go
+++ b/runtime/drivers/file/file.go
@@ -67,6 +67,7 @@ func (d driver) Open(config map[string]any, shared bool, client *activity.Client
 	}
 
 	c := &connection{
+		logger:       logger,
 		root:         absPath,
 		driverConfig: config,
 		driverName:   d.name,
@@ -110,6 +111,7 @@ func parseSourceProperties(props map[string]any) (*sourceProperties, error) {
 }
 
 type connection struct {
+	logger *zap.Logger
 	// root should be absolute path
 	root         string
 	driverConfig map[string]any

--- a/runtime/drivers/file/repo.go
+++ b/runtime/drivers/file/repo.go
@@ -145,7 +145,7 @@ func (c *connection) Sync(ctx context.Context) error {
 func (c *connection) Watch(ctx context.Context, cb drivers.WatchCallback) error {
 	c.watcherMu.Lock()
 	if c.watcher == nil {
-		w, err := newWatcher(c.root)
+		w, err := newWatcher(c.root, c.logger)
 		if err != nil {
 			c.watcherMu.Unlock()
 			return err


### PR DESCRIPTION
It seems like my last fix here did not make this issue go away: https://github.com/rilldata/rill/pull/4254.

I'm not able to reproduce the issue, but saw it again.

Adding a warning log for it to get more contextual information for next time I see it...