### PR TITLE
Hide the Metrics Inspector for OLAP engines that don't support modeling

### DIFF
--- a/web-common/src/features/metrics-views/workspace/MetricsWorkspace.svelte
+++ b/web-common/src/features/metrics-views/workspace/MetricsWorkspace.svelte
@@ -1,14 +1,24 @@
 <script lang="ts">
   import { WorkspaceContainer } from "../../../layout/workspace";
+  import { runtime } from "../../../runtime-client/runtime-store";
+  import { useIsModelingSupportedForCurrentOlapDriver } from "../../tables/selectors";
   import MetricsEditor from "./editor/MetricsEditor.svelte";
   import MetricsInspector from "./inspector/MetricsInspector.svelte";
   import MetricsWorkspaceHeader from "./MetricsWorkspaceHeader.svelte";
 
   export let metricsDefName: string;
+
+  $: isModelingSupportedForCurrentOlapDriver =
+    useIsModelingSupportedForCurrentOlapDriver($runtime.instanceId);
+  $: showInspector = $isModelingSupportedForCurrentOlapDriver.data;
 </script>
 
-<WorkspaceContainer>
-  <MetricsWorkspaceHeader slot="header" {metricsDefName} />
+<WorkspaceContainer inspector={showInspector}>
+  <MetricsWorkspaceHeader
+    slot="header"
+    {metricsDefName}
+    showInspectorToggle={showInspector}
+  />
   <MetricsEditor slot="body" {metricsDefName} />
   <MetricsInspector slot="inspector" {metricsDefName} />
 </WorkspaceContainer>

--- a/web-common/src/features/metrics-views/workspace/MetricsWorkspaceHeader.svelte
+++ b/web-common/src/features/metrics-views/workspace/MetricsWorkspaceHeader.svelte
@@ -15,6 +15,7 @@
   import GoToDashboardButton from "./GoToDashboardButton.svelte";
 
   export let metricsDefName;
+  export let showInspectorToggle = true;
 
   $: runtimeInstanceId = $runtime.instanceId;
   $: allNamesQuery = useAllNames(runtimeInstanceId);
@@ -55,6 +56,12 @@
   $: titleInput = metricsDefName;
 </script>
 
-<WorkspaceHeader {...{ titleInput, onChangeCallback }}>
+<WorkspaceHeader
+  {...{
+    titleInput,
+    onChangeCallback,
+    showInspectorToggle,
+  }}
+>
   <GoToDashboardButton {metricsDefName} slot="cta" />
 </WorkspaceHeader>


### PR DESCRIPTION
Closes https://github.com/rilldata/rill-private-issues/issues/234

The Metrics Inspector is enabled for DuckDB-backed projects:
![image](https://github.com/rilldata/rill/assets/14206386/ad43bb49-ee6f-4487-92a5-e20e87fbfd79)

The Metrics Inspector is hidden for ClickHouse & Druid projects:
![image](https://github.com/rilldata/rill/assets/14206386/c09552e6-72c3-4869-b553-fd8294734569)
