### PR TITLE
Feat: Resize Pivot header column

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotDrag.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotDrag.svelte
@@ -36,7 +36,7 @@
     </div>
   </button>
 
-  <div class="w-full h-fit overflow-scroll px-[2px] pb-2">
+  <div class="w-full h-fit overflow-y-auto overflow-x-hidden px-[2px] pb-2">
     {#if !collapsed}
       {#if items.length}
         <DragList {items} zone={title} />

--- a/web-common/src/features/dashboards/pivot/PivotPortalItem.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotPortalItem.svelte
@@ -46,7 +46,7 @@
 <style lang="postcss">
   .portal-item {
     @apply shadow-lg shadow-slate-300;
-    @apply z-10;
+    @apply z-50;
     @apply absolute pointer-events-none;
   }
 </style>

--- a/web-common/src/features/dashboards/pivot/PivotTable.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTable.svelte
@@ -3,9 +3,12 @@
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
   import {
+    ExpandedState,
+    SortingState,
     TableOptions,
-    createSvelteTable,
+    Updater,
     flexRender,
+    createSvelteTable,
     getCoreRowModel,
     getExpandedRowModel,
   } from "@tanstack/svelte-table";
@@ -13,20 +16,36 @@
     createVirtualizer,
     defaultRangeExtractor,
   } from "@tanstack/svelte-virtual";
+  import { isTimeDimension } from "./pivot-utils";
   import type { Readable } from "svelte/motion";
   import { derived } from "svelte/store";
+  import { getPivotConfig } from "./pivot-data-store";
   import type { PivotDataRow, PivotDataStore } from "./types";
+  import Resizer from "@rilldata/web-common/layout/Resizer.svelte";
 
   export let pivotDataStore: PivotDataStore;
 
-  const OVERSCAN = 80;
+  const OVERSCAN = 60;
   const ROW_HEIGHT = 24;
   const HEADER_HEIGHT = 30;
+  const MEASURE_PADDING = 16;
   // Distance threshold (in pixels) for triggering data fetch
   const ROW_THRESHOLD = 200;
+  const MIN_COL_WIDTH = 150;
+  const MAX_COL_WIDTH = 600;
+  const MAX_INIT_COL_WIDTH = 400;
 
   const stateManagers = getStateManagers();
-  const { dashboardStore, metricsViewName } = stateManagers;
+
+  const {
+    dashboardStore,
+    metricsViewName,
+    selectors: {
+      pivot: { rows: rowPills },
+    },
+  } = stateManagers;
+
+  const config = getPivotConfig(stateManagers);
 
   const pivotDashboardStore = derived(dashboardStore, (dashboard) => {
     return dashboard?.pivot;
@@ -46,9 +65,9 @@
           expanded: pivotConfig.expanded,
           sorting: pivotConfig.sorting,
         },
-        onExpandedChange: handleExpandedChange,
+        onExpandedChange,
         getSubRows: (row) => row.subRows,
-        onSortingChange: handleSorting,
+        onSortingChange,
         getExpandedRowModel: getExpandedRowModel(),
         getCoreRowModel: getCoreRowModel(),
         enableSortingRemoval: false,
@@ -61,6 +80,10 @@
 
   let containerRefElement: HTMLDivElement;
   let stickyRows = [0];
+  let rowScrollOffset = 0;
+
+  $: timeDimension = $config.time.timeDimension;
+  $: hasDimension = $rowPills.dimension.length > 0;
 
   $: reachedEndForRows = !!$pivotDataStore?.reachedEndForRowData;
   $: assembled = $pivotDataStore.assembled;
@@ -72,6 +95,26 @@
   $: measureCount = $dashboardStore.pivot?.columns?.measure?.length ?? 0;
   $: rows = $table.getRowModel().rows;
   $: totalHeaderHeight = headerGroups.length * HEADER_HEIGHT;
+  $: headers = headerGroups[0].headers;
+  $: firstColumnName = hasDimension
+    ? String(headers[0]?.column.columnDef.header)
+    : null;
+  $: firstColumnWidth =
+    hasDimension && firstColumnName
+      ? calculateFirstColumnWidth(firstColumnName)
+      : 0;
+
+  $: measureGroups = headerGroups[headerGroups.length - 2]?.headers?.slice(
+    hasDimension ? 1 : 0,
+  ) ?? [null];
+  $: measureGroupsLength = measureGroups.length;
+  $: measureLengths =
+    $dashboardStore.pivot?.columns?.measure?.map((measure) => {
+      return measure.title.length * 7 + MEASURE_PADDING;
+    }) ?? [];
+
+  $: totalMeasureWidth = measureLengths.reduce((acc, val) => acc + val, 0);
+  $: totalLength = measureGroupsLength * totalMeasureWidth;
 
   $: virtualizer = createVirtualizer<HTMLDivElement, HTMLTableRowElement>({
     count: rows.length,
@@ -89,7 +132,6 @@
   $: virtualRows = $virtualizer.getVirtualItems();
   $: totalRowSize = $virtualizer.getTotalSize();
 
-  let rowScrollOffset = 0;
   $: rowScrollOffset = $virtualizer?.scrollOffset || 0;
 
   // In this virtualization model, we create buffer rows before and after our real data
@@ -101,12 +143,15 @@
       ]
     : [0, 0];
 
-  function handleExpandedChange(updater) {
+  function onExpandedChange(updater: Updater<ExpandedState>) {
+    // Something is off with tanstack's types
+    //@ts-expect-error-free
+    //eslint-disable-next-line
     expanded = updater(expanded);
     metricsExplorerStore.setPivotExpanded($metricsViewName, expanded);
   }
 
-  function handleSorting(updater) {
+  function onSortingChange(updater: Updater<SortingState>) {
     if (updater instanceof Function) {
       sorting = updater(sorting);
     } else {
@@ -130,158 +175,193 @@
       }
     }
   };
+
+  function calculateFirstColumnWidth(firstColumnName: string) {
+    const rows = $pivotDataStore.data;
+
+    // Dates are displayed as shorter values
+    if (isTimeDimension(firstColumnName, timeDimension)) return MIN_COL_WIDTH;
+
+    const samples = extractSamples(
+      rows.map((row) => row[firstColumnName]),
+    ).filter((v): v is string => typeof v === "string");
+
+    const maxValueLength = samples.reduce((max, value) => {
+      return Math.max(max, value.length);
+    }, 0);
+
+    const finalBasis = Math.max(firstColumnName.length, maxValueLength);
+    const pixelLength = finalBasis * 7;
+    const final = Math.max(
+      MIN_COL_WIDTH,
+      Math.min(MAX_INIT_COL_WIDTH, pixelLength + 16),
+    );
+
+    return final;
+  }
+
+  function extractSamples<T>(arr: T[], sampleSize: number = 30) {
+    if (arr.length <= sampleSize) {
+      return arr.slice();
+    }
+
+    const sectionSize = Math.floor(sampleSize / 3);
+
+    const lastSectionSize = sampleSize - sectionSize * 2;
+
+    const first = arr.slice(0, sectionSize);
+
+    let middleStartIndex = Math.floor((arr.length - sectionSize) / 2);
+    const middle = arr.slice(middleStartIndex, middleStartIndex + sectionSize);
+
+    const last = arr.slice(-lastSectionSize);
+
+    return [...first, ...middle, ...last];
+  }
 </script>
 
 <div
+  class="table-wrapper"
+  class:with-row-dimension={hasDimension}
   style:--row-height="{ROW_HEIGHT}px"
-  style:--header-length="{totalHeaderHeight}px"
-  class="overflow-scroll h-fit max-h-full border rounded-md bg-white"
+  style:--header-height="{HEADER_HEIGHT}px"
+  style:--total-header-height="{totalHeaderHeight + headerGroups.length}px"
   bind:this={containerRefElement}
   on:scroll={() => handleScroll(containerRefElement)}
 >
-  <div style:height="{totalRowSize + totalHeaderHeight}px">
-    <table>
-      <thead>
-        {#each headerGroups as headerGroup}
-          <tr>
-            {#each headerGroup.headers as header}
-              {@const sortDirection = header.column.getIsSorted()}
-              <th
-                colSpan={header.colSpan}
-                class:with-row-dimension={rows.length > 1}
+  <table style:width="{totalLength}px">
+    {#if firstColumnName && firstColumnWidth}
+      <colgroup>
+        <col
+          style:width="{firstColumnWidth}px"
+          style:max-width="{firstColumnWidth}px"
+        />
+      </colgroup>
+    {/if}
+
+    {#each measureGroups as _}
+      <colgroup>
+        {#each measureLengths as length}
+          <col style:width="{length}px" style:max-width="{length}px" />
+        {/each}
+      </colgroup>
+    {/each}
+
+    <thead>
+      {#each headerGroups as headerGroup (headerGroup.id)}
+        <tr>
+          {#each headerGroup.headers as header, i (header.id)}
+            {@const sortDirection = header.column.getIsSorted()}
+            {@const canResize = i === 0 && hasDimension}
+            <th colSpan={header.colSpan}>
+              {#if canResize}
+                <Resizer
+                  min={MIN_COL_WIDTH}
+                  max={MAX_COL_WIDTH}
+                  basis={MIN_COL_WIDTH}
+                  bind:dimension={firstColumnWidth}
+                  side="right"
+                  direction="EW"
+                />
+              {/if}
+
+              <button
+                class="header-cell"
+                class:cursor-pointer={header.column.getCanSort()}
+                class:select-none={header.column.getCanSort()}
+                on:click={header.column.getToggleSortingHandler()}
               >
-                <div class="header-cell" style:height="{HEADER_HEIGHT}px">
-                  {#if !header.isPlaceholder}
-                    <button
-                      class="flex items-center gap-x-1"
-                      class:cursor-pointer={header.column.getCanSort()}
-                      class:select-none={header.column.getCanSort()}
-                      on:click={header.column.getToggleSortingHandler()}
+                {#if !header.isPlaceholder}
+                  {header.column.columnDef.header}
+                  {#if sortDirection}
+                    <span
+                      class="transition-transform -mr-1"
+                      class:-rotate-180={sortDirection === "asc"}
                     >
-                      {header.column.columnDef.header}
-                      {#if sortDirection}
-                        <span
-                          class="transition-transform -mr-1"
-                          class:-rotate-180={sortDirection === "asc"}
-                        >
-                          <ArrowDown />
-                        </span>
-                      {/if}
-                    </button>
-                  {:else}
-                    <button class="w-full h-full"></button>
+                      <ArrowDown />
+                    </span>
                   {/if}
-                </div>
-              </th>
-            {/each}
-          </tr>
-        {/each}
-      </thead>
-      <tbody>
-        <tr>
-          <td colspan={headerGroups.length} style:height="{before}px"> </td>
+                {/if}
+              </button>
+            </th>
+          {/each}
         </tr>
-        {#each virtualRows as row (row.index)}
-          {@const cells = rows[row.index].getVisibleCells()}
-          <tr>
-            {#each cells as cell, i (cell.id)}
-              {@const result =
-                typeof cell.column.columnDef.cell === "function"
-                  ? cell.column.columnDef.cell(cell.getContext())
-                  : cell.column.columnDef.cell}
-              <td
-                class:with-row-dimension={rows.length > 1}
-                class="ui-copy-number"
-                class:border-right={i % measureCount === 0 && i}
-              >
-                <div class="cell">
-                  {#if result?.component && result?.props}
-                    <svelte:component
-                      this={result.component}
-                      {...result.props}
-                      {assembled}
-                    />
-                  {:else if typeof result === "string" || typeof result === "number"}
-                    {result}
-                  {:else}
-                    <svelte:component
-                      this={flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext(),
-                      )}
-                    />
-                  {/if}
-                </div>
-              </td>
-            {/each}
-          </tr>
-        {/each}
+      {/each}
+    </thead>
+    <tbody>
+      <tr style:height="{before}px" />
+      {#each virtualRows as row (row.index)}
+        {@const cells = rows[row.index].getVisibleCells()}
         <tr>
-          <td colspan={headerGroups.length} style:height="{after}px"></td>
+          {#each cells as cell, i (cell.id)}
+            {@const result =
+              typeof cell.column.columnDef.cell === "function"
+                ? cell.column.columnDef.cell(cell.getContext())
+                : cell.column.columnDef.cell}
+            <td
+              class="ui-copy-number"
+              class:border-r={i % measureCount === 0 && i}
+            >
+              <div class="cell">
+                {#if result?.component && result?.props}
+                  <svelte:component
+                    this={result.component}
+                    {...result.props}
+                    {assembled}
+                  />
+                {:else if typeof result === "string" || typeof result === "number"}
+                  {result}
+                {:else}
+                  <svelte:component
+                    this={flexRender(
+                      cell.column.columnDef.cell,
+                      cell.getContext(),
+                    )}
+                  />
+                {/if}
+              </div>
+            </td>
+          {/each}
         </tr>
-      </tbody>
-    </table>
-  </div>
+      {/each}
+      <tr style:height="{after}px" />
+    </tbody>
+  </table>
 </div>
 
 <style lang="postcss">
-  table {
-    @apply bg-white;
-  }
-
   * {
     @apply border-slate-200;
+  }
+
+  table {
+    @apply p-0 m-0 border-spacing-0 border-separate w-fit;
+    @apply font-normal select-none;
+    @apply bg-white table-fixed;
+  }
+
+  .table-wrapper {
+    @apply overflow-auto h-fit max-h-full w-fit max-w-full;
+    @apply border rounded-md z-40;
   }
 
   /* Pin header */
   thead {
     @apply sticky top-0;
-    @apply z-10;
+    @apply z-30 bg-white;
   }
 
-  .header-cell {
-    @apply w-full h-full;
-    @apply bg-white;
-    @apply px-2;
-    @apply flex items-center justify-start;
-    @apply border-r border-b;
-    @apply text-left;
-    @apply text-ellipsis whitespace-nowrap overflow-hidden;
-  }
-
-  /* The leftmost header cells have no bottom border unless they're the last row */
-  thead
-    > tr:not(:last-of-type)
-    > .with-row-dimension:first-of-type
-    > .header-cell {
-    @apply border-b-0;
-  }
-
-  thead > tr:last-of-type > th > .header-cell {
-    @apply text-right;
+  tbody .cell {
+    height: var(--row-height);
   }
 
   th {
-    @apply p-0 m-0;
+    @apply p-0 m-0 text-xs;
+    @apply border-r border-b relative;
   }
 
-  td {
-    @apply border-none;
-    @apply text-right;
-    @apply p-0 m-0;
-  }
-
-  tr > .with-row-dimension:first-of-type,
-  tr > .with-row-dimension:first-of-type {
-    @apply sticky left-0 z-0;
-    @apply bg-white;
-    @apply truncate;
-    /* re-evaluate this when adding resizing and virtualization */
-    max-width: 500px;
-  }
-
-  tr > td:first-of-type:not(:last-of-type) > .cell {
-    @apply border-r font-medium;
+  th:last-of-type {
+    @apply border-r-0;
   }
 
   th,
@@ -289,28 +369,49 @@
     @apply whitespace-nowrap text-xs;
   }
 
+  td {
+    @apply text-right;
+    @apply p-0 m-0;
+  }
+
+  .header-cell {
+    @apply px-2 bg-white size-full;
+    @apply flex items-center gap-x-1 w-full truncate;
+    height: var(--header-height);
+  }
+
   .cell {
-    @apply p-1 px-2;
-    height: var(--row-height);
+    @apply size-full p-1 px-2;
   }
 
+  /* The leftmost header cells have no bottom border unless they're the last row */
+  .with-row-dimension thead > tr:not(:last-of-type) > th:first-of-type {
+    @apply border-b-0;
+  }
+
+  .with-row-dimension tr > th:first-of-type {
+    @apply sticky left-0 z-20;
+    @apply bg-white;
+  }
+
+  .with-row-dimension tr > td:first-of-type {
+    @apply sticky left-0 z-10;
+    @apply bg-white;
+  }
+
+  tr > td:first-of-type:not(:last-of-type) {
+    @apply border-r font-medium;
+  }
+
+  /* The totals row */
   tbody > tr:nth-of-type(2) {
-    @apply bg-slate-100 sticky z-10 font-semibold;
-    top: var(--header-length);
+    @apply bg-slate-100 sticky z-20 font-semibold;
+    top: var(--total-header-height);
   }
 
-  .border-right {
-    border-right: solid black 1px;
-    @apply border-gray-200;
-  }
-
-  tbody > tr:first-of-type > td:first-of-type > .cell {
-    @apply font-bold;
-  }
-
-  td:last-of-type,
-  th:last-of-type > .header-cell {
-    @apply border-r-0;
+  /* The totals row header */
+  tbody > tr:nth-of-type(2) > td:first-of-type {
+    @apply font-semibold;
   }
 
   tr:hover,

--- a/web-common/src/features/dashboards/pivot/pivot-data-store.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-data-store.ts
@@ -55,7 +55,9 @@ import {
 /**
  * Extract out config relevant to pivot from dashboard and meta store
  */
-function getPivotConfig(ctx: StateManagers): Readable<PivotDataStoreConfig> {
+export function getPivotConfig(
+  ctx: StateManagers,
+): Readable<PivotDataStoreConfig> {
   return derived(
     [useMetricsView(ctx), ctx.timeRangeSummaryStore, ctx.dashboardStore],
     ([metricsView, timeRangeSummary, dashboardStore], set) => {


### PR DESCRIPTION
To support the new infinite scrolling feature, this PR updates the `PivotTable` component to calculate an initial column width that remains fixed until changed manually via resizing or new pill state necessitates that it be recalculated.


Closes: #4432 