### PR TITLE
Fix OLAP Table list not invalidating in certain cases

### DIFF
--- a/web-common/src/features/entity-management/actions.ts
+++ b/web-common/src/features/entity-management/actions.ts
@@ -56,7 +56,8 @@ export async function renameFileArtifact(
       fromResName?.kind &&
       topLevelFromFolder !== topLevelToFolder &&
       FolderToResourceKind[removeLeadingSlash(topLevelFromFolder)] ===
-        fromResName?.kind
+        fromResName?.kind &&
+      !toPath.endsWith(".sql")
     ) {
       notifications.send({
         message: `Moving ${fromName} out of native folder. Please make sure to add "kind" key to denote the type.`,

--- a/web-common/src/features/entity-management/file-artifacts.ts
+++ b/web-common/src/features/entity-management/file-artifacts.ts
@@ -43,7 +43,7 @@ export class FileArtifact {
    */
   public lastStateUpdatedOn: string | undefined;
 
-  public isNew = true;
+  public hasTable = false;
 
   public constructor(filePath: string) {
     this.path = filePath;
@@ -59,7 +59,9 @@ export class FileArtifact {
         V1ReconcileStatus.RECONCILE_STATUS_RUNNING,
     );
     this.renaming = !!resource.meta?.renamedFrom;
-    this.isNew = false;
+    this.hasTable =
+      (!!resource.model && !!resource.model.state?.table) ||
+      (!!resource.source && !!resource.source.state?.table);
   }
 
   public updateReconciling(resource: V1Resource) {
@@ -238,10 +240,10 @@ export class FileArtifacts {
     });
   }
 
-  public isNew(resource: V1Resource) {
+  public hadTable(resource: V1Resource) {
     return (
       resource.meta?.filePaths?.some((filePath) => {
-        return this.artifacts[filePath].isNew;
+        return this.artifacts[filePath].hasTable;
       }) ?? false
     );
   }

--- a/web-common/src/features/entity-management/resource-invalidations.ts
+++ b/web-common/src/features/entity-management/resource-invalidations.ts
@@ -105,13 +105,18 @@ async function invalidateResource(
     return;
 
   if (
-    fileArtifacts.wasRenaming(resource) ||
-    (fileArtifacts.isNew(resource) &&
-      (resource.meta.name?.kind === ResourceKind.Source ||
-        resource.meta.name?.kind === ResourceKind.Model))
+    (resource.meta.name?.kind === ResourceKind.Source ||
+      resource.meta.name?.kind === ResourceKind.Model) &&
+    (fileArtifacts.wasRenaming(resource) || !fileArtifacts.hadTable(resource))
   ) {
     void queryClient.invalidateQueries(
-      getConnectorServiceOLAPListTablesQueryKey(),
+      getConnectorServiceOLAPListTablesQueryKey({
+        instanceId: get(runtime).instanceId,
+        connector:
+          resource.source?.state?.connector ??
+          resource.model?.state?.connector ??
+          "",
+      }),
     );
   }
   fileArtifacts.updateArtifacts(resource);

--- a/web-common/src/features/welcome/ProjectCards.svelte
+++ b/web-common/src/features/welcome/ProjectCards.svelte
@@ -58,14 +58,13 @@
         force: true,
       },
     });
-    console.log("Done unpack");
     await goto(firstPage);
   }
 </script>
 
 <section class="flex flex-col items-center gap-y-5">
   <Subheading>Or jump right into a project.</Subheading>
-  <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
     <EmptyProject />
     {#each EXAMPLES as example}
       <Card

--- a/web-common/src/features/welcome/ProjectCards.svelte
+++ b/web-common/src/features/welcome/ProjectCards.svelte
@@ -58,6 +58,7 @@
         force: true,
       },
     });
+    console.log("Done unpack");
     await goto(firstPage);
   }
 </script>

--- a/web-local/src/routes/(application)/custom-dashboards/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/custom-dashboards/[name]/+page.svelte
@@ -77,7 +77,6 @@
   $: if (data.fileArtifact) {
     fileArtifact = data.fileArtifact;
     filePath = fileArtifact.path;
-    customDashboardName = fileArtifact.getEntityName();
   } else {
     customDashboardName = $page.params.name;
     filePath = getFileAPIPathFromNameAndType(
@@ -86,6 +85,8 @@
     );
     fileArtifact = fileArtifacts.getFileArtifact(filePath);
   }
+  $: name = fileArtifact?.name;
+  $: customDashboardName = $name?.name ?? "";
 
   $: instanceId = $runtime.instanceId;
 

--- a/web-local/src/routes/(application)/dashboard/[name]/edit/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/edit/+page.svelte
@@ -50,7 +50,6 @@
   $: if (data.fileArtifact) {
     fileArtifact = data.fileArtifact;
     filePath = fileArtifact.path;
-    metricViewName = fileArtifact.getEntityName();
   } else {
     fileArtifact = fileArtifacts.getFileArtifact(filePath);
     metricViewName = $page.params.name;
@@ -60,6 +59,9 @@
     );
   }
   $: [, fileName] = splitFolderAndName(filePath);
+
+  $: name = fileArtifact?.name;
+  $: metricViewName = $name?.name ?? "";
 
   $: instanceId = $runtime.instanceId;
   $: initLocalUserPreferenceStore(metricViewName);


### PR DESCRIPTION
- [x] Fix OLAP table list not invalidating when a new project is unpacked.
- [x] Fix dashboard preview not updating when renamed.
- [x] If a model is moved out of its native folder do not show a warning message.