### PR TITLE
Let non-admin users remove themselves from orgs and projects

### DIFF
--- a/admin/server/admin_rbac_test.go
+++ b/admin/server/admin_rbac_test.go
@@ -467,6 +467,14 @@ func TestAdmin_RBAC(t *testing.T) {
 			Email:        viewerUser.Email,
 		})
 		require.NoError(t, err)
+
+		// Reverse the change
+		_, err = adminClient.AddOrganizationMember(ctx, &adminv1.AddOrganizationMemberRequest{
+			Organization: adminOrg.Organization.Name,
+			Email:        viewerUser.Email,
+			Role:         "viewer",
+		})
+		require.NoError(t, err)
 	})
 
 	// remove last admin tests

--- a/admin/server/admin_rbac_test.go
+++ b/admin/server/admin_rbac_test.go
@@ -460,6 +460,15 @@ func TestAdmin_RBAC(t *testing.T) {
 		})
 	}
 
+	// The viewer should be able to remove themselves from the org
+	t.Run("remove yourself from org", func(t *testing.T) {
+		_, err := viewerClient.RemoveOrganizationMember(ctx, &adminv1.RemoveOrganizationMemberRequest{
+			Organization: adminOrg.Organization.Name,
+			Email:        viewerUser.Email,
+		})
+		require.NoError(t, err)
+	})
+
 	// remove last admin tests
 	t.Run("test remove last admin", func(t *testing.T) {
 		_, err := adminClient.RemoveOrganizationMember(ctx, &adminv1.RemoveOrganizationMemberRequest{
@@ -469,7 +478,7 @@ func TestAdmin_RBAC(t *testing.T) {
 
 		require.Error(t, err)
 		require.Equal(t, codes.InvalidArgument, status.Code(err))
-		require.ErrorContains(t, err, "cannot remove the last owner")
+		require.ErrorContains(t, err, "cannot remove the last admin member")
 	})
 	t.Run("test leave last admin", func(t *testing.T) {
 		_, err := adminClient.LeaveOrganization(ctx, &adminv1.LeaveOrganizationRequest{

--- a/admin/server/organizations.go
+++ b/admin/server/organizations.go
@@ -447,10 +447,9 @@ func (s *Server) RemoveOrganizationMember(ctx context.Context, req *adminv1.Remo
 
 	// The caller must either have ManageOrgMembers permission or be the user being removed.
 	claims := auth.GetClaims(ctx)
-	allow := false
-	allow = allow || claims.OrganizationPermissions(ctx, org.ID).ManageOrgMembers
-	allow = allow || (claims.OwnerType() == auth.OwnerTypeUser && claims.OwnerID() == user.ID)
-	if !allow {
+	isManager := claims.OrganizationPermissions(ctx, org.ID).ManageOrgMembers
+	isSelf := claims.OwnerType() == auth.OwnerTypeUser && claims.OwnerID() == user.ID
+	if !isManager && !isSelf {
 		return nil, status.Error(codes.PermissionDenied, "not allowed to remove org members")
 	}
 

--- a/admin/server/organizations.go
+++ b/admin/server/organizations.go
@@ -415,17 +415,20 @@ func (s *Server) RemoveOrganizationMember(ctx context.Context, req *adminv1.Remo
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	claims := auth.GetClaims(ctx)
-	if !claims.OrganizationPermissions(ctx, org.ID).ManageOrgMembers {
-		return nil, status.Error(codes.PermissionDenied, "not allowed to remove org members")
-	}
-
 	user, err := s.admin.DB.FindUserByEmail(ctx, req.Email)
 	if err != nil {
 		if !errors.Is(err, database.ErrNotFound) {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
-		// check if there is a pending invite
+
+		// Only admins can remove pending invites.
+		// NOTE: If we change invites to accept/decline (instead of auto-accept on signup), we need to revisit this.
+		claims := auth.GetClaims(ctx)
+		if !claims.OrganizationPermissions(ctx, org.ID).ManageOrgMembers {
+			return nil, status.Error(codes.PermissionDenied, "not allowed to remove org members")
+		}
+
+		// Check if there is a pending invite
 		invite, err := s.admin.DB.FindOrganizationInvite(ctx, org.ID, req.Email)
 		if err != nil {
 			if errors.Is(err, database.ErrNotFound) {
@@ -433,27 +436,35 @@ func (s *Server) RemoveOrganizationMember(ctx context.Context, req *adminv1.Remo
 			}
 			return nil, status.Error(codes.Internal, err.Error())
 		}
+
 		err = s.admin.DB.DeleteOrganizationInvite(ctx, invite.ID)
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
+
 		return &adminv1.RemoveOrganizationMemberResponse{}, nil
 	}
 
-	role, err := s.admin.DB.FindOrganizationRole(ctx, database.OrganizationRoleNameAdmin)
-	if err != nil {
-		panic(err)
+	// The caller must either have ManageOrgMembers permission or be the user being removed.
+	claims := auth.GetClaims(ctx)
+	allow := false
+	allow = allow || claims.OrganizationPermissions(ctx, org.ID).ManageOrgMembers
+	allow = allow || (claims.OwnerType() == auth.OwnerTypeUser && claims.OwnerID() == user.ID)
+	if !allow {
+		return nil, status.Error(codes.PermissionDenied, "not allowed to remove org members")
 	}
 
-	// check if the user is the last owner
-	// TODO optimize this, may be extract roles during auth token validation
-	//  and store as part of the claims and fetch admins only if the user is an admin
+	// Check that the user is not the last admin
+	role, err := s.admin.DB.FindOrganizationRole(ctx, database.OrganizationRoleNameAdmin)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
 	users, err := s.admin.DB.FindOrganizationMemberUsersByRole(ctx, org.ID, role.ID)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if len(users) == 1 && users[0].ID == user.ID {
-		return nil, status.Error(codes.InvalidArgument, "cannot remove the last owner")
+		return nil, status.Error(codes.InvalidArgument, "cannot remove the last admin member")
 	}
 
 	ctx, tx, err := s.admin.DB.NewTx(ctx)
@@ -461,6 +472,7 @@ func (s *Server) RemoveOrganizationMember(ctx context.Context, req *adminv1.Remo
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	defer func() { _ = tx.Rollback() }()
+
 	err = s.admin.DB.DeleteOrganizationMemberUser(ctx, org.ID, user.ID)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())

--- a/admin/server/projects.go
+++ b/admin/server/projects.go
@@ -742,10 +742,9 @@ func (s *Server) RemoveProjectMember(ctx context.Context, req *adminv1.RemovePro
 
 	// The caller must either have ManageProjectMembers permission or be the user being removed.
 	claims := auth.GetClaims(ctx)
-	allow := false
-	allow = allow || claims.ProjectPermissions(ctx, proj.OrganizationID, proj.ID).ManageProjectMembers
-	allow = allow || (claims.OwnerType() == auth.OwnerTypeUser && claims.OwnerID() == user.ID)
-	if !allow {
+	isManager := claims.ProjectPermissions(ctx, proj.OrganizationID, proj.ID).ManageProjectMembers
+	isSelf := claims.OwnerType() == auth.OwnerTypeUser && claims.OwnerID() == user.ID
+	if !isManager && !isSelf {
 		return nil, status.Error(codes.PermissionDenied, "not allowed to remove project members")
 	}
 


### PR DESCRIPTION
Closes issue reported in [Slack](https://rilldata.slack.com/archives/CTZ8XBQ85/p1713218977194649).