### PR TITLE
Fix: Custom Dashboard component assignment name

### DIFF
--- a/web-local/src/routes/(application)/custom-dashboard/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/custom-dashboard/[name]/+page.svelte
@@ -141,7 +141,7 @@
     yaml = stringify(<V1DashboardSpec>{
       kind: "dashboard",
       ...dashboard,
-      newComponents,
+      components: newComponents,
     });
 
     await updateChartFile(new CustomEvent("update", { detail: yaml }));
@@ -160,7 +160,7 @@
     yaml = stringify(<V1DashboardSpec>{
       kind: "dashboard",
       ...dashboard,
-      newComponents,
+      components: newComponents,
     });
 
     await updateChartFile(new CustomEvent("update", { detail: yaml }));


### PR DESCRIPTION
Please go the the `Preview` tab and select the appropriate sub-template:

* [Applications](?expand=1&template=applications_template.md)
* [Others](?expand=1&template=fallback_template.md)