### PR TITLE
Fix: Post reorg tweaks

### DIFF
--- a/web-common/src/components/navigation/breadcrumbs/Breadcrumbs.svelte
+++ b/web-common/src/components/navigation/breadcrumbs/Breadcrumbs.svelte
@@ -19,6 +19,7 @@
   export let currentPath: (string | undefined)[] = [];
 
   $: currentPage = currentPath.findLastIndex(Boolean);
+  $: console.log(pathParts);
 </script>
 
 <nav class="flex gap-x-0 pl-1.5 items-center">

--- a/web-common/src/components/navigation/breadcrumbs/Breadcrumbs.svelte
+++ b/web-common/src/components/navigation/breadcrumbs/Breadcrumbs.svelte
@@ -19,7 +19,6 @@
   export let currentPath: (string | undefined)[] = [];
 
   $: currentPage = currentPath.findLastIndex(Boolean);
-  $: console.log(pathParts);
 </script>
 
 <nav class="flex gap-x-0 pl-1.5 items-center">

--- a/web-local/src/routes/(application)/+layout.svelte
+++ b/web-local/src/routes/(application)/+layout.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
   import NotificationCenter from "@rilldata/web-common/components/notifications/NotificationCenter.svelte";
-
   import FileDrop from "@rilldata/web-common/features/sources/modal/FileDrop.svelte";
   import SourceImportedModal from "@rilldata/web-common/features/sources/modal/SourceImportedModal.svelte";
   import { sourceImportedPath } from "@rilldata/web-common/features/sources/sources-store";
   import BlockingOverlayContainer from "@rilldata/web-common/layout/BlockingOverlayContainer.svelte";
-
   import {
     importOverlayVisible,
     overlay,
@@ -22,55 +20,45 @@
   }
 </script>
 
-<div class="body">
-  {#if $importOverlayVisible}
-    <PreparingImport />
-  {:else if showDropOverlay}
-    <FileDrop bind:showDropOverlay />
-  {:else if $overlay !== null}
-    <BlockingOverlayContainer
-      bg="linear-gradient(to right, rgba(0,0,0,.6), rgba(0,0,0,.8))"
-    >
-      <div slot="title" class="font-bold">
-        {$overlay?.title}
-      </div>
-      <svelte:fragment slot="detail">
-        {#if $overlay?.detail}
-          <svelte:component
-            this={$overlay.detail.component}
-            {...$overlay.detail.props}
-          />
-        {/if}
-      </svelte:fragment>
-    </BlockingOverlayContainer>
-  {/if}
+<main
+  role="application"
+  class="index-body absolute w-screen h-screen flex overflow-hidden"
+  on:drag|preventDefault|stopPropagation
+  on:drop|preventDefault|stopPropagation
+  on:dragenter|preventDefault|stopPropagation
+  on:dragleave|preventDefault|stopPropagation
+  on:dragover|preventDefault|stopPropagation={(e) => {
+    if (isEventWithFiles(e)) showDropOverlay = true;
+  }}
+>
+  <Navigation />
+  <section class="size-full overflow-hidden">
+    <slot />
+  </section>
+</main>
 
-  <AddSourceModal />
-  <SourceImportedModal sourcePath={$sourceImportedPath} />
-
-  <main
-    role="application"
-    class="index-body absolute w-screen h-screen flex overflow-hidden"
-    on:drag|preventDefault|stopPropagation
-    on:drop|preventDefault|stopPropagation
-    on:dragenter|preventDefault|stopPropagation
-    on:dragleave|preventDefault|stopPropagation
-    on:dragover|preventDefault|stopPropagation={(e) => {
-      if (isEventWithFiles(e)) showDropOverlay = true;
-    }}
+{#if $importOverlayVisible}
+  <PreparingImport />
+{:else if showDropOverlay}
+  <FileDrop bind:showDropOverlay />
+{:else if $overlay !== null}
+  <BlockingOverlayContainer
+    bg="linear-gradient(to right, rgba(0,0,0,.6), rgba(0,0,0,.8))"
   >
-    <Navigation />
-    <section class="size-full overflow-hidden">
-      <slot />
-    </section>
-  </main>
-</div>
+    <div slot="title" class="font-bold">
+      {$overlay?.title}
+    </div>
+    <svelte:fragment slot="detail">
+      {#if $overlay?.detail}
+        <svelte:component
+          this={$overlay.detail.component}
+          {...$overlay.detail.props}
+        />
+      {/if}
+    </svelte:fragment>
+  </BlockingOverlayContainer>
+{/if}
 
+<AddSourceModal />
+<SourceImportedModal sourcePath={$sourceImportedPath} />
 <NotificationCenter />
-
-<style>
-  /* Prevent trackpad navigation (like other code editors, like vscode.dev). */
-  :global(body) {
-    overscroll-behavior: none;
-  }
-</style>

--- a/web-local/src/routes/+layout.svelte
+++ b/web-local/src/routes/+layout.svelte
@@ -17,6 +17,11 @@
   import type { Writable } from "svelte/store";
   import ResourceWatcher from "@rilldata/web-common/features/entity-management/ResourceWatcher.svelte";
 
+  /** This function will initialize the existing node stores and will connect them
+   * to the Node server.
+   */
+  initializeNodeStoreContexts();
+
   const appBuildMetaStore: Writable<ApplicationBuildMetadata> =
     getContext("rill:app:metadata");
 
@@ -24,11 +29,6 @@
     error: AxiosError,
     query: Query,
   ) => errorEventHandler?.requestErrorEventHandler(error, query);
-
-  /** This function will initialize the existing node stores and will connect them
-   * to the Node server.
-   */
-  initializeNodeStoreContexts();
 
   beforeNavigate(retainFeaturesFlags);
 
@@ -54,8 +54,17 @@
   <QueryClientProvider client={queryClient}>
     <WelcomePageRedirect>
       <ResourceWatcher host={data.host} instanceId={data.instanceId}>
-        <slot />
+        <div class="body h-screen w-screen overflow-hidden">
+          <slot />
+        </div>
       </ResourceWatcher>
     </WelcomePageRedirect>
   </QueryClientProvider>
 </RillTheme>
+
+<style>
+  /* Prevent trackpad navigation (like other code editors, like vscode.dev). */
+  :global(body) {
+    overscroll-behavior: none;
+  }
+</style>

--- a/web-local/src/routes/welcome/+page.svelte
+++ b/web-local/src/routes/welcome/+page.svelte
@@ -1,16 +1,31 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
-  import { isProjectInitialized } from "@rilldata/web-common/features/welcome/is-project-initialized";
-  import Welcome from "@rilldata/web-common/features/welcome/Welcome.svelte";
-  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
-  import { onMount } from "svelte";
-
-  onMount(async () => {
-    const initialized = await isProjectInitialized($runtime.instanceId);
-
-    if (!initialized) return;
-    await goto("/");
-  });
+  import { fly } from "svelte/transition";
+  import ProjectCards from "@rilldata/web-common/features/welcome/ProjectCards.svelte";
+  import TitleContent from "@rilldata/web-common/features/welcome/TitleContent.svelte";
+  import UserTestCta from "@rilldata/web-common/features/welcome/UserTestCTA.svelte";
 </script>
 
-<Welcome />
+<div class="scroll" in:fly={{ duration: 1600, delay: 400, y: 8 }}>
+  <div class="wrapper column p-10 2xl:py-16">
+    <TitleContent />
+    <div class="column" in:fly={{ duration: 1600, delay: 1200, y: 4 }}>
+      <ProjectCards />
+      <UserTestCta />
+    </div>
+  </div>
+</div>
+
+<style lang="postcss">
+  .scroll {
+    @apply size-full overflow-x-hidden overflow-y-auto;
+  }
+
+  .wrapper {
+    @apply w-screen h-fit min-h-screen bg-no-repeat bg-cover;
+    background-image: url("$img/welcome-bg-art.png");
+  }
+
+  .column {
+    @apply flex flex-col items-center gap-y-6;
+  }
+</style>

--- a/web-local/src/routes/welcome/+page.svelte
+++ b/web-local/src/routes/welcome/+page.svelte
@@ -1,31 +1,5 @@
 <script lang="ts">
-  import { fly } from "svelte/transition";
-  import ProjectCards from "@rilldata/web-common/features/welcome/ProjectCards.svelte";
-  import TitleContent from "@rilldata/web-common/features/welcome/TitleContent.svelte";
-  import UserTestCta from "@rilldata/web-common/features/welcome/UserTestCTA.svelte";
+  import Welcome from "@rilldata/web-common/features/welcome/Welcome.svelte";
 </script>
 
-<div class="scroll" in:fly={{ duration: 1600, delay: 400, y: 8 }}>
-  <div class="wrapper column p-10 2xl:py-16">
-    <TitleContent />
-    <div class="column" in:fly={{ duration: 1600, delay: 1200, y: 4 }}>
-      <ProjectCards />
-      <UserTestCta />
-    </div>
-  </div>
-</div>
-
-<style lang="postcss">
-  .scroll {
-    @apply size-full overflow-x-hidden overflow-y-auto;
-  }
-
-  .wrapper {
-    @apply w-screen h-fit min-h-screen bg-no-repeat bg-cover;
-    background-image: url("$img/welcome-bg-art.png");
-  }
-
-  .column {
-    @apply flex flex-col items-center gap-y-6;
-  }
-</style>
+<Welcome />

--- a/web-local/src/routes/welcome/+page.ts
+++ b/web-local/src/routes/welcome/+page.ts
@@ -1,0 +1,10 @@
+import { isProjectInitialized } from "@rilldata/web-common/features/welcome/is-project-initialized";
+import { redirect } from "@sveltejs/kit";
+
+export async function load({ parent }) {
+  const parentData = await parent();
+  const initialized = await isProjectInitialized(parentData.instanceId);
+
+  if (!initialized) return;
+  throw redirect(303, "/");
+}


### PR DESCRIPTION
- Moves the global `body` div to the top level `+layout` file
- Eliminates page flashing by moving the redirect and `isProjectInitialized` conditional check that was originally part of the `/welcome` route (different from the `WelcomePageRedirect`) to a load function
- Moves the call to `initializeNodeStoreContexts` above the `getContext` call