### PR TITLE
Fix flicker for inline custom dashboard sub components

### DIFF
--- a/web-common/src/features/entity-management/file-artifacts.ts
+++ b/web-common/src/features/entity-management/file-artifacts.ts
@@ -141,6 +141,8 @@ export class FileArtifact {
   }
 
   private updateNameIfChanged(resource: V1Resource) {
+    const isSubResource = !!resource.component?.spec?.definedInDashboard;
+    if (isSubResource) return;
     const curName = get(this.name);
     if (
       curName?.name !== resource.meta?.name?.name ||


### PR DESCRIPTION
While editing a custom dashboard with inline components there is a flicker. This is due to inline component mapping to the same file. In this PR we are not setting the `name` for any sub resource.