### PR TITLE
fix: avoid crash from missing project

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -80,9 +80,10 @@ func New(ctx context.Context, opts *Options, logger *zap.Logger, issuer *auth.Is
 	if opts.MetricsProjectOrg != "" && opts.MetricsProjectName != "" {
 		proj, err := db.FindProjectByName(ctx, opts.MetricsProjectOrg, opts.MetricsProjectName)
 		if err != nil {
-			return nil, fmt.Errorf("error looking up metrics project: %w", err)
+			logger.Sugar().Warnf("error looking up metrics project: %w", err)
+		} else {
+			metricsProjectID = proj.ID
 		}
-		metricsProjectID = proj.ID
 	}
 
 	return &Service{


### PR DESCRIPTION
### Description

Log a warning for an invalid metrics project specified by the environment variable instead of throwing an error.

### Motivation

Currently, if a metrics project is specified in the environment variable, failure to find the project leads to the crash of the admin service.
I believe the main process of the admin service should not be affected by the metrics project or slot autoscaler.