### PR TITLE
chore: bump actions' verions to avoid ci crash

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Build and embed static UI
         run: make cli.prepare

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -28,24 +28,24 @@ jobs:
     runs-on: large-hosted
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Fetch tags required by goreleaser
         run: git fetch --prune --unshallow
 
       - name: Checkout sysroot for cross compilation
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: goreleaser/goreleaser-cross-example-sysroot
           path: sysroot
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.22
 
       - name: Set up NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
@@ -89,7 +89,7 @@ jobs:
 
 
       - name: Release - Upload install script to CDN bucket
-        uses: google-github-actions/upload-cloud-storage@v1
+        uses: google-github-actions/upload-cloud-storage@v2
         if: env.PUBLISH_RELEASE == 'true'
         with:
           path: scripts/install.sh
@@ -99,7 +99,7 @@ jobs:
 
       - name: Release - Upload latest version file to CDN bucket
         if: env.PUBLISH_RELEASE == 'true'
-        uses: google-github-actions/upload-cloud-storage@v1
+        uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: latest.txt
           destination: prod-cdn.rilldata.com/rill/
@@ -122,7 +122,7 @@ jobs:
 
       - name: Nightly - Upload nightly to CDN bucket
         if: env.PUBLISH_NIGHTLY == 'true'
-        uses: google-github-actions/upload-cloud-storage@v1
+        uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: nightly/
           destination: prod-cdn.rilldata.com/rill/
@@ -130,7 +130,7 @@ jobs:
             cache-control: no-store
 
       - name: Set up Cloud SDK
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: 'google-github-actions/setup-gcloud@v2'
 
       - name: CDN - Explicitly invalidate the old artifacts from CDN cache
         run: |-

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Build ${{ matrix.name }}
         run: npm install -w ${{ matrix.name }} && npm run build -w ${{ matrix.name }}

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 

--- a/.github/workflows/docs-crawler.yml
+++ b/.github/workflows/docs-crawler.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Algolia crawler creation and crawl
-        uses: algolia/algoliasearch-crawler-github-actions@v1.0.10
+        uses: algolia/algoliasearch-crawler-github-actions@v1.1.10
         id: algolia_crawler
         with:
           crawler-name: rilldata

--- a/.github/workflows/druid-test-image.yml
+++ b/.github/workflows/druid-test-image.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Authenticate GCloud
         uses: google-github-actions/auth@v2
@@ -20,7 +20,7 @@ jobs:
           credentials_json: "${{ secrets.RILL_BINARY_SA }}"
 
       - name: Set up GCloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
 
       - name: Build & Publish Rill docker image
         run: |-

--- a/.github/workflows/go-cover.yml
+++ b/.github/workflows/go-cover.yml
@@ -11,11 +11,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v5
       with:
         go-version: 1.22
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/checkout@v4
+    - uses: actions/cache@v4
       with:
         path: |
           ~/go/pkg/mod
@@ -31,7 +31,7 @@ jobs:
         # NOTE(2024-03-01): Coverage fails on the generated code in 'proto/gen' without GOEXPERIMENT=nocoverageredesign. See https://github.com/golang/go/issues/55953.
         GOEXPERIMENT=nocoverageredesign go test ./... -short -v -race -covermode=atomic -coverprofile=coverage.out -coverpkg=$PACKAGES
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.out

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -11,17 +11,19 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.22
       - name: Go report card
         uses: creekorful/goreportcard-action@v1.0
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v5
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          # Require: The version of golangci-lint to use.
+          # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
+          # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
           version: v1.57.2
 
           # Optional: working directory, useful for monorepos
@@ -31,18 +33,21 @@ jobs:
           # args: --issues-exit-code=
           args: --timeout=10m --config=.golangci.yml --verbose
 
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # Optional: Show only new issues.
+          # If you are using `merge_group` event (merge queue) you should add the option `fetch-depth: 0` to `actions/checkout` step.
+          # The default value is `false`.
           # only-new-issues: true
 
           # Optional: if set to true then the all caching functionality will be complete disabled,
           #           takes precedence over all other caching options.
           # skip-cache: true
 
-          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-          # skip-pkg-cache: true
+          # Optional: if set to true, caches will not be saved, but they may still be restored,
+          #           subject to other options
+          # skip-save-cache: true
 
-          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-          # skip-build-cache: true
+          # Optional: The mode to install golangci-lint. It can be 'binary' or 'goinstall'.
+          install-mode: "binary"
         env:
           # GitHub token for annotations (optional)
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -9,11 +9,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
         go-version: 1.22
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/checkout@v4
+    - uses: actions/cache@v4
       with:
         path: |
           ~/go/pkg/mod

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: NPM Install
         run: npm install

--- a/.github/workflows/proto-check.yml
+++ b/.github/workflows/proto-check.yml
@@ -7,7 +7,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: bufbuild/buf-setup-action@v1
       - uses: bufbuild/buf-lint-action@v1
         with:

--- a/.github/workflows/rill-cloud.yml
+++ b/.github/workflows/rill-cloud.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.22
 
@@ -35,7 +35,7 @@ jobs:
           credentials_json: "${{ secrets.RILL_BINARY_SA }}"
 
       - name: Set up GCloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
 
       - name: Build & Publish Rill docker image
         run: |-

--- a/.github/workflows/rill-ui.yml
+++ b/.github/workflows/rill-ui.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Setup Env variables from Inputs for Prod
         if: ( github.event_name == 'create' && startsWith(github.ref, 'refs/tags/v') ) || ( github.event_name == 'workflow_dispatch' && inputs.env == 'prod' )

--- a/.github/workflows/rill-ui.yml
+++ b/.github/workflows/rill-ui.yml
@@ -38,12 +38,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 18
 
       - name: Setup Env variables from Inputs for Prod
         if: ( github.event_name == 'create' && startsWith(github.ref, 'refs/tags/v') ) || ( github.event_name == 'workflow_dispatch' && inputs.env == 'prod' )

--- a/.github/workflows/web-test-code-quality.yml
+++ b/.github/workflows/web-test-code-quality.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Filter modified codepaths
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
@@ -33,7 +33,7 @@ jobs:
               - "web-common/**"
 
       - name: Set up NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 

--- a/.github/workflows/web-test-code-quality.yml
+++ b/.github/workflows/web-test-code-quality.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: NPM Install
         run: npm install

--- a/.github/workflows/web-test-e2e.yml
+++ b/.github/workflows/web-test-e2e.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Filter modified codepaths
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
@@ -43,16 +43,16 @@ jobs:
               - "web-common/**"
 
       - name: Set up NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 
       - name: Set up go for E2E
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.22
       - name: go build cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/go/pkg/mod
@@ -74,7 +74,7 @@ jobs:
         if: ${{ steps.filter.outputs.local == 'true' || steps.filter.outputs.common == 'true' }}
         run: npm run test -w web-local
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/web-test-e2e.yml
+++ b/.github/workflows/web-test-e2e.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Set up go for E2E
         uses: actions/setup-go@v5

--- a/.github/workflows/web-test-unit-tests.yml
+++ b/.github/workflows/web-test-unit-tests.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Filter modified codepaths
-        uses: dorny/paths-filter@v2
+        uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
@@ -33,7 +33,7 @@ jobs:
               - "web-common/**"
 
       - name: Set up NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 

--- a/.github/workflows/web-test-unit-tests.yml
+++ b/.github/workflows/web-test-unit-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: NPM Install
         run: npm install


### PR DESCRIPTION
### Description

Update GitHub Actions to the latest versions.

### Motivation

Recent failures in GitHub Actions were linked to outdated versions, leading to unexpected errors. For example:
https://rilldata.slack.com/archives/C01190F1R1D/p1714425925985609

Upgrading to the latest versions will help prevent such issues.