### PR TITLE
Rill Developer: Fix Welcome workflow

### DIFF
--- a/web-common/src/features/welcome/ProjectCards.svelte
+++ b/web-common/src/features/welcome/ProjectCards.svelte
@@ -59,7 +59,6 @@
       },
     });
     await goto(firstPage);
-    //  consider additionally opening up the project in a new tab
   }
 </script>
 

--- a/web-common/src/features/welcome/ProjectCards.svelte
+++ b/web-common/src/features/welcome/ProjectCards.svelte
@@ -21,14 +21,14 @@
       description: "Monitoring cloud infrastructure",
       image:
         "bg-[url('$img/welcome-bg-cost-monitoring.png')] bg-no-repeat bg-cover",
-      firstPage: "/dashboard/customer_margin_dash",
+      firstPage: "/files/dashboards/customer_margin_dash.yaml",
     },
     {
       name: "rill-openrtb-prog-ads",
       title: "OpenRTB Programmatic Ads",
       description: "Real-time Bidding (RTB) advertising",
       image: "bg-[url('$img/welcome-bg-openrtb.png')] bg-no-repeat bg-cover",
-      firstPage: "/dashboard/auction",
+      firstPage: "/files/dashboards/auction.yaml",
     },
     {
       name: "rill-github-analytics",
@@ -36,7 +36,7 @@
       description: "A Git project's commit activity",
       image:
         "bg-[url('$img/welcome-bg-github-analytics.png')] bg-no-repeat bg-cover",
-      firstPage: "/dashboard/duckdb_commits",
+      firstPage: "/files/dashboards/duckdb_commits.yaml",
     },
   ];
 
@@ -59,6 +59,7 @@
       },
     });
     await goto(firstPage);
+    //  consider additionally opening up the project in a new tab
   }
 </script>
 

--- a/web-local/src/routes/(application)/dashboard/[name]/edit/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/edit/+page.svelte
@@ -10,6 +10,7 @@
   import { getFileAPIPathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import type { FileArtifact } from "@rilldata/web-common/features/entity-management/file-artifacts";
   import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts";
+  import { resourceIsLoading } from "@rilldata/web-common/features/entity-management/resource-selectors";
   import { EntityType } from "@rilldata/web-common/features/entity-management/types";
   import { handleEntityRename } from "@rilldata/web-common/features/entity-management/ui-actions";
   import { featureFlags } from "@rilldata/web-common/features/feature-flags";
@@ -75,8 +76,10 @@
 
   $: allErrorsQuery = fileArtifact.getAllErrors(queryClient, instanceId);
   $: allErrors = $allErrorsQuery;
+  $: resourceQuery = fileArtifact.getResource(queryClient, instanceId);
+  $: isResourceLoading = resourceIsLoading($resourceQuery.data);
 
-  $: previewDisbaled = !yaml.length || !!allErrors?.length;
+  $: previewDisabled = !yaml.length || !!allErrors?.length || isResourceLoading;
 
   $: if (!yaml?.length) {
     previewStatus = [
@@ -135,7 +138,7 @@
         <PreviewButton
           dashboardName={metricViewName}
           status={previewStatus}
-          disabled={previewDisbaled}
+          disabled={previewDisabled}
         />
       </div>
     </WorkspaceHeader>

--- a/web-local/src/routes/(viz)/dashboard/[name]/+page.svelte
+++ b/web-local/src/routes/(viz)/dashboard/[name]/+page.svelte
@@ -1,114 +1,33 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
-  import { page } from "$app/stores";
   import { Dashboard } from "@rilldata/web-common/features/dashboards";
-  import DashboardStateProvider from "@rilldata/web-common/features/dashboards/stores/DashboardStateProvider.svelte";
+  import DashboardThemeProvider from "@rilldata/web-common/features/dashboards/DashboardThemeProvider.svelte";
   import { resetSelectedMockUserAfterNavigate } from "@rilldata/web-common/features/dashboards/granular-access-policies/resetSelectedMockUserAfterNavigate";
-  import { selectedMockUserStore } from "@rilldata/web-common/features/dashboards/granular-access-policies/stores";
   import DashboardURLStateProvider from "@rilldata/web-common/features/dashboards/proto-state/DashboardURLStateProvider.svelte";
   import StateManagersProvider from "@rilldata/web-common/features/dashboards/state-managers/StateManagersProvider.svelte";
-  import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts";
-  import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
-  import { ResourceStatus } from "@rilldata/web-common/features/entity-management/resource-status-utils";
-  import { featureFlags } from "@rilldata/web-common/features/feature-flags";
-  import { createRuntimeServiceGetFile } from "@rilldata/web-common/runtime-client";
-  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
-  import { error } from "@sveltejs/kit";
+  import DashboardStateProvider from "@rilldata/web-common/features/dashboards/stores/DashboardStateProvider.svelte";
   import { useQueryClient } from "@tanstack/svelte-query";
-  import { CATALOG_ENTRY_NOT_FOUND } from "@rilldata/web-local/lib/errors/messages";
-  import ReconcilingSpinner from "@rilldata/web-common/features/entity-management/ReconcilingSpinner.svelte";
-  import DashboardThemeProvider from "@rilldata/web-common/features/dashboards/DashboardThemeProvider.svelte";
 
   const queryClient = useQueryClient();
 
-  const { readOnly } = featureFlags;
-
-  $: metricViewName = $page.params.name;
-
-  $: fileArtifact = fileArtifacts.findFileArtifact(
-    ResourceKind.MetricsView,
-    metricViewName,
-  );
-  $: if (!fileArtifact) {
-    // wait for the artifact to be created
-    setTimeout(() => {
-      fileArtifact = fileArtifacts.findFileArtifact(
-        ResourceKind.MetricsView,
-        metricViewName,
-      );
-    }, 200);
-  }
-  $: filePath = fileArtifact?.path ?? "";
-
-  $: fileQuery = createRuntimeServiceGetFile($runtime.instanceId, filePath, {
-    query: {
-      onError: (err) => {
-        if (err.response?.data?.message.includes(CATALOG_ENTRY_NOT_FOUND)) {
-          throw error(404, "Dashboard not found");
-        }
-
-        throw error(err.response?.status || 500, err.message);
-      },
-    },
-  });
-
-  $: resourceStatusStore = fileArtifact?.getResourceStatusStore(
-    queryClient,
-    $runtime.instanceId,
-    (res) => !!res?.metricsView?.state?.validSpec,
-  );
-  let showErrorPage = false;
-  $: if (metricViewName && $resourceStatusStore) {
-    showErrorPage = false;
-    if ($resourceStatusStore.status === ResourceStatus.Errored) {
-      // When the catalog entry doesn't exist, the dashboard config is invalid
-      if ($readOnly) {
-        throw error(400, "Invalid dashboard");
-      }
-
-      // When a mock user doesn't have access to the dashboard, stay on the page to show a message
-      if (
-        $selectedMockUserStore === null ||
-        $resourceStatusStore?.error?.response?.status !== 404
-      ) {
-        // On all other errors, redirect to the `/edit` page
-        goto(`/dashboard/${metricViewName}/edit`);
-      } else {
-        showErrorPage = true;
-      }
-    } else if ($resourceStatusStore.status === ResourceStatus.Idle) {
-      // Redirect to the `/edit` page if no measures are defined
-      if (
-        !$readOnly &&
-        !$resourceStatusStore.resource?.metricsView?.state?.validSpec?.measures
-          ?.length
-      ) {
-        goto(`/dashboard/${metricViewName}/edit`);
-      }
-    }
-  }
+  export let data;
 
   resetSelectedMockUserAfterNavigate(queryClient);
+
+  $: metricsViewName = data.metricsView.meta?.name?.name as string;
 </script>
 
 <svelte:head>
-  <title>Rill Developer | {metricViewName}</title>
+  <title>Rill Developer | {metricsViewName}</title>
 </svelte:head>
 
-{#if ($fileQuery.data && $resourceStatusStore?.status === ResourceStatus.Idle) || showErrorPage}
-  {#key metricViewName}
-    <StateManagersProvider metricsViewName={metricViewName}>
-      <DashboardStateProvider {metricViewName}>
-        <DashboardURLStateProvider {metricViewName}>
-          <DashboardThemeProvider>
-            <Dashboard {metricViewName} />
-          </DashboardThemeProvider>
-        </DashboardURLStateProvider>
-      </DashboardStateProvider>
-    </StateManagersProvider>
-  {/key}
-{:else if $resourceStatusStore?.status === ResourceStatus.Busy}
-  <div class="grid h-screen w-full place-content-center">
-    <ReconcilingSpinner />
-  </div>
-{/if}
+{#key metricsViewName}
+  <StateManagersProvider {metricsViewName}>
+    <DashboardStateProvider metricViewName={metricsViewName}>
+      <DashboardURLStateProvider metricViewName={metricsViewName}>
+        <DashboardThemeProvider>
+          <Dashboard metricViewName={metricsViewName} />
+        </DashboardThemeProvider>
+      </DashboardURLStateProvider>
+    </DashboardStateProvider>
+  </StateManagersProvider>
+{/key}

--- a/web-local/src/routes/(viz)/dashboard/[name]/+page.ts
+++ b/web-local/src/routes/(viz)/dashboard/[name]/+page.ts
@@ -1,0 +1,51 @@
+import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors.js";
+import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient.js";
+import {
+  getRuntimeServiceGetResourceQueryKey,
+  runtimeServiceGetResource,
+} from "@rilldata/web-common/runtime-client";
+import { error } from "@sveltejs/kit";
+import type { QueryFunction } from "@tanstack/svelte-query";
+
+export async function load({ parent, params, depends }) {
+  const { instanceId } = await parent();
+
+  const dashboardName = params.name;
+
+  depends(dashboardName, "dashboard");
+
+  const queryParams = {
+    "name.kind": ResourceKind.MetricsView,
+    "name.name": dashboardName,
+  };
+
+  const queryKey = getRuntimeServiceGetResourceQueryKey(
+    instanceId,
+    queryParams,
+  );
+
+  const queryFunction: QueryFunction<
+    Awaited<ReturnType<typeof runtimeServiceGetResource>>
+  > = ({ signal }) =>
+    runtimeServiceGetResource(instanceId, queryParams, signal);
+
+  try {
+    const response = await queryClient.fetchQuery({
+      queryFn: queryFunction,
+      queryKey,
+    });
+
+    const metricsViewResource = response.resource;
+
+    if (!metricsViewResource?.metricsView) {
+      throw error(404, "Dashboard not found");
+    }
+
+    return {
+      metricsView: metricsViewResource,
+    };
+  } catch (e) {
+    console.error(e);
+    throw error(404, "Dashboard not found");
+  }
+}


### PR DESCRIPTION
Upon selecting an example project, the user is now directed to the dashboard YAML, rather than to the dashboard Preview. This both gives the user context for what a Rill project is and it buys time for the chosen data to load. The "Preview" button is now disabled until the resource is ready (notably until all dependent sources have been ingested).

In its implementation, this PR simplifies `(viz)/dashboard/[name]/+page.svelte` and mirrors the `+page.ts` data loading approach taken in `(viz)/custom/[name]/+page.svelte`.