### PR TITLE
Runtime: metrics sql template fix

### DIFF
--- a/runtime/resolvers/metrics_sql.go
+++ b/runtime/resolvers/metrics_sql.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 
 	"github.com/mitchellh/mapstructure"
+	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
+	"github.com/rilldata/rill/runtime/drivers"
 	metricssqlparser "github.com/rilldata/rill/runtime/pkg/metricssql"
 )
 
@@ -30,6 +32,18 @@ func newMetricsSQL(ctx context.Context, opts *runtime.ResolverOptions) (runtime.
 		return nil, errors.New(`metrics SQL: missing required property "sql"`)
 	}
 
+	instance, err := opts.Runtime.Instance(ctx, opts.InstanceID)
+	if err != nil {
+		return nil, err
+	}
+
+	var finalRefs []*runtimev1.ResourceName
+	// passing DialectDuckDB in all cases is not good but no way to identify metrics_view connector without parsing the SQL
+	props.SQL, finalRefs, err = resolveTemplate(props.SQL, drivers.DialectDuckDB, opts.Args, instance, opts.UserAttributes, opts.ForExport)
+	if err != nil {
+		return nil, err
+	}
+
 	ctrl, err := opts.Runtime.Controller(ctx, opts.InstanceID)
 	if err != nil {
 		return nil, err
@@ -39,6 +53,10 @@ func newMetricsSQL(ctx context.Context, opts *runtime.ResolverOptions) (runtime.
 	sql, connector, refs, err := compiler.Compile(ctx, props.SQL)
 	if err != nil {
 		return nil, err
+	}
+	if refs != nil {
+		finalRefs = append(finalRefs, refs...)
+		finalRefs = normalizeRefs(finalRefs)
 	}
 
 	// Build the options for the regular SQL resolver
@@ -53,6 +71,5 @@ func newMetricsSQL(ctx context.Context, opts *runtime.ResolverOptions) (runtime.
 		UserAttributes: opts.UserAttributes,
 		ForExport:      opts.ForExport,
 	}
-
-	return newSQLWithRefs(ctx, sqlResolverOpts, refs)
+	return newSQLSimple(ctx, sqlResolverOpts, finalRefs)
 }

--- a/runtime/resolvers/metrics_sql.go
+++ b/runtime/resolvers/metrics_sql.go
@@ -7,7 +7,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
-	"github.com/rilldata/rill/runtime/drivers"
 	metricssqlparser "github.com/rilldata/rill/runtime/pkg/metricssql"
 )
 
@@ -38,8 +37,7 @@ func newMetricsSQL(ctx context.Context, opts *runtime.ResolverOptions) (runtime.
 	}
 
 	var finalRefs []*runtimev1.ResourceName
-	// passing DialectDuckDB in all cases is not good but no way to identify metrics_view connector without parsing the SQL
-	props.SQL, finalRefs, err = resolveTemplate(props.SQL, drivers.DialectDuckDB, opts.Args, instance, opts.UserAttributes, opts.ForExport)
+	props.SQL, finalRefs, err = resolveTemplate(props.SQL, opts.Args, instance, opts.UserAttributes, opts.ForExport)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/resolvers/metrics_sql_test.go
+++ b/runtime/resolvers/metrics_sql_test.go
@@ -60,6 +60,32 @@ func TestTemplateMetricsSQLAPI(t *testing.T) {
 	require.Equal(t, "Yahoo", rows[0]["publisher"])
 }
 
+func TestComplexTemplateMetricsSQLAPI(t *testing.T) {
+	rt, instanceID := testruntime.NewInstanceForProject(t, "ad_bids")
+
+	testruntime.RequireParseErrors(t, rt, instanceID, nil)
+
+	api, err := rt.APIForName(context.Background(), instanceID, "templated_mv_sql_api_2")
+	require.NoError(t, err)
+
+	res, err := rt.Resolve(context.Background(), &runtime.ResolveOptions{
+		InstanceID:         instanceID,
+		Resolver:           api.Spec.Resolver,
+		ResolverProperties: api.Spec.ResolverProperties.AsMap(),
+		Args:               map[string]any{"domain": "yahoo.com", "pageSize": ""},
+		UserAttributes:     map[string]any{"domain": "yahoo.com"},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	var rows []map[string]interface{}
+	require.NoError(t, json.Unmarshal(res.Data, &rows))
+	require.Equal(t, 1, len(rows))
+	require.Equal(t, 3.0, rows[0]["measure_2"])
+	require.Equal(t, "yahoo.com", rows[0]["domain"])
+	require.Equal(t, "Yahoo", rows[0]["publisher"])
+}
+
 func TestPolicyMetricsSQLAPI(t *testing.T) {
 	rt, instanceID := testruntime.NewInstanceForProject(t, "ad_bids")
 

--- a/runtime/resolvers/sql.go
+++ b/runtime/resolvers/sql.go
@@ -248,7 +248,7 @@ func (r *sqlResolver) generalExport(ctx context.Context, w io.Writer, filename s
 // buildSQL resolves the SQL template and returns the resolved SQL and the resource names it references.
 func buildSQL(sqlTemplate string, dialect drivers.Dialect, args map[string]any, inst *drivers.Instance, userAttributes map[string]any, forExport bool) (string, []*runtimev1.ResourceName, error) {
 	// Resolve the SQL template
-	sql, refs, err := resolveTemplate(sqlTemplate, dialect, args, inst, userAttributes, forExport)
+	sql, refs, err := resolveTemplate(sqlTemplate, args, inst, userAttributes, forExport)
 	if err != nil {
 		return "", nil, err
 	}
@@ -273,7 +273,7 @@ func buildSQL(sqlTemplate string, dialect drivers.Dialect, args map[string]any, 
 	return sql, normalizeRefs(refs), nil
 }
 
-func resolveTemplate(sqlTemplate string, dialect drivers.Dialect, args map[string]any, inst *drivers.Instance, userAttributes map[string]any, forExport bool) (string, []*runtimev1.ResourceName, error) {
+func resolveTemplate(sqlTemplate string, args map[string]any, inst *drivers.Instance, userAttributes map[string]any, forExport bool) (string, []*runtimev1.ResourceName, error) {
 	var refs []*runtimev1.ResourceName
 	sql, err := compilerv1.ResolveTemplate(sqlTemplate, compilerv1.TemplateData{
 		Environment: inst.Environment,
@@ -296,7 +296,8 @@ func resolveTemplate(sqlTemplate string, dialect drivers.Dialect, args map[strin
 			}
 
 			// Return the escaped identifier
-			return dialect.EscapeIdentifier(ref.Name), nil
+			// TODO: As of now it is using `DialectDuckDB` in all cases since in certain cases like metrics_sql it is not possible to identify OLAP connector before template reslution.
+			return drivers.DialectDuckDB.EscapeIdentifier(ref.Name), nil
 		},
 	})
 	if err != nil {

--- a/runtime/resolvers/sql.go
+++ b/runtime/resolvers/sql.go
@@ -296,7 +296,7 @@ func resolveTemplate(sqlTemplate string, args map[string]any, inst *drivers.Inst
 			}
 
 			// Return the escaped identifier
-			// TODO: As of now it is using `DialectDuckDB` in all cases since in certain cases like metrics_sql it is not possible to identify OLAP connector before template reslution.
+			// TODO: As of now it is using `DialectDuckDB` in all cases since in certain cases like metrics_sql it is not possible to identify OLAP connector before template resolution.
 			return drivers.DialectDuckDB.EscapeIdentifier(ref.Name), nil
 		},
 	})

--- a/runtime/testruntime/testdata/ad_bids/apis/templated_mv_sql_api.yaml
+++ b/runtime/testruntime/testdata/ad_bids/apis/templated_mv_sql_api.yaml
@@ -1,3 +1,6 @@
 kind : api
 
-metrics_sql: select publisher, domain, measure_2 from ad_bids_mini_metrics where domain = '{{ .args.domain }}'
+metrics_sql: | 
+  SELECT publisher, domain, measure_2 
+  FROM ad_bids_mini_metrics
+  WHERE domain = '{{ .args.domain }}'

--- a/runtime/testruntime/testdata/ad_bids/apis/templated_mv_sql_api_2.yaml
+++ b/runtime/testruntime/testdata/ad_bids/apis/templated_mv_sql_api_2.yaml
@@ -1,0 +1,9 @@
+kind : api
+metrics_sql: |
+  SELECT publisher, domain, measure_2 
+  FROM ad_bids_mini_metrics
+  WHERE
+    -- can access user attributes with templating
+    {{ if (ne .user.domain "") }} domain = '{{ .user.domain }}' {{ end }}
+    -- can use Sprig functions, e.g. to easily set defaults
+    {{ if (not .export) }} LIMIT {{ default 1 .args.pageSize }} {{ end }}


### PR DESCRIPTION
The metrics SQL parser should resolve template first before parsing the SQL with template functions. This is required since the underlying parser can't always parse SQL with templates. Example below:
```
  SELECT publisher, domain, measure_2 
  FROM ad_bids_mini_metrics
  WHERE
    -- can access user attributes with templating
    {{ if (ne .user.domain "") }} domain = '{{ .user.domain }}' {{ end }}
    -- can use Sprig functions, e.g. to easily set defaults
    {{ if (not .export) }} LIMIT {{ default 1 .args.pageSize }} {{ end }}
```
