### PR TITLE
Remove dummy `web-admin` e2e test from CI

### DIFF
--- a/.github/workflows/web-test-e2e.yml
+++ b/.github/workflows/web-test-e2e.yml
@@ -81,8 +81,7 @@ jobs:
           path: web-local/playwright-report/
           retention-days: 30
 
-      - name: Build & Test the web admin
+      - name: Build web admin
         if: ${{ steps.filter.outputs.admin == 'true' || steps.filter.outputs.common == 'true' }}
         run: |-
           npm run build -w web-admin
-          npm run test -w web-admin


### PR DESCRIPTION
Currently, CI's `npm run test -w web-admin` errors out because it's taking >1 minute to build the application in advance of the test suite. `web-admin/playwright.config.ts` uses a default 60s timeout for starting up the Playwright `webServer`.

Rather than increase the timeout, this PR removes the `npm run test -w web-admin` command from CI. We currently only have one dummy `web-admin` e2e test.

We can revert this when we have 1) material e2e tests to run for `web-admin` and 2) a sustainable solution to the build timeout (such as re-using the output from `npm run build -w web-admin`).