### PR TITLE
Fix: Adjust file invalidation type and rill.yaml file path

### DIFF
--- a/web-common/src/features/entity-management/watch-files-client.ts
+++ b/web-common/src/features/entity-management/watch-files-client.ts
@@ -27,11 +27,11 @@ function handleWatchFileResponse(res: V1WatchFilesResponse) {
   if (!res.isDir) {
     switch (res.event) {
       case "FILE_EVENT_WRITE":
-        void queryClient.resetQueries(
+        void queryClient.refetchQueries(
           getRuntimeServiceGetFileQueryKey(instanceId, res.path),
         );
         void fileArtifacts.fileUpdated(res.path);
-        if (res.path === "rill.yaml") {
+        if (res.path === "/rill.yaml") {
           // If it's a rill.yaml file, invalidate the dev JWT queries
           void queryClient.invalidateQueries(
             getRuntimeServiceIssueDevJWTQueryKey(),


### PR DESCRIPTION
This PR changes the `resetQueries` call to `refetchQueries`, ensuring that file blobs are not reset to undefined as queries are fetching. There may have been a reason for this which I am not aware of, but this change is necessary for adding optimistic updates to our file mutations.

It also adds a leading slash to the `rill.yaml` conditional check as `FILE_EVENT_WRITE` sends paths in that format.