### PR TITLE
Add CustomDashboardEmbed and generic Component

### DIFF
--- a/web-common/src/features/custom-dashboards/Component.svelte
+++ b/web-common/src/features/custom-dashboards/Component.svelte
@@ -1,0 +1,89 @@
+<script lang="ts" context="module">
+  import { onMount } from "svelte";
+  import { writable } from "svelte/store";
+  import type ResizeHandle from "./ResizeHandle.svelte";
+  import type { ComponentType } from "svelte";
+
+  import { builderActions, getAttrs, type Builder } from "bits-ui";
+
+  const zIndex = writable(0);
+
+  const options = [0, 0.5, 1];
+  const allSides = options
+    .flatMap((y) => options.map((x) => [x, y] as [number, number]))
+    .filter(([x, y]) => !(x === 0.5 && y === 0.5));
+</script>
+
+<script lang="ts">
+  export let builders: Builder[] = [];
+  export let left: number;
+  export let top: number;
+  export let padding: number;
+  export let scale: number;
+  export let embed = false;
+  export let radius: number;
+  export let selected = false;
+  export let interacting = false;
+  export let width: number;
+  export let height: number;
+  export let i: number;
+  export let localZIndex = 0;
+
+  let ResizeHandleComponent: ComponentType<ResizeHandle>;
+
+  onMount(async () => {
+    localZIndex = $zIndex;
+    zIndex.set(++localZIndex);
+
+    if (!embed) {
+      ResizeHandleComponent = (await import("./ResizeHandle.svelte")).default;
+    }
+  });
+</script>
+
+<div
+  {...getAttrs(builders)}
+  use:builderActions={{ builders }}
+  role="presentation"
+  data-index={i}
+  class="wrapper hover:cursor-pointer active:cursor-grab pointer-events-auto cursor"
+  class:!cursor-default={embed}
+  style:z-index={localZIndex}
+  style:padding="{padding}px"
+  style:left="{left}px"
+  style:top="{top}px"
+  style:width="{width}px"
+  style:height="{height}px"
+  on:contextmenu
+  on:mousedown|capture
+>
+  <div class="size-full relative">
+    {#if ResizeHandleComponent && !embed}
+      {#each allSides as side}
+        <ResizeHandleComponent
+          {scale}
+          {i}
+          {side}
+          position={[left, top]}
+          dimensions={[width, height]}
+          {selected}
+          on:change
+        />
+      {/each}
+    {/if}
+
+    <div
+      class="size-full overflow-hidden"
+      class:shadow-lg={interacting}
+      style:border-radius="{radius}px"
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+
+<style lang="postcss">
+  .wrapper {
+    @apply absolute;
+  }
+</style>

--- a/web-common/src/features/custom-dashboards/CustomDashboardEmbed.svelte
+++ b/web-common/src/features/custom-dashboards/CustomDashboardEmbed.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import type { V1DashboardComponent } from "@rilldata/web-common/runtime-client";
+  import Chart from "./Chart.svelte";
+  import { DEFAULT_WIDTH, DEFAULT_RADIUS } from "./constants";
+  import Wrapper from "./Wrapper.svelte";
+  import Component from "./Component.svelte";
+
+  export let columns = 20;
+  export let charts: V1DashboardComponent[];
+  export let gap = 4;
+
+  let contentRect: DOMRectReadOnly = new DOMRectReadOnly(0, 0, 0, 0);
+
+  $: gridWidth = contentRect.width;
+  $: scale = gridWidth / DEFAULT_WIDTH;
+  $: gapSize = DEFAULT_WIDTH * (gap / 1000);
+  $: gridCell = DEFAULT_WIDTH / columns;
+  $: radius = gridCell * DEFAULT_RADIUS;
+
+  $: maxBottom = charts.reduce((max, el) => {
+    const bottom = Number(el.height) + Number(el.y);
+    return Math.max(max, bottom);
+  }, 0);
+</script>
+
+<Wrapper
+  {scale}
+  width={DEFAULT_WIDTH}
+  height={maxBottom * gridCell}
+  bind:contentRect
+>
+  {#each charts as chart, i (i)}
+    {#if chart.chart}
+      <Component
+        embed
+        {i}
+        {scale}
+        {radius}
+        padding={gapSize}
+        width={Number(chart.width) * gridCell}
+        height={Number(chart.height) * gridCell}
+        left={Number(chart.x) * gridCell}
+        top={Number(chart.y) * gridCell}
+      >
+        <Chart chartName={chart.chart} />
+      </Component>
+    {/if}
+  {/each}
+</Wrapper>

--- a/web-common/src/features/custom-dashboards/CustomDashboardPreview.svelte
+++ b/web-common/src/features/custom-dashboards/CustomDashboardPreview.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
   import type { V1DashboardComponent } from "@rilldata/web-common/runtime-client";
-  import GridLines from "./GridLines.svelte";
   import Element from "./Element.svelte";
   import type { Vector } from "./types";
   import { vector } from "./util";
   import { createEventDispatcher } from "svelte";
-
-  const DEFAULT_WIDTH = 2000;
+  import { DEFAULT_WIDTH, DEFAULT_RADIUS } from "./constants";
+  import Wrapper from "./Wrapper.svelte";
 
   const dispatch = createEventDispatcher();
   const zeroVector = [0, 0] as [0, 0];
@@ -37,7 +36,7 @@
 
   $: gapSize = DEFAULT_WIDTH * (gap / 1000);
   $: gridCell = DEFAULT_WIDTH / columns;
-  $: radius = gridCell * 0.08;
+  $: radius = gridCell * DEFAULT_RADIUS;
   $: gridVector = [gridCell, gridCell] as Vector;
 
   $: mouseDelta = vector.divide(vector.subtract(mousePosition, startMouse), [
@@ -164,65 +163,37 @@
 
 <svelte:window on:mouseup={handleMouseUp} on:mousemove={handleMouseMove} />
 
-<div bind:contentRect class="wrapper">
-  {#if showGrid || changing}
-    <GridLines {gridCell} {scrollOffset} {gapSize} {radius} {scale} />
-  {/if}
-  <div
-    role="presentation"
-    class="size-full overflow-y-auto overflow-x-hidden relative"
-    on:scroll={handleScroll}
-    on:click|self={deselect}
-  >
-    <div
-      class="dash pointer-events-none"
-      role="presentation"
-      style:width="{DEFAULT_WIDTH}px"
-      style:height="{maxBottom * gridCell}px"
-      style:transform="scale({scale})"
-    >
-      {#each charts as chart, i (i)}
-        {@const selected = i === selectedIndex}
-        {@const interacting = selected && changing}
-        {#if chart.chart}
-          <Element
-            {scale}
-            {i}
-            {chart}
-            {radius}
-            {selected}
-            {interacting}
-            {gapSize}
-            width={interacting
-              ? finalResize[0]
-              : Number(chart.width) * gridCell}
-            height={interacting
-              ? finalResize[1]
-              : Number(chart.height) * gridCell}
-            top={interacting ? finalDrag[1] : Number(chart.y) * gridCell}
-            left={interacting ? finalDrag[0] : Number(chart.x) * gridCell}
-            on:change={handleChange}
-          />
-        {/if}
-      {/each}
-    </div>
-  </div>
-</div>
-
-<style lang="postcss">
-  .wrapper {
-    width: 100%;
-    height: 100%;
-    position: relative;
-    overflow: hidden;
-    user-select: none;
-    margin: 0;
-    pointer-events: auto;
-  }
-
-  .dash {
-    transform-origin: top left;
-    position: absolute;
-    touch-action: none;
-  }
-</style>
+<Wrapper
+  width={DEFAULT_WIDTH}
+  height={maxBottom * gridCell}
+  {scale}
+  {showGrid}
+  {gapSize}
+  {gridCell}
+  {radius}
+  {changing}
+  bind:contentRect
+  on:scroll={handleScroll}
+  on:click={deselect}
+>
+  {#each charts as chart, i (i)}
+    {@const selected = i === selectedIndex}
+    {@const interacting = selected && changing}
+    {#if chart.chart}
+      <Element
+        {scale}
+        {i}
+        {chart}
+        {radius}
+        {selected}
+        {interacting}
+        {gapSize}
+        width={interacting ? finalResize[0] : Number(chart.width) * gridCell}
+        height={interacting ? finalResize[1] : Number(chart.height) * gridCell}
+        top={interacting ? finalDrag[1] : Number(chart.y) * gridCell}
+        left={interacting ? finalDrag[0] : Number(chart.x) * gridCell}
+        on:change={handleChange}
+      />
+    {/if}
+  {/each}
+</Wrapper>

--- a/web-common/src/features/custom-dashboards/Wrapper.svelte
+++ b/web-common/src/features/custom-dashboards/Wrapper.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import { type ComponentType, onMount } from "svelte";
+  import type GridLines from "./GridLines.svelte";
+
+  export let width: number;
+  export let height: number;
+  export let scale: number;
+  export let embed = false;
+  export let showGrid = false;
+  export let changing = false;
+  export let scrollOffset = 0;
+  export let gapSize = 0;
+  export let gridCell = 0;
+  export let radius = 0;
+  export let contentRect = new DOMRectReadOnly(0, 0, 0, 0);
+
+  let GridLinesComponent: ComponentType<GridLines>;
+
+  onMount(async () => {
+    if (!embed) {
+      GridLinesComponent = (await import("./GridLines.svelte")).default;
+    }
+  });
+</script>
+
+<div bind:contentRect class="wrapper">
+  {#if GridLinesComponent && (showGrid || changing)}
+    <GridLinesComponent {gridCell} {scrollOffset} {gapSize} {radius} {scale} />
+  {/if}
+  <div
+    role="presentation"
+    class="size-full overflow-y-auto overflow-x-hidden relative"
+    on:scroll
+    on:click|self
+  >
+    <div
+      class="dash pointer-events-none"
+      role="presentation"
+      style:width="{width}px"
+      style:height="{height}}px"
+      style:transform="scale({scale})"
+    >
+      <slot />
+    </div>
+  </div>
+</div>
+
+<style lang="postcss">
+  .wrapper {
+    width: 100%;
+    height: 100%;
+    position: relative;
+    overflow: hidden;
+    user-select: none;
+    margin: 0;
+    pointer-events: auto;
+  }
+
+  .dash {
+    transform-origin: top left;
+    position: absolute;
+    touch-action: none;
+  }
+</style>

--- a/web-common/src/features/custom-dashboards/constants.ts
+++ b/web-common/src/features/custom-dashboards/constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_WIDTH = 2000;
+export const DEFAULT_RADIUS = 0.08;

--- a/web-common/src/features/custom-dashboards/createCustomDashboard.ts
+++ b/web-common/src/features/custom-dashboards/createCustomDashboard.ts
@@ -10,7 +10,7 @@ export async function createCustomDashboard(
     instanceId,
     getFileAPIPathFromNameAndType(newCustomDashboardName, EntityType.Dashboard),
     {
-      blob: "abc",
+      blob: `kind: dashboard\ncolumns: 10\ngap: 2\n`,
       createOnly: true,
     },
   );

--- a/web-common/src/features/custom-dashboards/util.ts
+++ b/web-common/src/features/custom-dashboards/util.ts
@@ -5,7 +5,6 @@ export const vector = {
     return [add[0] + initial[0], add[1] + initial[1]];
   },
   multiply: (vector: Vector, multiplier: Vector): Vector => {
-    // console.log("multiply");
     return [vector[0] * multiplier[0], vector[1] * multiplier[1]];
   },
   subtract: (minuend: Vector, subtrahend: Vector): Vector => {

--- a/web-local/src/routes/(application)/custom-dashboard/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/custom-dashboard/[name]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/stores";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
-  import CustomDashboard from "@rilldata/web-common/features/custom-dashboards/CustomDashboard.svelte";
+  import CustomDashboardPreview from "@rilldata/web-common/features/custom-dashboards/CustomDashboardPreview.svelte";
   import CustomDashboardEditor from "@rilldata/web-common/features/custom-dashboards/CustomDashboardEditor.svelte";
   import {
     WorkspaceContainer,
@@ -264,7 +264,7 @@
     {/if}
 
     {#if selectedView == "viz" || selectedView == "split"}
-      <CustomDashboard
+      <CustomDashboardPreview
         {snap}
         {gap}
         {charts}


### PR DESCRIPTION
This PR reworks the organization of the CustomDashboard feature so that it can support a read-only embedding of a CustomDashboard as well as generic (non-chart) Components.