### PR TITLE
Fix: Perpetual loading state and infinite loop query

### DIFF
--- a/web-common/src/features/dashboards/selectors/index.ts
+++ b/web-common/src/features/dashboards/selectors/index.ts
@@ -19,7 +19,6 @@ import type {
 } from "@tanstack/svelte-query";
 import { Readable, derived } from "svelte/store";
 import type { StateManagers } from "../state-managers/state-managers";
-import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
 
 export const useMetricsView = <T = V1MetricsViewSpec>(
   ctx: StateManagers,
@@ -133,7 +132,7 @@ export function createMetricsViewSchema(
         {},
         {
           query: {
-            queryClient: queryClient,
+            queryClient: ctx.queryClient,
           },
         },
       ).subscribe(set),

--- a/web-common/src/features/dashboards/selectors/index.ts
+++ b/web-common/src/features/dashboards/selectors/index.ts
@@ -19,6 +19,7 @@ import type {
 } from "@tanstack/svelte-query";
 import { Readable, derived } from "svelte/store";
 import type { StateManagers } from "../state-managers/state-managers";
+import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
 
 export const useMetricsView = <T = V1MetricsViewSpec>(
   ctx: StateManagers,
@@ -113,7 +114,7 @@ export function createTimeRangeSummary(
         {
           query: {
             queryClient: ctx.queryClient,
-            enabled: !!metricsView.data?.timeDimension,
+            enabled: !metricsView.error && !!metricsView.data?.timeDimension,
           },
         },
       ).subscribe(set),
@@ -132,7 +133,7 @@ export function createMetricsViewSchema(
         {},
         {
           query: {
-            queryClient: ctx.queryClient,
+            queryClient: queryClient,
           },
         },
       ).subscribe(set),

--- a/web-common/src/features/dashboards/stores/DashboardStateProvider.svelte
+++ b/web-common/src/features/dashboards/stores/DashboardStateProvider.svelte
@@ -5,17 +5,17 @@
   import Spinner from "../../entity-management/Spinner.svelte";
   import { EntityStatus } from "../../entity-management/types";
 
+  const dashboardStoreReady = createDashboardStateSync(getStateManagers());
+
   export let metricViewName: string;
 
   $: initLocalUserPreferenceStore(metricViewName);
-
-  const dashboardStoreReady = createDashboardStateSync(getStateManagers());
 </script>
 
-{#if $dashboardStoreReady}
-  <slot />
-{:else}
-  <div class="grid place-items-center mt-40">
+{#if $dashboardStoreReady.isFetching}
+  <div class="grid place-items-center size-full">
     <Spinner status={EntityStatus.Running} size="40px" />
   </div>
+{:else}
+  <slot />
 {/if}

--- a/web-common/src/features/dashboards/stores/syncDashboardState.ts
+++ b/web-common/src/features/dashboards/stores/syncDashboardState.ts
@@ -47,13 +47,17 @@ export function createDashboardStateSync(
         metricsViewSpecRes.isFetching ||
         timeRangeRes.isFetching ||
         metricsViewSchemaRes.isFetching ||
-        initialUrlStateRes?.isFetching ||
-        // requests errored out
+        initialUrlStateRes?.isFetching
+      ) {
+        return { isFetching: true, error: false };
+      }
+
+      if (
         !metricsViewSpecRes.data ||
         (!!metricsViewSpecRes.data.timeDimension && !timeRangeRes.data) ||
         !metricsViewSchemaRes.data?.schema
       ) {
-        return false;
+        return { isFetching: false, error: true };
       }
 
       const metricViewName = get(ctx.metricsViewName);
@@ -81,7 +85,7 @@ export function createDashboardStateSync(
           metricsExplorerStore.sync(metricViewName, metricsViewSpecRes.data);
         }
       }
-      return true;
+      return { isFetching: false, error: false };
     },
   );
 }

--- a/web-common/src/features/dashboards/workspace/DashboardCTAs.svelte
+++ b/web-common/src/features/dashboards/workspace/DashboardCTAs.svelte
@@ -53,9 +53,9 @@
 </script>
 
 <div class="flex gap-2 flex-shrink-0">
-  {#if $dashboardPolicyCheck.data}
-    <ViewAsButton />
-  {/if}
+  <!-- {#if $dashboardPolicyCheck.data} -->
+  <ViewAsButton />
+  <!-- {/if} -->
   {#if !$readOnly}
     <Tooltip distance={8}>
       <Button

--- a/web-common/src/features/dashboards/workspace/DashboardCTAs.svelte
+++ b/web-common/src/features/dashboards/workspace/DashboardCTAs.svelte
@@ -53,9 +53,9 @@
 </script>
 
 <div class="flex gap-2 flex-shrink-0">
-  <!-- {#if $dashboardPolicyCheck.data} -->
-  <ViewAsButton />
-  <!-- {/if} -->
+  {#if $dashboardPolicyCheck.data}
+    <ViewAsButton />
+  {/if}
   {#if !$readOnly}
     <Tooltip distance={8}>
       <Button

--- a/web-common/src/runtime-client/invalidation.ts
+++ b/web-common/src/runtime-client/invalidation.ts
@@ -60,6 +60,7 @@ export async function invalidateAllMetricsViews(
 ) {
   // First, refetch the resource entries (which returns the available dimensions and measures)
   await queryClient.refetchQueries({
+    type: "active",
     predicate: (query) =>
       typeof query.queryKey[0] === "string" &&
       query.queryKey[0].startsWith(`/v1/instances/${instanceId}/resource`),


### PR DESCRIPTION
This PR is a fix for an issue where dashboards would fall into a perpetual "loading" state when viewing as a mock user with a limited security policy.

This was solved by altering the `createDashboardStateSync` function to return a greater specificity of state than a simple ready/not ready boolean.

As such, even when the dashboard store has failed to load data properly (which would be the case when a user does not have appropriate access), the Dashboard component will still render and handle the `mockUserHasNoAccess` conditional. This is somewhat of a stopgap solution for what should eventually be a more substantial reorganization of how this works.

Because the conditional rendering block doesn't exist in `DashboardStateProvider` in the same way, a conditional had to be added to the `createTimeRangeSummary` query that disables it when `metricsView` has errors. Without this, the `DashboardURLStateProvider` component would mount and it's use of `useDashboardUrlSync` would cause the parent component to fall back into a loading state, which would loop infinitely as it mounted/unmounted. Again, this requires a more significant reorganization. 

Generally, my view is that these are not actually providers and so should not be conditionally blocking the rendering of components further down the tree. The `Dashboard` and its children should be responsible for their own loading states.