### PR TITLE
Update AI feature flag scope

### DIFF
--- a/web-common/src/features/feature-flags.ts
+++ b/web-common/src/features/feature-flags.ts
@@ -15,8 +15,9 @@ class FeatureFlag {
   private _system = false;
   private state = writable(false);
 
-  constructor(scope: "user" | "system" = "user") {
+  constructor(scope: "user" | "system" = "user", initial = false) {
     this._system = scope === "system";
+    this.set(initial);
   }
 
   get system() {
@@ -33,7 +34,7 @@ type FeatureFlagKey = keyof Omit<FeatureFlags, "set">;
 class FeatureFlags {
   adminServer = new FeatureFlag("system");
   readOnly = new FeatureFlag("system");
-  ai = new FeatureFlag("system");
+  ai = new FeatureFlag("system", true);
   pivot = new FeatureFlag();
   cloudDataViewer = new FeatureFlag();
   customDashboards = new FeatureFlag();

--- a/web-common/src/features/feature-flags.ts
+++ b/web-common/src/features/feature-flags.ts
@@ -46,7 +46,7 @@ class FeatureFlags {
       Object.keys(this).forEach((key) => {
         const flag = this[key] as FeatureFlag;
         if (flag.system) return;
-        flag.set(userFlags.has(key));
+        if (userFlags.has(key)) flag.set(true);
       });
     }, 400);
 
@@ -72,7 +72,8 @@ class FeatureFlags {
         },
       }).subscribe((features) => {
         if (!Array.isArray(features?.data)) return;
-        updateFlags(new Set([...staticFlags, ...features.data]));
+        const yamlFlags = features.data;
+        updateFlags(new Set([...staticFlags, ...yamlFlags]));
       });
     });
   }

--- a/web-common/src/features/feature-flags.ts
+++ b/web-common/src/features/feature-flags.ts
@@ -12,11 +12,15 @@ export type DerivedReadables<T> = {
 };
 
 class FeatureFlag {
-  system = false;
+  private _system = false;
   private state = writable(false);
 
   constructor(scope: "user" | "system" = "user") {
-    this.system = scope === "system";
+    this._system = scope === "system";
+  }
+
+  get system() {
+    return this._system;
   }
 
   subscribe = this.state.subscribe;
@@ -29,8 +33,8 @@ type FeatureFlagKey = keyof Omit<FeatureFlags, "set">;
 class FeatureFlags {
   adminServer = new FeatureFlag("system");
   readOnly = new FeatureFlag("system");
+  ai = new FeatureFlag("system");
   pivot = new FeatureFlag();
-  ai = new FeatureFlag();
   cloudDataViewer = new FeatureFlag();
   customDashboards = new FeatureFlag();
 


### PR DESCRIPTION
This PR changes the scope of the AI feature flag from `user` to `system`, meaning it can't be set/overwritten via localStorage, URL or the YAML file.

Looking forward, the feature flags store should probably be broken up into three components: a `config` store that is project/organization specific and depends on data only available via the API, a `preferences` store for things that can be toggled on and off and are not intended to be hidden, and a `feature flags` store for things disabled by default and enabled manually. Also, there are certain things, like `adminServer` that don't need to be reactive or controlled during runtime that should be constants determined by environment variables.