### PR TITLE
Introducing `RILL_ADMIN_AUTOSCALER_CRON` Environment Variable

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -21,6 +21,7 @@ type Options struct {
 	VersionNumber      string
 	MetricsProjectOrg  string
 	MetricsProjectName string
+	AutoscalerCron     string
 }
 
 type Service struct {
@@ -35,6 +36,7 @@ type Service struct {
 	issuer           *auth.Issuer
 	VersionNumber    string
 	metricsProjectID string
+	AutoscalerCron   string
 }
 
 func New(ctx context.Context, opts *Options, logger *zap.Logger, issuer *auth.Issuer, emailClient *email.Client, github Github, aiClient ai.Client) (*Service, error) {
@@ -97,6 +99,7 @@ func New(ctx context.Context, opts *Options, logger *zap.Logger, issuer *auth.Is
 		issuer:           issuer,
 		VersionNumber:    opts.VersionNumber,
 		metricsProjectID: metricsProjectID,
+		AutoscalerCron:   opts.AutoscalerCron,
 	}, nil
 }
 

--- a/admin/worker/worker.go
+++ b/admin/worker/worker.go
@@ -57,7 +57,7 @@ func (w *Worker) Run(ctx context.Context) error {
 		return w.schedule(ctx, "upgrade_latest_version_projects", w.upgradeLatestVersionProjects, 6*time.Hour)
 	})
 	group.Go(func() error {
-		return w.scheduleCron(ctx, "run_autoscaler", w.runAutoscaler, "CRON_TZ=America/Los_Angeles 0 0 * * 1") // Run the scaling job at 00:00 on every Monday.
+		return w.scheduleCron(ctx, "run_autoscaler", w.runAutoscaler, w.admin.AutoscalerCron)
 	})
 
 	// NOTE: Add new scheduled jobs here

--- a/cli/cmd/admin/start.go
+++ b/cli/cmd/admin/start.go
@@ -77,6 +77,7 @@ type Config struct {
 	ActivitySinkKafkaBrokers string                 `default:"" split_words:"true"`
 	ActivityUISinkKafkaTopic string                 `default:"" split_words:"true"`
 	MetricsProject           string                 `default:"" split_words:"true"`
+	AutoscalerCron           string                 `default:"CRON_TZ=America/Los_Angeles 0 0 * * 1" split_words:"true"`
 }
 
 // StartCmd starts an admin server. It only allows configuration using environment variables.
@@ -243,6 +244,7 @@ func StartCmd(ch *cmdutil.Helper) *cobra.Command {
 				VersionNumber:      ch.Version.Number,
 				MetricsProjectOrg:  metricsProjectOrg,
 				MetricsProjectName: metricsProjectName,
+				AutoscalerCron:     conf.AutoscalerCron,
 			}
 			adm, err := admin.New(cmd.Context(), admOpts, logger, issuer, emailClient, gh, aiClient)
 			if err != nil {


### PR DESCRIPTION
#### Purpose

Allow configuration of the slot autoscaler cron job frequency.

#### Background

Previously, the run_autoscaler cron job frequency was hardcoded to _00:00 Monday PT_.

#### Change

The new `RILL_ADMIN_AUTOSCALER_CRON` variable enables flexible scheduling, facilitating more frequent runs in test or debug modes.

#### Usage

Set `RILL_ADMIN_AUTOSCALER_CRON` to the desired cron schedule, based on the [robfig-cron syntax](https://pkg.go.dev/github.com/robfig/cron/v3#hdr-Usage). e.g., `CRON_TZ=Asia/Tokyo 30 04 * * *` for _04:30 Tokyo time every day_.