### PR TITLE
feat: move alerts to top bar

### DIFF
--- a/web-admin/src/features/alerts/CreateAlert.svelte
+++ b/web-admin/src/features/alerts/CreateAlert.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { page } from "$app/stores";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";

--- a/web-admin/src/features/alerts/CreateAlert.svelte
+++ b/web-admin/src/features/alerts/CreateAlert.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { Button } from "@rilldata/web-common/components/button";
   import { BellPlusIcon } from "lucide-svelte";
+  import CreateAlertDialog from "@rilldata/web-common/features/alerts/CreateAlertDialog.svelte";
 
   const {
     selectors: {
@@ -13,17 +13,6 @@
   } = getStateManagers();
 
   let showAlertDialog = false;
-
-  // Only import the Create Alert dialog if in the Cloud context.
-  // This ensures Rill Developer doesn't try and fail to import the admin-client.
-  let CreateAlertDialog;
-  onMount(async () => {
-    CreateAlertDialog = (
-      await import(
-        "@rilldata/web-common/features/alerts/CreateAlertDialog.svelte"
-      )
-    ).default;
-  });
 </script>
 
 <Tooltip location="top" distance={8} suppress={!$isCustomTimeRange}>

--- a/web-admin/src/features/alerts/CreateAlert.svelte
+++ b/web-admin/src/features/alerts/CreateAlert.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import Tooltip from "../../components/tooltip/Tooltip.svelte";
-  import TooltipContent from "../../components/tooltip/TooltipContent.svelte";
-  import { getStateManagers } from "../dashboards/state-managers/state-managers";
+  import { page } from "$app/stores";
+  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
+  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
+  import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
+  import { Button } from "@rilldata/web-common/components/button";
+  import { BellPlusIcon } from "lucide-svelte";
 
   const {
     selectors: {
@@ -16,27 +19,30 @@
   // This ensures Rill Developer doesn't try and fail to import the admin-client.
   let CreateAlertDialog;
   onMount(async () => {
-    CreateAlertDialog = (await import("./CreateAlertDialog.svelte")).default;
+    CreateAlertDialog = (
+      await import(
+        "@rilldata/web-common/features/alerts/CreateAlertDialog.svelte"
+      )
+    ).default;
   });
 </script>
 
 <Tooltip location="top" distance={8} suppress={!$isCustomTimeRange}>
-  <button
+  <Button
     disabled={$isCustomTimeRange}
-    class="h-6 px-1.5 py-px flex items-center gap-[3px] rounded-sm hover:bg-gray-200 text-gray-700 disabled:cursor-not-allowed disabled:text-gray-400 disabled:hover:bg-gray-100"
-    on:click={() => {
-      showAlertDialog = true;
-    }}
+    on:click={() => (showAlertDialog = true)}
+    compact
+    type="secondary"
   >
-    Create alert
-  </button>
+    <BellPlusIcon class="inline-flex" size="16px" />
+  </Button>
   <TooltipContent slot="tooltip-content">
     To create an alert, set a non-custom time range.
   </TooltipContent>
 </Tooltip>
 
 <!-- Including `showAlertDialog` in the conditional ensures we tear 
-  down the form state when the dialog closes -->
+    down the form state when the dialog closes -->
 {#if showAlertDialog}
   <svelte:component
     this={CreateAlertDialog}

--- a/web-admin/src/features/alerts/listing/AlertsTableCompositeCell.svelte
+++ b/web-admin/src/features/alerts/listing/AlertsTableCompositeCell.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import AlertCircleOutline from "@rilldata/web-common/components/icons/AlertCircleOutline.svelte";
+  import { BellIcon } from "lucide-svelte";
   import CancelCircleInverse from "@rilldata/web-common/components/icons/CancelCircleInverse.svelte";
   import CheckCircleOutline from "@rilldata/web-common/components/icons/CheckCircleOutline.svelte";
   import ProjectAccessControls from "../../projects/ProjectAccessControls.svelte";
@@ -15,8 +15,8 @@
 </script>
 
 <a href={`alerts/${id}`} class="flex flex-col gap-y-0.5 group px-4 py-[5px]">
-  <div class="flex gap-x-2 items-center">
-    <AlertCircleOutline size={"14px"} className="text-slate-500" />
+  <div class="flex gap-x-2 items-center text-slate-500">
+    <BellIcon size="14px" />
     <div
       class="text-gray-700 text-sm font-semibold group-hover:text-primary-600"
     >

--- a/web-admin/src/features/alerts/listing/NoAlertsCTA.svelte
+++ b/web-admin/src/features/alerts/listing/NoAlertsCTA.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import ReportIcon from "@rilldata/web-common/components/icons/ReportIcon.svelte";
+  import { BellIcon } from "lucide-svelte";
 </script>
 
 <div
@@ -7,7 +7,7 @@
 >
   <div class="flex flex-col justify-center items-center">
     <div class="relative">
-      <ReportIcon className="text-slate-300 w-12 h-12" />
+      <BellIcon className="text-slate-300 w-12 h-12" />
     </div>
   </div>
   <div

--- a/web-admin/src/features/alerts/metadata/AlertMetadata.svelte
+++ b/web-admin/src/features/alerts/metadata/AlertMetadata.svelte
@@ -130,7 +130,7 @@
       <div class="flex flex-col gap-y-3">
         <MetadataLabel>Split by dimension</MetadataLabel>
         <MetadataValue>
-          {metricsViewAggregationRequest?.dimensions[0]?.name}
+          {metricsViewAggregationRequest?.dimensions[0]?.name ?? "None"}
         </MetadataValue>
       </div>
 

--- a/web-admin/src/features/navigation/TopNavigationBar.svelte
+++ b/web-admin/src/features/navigation/TopNavigationBar.svelte
@@ -15,6 +15,8 @@
   import ShareProjectButton from "../projects/ShareProjectButton.svelte";
   import Breadcrumbs from "./Breadcrumbs.svelte";
   import { isDashboardPage, isProjectPage } from "./nav-utils";
+  import StateManagersProvider from "@rilldata/web-common/features/dashboards/state-managers/StateManagersProvider.svelte";
+  import CreateAlert from "../alerts/CreateAlert.svelte";
 
   const user = createAdminServiceGetCurrentUser();
 
@@ -51,7 +53,7 @@
   {:else}
     <div />
   {/if}
-  <div class="flex gap-x-4 items-center">
+  <div class="flex gap-x-2 items-center">
     {#if $viewAsUserStore}
       <ViewAsUserChip />
     {/if}
@@ -59,11 +61,14 @@
       <ShareProjectButton {organization} {project} />
     {/if}
     {#if onDashboardPage}
-      <LastRefreshedDate {dashboard} />
-      {#if $user.isSuccess && $user.data.user}
-        <Bookmarks />
-      {/if}
-      <ShareDashboardButton />
+      <StateManagersProvider metricsViewName={dashboard}>
+        <LastRefreshedDate {dashboard} />
+        {#if $user.isSuccess && $user.data.user}
+          <CreateAlert />
+          <Bookmarks />
+        {/if}
+        <ShareDashboardButton />
+      </StateManagersProvider>
     {/if}
     {#if $user.isSuccess}
       {#if $user.data && $user.data.user}

--- a/web-common/src/features/alerts/CreateAlertDialog.svelte
+++ b/web-common/src/features/alerts/CreateAlertDialog.svelte
@@ -42,11 +42,24 @@
   } = getStateManagers();
   const timeControls = get(timeControlsState);
 
+  // Set defaults depending on UI state
+  // if in TDD take active measure and comparison dimension
+  // If expanded leaderboard, take first dimension and active dimensions
+  let dimension = "";
+  if ($dashboardStore.expandedMeasureName) {
+    dimension = $dashboardStore.selectedComparisonDimension ?? "";
+  } else {
+    dimension = $dashboardStore.selectedDimensionName ?? "";
+  }
+
   const formState = createForm({
     initialValues: {
       name: "",
-      measure: $dashboardStore.leaderboardMeasureName ?? "",
-      splitByDimension: $dashboardStore.selectedDimensionName ?? "",
+      measure:
+        $dashboardStore.expandedMeasureName ??
+        $dashboardStore.leaderboardMeasureName ??
+        "",
+      splitByDimension: dimension,
       evaluationInterval: "",
       criteria: [
         {

--- a/web-common/src/features/dashboards/dimension-table/DimensionHeader.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionHeader.svelte
@@ -14,7 +14,6 @@
   import { slideRight } from "@rilldata/web-common/lib/transitions";
   import { createEventDispatcher } from "svelte";
   import { fly } from "svelte/transition";
-  import CreateAlertButton from "../../alerts/CreateAlertButton.svelte";
   import Spinner from "../../entity-management/Spinner.svelte";
   import { SortType } from "../proto-state/derived-types";
   import { getStateManagers } from "../state-managers/state-managers";
@@ -152,9 +151,5 @@
     </Tooltip>
 
     <ExportDimensionTableDataButton includeScheduledReport={$adminServer} />
-
-    {#if $adminServer}
-      <CreateAlertButton />
-    {/if}
   </div>
 </div>


### PR DESCRIPTION
This PR:

- Moves Create Alert entrypoint to the top bar
- Removes the entry point from leaderboard
- Dynamic defaults in the Alerts form depending on UI state
- Updates icons in listings