### PR TITLE
Fix: Chart height override

### DIFF
--- a/web-common/src/features/custom-dashboards/Component.svelte
+++ b/web-common/src/features/custom-dashboards/Component.svelte
@@ -60,8 +60,9 @@
 >
   <div class="size-full relative">
     {#if ResizeHandleComponent && !embed}
-      {#each allSides as side}
-        <ResizeHandleComponent
+      {#each allSides as side, i (i)}
+        <svelte:component
+          this={ResizeHandleComponent}
           {scale}
           {i}
           {side}

--- a/web-common/src/features/custom-dashboards/CustomDashboardEmbed.svelte
+++ b/web-common/src/features/custom-dashboards/CustomDashboardEmbed.svelte
@@ -51,7 +51,7 @@
           fontSize={component.fontSize ?? defaults.FONT_SIZE}
         />
       {:else if component.chart}
-        <Chart chartName={component.chart} />
+        <Chart {chartView} chartName={component.chart} />
       {/if}
     </Component>
   {/each}


### PR DESCRIPTION
The `chartView` override was not being passed down correctly.

Also adds a key to the ResizeHandle each block and uses `svelte:component` to silence a warning.