### PR TITLE
Fix rename of a folder not correctly identifying inner entities are renamed

### DIFF
--- a/runtime/compilers/rillv1/parser.go
+++ b/runtime/compilers/rillv1/parser.go
@@ -246,6 +246,16 @@ func (p *Parser) IsIgnored(path string) bool {
 	return !pathIsYAML(path) && !pathIsSQL(path) && !pathIsDotEnv(path)
 }
 
+func (p *Parser) FindFilesInDir(dir string) []string {
+	var files []string
+	for path := range p.resourcesForPath {
+		if strings.HasPrefix(path, dir) {
+			files = append(files, path)
+		}
+	}
+	return files
+}
+
 // reload resets the parser's state and then parses the entire project.
 func (p *Parser) reload(ctx context.Context) error {
 	// Reset state

--- a/runtime/compilers/rillv1/parser.go
+++ b/runtime/compilers/rillv1/parser.go
@@ -246,14 +246,24 @@ func (p *Parser) IsIgnored(path string) bool {
 	return !pathIsYAML(path) && !pathIsSQL(path) && !pathIsDotEnv(path)
 }
 
-func (p *Parser) FindFilesInDir(dir string) []string {
-	var files []string
+func (p *Parser) IsInRestrictedDir(path string) bool {
+	return strings.HasPrefix(path, "/tmp")
+}
+
+// TrackedPathsInDir returns the paths under the given directory that the parser currently has cached results for.
+func (p *Parser) TrackedPathsInDir(dir string) []string {
+	// Ensure dir has a trailing path separator
+	if dir != "" && dir[len(dir)-1] != '/' {
+		dir += "/"
+	}
+	// Find paths
+	var paths []string
 	for path := range p.resourcesForPath {
 		if strings.HasPrefix(path, dir) {
-			files = append(files, path)
+			paths = append(paths, path)
 		}
 	}
-	return files
+	return paths
 }
 
 // reload resets the parser's state and then parses the entire project.

--- a/runtime/compilers/rillv1/parser.go
+++ b/runtime/compilers/rillv1/parser.go
@@ -15,10 +15,17 @@ import (
 )
 
 // Built-in parser limits
-var (
+const (
 	maxFiles    = 10000
 	maxFileSize = 1 << 17 // 128kb
 )
+
+// IgnoredPaths is a list of paths that are ignored by the parser.
+var IgnoredPaths = []string{
+	"/tmp",
+	"/.git",
+	"/node_modules",
+}
 
 // Resource parsed from code files.
 // One file may output multiple resources and multiple files may contribute config to one resource.
@@ -240,14 +247,23 @@ func (p *Parser) Reparse(ctx context.Context, paths []string) (*Diff, error) {
 	return p.reparseExceptRillYAML(ctx, paths)
 }
 
-// IsIgnored returns true if the path will be ignored by Reparse.
-// It's useful for callers to avoid triggering a reparse when they know the path is not relevant.
+// IsIgnored returns true if the path (and any files in nested directories) should be ignored.
 func (p *Parser) IsIgnored(path string) bool {
-	return !pathIsYAML(path) && !pathIsSQL(path) && !pathIsDotEnv(path)
+	for _, dir := range IgnoredPaths {
+		if path == dir {
+			return true
+		}
+		if strings.HasPrefix(path, dir) && path[len(dir)] == '/' {
+			return true
+		}
+	}
+	return false
 }
 
-func (p *Parser) IsInRestrictedDir(path string) bool {
-	return strings.HasPrefix(path, "/tmp")
+// IsSkippable returns true if the path will be skipped by Reparse.
+// It's useful for callers to avoid triggering a reparse when they know the path is not relevant.
+func (p *Parser) IsSkippable(path string) bool {
+	return !pathIsYAML(path) && !pathIsSQL(path) && !pathIsDotEnv(path)
 }
 
 // TrackedPathsInDir returns the paths under the given directory that the parser currently has cached results for.
@@ -285,9 +301,16 @@ func (p *Parser) reload(ctx context.Context) error {
 		return fmt.Errorf("could not list project files: %w", err)
 	}
 
-	paths := make([]string, len(files))
-	for i, file := range files {
-		paths[i] = file.Path
+	// Build paths slice
+	paths := make([]string, 0, len(files))
+	for _, file := range files {
+		// Filter out ignored files
+		// TODO: Incorporate the ignore list directly into the ListRecursive call.
+		if p.IsIgnored(file.Path) {
+			continue
+		}
+
+		paths = append(paths, file.Path)
 	}
 
 	// Parse all files
@@ -346,7 +369,10 @@ func (p *Parser) reparseExceptRillYAML(ctx context.Context, paths []string) (*Di
 		}
 		seenPaths[path] = true
 
-		// Skip files that aren't SQL or YAML or .env file
+		// Skip ignores files and files that aren't SQL or YAML or .env file
+		if p.IsIgnored(path) {
+			continue
+		}
 		isSQL := pathIsSQL(path)
 		isYAML := pathIsYAML(path)
 		isDotEnv := pathIsDotEnv(path)
@@ -355,12 +381,16 @@ func (p *Parser) reparseExceptRillYAML(ctx context.Context, paths []string) (*Di
 		}
 
 		// If a file exists at path, add it to the parse list
-		_, err := p.Repo.Stat(ctx, path)
+		info, err := p.Repo.Stat(ctx, path)
 		if err == nil {
+			if info.IsDir {
+				continue
+			}
 			parsePaths = append(parsePaths, path)
 		} else if !os.IsNotExist(err) {
 			return nil, fmt.Errorf("unexpected file stat error: %w", err)
 		}
+		// NOTE: Continue even if the file has been deleted because it may have associated state we need to clear.
 
 		// Check if path is .env and clear it (so we can re-parse it)
 		if isDotEnv {

--- a/runtime/drivers/admin/repo.go
+++ b/runtime/drivers/admin/repo.go
@@ -110,6 +110,7 @@ func (h *Handle) Stat(ctx context.Context, filePath string) (*drivers.RepoObject
 
 	return &drivers.RepoObjectStat{
 		LastUpdated: info.ModTime(),
+		IsDir:       info.IsDir(),
 	}, nil
 }
 

--- a/runtime/drivers/file/repo.go
+++ b/runtime/drivers/file/repo.go
@@ -91,6 +91,7 @@ func (c *connection) Stat(ctx context.Context, filePath string) (*drivers.RepoOb
 
 	return &drivers.RepoObjectStat{
 		LastUpdated: info.ModTime(),
+		IsDir:       info.IsDir(),
 	}, nil
 }
 

--- a/runtime/drivers/github/repo.go
+++ b/runtime/drivers/github/repo.go
@@ -120,6 +120,7 @@ func (c *connection) Stat(ctx context.Context, filePath string) (*drivers.RepoOb
 
 	return &drivers.RepoObjectStat{
 		LastUpdated: info.ModTime(),
+		IsDir:       info.IsDir(),
 	}, nil
 }
 

--- a/runtime/drivers/repo.go
+++ b/runtime/drivers/repo.go
@@ -37,6 +37,7 @@ type WatchEvent struct {
 
 type RepoObjectStat struct {
 	LastUpdated time.Time
+	IsDir       bool
 }
 
 var ErrFileAlreadyExists = errors.New("file already exists")


### PR DESCRIPTION
When a folder is renamed files within the new folder is considered as new files rather than renames. This is an attempt at fixing it by going through all files in the cache that have the prefix of a deleted folder.