### PR TITLE
Invalidate olap table list when a new source/model is added

### DIFF
--- a/web-common/src/features/entity-management/file-artifacts.ts
+++ b/web-common/src/features/entity-management/file-artifacts.ts
@@ -44,6 +44,8 @@ export class FileArtifact {
    */
   public lastStateUpdatedOn: string | undefined;
 
+  public isNew = true;
+
   public constructor(filePath: string) {
     this.path = filePath;
   }
@@ -58,6 +60,7 @@ export class FileArtifact {
         V1ReconcileStatus.RECONCILE_STATUS_RUNNING,
     );
     this.renaming = !!resource.meta?.renamedFrom;
+    this.isNew = false;
   }
 
   public updateReconciling(resource: V1Resource) {
@@ -282,6 +285,14 @@ export class FileArtifacts {
       this.artifacts[filePath] ??= new FileArtifact(filePath);
       this.artifacts[filePath].updateLastUpdated(resource);
     });
+  }
+
+  public isNew(resource: V1Resource) {
+    return (
+      resource.meta?.filePaths?.some((filePath) => {
+        return this.artifacts[filePath].isNew;
+      }) ?? false
+    );
   }
 
   public wasRenaming(resource: V1Resource) {

--- a/web-common/src/features/entity-management/resource-invalidations.ts
+++ b/web-common/src/features/entity-management/resource-invalidations.ts
@@ -104,7 +104,12 @@ async function invalidateResource(
   )
     return;
 
-  if (fileArtifacts.wasRenaming(resource)) {
+  if (
+    fileArtifacts.wasRenaming(resource) ||
+    (fileArtifacts.isNew(resource) &&
+      (resource.meta.name?.kind === ResourceKind.Source ||
+        resource.meta.name?.kind === ResourceKind.Model))
+  ) {
     void queryClient.invalidateQueries(
       getConnectorServiceOLAPListTablesQueryKey(),
     );


### PR DESCRIPTION
List of OLAP tables is not being invalidated when a new source/model is added. Since we could get multiple events when a new entity is added we need a state in fileArtifacts for new entities.