### PR TITLE
File Explorer: Fix new file names

### DIFF
--- a/web-common/src/features/entity-management/file-selectors.spec.ts
+++ b/web-common/src/features/entity-management/file-selectors.spec.ts
@@ -1,4 +1,7 @@
-import { useFileNamesInDirectorySelector } from "@rilldata/web-common/features/entity-management/file-selectors";
+import {
+  useDirectoryNamesInDirectorySelector,
+  useFileNamesInDirectorySelector,
+} from "@rilldata/web-common/features/entity-management/file-selectors";
 import { describe, expect, it } from "vitest";
 
 describe("useFileNamesInDirectorySelector", () => {
@@ -57,5 +60,64 @@ describe("useFileNamesInDirectorySelector", () => {
     const directoryPath = "/a";
     const result = useFileNamesInDirectorySelector(data, directoryPath);
     expect(result).toEqual(["alpha.txt", "beta.txt", "zeta.txt"]);
+  });
+});
+
+describe("useDirectoryNamesInDirectorySelector", () => {
+  it("returns an empty array if no files are present", () => {
+    const data = { files: undefined };
+    const directoryPath = "/";
+    const result = useDirectoryNamesInDirectorySelector(data, directoryPath);
+    expect(result).toEqual([]);
+  });
+
+  it("filters out non-directory entries", () => {
+    const data = {
+      files: [
+        { path: "/a/file.txt", isDir: false },
+        { path: "/a/b", isDir: true },
+      ],
+    };
+    const directoryPath = "/a";
+    const result = useDirectoryNamesInDirectorySelector(data, directoryPath);
+    expect(result).toEqual(["b"]);
+  });
+
+  it("excludes directories not directly under the specified path", () => {
+    const data = {
+      files: [
+        { path: "/a/b", isDir: true },
+        { path: "/a/b/c", isDir: true },
+      ],
+    };
+    const directoryPath = "/a";
+    const result = useDirectoryNamesInDirectorySelector(data, directoryPath);
+    expect(result).toEqual(["b"]);
+  });
+
+  it("does not include the same directory or nested deeper levels", () => {
+    const data = {
+      files: [
+        { path: "/a", isDir: true },
+        { path: "/a/b", isDir: true },
+        { path: "/a/b/c", isDir: true },
+      ],
+    };
+    const directoryPath = "/a";
+    const result = useDirectoryNamesInDirectorySelector(data, directoryPath);
+    expect(result).toEqual(["b"]);
+  });
+
+  it("sorts directory names alphabetically and case-insensitively", () => {
+    const data = {
+      files: [
+        { path: "/a/Zeta", isDir: true },
+        { path: "/a/alpha", isDir: true },
+        { path: "/a/Beta", isDir: true },
+      ],
+    };
+    const directoryPath = "/a";
+    const result = useDirectoryNamesInDirectorySelector(data, directoryPath);
+    expect(result).toEqual(["alpha", "Beta", "Zeta"]);
   });
 });

--- a/web-common/src/features/entity-management/file-selectors.spec.ts
+++ b/web-common/src/features/entity-management/file-selectors.spec.ts
@@ -1,0 +1,61 @@
+import { useFileNamesInDirectorySelector } from "@rilldata/web-common/features/entity-management/file-selectors";
+import { describe, expect, it } from "vitest";
+
+describe("useFileNamesInDirectorySelector", () => {
+  it("returns an empty array if no files are present", () => {
+    const data = { files: undefined };
+    const directoryPath = "/";
+    const result = useFileNamesInDirectorySelector(data, directoryPath);
+    expect(result).toEqual([]);
+  });
+
+  it("filters out files not in the immediate directory", () => {
+    const data = {
+      files: [
+        { path: "/a/file1.txt", isDir: false },
+        { path: "/a/b/file2.txt", isDir: false },
+        { path: "/b/file3.txt", isDir: false },
+      ],
+    };
+    const directoryPath = "/a";
+    const result = useFileNamesInDirectorySelector(data, directoryPath);
+    expect(result).toEqual(["file1.txt"]);
+  });
+
+  it("filters out directories and includes only files in the immediate directory", () => {
+    const data = {
+      files: [
+        { path: "/a/file1.txt", isDir: false },
+        { path: "/a/b", isDir: true },
+      ],
+    };
+    const directoryPath = "/a";
+    const result = useFileNamesInDirectorySelector(data, directoryPath);
+    expect(result).toEqual(["file1.txt"]);
+  });
+
+  it("ensures files from subdirectories are not included", () => {
+    const data = {
+      files: [
+        { path: "/a/file1.txt", isDir: false },
+        { path: "/a/b/file2.txt", isDir: false },
+      ],
+    };
+    const directoryPath = "/a";
+    const result = useFileNamesInDirectorySelector(data, directoryPath);
+    expect(result).toEqual(["file1.txt"]);
+  });
+
+  it("sorts filenames alphabetically and case-insensitively", () => {
+    const data = {
+      files: [
+        { path: "/a/zeta.txt", isDir: false },
+        { path: "/a/alpha.txt", isDir: false },
+        { path: "/a/beta.txt", isDir: false },
+      ],
+    };
+    const directoryPath = "/a";
+    const result = useFileNamesInDirectorySelector(data, directoryPath);
+    expect(result).toEqual(["alpha.txt", "beta.txt", "zeta.txt"]);
+  });
+});

--- a/web-common/src/features/entity-management/file-selectors.ts
+++ b/web-common/src/features/entity-management/file-selectors.ts
@@ -168,47 +168,51 @@ export function useFileNamesInDirectory(
   return createRuntimeServiceListFiles(instanceId, undefined, {
     query: {
       select: (data) => {
-        if (!data.files) {
-          return [];
-        }
-
-        const fileNames = data.files
-          // Filter for files in the immediate directory
-          .filter((file) => {
-            if (!file.path) {
-              return false;
-            }
-
-            const isNotDirectory = !file.isDir;
-            const startsWithDirectory = file.path?.startsWith(directoryPath);
-            const doesNotHaveSubdirectory =
-              directoryPath === "/"
-                ? file.path?.indexOf("/", 1) === -1
-                : file.path?.lastIndexOf("/") === directoryPath.length;
-
-            return (
-              isNotDirectory && startsWithDirectory && doesNotHaveSubdirectory
-            );
-          })
-
-          // Remove the directory path from each file path
-          .map((file) => {
-            const startIdx =
-              directoryPath === "/" ? 1 : directoryPath.length + 1;
-            return file.path?.substring(startIdx) ?? "";
-          })
-
-          // Sort filenames alphabetically, case-insensitive
-          .sort((fileNameA, fileNameB) =>
-            fileNameA.localeCompare(fileNameB, undefined, {
-              sensitivity: "base",
-            }),
-          );
-
-        return fileNames;
+        return useFileNamesInDirectorySelector(data, directoryPath);
       },
     },
   });
+}
+
+export function useFileNamesInDirectorySelector(
+  data: V1ListFilesResponse,
+  directoryPath: string,
+) {
+  if (!data.files) {
+    return [];
+  }
+
+  const fileNames = data.files
+    // Filter for files in the immediate directory
+    .filter((file) => {
+      if (!file.path) {
+        return false;
+      }
+
+      const isNotDirectory = !file.isDir;
+      const startsWithDirectory = file.path?.startsWith(directoryPath);
+      const doesNotHaveSubdirectory =
+        directoryPath === "/"
+          ? file.path?.indexOf("/", 1) === -1
+          : file.path?.lastIndexOf("/") === directoryPath.length;
+
+      return isNotDirectory && startsWithDirectory && doesNotHaveSubdirectory;
+    })
+
+    // Remove the directory path from each file path
+    .map((file) => {
+      const startIdx = directoryPath === "/" ? 1 : directoryPath.length + 1;
+      return file.path?.substring(startIdx) ?? "";
+    })
+
+    // Sort filenames alphabetically, case-insensitive
+    .sort((fileNameA, fileNameB) =>
+      fileNameA.localeCompare(fileNameB, undefined, {
+        sensitivity: "base",
+      }),
+    );
+
+  return fileNames;
 }
 
 export function useDirectoryNamesInDirectory(

--- a/web-common/src/features/entity-management/file-selectors.ts
+++ b/web-common/src/features/entity-management/file-selectors.ts
@@ -111,11 +111,18 @@ export function useAllFileNames(queryClient: QueryClient, instanceId: string) {
 export async function fetchAllFileNames(
   queryClient: QueryClient,
   instanceId: string,
+  includeExtensions = true,
 ) {
   const files = await fetchAllFiles(queryClient, instanceId);
   return files
     .filter((f) => !f.isDir)
     .map((f) => f.path?.split("/").pop() ?? "")
+    .map((fileName) => {
+      if (!includeExtensions) {
+        return fileName.split(".").slice(0, -1).join(".");
+      }
+      return fileName;
+    })
     .filter(Boolean);
 }
 
@@ -153,7 +160,9 @@ export function useFileNamesInDirectory(
   instanceId: string,
   directoryPath: string,
 ) {
-  directoryPath += "/";
+  if (!directoryPath.startsWith("/")) {
+    directoryPath += "/";
+  }
   return createRuntimeServiceListFiles(instanceId, undefined, {
     query: {
       select: (data) => {
@@ -181,7 +190,9 @@ export function useDirectoryNamesInDirectory(
   instanceId: string,
   directoryPath: string,
 ) {
-  directoryPath += "/";
+  if (!directoryPath.startsWith("/")) {
+    directoryPath += "/";
+  }
   return createRuntimeServiceListFiles(instanceId, undefined, {
     query: {
       select: (data) => {

--- a/web-common/src/features/entity-management/file-selectors.ts
+++ b/web-common/src/features/entity-management/file-selectors.ts
@@ -227,55 +227,62 @@ export function useDirectoryNamesInDirectory(
   return createRuntimeServiceListFiles(instanceId, undefined, {
     query: {
       select: (data) => {
-        if (!data.files) {
-          return [];
-        }
-
-        const directoryNames = data.files
-          // Filter for directories in the immediate directory
-          .filter((file) => {
-            if (!file.path) {
-              return false;
-            }
-
-            const isDirectory = file.isDir;
-            const startsWithDirectory = file.path?.startsWith(directoryPath);
-            const existsAtSameDirectoryLevel =
-              directoryPath === "/"
-                ? file.path?.indexOf("/", 1) === -1
-                : file.path?.lastIndexOf("/") === directoryPath.length;
-            const isNotSameDirectory = file.path !== directoryPath;
-
-            return (
-              isDirectory &&
-              startsWithDirectory &&
-              existsAtSameDirectoryLevel &&
-              isNotSameDirectory
-            );
-          })
-
-          // Extract the directory name from the path
-          .map((file) => {
-            if (!file.path) {
-              return "";
-            }
-
-            const startIdx = directoryPath.length + 1;
-            return directoryPath === "/"
-              ? file.path.substring(1)
-              : file.path.substring(startIdx);
-          })
-
-          // Sort directory names alphabetically, case-insensitive
-          .sort((dirNameA, dirNameB) => {
-            if (!dirNameA || !dirNameB) return 0;
-            return dirNameA.localeCompare(dirNameB, undefined, {
-              sensitivity: "base",
-            });
-          });
-
-        return directoryNames;
+        return useDirectoryNamesInDirectorySelector(data, directoryPath);
       },
     },
   });
+}
+
+export function useDirectoryNamesInDirectorySelector(
+  data: V1ListFilesResponse,
+  directoryPath: string,
+) {
+  if (!data.files) {
+    return [];
+  }
+
+  const directoryNames = data.files
+    // Filter for directories in the immediate directory
+    .filter((file) => {
+      if (!file.path) {
+        return false;
+      }
+
+      const isDirectory = file.isDir;
+      const startsWithDirectory = file.path?.startsWith(directoryPath);
+      const existsAtSameDirectoryLevel =
+        directoryPath === "/"
+          ? file.path?.indexOf("/", 1) === -1
+          : file.path?.lastIndexOf("/") === directoryPath.length;
+      const isNotSameDirectory = file.path !== directoryPath;
+
+      return (
+        isDirectory &&
+        startsWithDirectory &&
+        existsAtSameDirectoryLevel &&
+        isNotSameDirectory
+      );
+    })
+
+    // Extract the directory name from the path
+    .map((file) => {
+      if (!file.path) {
+        return "";
+      }
+
+      const startIdx = directoryPath.length + 1;
+      return directoryPath === "/"
+        ? file.path.substring(1)
+        : file.path.substring(startIdx);
+    })
+
+    // Sort directory names alphabetically, case-insensitive
+    .sort((dirNameA, dirNameB) => {
+      if (!dirNameA || !dirNameB) return 0;
+      return dirNameA.localeCompare(dirNameB, undefined, {
+        sensitivity: "base",
+      });
+    });
+
+  return directoryNames;
 }

--- a/web-common/src/features/entity-management/resource-selectors.ts
+++ b/web-common/src/features/entity-management/resource-selectors.ts
@@ -23,6 +23,10 @@ export enum ResourceKind {
   Dashboard = "rill.runtime.v1.Dashboard",
   API = "rill.runtime.v1.API",
 }
+export type UserFacingResourceKinds = Exclude<
+  ResourceKind,
+  ResourceKind.ProjectParser
+>;
 export const SingletonProjectParserName = "parser";
 export const ResourceShortNameToKind: Record<string, ResourceKind> = {
   source: ResourceKind.Source,

--- a/web-common/src/features/file-explorer/FileExplorer.svelte
+++ b/web-common/src/features/file-explorer/FileExplorer.svelte
@@ -3,12 +3,12 @@
   import { page } from "$app/stores";
   import { notifications } from "@rilldata/web-common/components/notifications";
   import GenerateChartYAMLPrompt from "@rilldata/web-common/features/charts/prompt/GenerateChartYAMLPrompt.svelte";
-  import { removeLeadingSlash } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import RenameAssetModal from "@rilldata/web-common/features/entity-management/RenameAssetModal.svelte";
   import {
     deleteFileArtifact,
     renameFileArtifact,
   } from "@rilldata/web-common/features/entity-management/actions";
+  import { removeLeadingSlash } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import NavEntryPortal from "@rilldata/web-common/features/file-explorer/NavEntryPortal.svelte";
   import {
     NavDragData,
@@ -68,6 +68,7 @@
   async function onDelete(filePath: string) {
     await deleteFileArtifact(instanceId, filePath);
     if (
+      !!$page.params.file &&
       removeLeadingSlash($page.params.file) === removeLeadingSlash(filePath)
     ) {
       await goto("/");

--- a/web-common/src/features/file-explorer/new-files.ts
+++ b/web-common/src/features/file-explorer/new-files.ts
@@ -1,6 +1,9 @@
 import { fetchAllFileNames } from "@rilldata/web-common/features/entity-management/file-selectors";
 import { getName } from "@rilldata/web-common/features/entity-management/name-utils";
-import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
+import {
+  ResourceKind,
+  UserFacingResourceKinds,
+} from "@rilldata/web-common/features/entity-management/resource-selectors";
 import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
 import { runtimeServicePutFile } from "@rilldata/web-common/runtime-client";
 import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
@@ -9,11 +12,10 @@ import { get } from "svelte/store";
 export async function handleEntityCreate(kind: ResourceKind) {
   if (!(kind in ResourceKindMap)) return;
   const instanceId = get(runtime).instanceId;
-  const allNames = await fetchAllFileNames(queryClient, instanceId);
-  const { name, folder, baseContent, extension } = ResourceKindMap[kind];
+  const allNames = await fetchAllFileNames(queryClient, instanceId, false);
+  const { name, extension, baseContent } = ResourceKindMap[kind];
   const newName = getName(name, allNames);
-
-  const newPath = `${folder ?? name + "s"}/${newName}${extension ?? ".yaml"}`;
+  const newPath = `${name + "s"}/${newName}${extension}`;
 
   await runtimeServicePutFile(instanceId, newPath, {
     blob: baseContent,
@@ -24,17 +26,16 @@ export async function handleEntityCreate(kind: ResourceKind) {
 }
 
 const ResourceKindMap: Record<
-  ResourceKind,
+  UserFacingResourceKinds,
   {
     name: string;
-    folder?: string; // adds "s" to name by default
+    extension: string;
     baseContent: string;
-    extension?: string;
   }
 > = {
-  [ResourceKind.ProjectParser]: { baseContent: "", name: "" },
   [ResourceKind.Source]: {
     name: "source",
+    extension: ".yaml",
     baseContent: "",
   },
   [ResourceKind.Model]: {
@@ -46,12 +47,14 @@ select ...
   },
   [ResourceKind.MetricsView]: {
     name: "dashboard",
+    extension: ".yaml",
     baseContent: `kind: metrics_view
 
 `,
   },
   [ResourceKind.API]: {
     name: "api",
+    extension: ".yaml",
     baseContent: `kind: api
 
 sql:
@@ -60,6 +63,7 @@ sql:
   },
   [ResourceKind.Chart]: {
     name: "chart",
+    extension: ".yaml",
     baseContent: `kind: chart
 data:
   metrics_sql: |
@@ -83,12 +87,14 @@ vega_lite: |
   },
   [ResourceKind.Dashboard]: {
     name: "custom-dashboard",
+    extension: ".yaml",
     baseContent: `kind: dashboard
 columns: 10
 gap: 2`,
   },
   [ResourceKind.Theme]: {
     name: "theme",
+    extension: ".yaml",
     baseContent: `kind: theme
 colors:
   primary: crimson 
@@ -97,6 +103,7 @@ colors:
   },
   [ResourceKind.Report]: {
     name: "report",
+    extension: ".yaml",
     baseContent: `kind: report
 
 ...
@@ -104,6 +111,7 @@ colors:
   },
   [ResourceKind.Alert]: {
     name: "alert",
+    extension: ".yaml",
     baseContent: `kind: alert
 
 ...

--- a/web-local/src/routes/(application)/custom-dashboards/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/custom-dashboards/[name]/+page.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
+  import { goto } from "$app/navigation";
   import { page } from "$app/stores";
-  import Button from "web-common/src/components/button/Button.svelte";
   import Label from "@rilldata/web-common/components/forms/Label.svelte";
   import Switch from "@rilldata/web-common/components/forms/Switch.svelte";
-  import { notifications } from "@rilldata/web-common/components/notifications";
   import ChartsEditor from "@rilldata/web-common/features/charts/editor/ChartsEditor.svelte";
   import AddChartMenu from "@rilldata/web-common/features/custom-dashboards/AddChartMenu.svelte";
   import CustomDashboardEditor from "@rilldata/web-common/features/custom-dashboards/CustomDashboardEditor.svelte";
@@ -40,6 +39,7 @@
   } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { slide } from "svelte/transition";
+  import Button from "web-common/src/components/button/Button.svelte";
   import { parse, stringify } from "yaml";
 
   const DEFAULT_EDITOR_HEIGHT = 300;
@@ -117,27 +117,19 @@
 
   $: ({ columns, gap, components = [] } = dashboard ?? ({} as V1DashboardSpec));
 
-  const onChangeCallback = async (
+  async function onChangeCallback(
     e: Event & {
       currentTarget: EventTarget & HTMLInputElement;
     },
-  ) => {
-    if (!e.currentTarget) return;
-    if (!e.currentTarget.value.match(/^[a-zA-Z_][a-zA-Z0-9_]*$/)) {
-      notifications.send({
-        message:
-          "Model name must start with a letter or underscore and contain only letters, numbers, and underscores",
-      });
-      e.currentTarget.value = customDashboardName; // resets the input
-      return;
-    }
-    await handleEntityRename(
-      instanceId,
+  ) {
+    const newRoute = await handleEntityRename(
+      $runtime.instanceId,
       e.currentTarget,
       filePath,
-      customDashboardName,
+      fileName,
     );
-  };
+    if (newRoute) await goto(newRoute);
+  }
 
   async function updateChartFile(e: CustomEvent<string>) {
     const content = e.detail;


### PR DESCRIPTION
This PR fixes cases where new files were not properly incrementing their names to e.g. `untitled_file_1`. There are a few permutations to handle:
- New blank files in the root directory
- New blank files in subdirectories
- New directories in the root directory
- New directories in subdirectories
- New resource files in their resource-specific directories

The PR also fixes some other CRUD-related errors:
- Removes a no-longer-needed constraint on renaming custom dashboards
- Fixes a console error when deleting files from the root page