### PR TITLE
fix: flicker during rename in the new file explorer

### DIFF
--- a/web-common/src/features/entity-management/actions.ts
+++ b/web-common/src/features/entity-management/actions.ts
@@ -1,21 +1,37 @@
 import { notifications } from "@rilldata/web-common/components/notifications";
+import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts";
+import { fileIsMainEntity } from "@rilldata/web-common/features/entity-management/file-selectors";
 import { extractFileName } from "@rilldata/web-common/features/sources/extract-file-name";
 import {
   runtimeServiceDeleteFile,
   runtimeServiceRenameFile,
 } from "@rilldata/web-common/runtime-client";
 import { httpRequestQueue } from "@rilldata/web-common/runtime-client/http-client";
-import { removeLeadingSlash } from "./entity-mappers";
+import { addLeadingSlash, removeLeadingSlash } from "./entity-mappers";
+import { get } from "svelte/store";
 
 export async function renameFileArtifact(
   instanceId: string,
   fromPath: string,
   toPath: string,
 ) {
-  // fromPath = removeLeadingSlash(fromPath);
   const fromName = extractFileName(fromPath);
-  // toPath = removeLeadingSlash(toPath);
   const toName = extractFileName(toPath);
+
+  if (fileIsMainEntity(fromPath)) {
+    // try and copy over kind+name proactively for main entities (.sql,.yml,.yaml)
+    // this fixes a flicker when renamed
+    const fromFileArtifact = fileArtifacts.getFileArtifact(
+      addLeadingSlash(fromPath),
+    );
+    const toFileArtifact = fileArtifacts.getFileArtifact(
+      addLeadingSlash(toPath),
+    );
+    if (!get(toFileArtifact.name)) {
+      // if there is no name set yet copy over from the source
+      toFileArtifact.name.set(get(fromFileArtifact.name));
+    }
+  }
 
   try {
     await runtimeServiceRenameFile(instanceId, {

--- a/web-common/src/features/entity-management/file-selectors.ts
+++ b/web-common/src/features/entity-management/file-selectors.ts
@@ -125,14 +125,16 @@ export async function fetchMainEntityFiles(
 ) {
   const files = await fetchAllFiles(queryClient, instanceId);
   return files
-    .filter(
-      (f) =>
-        !f.isDir &&
-        (f.path?.endsWith(".sql") ||
-          f.path?.endsWith(".yml") ||
-          f.path?.endsWith(".yaml")),
-    )
+    .filter((f) => !f.isDir && fileIsMainEntity(f.path ?? ""))
     .map((f) => f.path ?? "");
+}
+
+export function fileIsMainEntity(filePath: string) {
+  return (
+    filePath.endsWith(".sql") ||
+    filePath.endsWith(".yml") ||
+    filePath.endsWith(".yaml")
+  );
 }
 
 export async function fetchFileContent(


### PR DESCRIPTION
In the new file explorer we use name+kind to decide what type of editor we use. When renaming it switching from undefined to a valid one. This causes a flicker from entity's editor to fallback editor back to entity's editor. By proactively adding name+kind to the target path we can avoid this.