### PR TITLE
Fix: Dimension Table critical short term fixes

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/DimensionHeader.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionHeader.svelte
@@ -88,7 +88,7 @@
   }
 </script>
 
-<div class="flex justify-between items-center p-1">
+<div class="flex justify-between items-center p-1 pr-5">
   <button class="flex items-center" on:click={() => goBackToLeaderboard()}>
     {#if isFetching}
       <div>

--- a/web-common/src/features/dashboards/dimension-table/DimensionTable.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionTable.svelte
@@ -115,18 +115,7 @@ TableCells – the cell contents.
       config,
     );
 
-    const measureColumnSizeSum = estimateColumnSize
-      .slice(1)
-      .reduce((a, b) => a + b, 0);
-
-    // Dimension column should expand to cover whole container
-    // if not manually resized
-    if (manualDimensionColumnWidth === null) {
-      estimateColumnSize[0] = Math.max(
-        containerWidth - measureColumnSizeSum - FILTER_COLUMN_WIDTH,
-        estimateColumnSize[0],
-      );
-    } else {
+    if (manualDimensionColumnWidth !== null) {
       estimateColumnSize[0] = manualDimensionColumnWidth;
     }
   }
@@ -145,10 +134,10 @@ TableCells – the cell contents.
   });
 
   $: virtualRows = $rowVirtualizer?.getVirtualItems() ?? [];
-  $: virtualWidth = $rowVirtualizer?.getTotalSize() ?? 0;
+  $: virtualHeight = $rowVirtualizer?.getTotalSize() ?? 0;
 
   $: virtualColumns = $columnVirtualizer?.getVirtualItems() ?? [];
-  $: virtualHeight = $columnVirtualizer?.getTotalSize() ?? 0;
+  $: virtualWidth = $columnVirtualizer?.getTotalSize() ?? 0;
 
   let activeIndex;
   function setActiveIndex(event) {
@@ -205,7 +194,7 @@ TableCells – the cell contents.
     }}
     style:width="100%"
     style:height="100%"
-    class="overflow-auto grid"
+    class="overflow-auto grid max-w-fit"
     style:grid-template-columns="max-content auto"
     on:scroll={() => {
       /** capture to suppress cell tooltips. Otherwise,

--- a/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
@@ -230,16 +230,6 @@ export function estimateColumnSizes(
         config.defaultColumnWidth;
   });
 
-  const measureColumnSizeSum = estimatedColumnSizes
-    .slice(1)
-    .reduce((a, b) => a + b, 0);
-
-  /* Dimension column should expand to cover whole container */
-  estimatedColumnSizes[0] = Math.max(
-    containerWidth - measureColumnSizeSum - config.indexWidth,
-    estimatedColumnSizes[0],
-  );
-
   return estimatedColumnSizes;
 }
 


### PR DESCRIPTION
This PR features critical short term fixes for the `DimensionTable` component while the complete refactor (#4374) is in progress.

- Reverts incorrect width and height assignment
- Removes the forced expansion of the first column