### PR TITLE
Fix: Pivot expansion on infinite scroll

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-data-store.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-data-store.ts
@@ -168,6 +168,7 @@ export function createTableCellQuery(
   totalsRow: PivotDataRow,
   rowDimensionValues: string[],
 ) {
+  if (!rowDimensionValues.length) return readable(null);
   let allDimensions = config.colDimensionNames;
   if (anchorDimension) {
     allDimensions = config.colDimensionNames.concat([anchorDimension]);
@@ -374,8 +375,9 @@ function createPivotDataStore(ctx: StateManagers): PivotDataStore {
           );
         }
 
-        const displayTotalsRow =
-          rowDimensionNames.length && measureNames.length;
+        const displayTotalsRow = Boolean(
+          rowDimensionNames.length && measureNames.length,
+        );
         if (
           (rowDimensionNames.length || colDimensionNames.length) &&
           measureNames.length
@@ -427,18 +429,6 @@ function createPivotDataStore(ctx: StateManagers): PivotDataStore {
 
             const rowDimensionValues =
               rowDimensionAxes?.data?.[anchorDimension] || [];
-
-            if (rowDimensionValues.length === 0 && rowPage > 1) {
-              return axesSet({
-                isFetching: false,
-                data: lastPivotData,
-                columnDef: lastPivotColumnDef,
-                assembled: true,
-                totalColumns: lastTotalColumns,
-                totalsRowData: displayTotalsRow ? totalsRowData : undefined,
-                reachedEndForRowData: true,
-              });
-            }
 
             const totalColumns = getTotalColumnCount(totalsRowData);
 
@@ -583,12 +573,15 @@ function createPivotDataStore(ctx: StateManagers): PivotDataStore {
                     lastPivotColumnDef = columnDef;
                     lastTotalColumns = totalColumns;
 
+                    const reachedEndForRowData =
+                      rowDimensionValues.length === 0 && rowPage > 1;
                     return {
                       isFetching: false,
                       data: tableDataExpanded,
                       columnDef,
                       assembled: true,
                       totalColumns,
+                      reachedEndForRowData,
                       totalsRowData: displayTotalsRow
                         ? totalsRowData
                         : undefined,

--- a/web-common/src/features/dashboards/pivot/pivot-expansion.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-expansion.ts
@@ -274,7 +274,6 @@ export function addExpandedDataToPivot(
   columnDimensionAxes: Record<string, string[]>,
   expandedRowMeasureValues: ExpandedRowMeasureValues[],
 ): PivotDataRow[] {
-  console.log(tableData, expandedRowMeasureValues);
   const pivotData = tableData;
   const numRowDimensions = rowDimensions.length;
 

--- a/web-common/src/features/dashboards/pivot/pivot-expansion.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-expansion.ts
@@ -274,6 +274,7 @@ export function addExpandedDataToPivot(
   columnDimensionAxes: Record<string, string[]>,
   expandedRowMeasureValues: ExpandedRowMeasureValues[],
 ): PivotDataRow[] {
+  console.log(tableData, expandedRowMeasureValues);
   const pivotData = tableData;
   const numRowDimensions = rowDimensions.length;
 
@@ -322,6 +323,7 @@ export function addExpandedDataToPivot(
           columnDimensionAxes,
           skeletonSubTable,
           expandedRowData?.data,
+          true,
         );
       }
 

--- a/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
@@ -49,10 +49,11 @@ export function reduceTableCellDataIntoRows(
   columnDimensionAxes: Record<string, string[]>,
   tableData: PivotDataRow[],
   cellData: V1MetricsViewAggregationResponseDataItem[],
+  isExpanded = false,
 ) {
   const colDimensionNames = config.colDimensionNames;
   const rowPage = config.pivot.rowPage;
-  const rowOffset = (rowPage - 1) * NUM_ROWS_PER_PAGE;
+  const rowOffset = isExpanded ? 0 : (rowPage - 1) * NUM_ROWS_PER_PAGE;
 
   /**
    * Create a map of row dimension values to their index in the row dimension axes.


### PR DESCRIPTION
## Checklist
- [x] Manual verification
- [ ] Unit test coverage
- [ ] E2E test coverage
- [x] Needs manual QA?

## Summary
#### Issue addressed: 
1. Create a row nested pivot table with more than 100 rows
2. Scroll to the end of the table
3. Expand a row 

The expand doesn't work in this case

#### Details:
The table was being returned early which skipped expansion queries.

## Steps to Verify
Same as mentioned in the Issue