### PR TITLE
Use resource-specific reconcile terminology

### DIFF
--- a/web-common/src/features/entity-management/ReconcilingSpinner.svelte
+++ b/web-common/src/features/entity-management/ReconcilingSpinner.svelte
@@ -5,20 +5,31 @@
   import { EntityStatus } from "@rilldata/web-common/features/entity-management/types";
 
   $: reconcilingItems = fileArtifacts.getReconcilingResourceNames();
+  $: typedReconcilingItems = $reconcilingItems.map((reconcilingItem) => ({
+    name: reconcilingItem.name as string,
+    kind: reconcilingItem.kind as string,
+  }));
 
-  const KindToName: Partial<Record<ResourceKind, string>> = {
-    [ResourceKind.Source]: "source",
-    [ResourceKind.Model]: "model",
-    [ResourceKind.MetricsView]: "dashboard",
+  const userFriendlyPhrases: Partial<Record<ResourceKind, string>> = {
+    [ResourceKind.API]: "Building API",
+    [ResourceKind.Alert]: "Building alert",
+    [ResourceKind.Chart]: "Building chart",
+    [ResourceKind.Dashboard]: "Building dashboard",
+    [ResourceKind.MetricsView]: "Building dashboard",
+    [ResourceKind.Model]: "Building model",
+    [ResourceKind.Report]: "Building report",
+    [ResourceKind.Source]: "Ingesting source",
+    [ResourceKind.Theme]: "Building theme",
   };
 </script>
 
-<div class="h-full flex flex-col gap-y-2 items-center justify-center">
+<div class="size-full p-2 flex flex-col gap-y-2 items-center justify-center">
   <Spinner size="1.5em" status={EntityStatus.Running} />
-  <div class="flex flex-col gap-y-1">
-    {#each $reconcilingItems as reconcilingItem}
-      <div>
-        Ingesting {KindToName[reconcilingItem.kind ?? ""]}
+  <div class="flex flex-col w-full text-center gap-y-1">
+    {#each typedReconcilingItems as reconcilingItem}
+      {@const kind = reconcilingItem.kind}
+      <div class="w-full truncate">
+        {userFriendlyPhrases[kind]}
         <span class="font-mono font-medium">{reconcilingItem.name}</span>
       </div>
     {/each}


### PR DESCRIPTION
Previously in Rill Developer, we were using the term "Ingesting" whenever a resource was reconciling. This PR uses the term "Building" for all resources except for Sources.

Closes [#4543](https://github.com/rilldata/rill/issues/4543)