### PR TITLE
Udpate usage of notifiers to fix alert and report

### DIFF
--- a/admin/server/alerts.go
+++ b/admin/server/alerts.go
@@ -464,7 +464,7 @@ func (s *Server) yamlForManagedAlert(opts *adminv1.AlertOptions, ownerUserID str
 	// Notification options
 	res.Renotify = opts.Renotify
 	res.RenotifyAfter = opts.RenotifyAfterSeconds
-	res.Notify.Email.Emails = opts.EmailRecipients
+	res.Notify.Email.Recipients = opts.EmailRecipients
 	res.Notify.Slack.Channels = opts.SlackChannels
 	res.Notify.Slack.Users = opts.SlackUsers
 	res.Notify.Slack.Webhooks = opts.SlackWebhooks
@@ -496,7 +496,7 @@ func (s *Server) yamlForCommittedAlert(opts *adminv1.AlertOptions) ([]byte, erro
 	// Notification options
 	res.Renotify = opts.Renotify
 	res.RenotifyAfter = opts.RenotifyAfterSeconds
-	res.Notify.Email.Emails = opts.EmailRecipients
+	res.Notify.Email.Recipients = opts.EmailRecipients
 	res.Notify.Slack.Channels = opts.SlackChannels
 	res.Notify.Slack.Users = opts.SlackUsers
 	res.Notify.Slack.Webhooks = opts.SlackWebhooks
@@ -589,7 +589,7 @@ type alertYAML struct {
 	RenotifyAfter uint32 `yaml:"renotify_after"`
 	Notify        struct {
 		Email struct {
-			Emails []string `yaml:"emails"`
+			Recipients []string `yaml:"emails"`
 		}
 		Slack struct {
 			Users    []string `yaml:"users"`

--- a/web-admin/src/features/alerts/metadata/AlertMetadata.svelte
+++ b/web-admin/src/features/alerts/metadata/AlertMetadata.svelte
@@ -163,7 +163,7 @@
     <EmailRecipients
       emailRecipients={$alertQuery.data.resource.alert.spec.notifiers.find(
         (n) => n.connector === "email",
-      )?.properties?.email?.recipients ?? []}
+      )?.properties?.recipients ?? []}
     />
   </div>
 {/if}

--- a/web-admin/src/features/scheduled-reports/metadata/ReportMetadata.svelte
+++ b/web-admin/src/features/scheduled-reports/metadata/ReportMetadata.svelte
@@ -164,7 +164,7 @@
     <EmailRecipients
       emailRecipients={$reportQuery.data.resource.report.spec.notifiers.find(
         (n) => n.connector === "email",
-      )?.properties?.email?.recipients ?? []}
+      )?.properties?.recipients ?? []}
     />
   </div>
 {/if}

--- a/web-common/src/features/alerts/EditAlertDialog.svelte
+++ b/web-common/src/features/alerts/EditAlertDialog.svelte
@@ -55,7 +55,7 @@
       recipients:
         alertSpec?.notifiers
           ?.find((n) => n.connector === "email")
-          ?.properties?.email?.recipients?.map((r) => ({ email: r })) ?? [],
+          ?.properties?.recipients?.map((r) => ({ email: r })) ?? [],
       evaluationInterval: alertSpec.intervalsIsoDuration ?? "",
       ...extractAlertFormValues(
         queryArgsJson,

--- a/web-common/src/features/scheduled-reports/EditScheduledReportDialog.svelte
+++ b/web-common/src/features/scheduled-reports/EditScheduledReportDialog.svelte
@@ -58,7 +58,7 @@
       recipients:
         reportSpec.notifiers
           ?.find((n) => n.connector === "email")
-          ?.properties?.email?.recipients?.map((email) => ({
+          ?.properties?.recipients?.map((email) => ({
             email: email,
           })) ?? [],
     },


### PR DESCRIPTION
Pulling fixes from #4509 so that it is independent.

1. Fixes the create alert endpoint to populate the correct field.
2. Fixes the usage of email recipients in alerts and reports