### PR TITLE
Proposal: New Tooltip API

### DIFF
--- a/web-common/src/app.css
+++ b/web-common/src/app.css
@@ -202,6 +202,17 @@ button {
   @apply ui-copy;
 }
 
+
+
+* {
+  pointer-events: none;
+
+}
+
+a, button, input, textarea, .editor {
+  pointer-events: auto;
+}
+
 body {
   background-color: white;
   font-family: "Inter";

--- a/web-common/src/app.css
+++ b/web-common/src/app.css
@@ -202,8 +202,10 @@ button {
   @apply ui-copy;
 }
 
-
-
+svg {
+  pointer-events: none;
+}
+/* 
 * {
   pointer-events: none;
 
@@ -211,7 +213,7 @@ button {
 
 a, button, input, textarea, .editor {
   pointer-events: auto;
-}
+} */
 
 body {
   background-color: white;

--- a/web-common/src/components/data-types/Base.svelte
+++ b/web-common/src/components/data-types/Base.svelte
@@ -5,7 +5,9 @@
   $: color = dark ? "" : "text-gray-900";
 </script>
 
-<span class=" whitespace-nowrap inline-block {classes} {color} break-normal">
+<span
+  class="pointer-events-none whitespace-nowrap inline-block {classes} {color} break-normal"
+>
   {#if isNull}
     <span style:font-size=".925em" class="opacity-50 italic">no data</span>
   {:else}

--- a/web-common/src/components/virtualized-table/core/Cell.svelte
+++ b/web-common/src/components/virtualized-table/core/Cell.svelte
@@ -143,6 +143,7 @@
     <button
       aria-label={label ?? tooltipValue}
       data-tooltip-side="top"
+      data-tooltip
       data-suppress={suppressTooltip || !isClipboardApiSupported()}
       class="
           {isTextColumn ? 'text-left' : 'text-right'}

--- a/web-common/src/components/virtualized-table/core/Cell.svelte
+++ b/web-common/src/components/virtualized-table/core/Cell.svelte
@@ -1,17 +1,8 @@
 <script lang="ts">
   import { FormattedDataType } from "@rilldata/web-common/components/data-types";
   import { notifications } from "@rilldata/web-common/components/notifications";
-  import Shortcut from "@rilldata/web-common/components/tooltip/Shortcut.svelte";
-  import StackingWord from "@rilldata/web-common/components/tooltip/StackingWord.svelte";
-  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
-  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
-  import TooltipShortcutContainer from "@rilldata/web-common/components/tooltip/TooltipShortcutContainer.svelte";
-  import TooltipTitle from "@rilldata/web-common/components/tooltip/TooltipTitle.svelte";
   import { TOOLTIP_STRING_LIMIT } from "@rilldata/web-common/layout/config";
-  import {
-    createShiftClickAction,
-    isClipboardApiSupported,
-  } from "@rilldata/web-common/lib/actions/shift-click-action";
+  import { isClipboardApiSupported } from "@rilldata/web-common/lib/actions/shift-click-action";
   import { STRING_LIKES } from "@rilldata/web-common/lib/duckdb-data-types";
   import { formatDataTypeAsDuckDbQueryString } from "@rilldata/web-common/lib/formatters";
   import { createEventDispatcher, getContext } from "svelte";
@@ -41,8 +32,6 @@
   $: isTextColumn = type === "VARCHAR" || type === "CODE_STRING";
 
   const dispatch = createEventDispatcher();
-
-  const { shiftClickAction } = createShiftClickAction();
 
   function onFocus() {
     dispatch("inspect", row.index);

--- a/web-common/src/components/virtualized-table/core/Cell.svelte
+++ b/web-common/src/components/virtualized-table/core/Cell.svelte
@@ -17,6 +17,7 @@
   import { createEventDispatcher, getContext } from "svelte";
   import BarAndLabel from "../../BarAndLabel.svelte";
   import type { VirtualizedTableConfig } from "../types";
+  import { modifiedClick } from "@rilldata/web-common/lib/actions/modified-click";
 
   export let row;
   export let column;
@@ -110,13 +111,8 @@
   };
 </script>
 
-<Tooltip
-  distance={16}
-  location="top"
-  suppress={suppressTooltip || !isClipboardApiSupported()}
->
-  <div
-    class="
+<div
+  class="
       {positionStatic ? 'static' : 'absolute'}
       z-9
       text-ellipsis
@@ -124,58 +120,47 @@
       {isDimensionTable ? '' : 'border-r border-b'}
       {activityStatus}
       "
-    on:blur={onBlur}
-    on:click={onSelectItem}
-    on:focus={onFocus}
-    on:keydown
-    on:mouseout={onBlur}
-    on:mouseover={onFocus}
-    role="gridcell"
-    style:height="{row.size}px"
-    style:left="{column.start}px"
-    style:top="{row.start}px"
-    style:width="{column.size}px"
-    tabindex="0"
+  on:blur={onBlur}
+  on:click={onSelectItem}
+  on:focus={onFocus}
+  on:keydown
+  on:mouseout={onBlur}
+  on:mouseover={onFocus}
+  role="gridcell"
+  style:height="{row.size}px"
+  style:left="{column.start}px"
+  style:top="{row.start}px"
+  style:width="{column.size}px"
+  tabindex="0"
+>
+  <BarAndLabel
+    color={barColor}
+    customBackgroundColor="rgba(0,0,0,0)"
+    justify="left"
+    showBackground={false}
+    value={barValue}
   >
-    <BarAndLabel
-      color={barColor}
-      customBackgroundColor="rgba(0,0,0,0)"
-      justify="left"
-      showBackground={false}
-      value={barValue}
-    >
-      <button
-        aria-label={label}
-        class="
+    <button
+      aria-label={label ?? tooltipValue}
+      data-tooltip-side="top"
+      data-suppress={suppressTooltip || !isClipboardApiSupported()}
+      class="
           {isTextColumn ? 'text-left' : 'text-right'}
           {isDimensionTable ? '' : 'px-4'}
           w-full text-ellipsis overflow-x-hidden whitespace-nowrap
           "
-        on:shift-click={shiftClick}
-        style:height="{row.size}px"
-        use:shiftClickAction
-      >
-        <FormattedDataType
-          customStyle={formattedDataTypeStyle}
-          inTable
-          isNull={value === null || value === undefined}
-          {type}
-          value={formattedValue || value}
-        />
-      </button>
-    </BarAndLabel>
-  </div>
-  <TooltipContent maxWidth="360px" slot="tooltip-content">
-    <TooltipTitle>
-      <FormattedDataType dark slot="name" {type} value={tooltipValue} />
-    </TooltipTitle>
-    <TooltipShortcutContainer>
-      <div>
-        <StackingWord key="shift">Copy</StackingWord> this value to clipboard
-      </div>
-      <Shortcut>
-        <span style="font-family: var(--system);">⇧</span> + Click
-      </Shortcut>
-    </TooltipShortcutContainer>
-  </TooltipContent>
-</Tooltip>
+      use:modifiedClick={{
+        shift: [shiftClick, "Copy value to clipboard"],
+      }}
+      style:height="{row.size}px"
+    >
+      <FormattedDataType
+        customStyle={formattedDataTypeStyle}
+        inTable
+        isNull={value === null || value === undefined}
+        {type}
+        value={formattedValue || value}
+      />
+    </button>
+  </BarAndLabel>
+</div>

--- a/web-common/src/layout/BasicLayout.svelte
+++ b/web-common/src/layout/BasicLayout.svelte
@@ -4,15 +4,18 @@ BasicLayout is the backbone of the Rill application.
 -->
 <script lang="ts">
   import { page } from "$app/stores";
+  import TooltipRenderer from "./TooltipRenderer.svelte";
 
   import Navigation from "./navigation/Navigation.svelte";
 
   $: showNavigation = $page.route.id !== "/(application)/welcome";
 </script>
 
-<main class="flex overflow-hidden h-screen w-screen">
-  {#if showNavigation}
-    <Navigation />
-  {/if}
-  <slot />
-</main>
+<TooltipRenderer>
+  <main class="flex overflow-hidden h-screen w-screen">
+    {#if showNavigation}
+      <Navigation />
+    {/if}
+    <slot />
+  </main>
+</TooltipRenderer>

--- a/web-common/src/layout/GlobalTooltip.svelte
+++ b/web-common/src/layout/GlobalTooltip.svelte
@@ -1,0 +1,161 @@
+<script lang="ts" context="module">
+  import TooltipContent from "../components/tooltip/TooltipContent.svelte";
+  import TooltipShortcutContainer from "../components/tooltip/TooltipShortcutContainer.svelte";
+  import Shortcut from "../components/tooltip/Shortcut.svelte";
+  import TooltipTitle from "../components/tooltip/TooltipTitle.svelte";
+  import { portal } from "../lib/actions/portal";
+  import { onMount } from "svelte";
+
+  export type Side = keyof typeof translateVectors;
+  export type Align = keyof typeof alignValues;
+
+  const buffer = 8;
+
+  const translateVectors = {
+    top: `-50%, calc(-100% - ${buffer}px)`,
+    right: `${buffer}px, -50%`,
+    bottom: `-50%, ${buffer}px`,
+    left: `calc(-100% - ${buffer}px), -50%`,
+  };
+
+  function isMac() {
+    return window.navigator.userAgent.includes("Macintosh");
+  }
+
+  const modifierChar = {
+    command: isMac() ? "⌘" : "Ctrl",
+    shift: "⇧",
+    "shift-command": isMac() ? "⇧ + ⌘" : "Ctrl + Shift",
+  };
+
+  const alignValues = {
+    center: 0.5,
+    start: 0,
+    end: 1,
+  };
+</script>
+
+<script lang="ts">
+  export let anchorElement: HTMLElement;
+  export let innerWidth: number;
+  export let innerHeight: number;
+  export let label: string | undefined | null = null;
+  export let description: string | null = null;
+  export let shortcuts: [string, string][];
+  export let side: Side = "right";
+  export let align: Align = "center";
+  export let skipBoundsCheck = false;
+
+  const sideVectors = {
+    top: [alignValues[align], 0],
+    right: [1, alignValues[align]],
+    bottom: [alignValues[align], 1],
+    left: [0, alignValues[align]],
+  };
+
+  const {
+    height: anchorHeight,
+    width: anchorWidth,
+    top: anchorTop,
+    left: anchorLeft,
+  } = anchorElement.getBoundingClientRect();
+
+  let top: number;
+  let left: number;
+  let container: HTMLElement;
+  let hidden = true;
+  let xShift = 0;
+  let yShift = 0;
+
+  $: top = anchorTop + anchorHeight * sideVectors[side][1];
+
+  $: left = anchorLeft + anchorWidth * sideVectors[side][0];
+
+  onMount(() => {
+    if (skipBoundsCheck) {
+      hidden = false;
+      return;
+    }
+
+    const { x, y, width, height } = container.getBoundingClientRect();
+
+    if (x < 0) {
+      if (side === "left") {
+        side = "right";
+      } else {
+        xShift = -x + buffer;
+      }
+    }
+
+    if (x + width > innerWidth) {
+      if (side === "right") {
+        side = "left";
+      } else {
+        xShift = x + width - innerWidth - buffer;
+      }
+    }
+
+    if (y < 0) {
+      if (side === "top") {
+        side = "bottom";
+      } else {
+        yShift = -y + buffer;
+      }
+    }
+
+    if (y + height > innerHeight) {
+      if (side === "bottom") {
+        side = "top";
+      } else {
+        yShift = y + height - innerHeight - buffer;
+      }
+    }
+
+    hidden = false;
+  });
+</script>
+
+<div
+  id="tooltip"
+  class="absolute z-50 pointer-events-none"
+  class:opacity-0={hidden}
+  style:left="{left + xShift}px"
+  style:top="{top + yShift}px"
+  style:transform="translate({translateVectors[side]})"
+  use:portal
+  bind:this={container}
+>
+  <TooltipContent>
+    {#if shortcuts.length}
+      <TooltipTitle>
+        <svelte:fragment slot="name">
+          {label}
+        </svelte:fragment>
+
+        <svelte:fragment slot="description">
+          {#if description}
+            {description}
+          {/if}
+        </svelte:fragment>
+      </TooltipTitle>
+    {:else}
+      {label}
+    {/if}
+
+    {#each shortcuts as [modifier, action]}
+      <TooltipShortcutContainer>
+        <div>
+          {action}
+        </div>
+        <Shortcut>
+          {#if modifierChar[modifier]}
+            <span style:font-size="11.5px" style:font-family="var(--system)">
+              {modifierChar[modifier]} +
+            </span>
+          {/if}
+          Click
+        </Shortcut>
+      </TooltipShortcutContainer>
+    {/each}
+  </TooltipContent>
+</div>

--- a/web-common/src/layout/TooltipRenderer.svelte
+++ b/web-common/src/layout/TooltipRenderer.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { debounce } from "../lib/create-debouncer";
-  import { getConnectorServiceBigQueryListTablesQueryKey } from "../runtime-client";
   import GlobalTooltip from "./GlobalTooltip.svelte";
   import type { Side, Align } from "./GlobalTooltip.svelte";
 

--- a/web-common/src/layout/TooltipRenderer.svelte
+++ b/web-common/src/layout/TooltipRenderer.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  import { debounce } from "../lib/create-debouncer";
+  import GlobalTooltip from "./GlobalTooltip.svelte";
+  import type { Side, Align } from "./GlobalTooltip.svelte";
+
+  let label: string | undefined | null = null;
+  let description: string | null = null;
+  let anchorElement: HTMLElement | null = null;
+  let shortcuts: [string, string][] = [];
+  let align: Align;
+  let side: Side;
+
+  let innerHeight: number;
+  let innerWidth: number;
+
+  const debouncedHandleTooltip = debounce(handleTooltip, 80);
+
+  function handleTooltip(
+    e: MouseEvent & {
+      currentTarget: EventTarget & Window;
+    },
+  ) {
+    if (!(e.target instanceof HTMLElement) || e.target === anchorElement)
+      return;
+
+    if (e.target.getAttribute("data-suppress") === "true") return;
+
+    label = e.target?.getAttribute("aria-label");
+
+    side = (e.target.getAttribute("data-tooltip-side") ?? "right") as Side;
+
+    align = (e.target.getAttribute("data-tooltip-align") ?? "center") as Align;
+
+    e.target
+      .getAttribute("data-actions")
+      ?.split(",")
+      .forEach((shortcut) => {
+        const [modifier, action] = shortcut.split(":");
+        shortcuts.push([modifier, action]);
+      });
+
+    anchorElement = e.target;
+
+    const onMouseLeave = () => {
+      anchorElement?.removeEventListener("mouseleave", onMouseLeave);
+
+      reset();
+    };
+
+    anchorElement.addEventListener("mouseleave", onMouseLeave);
+  }
+
+  function reset() {
+    label = null;
+    anchorElement = null;
+    shortcuts = [];
+  }
+</script>
+
+<svelte:window
+  bind:innerHeight
+  bind:innerWidth
+  on:click={reset}
+  on:mousemove={debouncedHandleTooltip}
+/>
+
+<slot />
+
+{#if label && anchorElement}
+  <GlobalTooltip
+    {side}
+    {label}
+    {align}
+    {description}
+    {anchorElement}
+    {shortcuts}
+    {innerHeight}
+    {innerWidth}
+  />
+{/if}

--- a/web-common/src/layout/navigation/NavigationEntry.svelte
+++ b/web-common/src/layout/navigation/NavigationEntry.svelte
@@ -4,10 +4,6 @@
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu/";
   import MoreHorizontal from "@rilldata/web-common/components/icons/MoreHorizontal.svelte";
   import { notifications } from "@rilldata/web-common/components/notifications";
-  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
-  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
-  import { createCommandClickAction } from "../../lib/actions/command-click-action";
-  import { createShiftClickAction } from "../../lib/actions/shift-click-action";
   import { emitNavigationTelemetry } from "./navigation-utils";
   import { modifiedClick } from "@rilldata/web-common/lib/actions/modified-click";
   export let name: string;
@@ -15,9 +11,6 @@
   export let open = false;
   export let expandable = false;
   export let showContextMenu = true;
-
-  const { commandClickAction } = createCommandClickAction();
-  const { shiftClickAction } = createShiftClickAction();
 
   let showDetails = false;
   let contextMenuOpen = false;

--- a/web-common/src/layout/navigation/NavigationEntry.svelte
+++ b/web-common/src/layout/navigation/NavigationEntry.svelte
@@ -9,7 +9,7 @@
   import { createCommandClickAction } from "../../lib/actions/command-click-action";
   import { createShiftClickAction } from "../../lib/actions/shift-click-action";
   import { emitNavigationTelemetry } from "./navigation-utils";
-
+  import { modifiedClick } from "@rilldata/web-common/lib/actions/modified-click";
   export let name: string;
   export let href: string;
   export let open = false;
@@ -56,22 +56,22 @@
   <svelte:element
     this={open && expandable ? "button" : "a"}
     role="link"
-    class="clickable-text"
+    class="clickable-text truncate"
     class:expandable
     class:open
     tabindex={open ? -1 : 0}
     href={open ? undefined : href}
-    use:shiftClickAction
-    use:commandClickAction
-    on:command-click
+    aria-label={name}
+    data-tooltip-side="bottom"
     on:mousedown={handleMouseDown}
-    on:shift-click={shiftClickHandler}
-    on:click={handleClick}
+    use:modifiedClick={{
+      click: [handleClick, "Open in workspace"],
+      shift: [shiftClickHandler, "Copy name to clipboard"],
+    }}
   >
     <Tooltip distance={8}>
-      <div class="truncate">
-        {name}
-      </div>
+      <span class="truncate">{name}</span>
+
       {#if $$slots["icon"]}
         <span class="text-gray-400" style:width="1em" style:height="1em">
           <slot name="icon" />

--- a/web-common/src/layout/navigation/NavigationEntry.svelte
+++ b/web-common/src/layout/navigation/NavigationEntry.svelte
@@ -56,7 +56,7 @@
   <svelte:element
     this={open && expandable ? "button" : "a"}
     role="link"
-    class="clickable-text truncate"
+    class="clickable-text"
     class:expandable
     class:open
     tabindex={open ? -1 : 0}
@@ -69,20 +69,13 @@
       shift: [shiftClickHandler, "Copy name to clipboard"],
     }}
   >
-    <Tooltip distance={8}>
-      <span class="truncate">{name}</span>
+    <span class="truncate">{name}</span>
 
-      {#if $$slots["icon"]}
-        <span class="text-gray-400" style:width="1em" style:height="1em">
-          <slot name="icon" />
-        </span>
-      {/if}
-      <svelte:fragment slot="tooltip-content">
-        {#if $$slots["tooltip-content"]}
-          <TooltipContent><slot name="tooltip-content" /></TooltipContent>
-        {/if}
-      </svelte:fragment>
-    </Tooltip>
+    {#if $$slots["icon"]}
+      <span class="text-gray-400" style:width="1em" style:height="1em">
+        <slot name="icon" />
+      </span>
+    {/if}
   </svelte:element>
 
   {#if showContextMenu}

--- a/web-common/src/layout/navigation/NavigationEntry.svelte
+++ b/web-common/src/layout/navigation/NavigationEntry.svelte
@@ -63,13 +63,14 @@
     href={open ? undefined : href}
     aria-label={name}
     data-tooltip-side="bottom"
+    data-tooltip
     on:mousedown={handleMouseDown}
     use:modifiedClick={{
       click: [handleClick, "Open in workspace"],
       shift: [shiftClickHandler, "Copy name to clipboard"],
     }}
   >
-    <span class="truncate">{name}</span>
+    <span class="truncate pointer-events-none">{name}</span>
 
     {#if $$slots["icon"]}
       <span class="text-gray-400" style:width="1em" style:height="1em">

--- a/web-common/src/layout/navigation/SurfaceControlButton.svelte
+++ b/web-common/src/layout/navigation/SurfaceControlButton.svelte
@@ -22,22 +22,18 @@
   class:shift={!navOpen}
   style:left="{navWidth - 32}px"
   aria-label={label}
+  data-tooltip
   on:click
   on:mousedown={() => {
     active = false;
   }}
   use:portal
 >
-  <!-- <Tooltip location="bottom" alignment="start" distance={12} bind:active> -->
   {#if navOpen}
     <HideLeftSidebar size="18px" />
   {:else}
     <SurfaceView size="16px" mode={"hamburger"} />
   {/if}
-  <!-- <TooltipContent slot="tooltip-content">
-      {label}
-    </TooltipContent>
-  </Tooltip> -->
 </button>
 
 <style lang="postcss">

--- a/web-common/src/layout/navigation/SurfaceControlButton.svelte
+++ b/web-common/src/layout/navigation/SurfaceControlButton.svelte
@@ -28,16 +28,16 @@
   }}
   use:portal
 >
-  <Tooltip location="bottom" alignment="start" distance={12} bind:active>
-    {#if navOpen}
-      <HideLeftSidebar size="18px" />
-    {:else}
-      <SurfaceView size="16px" mode={"hamburger"} />
-    {/if}
-    <TooltipContent slot="tooltip-content">
+  <!-- <Tooltip location="bottom" alignment="start" distance={12} bind:active> -->
+  {#if navOpen}
+    <HideLeftSidebar size="18px" />
+  {:else}
+    <SurfaceView size="16px" mode={"hamburger"} />
+  {/if}
+  <!-- <TooltipContent slot="tooltip-content">
       {label}
     </TooltipContent>
-  </Tooltip>
+  </Tooltip> -->
 </button>
 
 <style lang="postcss">

--- a/web-common/src/layout/navigation/SurfaceControlButton.svelte
+++ b/web-common/src/layout/navigation/SurfaceControlButton.svelte
@@ -1,16 +1,12 @@
 <script lang="ts">
   import HideLeftSidebar from "@rilldata/web-common/components/icons/HideLeftSidebar.svelte";
   import SurfaceView from "@rilldata/web-common/components/icons/SurfaceView.svelte";
-  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
-  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { portal } from "@rilldata/web-common/lib/actions/portal";
 
   export let navWidth: number;
   export let navOpen: boolean;
   export let resizing: boolean;
   export let show = true;
-
-  let active = false;
 
   $: label = navOpen ? "Close sidebar" : "Show sidebar";
 </script>
@@ -24,9 +20,6 @@
   aria-label={label}
   data-tooltip
   on:click
-  on:mousedown={() => {
-    active = false;
-  }}
   use:portal
 >
   {#if navOpen}

--- a/web-common/src/lib/actions/modified-click.ts
+++ b/web-common/src/lib/actions/modified-click.ts
@@ -1,0 +1,53 @@
+type Description = string;
+type Handler = (e: MouseEvent) => Promise<void> | void;
+type Modifier = "command" | "shift" | "shift-command" | "click";
+
+type Params = Partial<Record<Modifier, [Handler, Description]>>;
+
+export function modifiedClick(node: HTMLElement, params: Params) {
+  function update(params: Params) {
+    //eslint-disable-next-line
+    node.addEventListener("click", async (e) => {
+      const { ctrlKey, shiftKey, metaKey } = e;
+
+      let handler: Handler | undefined = undefined;
+
+      if ((ctrlKey || metaKey) && shiftKey && params["shift-command"]) {
+        e.preventDefault();
+        handler = params["shift-command"][0];
+      } else if ((ctrlKey || metaKey) && params.command) {
+        e.preventDefault();
+        handler = params.command[0];
+      } else if (shiftKey && params.shift) {
+        e.preventDefault();
+        handler = params.shift[0];
+      } else if (params.click) {
+        handler = params.click[0];
+      }
+
+      if (handler) {
+        console.log("yeah");
+
+        await handler(e);
+      }
+    });
+
+    const actions = Object.entries(params)
+      .map(([key, value]) => `${key}:${value[1]}`)
+      .join(",");
+
+    node.setAttribute("data-actions", actions);
+  }
+
+  function destroy() {
+    if (node.parentNode) {
+      node.parentNode.removeChild(node);
+    }
+  }
+
+  void update(params);
+  return {
+    update,
+    destroy,
+  };
+}


### PR DESCRIPTION
The purpose of this WIP PR is to propose a new Tooltip API to be used across the app.

Why?
- Remove dozens (and sometimes hundreds!) of DOM elements and listeners
- Components that use tooltips are made more complex by extraneous slots and wrapping elements
- Tooltips should not be thought of as an inherent part of a component, but rather as a layer/system that exists on top of the application as a whole
- Tooltips, which are primarily about accessibility/clarity, should not take precedence over accessible labels

How?
- Create a global "tooltip renderer" that has a single debounced mouse move listener
- If the cursor stays on an element for a certain timeout period, check if it has an `aria-label` and other custom data properties
- If it does, render a tooltip in the portal
- Enable reactive tooltip suppression (like when scrolling in the table) via MutationObserver

Additional Benefits:
- A new `modifiedClick` action that solves issues with the existing approach (multiple handlers can be called) and automatically adds a `data-action` property that the tooltip renderer can parse to display modified click descriptions

This PR illustrates this new approach in the SurfaceControlButton, NavigationEntry and Cell components. Currently, the implementation requires that the `data-tooltip` property be set so that it does not interfere with the existing system.