### PR TITLE
Refactor dashboard state sync with metrics view spec

### DIFF
--- a/web-admin/src/features/bookmarks/selectors.ts
+++ b/web-admin/src/features/bookmarks/selectors.ts
@@ -3,6 +3,7 @@ import {
   type V1Bookmark,
 } from "@rilldata/web-admin/client";
 import { useProjectId } from "@rilldata/web-admin/features/projects/selectors";
+import type { CompoundQueryResult } from "@rilldata/web-common/features/compound-query-result";
 import { getDashboardStateFromUrl } from "@rilldata/web-common/features/dashboards/proto-state/fromProto";
 import {
   useMetricsView,
@@ -103,6 +104,42 @@ export function searchBookmarks(
     personal: bookmarks?.personal.filter(matchName) ?? [],
     shared: bookmarks?.shared.filter(matchName) ?? [],
   };
+}
+
+export function getHomeBookmark(
+  queryClient: QueryClient,
+  instanceId: string,
+  orgName: string,
+  projectName: string,
+  metricsViewName: string,
+): CompoundQueryResult<string> {
+  return derived(
+    getBookmarks(
+      queryClient,
+      instanceId,
+      orgName,
+      projectName,
+      metricsViewName,
+    ),
+    (bookmarks) => {
+      if (bookmarks.isFetching) {
+        return {
+          isFetching: true,
+          error: "",
+        };
+      } else if (bookmarks.isError) {
+        return {
+          isFetching: false,
+          error: bookmarks.error,
+        };
+      }
+      return {
+        isFetching: false,
+        error: "",
+        data: bookmarks.data.home?.resource?.data,
+      };
+    },
+  );
 }
 
 export function getPrettySelectedTimeRange(

--- a/web-admin/src/features/bookmarks/selectors.ts
+++ b/web-admin/src/features/bookmarks/selectors.ts
@@ -106,7 +106,7 @@ export function searchBookmarks(
   };
 }
 
-export function getHomeBookmark(
+export function getHomeBookmarkData(
   queryClient: QueryClient,
   instanceId: string,
   orgName: string,
@@ -122,7 +122,7 @@ export function getHomeBookmark(
       metricsViewName,
     ),
     (bookmarks) => {
-      if (bookmarks.isFetching) {
+      if (bookmarks.isFetching || !bookmarks.data) {
         return {
           isFetching: true,
           error: "",
@@ -136,7 +136,7 @@ export function getHomeBookmark(
       return {
         isFetching: false,
         error: "",
-        data: bookmarks.data.home?.resource?.data,
+        data: bookmarks.data?.home?.resource?.data,
       };
     },
   );

--- a/web-admin/src/features/dashboards/DashboardAdminStateProvider.svelte
+++ b/web-admin/src/features/dashboards/DashboardAdminStateProvider.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/stores";
   import { useQueryClient } from "@rilldata/svelte-query";
-  import { getHomeBookmark } from "@rilldata/web-admin/features/bookmarks/selectors";
+  import { getHomeBookmarkData } from "@rilldata/web-admin/features/bookmarks/selectors";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { createDashboardStateSync } from "@rilldata/web-common/features/dashboards/stores/syncDashboardState";
   import { initLocalUserPreferenceStore } from "@rilldata/web-common/features/dashboards/user-preferences";
@@ -13,7 +13,7 @@
 
   $: initLocalUserPreferenceStore(metricViewName);
   const queryClient = useQueryClient();
-  $: bookmarks = getHomeBookmark(
+  const homeBookmark = getHomeBookmarkData(
     queryClient,
     $runtime?.instanceId,
     $page.params.organization,
@@ -21,13 +21,13 @@
     metricViewName,
   );
 
-  const dashboardStateSync = createDashboardStateSync(
+  const dashboardStoreReady = createDashboardStateSync(
     getStateManagers(),
-    bookmarks,
+    homeBookmark,
   );
 </script>
 
-{#if $dashboardStateSync}
+{#if $dashboardStoreReady}
   <slot />
 {:else}
   <div class="grid place-items-center mt-40">

--- a/web-admin/src/features/dashboards/DashboardAdminStateProvider.svelte
+++ b/web-admin/src/features/dashboards/DashboardAdminStateProvider.svelte
@@ -1,18 +1,10 @@
 <script lang="ts">
   import { page } from "$app/stores";
   import { useQueryClient } from "@rilldata/svelte-query";
-  import { getBookmarks } from "@rilldata/web-admin/features/bookmarks/selectors";
-  import {
-    createTimeRangeSummary,
-    useMetricsView,
-    useModelHasTimeSeries,
-  } from "@rilldata/web-common/features/dashboards/selectors/index";
+  import { getHomeBookmark } from "@rilldata/web-admin/features/bookmarks/selectors";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
-  import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
-  import { hasPersistentDashboardData } from "@rilldata/web-common/features/dashboards/stores/persistent-dashboard-state";
-  import { syncDashboardState } from "@rilldata/web-common/features/dashboards/stores/syncDashboardState";
+  import { createDashboardStateSync } from "@rilldata/web-common/features/dashboards/stores/syncDashboardState";
   import { initLocalUserPreferenceStore } from "@rilldata/web-common/features/dashboards/user-preferences";
-  import { createQueryServiceMetricsViewSchema } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import Spinner from "@rilldata/web-common/features/entity-management/Spinner.svelte";
   import { EntityStatus } from "@rilldata/web-common/features/entity-management/types";
@@ -20,17 +12,8 @@
   export let metricViewName: string;
 
   $: initLocalUserPreferenceStore(metricViewName);
-  const stateManagers = getStateManagers();
-  const metricsView = useMetricsView(stateManagers);
-  const hasTimeSeries = useModelHasTimeSeries(stateManagers);
-  const timeRangeQuery = createTimeRangeSummary(stateManagers);
-  const metricsViewSchema = createQueryServiceMetricsViewSchema(
-    $runtime.instanceId,
-    metricViewName,
-  );
-
   const queryClient = useQueryClient();
-  $: bookmarks = getBookmarks(
+  $: bookmarks = getHomeBookmark(
     queryClient,
     $runtime?.instanceId,
     $page.params.organization,
@@ -38,37 +21,13 @@
     metricViewName,
   );
 
-  function syncDashboardStateLocal() {
-    let stateToLoad = $page.url.searchParams.get("state");
-    if (
-      !hasPersistentDashboardData() &&
-      !stateToLoad &&
-      $bookmarks.data?.home?.resource.data
-    ) {
-      stateToLoad = $bookmarks.data?.home?.resource.data;
-    }
-    syncDashboardState(
-      metricViewName,
-      $metricsView.data,
-      $metricsViewSchema.data?.schema,
-      $timeRangeQuery.data,
-      stateToLoad,
-    );
-  }
-
-  $: if (
-    $metricsView.data &&
-    $metricsViewSchema.data &&
-    ($timeRangeQuery.data || !$hasTimeSeries.data) &&
-    !$bookmarks.isFetching
-  ) {
-    syncDashboardStateLocal();
-  }
-
-  $: ready = metricViewName in $metricsExplorerStore.entities;
+  const dashboardStateSync = createDashboardStateSync(
+    getStateManagers(),
+    bookmarks,
+  );
 </script>
 
-{#if ready}
+{#if $dashboardStateSync}
   <slot />
 {:else}
   <div class="grid place-items-center mt-40">

--- a/web-common/src/features/dashboards/selectors/index.ts
+++ b/web-common/src/features/dashboards/selectors/index.ts
@@ -10,6 +10,8 @@ import {
   V1MetricsViewToplistResponse,
   createQueryServiceMetricsViewTimeRange,
   createQueryServiceMetricsViewToplist,
+  createQueryServiceMetricsViewSchema,
+  type V1MetricsViewSchemaResponse,
 } from "@rilldata/web-common/runtime-client";
 import type {
   CreateQueryResult,
@@ -114,6 +116,19 @@ export function createTimeRangeSummary(
             enabled: !!metricsView.data?.timeDimension,
           },
         },
+      ).subscribe(set),
+  );
+}
+
+export function createMetricsViewSchema(
+  ctx: StateManagers,
+): CreateQueryResult<V1MetricsViewSchemaResponse> {
+  return derived(
+    [ctx.runtime, ctx.metricsViewName],
+    ([runtime, metricsViewName], set) =>
+      createQueryServiceMetricsViewSchema(
+        runtime.instanceId,
+        metricsViewName,
       ).subscribe(set),
   );
 }

--- a/web-common/src/features/dashboards/stores/DashboardStateProvider.svelte
+++ b/web-common/src/features/dashboards/stores/DashboardStateProvider.svelte
@@ -1,53 +1,27 @@
 <script lang="ts">
   import { page } from "$app/stores";
-  import {
-    createTimeRangeSummary,
-    useMetricsView,
-    useModelHasTimeSeries,
-  } from "@rilldata/web-common/features/dashboards/selectors/index";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
-  import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
-  import { syncDashboardState } from "@rilldata/web-common/features/dashboards/stores/syncDashboardState";
+  import { createDashboardStateSync } from "@rilldata/web-common/features/dashboards/stores/syncDashboardState";
   import { initLocalUserPreferenceStore } from "@rilldata/web-common/features/dashboards/user-preferences";
-  import { createQueryServiceMetricsViewSchema } from "@rilldata/web-common/runtime-client";
-  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
+  import { writable } from "svelte/store";
   import Spinner from "../../entity-management/Spinner.svelte";
   import { EntityStatus } from "../../entity-management/types";
 
   export let metricViewName: string;
 
   $: initLocalUserPreferenceStore(metricViewName);
-  const stateManagers = getStateManagers();
-  const metricsView = useMetricsView(stateManagers);
-  const hasTimeSeries = useModelHasTimeSeries(stateManagers);
-  const timeRangeQuery = createTimeRangeSummary(stateManagers);
-  const metricsViewSchema = createQueryServiceMetricsViewSchema(
-    $runtime.instanceId,
-    metricViewName,
+
+  const dashboardStateSync = createDashboardStateSync(
+    getStateManagers(),
+    writable({
+      isFetching: false,
+      error: "",
+      data: $page.url.searchParams.get("state") ?? "",
+    }),
   );
-
-  function syncDashboardStateLocal() {
-    syncDashboardState(
-      metricViewName,
-      $metricsView.data,
-      $metricsViewSchema.data?.schema,
-      $timeRangeQuery.data,
-      $page.url.searchParams.get("state"),
-    );
-  }
-
-  $: if (
-    $metricsView.data &&
-    $metricsViewSchema.data &&
-    ($timeRangeQuery.data || !$hasTimeSeries.data)
-  ) {
-    syncDashboardStateLocal();
-  }
-
-  $: ready = metricViewName in $metricsExplorerStore.entities;
 </script>
 
-{#if ready}
+{#if $dashboardStateSync}
   <slot />
 {:else}
   <div class="grid place-items-center mt-40">

--- a/web-common/src/features/dashboards/stores/DashboardStateProvider.svelte
+++ b/web-common/src/features/dashboards/stores/DashboardStateProvider.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-  import { page } from "$app/stores";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { createDashboardStateSync } from "@rilldata/web-common/features/dashboards/stores/syncDashboardState";
   import { initLocalUserPreferenceStore } from "@rilldata/web-common/features/dashboards/user-preferences";
-  import { writable } from "svelte/store";
   import Spinner from "../../entity-management/Spinner.svelte";
   import { EntityStatus } from "../../entity-management/types";
 
@@ -11,17 +9,10 @@
 
   $: initLocalUserPreferenceStore(metricViewName);
 
-  const dashboardStateSync = createDashboardStateSync(
-    getStateManagers(),
-    writable({
-      isFetching: false,
-      error: "",
-      data: $page.url.searchParams.get("state") ?? "",
-    }),
-  );
+  const dashboardStoreReady = createDashboardStateSync(getStateManagers());
 </script>
 
-{#if $dashboardStateSync}
+{#if $dashboardStoreReady}
   <slot />
 {:else}
   <div class="grid place-items-center mt-40">

--- a/web-common/src/features/dashboards/stores/syncDashboardState.ts
+++ b/web-common/src/features/dashboards/stores/syncDashboardState.ts
@@ -50,7 +50,7 @@ export function createDashboardStateSync(
         initialUrlStateRes?.isFetching ||
         // requests errored out
         !metricsViewSpecRes.data ||
-        !timeRangeRes.data ||
+        (!!metricsViewSpecRes.data.timeDimension && !timeRangeRes.data) ||
         !metricsViewSchemaRes.data?.schema
       ) {
         return false;


### PR DESCRIPTION
During bookmark changes we added a layer to add loading of home bookmark. This PR refactors the code to streamline the sync code and generalise for local and cloud.