### PR TITLE
Fix: prevent the `ListProjectsForOrganization` request from firing before the `organization` is defined

### DIFF
--- a/web-admin/src/features/navigation/TopNavigationBar.svelte
+++ b/web-admin/src/features/navigation/TopNavigationBar.svelte
@@ -49,7 +49,7 @@
 
   $: projectsQuery = listProjects(organization, undefined, {
     query: {
-      enabled: !!organizations.length,
+      enabled: !!organization,
     },
   });
 


### PR DESCRIPTION
Addresses this [bug report in Slack](https://rilldata.slack.com/archives/CTZ8XBQ85/p1713229199298049).