### PR TITLE
Fix CSP error for Vega charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33873,6 +33873,7 @@
         "tsx": "^4.7.0",
         "ua-parser-js": "^1.0.2",
         "uuid": "^9.0.0",
+        "vega-interpreter": "^1.0.5",
         "vega-lite": "^5.17.0",
         "vitest": "^0.31.0",
         "yaml": "^2.1.3",

--- a/web-common/package.json
+++ b/web-common/package.json
@@ -82,6 +82,7 @@
     "tsx": "^4.7.0",
     "ua-parser-js": "^1.0.2",
     "uuid": "^9.0.0",
+    "vega-interpreter": "^1.0.5",
     "vega-lite": "^5.17.0",
     "vitest": "^0.31.0",
     "yaml": "^2.1.3",

--- a/web-common/src/features/charts/render/VegaLiteRenderer.svelte
+++ b/web-common/src/features/charts/render/VegaLiteRenderer.svelte
@@ -5,9 +5,10 @@
     SignalListeners,
     VegaLite,
     View,
-    type EmbedOptions,
     VisualizationSpec,
+    type EmbedOptions,
   } from "svelte-vega";
+  import { expressionInterpreter } from "vega-interpreter";
 
   export let data: Record<string, unknown> = {};
   export let spec: VisualizationSpec;
@@ -25,6 +26,8 @@
   $: options = <EmbedOptions>{
     config: getRillTheme(),
     renderer: "svg",
+    ast: true,
+    expr: expressionInterpreter,
     actions: false,
     logLevel: 0, // only show errors
     width: customDashboard ? width : undefined,

--- a/web-local/svelte.config.js
+++ b/web-local/svelte.config.js
@@ -11,6 +11,11 @@ const config = {
     adapter: adapter({
       fallback: "index.html",
     }),
+    csp: {
+      directives: {
+        "script-src": ["self"],
+      },
+    },
     files: {
       assets: "../web-common/static",
     },


### PR DESCRIPTION
Fix CSP errors using vega interpreter. 
Also sets the `web-local` CSP policy to match with cloud.