### PR TITLE
File Explorer: Fix 404 error from renaming a file in the root directory

### DIFF
--- a/web-common/src/features/entity-management/RenameAssetModal.svelte
+++ b/web-common/src/features/entity-management/RenameAssetModal.svelte
@@ -14,6 +14,7 @@
   import * as yup from "yup";
   import { runtime } from "../../runtime-client/runtime-store";
   import { renameFileArtifact } from "./actions";
+  import { removeLeadingSlash } from "./entity-mappers";
   import {
     INVALID_NAME_MESSAGE,
     VALID_NAME_PATTERN,
@@ -81,7 +82,7 @@
             );
           }
         } else {
-          await goto(`/files${newPath}`, {
+          await goto(`/files/${removeLeadingSlash(newPath)}`, {
             replaceState: true,
           });
         }


### PR DESCRIPTION
Addresses this [bug report](https://rilldata.slack.com/archives/C02T907FEUB/p1714418500302589) in Slack. A 404 resulted from renaming a file at the top-level of the root directory via the `RenameAssetModal`.