### PR TITLE
Re-use the Cloud error page in Rill Developer

### DIFF
--- a/web-admin/src/features/errors/ErrorBoundary.svelte
+++ b/web-admin/src/features/errors/ErrorBoundary.svelte
@@ -5,8 +5,8 @@
    */
 
   import { afterNavigate } from "$app/navigation";
+  import ErrorPage from "@rilldata/web-common/components/ErrorPage.svelte";
   import { errorStore, isErrorStoreEmpty } from "./error-store";
-  import ErrorPage from "./ErrorPage.svelte";
 
   afterNavigate(() => {
     // Checks to see if we're on the error page (and navigating away)

--- a/web-admin/src/routes/+error.svelte
+++ b/web-admin/src/routes/+error.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/stores";
+  import ErrorPage from "@rilldata/web-common/components/ErrorPage.svelte";
   import { createErrorPagePropsFromRoutingError } from "../features/errors/error-utils";
-  import ErrorPage from "../features/errors/ErrorPage.svelte";
 
   $: errorPageProps = createErrorPagePropsFromRoutingError($page.status);
 </script>

--- a/web-common/src/components/ErrorPage.svelte
+++ b/web-common/src/components/ErrorPage.svelte
@@ -6,7 +6,7 @@
   import CtaMessage from "@rilldata/web-common/components/calls-to-action/CTAMessage.svelte";
   import CtaNeedHelp from "@rilldata/web-common/components/calls-to-action/CTANeedHelp.svelte";
 
-  export let statusCode: number;
+  export let statusCode: number | undefined = undefined;
   export let header: string;
   export let body: string;
 </script>

--- a/web-local/src/routes/(viz)/dashboard/[name]/+page.svelte
+++ b/web-local/src/routes/(viz)/dashboard/[name]/+page.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+  import ErrorPage from "@rilldata/web-common/components/ErrorPage.svelte";
   import { Dashboard } from "@rilldata/web-common/features/dashboards";
   import DashboardThemeProvider from "@rilldata/web-common/features/dashboards/DashboardThemeProvider.svelte";
   import { resetSelectedMockUserAfterNavigate } from "@rilldata/web-common/features/dashboards/granular-access-policies/resetSelectedMockUserAfterNavigate";
   import DashboardURLStateProvider from "@rilldata/web-common/features/dashboards/proto-state/DashboardURLStateProvider.svelte";
   import StateManagersProvider from "@rilldata/web-common/features/dashboards/state-managers/StateManagersProvider.svelte";
   import DashboardStateProvider from "@rilldata/web-common/features/dashboards/stores/DashboardStateProvider.svelte";
+  import { useProjectParser } from "@rilldata/web-common/features/entity-management/resource-selectors.js";
   import { useQueryClient } from "@tanstack/svelte-query";
 
   const queryClient = useQueryClient();
@@ -14,20 +16,35 @@
   resetSelectedMockUserAfterNavigate(queryClient);
 
   $: metricsViewName = data.metricsView.meta?.name?.name as string;
+
+  $: filePaths = data.metricsView.meta?.filePaths as string[];
+  $: projectParserQuery = useProjectParser(queryClient, data.instanceId);
+  $: dashboardFileHasParseError =
+    $projectParserQuery.data?.projectParser?.state?.parseErrors?.filter(
+      (error) => filePaths.includes(error.filePath as string),
+    );
 </script>
 
 <svelte:head>
   <title>Rill Developer | {metricsViewName}</title>
 </svelte:head>
 
-{#key metricsViewName}
-  <StateManagersProvider {metricsViewName}>
-    <DashboardStateProvider metricViewName={metricsViewName}>
-      <DashboardURLStateProvider metricViewName={metricsViewName}>
-        <DashboardThemeProvider>
-          <Dashboard metricViewName={metricsViewName} />
-        </DashboardThemeProvider>
-      </DashboardURLStateProvider>
-    </DashboardStateProvider>
-  </StateManagersProvider>
-{/key}
+<!-- Handle errors from dashboard YAML edits from an external IDE   -->
+{#if dashboardFileHasParseError && dashboardFileHasParseError.length > 0}
+  <ErrorPage
+    header="Error parsing dashboard"
+    body="Please check your dashboard's YAML file for errors."
+  />
+{:else}
+  {#key metricsViewName}
+    <StateManagersProvider {metricsViewName}>
+      <DashboardStateProvider metricViewName={metricsViewName}>
+        <DashboardURLStateProvider metricViewName={metricsViewName}>
+          <DashboardThemeProvider>
+            <Dashboard metricViewName={metricsViewName} />
+          </DashboardThemeProvider>
+        </DashboardURLStateProvider>
+      </DashboardStateProvider>
+    </StateManagersProvider>
+  {/key}
+{/if}

--- a/web-local/src/routes/+error.svelte
+++ b/web-local/src/routes/+error.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { page } from "$app/stores";
+
+  import ErrorPage from "@rilldata/web-common/components/ErrorPage.svelte";
+
+  $: statusCode = $page.status;
+  $: header = ($page.error && $page.error.message) || "An error occurred";
+  $: body = "";
+</script>
+
+<ErrorPage {statusCode} {header} {body} />


### PR DESCRIPTION
This PR:
- Moves the Rill Cloud error page to `web-common`, so it can be re-used for Rill Developer
- Adds a fallback error page for Rill Developer at `web-local/src/routes/+error.svelte` 
- Handles parse errors triggered from an external IDE on the Rill Dev Preview Dashboard page

Addresses [a couple comments here](https://github.com/rilldata/rill/pull/4713#issuecomment-2076182153).

A couple things I noticed, but will keep out of this PR:
- We should rework the `CTAButton` to accept an `href`.
- One file write triggers multiple refetches of the Project Parser resource. Our resource invalidation really needs an audit.