### PR TITLE
fix: remove beta tag for pivot

### DIFF
--- a/web-common/src/features/dashboards/tab-bar/TabBar.svelte
+++ b/web-common/src/features/dashboards/tab-bar/TabBar.svelte
@@ -28,10 +28,12 @@
     {
       label: "Explore",
       Icon: Chart,
+      beta: false,
     },
     {
       label: "Pivot",
       Icon: Pivot,
+      beta: false,
     },
   ];
 

--- a/web-common/src/features/dashboards/tab-bar/TabBar.svelte
+++ b/web-common/src/features/dashboards/tab-bar/TabBar.svelte
@@ -32,7 +32,6 @@
     {
       label: "Pivot",
       Icon: Pivot,
-      beta: true,
     },
   ];
 


### PR DESCRIPTION
Removing the beta tag from the Pivot tab.
Keeping the beta logic around in case we add more tabs/feature surface areas in the future.