### PR TITLE
Debounce rill.yaml editor

### DIFF
--- a/web-common/src/features/generic-yaml-editor/YamlWorkspaceBody.svelte
+++ b/web-common/src/features/generic-yaml-editor/YamlWorkspaceBody.svelte
@@ -7,6 +7,7 @@
   import { runtime } from "../../runtime-client/runtime-store";
   import { saveFile } from "./actions";
   import ErrorPane from "./ErrorPane.svelte";
+  import { debounce } from "@rilldata/web-common/lib/create-debouncer";
 
   export let fileName: string;
 
@@ -22,6 +23,8 @@
       refetchOnWindowFocus: true,
     },
   });
+
+  const debouncedUpdate = debounce(handleUpdate, 300);
 
   async function handleUpdate(e: CustomEvent<{ content: string }>) {
     const blob = e.detail.content;
@@ -57,7 +60,7 @@
         bind:this={editor}
         bind:view
         content={$file?.data?.blob || ""}
-        on:update={handleUpdate}
+        on:update={debouncedUpdate}
       />
     </div>
   </div>


### PR DESCRIPTION
Due to issues that are outside the scope of this PR, which is intended to be a quick fix, each keystroke in the `rill.yaml` workspace causes three refetches and ~10 network requests. While those are investigated, this PR simply debounces updating in the editor.

<img width="584" alt="Screenshot 2024-04-05 at 1 48 50 AM" src="https://github.com/rilldata/rill/assets/120223836/c590147a-d6db-47b1-8381-7ce7ff2e6695">

<img width="1040" alt="Screenshot 2024-04-05 at 1 49 10 AM" src="https://github.com/rilldata/rill/assets/120223836/fa1f6072-cc43-4d66-b09a-6f9e3f086f83">
