### PR TITLE
Update default row and cell limits for exports

### DIFF
--- a/runtime/drivers/registry.go
+++ b/runtime/drivers/registry.go
@@ -114,8 +114,8 @@ func (i *Instance) ResolveVariables() map[string]string {
 func (i *Instance) Config() (InstanceConfig, error) {
 	// Default config
 	res := InstanceConfig{
-		DownloadRowLimit:                  10_000,
-		PivotCellLimit:                    1_000_000,
+		DownloadRowLimit:                  200_000,
+		PivotCellLimit:                    2_000_000,
 		InteractiveSQLRowLimit:            10_000,
 		StageChanges:                      true,
 		ModelDefaultMaterialize:           false,


### PR DESCRIPTION
Updates the default limits to:
- 200k rows for direct downloads (override with: `rill env set rill.download_row_limit <number>`)
- 2m cells for a single pivot query (override with: `rill env set rill.pivot_cell_limit <number>`)