### PR TITLE
Refactor measure filter components to be agnostic of proto types

### DIFF
--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterBody.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterBody.svelte
@@ -6,36 +6,38 @@
 <script lang="ts">
   import IconSpaceFixer from "@rilldata/web-common/components/button/IconSpaceFixer.svelte";
   import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
-  import { MeasureFilterOptions } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-options";
-  import type { V1Expression } from "@rilldata/web-common/runtime-client";
-  import { V1Operation } from "@rilldata/web-common/runtime-client";
+  import { MeasureFilterEntry } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry";
+  import {
+    MeasureFilterOperation,
+    MeasureFilterOptions,
+  } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-options";
 
   export let dimensionName: string;
   export let label: string | undefined;
-  export let expr: V1Expression | undefined;
+  export let filter: MeasureFilterEntry | undefined;
   export let labelMaxWidth = "160px";
   export let active = false;
   export let readOnly = false;
 
   let shortLabel: string | undefined;
-  $: if (expr?.cond?.op) {
-    if (
-      expr?.cond?.op === V1Operation.OPERATION_AND ||
-      expr?.cond?.op === V1Operation.OPERATION_OR
-    ) {
-      shortLabel = `${
-        expr?.cond?.op === V1Operation.OPERATION_OR ? "!" : ""
-      }(${JSON.stringify(
-        expr?.cond?.exprs?.[0]?.cond?.exprs?.[1]?.val ?? "",
-      )}, ${JSON.stringify(
-        expr?.cond?.exprs?.[1]?.cond?.exprs?.[1]?.val ?? "",
-      )})`;
-    } else {
-      shortLabel =
-        MeasureFilterOptions.find((o) => o.value === expr?.cond?.op)
-          ?.shortLabel +
-        " " +
-        JSON.stringify(expr?.cond?.exprs?.[1].val);
+  $: if (filter) {
+    switch (filter.operation) {
+      case MeasureFilterOperation.GreaterThan:
+      case MeasureFilterOperation.GreaterThanOrEquals:
+      case MeasureFilterOperation.LessThan:
+      case MeasureFilterOperation.LessThanOrEquals:
+        shortLabel =
+          MeasureFilterOptions.find((o) => o.value === filter.operation)
+            ?.shortLabel +
+          " " +
+          filter.value1;
+        break;
+      case MeasureFilterOperation.Between:
+        shortLabel = `(${filter.value1},${filter.value2})`;
+        break;
+      case MeasureFilterOperation.NotBetween:
+        shortLabel = `!(${filter.value1},${filter.value2})`;
+        break;
     }
   }
 </script>

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterBody.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterBody.svelte
@@ -27,8 +27,12 @@
       case MeasureFilterOperation.LessThan:
       case MeasureFilterOperation.LessThanOrEquals:
         shortLabel =
-          MeasureFilterOptions.find((o) => o.value === filter.operation)
-            ?.shortLabel +
+          MeasureFilterOptions.find(
+            (o) =>
+              // svelte-check is throwing an error here stating `filter could be undefined` so we need this
+              o.value === filter?.operation ??
+              MeasureFilterOperation.GreaterThan,
+          )?.shortLabel +
           " " +
           filter.value1;
         break;

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterReadOnlyChip.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterReadOnlyChip.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+  import {
+    mapExprToMeasureFilter,
+    MeasureFilterEntry,
+  } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry";
   import { Chip } from "../../../../components/chip";
   import {
     measureChipColors,
@@ -11,10 +15,13 @@
   export let label: string | undefined = undefined;
   export let colors: ChipColors = measureChipColors;
   export let expr: V1Expression | undefined = undefined;
+
+  let filter: MeasureFilterEntry | undefined;
+  $: filter = mapExprToMeasureFilter(expr);
 </script>
 
 <Chip {...colors} extraRounded={false} {label} outline readOnly>
   <div class="mx-2" slot="body">
-    <MeasureFilterBody {dimensionName} {expr} {label} readOnly />
+    <MeasureFilterBody {dimensionName} {filter} {label} readOnly />
   </div>
 </Chip>

--- a/web-common/src/features/dashboards/filters/measure-filters/measure-filter-entry.spec.ts
+++ b/web-common/src/features/dashboards/filters/measure-filters/measure-filter-entry.spec.ts
@@ -1,0 +1,169 @@
+import {
+  mapExprToMeasureFilter,
+  mapMeasureFilterToExpr,
+  MeasureFilterComparisonType,
+  MeasureFilterEntry,
+} from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry";
+import { MeasureFilterOperation } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-options";
+import {
+  createAndExpression,
+  createBinaryExpression,
+  createOrExpression,
+} from "@rilldata/web-common/features/dashboards/stores/filter-utils";
+import { V1Expression, V1Operation } from "@rilldata/web-common/runtime-client";
+import { describe, it, expect } from "vitest";
+
+const TestCases: [
+  title: string,
+  measureFilter: MeasureFilterEntry,
+  expr: V1Expression | undefined,
+][] = [
+  [
+    "greater than",
+    {
+      value1: "10",
+      value2: "",
+      measure: "imp",
+      operation: MeasureFilterOperation.GreaterThan,
+      comparison: MeasureFilterComparisonType.None,
+    },
+    createBinaryExpression("imp", V1Operation.OPERATION_GT, 10),
+  ],
+  [
+    "greater than or equals",
+    {
+      value1: "10",
+      value2: "",
+      measure: "imp",
+      operation: MeasureFilterOperation.GreaterThanOrEquals,
+      comparison: MeasureFilterComparisonType.None,
+    },
+    createBinaryExpression("imp", V1Operation.OPERATION_GTE, 10),
+  ],
+  [
+    "less than",
+    {
+      value1: "10",
+      value2: "",
+      measure: "imp",
+      operation: MeasureFilterOperation.LessThan,
+      comparison: MeasureFilterComparisonType.None,
+    },
+    createBinaryExpression("imp", V1Operation.OPERATION_LT, 10),
+  ],
+  [
+    "less than or equals",
+    {
+      value1: "10",
+      value2: "",
+      measure: "imp",
+      operation: MeasureFilterOperation.LessThanOrEquals,
+      comparison: MeasureFilterComparisonType.None,
+    },
+    createBinaryExpression("imp", V1Operation.OPERATION_LTE, 10),
+  ],
+  [
+    "between",
+    {
+      value1: "10",
+      value2: "20",
+      measure: "imp",
+      operation: MeasureFilterOperation.Between,
+      comparison: MeasureFilterComparisonType.None,
+    },
+    createAndExpression([
+      createBinaryExpression("imp", V1Operation.OPERATION_GT, 10),
+      createBinaryExpression("imp", V1Operation.OPERATION_LT, 20),
+    ]),
+  ],
+  [
+    "not between",
+    {
+      value1: "10",
+      value2: "20",
+      measure: "imp",
+      operation: MeasureFilterOperation.NotBetween,
+      comparison: MeasureFilterComparisonType.None,
+    },
+    createOrExpression([
+      createBinaryExpression("imp", V1Operation.OPERATION_LTE, 10),
+      createBinaryExpression("imp", V1Operation.OPERATION_GTE, 20),
+    ]),
+  ],
+  [
+    "invalid greater than",
+    {
+      value1: "10",
+      value2: "",
+      measure: "imp",
+      operation: MeasureFilterOperation.GreaterThan,
+      comparison: MeasureFilterComparisonType.PercentageComparison,
+    },
+    undefined,
+  ],
+  [
+    "increases by value",
+    {
+      value1: "10",
+      value2: "",
+      measure: "imp",
+      operation: MeasureFilterOperation.IncreasesBy,
+      comparison: MeasureFilterComparisonType.AbsoluteComparison,
+    },
+    createBinaryExpression("imp__delta_abs", V1Operation.OPERATION_GT, 10),
+  ],
+  [
+    "decreases by percent",
+    {
+      value1: "10",
+      value2: "",
+      measure: "imp",
+      operation: MeasureFilterOperation.DecreasesBy,
+      comparison: MeasureFilterComparisonType.PercentageComparison,
+    },
+    createBinaryExpression("imp__delta_rel", V1Operation.OPERATION_LT, -0.1),
+  ],
+  [
+    "changes by percent",
+    {
+      value1: "10",
+      value2: "",
+      measure: "imp",
+      operation: MeasureFilterOperation.ChangesBy,
+      comparison: MeasureFilterComparisonType.PercentageComparison,
+    },
+    createOrExpression([
+      createBinaryExpression("imp__delta_rel", V1Operation.OPERATION_LT, -0.1),
+      createBinaryExpression("imp__delta_rel", V1Operation.OPERATION_GT, 0.1),
+    ]),
+  ],
+  [
+    // TODO
+    "share of totals",
+    {
+      value1: "10",
+      value2: "",
+      measure: "imp",
+      operation: MeasureFilterOperation.ShareOfTotalsGreaterThan,
+      comparison: MeasureFilterComparisonType.PercentageComparison,
+    },
+    undefined,
+  ],
+];
+
+describe("mapMeasureFilterToExpr", () => {
+  TestCases.forEach(([title, criteria, expr]) => {
+    it(title, () => {
+      expect(mapMeasureFilterToExpr(criteria)).toEqual(expr);
+    });
+  });
+});
+
+describe("mapExprToMeasureFilter", () => {
+  TestCases.forEach(([title, criteria, expr]) => {
+    if (!expr) return;
+    it(title, () => {
+      expect(mapExprToMeasureFilter(expr)).toEqual(criteria);
+    });
+  });
+});

--- a/web-common/src/features/dashboards/filters/measure-filters/measure-filter-entry.ts
+++ b/web-common/src/features/dashboards/filters/measure-filters/measure-filter-entry.ts
@@ -1,0 +1,174 @@
+import {
+  MeasureFilterOperation,
+  MeasureFilterToProtoOperation,
+  ProtoToCompareMeasureFilterOperation,
+  ProtoToMeasureFilterOperations,
+} from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-options";
+import {
+  createBetweenExpression,
+  createBinaryExpression,
+  createOrExpression,
+} from "@rilldata/web-common/features/dashboards/stores/filter-utils";
+import { V1Expression, V1Operation } from "@rilldata/web-common/runtime-client";
+
+export enum MeasureFilterComparisonType {
+  None,
+  AbsoluteComparison,
+  PercentageComparison,
+  AbsoluteShareOfTotal,
+  PercentageShareOfTotal,
+}
+
+export type MeasureFilterEntry = {
+  measure: string;
+  operation: MeasureFilterOperation;
+  comparison: MeasureFilterComparisonType;
+  value1: string;
+  value2: string;
+};
+
+const DeltaAbsoluteSuffix = "__delta_abs";
+const DeltaRelativeSuffix = "__delta_rel";
+const HasSuffixRegex = /__delta_(rel|abs)/;
+
+export function mapExprToMeasureFilter(
+  expr: V1Expression | undefined,
+): MeasureFilterEntry | undefined {
+  if (!expr) return undefined;
+
+  let value1 = 0;
+  let value2: number | undefined;
+  let field = "";
+  let operation = MeasureFilterOperation.GreaterThan;
+  let comparison = MeasureFilterComparisonType.None;
+
+  switch (expr.cond?.op) {
+    case V1Operation.OPERATION_OR:
+      field = expr.cond.exprs?.[0].cond?.exprs?.[0].ident ?? "";
+      if (HasSuffixRegex.test(field)) {
+        // handle ChangeBy
+        value1 =
+          (expr.cond.exprs?.[1].cond?.exprs?.[1].val as number) * 100 ?? 0;
+        operation = MeasureFilterOperation.ChangesBy;
+        break;
+      }
+    // eslint-disable-next-line no-fallthrough
+    case V1Operation.OPERATION_AND:
+      // handle between and not-between
+      field = expr.cond.exprs?.[0].cond?.exprs?.[0].ident ?? "";
+      value1 = (expr.cond.exprs?.[0].cond?.exprs?.[1].val as number) ?? 0;
+      value2 = (expr.cond.exprs?.[1].cond?.exprs?.[1].val as number) ?? 0;
+      operation =
+        expr.cond?.op === V1Operation.OPERATION_AND
+          ? MeasureFilterOperation.Between
+          : MeasureFilterOperation.NotBetween;
+      break;
+
+    case V1Operation.OPERATION_GT:
+    case V1Operation.OPERATION_GTE:
+    case V1Operation.OPERATION_LT:
+    case V1Operation.OPERATION_LTE:
+      field = expr.cond.exprs?.[0].ident ?? "";
+      value1 = Math.abs((expr.cond.exprs?.[1].val as number) ?? 0);
+      if (field.endsWith(DeltaRelativeSuffix)) {
+        // convert decimal to percent
+        value1 *= 100;
+      }
+      operation =
+        (HasSuffixRegex.test(field)
+          ? ProtoToCompareMeasureFilterOperation[expr.cond?.op]
+          : ProtoToMeasureFilterOperations[expr.cond?.op]) ??
+        MeasureFilterOperation.GreaterThan;
+      break;
+  }
+
+  if (field.endsWith(DeltaAbsoluteSuffix)) {
+    comparison = MeasureFilterComparisonType.AbsoluteComparison;
+  } else if (field.endsWith(DeltaRelativeSuffix)) {
+    comparison = MeasureFilterComparisonType.PercentageComparison;
+  }
+
+  return {
+    measure: field.replace(HasSuffixRegex, ""),
+    value1: value1.toString(),
+    value2: value2?.toString() ?? "",
+    operation,
+    comparison,
+  };
+}
+
+export function mapMeasureFilterToExpr(
+  measureFilter: MeasureFilterEntry,
+): V1Expression | undefined {
+  const value =
+    Number(measureFilter.value1) /
+    (measureFilter.comparison ===
+    MeasureFilterComparisonType.PercentageComparison
+      ? 100
+      : 1);
+  const comparisonSuffix =
+    measureFilter.comparison ===
+    MeasureFilterComparisonType.PercentageComparison
+      ? DeltaRelativeSuffix
+      : DeltaAbsoluteSuffix;
+
+  switch (measureFilter.operation) {
+    case MeasureFilterOperation.GreaterThan:
+    case MeasureFilterOperation.GreaterThanOrEquals:
+    case MeasureFilterOperation.LessThan:
+    case MeasureFilterOperation.LessThanOrEquals:
+      if (measureFilter.comparison !== MeasureFilterComparisonType.None)
+        return undefined;
+      return createBinaryExpression(
+        measureFilter.measure,
+        MeasureFilterToProtoOperation[measureFilter.operation],
+        value,
+      );
+
+    case MeasureFilterOperation.Between:
+    case MeasureFilterOperation.NotBetween:
+      return createBetweenExpression(
+        measureFilter.measure,
+        value,
+        Number(measureFilter.value2 ?? "0"),
+        measureFilter.operation === MeasureFilterOperation.NotBetween,
+      );
+
+    case MeasureFilterOperation.IncreasesBy:
+      // Δ<field> > <value>
+      // or
+      // Δ%<field> > <value>
+      return createBinaryExpression(
+        measureFilter.measure + comparisonSuffix,
+        V1Operation.OPERATION_GT,
+        value,
+      );
+
+    case MeasureFilterOperation.DecreasesBy:
+      // Δ<field> < -<value>
+      // or
+      // Δ%<field> < -<value>
+      return createBinaryExpression(
+        measureFilter.measure + comparisonSuffix,
+        V1Operation.OPERATION_LT,
+        -Math.abs(value),
+      );
+
+    case MeasureFilterOperation.ChangesBy:
+      // Δ<field> < -<value> && Δ<field> > <value>
+      // or
+      // Δ%<field> < -<value> && Δ%<field> > <value>
+      return createOrExpression([
+        createBinaryExpression(
+          measureFilter.measure + comparisonSuffix,
+          V1Operation.OPERATION_LT,
+          -Math.abs(value),
+        ),
+        createBinaryExpression(
+          measureFilter.measure + comparisonSuffix,
+          V1Operation.OPERATION_GT,
+          value,
+        ),
+      ]);
+  }
+}

--- a/web-common/src/features/dashboards/filters/measure-filters/measure-filter-options.ts
+++ b/web-common/src/features/dashboards/filters/measure-filters/measure-filter-options.ts
@@ -1,39 +1,74 @@
 import { V1Operation } from "@rilldata/web-common/runtime-client";
 
 export type MeasureFilterOption = {
-  value: V1Operation;
+  value: MeasureFilterOperation;
   label: string;
   shortLabel: string;
 };
 
+export enum MeasureFilterOperation {
+  GreaterThan = "OPERATION_GT",
+  GreaterThanOrEquals = "OPERATION_GTE",
+  LessThan = "OPERATION_LT",
+  LessThanOrEquals = "OPERATION_LTE",
+  Between = "Between",
+  NotBetween = "NotBetween",
+  IncreasesBy = "IncreasesBy",
+  DecreasesBy = "DecreasesBy",
+  ChangesBy = "ChangesBy",
+  ShareOfTotalsGreaterThan = "ShareOfTotalsGreaterThan",
+  ShareOfTotalsLessThan = "ShareOfTotalsLessThan",
+}
+
+export const MeasureFilterToProtoOperation = {
+  [MeasureFilterOperation.GreaterThan]: V1Operation.OPERATION_GT,
+  [MeasureFilterOperation.GreaterThanOrEquals]: V1Operation.OPERATION_GTE,
+  [MeasureFilterOperation.LessThan]: V1Operation.OPERATION_LT,
+  [MeasureFilterOperation.LessThanOrEquals]: V1Operation.OPERATION_LTE,
+};
+export const ProtoToMeasureFilterOperations: Partial<
+  Record<V1Operation, MeasureFilterOperation>
+> = {};
+for (const MeasureFilterOperation in MeasureFilterToProtoOperation) {
+  ProtoToMeasureFilterOperations[
+    MeasureFilterToProtoOperation[MeasureFilterOperation]
+  ] = MeasureFilterOperation;
+}
+export const ProtoToCompareMeasureFilterOperation = {
+  [V1Operation.OPERATION_GT]: MeasureFilterOperation.IncreasesBy,
+  [V1Operation.OPERATION_GTE]: MeasureFilterOperation.IncreasesBy,
+  [V1Operation.OPERATION_LT]: MeasureFilterOperation.DecreasesBy,
+  [V1Operation.OPERATION_LTE]: MeasureFilterOperation.DecreasesBy,
+};
+
 export const MeasureFilterOptions: MeasureFilterOption[] = [
   {
-    value: V1Operation.OPERATION_LT,
-    label: "Less Than",
-    shortLabel: "<",
-  },
-  {
-    value: V1Operation.OPERATION_LTE,
-    label: "Less Than Or Equals",
-    shortLabel: "<=",
-  },
-  {
-    value: V1Operation.OPERATION_GT,
+    value: MeasureFilterOperation.GreaterThan,
     label: "Greater Than",
     shortLabel: ">",
   },
   {
-    value: V1Operation.OPERATION_GTE,
+    value: MeasureFilterOperation.GreaterThanOrEquals,
     label: "Greater Than Or Equals",
     shortLabel: ">=",
   },
   {
-    value: V1Operation.OPERATION_AND,
+    value: MeasureFilterOperation.LessThan,
+    label: "Less Than",
+    shortLabel: "<",
+  },
+  {
+    value: MeasureFilterOperation.LessThanOrEquals,
+    label: "Less Than Or Equals",
+    shortLabel: "<=",
+  },
+  {
+    value: MeasureFilterOperation.Between,
     label: "Between",
     shortLabel: "",
   },
   {
-    value: V1Operation.OPERATION_OR,
+    value: MeasureFilterOperation.NotBetween,
     label: "Not Between",
     shortLabel: "",
   },


### PR DESCRIPTION
For ease of use mapping to and from proto type `V1Expression` should be separate from the measure filter forms and pills.

This PR is a 1st step towards this. It refactors all components dealing with measure filter editing and the pills to use a new format that can be mapped directly to the form.
Note: this makes things easier for comparison in alerts.

A follow up PR will refactor our dashboard state to store this directly.