### PR TITLE
Disable reports and alerts for dashboards with no timestamp column

### DIFF
--- a/web-admin/src/features/alerts/CreateAlert.svelte
+++ b/web-admin/src/features/alerts/CreateAlert.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
+  import { useMetricsView } from "@rilldata/web-common/features/dashboards/selectors";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { Button } from "@rilldata/web-common/components/button";
   import { BellPlusIcon } from "lucide-svelte";
@@ -10,24 +11,31 @@
     selectors: {
       timeRangeSelectors: { isCustomTimeRange },
     },
+    runtime,
+    metricsViewName,
   } = getStateManagers();
+
+  $: metricsView = useMetricsView($runtime?.instanceId, $metricsViewName);
+  $: hasTimeDimension = !!$metricsView?.data?.timeDimension;
 
   let showAlertDialog = false;
 </script>
 
-<Tooltip location="top" distance={8} suppress={!$isCustomTimeRange}>
-  <Button
-    disabled={$isCustomTimeRange}
-    on:click={() => (showAlertDialog = true)}
-    compact
-    type="secondary"
-  >
-    <BellPlusIcon class="inline-flex" size="16px" />
-  </Button>
-  <TooltipContent slot="tooltip-content">
-    To create an alert, set a non-custom time range.
-  </TooltipContent>
-</Tooltip>
+{#if hasTimeDimension}
+  <Tooltip distance={8} location="top" suppress={!$isCustomTimeRange}>
+    <Button
+      compact
+      disabled={$isCustomTimeRange}
+      on:click={() => (showAlertDialog = true)}
+      type="secondary"
+    >
+      <BellPlusIcon class="inline-flex" size="16px" />
+    </Button>
+    <TooltipContent slot="tooltip-content">
+      To create an alert, set a non-custom time range.
+    </TooltipContent>
+  </Tooltip>
+{/if}
 
 <!-- Including `showAlertDialog` in the conditional ensures we tear 
     down the form state when the dialog closes -->

--- a/web-common/src/features/dashboards/dimension-table/ExportDimensionTableDataButton.svelte
+++ b/web-common/src/features/dashboards/dimension-table/ExportDimensionTableDataButton.svelte
@@ -95,7 +95,7 @@
     >
       Export as XLSX
     </MenuItem>
-    {#if includeScheduledReport}
+    {#if includeScheduledReport && $scheduledReportsQueryArgs}
       <MenuItem
         on:select={() => {
           toggleFloatingElement();
@@ -110,7 +110,7 @@
 
 <!-- Including `showScheduledReportDialog` in the conditional ensures we tear 
   down the form state when the dialog closes -->
-{#if includeScheduledReport && CreateScheduledReportDialog && showScheduledReportDialog}
+{#if includeScheduledReport && CreateScheduledReportDialog && showScheduledReportDialog && $scheduledReportsQueryArgs}
   <svelte:component
     this={CreateScheduledReportDialog}
     queryName="MetricsViewComparison"


### PR DESCRIPTION
We currently do not gracefully handle when timestamp column is not present for reports and alerts.

Temporarily disabling creating them when timestamp column is not present in the dashboard.