### PR TITLE
Update chart generation prompt for new metrics sql syntax

### DIFF
--- a/web-common/src/features/charts/chartYaml.ts
+++ b/web-common/src/features/charts/chartYaml.ts
@@ -1,4 +1,5 @@
-import { Document } from "yaml";
+import type { V1ChartSpec } from "@rilldata/web-common/runtime-client";
+import { Document, parse } from "yaml";
 
 export function getChartYaml(
   vegaLite: string | undefined,
@@ -20,4 +21,30 @@ export function getChartYaml(
   doc.set("vega_lite", vegaLite ?? "{}");
 
   return doc.toString();
+}
+
+export function parseChartYaml(chartContent: string): V1ChartSpec {
+  const chartYaml = parse(chartContent);
+
+  let resolver = "";
+  const resolverProperties: Record<string, string> = {};
+
+  console.log(chartYaml);
+  if (chartYaml.data?.sql) {
+    resolver = "sql";
+    resolverProperties.sql = chartYaml.data?.sql;
+  } else if (chartYaml.data?.metrics_sql) {
+    resolver = "metrics_sql";
+    resolverProperties.sql = chartYaml.data?.metrics_sql;
+  } else if (chartYaml.data?.api) {
+    resolver = "api";
+    resolverProperties.api = chartYaml.data?.api;
+  }
+
+  return {
+    title: chartYaml.title,
+    vegaLiteSpec: chartYaml.vegaLiteSpec,
+    resolver,
+    resolverProperties,
+  };
 }


### PR DESCRIPTION
There were some slight changes to the metrics sql syntax. This leads to some issues where chatgpt tries to add aggregations to columns that are already aggregates like measures.

Also updates the button in charts page to work on errored charts.