### PR TITLE
Fix missing project title icon

### DIFF
--- a/web-common/src/features/project/ProjectTitle.svelte
+++ b/web-common/src/features/project/ProjectTitle.svelte
@@ -32,7 +32,7 @@
           style:height="20px"
         >
           <div>
-            {shorthandTitle($projectTitle.data || "Ri")}
+            {shorthandTitle($projectTitle.data)}
           </div>
         </div>
       </a>
@@ -44,12 +44,10 @@
         class="font-semibold text-black grow text-ellipsis overflow-hidden whitespace-nowrap pr-9"
         href="/"
       >
-        {$projectTitle.data || "Untitled Rill Project"}
+        {$projectTitle.data}
       </a>
       <TooltipContent maxWidth="300px" slot="tooltip-content">
-        <div class="font-bold">
-          {$projectTitle.data || "Untitled Rill Project"}
-        </div>
+        Go to home page
       </TooltipContent>
     </Tooltip>
   </h1>

--- a/web-common/src/features/project/selectors.ts
+++ b/web-common/src/features/project/selectors.ts
@@ -1,14 +1,25 @@
-import { parseDocument } from "yaml";
+import { parse } from "yaml";
 import { createRuntimeServiceGetFile } from "../../runtime-client";
 
 export function useProjectTitle(instanceId: string) {
   return createRuntimeServiceGetFile(instanceId, "rill.yaml", {
     query: {
       select: (data) => {
-        const projectData = parseDocument(data.blob, {
-          logLevel: "error",
-        })?.toJS();
-        return projectData?.title ?? projectData?.name;
+        if (!data.blob) return "";
+
+        let projectData: { title?: string; name?: string } = {};
+        try {
+          projectData = parse(data.blob, {
+            logLevel: "silent",
+          }) as {
+            title?: string;
+            name?: string;
+          };
+        } catch (e) {
+          // Ignore
+        }
+
+        return projectData.title || projectData.name || "Untitled Rill Project";
       },
     },
   });


### PR DESCRIPTION
I noticed the project title icon was sometimes missing. I'm not sure what changed recently, but this PR touches up this code to avoid a missing icon.

![image](https://github.com/rilldata/rill/assets/14206386/29cf6d6b-e533-48f7-ad75-b3e79ce0cfc1)
