### PR TITLE
Add rill theme to custom charts

### DIFF
--- a/web-common/src/features/charts/createChart.ts
+++ b/web-common/src/features/charts/createChart.ts
@@ -10,9 +10,10 @@ export async function createChart(instanceId: string, newChartName: string) {
       blob: `kind: chart
 data:
   metrics_sql: |
-    SELECT advertiser_name, AGGREGATE(measure_2) as measure_2
+    SELECT advertiser_name, AGGREGATE(measure_2)
     FROM Bids_Sample_Dash
     GROUP BY advertiser_name
+    ORDER BY measure_2 DESC
     LIMIT 20
 
 vega_lite: |

--- a/web-common/src/features/charts/render/VegaLiteRenderer.svelte
+++ b/web-common/src/features/charts/render/VegaLiteRenderer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getVegaConfig } from "@rilldata/web-common/features/charts/render/vega-config";
+  import { getRillTheme } from "@rilldata/web-common/features/charts/render/vega-config";
   import { VegaLite, View } from "svelte-vega";
 
   export let data: Record<string, unknown> = {};
@@ -12,7 +12,7 @@
   }
 
   let options: Options = {
-    config: getVegaConfig(),
+    config: getRillTheme(),
     renderer: "svg",
   };
 

--- a/web-common/src/features/charts/render/VegaLiteRenderer.svelte
+++ b/web-common/src/features/charts/render/VegaLiteRenderer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { getVegaConfig } from "@rilldata/web-common/features/charts/render/vega-config";
   import { VegaLite, View } from "svelte-vega";
 
   export let data: Record<string, unknown> = {};
@@ -6,11 +7,13 @@
 
   // EmbedOptions type missing from svelte-vega
   interface Options {
-    theme: undefined | "vox" | "ggplot2";
+    config: undefined | Record<string, unknown>;
+    renderer: "canvas" | "svg";
   }
 
   let options: Options = {
-    theme: "vox",
+    config: getVegaConfig(),
+    renderer: "svg",
   };
 
   let viewVL: View;

--- a/web-common/src/features/charts/render/vega-config.ts
+++ b/web-common/src/features/charts/render/vega-config.ts
@@ -1,0 +1,64 @@
+const markColor = "royalblue";
+const axisColor = "#E5E7EB";
+const axisLabelColor = "#727883";
+
+export const getVegaConfig = () => ({
+  mark: {
+    color: markColor,
+  },
+  arc: { fill: markColor },
+  area: { fill: markColor },
+  line: { stroke: markColor },
+  path: { stroke: markColor },
+  rect: { fill: markColor },
+  shape: { stroke: markColor },
+  symbol: { fill: markColor },
+
+  axisY: {
+    gridColor: axisColor,
+    tickColor: axisColor,
+    domain: false,
+    labelFont: "Inter, sans-serif",
+    labelFontSize: 10,
+    labelFontWeight: "normal",
+    labelColor: axisLabelColor,
+    labelPadding: 5,
+    titleColor: axisLabelColor,
+    titleFont: "Inter, sans-serif",
+    titleFontSize: 12,
+    titleFontWeight: "bold",
+    titlePadding: 10,
+    labelOverlap: false,
+  },
+  axisX: {
+    gridColor: axisColor,
+    tickColor: axisColor,
+    tickSize: 0,
+    domain: false,
+    labelFont: "Inter, sans-serif",
+    labelFontSize: 10,
+    labelFontWeight: "normal",
+    labelPadding: 5,
+    labelColor: axisLabelColor,
+    titleColor: axisLabelColor,
+    titleFont: "Inter, sans-serif",
+    titleFontSize: 12,
+    titleFontWeight: "bold",
+    titlePadding: 10,
+  },
+  view: {
+    strokeWidth: 0,
+  },
+  range: {
+    category: [
+      "#3e5c69",
+      "#6793a6",
+      "#182429",
+      "#0570b0",
+      "#3690c0",
+      "#74a9cf",
+      "#a6bddb",
+      "#e2ddf2",
+    ],
+  },
+});

--- a/web-common/src/features/charts/render/vega-config.ts
+++ b/web-common/src/features/charts/render/vega-config.ts
@@ -6,7 +6,7 @@ import {
 
 const markColor = MainLineColor;
 const axisColor = "#E5E7EB";
-const axisLabelColor = "#727880";
+const axisLabelColor = "#4b5563";
 
 export const getRillTheme = () => ({
   arc: { fill: markColor },

--- a/web-common/src/features/charts/render/vega-config.ts
+++ b/web-common/src/features/charts/render/vega-config.ts
@@ -6,7 +6,7 @@ import {
 
 const markColor = MainLineColor;
 const axisColor = "#E5E7EB";
-const axisLabelColor = "#4b5563";
+const axisLabelColor = "#4b5563"; // gray-600
 
 export const getRillTheme = () => ({
   arc: { fill: markColor },
@@ -40,6 +40,7 @@ export const getRillTheme = () => ({
 
   axisY: {
     gridColor: axisColor,
+    gridDash: [2],
     tickColor: axisColor,
     domain: false,
     labelFont: "Inter, sans-serif",
@@ -56,6 +57,7 @@ export const getRillTheme = () => ({
   },
   axisX: {
     gridColor: axisColor,
+    gridDash: [2],
     tickColor: axisColor,
     tickSize: 0,
     domain: false,

--- a/web-common/src/features/charts/render/vega-config.ts
+++ b/web-common/src/features/charts/render/vega-config.ts
@@ -2,7 +2,7 @@ const markColor = "royalblue";
 const axisColor = "#E5E7EB";
 const axisLabelColor = "#727883";
 
-export const getVegaConfig = () => ({
+export const getRillTheme = () => ({
   mark: {
     color: markColor,
   },

--- a/web-common/src/features/charts/render/vega-config.ts
+++ b/web-common/src/features/charts/render/vega-config.ts
@@ -1,13 +1,37 @@
-const markColor = "royalblue";
+import {
+  MainAreaColorGradientDark,
+  MainAreaColorGradientLight,
+  MainLineColor,
+} from "@rilldata/web-common/features/dashboards/time-series/chart-colors";
+
+const markColor = MainLineColor;
 const axisColor = "#E5E7EB";
-const axisLabelColor = "#727883";
+const axisLabelColor = "#727880";
 
 export const getRillTheme = () => ({
-  mark: {
-    color: markColor,
-  },
   arc: { fill: markColor },
-  area: { fill: markColor },
+  area: {
+    stroke: null,
+    line: markColor,
+    color: {
+      x1: 1,
+      y1: 1,
+      x2: 1,
+      y2: 0,
+      gradient: "linear",
+      stops: [
+        {
+          offset: 0,
+          color: MainAreaColorGradientLight,
+        },
+        {
+          offset: 1,
+          color: MainAreaColorGradientDark,
+        },
+      ],
+    },
+  },
+  bar: { fill: markColor },
   line: { stroke: markColor },
   path: { stroke: markColor },
   rect: { fill: markColor },
@@ -20,7 +44,7 @@ export const getRillTheme = () => ({
     domain: false,
     labelFont: "Inter, sans-serif",
     labelFontSize: 10,
-    labelFontWeight: "normal",
+    labelFontWeight: 500,
     labelColor: axisLabelColor,
     labelPadding: 5,
     titleColor: axisLabelColor,
@@ -37,7 +61,7 @@ export const getRillTheme = () => ({
     domain: false,
     labelFont: "Inter, sans-serif",
     labelFontSize: 10,
-    labelFontWeight: "normal",
+    labelFontWeight: 500,
     labelPadding: 5,
     labelColor: axisLabelColor,
     titleColor: axisLabelColor,
@@ -48,17 +72,5 @@ export const getRillTheme = () => ({
   },
   view: {
     strokeWidth: 0,
-  },
-  range: {
-    category: [
-      "#3e5c69",
-      "#6793a6",
-      "#182429",
-      "#0570b0",
-      "#3690c0",
-      "#74a9cf",
-      "#a6bddb",
-      "#e2ddf2",
-    ],
   },
 });


### PR DESCRIPTION
First pass at adding Rill theme to custom charts. This might change soon with design input

![image](https://github.com/rilldata/rill/assets/4402679/4a5b4cef-e847-4a72-afca-fd3a8ac646ac)

![image](https://github.com/rilldata/rill/assets/4402679/c339a526-da18-49fa-bf9f-adcbda264296)
