### PR TITLE
Admin: Add DB migration and docs for create_alerts and manage_alerts permissions

### DIFF
--- a/admin/database/postgres/migrations/0023.sql
+++ b/admin/database/postgres/migrations/0023.sql
@@ -1,0 +1,5 @@
+ALTER TABLE project_roles ADD create_alerts BOOLEAN NOT NULL DEFAULT false;
+UPDATE project_roles SET create_alerts = read_prod;
+
+ALTER TABLE project_roles ADD manage_alerts BOOLEAN NOT NULL DEFAULT false;
+UPDATE project_roles SET manage_alerts = manage_prod;

--- a/docs/docs/manage/roles-permissions.md
+++ b/docs/docs/manage/roles-permissions.md
@@ -43,6 +43,8 @@ There are two roles available at the project-level: **Viewer** and **Admin**.
 | `manage_project_members` | Add, remove or change roles of project members             |        |     ✔ |
 | `create_reports`         | Create and edit new scheduled reports                      |      ✔ |     ✔ |
 | `manage_reports`         | Edit and change scheduled reports created by others        |        |     ✔ |
+| `create_alerts`          | Create and edit new alerts                                 |      ✔ |     ✔ |
+| `manage_alerts`          | Edit and change alerts created by others                   |        |     ✔ |
 <!--
 | `read_dev`               | View dashboards deployed from non-production branches      |        |     ✔ |
 | `read_dev_status`        | View logs for non-production deployments                   |        |     ✔ |


### PR DESCRIPTION
This was missing from the initial alerts PR. It fails silently by not letting viewer roles create alerts.

Closes https://github.com/rilldata/rill-private-issues/issues/251