### PR TITLE
Rill Developer: Fix dashboard's "Edit model" button

### DIFF
--- a/web-admin/src/features/dashboards/listing/selectors.ts
+++ b/web-admin/src/features/dashboards/listing/selectors.ts
@@ -8,11 +8,9 @@ import {
   PollTimeWhenProjectDeploymentError,
   PollTimeWhenProjectDeploymentPending,
 } from "@rilldata/web-admin/features/projects/status/selectors";
+import { useDashboards } from "@rilldata/web-common/features/dashboards/selectors";
 import { refreshResource } from "@rilldata/web-common/features/entity-management/resource-invalidations";
-import {
-  ResourceKind,
-  useFilteredResources,
-} from "@rilldata/web-common/features/entity-management/resource-selectors";
+import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
 import type { V1Resource } from "@rilldata/web-common/runtime-client";
 import {
   createRuntimeServiceListResources,
@@ -61,12 +59,6 @@ export async function getDashboardsForProject(
   const catalogEntries = catalogEntriesResponse.data?.resources as V1Resource[];
 
   return catalogEntries.filter((e) => !!e.metricsView);
-}
-
-export function useDashboards(instanceId: string) {
-  return useFilteredResources(instanceId, ResourceKind.MetricsView, (data) =>
-    data.resources.filter((res) => !!res.metricsView?.state?.validSpec),
-  );
 }
 
 export function useDashboardsLastUpdated(

--- a/web-admin/src/features/dashboards/listing/selectors.ts
+++ b/web-admin/src/features/dashboards/listing/selectors.ts
@@ -8,7 +8,7 @@ import {
   PollTimeWhenProjectDeploymentError,
   PollTimeWhenProjectDeploymentPending,
 } from "@rilldata/web-admin/features/projects/status/selectors";
-import { useDashboards } from "@rilldata/web-common/features/dashboards/selectors";
+import { useValidDashboards } from "@rilldata/web-common/features/dashboards/selectors";
 import { refreshResource } from "@rilldata/web-common/features/entity-management/resource-invalidations";
 import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
 import type { V1Resource } from "@rilldata/web-common/runtime-client";
@@ -68,7 +68,7 @@ export function useDashboardsLastUpdated(
 ) {
   return derived(
     [
-      useDashboards(instanceId),
+      useValidDashboards(instanceId),
       createAdminServiceGetProject(organization, project),
     ],
     ([dashboardsResp, projResp]) => {
@@ -148,7 +148,7 @@ export function listenAndInvalidateDashboards(
   instanceId: string,
 ) {
   const store = derived(
-    [useDashboardsStatus(instanceId), useDashboards(instanceId)],
+    [useDashboardsStatus(instanceId), useValidDashboards(instanceId)],
     (state) => state,
   );
 

--- a/web-admin/src/features/embeds/TopNavigationBarEmbed.svelte
+++ b/web-admin/src/features/embeds/TopNavigationBarEmbed.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { useDashboards } from "@rilldata/web-common/features/dashboards/selectors";
+  import { useValidDashboards } from "@rilldata/web-common/features/dashboards/selectors";
   import type {
     V1MetricsViewSpec,
     V1Resource,
@@ -18,7 +18,7 @@
   $: onProjectPage = !activeResourceName;
 
   // Dashboard breadcrumb
-  $: dashboards = useDashboards(instanceId);
+  $: dashboards = useValidDashboards(instanceId);
   let currentResource: V1Resource;
   $: currentResource = $dashboards?.data?.find(
     (listing) => listing.meta.name.name === activeResourceName,

--- a/web-admin/src/features/embeds/TopNavigationBarEmbed.svelte
+++ b/web-admin/src/features/embeds/TopNavigationBarEmbed.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+  import { useDashboards } from "@rilldata/web-common/features/dashboards/selectors";
   import type {
     V1MetricsViewSpec,
     V1Resource,
   } from "@rilldata/web-common/runtime-client";
   import { createEventDispatcher } from "svelte";
   import LastRefreshedDate from "../dashboards/listing/LastRefreshedDate.svelte";
-  import { useDashboards } from "../dashboards/listing/selectors";
   import { isErrorStoreEmpty } from "../errors/error-store";
   import BreadcrumbItem from "../navigation/BreadcrumbItem.svelte";
 

--- a/web-admin/src/features/navigation/Breadcrumbs.svelte
+++ b/web-admin/src/features/navigation/Breadcrumbs.svelte
@@ -2,7 +2,7 @@
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";
   import { useAlerts } from "@rilldata/web-admin/features/alerts/selectors";
-  import { useDashboards } from "@rilldata/web-common/features/dashboards/selectors";
+  import { useValidDashboards } from "@rilldata/web-common/features/dashboards/selectors";
   import type {
     V1MetricsViewSpec,
     V1Resource,
@@ -66,7 +66,7 @@
   $: onProjectPage = isProjectPage($page);
 
   // Dashboard breadcrumb
-  $: dashboards = useDashboards(instanceId);
+  $: dashboards = useValidDashboards(instanceId);
   let currentResource: V1Resource;
   $: currentResource = $dashboards?.data?.find(
     (listing) => listing.meta.name.name === $page.params.dashboard,

--- a/web-admin/src/features/navigation/Breadcrumbs.svelte
+++ b/web-admin/src/features/navigation/Breadcrumbs.svelte
@@ -2,6 +2,7 @@
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";
   import { useAlerts } from "@rilldata/web-admin/features/alerts/selectors";
+  import { useDashboards } from "@rilldata/web-common/features/dashboards/selectors";
   import type {
     V1MetricsViewSpec,
     V1Resource,
@@ -14,7 +15,6 @@
     createAdminServiceListOrganizations,
     createAdminServiceListProjectsForOrganization,
   } from "../../client";
-  import { useDashboards } from "../dashboards/listing/selectors";
   import { getActiveOrgLocalStorageKey } from "../organizations/active-org/local-storage";
   import { useReports } from "../scheduled-reports/selectors";
   import BreadcrumbItem from "./BreadcrumbItem.svelte";

--- a/web-common/src/features/dashboards/DashboardAssets.svelte
+++ b/web-common/src/features/dashboards/DashboardAssets.svelte
@@ -112,18 +112,25 @@
   };
 
   /**
-   * Get the name of a dashboard's underlying model (if any).
-   * Note that not all dashboards have an underlying model.
-   * Some dashboards are underpinned by a source/table.
+   * Get the name of the dashboard's underlying model (if any).
+   * Note that not all dashboards have an underlying model. Some dashboards are
+   * underpinned by a source/table.
    */
-  function getModelForDashboard(dashboardName: string) {
+  function getReferenceModelNameForDashboard(
+    dashboardName: string,
+  ): string | undefined {
+    // Get the dashboard resource from the dashboard list
     const dashboard = $dashboards.data?.filter(
       (dashboard) => dashboard.meta?.name?.name === dashboardName,
     )[0];
+
+    // Get the model reference (if any) from the dashboard resource
     const modelRef = dashboard?.meta?.refs?.filter(
       (ref) => ref?.kind === ResourceKind.Model,
     )[0];
-    if (!modelRef) return "";
+
+    // Return the model name (if any)
+    if (!modelRef) return undefined;
     return modelRef?.name;
   }
 
@@ -216,7 +223,8 @@
             $fileArtifactsStore.entities,
             dashboardName,
           )}
-          {@const modelForDashboard = getModelForDashboard(dashboardName)}
+          {@const referenceModelName =
+            getReferenceModelNameForDashboard(dashboardName)}
           <li animate:flip={{ duration }} aria-label={dashboardName}>
             <NavigationEntry
               showContextMenu={!$readOnly}
@@ -232,10 +240,10 @@
                 {@const hasSourceError =
                   selectionError !== SourceModelValidationStatus.OK &&
                   selectionError !== ""}
-                {#if modelForDashboard}
+                {#if referenceModelName}
                   <NavigationMenuItem
                     disabled={hasSourceError}
-                    on:click={() => editModel(modelForDashboard)}
+                    on:click={() => editModel(referenceModelName)}
                   >
                     <Model slot="icon" />
                     Edit model

--- a/web-common/src/features/dashboards/DashboardAssets.svelte
+++ b/web-common/src/features/dashboards/DashboardAssets.svelte
@@ -127,19 +127,11 @@
     return modelRef?.name;
   }
 
-  const editModel = async (dashboardName: string) => {
-    await getDashboardArtifact(instanceId, dashboardName);
-
-    const dashboardData = getDashboardData(
-      $fileArtifactsStore.entities,
-      dashboardName,
-    );
-    const sourceModelName = dashboardData.jsonRepresentation?.model as string;
-
+  const editModel = async (modelName: string) => {
     const previousActiveEntity = $appScreen?.type;
-    await goto(`/model/${sourceModelName}`);
+    await goto(`/model/${modelName}`);
     await behaviourEvent.fireNavigationEvent(
-      sourceModelName,
+      modelName,
       BehaviourEventMedium.Menu,
       MetricsEventSpace.LeftPanel,
       previousActiveEntity,
@@ -243,7 +235,7 @@
                 {#if modelForDashboard}
                   <NavigationMenuItem
                     disabled={hasSourceError}
-                    on:click={() => editModel(dashboardName)}
+                    on:click={() => editModel(modelForDashboard)}
                   >
                     <Model slot="icon" />
                     Edit model

--- a/web-common/src/features/dashboards/DashboardAssets.svelte
+++ b/web-common/src/features/dashboards/DashboardAssets.svelte
@@ -7,7 +7,7 @@
   import Model from "@rilldata/web-common/components/icons/Model.svelte";
   import {
     useDashboardFileNames,
-    useDashboards,
+    useValidDashboards,
   } from "@rilldata/web-common/features/dashboards/selectors";
   import { deleteFileArtifact } from "@rilldata/web-common/features/entity-management/actions";
   import {
@@ -53,7 +53,7 @@
   $: sourceNames = useSourceFileNames(instanceId);
   $: modelNames = useModelFileNames(instanceId);
   $: dashboardNames = useDashboardFileNames(instanceId);
-  $: dashboards = useDashboards(instanceId);
+  $: dashboards = useValidDashboards(instanceId);
 
   const MetricsSourceSelectionError = (
     errors: Array<V1ReconcileError> | undefined,

--- a/web-common/src/features/dashboards/selectors.ts
+++ b/web-common/src/features/dashboards/selectors.ts
@@ -30,7 +30,7 @@ export function useDashboard(instanceId: string, metricViewName: string) {
   return useResource(instanceId, metricViewName, ResourceKind.MetricsView);
 }
 
-export function useDashboards(instanceId: string) {
+export function useValidDashboards(instanceId: string) {
   return useFilteredResources(instanceId, ResourceKind.MetricsView, (data) =>
     data?.resources?.filter((res) => !!res.metricsView?.state?.validSpec),
   );

--- a/web-common/src/features/dashboards/selectors.ts
+++ b/web-common/src/features/dashboards/selectors.ts
@@ -30,6 +30,12 @@ export function useDashboard(instanceId: string, metricViewName: string) {
   return useResource(instanceId, metricViewName, ResourceKind.MetricsView);
 }
 
+export function useDashboards(instanceId: string) {
+  return useFilteredResources(instanceId, ResourceKind.MetricsView, (data) =>
+    data?.resources?.filter((res) => !!res.metricsView?.state?.validSpec),
+  );
+}
+
 /**
  * Gets the valid metrics view spec. Only to be used in displaying a dashboard.
  * Use {@link useDashboard} in the metrics view editor and other use cases.


### PR DESCRIPTION
Quick fix for [this bug reported in Slack](https://rilldata.slack.com/archives/CTZ8XBQ85/p1710963629492489).

Not all dashboards have an underlying Model. Some dashboards are built directly on top of a Source or Table resource. This PR hides the "Edit model" menu item when there is no Model to edit.