### PR TITLE
old_implicit_casting to cast numbers to strings while table union by name

### DIFF
--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -441,6 +441,7 @@ func (c *connection) reopenDB() error {
 		"LOAD 'sqlite'",
 		"SET max_expression_depth TO 250",
 		"SET timezone='UTC'",
+		"SET old_implicit_casting = true", // Implicit Cast to VARCHAR
 	)
 
 	// We want to set preserve_insertion_order=false in hosted environments only (where source data is never viewed directly). Setting it reduces batch data ingestion time by ~40%.


### PR DESCRIPTION
seems like this is a consequence of a [breaking change](https://duckdb.org/2024/02/13/announcing-duckdb-0100.html#breaking-sql-changes) 