### PR TITLE
Update metrics definition editor to use file path

### DIFF
--- a/web-common/src/features/dashboards/granular-access-policies/useDashboardPolicyCheck.ts
+++ b/web-common/src/features/dashboards/granular-access-policies/useDashboardPolicyCheck.ts
@@ -1,23 +1,14 @@
 import { parse } from "yaml";
 import { createRuntimeServiceGetFile } from "../../../runtime-client";
-import { getFilePathFromNameAndType } from "../../entity-management/entity-mappers";
-import { EntityType } from "../../entity-management/types";
 
-export function useDashboardPolicyCheck(
-  instanceId: string,
-  dashboardName: string,
-) {
-  return createRuntimeServiceGetFile(
-    instanceId,
-    getFilePathFromNameAndType(dashboardName, EntityType.MetricsDefinition),
-    {
-      query: {
-        select: (data) => {
-          const yamlObj = parse(data?.blob);
-          const securityPolicy = yamlObj?.security;
-          return !!securityPolicy;
-        },
+export function useDashboardPolicyCheck(instanceId: string, filePath: string) {
+  return createRuntimeServiceGetFile(instanceId, filePath, {
+    query: {
+      select: (data) => {
+        const yamlObj = parse(data?.blob);
+        const securityPolicy = yamlObj?.security;
+        return !!securityPolicy;
       },
     },
-  );
+  });
 }

--- a/web-common/src/features/dashboards/workspace/DashboardCTAs.svelte
+++ b/web-common/src/features/dashboards/workspace/DashboardCTAs.svelte
@@ -20,14 +20,15 @@
 
   export let metricViewName: string;
 
+  $: dashboardQuery = useDashboard($runtime.instanceId, metricViewName);
+
   $: dashboardPolicyCheck = useDashboardPolicyCheck(
     $runtime.instanceId,
-    metricViewName,
+    $dashboardQuery.data?.meta?.filePaths?.[0] ?? "",
   );
 
   const { readOnly } = featureFlags;
 
-  $: dashboardQuery = useDashboard($runtime.instanceId, metricViewName);
   $: dashboardIsIdle =
     $dashboardQuery.data?.meta?.reconcileStatus ===
     V1ReconcileStatus.RECONCILE_STATUS_IDLE;

--- a/web-common/src/features/metrics-views/workspace/GoToDashboardButton.svelte
+++ b/web-common/src/features/metrics-views/workspace/GoToDashboardButton.svelte
@@ -8,6 +8,7 @@
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts";
+  import { extractFileName } from "@rilldata/web-common/features/sources/extract-file-name";
   import { behaviourEvent } from "@rilldata/web-common/metrics/initMetrics";
   import { BehaviourEventMedium } from "@rilldata/web-common/metrics/service/BehaviourEventTypes";
   import {
@@ -17,14 +18,9 @@
   import { createRuntimeServiceGetFile } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { useQueryClient } from "@tanstack/svelte-query";
-  import { getFilePathFromNameAndType } from "../../entity-management/entity-mappers";
-  import { EntityType } from "../../entity-management/types";
 
-  export let metricsDefName;
-  $: filePath = getFilePathFromNameAndType(
-    metricsDefName,
-    EntityType.MetricsDefinition,
-  );
+  export let filePath: string;
+  $: metricsDefName = extractFileName(filePath);
   $: fileArtifact = fileArtifacts.getFileArtifact(filePath);
 
   const queryClient = useQueryClient();
@@ -37,7 +33,7 @@
   let buttonStatus;
 
   const viewDashboard = () => {
-    goto(`/dashboard/${metricsDefName}`);
+    goto(`/dashboard/${metricsDefName}`); // TODO: update to use new paths
 
     behaviourEvent.fireNavigationEvent(
       metricsDefName,

--- a/web-common/src/features/metrics-views/workspace/MetricsWorkspace.svelte
+++ b/web-common/src/features/metrics-views/workspace/MetricsWorkspace.svelte
@@ -6,7 +6,7 @@
   import MetricsInspector from "./inspector/MetricsInspector.svelte";
   import MetricsWorkspaceHeader from "./MetricsWorkspaceHeader.svelte";
 
-  export let metricsDefName: string;
+  export let filePath: string;
 
   $: isModelingSupportedForCurrentOlapDriver =
     useIsModelingSupportedForCurrentOlapDriver($runtime.instanceId);
@@ -15,10 +15,10 @@
 
 <WorkspaceContainer inspector={showInspector}>
   <MetricsWorkspaceHeader
-    slot="header"
-    {metricsDefName}
+    {filePath}
     showInspectorToggle={showInspector}
+    slot="header"
   />
-  <MetricsEditor slot="body" {metricsDefName} />
-  <MetricsInspector slot="inspector" {metricsDefName} />
+  <MetricsEditor {filePath} slot="body" />
+  <MetricsInspector {filePath} slot="inspector" />
 </WorkspaceContainer>

--- a/web-common/src/features/metrics-views/workspace/MetricsWorkspaceHeader.svelte
+++ b/web-common/src/features/metrics-views/workspace/MetricsWorkspaceHeader.svelte
@@ -1,71 +1,36 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
-  import { notifications } from "@rilldata/web-common/components/notifications";
-  import { renameFileArtifact } from "@rilldata/web-common/features/entity-management/actions";
-  import { getFileAPIPathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
-  import {
-    INVALID_NAME_MESSAGE,
-    VALID_NAME_PATTERN,
-    isDuplicateName,
-  } from "@rilldata/web-common/features/entity-management/name-utils";
-  import { useAllNames } from "@rilldata/web-common/features/entity-management/resource-selectors";
   import { EntityType } from "@rilldata/web-common/features/entity-management/types";
+  import { handleEntityRename } from "@rilldata/web-common/features/entity-management/ui-actions";
+  import { extractFileName } from "@rilldata/web-common/features/sources/extract-file-name";
   import { WorkspaceHeader } from "../../../layout/workspace";
   import { runtime } from "../../../runtime-client/runtime-store";
   import GoToDashboardButton from "./GoToDashboardButton.svelte";
 
-  export let metricsDefName: string;
+  export let filePath: string;
   export let showInspectorToggle = true;
 
-  $: runtimeInstanceId = $runtime.instanceId;
-  $: allNamesQuery = useAllNames(runtimeInstanceId);
+  $: metricsDefName = extractFileName(filePath);
 
   const onChangeCallback = async (
     e: Event & {
       currentTarget: EventTarget & HTMLInputElement;
     },
   ) => {
-    if (!e.currentTarget.value.match(VALID_NAME_PATTERN)) {
-      notifications.send({
-        message: INVALID_NAME_MESSAGE,
-      });
-      e.currentTarget.value = metricsDefName; // resets the input
-      return;
-    }
-    if (
-      isDuplicateName(
-        e.currentTarget.value,
-        metricsDefName,
-        $allNamesQuery.data ?? [],
-      )
-    ) {
-      notifications.send({
-        message: `Name ${e.currentTarget.value} is already in use`,
-      });
-      e.currentTarget.value = metricsDefName; // resets the input
-      return;
-    }
-
-    try {
-      const toName = e.currentTarget.value;
-      const type = EntityType.MetricsDefinition;
-      await renameFileArtifact(
-        runtimeInstanceId,
-        getFileAPIPathFromNameAndType(metricsDefName, type),
-        getFileAPIPathFromNameAndType(toName, type),
-        type,
-      );
-      await goto(`/dashboard/${toName}/edit`, { replaceState: true });
-    } catch (err) {
-      console.error(err.response.data.message);
-    }
+    const newRoute = await handleEntityRename(
+      $runtime.instanceId,
+      e.currentTarget,
+      filePath,
+      EntityType.MetricsDefinition,
+    );
+    if (newRoute) await goto(newRoute);
   };
 </script>
 
 <WorkspaceHeader
-  titleInput={metricsDefName}
   on:change={onChangeCallback}
   {showInspectorToggle}
+  titleInput={metricsDefName}
 >
-  <GoToDashboardButton {metricsDefName} slot="cta" />
+  <GoToDashboardButton {filePath} slot="cta" />
 </WorkspaceHeader>

--- a/web-common/src/features/metrics-views/workspace/editor/MetricsEditor.svelte
+++ b/web-common/src/features/metrics-views/workspace/editor/MetricsEditor.svelte
@@ -2,10 +2,8 @@
   import type { EditorView } from "@codemirror/view";
   import YAMLEditor from "@rilldata/web-common/components/editor/YAMLEditor.svelte";
   import { setLineStatuses } from "@rilldata/web-common/components/editor/line-status";
-  import { useDashboard } from "@rilldata/web-common/features/dashboards/selectors";
-  import { getFilePathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts";
-  import { EntityType } from "@rilldata/web-common/features/entity-management/types";
+  import { extractFileName } from "@rilldata/web-common/features/sources/extract-file-name";
   import { createRuntimeServiceGetFile } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { useQueryClient } from "@tanstack/svelte-query";
@@ -14,7 +12,8 @@
   import { createPlaceholder } from "./create-placeholder";
   import { createUpdateMetricsCallback } from "./update-metrics";
 
-  export let metricsDefName: string;
+  export let filePath: string;
+  $: metricsDefName = extractFileName(filePath);
 
   let editor: YAMLEditor;
 
@@ -31,17 +30,13 @@
   /** create an updateMetrics event callback based on the queryClient
    * and metricsDefName.
    */
-  const updateMetrics = createUpdateMetricsCallback(metricsDefName);
+  const updateMetrics = createUpdateMetricsCallback(filePath, metricsDefName);
 
-  $: filePath = getFilePathFromNameAndType(
-    metricsDefName,
-    EntityType.MetricsDefinition,
-  );
   $: fileArtifact = fileArtifacts.getFileArtifact(filePath);
 
   $: fileQuery = createRuntimeServiceGetFile($runtime.instanceId, filePath);
 
-  $: dashboard = useDashboard($runtime.instanceId, metricsDefName);
+  $: dashboard = fileArtifact.getResource(queryClient, $runtime.instanceId);
 
   // get the yaml blob from the file.
   $: yaml = $fileQuery.data?.blob || "";

--- a/web-common/src/features/metrics-views/workspace/editor/update-metrics.ts
+++ b/web-common/src/features/metrics-views/workspace/editor/update-metrics.ts
@@ -2,14 +2,13 @@ import { skipDebounceAnnotation } from "@rilldata/web-common/components/editor/a
 import { setLineStatuses } from "@rilldata/web-common/components/editor/line-status";
 import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
 import { createPersistentDashboardStore } from "@rilldata/web-common/features/dashboards/stores/persistent-dashboard-state";
-import { getFileAPIPathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
-import { EntityType } from "@rilldata/web-common/features/entity-management/types";
 import { createDebouncer } from "@rilldata/web-common/lib/create-debouncer";
 import { createRuntimeServicePutFile } from "@rilldata/web-common/runtime-client";
 import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
 import { get } from "svelte/store";
 
 export function createUpdateMetricsCallback(
+  filePath: string,
   metricsDefName: string,
 ): (event: CustomEvent) => void {
   const debounce = createDebouncer();
@@ -18,10 +17,6 @@ export function createUpdateMetricsCallback(
 
   async function reconcileNewMetricsContent(blob: string) {
     const instanceId = get(runtime).instanceId;
-    const filePath = getFileAPIPathFromNameAndType(
-      metricsDefName,
-      EntityType.MetricsDefinition,
-    );
     await get(fileSaver).mutateAsync({
       instanceId,
       path: filePath,

--- a/web-common/src/features/metrics-views/workspace/inspector/MetricsInspector.svelte
+++ b/web-common/src/features/metrics-views/workspace/inspector/MetricsInspector.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { getFilePathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
-  import { EntityType } from "@rilldata/web-common/features/entity-management/types";
   import {
     useModel,
     useModels,
@@ -16,12 +14,9 @@
   } from "../../utils";
   import WorkspaceInspector from "@rilldata/web-common/features/sources/inspector/WorkspaceInspector.svelte";
 
-  export let metricsDefName: string;
+  export let filePath: string;
 
-  $: fileQuery = createRuntimeServiceGetFile(
-    $runtime.instanceId,
-    getFilePathFromNameAndType(metricsDefName, EntityType.MetricsDefinition),
-  );
+  $: fileQuery = createRuntimeServiceGetFile($runtime.instanceId, filePath);
   $: yaml = $fileQuery.data?.blob || "";
 
   // get file.

--- a/web-local/src/routes/(application)/dashboard/[name]/edit/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/edit/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/stores";
   import { initLocalUserPreferenceStore } from "@rilldata/web-common/features/dashboards/user-preferences";
-  import { getFilePathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
+  import { getFileAPIPathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import { EntityType } from "@rilldata/web-common/features/entity-management/types";
   import { featureFlags } from "@rilldata/web-common/features/feature-flags";
   import { MetricsWorkspace } from "@rilldata/web-common/features/metrics-views";
@@ -12,6 +12,10 @@
   import { CATALOG_ENTRY_NOT_FOUND } from "../../../../../lib/errors/messages";
 
   $: metricViewName = $page.params.name;
+  $: filePath = getFileAPIPathFromNameAndType(
+    metricViewName,
+    EntityType.MetricsDefinition,
+  );
 
   const { readOnly } = featureFlags;
 
@@ -21,23 +25,19 @@
     }
   });
 
-  $: fileQuery = createRuntimeServiceGetFile(
-    $runtime.instanceId,
-    getFilePathFromNameAndType(metricViewName, EntityType.MetricsDefinition),
-    {
-      query: {
-        onError: (err) => {
-          if (err.response?.data?.message.includes(CATALOG_ENTRY_NOT_FOUND)) {
-            throw error(404, "Dashboard not found");
-          }
+  $: fileQuery = createRuntimeServiceGetFile($runtime.instanceId, filePath, {
+    query: {
+      onError: (err) => {
+        if (err.response?.data?.message.includes(CATALOG_ENTRY_NOT_FOUND)) {
+          throw error(404, "Dashboard not found");
+        }
 
-          throw error(err.response?.status || 500, err.message);
-        },
-        // this will ensure that any changes done outside our app is pulled in.
-        refetchOnWindowFocus: true,
+        throw error(err.response?.status || 500, err.message);
       },
+      // this will ensure that any changes done outside our app is pulled in.
+      refetchOnWindowFocus: true,
     },
-  );
+  });
 
   $: yaml = $fileQuery.data?.blob || "";
 
@@ -49,5 +49,5 @@
 </svelte:head>
 
 {#if $fileQuery.data && yaml !== undefined}
-  <MetricsWorkspace metricsDefName={metricViewName} />
+  <MetricsWorkspace {filePath} />
 {/if}


### PR DESCRIPTION
This PR refactors all of metrics definition editor to use file path.
It also refactors dashboard viewer to make sure to not use `getFilePathFromNameAndType`. But components use names to keep it consistent with cloud.