### PR TITLE
Refac: Move totals row out of data

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotTable.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTable.svelte
@@ -34,21 +34,27 @@
 
   const options: Readable<TableOptions<PivotDataRow>> = derived(
     [pivotDashboardStore, pivotDataStore],
-    ([pivotConfig, pivotData]) => ({
-      data: pivotData.data,
-      columns: pivotData.columnDef,
-      state: {
-        expanded: pivotConfig.expanded,
-        sorting: pivotConfig.sorting,
-      },
-      onExpandedChange: handleExpandedChange,
-      getSubRows: (row) => row.subRows,
-      onSortingChange: handleSorting,
-      getExpandedRowModel: getExpandedRowModel(),
-      getCoreRowModel: getCoreRowModel(),
-      enableSortingRemoval: false,
-      enableExpanding: true,
-    }),
+    ([pivotConfig, pivotData]) => {
+      let tableData = pivotData.data;
+      if (pivotData.totalsRowData) {
+        tableData = [pivotData.totalsRowData, ...pivotData.data];
+      }
+      return {
+        data: tableData,
+        columns: pivotData.columnDef,
+        state: {
+          expanded: pivotConfig.expanded,
+          sorting: pivotConfig.sorting,
+        },
+        onExpandedChange: handleExpandedChange,
+        getSubRows: (row) => row.subRows,
+        onSortingChange: handleSorting,
+        getExpandedRowModel: getExpandedRowModel(),
+        getCoreRowModel: getCoreRowModel(),
+        enableSortingRemoval: false,
+        enableExpanding: true,
+      };
+    },
   );
 
   const table = createSvelteTable(options);

--- a/web-common/src/features/dashboards/pivot/pivot-data-store.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-data-store.ts
@@ -435,7 +435,7 @@ function createPivotDataStore(ctx: StateManagers): PivotDataStore {
                 columnDef: lastPivotColumnDef,
                 assembled: true,
                 totalColumns: lastTotalColumns,
-                totalsRowData,
+                totalsRowData: displayTotalsRow ? totalsRowData : undefined,
                 reachedEndForRowData: true,
               });
             }

--- a/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
@@ -107,6 +107,34 @@ export function reduceTableCellDataIntoRows(
   return tableData;
 }
 
+export function getTotalsRowSkeleton(
+  config: PivotDataStoreConfig,
+  columnDimensionAxes: Record<string, string[]> = {},
+) {
+  const { rowDimensionNames, measureNames } = config;
+  const anchorDimensionName = rowDimensionNames[0];
+
+  let totalsRow: PivotDataRow = {};
+  if (measureNames.length) {
+    const totalsRowTable = reduceTableCellDataIntoRows(
+      config,
+      "",
+      [],
+      columnDimensionAxes || {},
+      [],
+      [],
+    );
+
+    totalsRow = totalsRowTable[0] || {};
+
+    if (anchorDimensionName) {
+      totalsRow[anchorDimensionName] = "Total";
+    }
+  }
+
+  return totalsRow;
+}
+
 export function getTotalsRow(
   config: PivotDataStoreConfig,
   columnDimensionAxes: Record<string, string[]> = {},

--- a/web-common/src/features/dashboards/pivot/types.ts
+++ b/web-common/src/features/dashboards/pivot/types.ts
@@ -20,6 +20,7 @@ export interface PivotDataState {
   assembled: boolean;
   totalColumns: number; // total columns excluding row and group totals columns
   reachedEndForRowData?: boolean;
+  totalsRowData?: PivotDataRow;
 }
 
 export type PivotDataStore = Readable<PivotDataState>;


### PR DESCRIPTION
Separate the totals data row rather than clubbing it with the overall pivot data. 
Also makes sure that totals data row is always present when needed ensuring fixed array size while making changes to pivot/scrolling.