### PR TITLE
Fix common console error in the Model Workspace

### DIFF
--- a/web-local/src/routes/(application)/[type=workspace]/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/[type=workspace]/[name]/+page.svelte
@@ -58,6 +58,7 @@
   import { httpRequestQueue } from "@rilldata/web-common/runtime-client/http-client";
   import { isProfilingQuery } from "@rilldata/web-common/runtime-client/query-matcher";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
+  import type { CreateQueryResult } from "@tanstack/svelte-query";
   import { getContext, onMount } from "svelte";
   import { get, type Writable } from "svelte/store";
   import { fade, slide } from "svelte/transition";
@@ -141,9 +142,11 @@
   $: refreshedOn = resource?.state?.refreshedOn;
   $: resourceIsReconciling = resourceIsLoading($resourceQuery.data);
 
-  $: isLocalFileConnectorQuery = useIsLocalFileConnector(instanceId, filePath);
-  $: isLocalFileConnector =
-    type === "source" && !!$isLocalFileConnectorQuery.data;
+  let isLocalFileConnectorQuery: CreateQueryResult<boolean>;
+  $: if (type === "source") {
+    isLocalFileConnectorQuery = useIsLocalFileConnector(instanceId, filePath);
+  }
+  $: isLocalFileConnector = !!$isLocalFileConnectorQuery?.data;
 
   $: selections = $queryHighlight?.map((selection) => ({
     from: selection?.referenceIndex,


### PR DESCRIPTION
The `isLocalFileConnector()` function was being called for Models, triggering this YAML parse error in the console:

![image](https://github.com/rilldata/rill/assets/14206386/8ba43aea-6d5e-4330-9c0e-acb82f33e04d)

In this case, the `enabled` flag of the `isLocalFileConnector` TanStack Query call _is_ set to `false`, so it seems like a separate call to `GetFile` has been triggering the `select` function.