### PR TITLE
Fix base time range not getting set from url state

### DIFF
--- a/web-common/src/features/dashboards/time-controls/TimeControls.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeControls.svelte
@@ -74,11 +74,11 @@
       localUserPreferences.set({ timeZone: "UTC" });
     }
 
-    baseTimeRange = $dashboardStore.selectedTimeRange?.start &&
-      $dashboardStore.selectedTimeRange?.end && {
-        name: $dashboardStore.selectedTimeRange?.name,
-        start: $dashboardStore.selectedTimeRange.start,
-        end: $dashboardStore.selectedTimeRange.end,
+    baseTimeRange = $timeControlsStore.selectedTimeRange?.start &&
+      $timeControlsStore.selectedTimeRange?.end && {
+        name: $timeControlsStore.selectedTimeRange?.name,
+        start: $timeControlsStore.selectedTimeRange.start,
+        end: $timeControlsStore.selectedTimeRange.end,
       };
   }
 


### PR DESCRIPTION
A recent change broke the way we set `baseTimeRange`. `dashboardStore.selectedTimeRange` is not guaranteed to have start and end just when a url state is loaded. But `timeControlsStore.selectedTimeRange` is sure to be filled in.