### PR TITLE
remove limit for druid exactify toplist query

### DIFF
--- a/runtime/queries/metricsview_comparison_toplist.go
+++ b/runtime/queries/metricsview_comparison_toplist.go
@@ -183,6 +183,10 @@ func (q *MetricsViewComparison) executeDruidApproximateToplist(ctx context.Conte
 	q.addDimsAsFilter()
 
 	q.Measures = originalMeasures
+
+	// remove limit since we have already added filter with only toplist values and order clause will be present
+	q.Limit = 0
+
 	return q.executeToplist(ctx, olap, mv, priority, security)
 }
 


### PR DESCRIPTION
For druid if there are more than 5 measures in the toplist or if toplist returns results equal to the limit rows then we do a second query by adding those top values as a filter. It has been observed in past for kargo and now for automatad as well that if we remove the limit clause from this query then this is run as a groupby query (instead of topN) and it is much faster than topN. More details in an internal notion doc.