### PR TITLE
Fix edge cases around rename

### DIFF
--- a/runtime/drivers/file/watcher.go
+++ b/runtime/drivers/file/watcher.go
@@ -157,10 +157,10 @@ func (w *watcher) runInner() error {
 			}
 
 			we := drivers.WatchEvent{}
-			if e.Has(fsnotify.Create) || e.Has(fsnotify.Write) || e.Has(fsnotify.Chmod) {
-				we.Type = runtimev1.FileEvent_FILE_EVENT_WRITE
-			} else if e.Has(fsnotify.Remove) || e.Has(fsnotify.Rename) {
+			if e.Has(fsnotify.Remove) || e.Has(fsnotify.Rename) {
 				we.Type = runtimev1.FileEvent_FILE_EVENT_DELETE
+			} else if e.Has(fsnotify.Create) || e.Has(fsnotify.Write) || e.Has(fsnotify.Chmod) {
+				we.Type = runtimev1.FileEvent_FILE_EVENT_WRITE
 			} else {
 				continue
 			}

--- a/web-common/src/features/entity-management/resource-invalidations.ts
+++ b/web-common/src/features/entity-management/resource-invalidations.ts
@@ -113,15 +113,12 @@ async function invalidateResource(
   const failed = !!resource.meta.reconcileError;
 
   const name = resource.meta?.name?.name ?? "";
+  let table: string | undefined;
   switch (resource.meta.name?.kind) {
     case ResourceKind.Source:
-      if (resource.source?.state?.table)
-        // make sure table is populated
-        return invalidateProfilingQueries(queryClient, name, failed);
-      break;
-
     case ResourceKind.Model:
-      if (resource.model?.state?.table)
+      table = resource.source?.state?.table ?? resource.model?.state?.table;
+      if (table && resource.meta.name?.name === table)
         // make sure table is populated
         return invalidateProfilingQueries(queryClient, name, failed);
       break;

--- a/web-common/src/features/models/selectors.ts
+++ b/web-common/src/features/models/selectors.ts
@@ -22,7 +22,7 @@ import {
 
 export function useModels(instanceId: string) {
   return useFilteredResources(instanceId, ResourceKind.Model, (data) =>
-    data.resources?.filter((r) => !!r.model?.state?.table),
+    data.resources?.filter((r) => r.meta?.name?.name === r.model?.state?.table),
   );
 }
 


### PR DESCRIPTION
- [x] Just after a rename Model/Source resource would be idle with old table name. This lead to us resending the column profile leading to no table found error. Added a check to make sure table name is updated before invalidating the queries.
- [x] Every now and then a rename would send WRITE event for both source and destination, leading to errored page with old file name. This was because fsnotify would set CHMOD and RENAME to true. Flipping the condition fixes this