### PR TITLE
Fix: Key ShadCN MenuItem on disabled prop

### DIFF
--- a/web-common/src/components/dropdown-menu/DropdownMenuItem.svelte
+++ b/web-common/src/components/dropdown-menu/DropdownMenuItem.svelte
@@ -10,12 +10,11 @@
   let className: $$Props["class"] = undefined;
   export let inset: $$Props["inset"] = undefined;
   export { className as class };
-  console.log($$restProps);
 </script>
 
 <DropdownMenuPrimitive.Item
   class={cn(
-    "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[highlighted]:cursor-pointer",
+    "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[highlighted]:cursor-pointer  data-[disabled]:pointer-events-none  data-[disabled]:opacity-50",
     inset && "pl-8",
     className,
   )}

--- a/web-common/src/components/dropdown-menu/DropdownMenuItem.svelte
+++ b/web-common/src/components/dropdown-menu/DropdownMenuItem.svelte
@@ -14,7 +14,7 @@
 
 <DropdownMenuPrimitive.Item
   class={cn(
-    "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[highlighted]:cursor-pointer  data-[disabled]:pointer-events-none  data-[disabled]:opacity-50",
+    "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[highlighted]:cursor-pointer data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
     inset && "pl-8",
     className,
   )}

--- a/web-common/src/components/dropdown-menu/DropdownMenuItem.svelte
+++ b/web-common/src/components/dropdown-menu/DropdownMenuItem.svelte
@@ -10,11 +10,12 @@
   let className: $$Props["class"] = undefined;
   export let inset: $$Props["inset"] = undefined;
   export { className as class };
+  console.log($$restProps);
 </script>
 
 <DropdownMenuPrimitive.Item
   class={cn(
-    "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[highlighted]:cursor-pointer data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+    "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[highlighted]:cursor-pointer",
     inset && "pl-8",
     className,
   )}

--- a/web-common/src/layout/navigation/NavigationMenuItem.svelte
+++ b/web-common/src/layout/navigation/NavigationMenuItem.svelte
@@ -6,7 +6,7 @@
 
 {#key disabled}
   <DropdownMenu.Item
-    class="data-[highlighted]:bg-gray-600 dark gap-2 data-[disabled]:pointer-events-none"
+    class="data-[highlighted]:bg-gray-600 dark gap-2"
     aria-disabled={disabled}
     {disabled}
     on:click

--- a/web-common/src/layout/navigation/NavigationMenuItem.svelte
+++ b/web-common/src/layout/navigation/NavigationMenuItem.svelte
@@ -4,42 +4,44 @@
   export let disabled = false;
 </script>
 
-<DropdownMenu.Item
-  class="data-[highlighted]:bg-gray-600 dark gap-2 disabled:text-gray-500"
-  aria-disabled={disabled}
-  {disabled}
-  on:click
->
-  {#if $$slots.icon}
-    <div
-      class="grid place-content-center opacity-80 ui-copy-icon dark:text-white"
-      style:height="18px"
-    >
-      <slot name="icon" />
-    </div>
-  {/if}
-  <div
-    class:ui-copy={!disabled}
-    class:ui-copy-disabled={disabled}
-    class="text-left"
+{#key disabled}
+  <DropdownMenu.Item
+    class="data-[highlighted]:bg-gray-600 dark gap-2 data-[disabled]:pointer-events-none"
+    aria-disabled={disabled}
+    {disabled}
+    on:click
   >
-    <slot />
-
+    {#if $$slots.icon}
+      <div
+        class="grid place-content-center opacity-80 ui-copy-icon dark:text-white"
+        style:height="18px"
+      >
+        <slot name="icon" />
+      </div>
+    {/if}
     <div
-      class:ui-copy-muted={!disabled}
-      class:ui-copy-disabled-faint={disabled}
-      style:font-size="11px"
+      class:ui-copy={!disabled}
+      class:ui-copy-disabled={disabled}
+      class="text-left"
     >
-      <slot name="description" />
-    </div>
-  </div>
+      <slot />
 
-  {#if $$slots["right"]}
-    <div
-      class="grid place-content-center text-right ui-copy-muted"
-      style:height="18px"
-    >
-      <slot name="right" />
+      <div
+        class:ui-copy-muted={!disabled}
+        class:ui-copy-disabled-faint={disabled}
+        style:font-size="11px"
+      >
+        <slot name="description" />
+      </div>
     </div>
-  {/if}
-</DropdownMenu.Item>
+
+    {#if $$slots["right"]}
+      <div
+        class="grid place-content-center text-right ui-copy-muted"
+        style:height="18px"
+      >
+        <slot name="right" />
+      </div>
+    {/if}
+  </DropdownMenu.Item>
+{/key}


### PR DESCRIPTION
This PR addresses an apparent bug with the ShadCN menu component where it is not responsive to changes in the disabled prop. This PR adds a `#key` block to force the component to re-render.