### PR TITLE
Runtime: change error log to debug

### DIFF
--- a/runtime/drivers/duckdb/olap.go
+++ b/runtime/drivers/duckdb/olap.go
@@ -593,7 +593,7 @@ func (c *connection) detachAndRemoveFile(db, dbFile string) {
 		return err
 	})
 	if err != nil {
-		c.logger.Error("detach failed", zap.String("db", db), zap.Error(err))
+		c.logger.Warn("detach failed", zap.String("db", db), zap.Error(err))
 	}
 }
 

--- a/runtime/drivers/duckdb/olap.go
+++ b/runtime/drivers/duckdb/olap.go
@@ -593,7 +593,7 @@ func (c *connection) detachAndRemoveFile(db, dbFile string) {
 		return err
 	})
 	if err != nil {
-		c.logger.Warn("detach failed", zap.String("db", db), zap.Error(err))
+		c.logger.Debug("detach failed", zap.String("db", db), zap.Error(err))
 	}
 }
 


### PR DESCRIPTION
Here is my hypothesis around how detach can fail even in happy scenarios:

1. The db file is created and we start ingesting data. 
2. The ingestion fails due to n number of reasons like duckdb memory limit exhausted, cancellation etc.
3. In the cleanup we `reopen` db which re-attaches all files and removes directory with a db file but no version.txt file.
4. Now the detach in cleanup will complain that db file does not exist.