### PR TITLE
Fix: Navigate after delete

### DIFF
--- a/web-common/src/features/charts/ChartAssets.svelte
+++ b/web-common/src/features/charts/ChartAssets.svelte
@@ -31,13 +31,14 @@
     <ol transition:slide={{ duration }}>
       {#if $chartFileNames?.data}
         {#each $chartFileNames.data as chartName (chartName)}
+          {@const open = $page.url.pathname === `/chart/${chartName}`}
           <li animate:flip={{ duration }} aria-label={chartName}>
             <NavigationEntry
               name={chartName}
               href={`/chart/${chartName}`}
-              open={$page.url.pathname === `/chart/${chartName}`}
+              {open}
             >
-              <ChartMenuItems slot="menu-items" {chartName} />
+              <ChartMenuItems slot="menu-items" {chartName} {open} />
             </NavigationEntry>
           </li>
         {/each}

--- a/web-common/src/features/charts/ChartMenuItems.svelte
+++ b/web-common/src/features/charts/ChartMenuItems.svelte
@@ -5,18 +5,23 @@
   import { deleteFileArtifact } from "../entity-management/actions";
   import { EntityType } from "../entity-management/types";
   import { useChartRoutes } from "./selectors";
+  import { getNextRoute } from "../models/utils/navigate-to-next";
+  import { goto } from "$app/navigation";
 
   export let chartName: string;
+  export let open: boolean;
 
-  $: chartRoutes = useChartRoutes($runtime.instanceId);
+  $: chartRoutesQuery = useChartRoutes($runtime.instanceId);
+  $: chartRoutes = $chartRoutesQuery.data ?? [];
 
   async function handleDeleteChart() {
     await deleteFileArtifact(
       $runtime.instanceId,
       getFileAPIPathFromNameAndType(chartName, EntityType.Chart),
       EntityType.Chart,
-      $chartRoutes.data ?? [],
     );
+
+    if (open) await goto(getNextRoute(chartRoutes));
   }
 </script>
 

--- a/web-common/src/features/custom-dashboards/CustomDashboardAssets.svelte
+++ b/web-common/src/features/custom-dashboards/CustomDashboardAssets.svelte
@@ -38,14 +38,16 @@
     <ol transition:slide={{ duration }}>
       {#if $customDashboardFileNames?.data}
         {#each $customDashboardFileNames.data as customDashboardName (customDashboardName)}
+          {@const open =
+            $page.url.pathname === `/custom-dashboard/${customDashboardName}`}
           <li animate:flip={{ duration }} aria-label={customDashboardName}>
             <NavigationEntry
               name={customDashboardName}
               href={`/custom-dashboard/${customDashboardName}`}
-              open={$page.url.pathname ===
-                `/custom-dashboard/${customDashboardName}`}
+              {open}
             >
               <CustomDashboardMenuItems
+                {open}
                 slot="menu-items"
                 {customDashboardName}
               />

--- a/web-common/src/features/custom-dashboards/CustomDashboardMenuItems.svelte
+++ b/web-common/src/features/custom-dashboards/CustomDashboardMenuItems.svelte
@@ -5,18 +5,30 @@
   import { EntityType } from "../entity-management/types";
   import { useCustomDashboardRoutes } from "./selectors";
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu/";
+  import { goto } from "$app/navigation";
+  import { getNextRoute } from "../models/utils/navigate-to-next";
 
   export let customDashboardName: string;
+  export let open: boolean;
 
-  $: customDashboardRoutes = useCustomDashboardRoutes($runtime.instanceId);
+  $: customDashboardRoutesQuery = useCustomDashboardRoutes($runtime.instanceId);
+  $: customDashboardRoutes = $customDashboardRoutesQuery.data ?? [];
 
   async function handleDeleteCustomDashboard() {
-    await deleteFileArtifact(
-      $runtime.instanceId,
-      getFileAPIPathFromNameAndType(customDashboardName, EntityType.Dashboard),
-      EntityType.Dashboard,
-      $customDashboardRoutes.data ?? [],
-    );
+    try {
+      await deleteFileArtifact(
+        $runtime.instanceId,
+        getFileAPIPathFromNameAndType(
+          customDashboardName,
+          EntityType.Dashboard,
+        ),
+        EntityType.Dashboard,
+      );
+
+      if (open) await goto(getNextRoute(customDashboardRoutes));
+    } catch (error) {
+      console.error(error);
+    }
   }
 </script>
 

--- a/web-common/src/features/dashboards/DashboardAssets.svelte
+++ b/web-common/src/features/dashboards/DashboardAssets.svelte
@@ -84,15 +84,18 @@
     <ol transition:slide={{ duration }} id="assets-metrics-list">
       {#if $dashboardNames.data}
         {#each $dashboardNames.data as dashboardName (dashboardName)}
+          {@const open =
+            $page.url.pathname === `/dashboard/${dashboardName}` ||
+            $page.url.pathname === `/dashboard/${dashboardName}/edit`}
           <li animate:flip={{ duration }} aria-label={dashboardName}>
             <NavigationEntry
               showContextMenu={!$readOnly}
               name={dashboardName}
               href={`/dashboard/${dashboardName}`}
-              open={$page.url.pathname === `/dashboard/${dashboardName}` ||
-                $page.url.pathname === `/dashboard/${dashboardName}/edit`}
+              {open}
             >
               <DashboardMenuItems
+                {open}
                 slot="menu-items"
                 metricsViewName={dashboardName}
                 on:rename={() => openRenameMetricsDefModal(dashboardName)}

--- a/web-common/src/features/entity-management/actions.ts
+++ b/web-common/src/features/entity-management/actions.ts
@@ -1,15 +1,11 @@
-import { goto } from "$app/navigation";
 import { notifications } from "@rilldata/web-common/components/notifications";
 import { extractFileName } from "@rilldata/web-common/features/sources/extract-file-name";
-import { appScreen } from "@rilldata/web-common/layout/app-store";
 import {
   runtimeServiceDeleteFile,
   runtimeServiceRenameFile,
 } from "@rilldata/web-common/runtime-client";
 import { httpRequestQueue } from "@rilldata/web-common/runtime-client/http-client";
-import { get } from "svelte/store";
 import { getLabel, removeLeadingSlash } from "./entity-mappers";
-import { getNextEntityName } from "./name-utils";
 import type { EntityType } from "./types";
 
 export async function renameFileArtifact(
@@ -36,7 +32,6 @@ export async function deleteFileArtifact(
   instanceId: string,
   filePath: string,
   type: EntityType,
-  allPaths: Array<string>,
   showNotification = true,
 ) {
   const name = extractFileName(filePath);
@@ -46,10 +41,6 @@ export async function deleteFileArtifact(
     httpRequestQueue.removeByName(name);
     if (showNotification) {
       notifications.send({ message: `Deleted ${getLabel(type)} ${name}` });
-    }
-
-    if (get(appScreen)?.name === name) {
-      await goto(getNextEntityName(allPaths, name));
     }
   } catch (err) {
     console.error(err);

--- a/web-common/src/features/entity-management/name-utils.ts
+++ b/web-common/src/features/entity-management/name-utils.ts
@@ -29,18 +29,6 @@ export function getName(name: string, others: string[]): string {
   return result;
 }
 
-export function getNextEntityName(
-  entityNames: Array<string>,
-  entityName: string,
-): string {
-  const idx = entityNames.indexOf(entityName);
-  if (idx <= 0) {
-    return entityNames[idx + 1];
-  } else {
-    return entityNames[idx - 1];
-  }
-}
-
 export function isDuplicateName(
   name: string,
   fromName: string,

--- a/web-common/src/features/models/navigation/ModelAssets.svelte
+++ b/web-common/src/features/models/navigation/ModelAssets.svelte
@@ -61,12 +61,13 @@
   {#if showModels}
     <ol transition:slide={{ duration }} id="assets-model-list">
       {#each modelNames as modelName (modelName)}
+        {@const open = $page.url.pathname === `/model/${modelName}`}
         <li animate:flip={{ duration }} aria-label={modelName}>
           <NavigationEntry
             expandable
             name={modelName}
             href={`/model/${modelName}`}
-            open={$page.url.pathname === `/model/${modelName}`}
+            {open}
           >
             <div transition:slide={{ duration }} slot="more">
               <ColumnProfile indentLevel={1} objectName={modelName} />
@@ -75,6 +76,7 @@
             <ModelTooltip slot="tooltip-content" {modelName} />
 
             <ModelMenuItems
+              {open}
               slot="menu-items"
               {modelName}
               on:rename-asset={() => {

--- a/web-common/src/features/models/utils/navigate-to-next.ts
+++ b/web-common/src/features/models/utils/navigate-to-next.ts
@@ -1,0 +1,17 @@
+import { page } from "$app/stores";
+import { get } from "svelte/store";
+
+export function getNextRoute(assetRoutes: string[]) {
+  const currentPage = get(page);
+  const currentPageIndex = assetRoutes.indexOf(currentPage.url.pathname);
+
+  if (assetRoutes.length <= 1 || currentPageIndex === -1) {
+    return "/";
+  }
+
+  if (currentPageIndex === assetRoutes.length - 1) {
+    return assetRoutes[0];
+  }
+
+  return assetRoutes[currentPageIndex + 1];
+}

--- a/web-common/src/features/sources/navigation/SourceAssets.svelte
+++ b/web-common/src/features/sources/navigation/SourceAssets.svelte
@@ -77,6 +77,7 @@
     <ol transition:slide={{ duration }}>
       {#if $sourceNames?.data}
         {#each $sourceNames.data as sourceName (sourceName)}
+          {@const open = $page.url.pathname === `/source/${sourceName}`}
           <li
             animate:flip={{ duration: 200 }}
             transition:slide={{ duration }}
@@ -86,7 +87,7 @@
               expandable
               name={sourceName}
               href={`/source/${sourceName}`}
-              open={$page.url.pathname === `/source/${sourceName}`}
+              {open}
               on:command-click={() => queryHandler(sourceName)}
             >
               <div slot="more" transition:slide={{ duration }}>
@@ -96,6 +97,7 @@
               <SourceTooltip slot="tooltip-content" {sourceName} connector="" />
 
               <SourceMenuItems
+                {open}
                 slot="menu-items"
                 {sourceName}
                 on:rename-asset={() => {


### PR DESCRIPTION
This PR fixes a variety of issues with the navigate after delete functionality.

- Removes the navigation side effect from the `deleteFileArtifact` function
- Corrects the DashboardMenuItems component to use dashboard routes instead of names
- Adds a new clearer function for getting the next possible route

The intended logic is as follows:

If you delete a file that you're not viewing, no navigation should take place. If you delete a file you are viewing, you should be directed to either the next available file of the same type or, if none are available, to the root page.

The details of this implementation will of course change with the file explorer and should allow us to abstract the `Assets` and `MenuItems` components so that this logic only exists in one place.