### PR TITLE
Runtime: Pass instanceID to drivers.Open for use in telemetry

### DIFF
--- a/cli/cmd/runtime/install_duckdb_extensions.go
+++ b/cli/cmd/runtime/install_duckdb_extensions.go
@@ -17,7 +17,7 @@ func InstallDuckDBExtensionsCmd(ch *cmdutil.Helper) *cobra.Command {
 		Use: "install-duckdb-extensions",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := map[string]any{"dsn": ":memory:"} // In-memory
-			h, err := drivers.Open("duckdb", cfg, false, activity.NewNoopClient(), zap.NewNop())
+			h, err := drivers.Open("duckdb", "default", cfg, activity.NewNoopClient(), zap.NewNop())
 			if err != nil {
 				return fmt.Errorf("failed to open ephemeral duckdb: %w", err)
 			}

--- a/cli/pkg/cmdutil/project.go
+++ b/cli/pkg/cmdutil/project.go
@@ -12,7 +12,7 @@ import (
 // RepoForProjectPath creates an ad-hoc drivers.RepoStore for a local project file path
 func RepoForProjectPath(path string) (drivers.RepoStore, string, error) {
 	instanceID := "default"
-	repoHandle, err := drivers.Open("file", map[string]any{"dsn": path}, false, activity.NewNoopClient(), zap.NewNop())
+	repoHandle, err := drivers.Open("file", instanceID, map[string]any{"dsn": path}, activity.NewNoopClient(), zap.NewNop())
 	if err != nil {
 		return nil, "", err
 	}

--- a/runtime/compilers/rillv1/parser_test.go
+++ b/runtime/compilers/rillv1/parser_test.go
@@ -1478,7 +1478,7 @@ func requireResourcesAndErrors(t testing.TB, p *Parser, wantResources []*Resourc
 
 func makeRepo(t testing.TB, files map[string]string) drivers.RepoStore {
 	root := t.TempDir()
-	handle, err := drivers.Open("file", map[string]any{"dsn": root}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := drivers.Open("file", "default", map[string]any{"dsn": root}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	repo, ok := handle.AsRepoStore("")

--- a/runtime/connections.go
+++ b/runtime/connections.go
@@ -23,7 +23,7 @@ func (r *Runtime) AcquireSystemHandle(ctx context.Context, connector string) (dr
 				cfg[strings.ToLower(k)] = v
 			}
 			cfg["allow_host_access"] = r.opts.AllowHostAccess
-			return r.getConnection(ctx, "", c.Type, cfg, true)
+			return r.getConnection(ctx, "", c.Type, cfg)
 		}
 	}
 	return nil, nil, fmt.Errorf("connector %s doesn't exist", connector)
@@ -40,7 +40,7 @@ func (r *Runtime) AcquireHandle(ctx context.Context, instanceID, connector strin
 		// So we take this moment to make sure the ctx gets checked for cancellation at least every once in a while.
 		return nil, nil, ctx.Err()
 	}
-	return r.getConnection(ctx, instanceID, cfg.Driver, cfg.Resolve(), false)
+	return r.getConnection(ctx, instanceID, cfg.Driver, cfg.Resolve())
 }
 
 func (r *Runtime) Repo(ctx context.Context, instanceID string) (drivers.RepoStore, func(), error) {

--- a/runtime/drivers/admin/admin.go
+++ b/runtime/drivers/admin/admin.go
@@ -63,13 +63,13 @@ type configProperties struct {
 	TempDir     string `mapstructure:"temp_dir"`
 }
 
-func (d driver) Open(cfgMap map[string]any, shared bool, ac *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
-	if shared {
-		return nil, fmt.Errorf("admin driver can't be shared")
+func (d driver) Open(instanceID string, config map[string]any, ac *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+	if instanceID == "" {
+		return nil, errors.New("admin driver can't be shared")
 	}
 
 	cfg := &configProperties{}
-	err := mapstructure.WeakDecode(cfgMap, cfg)
+	err := mapstructure.WeakDecode(config, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/drivers/athena/athena.go
+++ b/runtime/drivers/athena/athena.go
@@ -2,7 +2,7 @@ package athena
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/rilldata/rill/runtime/drivers"
@@ -76,10 +76,11 @@ type configProperties struct {
 	AllowHostAccess bool   `mapstructure:"allow_host_access"`
 }
 
-func (d driver) Open(config map[string]any, shared bool, _ *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
-	if shared {
-		return nil, fmt.Errorf("athena driver can't be shared")
+func (d driver) Open(instanceID string, config map[string]any, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+	if instanceID == "" {
+		return nil, errors.New("athena driver can't be shared")
 	}
+
 	conf := &configProperties{}
 	err := mapstructure.WeakDecode(config, conf)
 	if err != nil {

--- a/runtime/drivers/bigquery/bigquery.go
+++ b/runtime/drivers/bigquery/bigquery.go
@@ -2,6 +2,7 @@ package bigquery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"cloud.google.com/go/bigquery"
@@ -67,10 +68,11 @@ type configProperties struct {
 	AllowHostAccess bool   `mapstructure:"allow_host_access"`
 }
 
-func (d driver) Open(config map[string]any, shared bool, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
-	if shared {
-		return nil, fmt.Errorf("bigquery driver can't be shared")
+func (d driver) Open(instanceID string, config map[string]any, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+	if instanceID == "" {
+		return nil, errors.New("bigquery driver can't be shared")
 	}
+
 	conf := &configProperties{}
 	err := mapstructure.WeakDecode(config, conf)
 	if err != nil {

--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -2,6 +2,7 @@ package clickhouse
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
@@ -54,13 +55,13 @@ type configProperties struct {
 
 // Open connects to Clickhouse using std API.
 // Connection string format : https://github.com/ClickHouse/clickhouse-go?tab=readme-ov-file#dsn
-func (d driver) Open(confMap map[string]any, shared bool, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
-	if shared {
-		return nil, fmt.Errorf("clickhouse driver can't be shared")
+func (d driver) Open(instanceID string, config map[string]any, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+	if instanceID == "" {
+		return nil, errors.New("clickhouse driver can't be shared")
 	}
 
 	conf := &configProperties{}
-	err := mapstructure.WeakDecode(confMap, conf)
+	err := mapstructure.WeakDecode(config, conf)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/drivers/clickhouse/information_schema_test.go
+++ b/runtime/drivers/clickhouse/information_schema_test.go
@@ -37,7 +37,7 @@ func TestInformationSchema(t *testing.T) {
 	port, err := clickHouseContainer.MappedPort(ctx, "9000/tcp")
 	require.NoError(t, err)
 
-	conn, err := driver{}.Open(map[string]any{"dsn": fmt.Sprintf("clickhouse://clickhouse:clickhouse@%v:%v", host, port.Port())}, false, activity.NewNoopClient(), zap.NewNop())
+	conn, err := driver{}.Open("default", map[string]any{"dsn": fmt.Sprintf("clickhouse://clickhouse:clickhouse@%v:%v", host, port.Port())}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	prepareConn(t, conn)
 	t.Run("testInformationSchemaAll", func(t *testing.T) { testInformationSchemaAll(t, conn) })

--- a/runtime/drivers/drivers.go
+++ b/runtime/drivers/drivers.go
@@ -35,7 +35,7 @@ func Register(name string, driver Driver) {
 // Open opens a new connection.
 // If instanceID is empty, the connection is considered shared and its As...() functions may be invoked with different instance IDs.
 // If instanceID is not empty, the connection is considered instance-specific and its As...() functions will only be invoked with the same instance ID.
-func Open(driver string, instanceID string, config map[string]any, client *activity.Client, logger *zap.Logger) (Handle, error) {
+func Open(driver, instanceID string, config map[string]any, client *activity.Client, logger *zap.Logger) (Handle, error) {
 	d, ok := Drivers[driver]
 	if !ok {
 		return nil, fmt.Errorf("unknown driver: %s", driver)

--- a/runtime/drivers/drivers_test.go
+++ b/runtime/drivers/drivers_test.go
@@ -20,7 +20,7 @@ import (
 // This should be the only "real" test in the package. Other tests should be added
 // as subtests of TestAll.
 func TestAll(t *testing.T) {
-	var matrix = []func(t *testing.T, fn func(driver string, shared bool, cfg map[string]any)) error{
+	var matrix = []func(t *testing.T, fn func(driver string, instanceID string, cfg map[string]any)) error{
 		withDuckDB,
 		withFile,
 		withPostgres,
@@ -29,9 +29,9 @@ func TestAll(t *testing.T) {
 	}
 
 	for _, withDriver := range matrix {
-		err := withDriver(t, func(driver string, shared bool, cfg map[string]any) {
+		err := withDriver(t, func(driver string, instanceID string, cfg map[string]any) {
 			// Open
-			conn, err := drivers.Open(driver, cfg, shared, activity.NewNoopClient(), zap.NewNop())
+			conn, err := drivers.Open(driver, instanceID, cfg, activity.NewNoopClient(), zap.NewNop())
 			require.NoError(t, err)
 			require.NotNil(t, conn)
 
@@ -63,26 +63,26 @@ func TestAll(t *testing.T) {
 	}
 }
 
-func withDuckDB(t *testing.T, fn func(driver string, shared bool, cfg map[string]any)) error {
-	fn("duckdb", false, map[string]any{"dsn": ":memory:?access_mode=read_write", "pool_size": 4})
+func withDuckDB(t *testing.T, fn func(driver string, instanceID string, cfg map[string]any)) error {
+	fn("duckdb", "default", map[string]any{"dsn": ":memory:?access_mode=read_write", "pool_size": 4})
 	return nil
 }
 
-func withFile(t *testing.T, fn func(driver string, shared bool, cfg map[string]any)) error {
+func withFile(t *testing.T, fn func(driver string, instanceID string, cfg map[string]any)) error {
 	dsn := t.TempDir()
-	fn("file", false, map[string]any{"dsn": dsn})
+	fn("file", "default", map[string]any{"dsn": dsn})
 	return nil
 }
 
-func withPostgres(t *testing.T, fn func(driver string, shared bool, cfg map[string]any)) error {
+func withPostgres(t *testing.T, fn func(driver string, instanceID string, cfg map[string]any)) error {
 	pg := pgtestcontainer.New(t)
 	defer pg.Terminate(t)
 
-	fn("postgres", true, map[string]any{"dsn": pg.DatabaseURL})
+	fn("postgres", "default", map[string]any{"dsn": pg.DatabaseURL})
 	return nil
 }
 
-func withSQLite(t *testing.T, fn func(driver string, shared bool, cfg map[string]any)) error {
-	fn("sqlite", true, map[string]any{"dsn": ":memory:"})
+func withSQLite(t *testing.T, fn func(driver string, instanceID string, cfg map[string]any)) error {
+	fn("sqlite", "", map[string]any{"dsn": ":memory:"})
 	return nil
 }

--- a/runtime/drivers/drivers_test.go
+++ b/runtime/drivers/drivers_test.go
@@ -20,7 +20,7 @@ import (
 // This should be the only "real" test in the package. Other tests should be added
 // as subtests of TestAll.
 func TestAll(t *testing.T) {
-	var matrix = []func(t *testing.T, fn func(driver string, instanceID string, cfg map[string]any)) error{
+	var matrix = []func(t *testing.T, fn func(driver, instanceID string, cfg map[string]any)) error{
 		withDuckDB,
 		withFile,
 		withPostgres,
@@ -29,7 +29,7 @@ func TestAll(t *testing.T) {
 	}
 
 	for _, withDriver := range matrix {
-		err := withDriver(t, func(driver string, instanceID string, cfg map[string]any) {
+		err := withDriver(t, func(driver, instanceID string, cfg map[string]any) {
 			// Open
 			conn, err := drivers.Open(driver, instanceID, cfg, activity.NewNoopClient(), zap.NewNop())
 			require.NoError(t, err)
@@ -63,18 +63,18 @@ func TestAll(t *testing.T) {
 	}
 }
 
-func withDuckDB(t *testing.T, fn func(driver string, instanceID string, cfg map[string]any)) error {
+func withDuckDB(t *testing.T, fn func(driver, instanceID string, cfg map[string]any)) error {
 	fn("duckdb", "default", map[string]any{"dsn": ":memory:?access_mode=read_write", "pool_size": 4})
 	return nil
 }
 
-func withFile(t *testing.T, fn func(driver string, instanceID string, cfg map[string]any)) error {
+func withFile(t *testing.T, fn func(driver, instanceID string, cfg map[string]any)) error {
 	dsn := t.TempDir()
 	fn("file", "default", map[string]any{"dsn": dsn})
 	return nil
 }
 
-func withPostgres(t *testing.T, fn func(driver string, instanceID string, cfg map[string]any)) error {
+func withPostgres(t *testing.T, fn func(driver, instanceID string, cfg map[string]any)) error {
 	pg := pgtestcontainer.New(t)
 	defer pg.Terminate(t)
 
@@ -82,7 +82,7 @@ func withPostgres(t *testing.T, fn func(driver string, instanceID string, cfg ma
 	return nil
 }
 
-func withSQLite(t *testing.T, fn func(driver string, instanceID string, cfg map[string]any)) error {
+func withSQLite(t *testing.T, fn func(driver, instanceID string, cfg map[string]any)) error {
 	fn("sqlite", "", map[string]any{"dsn": ":memory:"})
 	return nil
 }

--- a/runtime/drivers/druid/druid.go
+++ b/runtime/drivers/druid/druid.go
@@ -2,6 +2,7 @@ package druid
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -51,13 +52,13 @@ type configProperties struct {
 
 // Opens a connection to Apache Druid using HTTP API.
 // Note that the Druid connection string must have the form "http://user:password@host:port/druid/v2/sql".
-func (d *driver) Open(confMap map[string]any, shared bool, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
-	if shared {
-		return nil, fmt.Errorf("druid driver can't be shared")
+func (d driver) Open(instanceID string, config map[string]any, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+	if instanceID == "" {
+		return nil, errors.New("druid driver can't be shared")
 	}
 
 	conf := &configProperties{}
-	err := mapstructure.WeakDecode(confMap, conf)
+	err := mapstructure.WeakDecode(config, conf)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/drivers/druid/druid_test.go
+++ b/runtime/drivers/druid/druid_test.go
@@ -108,7 +108,7 @@ func TestDruid(t *testing.T) {
 	require.NoError(t, err)
 
 	dd := &driver{}
-	conn, err := dd.Open(map[string]any{"dsn": druidAPIURL}, false, activity.NewNoopClient(), zap.NewNop())
+	conn, err := dd.Open("default", map[string]any{"dsn": druidAPIURL}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	olap, ok := conn.AsOLAP("")

--- a/runtime/drivers/druid/sql_driver_test.go
+++ b/runtime/drivers/druid/sql_driver_test.go
@@ -2,10 +2,11 @@ package druid
 
 import (
 	"context"
-	"github.com/rilldata/rill/runtime/drivers"
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
+
+	"github.com/rilldata/rill/runtime/drivers"
+	"github.com/stretchr/testify/require"
 
 	"github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/rilldata/rill/runtime/pkg/pbutil"
@@ -18,7 +19,7 @@ import (
  */
 func Ignore_TestDriver_types(t *testing.T) {
 	driver := &driver{}
-	handle, err := driver.Open(map[string]any{"pool_size": 2, "dsn": "http://localhost:8888/druid/v2/sql"}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := driver.Open("default", map[string]any{"pool_size": 2, "dsn": "http://localhost:8888/druid/v2/sql"}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	olap, ok := handle.AsOLAP("")
@@ -55,7 +56,7 @@ func Ignore_TestDriver_types(t *testing.T) {
 
 func Ignore_TestDriver_array_type(t *testing.T) {
 	driver := &driver{}
-	handle, err := driver.Open(map[string]any{"pool_size": 2, "dsn": "http://localhost:8888/druid/v2/sql"}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := driver.Open("default", map[string]any{"pool_size": 2, "dsn": "http://localhost:8888/druid/v2/sql"}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	olap, ok := handle.AsOLAP("")
@@ -81,7 +82,7 @@ func Ignore_TestDriver_array_type(t *testing.T) {
 
 func Ignore_TestDriver_json_type(t *testing.T) {
 	driver := &driver{}
-	handle, err := driver.Open(map[string]any{"pool_size": 2, "dsn": "http://localhost:8888/druid/v2/sql"}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := driver.Open("default", map[string]any{"pool_size": 2, "dsn": "http://localhost:8888/druid/v2/sql"}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	olap, ok := handle.AsOLAP("")
@@ -106,7 +107,7 @@ func Ignore_TestDriver_json_type(t *testing.T) {
 
 func Ignore_TestDriver_multiple_rows(t *testing.T) {
 	driver := &driver{}
-	handle, err := driver.Open(map[string]any{"pool_size": 2, "dsn": "http://localhost:8888/druid/v2/sql"}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := driver.Open("default", map[string]any{"pool_size": 2, "dsn": "http://localhost:8888/druid/v2/sql"}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	olap, ok := handle.AsOLAP("")
@@ -142,7 +143,7 @@ func Ignore_TestDriver_multiple_rows(t *testing.T) {
 
 func Ignore_TestDriver_error(t *testing.T) {
 	driver := &driver{}
-	handle, err := driver.Open(map[string]any{"pool_size": 2, "dsn": "http://localhost:8888/druid/v2/sql"}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := driver.Open("default", map[string]any{"pool_size": 2, "dsn": "http://localhost:8888/druid/v2/sql"}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	olap, ok := handle.AsOLAP("")

--- a/runtime/drivers/duckdb/config_test.go
+++ b/runtime/drivers/duckdb/config_test.go
@@ -92,7 +92,7 @@ func Test_specialCharInPath(t *testing.T) {
 	require.NoError(t, err)
 
 	dbFile := filepath.Join(path, "st@g3's.db")
-	conn, err := Driver{}.Open(map[string]any{"path": dbFile, "memory_limit_gb": "4", "cpu": "2"}, false, activity.NewNoopClient(), zap.NewNop())
+	conn, err := Driver{}.Open("default", map[string]any{"path": dbFile, "memory_limit_gb": "4", "cpu": "2"}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	config := conn.(*connection).config
 	require.Equal(t, filepath.Join(path, "st@g3's.db?custom_user_agent=rill&max_memory=4GB&threads=1"), config.DSN)
@@ -109,7 +109,7 @@ func Test_specialCharInPath(t *testing.T) {
 
 func TestOverrides(t *testing.T) {
 	cfgMap := map[string]any{"path": "duck.db", "memory_limit_gb": "4", "cpu": "2", "max_memory_gb_override": "2", "threads_override": "10"}
-	handle, err := Driver{}.Open(cfgMap, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open("default", cfgMap, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	olap, ok := handle.AsOLAP("")

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -87,9 +87,9 @@ type Driver struct {
 	name string
 }
 
-func (d Driver) Open(cfgMap map[string]any, shared bool, ac *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
-	if shared {
-		return nil, fmt.Errorf("duckdb driver can't be shared")
+func (d Driver) Open(instanceID string, cfgMap map[string]any, ac *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+	if instanceID == "" {
+		return nil, errors.New("duckdb driver can't be shared")
 	}
 
 	cfg, err := newConfig(cfgMap)
@@ -130,6 +130,7 @@ func (d Driver) Open(cfgMap map[string]any, shared bool, ac *activity.Client, lo
 
 	ctx, cancel := context.WithCancel(context.Background())
 	c := &connection{
+		instanceID:     instanceID,
 		config:         cfg,
 		logger:         logger,
 		activity:       ac,
@@ -139,7 +140,6 @@ func (d Driver) Open(cfgMap map[string]any, shared bool, ac *activity.Client, lo
 		dbCond:         sync.NewCond(&sync.Mutex{}),
 		driverConfig:   cfgMap,
 		driverName:     d.name,
-		shared:         shared,
 		connTimes:      make(map[int]time.Time),
 		ctx:            ctx,
 		cancel:         cancel,
@@ -266,7 +266,8 @@ func (d Driver) TertiarySourceConnectors(ctx context.Context, src map[string]any
 }
 
 type connection struct {
-	db *sqlx.DB
+	instanceID string
+	db         *sqlx.DB
 	// driverConfig is input config passed during Open
 	driverConfig map[string]any
 	driverName   string
@@ -296,7 +297,6 @@ type connection struct {
 	dbCond      *sync.Cond
 	dbReopen    bool
 	dbErr       error
-	shared      bool
 	// State for maintaining connection acquire times, which enables periodically checking for hanging DuckDB queries (we have previously seen deadlocks in DuckDB).
 	connTimesMu sync.Mutex
 	nextConnID  int
@@ -306,8 +306,6 @@ type connection struct {
 	cancel context.CancelFunc
 	// registration should be unregistered on close
 	registration metric.Registration
-
-	instanceID string
 }
 
 var _ drivers.OLAPStore = &connection{}
@@ -336,10 +334,6 @@ func (c *connection) AsRegistry() (drivers.RegistryStore, bool) {
 
 // AsCatalogStore Catalog implements drivers.Connection.
 func (c *connection) AsCatalogStore(instanceID string) (drivers.CatalogStore, bool) {
-	if c.shared {
-		// duckdb catalog is instance specific
-		return nil, false
-	}
 	return c, true
 }
 
@@ -360,11 +354,6 @@ func (c *connection) AsAI(instanceID string) (drivers.AIService, bool) {
 
 // AsOLAP OLAP implements drivers.Connection.
 func (c *connection) AsOLAP(instanceID string) (drivers.OLAPStore, bool) {
-	if c.shared {
-		// duckdb olap is instance specific
-		return nil, false
-	}
-	c.instanceID = instanceID
 	return c, true
 }
 

--- a/runtime/drivers/duckdb/duckdb_test.go
+++ b/runtime/drivers/duckdb/duckdb_test.go
@@ -19,7 +19,7 @@ func TestOpenDrop(t *testing.T) {
 	walpath := path + ".wal"
 	dsn := path
 
-	handle, err := Driver{}.Open(map[string]any{"path": dsn, "pool_size": 2}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open("default", map[string]any{"path": dsn, "pool_size": 2}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	olap, ok := handle.AsOLAP("")
@@ -43,7 +43,7 @@ func TestNoFatalErr(t *testing.T) {
 
 	dsn := filepath.Join(t.TempDir(), "tmp.db")
 
-	handle, err := Driver{}.Open(map[string]any{"path": dsn, "pool_size": 2}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open("default", map[string]any{"path": dsn, "pool_size": 2}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	olap, ok := handle.AsOLAP("")
@@ -105,7 +105,7 @@ func TestNoFatalErrConcurrent(t *testing.T) {
 
 	dsn := filepath.Join(t.TempDir(), "tmp.db")
 
-	handle, err := Driver{}.Open(map[string]any{"path": dsn, "pool_size": 3}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open("default", map[string]any{"path": dsn, "pool_size": 3}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	olap, ok := handle.AsOLAP("")

--- a/runtime/drivers/duckdb/olap_crud_test.go
+++ b/runtime/drivers/duckdb/olap_crud_test.go
@@ -20,14 +20,14 @@ func Test_connection_CreateTableAsSelect(t *testing.T) {
 	temp := t.TempDir()
 	require.NoError(t, os.Mkdir(filepath.Join(temp, "default"), fs.ModePerm))
 	dbPath := filepath.Join(temp, "default", "normal.db")
-	handle, err := Driver{}.Open(map[string]any{"path": dbPath}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open("default", map[string]any{"path": dbPath}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	normalConn := handle.(*connection)
 	normalConn.AsOLAP("default")
 	require.NoError(t, normalConn.Migrate(context.Background()))
 
 	dbPath = filepath.Join(temp, "default", "view.db")
-	handle, err = Driver{}.Open(map[string]any{"path": dbPath, "external_table_storage": true}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err = Driver{}.Open("default", map[string]any{"path": dbPath, "external_table_storage": true}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	viewConnection := handle.(*connection)
 	require.NoError(t, viewConnection.Migrate(context.Background()))
@@ -100,7 +100,7 @@ func Test_connection_CreateTableAsSelectMultipleTimes(t *testing.T) {
 	temp := t.TempDir()
 
 	dbPath := filepath.Join(temp, "view.db")
-	handle, err := Driver{}.Open(map[string]any{"path": dbPath, "external_table_storage": true}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open("default", map[string]any{"path": dbPath, "external_table_storage": true}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	c := handle.(*connection)
 	require.NoError(t, c.Migrate(context.Background()))
@@ -145,7 +145,7 @@ func Test_connection_DropTable(t *testing.T) {
 	temp := t.TempDir()
 
 	dbPath := filepath.Join(temp, "view.db")
-	handle, err := Driver{}.Open(map[string]any{"path": dbPath, "external_table_storage": true}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open("default", map[string]any{"path": dbPath, "external_table_storage": true}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	c := handle.(*connection)
 	require.NoError(t, c.Migrate(context.Background()))
@@ -174,7 +174,7 @@ func Test_connection_InsertTableAsSelect(t *testing.T) {
 	temp := t.TempDir()
 
 	dbPath := filepath.Join(temp, "view.db")
-	handle, err := Driver{}.Open(map[string]any{"path": dbPath, "external_table_storage": true}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open("default", map[string]any{"path": dbPath, "external_table_storage": true}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	c := handle.(*connection)
 	require.NoError(t, c.Migrate(context.Background()))
@@ -203,7 +203,7 @@ func Test_connection_RenameTable(t *testing.T) {
 	os.Mkdir(temp, fs.ModePerm)
 
 	dbPath := filepath.Join(temp, "view.db")
-	handle, err := Driver{}.Open(map[string]any{"path": dbPath, "external_table_storage": true}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open("default", map[string]any{"path": dbPath, "external_table_storage": true}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	c := handle.(*connection)
 	require.NoError(t, c.Migrate(context.Background()))
@@ -229,7 +229,7 @@ func Test_connection_RenameToExistingTable(t *testing.T) {
 	os.Mkdir(temp, fs.ModePerm)
 
 	dbPath := filepath.Join(temp, "default", "view.db")
-	handle, err := Driver{}.Open(map[string]any{"path": dbPath, "external_table_storage": true}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open("default", map[string]any{"path": dbPath, "external_table_storage": true}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	c := handle.(*connection)
 	require.NoError(t, c.Migrate(context.Background()))
@@ -258,7 +258,7 @@ func Test_connection_AddTableColumn(t *testing.T) {
 	os.Mkdir(temp, fs.ModePerm)
 
 	dbPath := filepath.Join(temp, "view.db")
-	handle, err := Driver{}.Open(map[string]any{"path": dbPath, "external_table_storage": true}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open("default", map[string]any{"path": dbPath, "external_table_storage": true}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	c := handle.(*connection)
 	require.NoError(t, c.Migrate(context.Background()))
@@ -287,7 +287,7 @@ func Test_connection_AddTableColumn(t *testing.T) {
 }
 
 func Test_connection_RenameToExistingTableOld(t *testing.T) {
-	handle, err := Driver{}.Open(map[string]any{"dsn": ":memory:"}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open("default", map[string]any{"dsn": ":memory:"}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	c := handle.(*connection)
 	require.NoError(t, c.Migrate(context.Background()))
@@ -315,14 +315,14 @@ func Test_connection_CreateTableAsSelectStorageLimits(t *testing.T) {
 	temp := t.TempDir()
 	require.NoError(t, os.Mkdir(filepath.Join(temp, "default"), fs.ModePerm))
 	dbPath := filepath.Join(temp, "default", "normal.db")
-	handle, err := Driver{}.Open(map[string]any{"path": dbPath, "storage_limit_bytes": 1024 * 1024}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open("default", map[string]any{"path": dbPath, "storage_limit_bytes": 1024 * 1024}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	normalConn := handle.(*connection)
 	normalConn.AsOLAP("default")
 	require.NoError(t, normalConn.Migrate(context.Background()))
 
 	dbPath = filepath.Join(temp, "default", "view.db")
-	handle, err = Driver{}.Open(map[string]any{"path": dbPath, "external_table_storage": true, "storage_limit_bytes": 1024 * 1024}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err = Driver{}.Open("default", map[string]any{"path": dbPath, "external_table_storage": true, "storage_limit_bytes": 1024 * 1024}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	viewConnection := handle.(*connection)
 	require.NoError(t, viewConnection.Migrate(context.Background()))
@@ -366,7 +366,7 @@ func Test_connection_InsertTableAsSelectLimits(t *testing.T) {
 	temp := t.TempDir()
 
 	dbPath := filepath.Join(temp, "view.db")
-	handle, err := Driver{}.Open(map[string]any{"path": dbPath, "external_table_storage": true, "storage_limit_bytes": 10 * 1024 * 1024}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open("default", map[string]any{"path": dbPath, "external_table_storage": true, "storage_limit_bytes": 10 * 1024 * 1024}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	c := handle.(*connection)
 	require.NoError(t, c.Migrate(context.Background()))
@@ -389,7 +389,7 @@ func Test_connection_CastEnum(t *testing.T) {
 	os.Mkdir(temp, fs.ModePerm)
 
 	dbPath := filepath.Join(temp, "view.db")
-	handle, err := Driver{}.Open(map[string]any{"path": dbPath, "external_table_storage": true}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open("default", map[string]any{"path": dbPath, "external_table_storage": true}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	c := handle.(*connection)
 	require.NoError(t, c.Migrate(context.Background()))
@@ -434,7 +434,7 @@ func Test_connection_CreateTableAsSelectWithComments(t *testing.T) {
 	temp := t.TempDir()
 	require.NoError(t, os.Mkdir(filepath.Join(temp, "default"), fs.ModePerm))
 	dbPath := filepath.Join(temp, "default", "normal.db")
-	handle, err := Driver{}.Open(map[string]any{"path": dbPath}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open("default", map[string]any{"path": dbPath}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	normalConn := handle.(*connection)
 	normalConn.AsOLAP("default")
@@ -471,7 +471,7 @@ func Test_connection_ChangingOrder(t *testing.T) {
 
 	// on cloud
 	dbPath := filepath.Join(temp, "view.db")
-	handle, err := Driver{}.Open(map[string]any{"path": dbPath, "external_table_storage": true, "allow_host_access": false}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := Driver{}.Open("default", map[string]any{"path": dbPath, "external_table_storage": true, "allow_host_access": false}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	c := handle.(*connection)
 	require.NoError(t, c.Migrate(context.Background()))
@@ -494,7 +494,7 @@ func Test_connection_ChangingOrder(t *testing.T) {
 
 	// on local
 	dbPath = filepath.Join(temp, "local.db")
-	handle, err = Driver{}.Open(map[string]any{"path": dbPath, "external_table_storage": true, "allow_host_access": true}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err = Driver{}.Open("default", map[string]any{"path": dbPath, "external_table_storage": true, "allow_host_access": true}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	c = handle.(*connection)
 	require.NoError(t, c.Migrate(context.Background()))

--- a/runtime/drivers/duckdb/olap_test.go
+++ b/runtime/drivers/duckdb/olap_test.go
@@ -212,7 +212,7 @@ func TestClose(t *testing.T) {
 }
 
 func prepareConn(t *testing.T) drivers.Handle {
-	conn, err := Driver{}.Open(map[string]any{"dsn": ":memory:?access_mode=read_write", "pool_size": 4}, false, activity.NewNoopClient(), zap.NewNop())
+	conn, err := Driver{}.Open("default", map[string]any{"dsn": ":memory:?access_mode=read_write", "pool_size": 4}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	olap, ok := conn.AsOLAP("")
@@ -248,11 +248,11 @@ func Test_safeSQLString(t *testing.T) {
 	require.NoError(t, err)
 
 	dbFile := filepath.Join(path, "st@g3's.db")
-	conn, err := Driver{}.Open(map[string]any{"path": dbFile}, false, activity.NewNoopClient(), zap.NewNop())
+	conn, err := Driver{}.Open("default", map[string]any{"path": dbFile}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	require.NoError(t, conn.Close())
 
-	conn, err = Driver{}.Open(map[string]any{}, false, activity.NewNoopClient(), zap.NewNop())
+	conn, err = Driver{}.Open("default", map[string]any{}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	olap, ok := conn.AsOLAP("")

--- a/runtime/drivers/duckdb/transporter_duckDB_to_duckDB_test.go
+++ b/runtime/drivers/duckdb/transporter_duckDB_to_duckDB_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestDuckDBToDuckDBTransfer(t *testing.T) {
 	tempDir := t.TempDir()
-	conn, err := Driver{}.Open(map[string]any{"path": fmt.Sprintf("%s.db", filepath.Join(tempDir, "tranfser"))}, false, activity.NewNoopClient(), zap.NewNop())
+	conn, err := Driver{}.Open("default", map[string]any{"path": fmt.Sprintf("%s.db", filepath.Join(tempDir, "tranfser"))}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	olap, ok := conn.AsOLAP("")
@@ -31,7 +31,7 @@ func TestDuckDBToDuckDBTransfer(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, conn.Close())
 
-	to, err := Driver{}.Open(map[string]any{"dsn": ":memory:"}, false, activity.NewNoopClient(), zap.NewNop())
+	to, err := Driver{}.Open("default", map[string]any{"dsn": ":memory:"}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	olap, _ = to.AsOLAP("")

--- a/runtime/drivers/duckdb/transporter_mysql_to_duckDB_test.go
+++ b/runtime/drivers/duckdb/transporter_mysql_to_duckDB_test.go
@@ -11,10 +11,11 @@ import (
 	"go.uber.org/zap"
 
 	"fmt"
+	"time"
+
 	_ "github.com/rilldata/rill/runtime/drivers/mysql"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"time"
 )
 
 var mysqlInitStmt = `
@@ -101,12 +102,12 @@ func allMySQLDataTypesTest(t *testing.T, db *sql.DB, dsn string) {
 	_, err := db.ExecContext(ctx, mysqlInitStmt)
 	require.NoError(t, err)
 
-	handle, err := drivers.Open("mysql", map[string]any{"dsn": dsn}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := drivers.Open("mysql", "default", map[string]any{"dsn": dsn}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	require.NotNil(t, handle)
 
 	sqlStore, _ := handle.AsSQLStore()
-	to, err := drivers.Open("duckdb", map[string]any{"dsn": ":memory:"}, false, activity.NewNoopClient(), zap.NewNop())
+	to, err := drivers.Open("duckdb", "default", map[string]any{"dsn": ":memory:"}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	olap, _ := to.AsOLAP("")
 

--- a/runtime/drivers/duckdb/transporter_postgres_to_duckDB_test.go
+++ b/runtime/drivers/duckdb/transporter_postgres_to_duckDB_test.go
@@ -66,12 +66,12 @@ func allDataTypesTest(t *testing.T, db *sql.DB, dbURL string) {
 	_, err := db.ExecContext(ctx, sqlStmt)
 	require.NoError(t, err)
 
-	handle, err := drivers.Open("postgres", map[string]any{"database_url": dbURL}, false, activity.NewNoopClient(), zap.NewNop())
+	handle, err := drivers.Open("postgres", "default", map[string]any{"database_url": dbURL}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	require.NotNil(t, handle)
 
 	sqlStore, _ := handle.AsSQLStore()
-	to, err := drivers.Open("duckdb", map[string]any{"dsn": ":memory:"}, false, activity.NewNoopClient(), zap.NewNop())
+	to, err := drivers.Open("duckdb", "default", map[string]any{"dsn": ":memory:"}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	olap, _ := to.AsOLAP("")
 

--- a/runtime/drivers/duckdb/transporter_sqlite_to_duckDB_test.go
+++ b/runtime/drivers/duckdb/transporter_sqlite_to_duckDB_test.go
@@ -29,7 +29,7 @@ func Test_sqliteToDuckDB_Transfer(t *testing.T) {
 	require.NoError(t, err)
 	db.Close()
 
-	to, err := drivers.Open("duckdb", map[string]any{"dsn": ":memory:"}, false, activity.NewNoopClient(), zap.NewNop())
+	to, err := drivers.Open("duckdb", "default", map[string]any{"dsn": ":memory:"}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	olap, _ := to.AsOLAP("")
 

--- a/runtime/drivers/duckdb/transporter_test.go
+++ b/runtime/drivers/duckdb/transporter_test.go
@@ -588,7 +588,7 @@ func TestIterativeJSONIngestionWithVariableSchema(t *testing.T) {
 }
 
 func runOLAPStore(t *testing.T) drivers.OLAPStore {
-	conn, err := drivers.Open("duckdb", map[string]any{"dsn": ":memory:?access_mode=read_write"}, false, activity.NewNoopClient(), zap.NewNop())
+	conn, err := drivers.Open("duckdb", "default", map[string]any{"dsn": ":memory:?access_mode=read_write"}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	olap, canServe := conn.AsOLAP("")
 	require.True(t, canServe)

--- a/runtime/drivers/gcs/gcs.go
+++ b/runtime/drivers/gcs/gcs.go
@@ -69,10 +69,11 @@ type configProperties struct {
 	AllowHostAccess bool   `mapstructure:"allow_host_access"`
 }
 
-func (d driver) Open(config map[string]any, shared bool, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
-	if shared {
-		return nil, fmt.Errorf("gcs driver can't be shared")
+func (d driver) Open(instanceID string, config map[string]any, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+	if instanceID == "" {
+		return nil, errors.New("gcs driver can't be shared")
 	}
+
 	conf := &configProperties{}
 	err := mapstructure.WeakDecode(config, conf)
 	if err != nil {

--- a/runtime/drivers/github/github.go
+++ b/runtime/drivers/github/github.go
@@ -56,9 +56,9 @@ type configProperties struct {
 	TempDir string `mapstructure:"temp_dir"`
 }
 
-func (d driver) Open(config map[string]any, shared bool, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
-	if shared {
-		return nil, fmt.Errorf("github driver can't be shared")
+func (d driver) Open(instanceID string, config map[string]any, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+	if instanceID == "" {
+		return nil, errors.New("github driver can't be shared")
 	}
 
 	conf := &configProperties{}
@@ -102,7 +102,6 @@ func (d driver) Open(config map[string]any, shared bool, client *activity.Client
 		tempdir:      tempdir,
 		projectdir:   projectDir,
 		singleflight: &singleflight.Group{},
-		shared:       shared,
 	}, nil
 }
 

--- a/runtime/drivers/https/https.go
+++ b/runtime/drivers/https/https.go
@@ -2,6 +2,7 @@ package https
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -37,9 +38,9 @@ var spec = drivers.Spec{
 
 type driver struct{}
 
-func (d driver) Open(config map[string]any, shared bool, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
-	if shared {
-		return nil, fmt.Errorf("https driver can't be shared")
+func (d driver) Open(instanceID string, config map[string]any, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+	if instanceID == "" {
+		return nil, errors.New("https driver can't be shared")
 	}
 	conn := &connection{
 		config: config,

--- a/runtime/drivers/mysql/mysql.go
+++ b/runtime/drivers/mysql/mysql.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"context"
+	"errors"
 
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/pkg/activity"
@@ -48,7 +49,10 @@ var spec = drivers.Spec{
 
 type driver struct{}
 
-func (d driver) Open(config map[string]any, shared bool, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+func (d driver) Open(instanceID string, config map[string]any, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+	if instanceID == "" {
+		return nil, errors.New("mysql driver can't be shared")
+	}
 	// actual db connection is opened during query
 	return &connection{
 		config: config,

--- a/runtime/drivers/postgres/postgres.go
+++ b/runtime/drivers/postgres/postgres.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"errors"
 
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/pkg/activity"
@@ -46,7 +47,10 @@ var spec = drivers.Spec{
 
 type driver struct{}
 
-func (d driver) Open(config map[string]any, shared bool, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+func (d driver) Open(instanceID string, config map[string]any, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+	if instanceID == "" {
+		return nil, errors.New("postgres driver can't be shared")
+	}
 	// actual db connection is opened during query
 	return &connection{
 		config: config,

--- a/runtime/drivers/redshift/redshift.go
+++ b/runtime/drivers/redshift/redshift.go
@@ -2,7 +2,7 @@ package redshift
 
 import (
 	"context"
-	"fmt"
+	"errors"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/rilldata/rill/runtime/drivers"
@@ -101,10 +101,11 @@ type configProperties struct {
 	AllowHostAccess bool   `mapstructure:"allow_host_access"`
 }
 
-func (d driver) Open(config map[string]any, shared bool, _ *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
-	if shared {
-		return nil, fmt.Errorf("redshift driver can't be shared")
+func (d driver) Open(instanceID string, config map[string]any, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+	if instanceID == "" {
+		return nil, errors.New("redshift driver can't be shared")
 	}
+
 	conf := &configProperties{}
 	err := mapstructure.WeakDecode(config, conf)
 	if err != nil {

--- a/runtime/drivers/salesforce/salesforce.go
+++ b/runtime/drivers/salesforce/salesforce.go
@@ -2,6 +2,7 @@ package salesforce
 
 import (
 	"context"
+	"errors"
 
 	force "github.com/ForceCLI/force/lib"
 	"github.com/rilldata/rill/runtime/drivers"
@@ -119,7 +120,10 @@ var spec = drivers.Spec{
 
 type driver struct{}
 
-func (d driver) Open(config map[string]any, shared bool, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+func (d driver) Open(instanceID string, config map[string]any, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+	if instanceID == "" {
+		return nil, errors.New("salesforce driver can't be shared")
+	}
 	// actual db connection is opened during query
 	return &connection{
 		config: config,

--- a/runtime/drivers/slack/slack.go
+++ b/runtime/drivers/slack/slack.go
@@ -35,8 +35,8 @@ func (d driver) Spec() drivers.Spec {
 	return spec
 }
 
-func (d driver) Open(config map[string]any, shared bool, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
-	if shared {
+func (d driver) Open(instanceID string, config map[string]any, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+	if instanceID == "" {
 		return nil, fmt.Errorf("slack driver can't be shared")
 	}
 	conf := &configProperties{}

--- a/runtime/drivers/snowflake/snowflake.go
+++ b/runtime/drivers/snowflake/snowflake.go
@@ -2,6 +2,7 @@ package snowflake
 
 import (
 	"context"
+	"errors"
 
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/pkg/activity"
@@ -47,7 +48,10 @@ var spec = drivers.Spec{
 
 type driver struct{}
 
-func (d driver) Open(config map[string]any, shared bool, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+func (d driver) Open(instanceID string, config map[string]any, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+	if instanceID == "" {
+		return nil, errors.New("snowflake driver can't be shared")
+	}
 	// actual db connection is opened during query
 	return &connection{
 		config: config,

--- a/runtime/drivers/sqlite/sqlite.go
+++ b/runtime/drivers/sqlite/sqlite.go
@@ -22,7 +22,7 @@ func init() {
 
 type driver struct{}
 
-func (d driver) Open(config map[string]any, shared bool, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
+func (d driver) Open(_ string, config map[string]any, client *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
 	dsn, ok := config["dsn"].(string)
 	if !ok {
 		return nil, fmt.Errorf("require dsn to open sqlite connection")
@@ -47,7 +47,6 @@ func (d driver) Open(config map[string]any, shared bool, client *activity.Client
 	return &connection{
 		db:     dbx,
 		config: config,
-		shared: shared,
 	}, nil
 }
 
@@ -89,7 +88,6 @@ func (d driver) TertiarySourceConnectors(ctx context.Context, src map[string]any
 type connection struct {
 	db     *sqlx.DB
 	config map[string]any
-	shared bool
 }
 
 var _ drivers.Handle = &connection{}

--- a/runtime/server/queries_test.go
+++ b/runtime/server/queries_test.go
@@ -132,7 +132,7 @@ func TestServer_UpdateLimit_UNION(t *testing.T) {
 }
 
 func prepareOLAPStore(t *testing.T) drivers.OLAPStore {
-	conn, err := drivers.Open("duckdb", map[string]any{"dsn": ":memory:?access_mode=read_write", "pool_size": 4}, false, activity.NewNoopClient(), zap.NewNop())
+	conn, err := drivers.Open("duckdb", "default", map[string]any{"dsn": ":memory:?access_mode=read_write", "pool_size": 4}, activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 	olap, ok := conn.AsOLAP("")
 	require.True(t, ok)


### PR DESCRIPTION
Refactors the `drivers.Open` function signature:

```go
// New
Open(instanceID string, config map[string]any, client *activity.Client, logger *zap.Logger) (Handle, error)

// Previous
Open(config map[string]any, shared bool, client *activity.Client, logger *zap.Logger) (Handle, error)
```

The `shared bool` args is replaced by a convention that a connection is considered shared if `instanceID == ""` (this is clarified in docstrings throughout the PR).

This change enables capturing the `instanceID` when a connection is opened (e.g. for use in telemetry). Previously, it had to be captured in the connection's `As...` functions (as added in [this PR](https://github.com/rilldata/rill/pull/4614)), which is prone to race conditions, which are currently causing race tests to fail on main ([example](https://github.com/rilldata/rill/actions/runs/8719855754/job/23920121688)).