### PR TITLE
Configure CSS nesting and unify postcss configs

### DIFF
--- a/web-admin/postcss.config.cjs
+++ b/web-admin/postcss.config.cjs
@@ -1,6 +1,1 @@
-module.exports = {
-  plugins: {
-    autoprefixer: {},
-    tailwindcss: {},
-  },
-};
+module.exports = require("../web-common/postcss.config.cjs")

--- a/web-admin/src/routes/[organization]/[project]/-/dashboards/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/dashboards/[dashboard]/+page.svelte
@@ -25,4 +25,4 @@
   } = dashboard || { items: [], columns: 10, gap: 2 });
 </script>
 
-<CustomDashboardEmbed {columns} components={items} {gap} />
+<CustomDashboardEmbed {columns} {items} {gap} />

--- a/web-auth/postcss.config.cjs
+++ b/web-auth/postcss.config.cjs
@@ -1,4 +1,1 @@
-module.exports = {
-  plugins: [require("tailwindcss"), require("autoprefixer")],
-};
-
+module.exports = require("../web-common/postcss.config.cjs")

--- a/web-common/postcss.config.cjs
+++ b/web-common/postcss.config.cjs
@@ -1,13 +1,10 @@
-const tailwindcss = require('tailwindcss');
-const autoprefixer = require('autoprefixer');
-
+/** @type {import('postcss-load-config').Config} */
 const config = {
 	plugins: [
-		//Some plugins, like tailwindcss/nesting, need to run before Tailwind,
-		tailwindcss(),
-		//But others, like autoprefixer, need to run after,
-		autoprefixer
+		require('tailwindcss/nesting'),
+		require('tailwindcss'),		
+		require('autoprefixer'),
 	]
-};
-
-module.exports = config;
+  }
+  
+  module.exports = config

--- a/web-local/postcss.config.cjs
+++ b/web-local/postcss.config.cjs
@@ -1,8 +1,1 @@
-// postcss.config.js
-
-module.exports = {
-  plugins: {
-    autoprefixer: {},
-    tailwindcss: {},
-  },
-};
+module.exports = require("../web-common/postcss.config.cjs")


### PR DESCRIPTION
This PR adds `tailwind/nesting` to our postcss config and ensures that all repo configs are based off the one in `web-common`