### PR TITLE
Fix/Feat: Resizable Pivot measure columns

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotTable.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTable.svelte
@@ -23,27 +23,24 @@
   import type { PivotDataRow, PivotDataStore } from "./types";
   import Resizer from "@rilldata/web-common/layout/Resizer.svelte";
 
-  export let pivotDataStore: PivotDataStore;
-
+  // Distance threshold (in pixels) for triggering data fetch
+  const ROW_THRESHOLD = 200;
   const OVERSCAN = 60;
   const ROW_HEIGHT = 24;
   const HEADER_HEIGHT = 30;
   const MEASURE_PADDING = 16;
-  // Distance threshold (in pixels) for triggering data fetch
-  const ROW_THRESHOLD = 200;
   const MIN_COL_WIDTH = 150;
   const MAX_COL_WIDTH = 600;
   const MAX_INIT_COL_WIDTH = 400;
+  const MIN_MEASURE_WIDTH = 60;
+  const MAX_MEAUSRE_WIDTH = 300;
+  const INIT_MEASURE_WIDTH = 90;
+
+  export let pivotDataStore: PivotDataStore;
 
   const stateManagers = getStateManagers();
 
-  const {
-    dashboardStore,
-    metricsViewName,
-    selectors: {
-      pivot: { rows: rowPills },
-    },
-  } = stateManagers;
+  const { dashboardStore, metricsViewName } = stateManagers;
 
   const config = getPivotConfig(stateManagers);
 
@@ -81,19 +78,39 @@
   let containerRefElement: HTMLDivElement;
   let stickyRows = [0];
   let rowScrollOffset = 0;
+  let scrollLeft = 0;
+  let initialMeasureIndexOnResize = 0;
+  let initLengthOnResize = 0;
+  let initScrollOnResize = 0;
+  let percentOfChangeDuringResize = 0;
+  let resizingMeasure = false;
+
+  $: ({
+    expanded,
+    sorting,
+    rowPage,
+    columns,
+    rows: rowPills,
+  } = $pivotDashboardStore);
 
   $: timeDimension = $config.time.timeDimension;
-  $: hasDimension = $rowPills.dimension.length > 0;
-
+  $: hasDimension = rowPills.dimension.length > 0;
   $: reachedEndForRows = !!$pivotDataStore?.reachedEndForRowData;
   $: assembled = $pivotDataStore.assembled;
-  $: expanded = $dashboardStore?.pivot?.expanded ?? {};
-  $: sorting = $dashboardStore?.pivot?.sorting ?? [];
 
-  $: rowPage = $dashboardStore?.pivot?.rowPage;
+  $: measureNames = columns.measure.map((measure) => measure.title) ?? [];
+  $: measureCount = measureNames.length;
+  $: measureLengths = measureNames.map((name) =>
+    Math.max(INIT_MEASURE_WIDTH, name.length * 7 + MEASURE_PADDING),
+  );
+  $: measureGroups = headerGroups[headerGroups.length - 2]?.headers?.slice(
+    hasDimension ? 1 : 0,
+  ) ?? [null];
+  $: measureGroupsLength = measureGroups.length;
+  $: totalMeasureWidth = measureLengths.reduce((acc, val) => acc + val, 0);
+  $: totalLength = measureGroupsLength * totalMeasureWidth;
+
   $: headerGroups = $table.getHeaderGroups();
-  $: measureCount = $dashboardStore.pivot?.columns?.measure?.length ?? 0;
-  $: rows = $table.getRowModel().rows;
   $: totalHeaderHeight = headerGroups.length * HEADER_HEIGHT;
   $: headers = headerGroups[0].headers;
   $: firstColumnName = hasDimension
@@ -104,37 +121,7 @@
       ? calculateFirstColumnWidth(firstColumnName)
       : 0;
 
-  $: measureGroups = headerGroups[headerGroups.length - 2]?.headers?.slice(
-    hasDimension ? 1 : 0,
-  ) ?? [null];
-  $: measureGroupsLength = measureGroups.length;
-
-  const columnSizes = (() => {
-    const sizes = new Map<string, number[]>();
-    return {
-      get: (key: string, calculator: () => number[]): number[] => {
-        let array = sizes.get(key);
-        if (!array) {
-          array = calculator();
-          sizes.set(key, array);
-        }
-        return array;
-      },
-      set: (key: string, value: number[]) => sizes.set(key, value),
-    };
-  })();
-
-  $: measureLengths = columnSizes.get("measureWidths", () => {
-    return (
-      $dashboardStore.pivot?.columns?.measure?.map((measure) => {
-        return Math.max(90, measure.title.length * 7 + MEASURE_PADDING);
-      }) ?? []
-    );
-  });
-
-  $: totalMeasureWidth = measureLengths.reduce((acc, val) => acc + val, 0);
-  $: totalLength = measureGroupsLength * totalMeasureWidth;
-
+  $: rows = $table.getRowModel().rows;
   $: virtualizer = createVirtualizer<HTMLDivElement, HTMLTableRowElement>({
     count: rows.length,
     getScrollElement: () => containerRefElement,
@@ -162,6 +149,14 @@
       ]
     : [0, 0];
 
+  $: if (resizingMeasure && containerRefElement && measureLengths) {
+    containerRefElement.scrollTo({
+      left:
+        initScrollOnResize +
+        percentOfChangeDuringResize * (totalLength - initLengthOnResize),
+    });
+  }
+
   function onExpandedChange(updater: Updater<ExpandedState>) {
     // Something is off with tanstack's types
     //@ts-expect-error-free
@@ -179,7 +174,6 @@
     metricsExplorerStore.setPivotSort($metricsViewName, sorting);
   }
 
-  let scrollLeft = 0;
   const handleScroll = (containerRefElement?: HTMLDivElement | null) => {
     if (containerRefElement) {
       const { scrollHeight, scrollTop, clientHeight } = containerRefElement;
@@ -240,21 +234,7 @@
     return [...first, ...middle, ...last];
   }
 
-  let initialMeasureIndex = 0;
-  let initLengthOnResize = 0;
-  let initScrollOnResize = 0;
-  let percentOfChange = 0;
-  let resizingMeasure = false;
-
-  $: if (resizingMeasure && containerRefElement && measureLengths) {
-    containerRefElement.scrollTo({
-      left:
-        initScrollOnResize +
-        percentOfChange * (totalLength - initLengthOnResize),
-    });
-  }
-
-  function onMouseDown(e: MouseEvent) {
+  function onResizeStart(e: MouseEvent) {
     initLengthOnResize = totalLength;
     initScrollOnResize = scrollLeft;
 
@@ -262,12 +242,14 @@
       e.clientX -
       containerRefElement.getBoundingClientRect().left -
       firstColumnWidth -
-      measureLengths.reduce((acc, val, i) => {
-        return i <= initialMeasureIndex ? acc + val : acc;
+      measureLengths.reduce((rollingSum, length, i) => {
+        return i <= initialMeasureIndexOnResize
+          ? rollingSum + length
+          : rollingSum;
       }, 0) +
       4;
 
-    percentOfChange = (scrollLeft + offset) / totalLength;
+    percentOfChangeDuringResize = (scrollLeft + offset) / totalLength;
   }
 </script>
 
@@ -303,38 +285,33 @@
         <tr>
           {#each headerGroup.headers as header, i (header.id)}
             {@const sortDirection = header.column.getIsSorted()}
-            {@const canResize =
-              (hasDimension && group === 0 && i === 0) || group !== 0}
+            {@const isFirstColumn = i === 0}
+            {@const canResize = hasDimension && (isFirstColumn || group !== 0)}
             {@const measureIndex = (i - 1) % measureLengths.length}
             <th colSpan={header.colSpan}>
               {#if canResize}
-                {#if i === 0}
-                  <Resizer
-                    min={MIN_COL_WIDTH}
-                    max={MAX_COL_WIDTH}
-                    basis={MIN_COL_WIDTH}
-                    bind:dimension={firstColumnWidth}
-                    side="right"
-                    direction="EW"
-                    onMouseDown={() => {
-                      resizingMeasure = false;
-                    }}
-                  />
-                {:else}
-                  <Resizer
-                    min={60}
-                    max={300}
-                    basis={MIN_COL_WIDTH}
-                    bind:dimension={measureLengths[measureIndex]}
-                    side="right"
-                    direction="EW"
-                    onMouseDown={(e) => {
-                      resizingMeasure = true;
-                      initialMeasureIndex = measureIndex;
-                      onMouseDown(e);
-                    }}
-                  />
-                {/if}
+                <Resizer
+                  side="right"
+                  direction="EW"
+                  min={isFirstColumn ? MIN_COL_WIDTH : MIN_MEASURE_WIDTH}
+                  max={isFirstColumn ? MAX_COL_WIDTH : MAX_MEAUSRE_WIDTH}
+                  basis={isFirstColumn ? MIN_COL_WIDTH : INIT_MEASURE_WIDTH}
+                  dimension={isFirstColumn
+                    ? firstColumnWidth
+                    : measureLengths[measureIndex]}
+                  onMouseDown={(e) => {
+                    resizingMeasure = !isFirstColumn;
+                    initialMeasureIndexOnResize = measureIndex;
+                    if (resizingMeasure) onResizeStart(e);
+                  }}
+                  onUpdate={(d) => {
+                    if (isFirstColumn) {
+                      firstColumnWidth = d;
+                    } else {
+                      measureLengths[measureIndex] = d;
+                    }
+                  }}
+                />
               {/if}
 
               <button

--- a/web-common/src/layout/Resizer.svelte
+++ b/web-common/src/layout/Resizer.svelte
@@ -15,6 +15,7 @@
   export let resizing = false;
   export let absolute = true;
   export let onMouseDown: ((e: MouseEvent) => void) | null = null;
+  export let onUpdate: ((dimension: number) => void) | null = null;
 
   let start = 0;
   let startingDimension = dimension;
@@ -53,6 +54,7 @@
     }
     requestAnimationFrame(() => {
       dimension = Math.min(max, Math.max(min, startingDimension + delta));
+      if (onUpdate) onUpdate(dimension);
     });
   }
 
@@ -64,6 +66,7 @@
 
   function handleDoubleClick() {
     dimension = basis;
+    if (onUpdate) onUpdate(dimension);
   }
 </script>
 

--- a/web-common/src/layout/Resizer.svelte
+++ b/web-common/src/layout/Resizer.svelte
@@ -14,6 +14,7 @@
   export let basis = 200;
   export let resizing = false;
   export let absolute = true;
+  export let onMouseDown: (e: MouseEvent) => void;
 
   let start = 0;
   let startingDimension = dimension;
@@ -28,6 +29,7 @@
       start = e.clientY;
     }
 
+    onMouseDown(e);
     window.addEventListener("mousemove", onMouseMove);
     window.addEventListener("mouseup", onMouseUp);
   }

--- a/web-common/src/layout/Resizer.svelte
+++ b/web-common/src/layout/Resizer.svelte
@@ -14,7 +14,7 @@
   export let basis = 200;
   export let resizing = false;
   export let absolute = true;
-  export let onMouseDown: (e: MouseEvent) => void;
+  export let onMouseDown: ((e: MouseEvent) => void) | null = null;
 
   let start = 0;
   let startingDimension = dimension;
@@ -29,7 +29,7 @@
       start = e.clientY;
     }
 
-    onMouseDown(e);
+    if (onMouseDown) onMouseDown(e);
     window.addEventListener("mousemove", onMouseMove);
     window.addEventListener("mouseup", onMouseUp);
   }


### PR DESCRIPTION
This PR sets a minimum width for measure columns and adds the ability to resize them across the table.

In the examples below, the first image shows the initial layout (measures are given more space without having to reference the associated dimension name) and the other two show resizing the measure up or down.

<img width="462" alt="Screenshot 2024-04-16 at 5 01 29 PM" src="https://github.com/rilldata/rill/assets/120223836/5f0c3a38-76f7-4bbe-a529-7c360ca30d2d">
<img width="903" alt="Screenshot 2024-04-16 at 5 01 07 PM" src="https://github.com/rilldata/rill/assets/120223836/d2af1b39-ac44-408d-a971-2f7c65c8ea7d">
<img width="355" alt="Screenshot 2024-04-16 at 5 00 58 PM" src="https://github.com/rilldata/rill/assets/120223836/f363696b-a0a5-41da-8c9f-24b5224b4f3f">

Seeing some rendering artifacts in Safari, but is stable in Chrome.
