### PR TITLE
Fix non-deterministic coverage/race tests

### DIFF
--- a/runtime/queries/column_timeseries_test.go
+++ b/runtime/queries/column_timeseries_test.go
@@ -181,6 +181,11 @@ func TestTimeseries_normaliseTimeRange_Specified(t *testing.T) {
 }
 
 func TestTimeseries_SparkOnly_same_timestamp(t *testing.T) {
+	if testing.Short() {
+		// Ignoring test in CI because it sometimes fails with a segmentation fault in DuckDB when running with -race
+		t.SkipNow()
+	}
+
 	time.Local = time.UTC
 
 	rt, instanceID := instanceWithSparkSameTimestampModel(t)
@@ -200,6 +205,11 @@ func TestTimeseries_SparkOnly_same_timestamp(t *testing.T) {
 }
 
 func TestTimeseries_SparkOnly(t *testing.T) {
+	if testing.Short() {
+		// Ignoring test in CI because it sometimes fails with a segmentation fault in DuckDB when running with -race
+		t.SkipNow()
+	}
+
 	time.Local = time.UTC
 
 	rt, instanceID := instanceWithSparkModel(t)


### PR DESCRIPTION
See here for an example of the non-deterministic failure: https://github.com/rilldata/rill/actions/runs/8880726494/job/24381441904#step:5:2297

```
=== RUN   TestTimeseries_SparkOnly
signal: segmentation fault (core dumped)
FAIL	github.com/rilldata/rill/runtime/queries	8.167s
```

