### PR TITLE
Populate available_time_ranges with defaults

### DIFF
--- a/runtime/server/generate_metrics_view.go
+++ b/runtime/server/generate_metrics_view.go
@@ -398,6 +398,7 @@ type metricsViewYAML struct {
 	Dimensions         []*metricsViewDimensionYAML `yaml:"dimensions,omitempty"`
 	Measures           []*metricsViewMeasureYAML   `yaml:"measures,omitempty"`
 	AvailableTimeZones []string                    `yaml:"available_time_zones,omitempty"`
+	AvailableTimeRanges []string                   `yaml:"available_time_ranges,omitempty"`
 }
 
 type metricsViewDimensionYAML struct {
@@ -429,6 +430,27 @@ func marshalMetricsViewYAML(doc *metricsViewYAML, aiPowered bool) (string, error
 		"Asia/Tokyo",
 		"Australia/Sydney",
 	}
+
+	doc.AvailableTimeRanges = []string{
+		"PT6H",
+		"PT24H",
+		"P7D",
+		"P14D",
+		"P4W",
+		"P3M",
+		"P12M",
+		"rill-TD",
+		"rill-WTD",
+		"rill-MTD",
+		"rill-QTD",
+		"rill-YTD",
+		"rill-PDC",
+		"rill-PWC",
+		"rill-PMC",
+		"rill-PQC",
+		"rill-PYC",
+	}
+
 
 	buf := new(bytes.Buffer)
 

--- a/runtime/server/generate_metrics_view.go
+++ b/runtime/server/generate_metrics_view.go
@@ -387,18 +387,18 @@ func generateMetricsViewYAMLSimpleMeasures(schema *runtimev1.StructType) []*metr
 // metricsViewYAML is a struct for generating a metrics view YAML file.
 // We do not use the parser's structs since they are not suitable for generating pretty output YAML.
 type metricsViewYAML struct {
-	Kind               string                      `yaml:"kind,omitempty"`
-	Title              string                      `yaml:"title,omitempty"`
-	Connector          string                      `yaml:"connector,omitempty"`
-	Database           string                      `yaml:"database,omitempty"`
-	DatabaseSchema     string                      `yaml:"database_schema,omitempty"`
-	Table              string                      `yaml:"table,omitempty"`
-	Model              string                      `yaml:"model,omitempty"`
-	TimeDimension      string                      `yaml:"timeseries,omitempty"`
-	Dimensions         []*metricsViewDimensionYAML `yaml:"dimensions,omitempty"`
-	Measures           []*metricsViewMeasureYAML   `yaml:"measures,omitempty"`
-	AvailableTimeZones []string                    `yaml:"available_time_zones,omitempty"`
-	AvailableTimeRanges []string                   `yaml:"available_time_ranges,omitempty"`
+	Kind                string                      `yaml:"kind,omitempty"`
+	Title               string                      `yaml:"title,omitempty"`
+	Connector           string                      `yaml:"connector,omitempty"`
+	Database            string                      `yaml:"database,omitempty"`
+	DatabaseSchema      string                      `yaml:"database_schema,omitempty"`
+	Table               string                      `yaml:"table,omitempty"`
+	Model               string                      `yaml:"model,omitempty"`
+	TimeDimension       string                      `yaml:"timeseries,omitempty"`
+	Dimensions          []*metricsViewDimensionYAML `yaml:"dimensions,omitempty"`
+	Measures            []*metricsViewMeasureYAML   `yaml:"measures,omitempty"`
+	AvailableTimeZones  []string                    `yaml:"available_time_zones,omitempty"`
+	AvailableTimeRanges []string                    `yaml:"available_time_ranges,omitempty"`
 }
 
 type metricsViewDimensionYAML struct {
@@ -450,7 +450,6 @@ func marshalMetricsViewYAML(doc *metricsViewYAML, aiPowered bool) (string, error
 		"rill-PQC",
 		"rill-PYC",
 	}
-
 
 	buf := new(bytes.Buffer)
 

--- a/web-common/src/lib/time/config.ts
+++ b/web-common/src/lib/time/config.ts
@@ -271,6 +271,30 @@ export const PERIOD_TO_DATE_RANGES: TimeRangeMetaSet = {
       ],
     },
   },
+  [TimeRangePreset.QUARTER_TO_DATE]: {
+    label: "Quarter to Date",
+    rangePreset: RangePresetType.PERIOD_ANCHORED,
+    defaultComparison: TimeComparisonOption.CONTIGUOUS,
+    start: {
+      reference: ReferencePoint.MIN_OF_LATEST_DATA_AND_NOW,
+      transformation: [
+        {
+          period: Period.QUARTER,
+          truncationType: TimeTruncationType.START_OF_PERIOD,
+        },
+      ],
+    },
+    end: {
+      reference: ReferencePoint.MIN_OF_LATEST_DATA_AND_NOW,
+      transformation: [
+        { duration: "P1D", operationType: TimeOffsetType.ADD },
+        {
+          period: Period.DAY,
+          truncationType: TimeTruncationType.START_OF_PERIOD,
+        },
+      ],
+    },
+  },
   [TimeRangePreset.YEAR_TO_DATE]: {
     label: "Year to Date",
     rangePreset: RangePresetType.PERIOD_ANCHORED,

--- a/web-common/src/lib/time/types.ts
+++ b/web-common/src/lib/time/types.ts
@@ -120,6 +120,7 @@ export enum TimeRangePreset {
   LAST_7_DAYS = "P7D",
   LAST_14_DAYS = "P14D",
   LAST_4_WEEKS = "P4W",
+  LAST_3_MONTHS = "P3M",
   LAST_12_MONTHS = "P12M",
   TODAY = "rill-TD",
   WEEK_TO_DATE = "rill-WTD",


### PR DESCRIPTION
This PR populates the `available_time_ranges` field in a dashboard config with our standard defaults. It also solves a bug where `rill-QTD` would not populate because it did not have a corresponding entry in the `PERIOD_TO_DATE` dictionary.