### PR TITLE
Update 0.42.md

### DIFF
--- a/docs/blog/0.42.md
+++ b/docs/blog/0.42.md
@@ -65,4 +65,4 @@ More details on [bookmarks here](/explore/bookmarks).
 - Added shorthands for configuring environment-specific overrides for the `dev` and `prod` environments.
 - Fixed the leaderboard column alignment so that the column values are better right-aligned (instead of left-aligned).
 - Fixed bug where having an incorrect condition could prevent a measure filter from being applied.
-- Added support for serving Rill Developer over HTTPS by passing in appropriate `--cert` and `--key` flags via the CLI.
+- Added support for serving Rill Developer over HTTPS by passing in appropriate `--tls-cert` and `--tls-key` flags via the CLI.


### PR DESCRIPTION
Correcting how to pass in the cert and key when enabling HTTPS in Rill Developer