### PR TITLE
docs: adding blog to header

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -123,6 +123,11 @@ const config = {
             position: "left",
           },
           {
+            href: "https://www.rilldata.com/blog",
+            label: "Blog",
+            position: "left",
+          },
+          {
             type: "search",
             position: "right"
           }


### PR DESCRIPTION
Adding a link to the Rill blog in the top navigation header