### PR TITLE
Avoid 404s for get resource while modelling

### DIFF
--- a/web-admin/src/features/dashboards/listing/selectors.ts
+++ b/web-admin/src/features/dashboards/listing/selectors.ts
@@ -188,9 +188,13 @@ export function listenAndInvalidateDashboards(
         );
         if (prevStateUpdatedOn.getTime() < stateUpdatedOn.getTime()) {
           // invalidate if it was updated
-          refreshResource(queryClient, instanceId, dashboardResource).then(() =>
-            invalidateMetricsViewData(queryClient, instanceId, false),
+          refreshResource(
+            queryClient,
+            instanceId,
+            dashboardResource.meta.name,
+            dashboardResource,
           );
+          invalidateMetricsViewData(queryClient, instanceId, false);
           dashboardChanged = true;
         }
       }

--- a/web-admin/src/features/errors/error-utils.ts
+++ b/web-admin/src/features/errors/error-utils.ts
@@ -18,7 +18,7 @@ import { ErrorStoreState, errorStore } from "./error-store";
 
 export function createGlobalErrorCallback(queryClient: QueryClient) {
   return (error: AxiosError, query: Query) => {
-    errorEventHandler?.requestErrorEventHandler(error, query);
+    errorEventHandler?.handleSvelteQueryError(error, query);
 
     // If unauthorized to the admin server, redirect to login page
     if (isAdminServerQuery(query) && error.response?.status === 401) {

--- a/web-common/src/features/entity-management/resource-selectors.ts
+++ b/web-common/src/features/entity-management/resource-selectors.ts
@@ -6,7 +6,11 @@ import {
   V1ReconcileStatus,
   V1Resource,
 } from "@rilldata/web-common/runtime-client";
-import type { QueryClient } from "@tanstack/svelte-query";
+import type {
+  CreateQueryResult,
+  QueryClient,
+  QueryObserverResult,
+} from "@tanstack/svelte-query";
 import { derived } from "svelte/store";
 
 export enum ResourceKind {
@@ -135,9 +139,12 @@ export function createSchemaForTable(
   ) as ReturnType<typeof createConnectorServiceOLAPGetTable>;
 }
 
-export function resourceIsLoading(resource?: V1Resource) {
+export function resourceIsLoading(resp: QueryObserverResult<V1Resource>) {
+  if (resp.isFetching) return true;
   return (
-    !!resource &&
-    resource.meta?.reconcileStatus !== V1ReconcileStatus.RECONCILE_STATUS_IDLE
+    resp.data?.meta?.reconcileStatus ===
+      V1ReconcileStatus.RECONCILE_STATUS_PENDING ||
+    resp.data?.meta?.reconcileStatus ===
+      V1ReconcileStatus.RECONCILE_STATUS_RUNNING
   );
 }

--- a/web-common/src/features/entity-management/watch-resources-client.ts
+++ b/web-common/src/features/entity-management/watch-resources-client.ts
@@ -10,16 +10,7 @@ export function startWatchResourcesClient(queryClient: QueryClient) {
   return new WatchRequestClient<V1WatchResourcesResponse>(
     (runtime) =>
       `${runtime.host}/v1/instances/${runtime.instanceId}/resources/-/watch`,
-    (res) => handleWatchResourceResponse(queryClient, res),
+    (res) => invalidateResourceResponse(queryClient, res),
     () => invalidateAllResources(queryClient),
   ).start();
-}
-
-function handleWatchResourceResponse(
-  queryClient: QueryClient,
-  res: V1WatchResourcesResponse,
-) {
-  if (!res.resource) return;
-
-  invalidateResourceResponse(queryClient, res);
 }

--- a/web-common/src/features/models/workspace/ModelBody.svelte
+++ b/web-common/src/features/models/workspace/ModelBody.svelte
@@ -143,7 +143,7 @@
       {#if !$modelEmpty?.data}
         <ConnectedPreviewTable
           objectName={$modelQuery?.data?.model?.state?.table}
-          loading={resourceIsLoading($modelQuery?.data)}
+          loading={resourceIsLoading($modelQuery)}
           {limit}
         />
       {/if}

--- a/web-common/src/features/models/workspace/inspector/ModelInspector.svelte
+++ b/web-common/src/features/models/workspace/inspector/ModelInspector.svelte
@@ -24,7 +24,7 @@
 </script>
 
 {#if !$emptyModel?.data}
-  {#if resourceIsLoading($modelQuery?.data)}
+  {#if resourceIsLoading($modelQuery)}
     <div class="mt-6">
       <ReconcilingSpinner />
     </div>

--- a/web-common/src/features/sources/inspector/SourceInspector.svelte
+++ b/web-common/src/features/sources/inspector/SourceInspector.svelte
@@ -114,7 +114,7 @@
 </script>
 
 <div class="{isSourceUnsaved && 'grayscale'} transition duration-200">
-  {#if resourceIsLoading($sourceQuery?.data)}
+  {#if resourceIsLoading($sourceQuery)}
     <div class="mt-6">
       <ReconcilingSpinner />
     </div>

--- a/web-common/src/features/sources/workspace/SourceWorkspaceBody.svelte
+++ b/web-common/src/features/sources/workspace/SourceWorkspaceBody.svelte
@@ -55,7 +55,7 @@
     {#if !$allErrors?.length}
       <ConnectedPreviewTable
         objectName={$sourceQuery?.data?.source?.state?.table}
-        loading={resourceIsLoading($sourceQuery?.data)}
+        loading={resourceIsLoading($sourceQuery)}
       />
     {:else if $allErrors[0].message}
       <ErrorPane {sourceName} errorMessage={$allErrors[0].message} />

--- a/web-common/src/features/sources/workspace/SourceWorkspaceHeader.svelte
+++ b/web-common/src/features/sources/workspace/SourceWorkspaceHeader.svelte
@@ -73,7 +73,7 @@
 
   let source: V1SourceV2 | undefined;
   $: source = $sourceQuery.data?.source;
-  $: sourceIsReconciling = resourceIsLoading($sourceQuery.data);
+  $: sourceIsReconciling = resourceIsLoading($sourceQuery);
 
   let connector: string | undefined;
   $: connector = source?.state?.connector;
@@ -205,7 +205,7 @@
         </div>
       {/if}
     </svelte:fragment>
-    <svelte:fragment slot="cta" let:width={headerWidth}>
+    <svelte:fragment let:width={headerWidth} slot="cta">
       <PanelCTA side="right">
         <Button
           disabled={!isSourceUnsaved}
@@ -259,10 +259,10 @@
           </Button>
           <Menu
             dark
+            let:toggleFloatingElement
             on:click-outside={toggleFloatingElement}
             on:escape={toggleFloatingElement}
             slot="floating-element"
-            let:toggleFloatingElement
           >
             <MenuItem
               on:select={() => {

--- a/web-common/src/metrics/ErrorEventHandler.ts
+++ b/web-common/src/metrics/ErrorEventHandler.ts
@@ -23,7 +23,7 @@ export class ErrorEventHandler {
     this.commonUserMetrics = commonUserMetrics;
   }
 
-  public requestErrorEventHandler(error: AxiosError, query: Query) {
+  public handleSvelteQueryError(error: AxiosError, query: Query) {
     const screenName = this.screenNameGetter();
     if (!error.response) {
       this.fireHTTPErrorBoundaryEvent(

--- a/web-local/src/routes/(application)/+layout.svelte
+++ b/web-local/src/routes/(application)/+layout.svelte
@@ -17,7 +17,7 @@
   queryClient.getQueryCache().config.onError = (
     error: AxiosError,
     query: Query,
-  ) => errorEventHandler?.requestErrorEventHandler(error, query);
+  ) => errorEventHandler?.handleSvelteQueryError(error, query);
 
   beforeNavigate(retainFeaturesFlags);
 


### PR DESCRIPTION
While actively modelling or updating metrics config we need not refetch the resource query since we get the updated resource object in watch-resource API.

This will also avoid 404s when the resource went into an error state because of any change in the editor.