### PR TITLE
Handle errors when rendering the `PreviewTable`

### DIFF
--- a/web-common/src/components/WorkspaceError.svelte
+++ b/web-common/src/components/WorkspaceError.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import AlertCircleOutline from "./icons/AlertCircleOutline.svelte";
+
+  export let message: string;
+</script>
+
+<div class="size-full grid place-content-center">
+  <div class="flex flex-col items-center gap-y-2">
+    <AlertCircleOutline size="40px" />
+    <h1>
+      {message}
+    </h1>
+  </div>
+</div>

--- a/web-local/src/routes/(application)/[type=workspace]/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/[type=workspace]/[name]/+page.svelte
@@ -2,7 +2,7 @@
   import { beforeNavigate, goto } from "$app/navigation";
   import { page } from "$app/stores";
   import type { SelectionRange } from "@codemirror/state";
-  import AlertCircleOutline from "@rilldata/web-common/components/icons/AlertCircleOutline.svelte";
+  import WorkspaceError from "@rilldata/web-common/components/WorkspaceError.svelte";
   import ConnectedPreviewTable from "@rilldata/web-common/components/preview-table/ConnectedPreviewTable.svelte";
   import {
     getFileAPIPathFromNameAndType,
@@ -270,14 +270,7 @@
 </svelte:head>
 
 {#if fileNotFound}
-  <div class="size-full grid place-content-center">
-    <div class="flex flex-col items-center gap-y-2">
-      <AlertCircleOutline size="40px" />
-      <h1>
-        Unable to find file {assetName}
-      </h1>
-    </div>
-  </div>
+  <WorkspaceError message="File not found." />
 {:else}
   <WorkspaceContainer>
     <WorkspaceHeader

--- a/web-local/src/routes/(application)/dashboard/[name]/edit/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/edit/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { beforeNavigate, goto } from "$app/navigation";
   import { page } from "$app/stores";
+  import WorkspaceError from "@rilldata/web-common/components/WorkspaceError.svelte";
   import Button from "@rilldata/web-common/components/button/Button.svelte";
-  import AlertCircleOutline from "@rilldata/web-common/components/icons/AlertCircleOutline.svelte";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { initLocalUserPreferenceStore } from "@rilldata/web-common/features/dashboards/user-preferences";
@@ -114,12 +114,7 @@
 </svelte:head>
 
 {#if fileNotFound}
-  <div class="size-full grid place-content-center">
-    <div class="flex flex-col items-center gap-y-2">
-      <AlertCircleOutline size="40px" />
-      <h1>Page not found</h1>
-    </div>
-  </div>
+  <WorkspaceError message="File not found." />
 {:else}
   <WorkspaceContainer inspector={isModelingSupported}>
     <WorkspaceHeader

--- a/web-local/src/routes/(application)/files/[...file]/+page.svelte
+++ b/web-local/src/routes/(application)/files/[...file]/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { afterNavigate } from "$app/navigation";
   import { page } from "$app/stores";
+  import WorkspaceError from "@rilldata/web-common/components/WorkspaceError.svelte";
   import { yaml } from "@rilldata/web-common/components/editor/presets/yaml";
-  import AlertCircleOutline from "@rilldata/web-common/components/icons/AlertCircleOutline.svelte";
   import Editor from "@rilldata/web-common/features/editor/Editor.svelte";
   import FileWorkspaceHeader from "@rilldata/web-common/features/editor/FileWorkspaceHeader.svelte";
   import {
@@ -95,21 +95,9 @@
 </script>
 
 {#if fileTypeUnsupported}
-  <div class="size-full grid place-content-center">
-    <div class="flex flex-col items-center gap-y-2">
-      <AlertCircleOutline size="40px" />
-      <h1>Unsupported file type.</h1>
-    </div>
-  </div>
+  <WorkspaceError message="Unsupported file type." />
 {:else if fileError}
-  <div class="size-full grid place-content-center">
-    <div class="flex flex-col items-center gap-y-2">
-      <AlertCircleOutline size="40px" />
-      <h1>
-        Error loading file: {fileErrorMessage}
-      </h1>
-    </div>
-  </div>
+  <WorkspaceError message={`Error loading file: ${fileErrorMessage}`} />
 {:else if isSource || isModel}
   <SourceModelPage data={{ fileArtifact }} />
 {:else if isDashboard}


### PR DESCRIPTION
Previously, we weren't handling errors when rendering a Preview Table. This became apparent when a ClickHouse table contained some invalid UTF-8 strings. This PR shows an error message in these circumstances.

Closes #4542 

Before:

![image](https://github.com/rilldata/rill/assets/14206386/806c0c31-fc36-41e8-84e8-90b582cbe005)

After:

![image](https://github.com/rilldata/rill/assets/14206386/a3d0e96d-f730-4471-b614-9d7d5a364c05)