### PR TITLE
Admin: Scaffolding for metrics project integration for autoscaling

### DIFF
--- a/admin/metrics.go
+++ b/admin/metrics.go
@@ -1,0 +1,58 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rilldata/rill/admin/metrics"
+	"github.com/rilldata/rill/runtime/server/auth"
+)
+
+const metricsProjectClientTTL = 30 * time.Minute
+
+// OpenMetricsProject opens a client for accessing the metrics project.
+// If a metrics project is not configured, it returns false for the second return value.
+// The returned client has a TTL of 30 minutes.
+// TODO: Encapsulate token refresh logic in the metrics client.
+func (s *Service) OpenMetricsProject(ctx context.Context) (*metrics.Client, bool, error) {
+	// Check if a metrics project is configured
+	if s.metricsProjectID == "" {
+		return nil, false, nil
+	}
+
+	// Find the production deployment for the metrics project
+	proj, err := s.DB.FindProject(ctx, s.metricsProjectID)
+	if err != nil {
+		return nil, false, err
+	}
+	if proj.ProdDeploymentID == nil {
+		return nil, false, fmt.Errorf("project does not have a production deployment")
+	}
+	depl, err := s.DB.FindDeployment(ctx, *proj.ProdDeploymentID)
+	if err != nil {
+		return nil, false, err
+	}
+	s.Used.Deployment(depl.ID)
+
+	// Mint a JWT for the metrics project
+	jwt, err := s.issuer.NewToken(auth.TokenOptions{
+		AudienceURL: depl.RuntimeAudience,
+		Subject:     "admin-service",
+		TTL:         metricsProjectClientTTL,
+		InstancePermissions: map[string][]auth.Permission{
+			depl.RuntimeInstanceID: {
+				auth.ReadAPI,
+				auth.ReadMetrics,
+				auth.ReadObjects,
+			},
+		},
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("could not issue jwt: %w", err)
+	}
+
+	// Create the metrics project client
+	client := metrics.NewClient(depl.RuntimeHost, depl.RuntimeInstanceID, jwt)
+	return client, true, nil
+}

--- a/admin/metrics/client.go
+++ b/admin/metrics/client.go
@@ -1,0 +1,84 @@
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"time"
+)
+
+// It can be used for such use cases as autoscaling, health checks, breached quotas, and usage calculations for billing.
+type Client struct {
+	RuntimeHost string
+	InstanceID  string
+	AccessToken string
+}
+
+// NewClient creates a new metrics project client.
+// It must be re-created after the provided access token expires.
+// TODO: Move minting and refresh of the access token to the client.
+func NewClient(runtimeHost, instanceID, accessToken string) *Client {
+	return &Client{
+		RuntimeHost: runtimeHost,
+		InstanceID:  instanceID,
+		AccessToken: accessToken,
+	}
+}
+
+// AutoscalerSlotsRecommendation represents a recommendation for the number of slots to use for a project.
+type AutoscalerSlotsRecommendation struct {
+	ProjectID        string    `json:"project_id"`
+	RecommendedSlots int       `json:"recommended_slots"`
+	UpdatedOn        time.Time `json:"updated_on"`
+}
+
+// AutoscalerSlotsRecommendations invokes the "autoscaler-slots-recommendations" API endpoint to get a list of recommendations for the number of slots to use for projects.
+func (c *Client) AutoscalerSlotsRecommendations(ctx context.Context, limit, offset int) ([]AutoscalerSlotsRecommendation, error) {
+	// Create the URL for the request
+	uri, err := url.Parse(c.RuntimeHost)
+	if err != nil {
+		return nil, err
+	}
+	uri.Path = path.Join("/v1/instances", c.InstanceID, "/api/autoscaler-slots-recommendations")
+	if limit > 0 {
+		uri.Query().Set("limit", fmt.Sprintf("%d", limit))
+	}
+	if offset > 0 {
+		uri.Query().Set("offset", fmt.Sprintf("%d", offset))
+	}
+	apiURL := uri.String()
+
+	// Create a new HTTP request
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the access token in the request headers
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.AccessToken))
+
+	// Send the request
+	client := http.DefaultClient
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// Check the response status code
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request failed with status code %d", resp.StatusCode)
+	}
+
+	// Decode the JSON response into AutoscalerSlotsRecommendation structs
+	var recommendations []AutoscalerSlotsRecommendation
+	err = json.NewDecoder(resp.Body).Decode(&recommendations)
+	if err != nil {
+		return nil, err
+	}
+
+	return recommendations, nil
+}

--- a/admin/metrics/client.go
+++ b/admin/metrics/client.go
@@ -43,16 +43,20 @@ func (c *Client) AutoscalerSlotsRecommendations(ctx context.Context, limit, offs
 		return nil, err
 	}
 	uri.Path = path.Join("/v1/instances", c.InstanceID, "/api/autoscaler-slots-recommendations")
+
+	// Add URL query parameters
+	qry := uri.Query()
 	if limit > 0 {
-		uri.Query().Set("limit", fmt.Sprintf("%d", limit))
+		qry.Set("limit", fmt.Sprintf("%d", limit))
 	}
 	if offset > 0 {
-		uri.Query().Set("offset", fmt.Sprintf("%d", offset))
+		qry.Set("offset", fmt.Sprintf("%d", offset))
 	}
+	uri.RawQuery = qry.Encode()
 	apiURL := uri.String()
 
 	// Create a new HTTP request
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/admin/worker/run_autoscaler.go
+++ b/admin/worker/run_autoscaler.go
@@ -1,0 +1,55 @@
+package worker
+
+import (
+	"context"
+
+	"github.com/rilldata/rill/admin/metrics"
+	"go.uber.org/zap"
+)
+
+func (w *Worker) runAutoscaler(ctx context.Context) error {
+	recs, ok, err := w.allRecommendations(ctx)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		w.logger.Debug("skipping autoscaler: no metrics project configured")
+		return nil
+	}
+
+	for _, rec := range recs {
+		// TODO: Add autoscaling logic based on the recommendation here.
+		// Consider checking rec.UpdatedOn to avoid making autoscaling decision on stale data!
+		w.logger.Info("autoscaler recommendation", zap.String("project_id", rec.ProjectID), zap.Int("recommended_slots", rec.RecommendedSlots))
+		break
+	}
+
+	return nil
+}
+
+func (w *Worker) allRecommendations(ctx context.Context) ([]metrics.AutoscalerSlotsRecommendation, bool, error) {
+	client, ok, err := w.admin.OpenMetricsProject(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	if !ok {
+		return nil, false, nil
+	}
+
+	var recs []metrics.AutoscalerSlotsRecommendation
+	limit := 1000
+	offset := 0
+	for {
+		batch, err := client.AutoscalerSlotsRecommendations(ctx, limit, offset)
+		if err != nil {
+			return nil, false, err
+		}
+		if len(batch) == 0 {
+			break
+		}
+		recs = append(recs, batch...)
+		offset += limit
+	}
+
+	return recs, true, nil
+}

--- a/admin/worker/worker.go
+++ b/admin/worker/worker.go
@@ -56,7 +56,7 @@ func (w *Worker) Run(ctx context.Context) error {
 		return w.schedule(ctx, "upgrade_latest_version_projects", w.upgradeLatestVersionProjects, 6*time.Hour)
 	})
 	group.Go(func() error {
-		return w.schedule(ctx, "run_autoscaler", w.hibernateExpiredDeployments, 6*time.Hour)
+		return w.schedule(ctx, "run_autoscaler", w.runAutoscaler, 6*time.Hour)
 	})
 
 	// NOTE: Add new scheduled jobs here

--- a/admin/worker/worker.go
+++ b/admin/worker/worker.go
@@ -55,6 +55,10 @@ func (w *Worker) Run(ctx context.Context) error {
 	group.Go(func() error {
 		return w.schedule(ctx, "upgrade_latest_version_projects", w.upgradeLatestVersionProjects, 6*time.Hour)
 	})
+	group.Go(func() error {
+		return w.schedule(ctx, "run_autoscaler", w.hibernateExpiredDeployments, 6*time.Hour)
+	})
+
 	// NOTE: Add new scheduled jobs here
 
 	w.logger.Info("worker started")


### PR DESCRIPTION
This is a prototype PR that makes the admin service capable of querying custom APIs on the https://github.com/rilldata/rill-cloud-metrics project.

This enables dogfooding Rill for various analytics use cases, such as autoscaling, health checks, quota enforcement, usage-based billing, etc.

Setting a metrics project is optional. If not set, the admin service will still work (to avoid circular dependencies!).
You can provide a metrics project by setting the following environment variable:
```
RILL_ADMIN_METRICS_PROJECT=rilldata/internal-rill-cloud-metrics
```

The PR includes an initial integration with a prototype `autoscaler-slots-recommendations` custom API and adds scaffolding for an autoscaling job that leverages those recommendations (not actually implemented).

Todo for a complete autoscaling solution:
- [ ] Implement autoscaling logic in `admin/worker/run_autoscaler.go`
- [ ] Set the `RILL_ADMIN_METRICS_PROJECT` environment variable in our different environments
- [ ] Test it :) 