### PR TITLE
fix: bump node version to resolve ui build failure

### DIFF
--- a/.github/workflows/rill-ui.yml
+++ b/.github/workflows/rill-ui.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up NodeJS
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Setup Env variables from Inputs for Prod
         if: ( github.event_name == 'create' && startsWith(github.ref, 'refs/tags/v') ) || ( github.event_name == 'workflow_dispatch' && inputs.env == 'prod' )


### PR DESCRIPTION
#### Description

Bump nodejs version to build UI in ci.

#### Motivation

Try resolving `Netlify credentials not provided, not deployable` issue.