### PR TITLE
Runtime : Detach duckdb files with `tx` lock

### DIFF
--- a/runtime/drivers/duckdb/olap.go
+++ b/runtime/drivers/duckdb/olap.go
@@ -499,7 +499,8 @@ func (c *connection) RenameTable(ctx context.Context, oldName, newName string, v
 
 		cleanupFunc = func() {
 			// detach old db
-			_ = c.WithConnection(ctx, 100, false, true, func(_, bgCtx context.Context, conn *dbsql.Conn) error {
+			// need to pass background ctx so we don't use connection from outer WithConnection
+			_ = c.WithConnection(context.Background(), 100, false, true, func(_, bgCtx context.Context, conn *dbsql.Conn) error {
 				err = c.Exec(bgCtx, &drivers.Statement{Query: fmt.Sprintf("DETACH %s", safeSQLName(dbName(oldName, oldVersion)))})
 				if err != nil {
 					c.logger.Error("rename: detach %q db failed", zap.String("db", dbName(oldName, oldVersion)), zap.Error(err))

--- a/runtime/drivers/duckdb/olap.go
+++ b/runtime/drivers/duckdb/olap.go
@@ -588,11 +588,9 @@ func (c *connection) dropAndReplace(ctx context.Context, oldName, newName string
 
 func (c *connection) detachAndRemoveFile(db, dbFile string) {
 	err := c.WithConnection(context.Background(), 100, false, true, func(ctx, ensuredCtx context.Context, conn *dbsql.Conn) error {
-		if err := c.Exec(ctx, &drivers.Statement{Query: fmt.Sprintf("DETACH %s", safeSQLName(db)), Priority: 100}); err != nil {
-			return err
-		}
+		err := c.Exec(ctx, &drivers.Statement{Query: fmt.Sprintf("DETACH %s", safeSQLName(db)), Priority: 100})
 		removeDBFile(dbFile)
-		return nil
+		return err
 	})
 	if err != nil {
 		c.logger.Error("detach failed", zap.String("db", db), zap.Error(err))

--- a/runtime/drivers/duckdb/transporter_duckDB_to_duckDB.go
+++ b/runtime/drivers/duckdb/transporter_duckDB_to_duckDB.go
@@ -143,7 +143,10 @@ func (t *duckDBToDuckDB) transferFromExternalDB(ctx context.Context, srcProps *d
 		}
 
 		defer func() {
-			if err = t.to.Exec(ensuredCtx, &drivers.Statement{Query: fmt.Sprintf("DETACH %s;", safeSQLName(dbName))}); err != nil {
+			err := t.to.WithConnection(ensuredCtx, 100, false, true, func(wrappedCtx, ensuredCtx context.Context, conn *sql.Conn) error {
+				return t.to.Exec(ensuredCtx, &drivers.Statement{Query: fmt.Sprintf("DETACH %s;", safeSQLName(dbName))})
+			})
+			if err != nil {
 				t.logger.Error("failed to detach db", zap.Error(err))
 			}
 		}()

--- a/runtime/drivers/duckdb/transporter_duckDB_to_duckDB.go
+++ b/runtime/drivers/duckdb/transporter_duckDB_to_duckDB.go
@@ -143,7 +143,7 @@ func (t *duckDBToDuckDB) transferFromExternalDB(ctx context.Context, srcProps *d
 		}
 
 		defer func() {
-			err := t.to.WithConnection(ensuredCtx, 100, false, true, func(wrappedCtx, ensuredCtx context.Context, conn *sql.Conn) error {
+			err := t.to.WithConnection(context.Background(), 100, false, true, func(wrappedCtx, ensuredCtx context.Context, conn *sql.Conn) error {
 				return t.to.Exec(ensuredCtx, &drivers.Statement{Query: fmt.Sprintf("DETACH %s;", safeSQLName(dbName))})
 			})
 			if err != nil {

--- a/runtime/drivers/duckdb/transporter_duckDB_to_duckDB.go
+++ b/runtime/drivers/duckdb/transporter_duckDB_to_duckDB.go
@@ -116,7 +116,8 @@ func (t *duckDBToDuckDB) Transfer(ctx context.Context, srcProps, sinkProps map[s
 }
 
 func (t *duckDBToDuckDB) transferFromExternalDB(ctx context.Context, srcProps *dbSourceProperties, sinkProps *sinkProperties) error {
-	return t.to.WithConnection(ctx, 1, true, false, func(ctx, ensuredCtx context.Context, _ *sql.Conn) error {
+	var cleanupFunc func()
+	err := t.to.WithConnection(ctx, 1, true, false, func(ctx, ensuredCtx context.Context, _ *sql.Conn) error {
 		res, err := t.to.Execute(ctx, &drivers.Statement{Query: "SELECT current_database(),current_schema();"})
 		if err != nil {
 			return err
@@ -142,14 +143,15 @@ func (t *duckDBToDuckDB) transferFromExternalDB(ctx context.Context, srcProps *d
 			return fmt.Errorf("failed to attach db %q: %w", srcProps.Database, err)
 		}
 
-		defer func() {
+		// make sure that dbName is not updated in any code below
+		cleanupFunc = func() {
 			err := t.to.WithConnection(context.Background(), 100, false, true, func(wrappedCtx, ensuredCtx context.Context, conn *sql.Conn) error {
 				return t.to.Exec(ensuredCtx, &drivers.Statement{Query: fmt.Sprintf("DETACH %s;", safeSQLName(dbName))})
 			})
 			if err != nil {
 				t.logger.Error("failed to detach db", zap.Error(err))
 			}
-		}()
+		}
 
 		if err := t.to.Exec(ctx, &drivers.Statement{Query: fmt.Sprintf("USE %s;", safeName(dbName))}); err != nil {
 			return err
@@ -166,6 +168,10 @@ func (t *duckDBToDuckDB) transferFromExternalDB(ctx context.Context, srcProps *d
 		query := fmt.Sprintf("CREATE OR REPLACE TABLE %s.%s.%s AS (%s\n);", safeName(localDB), safeName(localSchema), safeName(sinkProps.Table), userQuery)
 		return t.to.Exec(ctx, &drivers.Statement{Query: query})
 	})
+	if cleanupFunc != nil {
+		cleanupFunc()
+	}
+	return err
 }
 
 // rewriteLocalPaths rewrites a DuckDB SQL statement such that relative paths become absolute paths relative to the basePath,

--- a/runtime/reconcilers/model.go
+++ b/runtime/reconcilers/model.go
@@ -226,9 +226,6 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceNa
 	createErr := r.createModel(ctx, self, stagingTableName, !materialize)
 	if createErr != nil {
 		createErr = fmt.Errorf("failed to create model: %w", createErr)
-	} else if !r.C.Runtime.AllowHostAccess() {
-		// temporarily for debugging
-		logTableNameAndType(ctx, r.C, connector, stagingTableName)
 	}
 
 	if createErr == nil && stage {

--- a/runtime/reconcilers/source.go
+++ b/runtime/reconcilers/source.go
@@ -186,9 +186,6 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceN
 	ingestErr := r.ingestSource(ctx, self, stagingTableName)
 	if ingestErr != nil {
 		ingestErr = fmt.Errorf("failed to ingest source: %w", ingestErr)
-	} else if !r.C.Runtime.AllowHostAccess() {
-		// temporarily for debugging
-		logTableNameAndType(ctx, r.C, connector, stagingTableName)
 	}
 
 	if ingestErr == nil && src.Spec.StageChanges {


### PR DESCRIPTION
Details here : 

https://github.com/duckdb/duckdb/issues/9342
https://github.com/duckdb/duckdb/pull/11297 

Even though we don't run any `ATTACH` & `DETACH` in parallel but I think that duckDB is also getting into this condition when running any information_schema call in parallel to DETACH operation.
We ensure all `DETACH` happen in isolation and sequentially using internal drivers `tx` lock.