### PR TITLE
File Explorer: make the Tables section position user-controlled

### DIFF
--- a/web-common/src/features/tables/TableAssets.svelte
+++ b/web-common/src/features/tables/TableAssets.svelte
@@ -58,7 +58,7 @@
       direction="NS"
       side="top"
       min={10}
-      basis={MIN_HEIGHT}
+      basis={showTables ? startingHeight : MIN_HEIGHT}
       max={2000}
       absolute={false}
     />

--- a/web-common/src/features/tables/TableAssets.svelte
+++ b/web-common/src/features/tables/TableAssets.svelte
@@ -3,6 +3,7 @@
   import { flip } from "svelte/animate";
   import { slide } from "svelte/transition";
   import CaretDownIcon from "../../components/icons/CaretDownIcon.svelte";
+  import Resizer from "../../layout/Resizer.svelte";
   import { LIST_SLIDE_DURATION as duration } from "../../layout/config";
   import NavigationEntry from "../../layout/navigation/NavigationEntry.svelte";
   import {
@@ -15,7 +16,12 @@
   import { makeFullyQualifiedTableName } from "./olap-config";
   import { useTables } from "./selectors";
 
+  export let startingHeight: number;
+
+  const MIN_HEIGHT = 43; // The height of the "Tables" header
+
   let showTables = true;
+  let sectionHeight = startingHeight;
 
   $: instance = createRuntimeServiceGetInstance($runtime.instanceId);
   $: connectorInstanceId = $instance.data?.instance?.instanceId;
@@ -42,9 +48,22 @@
 </script>
 
 {#if connectorInstanceId && olapConnector}
-  <section class="flex flex-col border-t border-t-gray-200">
+  <section
+    class="flex flex-col border-t border-t-gray-200"
+    style:min-height="{MIN_HEIGHT}px"
+    style:height="{sectionHeight}px"
+  >
+    <Resizer
+      bind:dimension={sectionHeight}
+      direction="NS"
+      side="top"
+      min={10}
+      basis={MIN_HEIGHT}
+      max={2000}
+      absolute={false}
+    />
     <button
-      class="flex justify-between items-center w-full pl-2 pr-3.5 pt-3 pb-2 text-gray-500"
+      class="flex justify-between items-center w-full pl-2 pr-3.5 pt-2 pb-2 text-gray-500"
       on:click={() => {
         showTables = !showTables;
       }}
@@ -56,7 +75,7 @@
           : '-rotate-180'}"
       />
     </button>
-    <div class="h-fit flex flex-col">
+    <div class="h-fit flex flex-col overflow-y-auto">
       {#if showTables}
         <ol transition:slide={{ duration }}>
           {#if tables && tables.length > 0}

--- a/web-common/src/layout/navigation/Navigation.svelte
+++ b/web-common/src/layout/navigation/Navigation.svelte
@@ -23,6 +23,7 @@
   let previousWidth: number;
   let container: HTMLElement;
   let resizing = false;
+  let navWrapperHeight: number;
 
   function handleResize(
     e: UIEvent & {
@@ -61,9 +62,12 @@
 
     <AddAssetButton />
     <div class="scroll-container">
-      <div class="nav-wrapper">
+      <div class="nav-wrapper" bind:clientHeight={navWrapperHeight}>
         <FileExplorer />
-        <TableAssets />
+        <div class="grow" />
+        {#if navWrapperHeight}
+          <TableAssets startingHeight={navWrapperHeight / 2} />
+        {/if}
       </div>
     </div>
     <Footer />
@@ -91,12 +95,12 @@
   }
 
   .nav-wrapper {
-    @apply flex flex-col h-fit w-full gap-y-2;
+    @apply flex flex-col h-full w-full gap-y-2;
   }
 
   .scroll-container {
     @apply overflow-y-auto overflow-x-hidden;
-    @apply transition-colors h-full bg-white pb-8;
+    @apply transition-colors h-full bg-white;
   }
 
   .sidebar:not(.resizing) {


### PR DESCRIPTION
- The Tables section is now initially positioned at the midpoint of the sidebar
- The section can be moved up/down by the user

![image](https://github.com/rilldata/rill/assets/14206386/0d003895-8991-4e06-bd30-722d7587a2af)

Contributes to https://github.com/rilldata/rill-private-issues/issues/309