### PR TITLE
Add preliminary components to cloud custom dashboard page

### DIFF
--- a/web-admin/src/components/layout/ContentContainer.svelte
+++ b/web-admin/src/components/layout/ContentContainer.svelte
@@ -1,3 +1,3 @@
-<div class="mx-8 my-8 sm:mx-16 lg:mx-32 lg:my-12 2xl:mx-40">
+<div class="mx-8 my-8 sm:mx-16 lg:mx-32 lg:my-12 2xl:mx-40 pb-8">
   <slot />
 </div>

--- a/web-admin/src/routes/+layout.svelte
+++ b/web-admin/src/routes/+layout.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { beforeNavigate } from "$app/navigation";
   import { page } from "$app/stores";
-  import { isMetricsExplorerPage } from "@rilldata/web-admin/features/navigation/nav-utils";
   import { initCloudMetrics } from "@rilldata/web-admin/features/telemetry/initCloudMetrics";
   import NotificationCenter from "@rilldata/web-common/components/notifications/NotificationCenter.svelte";
   import {

--- a/web-admin/src/routes/+layout.svelte
+++ b/web-admin/src/routes/+layout.svelte
@@ -35,12 +35,6 @@
   onMount(() => errorEventHandler?.addJavascriptErrorListeners());
 
   $: isEmbed = $page.url.pathname === "/-/embed";
-
-  // The Dashboard (Metrics Explorer) component assumes a page height of `h-screen`. This is somehow motivated by
-  // making the line charts and leaderboards scroll independently.
-  // However, `h-screen` screws up overflow/scroll on all other pages, so we only apply it to the dashboard.
-  // (This all feels hacky and should not be considered optimal.)
-  $: onMetricsExplorerPage = isMetricsExplorerPage($page);
 </script>
 
 <svelte:head>
@@ -49,9 +43,7 @@
 
 <RillTheme>
   <QueryClientProvider client={queryClient}>
-    <main
-      class="flex flex-col min-h-screen {onMetricsExplorerPage && 'h-screen'}"
-    >
+    <main class="flex flex-col min-h-screen h-screen">
       {#if !isEmbed}
         <TopNavigationBar />
       {/if}

--- a/web-admin/src/routes/[organization]/[project]/-/dashboards/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/dashboards/[dashboard]/+page.svelte
@@ -1,11 +1,28 @@
 <script lang="ts">
+  import CustomDashboardEmbed from "@rilldata/web-common/features/custom-dashboards/CustomDashboardEmbed.svelte";
+  import {
+    ResourceKind,
+    useResource,
+  } from "@rilldata/web-common/features/entity-management/resource-selectors.js";
   import { page } from "$app/stores";
+  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store.js";
 
-  $: customDashboardName = $page.params.dashboard;
+  $: instanceId = $runtime?.instanceId;
+  $: dashboardName = $page.params.dashboard;
+
+  $: dashboardQuery = useResource(
+    instanceId,
+    dashboardName,
+    ResourceKind.Dashboard,
+  );
+
+  $: dashboard = $dashboardQuery.data?.dashboard.spec;
+
+  $: ({
+    components = [],
+    columns,
+    gap,
+  } = dashboard || { components: [], columns: 10, gap: 2 });
 </script>
 
-<div>
-  A "read-only" version of the Custom Dashboard named <span
-    class="font-semibold">{customDashboardName}</span
-  > goes here.
-</div>
+<CustomDashboardEmbed {components} {columns} {gap} />

--- a/web-common/src/features/custom-dashboards/Chart.svelte
+++ b/web-common/src/features/custom-dashboards/Chart.svelte
@@ -22,6 +22,7 @@
     error = null;
   } catch (e: unknown) {
     error = JSON.stringify(e);
+    console.error(error);
   }
 
   $: metricsQuery = $chart?.data?.chart?.spec?.resolverProperties;

--- a/web-common/src/features/custom-dashboards/Chart.svelte
+++ b/web-common/src/features/custom-dashboards/Chart.svelte
@@ -37,5 +37,5 @@
 </script>
 
 {#if parsedVegaSpec}
-  <VegaLiteRenderer data={{ table: data }} spec={parsedVegaSpec} {error} />
+  <VegaLiteRenderer data={{ table: data }} spec={parsedVegaSpec} />
 {/if}

--- a/web-common/src/features/custom-dashboards/CustomDashboardEmbed.svelte
+++ b/web-common/src/features/custom-dashboards/CustomDashboardEmbed.svelte
@@ -28,7 +28,7 @@
   width={DEFAULT_WIDTH}
   height={maxBottom * gridCell}
   bind:contentRect
-  color="bg-gray-100"
+  color="bg-slate-50"
 >
   {#each components as component, i (i)}
     {#if component.chart && component.width && component.height}


### PR DESCRIPTION
Adds structure to the custom dashboard page for `web-admin`. It is expected that this route may throw errors depending on your chart/custom-dashboard spec as Chart data fetching, which is currently using a manual client, throws uncaught errors.

This also removes a conditional check that was being used to apply `h-screen` on the root component for `web-admin`. I didn't see any obvious issues caused by removing this, though we should probably rework the layout for `web-admin` to allow for a sticky `TopNavigationBar` and scrollable tables.