### PR TITLE
Associate history entries with AddSourceModal state

### DIFF
--- a/web-common/src/features/sources/modal/LocalSourceUpload.svelte
+++ b/web-common/src/features/sources/modal/LocalSourceUpload.svelte
@@ -63,11 +63,11 @@
         );
 
         await createSource(runtimeInstanceId, tableName, yaml);
-        checkSourceImported(
+        await checkSourceImported(
           queryClient,
           getFilePathFromNameAndType(tableName, EntityType.Table),
         );
-        goto(`/source/${tableName}`);
+        await goto(`/source/${tableName}`);
       } catch (err) {
         console.error(err);
       }

--- a/web-common/src/features/sources/modal/add-source-visibility.ts
+++ b/web-common/src/features/sources/modal/add-source-visibility.ts
@@ -1,12 +1,14 @@
-import { writable } from "svelte/store";
-
 export const addSourceModal = (() => {
-  const { subscribe, set, update } = writable(false);
-
   return {
-    subscribe,
-    open: () => set(true),
-    close: () => set(false),
-    toggle: () => update((state) => !state),
+    open: () => {
+      const state = { step: 1, connector: null, requestConnector: false };
+      window.history.pushState(state, "", "");
+      dispatchEvent(new PopStateEvent("popstate", { state: state }));
+    },
+    close: () => {
+      const state = { step: 0, connector: null, requestConnector: false };
+      window.history.pushState(state, "", "");
+      dispatchEvent(new PopStateEvent("popstate", { state: state }));
+    },
   };
 })();

--- a/web-common/src/layout/RillDeveloperLayout.svelte
+++ b/web-common/src/layout/RillDeveloperLayout.svelte
@@ -3,10 +3,7 @@
   import { featureFlags } from "@rilldata/web-common/features/feature-flags";
   import FileDrop from "@rilldata/web-common/features/sources/modal/FileDrop.svelte";
   import SourceImportedModal from "@rilldata/web-common/features/sources/modal/SourceImportedModal.svelte";
-  import {
-    duplicateSourceName,
-    sourceImportedName,
-  } from "@rilldata/web-common/features/sources/sources-store";
+  import { sourceImportedName } from "@rilldata/web-common/features/sources/sources-store";
   import BlockingOverlayContainer from "@rilldata/web-common/layout/BlockingOverlayContainer.svelte";
   import type { ApplicationBuildMetadata } from "@rilldata/web-common/layout/build-metadata";
   import { initMetrics } from "@rilldata/web-common/metrics/initMetrics";
@@ -14,7 +11,7 @@
   import type { Writable } from "svelte/store";
   import AddSourceModal from "../features/sources/modal/AddSourceModal.svelte";
   import PreparingImport from "../features/sources/modal/PreparingImport.svelte";
-  import { addSourceModal } from "../features/sources/modal/add-source-visibility";
+
   import WelcomePageRedirect from "../features/welcome/WelcomePageRedirect.svelte";
   import { runtimeServiceGetConfig } from "../runtime-client/manual-clients";
   import BasicLayout from "./BasicLayout.svelte";
@@ -69,9 +66,8 @@
     </BlockingOverlayContainer>
   {/if}
 
-  {#if $addSourceModal || $duplicateSourceName}
-    <AddSourceModal />
-  {/if}
+  <AddSourceModal />
+
   <SourceImportedModal source={$sourceImportedName} />
 
   <div


### PR DESCRIPTION
This PR adds history entries associated with the state of the Add Source modal. This is something that is trivial and has a pretty clean API in SvelteKit 2.0, but is kind of cumbersome using native browser APIs. As such, this is kind of a patchy approach and another reason to move to 2.0 as soon as possible.

Closes: #4541