### PR TITLE
Disable search for non-string dimensions

### DIFF
--- a/web-common/src/components/chip/removable-list-chip/RemovableListChip.svelte
+++ b/web-common/src/components/chip/removable-list-chip/RemovableListChip.svelte
@@ -29,6 +29,7 @@ are details left to the consumer of the component; this component should remain 
   export let name: string;
   export let selectedValues: string[];
   export let allValues: string[] | null;
+  export let enableSearch = true;
 
   /** an optional type label that will appear in the tooltip */
   export let typeLabel: string;
@@ -54,29 +55,29 @@ are details left to the consumer of the component; this component should remain 
 </script>
 
 <WithTogglableFloatingElement
-  bind:active
-  let:toggleFloatingElement
-  distance={8}
   alignment="start"
+  bind:active
+  distance={8}
+  let:toggleFloatingElement
 >
   <Tooltip
-    location="bottom"
+    activeDelay={60}
     alignment="start"
     distance={8}
-    activeDelay={60}
+    location="bottom"
     suppress={active}
   >
     <Chip
-      removable
+      {...colors}
+      {active}
+      {label}
       on:click={() => {
         toggleFloatingElement();
         dispatch("click");
       }}
       on:remove={() => dispatch("remove")}
-      {active}
-      {...colors}
-      {label}
       outline
+      removable
     >
       <!-- remove button tooltip -->
       <svelte:fragment slot="remove-tooltip">
@@ -87,11 +88,11 @@ are details left to the consumer of the component; this component should remain 
       </svelte:fragment>
       <!-- body -->
       <RemovableListBody
-        slot="body"
-        label={name}
-        values={selectedValues}
-        show={1}
         {active}
+        label={name}
+        show={1}
+        slot="body"
+        values={selectedValues}
       />
     </Chip>
     <div slot="tooltip-content" transition:fly={{ duration: 100, y: 4 }}>
@@ -108,14 +109,15 @@ are details left to the consumer of the component; this component should remain 
     </div>
   </Tooltip>
   <RemovableListMenu
-    slot="floating-element"
-    {excludeMode}
     {allValues}
-    {selectedValues}
-    on:escape={handleDismiss}
-    on:click-outside={handleDismiss}
+    {enableSearch}
+    {excludeMode}
     on:apply
+    on:click-outside={handleDismiss}
+    on:escape={handleDismiss}
     on:search
     on:toggle
+    {selectedValues}
+    slot="floating-element"
   />
 </WithTogglableFloatingElement>

--- a/web-common/src/components/chip/removable-list-chip/RemovableListMenu.svelte
+++ b/web-common/src/components/chip/removable-list-chip/RemovableListMenu.svelte
@@ -11,6 +11,7 @@
   export let excludeMode: boolean;
   export let selectedValues: string[];
   export let allValues: string[] | null = [];
+  export let enableSearch = true;
 
   let searchText = "";
 
@@ -37,25 +38,27 @@
 </script>
 
 <Menu
-  paddingTop={1}
-  paddingBottom={0}
-  rounded={false}
   focusOnMount={false}
+  maxHeight="400px"
   maxWidth="480px"
   minHeight="150px"
-  maxHeight="400px"
-  on:escape
   on:click-outside
+  on:escape
+  paddingBottom={0}
+  paddingTop={1}
+  rounded={false}
 >
-  <!-- the min-height is set to have about 3 entries in it -->
-  <div class="px-3 py-2">
-    <Search
-      bind:value={searchText}
-      on:input={onSearch}
-      label="Search list"
-      showBorderOnFocus={false}
-    />
-  </div>
+  {#if enableSearch}
+    <!-- the min-height is set to have about 3 entries in it -->
+    <div class="px-3 py-2">
+      <Search
+        bind:value={searchText}
+        on:input={onSearch}
+        label="Search list"
+        showBorderOnFocus={false}
+      />
+    </div>
+  {/if}
 
   <!-- apply a wrapped flex element to ensure proper bottom spacing between body and footer -->
   <div class="flex flex-col flex-1 overflow-auto w-full pb-1">
@@ -95,7 +98,7 @@
     {/if}
   </div>
   <Footer>
-    <Button type="text" on:click={toggleSelectAll}>
+    <Button on:click={toggleSelectAll} type="text">
       {#if allSelected}
         Deselect all
       {:else}
@@ -103,7 +106,7 @@
       {/if}
     </Button>
 
-    <Button type="secondary" on:click={() => dispatch("toggle")}>
+    <Button on:click={() => dispatch("toggle")} type="secondary">
       {#if excludeMode}
         Include
       {:else}

--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { getDimensionType } from "@rilldata/web-common/features/dashboards/filters/dimension-filters/getDimensionType";
+
   /**
    * DimensionDisplay.svelte
    * -------------------------
@@ -7,6 +9,7 @@
    */
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
+  import { STRING_LIKES } from "@rilldata/web-common/lib/duckdb-data-types";
   import {
     createQueryServiceMetricsViewComparison,
     createQueryServiceMetricsViewTotals,
@@ -55,6 +58,12 @@
   let searchText = "";
 
   $: instanceId = $runtime.instanceId;
+  $: dimensionType = getDimensionType(
+    instanceId,
+    $metricsViewName,
+    dimensionName,
+  );
+  $: stringLikeDimension = STRING_LIKES.has($dimensionType.data ?? "");
 
   const timeControlsStore = useTimeControlStore(stateManagers);
 
@@ -158,9 +167,10 @@
         isRowsEmpty={!tableRows.length}
         isFetching={$sortedQuery?.isFetching}
         on:search={(event) => {
-          searchText = event.detail;
+          if (stringLikeDimension) searchText = event.detail;
         }}
         on:toggle-all-search-items={() => toggleAllSearchItems()}
+        enableSearch={stringLikeDimension}
       />
     </div>
 

--- a/web-common/src/features/dashboards/dimension-table/DimensionHeader.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionHeader.svelte
@@ -24,6 +24,7 @@
   export let isFetching: boolean;
   export let areAllTableRowsSelected = false;
   export let isRowsEmpty = true;
+  export let enableSearch = true;
 
   const dispatch = createEventDispatcher();
 
@@ -120,7 +121,7 @@
           <Close />
         </button>
       </div>
-    {:else}
+    {:else if enableSearch}
       <button
         class="flex items-center gap-x-2 p-1.5 text-gray-700"
         in:fly|global={{ x: 10, duration: 300 }}

--- a/web-common/src/features/dashboards/filters/FilterChips.svelte
+++ b/web-common/src/features/dashboards/filters/FilterChips.svelte
@@ -75,9 +75,9 @@ The main feature-set component for dashboard filters
 </script>
 
 <div
+  class="grid items-center place-items-center"
   class:ui-copy-icon={true}
   class:ui-copy-icon-inactive={false}
-  class="grid items-center place-items-center"
   style:height={ROW_HEIGHT}
   style:width={ROW_HEIGHT}
 >
@@ -101,7 +101,6 @@ The main feature-set component for dashboard filters
             {name}
             {label}
             {selectedValues}
-            column={dimension.column}
             on:remove={() => removeDimensionFilter(name)}
             on:apply={(event) =>
               toggleDimensionValueSelection(name, event.detail, true)}

--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -106,7 +106,6 @@
               {name}
               {label}
               {selectedValues}
-              column={dimensionName}
               on:remove={() => removeDimensionFilter(name)}
               on:apply={(event) =>
                 toggleDimensionValueSelection(name, event.detail, true)}

--- a/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
+++ b/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
@@ -3,6 +3,9 @@
     defaultChipColors,
     excludeChipColors,
   } from "@rilldata/web-common/components/chip/chip-types";
+  import { getDimensionType } from "@rilldata/web-common/features/dashboards/filters/dimension-filters/getDimensionType";
+  import { STRING_LIKES } from "@rilldata/web-common/lib/duckdb-data-types";
+  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import RemovableListChip from "../../../../components/chip/removable-list-chip/RemovableListChip.svelte";
   import { getFilterSearchList } from "../../selectors/index";
   import { getStateManagers } from "../../state-managers/state-managers";
@@ -18,6 +21,7 @@
     actions: {
       dimensionsFilter: { toggleDimensionFilterMode },
     },
+    metricsViewName,
   } = StateManagers;
 
   $: isInclude = !$dashboardStore.dimensionFilterExcludeMode.get(name);
@@ -27,11 +31,19 @@
   let allValues: Record<string, string[]> = {};
   let topListQuery: ReturnType<typeof getFilterSearchList> | undefined;
 
+  $: dimensionType = getDimensionType(
+    $runtime.instanceId,
+    $metricsViewName,
+    name,
+  );
+  $: stringLikeDimension = STRING_LIKES.has($dimensionType.data);
+
   $: if (isOpen) {
     topListQuery = getFilterSearchList(StateManagers, {
       dimension: name,
       searchText,
-      addNull: "null".includes(searchText),
+      addNull: searchText.length !== 0 && "null".includes(searchText),
+      type: $dimensionType.data,
     });
   }
 
@@ -54,21 +66,22 @@
 </script>
 
 <RemovableListChip
-  on:remove
+  allValues={allValues[name]}
+  colors={getColorForChip(isInclude)}
+  enableSearch={stringLikeDimension}
+  excludeMode={!isInclude}
+  label="View filter"
+  name={isInclude ? label : `Exclude ${label}`}
   on:apply
-  on:mount={() => setOpen()}
   on:click={() => setOpen()}
-  on:toggle={() => toggleDimensionFilterMode(name)}
+  on:mount={() => setOpen()}
+  on:remove
   on:search={(event) => {
     handleSearch(event.detail);
   }}
-  typeLabel="dimension"
-  name={isInclude ? label : `Exclude ${label}`}
-  excludeMode={!isInclude}
-  colors={getColorForChip(isInclude)}
-  label="View filter"
+  on:toggle={() => toggleDimensionFilterMode(name)}
   {selectedValues}
-  allValues={allValues[name]}
+  typeLabel="dimension"
 >
   <svelte:fragment slot="body-tooltip-content">
     Click to edit the the filters in this dimension

--- a/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
+++ b/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
@@ -48,8 +48,9 @@
   }
 
   $: if (!$topListQuery?.isFetching) {
-    const topListData = $topListQuery?.data?.data ?? [];
-    allValues[name] = topListData.map((datum) => datum[column]) ?? [];
+    const topListData = $topListQuery?.data?.rows ?? [];
+    allValues[name] =
+      topListData.map((datum) => datum.dimensionValue as any) ?? [];
   }
 
   function getColorForChip(isInclude: boolean) {

--- a/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
+++ b/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
@@ -12,7 +12,6 @@
 
   export let name: string;
   export let label: string;
-  export let column: string;
   export let selectedValues: string[];
 
   const StateManagers = getStateManagers();

--- a/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
+++ b/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
@@ -36,7 +36,7 @@
     $metricsViewName,
     name,
   );
-  $: stringLikeDimension = STRING_LIKES.has($dimensionType.data);
+  $: stringLikeDimension = STRING_LIKES.has($dimensionType.data ?? "");
 
   $: if (isOpen) {
     topListQuery = getFilterSearchList(StateManagers, {

--- a/web-common/src/features/dashboards/filters/dimension-filters/getDimensionType.ts
+++ b/web-common/src/features/dashboards/filters/dimension-filters/getDimensionType.ts
@@ -1,0 +1,20 @@
+import { createQueryServiceMetricsViewSchema } from "@rilldata/web-common/runtime-client";
+
+export function getDimensionType(
+  instanceId: string,
+  metricsViewName: string,
+  dimensionName: string,
+) {
+  return createQueryServiceMetricsViewSchema(
+    instanceId,
+    metricsViewName,
+    {},
+    {
+      query: {
+        select: (data) =>
+          data.schema?.fields?.find((f) => f.name === dimensionName)?.type
+            ?.code as string,
+      },
+    },
+  );
+}

--- a/web-common/src/features/dashboards/selectors/index.ts
+++ b/web-common/src/features/dashboards/selectors/index.ts
@@ -63,7 +63,7 @@ export const getFilterSearchList = (
     dimension: string;
     addNull: boolean;
     searchText: string;
-    type: string;
+    type: string | undefined;
   },
 ): Readable<QueryObserverResult<V1MetricsViewToplistResponse, RpcStatus>> => {
   return derived(
@@ -87,7 +87,7 @@ export const getFilterSearchList = (
           sort: [],
           where: addNull
             ? createInExpression(dimension, [null])
-            : STRING_LIKES.has(type)
+            : STRING_LIKES.has(type ?? "")
               ? createLikeExpression(dimension, `%${searchText}%`)
               : undefined,
         },

--- a/web-common/src/features/dashboards/selectors/index.ts
+++ b/web-common/src/features/dashboards/selectors/index.ts
@@ -12,11 +12,11 @@ import {
   RpcStatus,
   V1MetricsViewSpec,
   V1MetricsViewTimeRangeResponse,
-  V1MetricsViewToplistResponse,
   createQueryServiceMetricsViewTimeRange,
-  createQueryServiceMetricsViewToplist,
   createQueryServiceMetricsViewSchema,
   type V1MetricsViewSchemaResponse,
+  createQueryServiceMetricsViewComparison,
+  V1MetricsViewComparisonResponse,
 } from "@rilldata/web-common/runtime-client";
 import type {
   CreateQueryResult,
@@ -65,7 +65,9 @@ export const getFilterSearchList = (
     searchText: string;
     type: string | undefined;
   },
-): Readable<QueryObserverResult<V1MetricsViewToplistResponse, RpcStatus>> => {
+): Readable<
+  QueryObserverResult<V1MetricsViewComparisonResponse, RpcStatus>
+> => {
   return derived(
     [
       ctx.dashboardStore,
@@ -74,17 +76,19 @@ export const getFilterSearchList = (
       ctx.runtime,
     ],
     ([metricsExplorer, timeControls, metricViewName, runtime], set) => {
-      return createQueryServiceMetricsViewToplist(
+      return createQueryServiceMetricsViewComparison(
         runtime.instanceId,
         metricViewName,
         {
-          dimensionName: dimension,
-          measureNames: [metricsExplorer.leaderboardMeasureName],
-          timeStart: timeControls.timeStart,
-          timeEnd: timeControls.timeEnd,
+          dimension: { name: dimension },
+          measures: [{ name: metricsExplorer.leaderboardMeasureName }],
+          timeRange: {
+            start: timeControls.timeStart,
+            end: timeControls.timeEnd,
+          },
           limit: "100",
           offset: "0",
-          sort: [],
+          sort: [{ name: dimension }],
           where: addNull
             ? createInExpression(dimension, [null])
             : STRING_LIKES.has(type ?? "")


### PR DESCRIPTION
This PR disables search for non-string dimensions in,
- [x] Filter pill
- [x] Dimension Table
- [ ] Time Dimension Detail (?)
- [ ] Pivot (?)

Also removes a usage of old filters in getting the filter list in pills. Also updates to use MetricsViewComparison instead of MetricsViewToplist (deprecated)