### PR TITLE
Fix: Mock user JWT invalidation and queryClient access

### DIFF
--- a/web-common/src/features/dashboards/granular-access-policies/resetSelectedMockUserAfterNavigate.ts
+++ b/web-common/src/features/dashboards/granular-access-policies/resetSelectedMockUserAfterNavigate.ts
@@ -1,4 +1,4 @@
-import { afterNavigate } from "$app/navigation";
+import { beforeNavigate } from "$app/navigation";
 import { selectedMockUserStore } from "@rilldata/web-common/features/dashboards/granular-access-policies/stores";
 import { updateDevJWT } from "@rilldata/web-common/features/dashboards/granular-access-policies/updateDevJWT";
 import type { QueryClient } from "@tanstack/svelte-query";
@@ -14,12 +14,14 @@ import { get } from "svelte/store";
  * `Dashboard.svelte` component.
  */
 export function resetSelectedMockUserAfterNavigate(queryClient: QueryClient) {
-  afterNavigate((nav) => {
+  beforeNavigate(({ to, from }) => {
+    if (!to?.params || !from?.params) return;
+
     if (
-      nav.from.params.name !== nav.to.params.name &&
+      from.params.name !== to.params.name &&
       get(selectedMockUserStore) !== null
     ) {
-      updateDevJWT(queryClient, null);
+      updateDevJWT(queryClient, null).catch(console.error);
     }
   });
 }

--- a/web-common/src/features/dashboards/selectors/index.ts
+++ b/web-common/src/features/dashboards/selectors/index.ts
@@ -129,6 +129,12 @@ export function createMetricsViewSchema(
       createQueryServiceMetricsViewSchema(
         runtime.instanceId,
         metricsViewName,
+        {},
+        {
+          query: {
+            queryClient: ctx.queryClient,
+          },
+        },
       ).subscribe(set),
   );
 }

--- a/web-common/src/runtime-client/http-client.ts
+++ b/web-common/src/runtime-client/http-client.ts
@@ -29,7 +29,7 @@ export const httpClient = async <T>(
 
   // Set JWT
   let jwt = get(runtime).jwt;
-  if (jwt) {
+  if (jwt && jwt.token) {
     jwt = await maybeWaitForFreshJWT(jwt);
     interceptedConfig.headers = {
       ...interceptedConfig.headers,


### PR DESCRIPTION
This PR solves an issue where JWTs were being invalidated incorrectly according to the expectation of the HTTP Client. Additionally, it solves a bug where `createMetricsViewSchema` was accessing the queryClient incorrectly.