### PR TITLE
Adjusting the spacing in slack notification section to match other sections

### DIFF
--- a/web-common/src/components/forms/FormSection.svelte
+++ b/web-common/src/components/forms/FormSection.svelte
@@ -30,7 +30,9 @@
         <Switch bind:checked={enabled} />
       {/if}
     </span>
-    {#if description}
+    {#if $$slots["description"]}
+      <slot name="description" />
+    {:else if description}
       <span class="text-sm text-slate-600">{description}</span>
     {/if}
   </div>

--- a/web-common/src/features/alerts/delivery-tab/AlertDialogDeliveryTab.svelte
+++ b/web-common/src/features/alerts/delivery-tab/AlertDialogDeliveryTab.svelte
@@ -58,14 +58,16 @@
     </FormSection>
   {:else}
     <FormSection title="Slack notifications">
-      <span class="text-sm text-slate-600">
-        Slack has not been configured for this project. Read the <a
-          href="https://docs.rilldata.com/explore/alerts/slack"
-          target="_blank"
-        >
-          docs
-        </a> to learn more.
-      </span>
+      <svelte:fragment slot="description">
+        <span class="text-sm text-slate-600">
+          Slack has not been configured for this project. Read the <a
+            href="https://docs.rilldata.com/explore/alerts/slack"
+            target="_blank"
+          >
+            docs
+          </a> to learn more.
+        </span>
+      </svelte:fragment>
     </FormSection>
   {/if}
   <FormSection


### PR DESCRIPTION
When slack is not enabled we show a message directing users to the docs. This PR adjusts the spacing to match other sections.