### PR TITLE
Updating OLAP engine docs with correct param

### DIFF
--- a/docs/docs/reference/olap-engines/clickhouse.md
+++ b/docs/docs/reference/olap-engines/clickhouse.md
@@ -16,7 +16,7 @@ Rill supports connecting to an existing ClickHouse instance and using it as an O
 
 ## Connection string (DSN)
 
-Rill is able to connect to ClickHouse using the [ClickHouse Go Driver](https://clickhouse.com/docs/en/integrations/go). An appropriate connection string (DSN) will need to be set through the `connection.clickhouse.dsn` property in Rill.
+Rill is able to connect to ClickHouse using the [ClickHouse Go Driver](https://clickhouse.com/docs/en/integrations/go). An appropriate connection string (DSN) will need to be set through the `connector.clickhouse.dsn` property in Rill.
 
 A very simple example might look like the following:
 

--- a/docs/docs/reference/olap-engines/druid.md
+++ b/docs/docs/reference/olap-engines/druid.md
@@ -13,7 +13,7 @@ Rill supports connecting to an existing Druid cluster and using it as an OLAP en
 
 ## Connection string (DSN)
 
-Rill connects to Druid using the [Avatica protobuf endpoint](https://druid.apache.org/docs/latest/api-reference/sql-jdbc/) and requires using a connection string of the following format: `http://<host>/druid/v2/sql/avatica-protobuf/`. This should be set in the `connection.druid.dsn` property in Rill.
+Rill connects to Druid using the [Avatica protobuf endpoint](https://druid.apache.org/docs/latest/api-reference/sql-jdbc/) and requires using a connection string of the following format: `http://<host>/druid/v2/sql/avatica-protobuf/`. This should be set in the `connector.druid.dsn` property in Rill.
 
 As an example, this typically looks something like:
 
@@ -54,8 +54,8 @@ Please see our [Using Multiple OLAP Engines](multiple-olap.md) page.
 ## Configuring Rill Developer
 
 When using Rill for local development, there are two options to configure Rill to enable Druid as an OLAP engine:
-- You can set `connection.druid.dsn` in your project's `.env` file or try pulling existing credentials locally using `rill env pull` if the project has already been deployed to Rill Cloud
-- You can pass in `connection.druid.dsn` as a variable to `rill start` directly (e.g. `rill start --var connection.druid.dsn=...`)
+- You can set `connector.druid.dsn` in your project's `.env` file or try pulling existing credentials locally using `rill env pull` if the project has already been deployed to Rill Cloud
+- You can pass in `connector.druid.dsn` as a variable to `rill start` directly (e.g. `rill start --var connector.druid.dsn=...`)
 
 :::tip Getting DSN errors in dashboards after setting `.env`?
 
@@ -66,8 +66,8 @@ If you are facing issues related to DSN connection errors in your dashboards eve
 ## Configuring Rill Cloud
 
 When deploying a Druid-backed project to Rill Cloud, you have the following options to pass the appropriate connection string to Rill Cloud:
-- Use the `rill env configure` command to set `connection.druid.dsn` after deploying the project
-- If `connection.druid.dsn` has already been set in your project `.env`, you can push and update these variables directly in your cloud deployment by using the `rill env push` command
+- Use the `rill env configure` command to set `connector.druid.dsn` after deploying the project
+- If `connector.druid.dsn` has already been set in your project `.env`, you can push and update these variables directly in your cloud deployment by using the `rill env push` command
 
 :::info
 

--- a/docs/docs/reference/olap-engines/multiple-olap.md
+++ b/docs/docs/reference/olap-engines/multiple-olap.md
@@ -35,7 +35,7 @@ Before getting started, you'll need to first configure the appopriate connection
 
 **For Rill Developer:**
 - You can set these variables in your project's `.env` file or try pulling existing credentials locally using `rill env pull` if the project has already been deployed to Rill Cloud
-- Alternatively, you can pass in these connector DSN variables to `rill start` directly when starting Rill (e.g. `rill start --var connection.druid.dsn=... --var connection.clickhouse.dsn=...`)
+- Alternatively, you can pass in these connector DSN variables to `rill start` directly when starting Rill (e.g. `rill start --var connector.druid.dsn=... --var connector.clickhouse.dsn=...`)
 
 :::tip Getting DSN errors in dashboards after setting `.env`?
 
@@ -45,7 +45,7 @@ There might be instances where you've configured the project's `.env` file with 
 
 **For Rill Cloud:**
 - You can pass in the appropriate DSN connection string for each required OLAP engine by using the `rill env configure` command
-- Alternatively, if the required `connection.<olap-engine>.dsn` parameters have been set in your project's `.env`, you can "push" these updated variables to your deployed project directly using `rill env push`
+- Alternatively, if the required `connector.<olap-engine>.dsn` parameters have been set in your project's `.env`, you can "push" these updated variables to your deployed project directly using `rill env push`
 
 :::info
 


### PR DESCRIPTION
Correcting all instances of `connection.<olap>.dsn` with `connector.<olap>.dsn` in the OLAP engine section of our docs based on typos / corrections in #4399