### PR TITLE
Fix loading state of Source/Model preview table

### DIFF
--- a/web-local/src/routes/(application)/[type=workspace]/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/[type=workspace]/[name]/+page.svelte
@@ -350,7 +350,11 @@
           {#if type === "source" && $allErrors[0]?.message}
             <ErrorPane {filePath} errorMessage={$allErrors[0].message} />
           {:else if tableName}
-            <ConnectedPreviewTable {connector} table={tableName} />
+            <ConnectedPreviewTable
+              {connector}
+              table={tableName}
+              loading={resourceIsReconciling}
+            />
           {/if}
           <svelte:fragment slot="error">
             {#if type === "model"}


### PR DESCRIPTION
Fixes a regression where the Source/Model workspace's preview table was not showing its loading state when the Source/Model was reconciling.

Now:
![image](https://github.com/rilldata/rill/assets/14206386/14d55d7e-3c44-4c73-8b82-6b863f42f6f8)
