### PR TITLE
Consolidate TDD state and include chart type

### DIFF
--- a/proto/rill/ui/v1/dashboard.proto
+++ b/proto/rill/ui/v1/dashboard.proto
@@ -111,8 +111,10 @@ message DashboardState {
 
   // Expanded measure for TDD view
   optional string expanded_measure = 18;
-
+  // Pin index for TDD table selected values
   optional int32 pin_index = 19;
+  // Type of visualization for TDD view
+  optional string chart_type = 33;
 
   /**
    * Pivot related fields

--- a/web-common/src/features/alerts/CreateAlertDialog.svelte
+++ b/web-common/src/features/alerts/CreateAlertDialog.svelte
@@ -46,7 +46,7 @@
   // if in TDD take active measure and comparison dimension
   // If expanded leaderboard, take first dimension and active dimensions
   let dimension = "";
-  if ($dashboardStore.expandedMeasureName) {
+  if ($dashboardStore.tdd.expandedMeasureName) {
     dimension = $dashboardStore.selectedComparisonDimension ?? "";
   } else {
     dimension = $dashboardStore.selectedDimensionName ?? "";
@@ -56,7 +56,7 @@
     initialValues: {
       name: "",
       measure:
-        $dashboardStore.expandedMeasureName ??
+        $dashboardStore.tdd.expandedMeasureName ??
         $dashboardStore.leaderboardMeasureName ??
         "",
       splitByDimension: dimension,

--- a/web-common/src/features/dashboards/proto-state/toProto.ts
+++ b/web-common/src/features/dashboards/proto-state/toProto.ts
@@ -98,8 +98,12 @@ export function getProtoFromDashboardState(
   if (metrics.leaderboardMeasureName) {
     state.leaderboardMeasure = metrics.leaderboardMeasureName;
   }
-  if (metrics.pinIndex !== undefined) {
-    state.pinIndex = metrics.pinIndex;
+
+  if (metrics.tdd.pinIndex !== undefined) {
+    state.pinIndex = metrics.tdd.pinIndex;
+  }
+  if (metrics.tdd.chartType !== undefined) {
+    state.chartType = metrics.tdd.chartType;
   }
 
   if (metrics.allMeasuresVisible) {
@@ -300,7 +304,7 @@ function toActivePageProto(
     case DashboardState_ActivePage.TIME_DIMENSIONAL_DETAIL:
       return {
         activePage: metrics.activePage,
-        expandedMeasure: metrics.expandedMeasureName,
+        expandedMeasure: metrics.tdd.expandedMeasureName,
       };
   }
 

--- a/web-common/src/features/dashboards/state-managers/actions/dimension-filters.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/dimension-filters.ts
@@ -49,8 +49,8 @@ export function toggleDimensionValueSelection(
   } else {
     expr.cond.exprs.splice(inIdx, 1);
     // Only decrement pinIndex if the removed value was before the pinned value
-    if (dashboard.pinIndex >= inIdx) {
-      dashboard.pinIndex--;
+    if (dashboard.tdd.pinIndex >= inIdx) {
+      dashboard.tdd.pinIndex--;
     }
     // remove the dimension entry if all values are removed
     if (expr.cond.exprs.length === 1) {

--- a/web-common/src/features/dashboards/state-managers/actions/filters.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/filters.ts
@@ -15,7 +15,7 @@ export function clearAllFilters({ dashboard }: DashboardMutables) {
   dashboard.dimensionThresholdFilters = [];
   dashboard.temporaryFilterName = null;
   dashboard.dimensionFilterExcludeMode.clear();
-  dashboard.pinIndex = -1;
+  dashboard.tdd.pinIndex = -1;
 }
 
 export function setTemporaryFilterName(

--- a/web-common/src/features/dashboards/stores/dashboard-store-defaults.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-store-defaults.ts
@@ -9,6 +9,7 @@ import {
   type MetricsExplorerEntity,
 } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import { getPersistentDashboardState } from "@rilldata/web-common/features/dashboards/stores/persistent-dashboard-state";
+import { TDDChart } from "@rilldata/web-common/features/dashboards/time-dimension-details/types";
 import { getLocalUserPreferences } from "@rilldata/web-common/features/dashboards/user-preferences";
 import { getTimeComparisonParametersForComponent } from "@rilldata/web-common/lib/time/comparisons";
 import { DEFAULT_TIME_RANGES } from "@rilldata/web-common/lib/time/config";
@@ -168,6 +169,10 @@ export function getDefaultMetricsExplorerEntity(
     dimensionSearchText: "",
     temporaryFilterName: null,
     pinIndex: -1,
+    tdd: {
+      chartType: TDDChart.DEFAULT,
+      pinIndex: -1,
+    },
     pivot: {
       active: false,
       rows: {

--- a/web-common/src/features/dashboards/stores/dashboard-store-defaults.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-store-defaults.ts
@@ -168,7 +168,6 @@ export function getDefaultMetricsExplorerEntity(
     showTimeComparison: false,
     dimensionSearchText: "",
     temporaryFilterName: null,
-    pinIndex: -1,
     tdd: {
       chartType: TDDChart.DEFAULT,
       pinIndex: -1,

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -12,6 +12,7 @@ import {
   forEachIdentifier,
 } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
 import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import { TDDChart } from "@rilldata/web-common/features/dashboards/time-dimension-details/types";
 import { getMapFromArray } from "@rilldata/web-common/lib/arrayUtils";
 import type {
   DashboardTimeControls,
@@ -387,6 +388,12 @@ const metricViewReducers = {
   setPinIndex(name: string, index: number) {
     updateMetricsExplorerByName(name, (metricsExplorer) => {
       metricsExplorer.tdd.pinIndex = index;
+    });
+  },
+
+  setTDDChartType(name: string, type: TDDChart) {
+    updateMetricsExplorerByName(name, (metricsExplorer) => {
+      metricsExplorer.tdd.chartType = type;
     });
   },
 

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -238,7 +238,7 @@ const metricViewReducers = {
         metricsExplorer.activePage = DashboardState_ActivePage.PIVOT;
       } else if (metricsExplorer.selectedDimensionName) {
         metricsExplorer.activePage = DashboardState_ActivePage.DIMENSION_TABLE;
-      } else if (metricsExplorer.expandedMeasureName) {
+      } else if (metricsExplorer.tdd.expandedMeasureName) {
         metricsExplorer.activePage =
           DashboardState_ActivePage.TIME_DIMENSIONAL_DETAIL;
       } else {
@@ -365,7 +365,7 @@ const metricViewReducers = {
 
   setExpandedMeasureName(name: string, measureName: string | undefined) {
     updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.expandedMeasureName = measureName;
+      metricsExplorer.tdd.expandedMeasureName = measureName;
       if (measureName) {
         metricsExplorer.activePage =
           DashboardState_ActivePage.TIME_DIMENSIONAL_DETAIL;
@@ -376,7 +376,7 @@ const metricViewReducers = {
       // If going into TDD view and already having a comparison dimension,
       // then set the pinIndex
       if (metricsExplorer.selectedComparisonDimension) {
-        metricsExplorer.pinIndex = getPinIndexForDimension(
+        metricsExplorer.tdd.pinIndex = getPinIndexForDimension(
           metricsExplorer,
           metricsExplorer.selectedComparisonDimension,
         );
@@ -386,7 +386,7 @@ const metricViewReducers = {
 
   setPinIndex(name: string, index: number) {
     updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.pinIndex = index;
+      metricsExplorer.tdd.pinIndex = index;
     });
   },
 
@@ -422,7 +422,7 @@ const metricViewReducers = {
         setDisplayComparison(metricsExplorer, false);
       }
       metricsExplorer.selectedComparisonDimension = dimensionName;
-      metricsExplorer.pinIndex = getPinIndexForDimension(
+      metricsExplorer.tdd.pinIndex = getPinIndexForDimension(
         metricsExplorer,
         dimensionName,
       );

--- a/web-common/src/features/dashboards/stores/metrics-explorer-entity.ts
+++ b/web-common/src/features/dashboards/stores/metrics-explorer-entity.ts
@@ -1,9 +1,10 @@
-import type { PivotState } from "@rilldata/web-common/features/dashboards/pivot/types";
 import { LeaderboardContextColumn } from "@rilldata/web-common/features/dashboards/leaderboard-context-column";
+import type { PivotState } from "@rilldata/web-common/features/dashboards/pivot/types";
 import type {
   SortDirection,
   SortType,
 } from "@rilldata/web-common/features/dashboards/proto-state/derived-types";
+import { TDDState } from "@rilldata/web-common/features/dashboards/time-dimension-details/types";
 import type {
   DashboardTimeControls,
   ScrubRange,
@@ -159,6 +160,11 @@ export interface MetricsExplorerEntity {
    * is not shown.
    */
   selectedDimensionName?: string;
+
+  /**
+   * Consolidated state for Time Dimenstion Detail view
+   */
+  tdd: TDDState;
 
   pivot: PivotState;
 

--- a/web-common/src/features/dashboards/stores/metrics-explorer-entity.ts
+++ b/web-common/src/features/dashboards/stores/metrics-explorer-entity.ts
@@ -60,19 +60,6 @@ export interface MetricsExplorerEntity {
    */
   leaderboardMeasureName: string;
 
-  /***
-   * The name of the measure that is currently being expanded
-   * in the Time Detailed Dimension view
-   */
-  expandedMeasureName?: string;
-
-  /**
-   * The index at which selected dimension values are pinned in the
-   * time detailed dimension view. Values above this index preserve
-   * their original order
-   */
-  pinIndex: number;
-
   /**
    * This is the sort type that will be used for the leaderboard
    * and dimension detail table. See SortType for more details.

--- a/web-common/src/features/dashboards/time-dimension-details/TDDHeader.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TDDHeader.svelte
@@ -52,7 +52,7 @@
   $: metricsView = useMetricsView(getStateManagers());
   $: dashboardStore = useDashboardStore(metricViewName);
 
-  $: expandedMeasureName = $dashboardStore?.expandedMeasureName;
+  $: expandedMeasureName = $dashboardStore?.tdd.expandedMeasureName;
   $: allMeasures = $metricsView?.data?.measures ?? [];
 
   $: selectableMeasures = allMeasures

--- a/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDisplay.svelte
@@ -44,14 +44,16 @@
 
   $: metricsView = useMetricsView(stateManagers);
   $: dimensionName = $dashboardStore?.selectedComparisonDimension ?? "";
+  $: expandedMeasureName = $dashboardStore?.tdd.expandedMeasureName;
+
+  $: pinIndex = $dashboardStore?.tdd.pinIndex;
 
   $: timeGrain = $timeControlStore.selectedTimeRange?.interval;
 
   // Get labels for table headers
   $: measureLabel =
-    $metricsView?.data?.measures?.find(
-      (m) => m.name === $dashboardStore?.expandedMeasureName,
-    )?.label ?? "";
+    $metricsView?.data?.measures?.find((m) => m.name === expandedMeasureName)
+      ?.label ?? "";
 
   let dimensionLabel = "";
   $: if ($timeDimensionDataStore?.comparing === "dimension") {
@@ -143,7 +145,6 @@
   }
 
   function togglePin() {
-    const pinIndex = $dashboardStore?.pinIndex;
     let newPinIndex = -1;
 
     // Pin if some selected items are not pinned yet
@@ -213,7 +214,7 @@
       {timeFormatter}
       tableData={formattedData}
       highlightedCol={$chartInteractionColumn?.hover}
-      pinIndex={$dashboardStore?.pinIndex}
+      {pinIndex}
       scrubPos={{
         start: $chartInteractionColumn?.scrubStart,
         end: $chartInteractionColumn?.scrubEnd,

--- a/web-common/src/features/dashboards/time-dimension-details/export-tdd.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/export-tdd.ts
@@ -43,7 +43,7 @@ export default async function exportTDD({
           where: sanitiseExpression(dashboard.whereFilter, measureFilters),
           instanceId: get(runtime).instanceId,
           limit: undefined, // the backend handles export limits
-          measures: [{ name: dashboard.expandedMeasureName }],
+          measures: [{ name: dashboard.tdd.expandedMeasureName }],
           metricsView,
           offset: "0",
           pivotOn: [timeDimension], // spreads the time dimension across columns

--- a/web-common/src/features/dashboards/time-dimension-details/time-dimension-data-store.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/time-dimension-data-store.ts
@@ -358,7 +358,7 @@ function createDimensionTableData(
   ctx: StateManagers,
 ): Readable<DimensionDataItem[]> {
   return derived(ctx.dashboardStore, (dashboardStore, set) => {
-    const measureName = dashboardStore?.expandedMeasureName;
+    const measureName = dashboardStore?.tdd?.expandedMeasureName;
     if (!measureName) return set([]);
     return derived(
       getDimensionValueTimeSeries(ctx, [measureName], "table"),
@@ -400,13 +400,13 @@ export function createTimeDimensionDataStore(
       )
         return { isFetching: true };
 
-      const measureName = dashboardStore?.expandedMeasureName;
+      const measureName = dashboardStore?.tdd?.expandedMeasureName;
 
       if (!measureName) {
         return { isFetching: false };
       }
 
-      const pinIndex = dashboardStore?.pinIndex;
+      const pinIndex = dashboardStore?.tdd.pinIndex;
       const dimensionName = dashboardStore?.selectedComparisonDimension;
 
       // Fix types in V1MetricsViewAggregationResponseDataItem

--- a/web-common/src/features/dashboards/time-dimension-details/types.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/types.ts
@@ -1,3 +1,16 @@
+export enum TDDChart {
+  DEFAULT = "default",
+  BAR = "bar",
+  STACKED_BAR = "stacked_bar",
+  GROUPED_BAR = "grouped_bar",
+  STACKED_AREA = "stacked_area",
+}
+export interface TDDState {
+  expandedMeasureName?: string;
+  pinIndex: number;
+  chartType: TDDChart;
+}
+
 export interface HeaderData<T> {
   value: T | null | undefined;
   spark?: string;

--- a/web-common/src/features/dashboards/time-dimension-details/types.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/types.ts
@@ -6,7 +6,16 @@ export enum TDDChart {
   STACKED_AREA = "stacked_area",
 }
 export interface TDDState {
+  /***
+   * The name of the measure that is currently being expanded
+   * in the Time Detailed Dimension view
+   */
   expandedMeasureName?: string;
+  /**
+   * The index at which selected dimension values are pinned in the
+   * time detailed dimension view. Values above this index preserve
+   * their original order
+   */
   pinIndex: number;
   chartType: TDDChart;
 }

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -68,7 +68,8 @@
     metricsView,
   );
 
-  $: expandedMeasureName = $dashboardStore?.expandedMeasureName;
+  $: expandedMeasureName = $dashboardStore?.tdd?.expandedMeasureName;
+  $: isInTimeDimensionView = Boolean(expandedMeasureName);
   $: comparisonDimension = $dashboardStore?.selectedComparisonDimension;
   $: showComparison = !comparisonDimension && $timeControlsStore.showComparison;
   $: interval =
@@ -170,7 +171,7 @@
   }
 
   $: if (
-    expandedMeasureName &&
+    isInTimeDimensionView &&
     formattedData &&
     $timeControlsStore.selectedTimeRange &&
     !isScrubbing
@@ -210,13 +211,13 @@
 </script>
 
 <TimeSeriesChartContainer
-  enableFullWidth={Boolean(expandedMeasureName)}
+  enableFullWidth={isInTimeDimensionView}
   end={endValue}
   start={startValue}
   {workspaceWidth}
 >
   <div class="flex pl-1">
-    {#if expandedMeasureName}
+    {#if isInTimeDimensionView}
       <BackToOverview {metricViewName} />
     {:else}
       <SearchableFilterButton
@@ -274,7 +275,7 @@
           <MeasureBigNumber
             {measure}
             value={bigNum}
-            isMeasureExpanded={!!expandedMeasureName}
+            isMeasureExpanded={isInTimeDimensionView}
             {showComparison}
             comparisonOption={$timeControlsStore?.selectedComparisonTimeRange
               ?.name}

--- a/web-common/src/features/dashboards/time-series/multiple-dimension-queries.ts
+++ b/web-common/src/features/dashboards/time-series/multiple-dimension-queries.ts
@@ -91,7 +91,7 @@ export function getDimensionValuesForComparison(
         measures?.length > 0 && measures?.every((m) => m !== undefined);
 
       const dimensionName = dashboardStore?.selectedComparisonDimension;
-      const isInTimeDimensionView = dashboardStore?.expandedMeasureName;
+      const isInTimeDimensionView = dashboardStore?.tdd.expandedMeasureName;
 
       if (!isValidMeasureList || !dimensionName) return;
 
@@ -126,7 +126,7 @@ export function getDimensionValuesForComparison(
         });
       } else if (surface === "table") {
         let sortBy = isInTimeDimensionView
-          ? dashboardStore.expandedMeasureName
+          ? dashboardStore.tdd.expandedMeasureName
           : dashboardStore.leaderboardMeasureName;
         if (dashboardStore?.dashboardSortType === SortType.DIMENSION) {
           sortBy = dimensionName;

--- a/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
+++ b/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
@@ -125,9 +125,10 @@ export function createTimeSeriesDataStore(
         metricsView.data?.measures?.map((measure) => measure.name as string) ||
         [];
       let measures = allMeasures;
-      if (dashboardStore?.expandedMeasureName) {
+      const expandedMeasuerName = dashboardStore?.tdd?.expandedMeasureName;
+      if (expandedMeasuerName) {
         measures = allMeasures.filter(
-          (measure) => measure === dashboardStore.expandedMeasureName,
+          (measure) => measure === expandedMeasuerName,
         );
       } else {
         measures = dashboardStore?.visibleMeasureKeys

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -6,6 +6,7 @@
   } from "@rilldata/web-common/features/dashboards/selectors";
   import TabBar from "@rilldata/web-common/features/dashboards/tab-bar/TabBar.svelte";
   import { featureFlags } from "@rilldata/web-common/features/feature-flags";
+  import { navigationOpen } from "@rilldata/web-common/layout/navigation/Navigation.svelte";
   import { useDashboardStore } from "web-common/src/features/dashboards/stores/dashboard-stores";
   import { runtime } from "../../../runtime-client/runtime-store";
   import MeasuresContainer from "../big-number/MeasuresContainer.svelte";
@@ -20,7 +21,6 @@
   import MetricsTimeSeriesCharts from "../time-series/MetricsTimeSeriesCharts.svelte";
   import DashboardCTAs from "./DashboardCTAs.svelte";
   import DashboardTitle from "./DashboardTitle.svelte";
-  import { navigationOpen } from "@rilldata/web-common/layout/navigation/Navigation.svelte";
 
   export let metricViewName: string;
 
@@ -33,7 +33,7 @@
   $: metricsExplorer = useDashboardStore(metricViewName);
 
   $: selectedDimensionName = $metricsExplorer?.selectedDimensionName;
-  $: expandedMeasureName = $metricsExplorer?.expandedMeasureName;
+  $: expandedMeasureName = $metricsExplorer?.tdd?.expandedMeasureName;
   $: showPivot = $metricsExplorer?.pivot?.active;
   $: metricTimeSeries = useModelHasTimeSeries(
     $runtime.instanceId,

--- a/web-common/src/proto/gen/rill/ui/v1/dashboard_pb.ts
+++ b/web-common/src/proto/gen/rill/ui/v1/dashboard_pb.ts
@@ -145,9 +145,18 @@ export class DashboardState extends Message<DashboardState> {
   expandedMeasure?: string;
 
   /**
+   * Pin index for TDD table selected values
+   *
    * @generated from field: optional int32 pin_index = 19;
    */
   pinIndex?: number;
+
+  /**
+   * Type of visualization for TDD view
+   *
+   * @generated from field: optional string chart_type = 33;
+   */
+  chartType?: string;
 
   /**
    * *
@@ -248,6 +257,7 @@ export class DashboardState extends Message<DashboardState> {
     { no: 17, name: "comparison_dimension", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 18, name: "expanded_measure", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 19, name: "pin_index", kind: "scalar", T: 5 /* ScalarType.INT32 */, opt: true },
+    { no: 33, name: "chart_type", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
     { no: 22, name: "pivot_is_active", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
     { no: 23, name: "pivot_row_time_dimensions", kind: "enum", T: proto3.getEnumType(TimeGrain), repeated: true },
     { no: 24, name: "pivot_row_dimensions", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },


### PR DESCRIPTION
This PR refactors the TDD state by consolidating `expandedMeasureName` and `pinIndex` inside `tdd`. It also introduces `chartType` state for tdd.

Todo
- [x] Update proto for the new refactored state