### PR TITLE
Fix: Sidebar scroll and title cutoff

### DIFF
--- a/web-common/src/features/project/ProjectTitle.svelte
+++ b/web-common/src/features/project/ProjectTitle.svelte
@@ -21,7 +21,7 @@
 >
   <!-- the pl-[.875rem] is a fix to move this new element over a pinch.-->
   <h1
-    class="grid grid-flow-col justify-start gap-x-3 p-4 pl-[.75rem] items-center content-center"
+    class="grid grid-flow-col justify-start gap-x-3 py-4 pl-[.75rem] items-center content-center"
   >
     {#if mounted && $projectTitle.isSuccess}
       <a href="/">
@@ -41,7 +41,7 @@
     {/if}
     <Tooltip distance={8}>
       <a
-        class="font-semibold text-black grow text-ellipsis overflow-hidden whitespace-nowrap pr-12"
+        class="font-semibold text-black grow text-ellipsis overflow-hidden whitespace-nowrap pr-9"
         href="/"
       >
         {$projectTitle.data || "Untitled Rill Project"}

--- a/web-common/src/layout/navigation/Navigation.svelte
+++ b/web-common/src/layout/navigation/Navigation.svelte
@@ -118,7 +118,7 @@
   }
 
   .inner {
-    @apply h-full;
+    @apply h-full overflow-hidden flex flex-col;
     will-change: width;
   }
 
@@ -127,8 +127,7 @@
   }
 
   .scroll-container {
-    @apply grow;
-    @apply overflow-y-scroll overflow-x-hidden;
+    @apply overflow-y-auto overflow-x-hidden;
     @apply transition-colors h-full bg-white pb-8;
   }
 


### PR DESCRIPTION
This PR fixes an issue where the sidebar scrollbars would appear when the container was not overflowing. It also gives the project title a few more characters worth of space.