### PR TITLE
Admin: Fix version missing error for "rill deploy" from old versions

### DIFF
--- a/admin/deployments.go
+++ b/admin/deployments.go
@@ -60,7 +60,7 @@ func (s *Service) createDeployment(ctx context.Context, opts *createDeploymentOp
 	if runtimeVersion != "latest" {
 		_, err := version.NewVersion(runtimeVersion)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to parse version %q: %w", runtimeVersion, err)
 		}
 	}
 

--- a/admin/server/projects.go
+++ b/admin/server/projects.go
@@ -300,6 +300,11 @@ func (s *Server) CreateProject(ctx context.Context, req *adminv1.CreateProjectRe
 		prodTTL = &tmp
 	}
 
+	// Backwards compatibility: if prod version is not set, default to "latest"
+	if req.ProdVersion == "" {
+		req.ProdVersion = "latest"
+	}
+
 	// Create the project
 	proj, err := s.admin.CreateProject(ctx, org, claims.OwnerID(), &database.InsertProjectOptions{
 		OrganizationID:       org.ID,


### PR DESCRIPTION
This PR makes `CreateProject.ProdVersion` default to `latest` on the server-side. This is necessary since older versions of Rill do not pass a `ProdVersion`.

Without this change, I'm getting this error during `rill deploy` from `v0.42.3`:
```
Error: create project failed with error rpc error: code = InvalidArgument desc = Malformed version:  (InvalidArgument)
```
