### PR TITLE
Fix measure filter returning no data

### DIFF
--- a/web-common/src/features/dashboards/filters/measure-filters/measure-filter-utils.ts
+++ b/web-common/src/features/dashboards/filters/measure-filters/measure-filter-utils.ts
@@ -86,9 +86,11 @@ export function prepareMeasureFilterResolutions(
         // then add a `false` in the condition to not match any rows
         return {
           ready: true,
-          filter: {
-            val: false,
-          },
+          filter: createAndExpression([
+            {
+              val: false,
+            },
+          ]),
         };
       }
 


### PR DESCRIPTION
When there is no data for a measure filter instead of showing an empty dashboard it shows a full dashboard.

This fixes that use case and makes sure we apply empty response filters properly.