### PR TITLE
Use `type:` instead of `kind:` for resource types

### DIFF
--- a/admin/server/alerts.go
+++ b/admin/server/alerts.go
@@ -451,7 +451,7 @@ func (s *Server) GetAlertYAML(ctx context.Context, req *adminv1.GetAlertYAMLRequ
 
 func (s *Server) yamlForManagedAlert(opts *adminv1.AlertOptions, ownerUserID string) ([]byte, error) {
 	res := alertYAML{}
-	res.Kind = "alert"
+	res.Type = "alert"
 	// Trigger the alert when the metrics view refreshes.
 	res.Refs = []string{fmt.Sprintf("MetricsView/%s", opts.MetricsViewName)}
 	res.Title = opts.Title
@@ -485,7 +485,7 @@ func (s *Server) yamlForCommittedAlert(opts *adminv1.AlertOptions) ([]byte, erro
 	}
 
 	res := alertYAML{}
-	res.Kind = "alert"
+	res.Type = "alert"
 	// Trigger the alert when the metrics view refreshes.
 	res.Refs = []string{fmt.Sprintf("MetricsView/%s", opts.MetricsViewName)}
 	res.Title = opts.Title
@@ -570,7 +570,7 @@ func recreateAlertOptionsFromSpec(spec *runtimev1.AlertSpec) (*adminv1.AlertOpti
 
 // alertYAML is derived from rillv1.AlertYAML, but adapted for generating (as opposed to parsing) the alert YAML.
 type alertYAML struct {
-	Kind      string   `yaml:"kind"`
+	Type      string   `yaml:"type"`
 	Refs      []string `yaml:"refs"`
 	Title     string   `yaml:"title"`
 	Watermark string   `yaml:"watermark"`

--- a/admin/server/reports.go
+++ b/admin/server/reports.go
@@ -434,7 +434,7 @@ func (s *Server) GenerateReportYAML(ctx context.Context, req *adminv1.GenerateRe
 
 func (s *Server) yamlForManagedReport(opts *adminv1.ReportOptions, ownerUserID string) ([]byte, error) {
 	res := reportYAML{}
-	res.Kind = "report"
+	res.Type = "report"
 	res.Title = opts.Title
 	res.Refresh.Cron = opts.RefreshCron
 	res.Refresh.TimeZone = opts.RefreshTimeZone
@@ -477,7 +477,7 @@ func (s *Server) yamlForCommittedReport(opts *adminv1.ReportOptions) ([]byte, er
 	}
 
 	res := reportYAML{}
-	res.Kind = "report"
+	res.Type = "report"
 	res.Title = opts.Title
 	res.Refresh.Cron = opts.RefreshCron
 	res.Refresh.TimeZone = opts.RefreshTimeZone
@@ -566,7 +566,7 @@ func recreateReportOptionsFromSpec(spec *runtimev1.ReportSpec) (*adminv1.ReportO
 
 // reportYAML is derived from rillv1.ReportYAML, but adapted for generating (as opposed to parsing) the report YAML.
 type reportYAML struct {
-	Kind    string `yaml:"kind"`
+	Type    string `yaml:"type"`
 	Title   string `yaml:"title"`
 	Refresh struct {
 		Cron     string `yaml:"cron"`

--- a/cli/cmd/project/describe.go
+++ b/cli/cmd/project/describe.go
@@ -17,7 +17,7 @@ func DescribeCmd(ch *cmdutil.Helper) *cobra.Command {
 	var project, path string
 
 	statusCmd := &cobra.Command{
-		Use:   "describe [<project-name>] <kind> <name>",
+		Use:   "describe [<project-name>] <type> <name>",
 		Args:  cobra.MatchAll(cobra.MinimumNArgs(2), cobra.MaximumNArgs(3)),
 		Short: "Retrieve detailed state for a resource",
 		Long:  "Retrieve detailed state for a specific resource (source, model, dashboard, ...)",
@@ -97,7 +97,7 @@ func parseResourceKind(k string) string {
 		return runtime.ResourceKindSource
 	case "model":
 		return runtime.ResourceKindModel
-	case "metricsview", "metrics_view", "dashboard":
+	case "metricsview", "metrics_view":
 		return runtime.ResourceKindMetricsView
 	case "migration":
 		return runtime.ResourceKindMigration
@@ -105,6 +105,14 @@ func parseResourceKind(k string) string {
 		return runtime.ResourceKindReport
 	case "alert":
 		return runtime.ResourceKindAlert
+	case "theme":
+		return runtime.ResourceKindTheme
+	case "component":
+		return runtime.ResourceKindComponent
+	case "dashboard":
+		return runtime.ResourceKindDashboard
+	case "api":
+		return runtime.ResourceKindAPI
 	default:
 		return k
 	}

--- a/cli/cmd/project/status.go
+++ b/cli/cmd/project/status.go
@@ -132,7 +132,7 @@ func StatusCmd(ch *cmdutil.Helper) *cobra.Command {
 }
 
 type resourceTableRow struct {
-	Kind   string `header:"kind"`
+	Type   string `header:"type"`
 	Name   string `header:"name"`
 	Status string `header:"status"`
 	Error  string `header:"error"`
@@ -145,7 +145,7 @@ func newResourceTableRow(r *runtimev1.Resource) *resourceTableRow {
 	}
 
 	return &resourceTableRow{
-		Kind:   formatResourceKind(r.Meta.Name.Kind),
+		Type:   formatResourceKind(r.Meta.Name.Kind),
 		Name:   r.Meta.Name.Name,
 		Status: formatReconcileStatus(r.Meta.ReconcileStatus),
 		Error:  truncErr,

--- a/runtime/compilers/rillv1/connectors_test.go
+++ b/runtime/compilers/rillv1/connectors_test.go
@@ -38,10 +38,10 @@ connector: duckdb
 sql: SELECT * FROM read_csv('s3://bucket/path.csv')
 `,
 		"/alerts/a1.yaml": `
-kind: alert
+type: alert
 title: Test Alert
 refs:
-- kind: MetricsView
+- type: MetricsView
   name: mv1
 watermark: inherit
 intervals:
@@ -127,10 +127,10 @@ func TestAnonSlackConnector(t *testing.T) {
 	repo := makeRepo(t, map[string]string{
 		`rill.yaml`: ``,
 		"/alerts/a1.yaml": `
-kind: alert
+type: alert
 title: Test Alert
 refs:
-- kind: MetricsView
+- type: MetricsView
   name: mv1
 watermark: inherit
 intervals:

--- a/runtime/compilers/rillv1/parser.go
+++ b/runtime/compilers/rillv1/parser.go
@@ -132,7 +132,7 @@ func (k ResourceKind) String() string {
 	case ResourceKindAPI:
 		return "API"
 	default:
-		panic(fmt.Sprintf("unexpected resource kind: %d", k))
+		panic(fmt.Sprintf("unexpected resource type: %d", k))
 	}
 }
 
@@ -780,7 +780,7 @@ func (p *Parser) insertResource(kind ResourceKind, name string, paths []string, 
 	case ResourceKindAPI:
 		r.APISpec = &runtimev1.APISpec{}
 	default:
-		panic(fmt.Errorf("unexpected resource kind: %s", kind.String()))
+		panic(fmt.Errorf("unexpected resource type: %s", kind.String()))
 	}
 
 	// Track it

--- a/runtime/compilers/rillv1/parser_test.go
+++ b/runtime/compilers/rillv1/parser_test.go
@@ -1454,6 +1454,11 @@ type: s3
 		// api a1
 		`/apis/a1.yaml`: `
 kind: api
+refs:
+- kind: source
+  name: s1
+- type: source
+  name: s2
 sql: select 1
 `,
 		// migration m1
@@ -1484,6 +1489,7 @@ select 3
 		{
 			Name:  ResourceName{Kind: ResourceKindAPI, Name: "a1"},
 			Paths: []string{"/apis/a1.yaml"},
+			Refs:  []ResourceName{{Kind: ResourceKindSource, Name: "s1"}, {Kind: ResourceKindSource, Name: "s2"}},
 			APISpec: &runtimev1.APISpec{
 				Resolver:           "sql",
 				ResolverProperties: must(structpb.NewStruct(map[string]any{"sql": "select 1"})),

--- a/runtime/compilers/rillv1/parser_test.go
+++ b/runtime/compilers/rillv1/parser_test.go
@@ -107,14 +107,14 @@ available_time_ranges:
 `,
 		// migration c1
 		`custom/c1.yml`: `
-kind: migration
+type: migration
 version: 3
 sql: |
   CREATE TABLE a(a integer);
 `,
 		// model c2
 		`custom/c2.sql`: `
-{{ configure "kind" "model" }}
+{{ configure "type" "model" }}
 {{ configure "materialize" true }}
 SELECT * FROM {{ ref "m2" }}
 `,
@@ -590,7 +590,7 @@ func TestReparseMultiKindNameCollision(t *testing.T) {
 		`models/m1.sql`:        `SELECT 10`,
 		`models/nested/m1.sql`: `SELECT 20`,
 		`sources/m1.yaml`: `
-type: s3
+connector: s3
 path: hello
 `,
 	})
@@ -1019,7 +1019,7 @@ func TestReport(t *testing.T) {
 	repo := makeRepo(t, map[string]string{
 		`rill.yaml`: ``,
 		`reports/r1.yaml`: `
-kind: report
+type: report
 title: My Report
 
 refresh:
@@ -1043,7 +1043,7 @@ annotations:
   foo: bar
 `,
 		`reports/r2.yaml`: `
-kind: report
+type: report
 title: My Report
 
 refresh:
@@ -1132,7 +1132,7 @@ func TestAlert(t *testing.T) {
 		// model m1
 		`models/m1.sql`: `SELECT 1`,
 		`alerts/a1.yaml`: `
-kind: alert
+type: alert
 title: My Alert
 
 refs:
@@ -1254,7 +1254,7 @@ func TestTheme(t *testing.T) {
 	repo := makeRepo(t, map[string]string{
 		`rill.yaml`: ``,
 		`themes/t1.yaml`: `
-kind: theme
+type: theme
 
 colors:
   primary: red
@@ -1306,7 +1306,7 @@ func TestComponentsAndDashboard(t *testing.T) {
 	repo := makeRepo(t, map[string]string{
 		`rill.yaml`: ``,
 		`components/c1.yaml`: fmt.Sprintf(`
-kind: component
+type: component
 data:
   api: MetricsViewAggregation
   args:
@@ -1314,7 +1314,7 @@ data:
 vega_lite: |%s
 `, vegaLiteSpec),
 		`components/c2.yaml`: fmt.Sprintf(`
-kind: component
+type: component
 data:
   api: MetricsViewAggregation
   args:
@@ -1322,7 +1322,7 @@ data:
 vega_lite: |%s
 `, vegaLiteSpec),
 		`dashboards/d1.yaml`: `
-kind: dashboard
+type: dashboard
 columns: 4
 gap: 3
 items:
@@ -1400,12 +1400,12 @@ func TestAPI(t *testing.T) {
 		`models/m1.sql`: `SELECT 1`,
 		// api a1
 		`apis/a1.yaml`: `
-kind: api
+type: api
 sql: select * from m1
 `,
 		// api a2
 		`apis/a2.yaml`: `
-kind: api
+type: api
 metrics_sql: select * from m1
 `,
 	})
@@ -1438,6 +1438,79 @@ metrics_sql: select * from m1
 		},
 	}
 
+	p, err := Parse(ctx, repo, "", "", "duckdb")
+	require.NoError(t, err)
+	requireResourcesAndErrors(t, p, resources, nil)
+}
+
+func TestKindBackwardsCompatibility(t *testing.T) {
+	files := map[string]string{
+		// rill.yaml
+		`rill.yaml`: ``,
+		// source s1
+		`sources/s1.yaml`: `
+type: s3
+`,
+		// api a1
+		`/apis/a1.yaml`: `
+kind: api
+sql: select 1
+`,
+		// migration m1
+		`/migrations/m1.sql`: `
+-- @kind: migration
+select 2
+`,
+		// migration m2
+		`/migrations/m2.sql`: `
+-- @type: migration
+select 3
+`,
+	}
+
+	resources := []*Resource{
+		// s1
+		{
+			Name:  ResourceName{Kind: ResourceKindSource, Name: "s1"},
+			Paths: []string{"/sources/s1.yaml"},
+			SourceSpec: &runtimev1.SourceSpec{
+				SourceConnector: "s3",
+				SinkConnector:   "duckdb",
+				Properties:      must(structpb.NewStruct(map[string]any{})),
+				RefreshSchedule: &runtimev1.Schedule{RefUpdate: true},
+			},
+		},
+		// a1
+		{
+			Name:  ResourceName{Kind: ResourceKindAPI, Name: "a1"},
+			Paths: []string{"/apis/a1.yaml"},
+			APISpec: &runtimev1.APISpec{
+				Resolver:           "sql",
+				ResolverProperties: must(structpb.NewStruct(map[string]any{"sql": "select 1"})),
+			},
+		},
+		// m1
+		{
+			Name:  ResourceName{Kind: ResourceKindMigration, Name: "m1"},
+			Paths: []string{"/migrations/m1.sql"},
+			MigrationSpec: &runtimev1.MigrationSpec{
+				Connector: "duckdb",
+				Sql:       strings.TrimSpace(files["/migrations/m1.sql"]),
+			},
+		},
+		// m2
+		{
+			Name:  ResourceName{Kind: ResourceKindMigration, Name: "m2"},
+			Paths: []string{"/migrations/m2.sql"},
+			MigrationSpec: &runtimev1.MigrationSpec{
+				Connector: "duckdb",
+				Sql:       strings.TrimSpace(files["/migrations/m2.sql"]),
+			},
+		},
+	}
+
+	ctx := context.Background()
+	repo := makeRepo(t, files)
 	p, err := Parse(ctx, repo, "", "", "duckdb")
 	require.NoError(t, err)
 	requireResourcesAndErrors(t, p, resources, nil)

--- a/runtime/controller.go
+++ b/runtime/controller.go
@@ -1108,7 +1108,7 @@ func (c *Controller) markPending(n *runtimev1.ResourceName) (skip bool, err erro
 			return false, err
 		}
 		if !r.Meta.Hidden {
-			logArgs := []zap.Field{zap.String("name", n.Name), zap.String("kind", unqualifiedKind(n.Kind)), zap.Any("error", errCyclicDependency)}
+			logArgs := []zap.Field{zap.String("name", n.Name), zap.String("type", unqualifiedKind(n.Kind)), zap.Any("error", errCyclicDependency)}
 			c.Logger.Warn("Skipping resource", logArgs...)
 		}
 		return true, nil
@@ -1249,7 +1249,7 @@ func (c *Controller) invoke(r *runtimev1.Resource) error {
 
 	// Log invocation
 	if !inv.isHidden {
-		logArgs := []zap.Field{zap.String("name", n.Name), zap.String("kind", unqualifiedKind(n.Kind))}
+		logArgs := []zap.Field{zap.String("name", n.Name), zap.String("type", unqualifiedKind(n.Kind))}
 		if inv.isDelete {
 			logArgs = append(logArgs, zap.Bool("deleted", inv.isDelete))
 		}
@@ -1268,7 +1268,7 @@ func (c *Controller) invoke(r *runtimev1.Resource) error {
 			if r := recover(); r != nil {
 				stack := make([]byte, 64<<10)
 				stack = stack[:runtime.Stack(stack, false)]
-				c.Logger.Error("panic in reconciler", zap.String("name", n.Name), zap.String("kind", n.Kind), zap.Any("error", r), zap.String("stack", string(stack)))
+				c.Logger.Error("panic in reconciler", zap.String("name", n.Name), zap.String("type", n.Kind), zap.Any("error", r), zap.String("stack", string(stack)))
 
 				inv.result = ReconcileResult{Err: fmt.Errorf("panic: %v", r)}
 				if inv.holdsLock {
@@ -1285,7 +1285,7 @@ func (c *Controller) invoke(r *runtimev1.Resource) error {
 		tracerAttrs := []attribute.KeyValue{
 			attribute.String("instance_id", c.InstanceID),
 			attribute.String("name", n.Name),
-			attribute.String("kind", unqualifiedKind(n.Kind)),
+			attribute.String("type", unqualifiedKind(n.Kind)),
 		}
 		if inv.isDelete {
 			tracerAttrs = append(tracerAttrs, attribute.Bool("deleted", inv.isDelete))
@@ -1318,7 +1318,7 @@ func (c *Controller) processCompletedInvocation(inv *invocation) error {
 	// Log result
 	logArgs := []zap.Field{
 		zap.String("name", inv.name.Name),
-		zap.String("kind", unqualifiedKind(inv.name.Kind)),
+		zap.String("type", unqualifiedKind(inv.name.Kind)),
 	}
 	elapsed := time.Since(inv.startedOn).Round(time.Millisecond)
 	if elapsed > 0 {

--- a/runtime/controller_test.go
+++ b/runtime/controller_test.go
@@ -24,7 +24,7 @@ func TestComplete(t *testing.T) {
 1,2,3,4,5
 `,
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/foo.csv
 `,
 		"/models/bar.sql": `
@@ -122,7 +122,7 @@ measures:
 	// Add syntax error in source, check downstream resources error
 	testruntime.PutFiles(t, rt, id, map[string]string{
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path
 `,
 	})
@@ -171,7 +171,7 @@ path
 	// Fix source, check downstream resources succeed
 	testruntime.PutFiles(t, rt, id, map[string]string{
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/foo.csv
 `,
 	})
@@ -189,7 +189,7 @@ func TestSource(t *testing.T) {
 1,2,3,4,5
 `,
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/foo.csv
 `,
 	})
@@ -247,7 +247,7 @@ path: data/foo.csv
 	// Change the source so it errors
 	testruntime.PutFiles(t, rt, id, map[string]string{
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/bar.csv
 `,
 	})
@@ -258,7 +258,7 @@ path: data/bar.csv
 	// Restore the source, verify it works again
 	testruntime.PutFiles(t, rt, id, map[string]string{
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/foo.csv
 `,
 	})
@@ -326,7 +326,7 @@ func TestCacheInvalidation(t *testing.T) {
 1,2,3,4,5
 `,
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/foo.csv
 `,
 		"/models/bar.sql": `SELECT * FROM foo`,
@@ -358,7 +358,7 @@ func TestSourceRefreshSchedule(t *testing.T) {
 1,2,3,4,5
 1,2,3,4,5`,
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/foo.csv
 refresh:
   every: 1
@@ -395,7 +395,7 @@ func TestSourceAndModelNameCollission(t *testing.T) {
 1,2,3,4,5
 `,
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/foo.csv
 `,
 	})
@@ -406,8 +406,8 @@ path: data/foo.csv
 	// Create a source with same name within a different folder
 	testruntime.PutFiles(t, rt, id, map[string]string{
 		"/other_folder/foo.yaml": `
-kind: source
-type: local_file
+type: source
+connector: local_file
 path: data/foo.csv
 `,
 	})
@@ -425,7 +425,7 @@ path: data/foo.csv
 	testruntime.PutFiles(t, rt, id, map[string]string{
 		"/sources/foo_1.yaml": `
 name: foo
-type: local_file
+connector: local_file
 path: data/foo.csv
 `,
 	})
@@ -504,7 +504,7 @@ func TestModelCTE(t *testing.T) {
 1,2,3,4,5
 `,
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/foo.csv
 `,
 		"/models/bar.sql": `SELECT * FROM foo`,
@@ -552,7 +552,7 @@ func TestRename(t *testing.T) {
 1,2,3,4,5
 `,
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/foo.csv
 `,
 		"/models/bar.sql": `SELECT * FROM foo`,
@@ -612,7 +612,7 @@ func TestRenameToOther(t *testing.T) {
 1,2,3,4,5
 `,
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/foo.csv
 `,
 		"/models/bar1.sql": `SELECT * FROM foo limit 1`,
@@ -645,7 +645,7 @@ func TestInterdependence(t *testing.T) {
 1,2,3,4,5
 `,
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/foo.csv
 `,
 		"/models/bar1.sql": `SELECT * FROM foo`,
@@ -673,7 +673,7 @@ measures:
 	// Update the source to invalid file
 	testruntime.PutFiles(t, rt, id, map[string]string{
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/bar.csv
 `,
 	})
@@ -744,7 +744,7 @@ func TestCyclesWithThreeModels(t *testing.T) {
 1,2,3,4,5
 `,
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/foo.csv
 `,
 		"/models/bar1.sql": `SELECT * FROM bar2`,
@@ -796,7 +796,7 @@ func TestMetricsView(t *testing.T) {
 1,2,3,4,5
 `,
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/foo.csv
 `,
 		"/models/bar.sql": `SELECT * FROM foo`,
@@ -977,7 +977,7 @@ func TestStageChanges(t *testing.T) {
 1,2,3,4,5
 `,
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/foo.csv
 `,
 		"/models/bar.sql": `SELECT * FROM foo`,
@@ -1003,7 +1003,7 @@ measures:
 	// Invalid source
 	testruntime.PutFiles(t, rt, id, map[string]string{
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/bar.csv
 `,
 	})
@@ -1052,7 +1052,7 @@ func TestWatch(t *testing.T) {
 1,2,3,4,5
 `,
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/foo.csv
 `,
 	})
@@ -1099,7 +1099,7 @@ func TestDashboardTheme(t *testing.T) {
 1,2,3,4,5
 `,
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/foo.csv
 `,
 		"/models/bar.sql": `SELECT * FROM foo`,
@@ -1113,7 +1113,7 @@ measures:
 - expression: count(*)
 `,
 		`themes/t1.yaml`: `
-kind: theme
+type: theme
 colors:
   primary: red
   secondary: grey
@@ -1157,7 +1157,7 @@ colors:
 	// make the theme invalid
 	testruntime.PutFiles(t, rt, id, map[string]string{
 		`themes/t1.yaml`: `
-kind: theme
+type: theme
 colors:
   primary: xxx
   secondary: xxx
@@ -1172,7 +1172,7 @@ colors:
 	// make the theme valid
 	testruntime.PutFiles(t, rt, id, map[string]string{
 		`themes/t1.yaml`: `
-kind: theme
+type: theme
 colors:
   primary: red
   secondary: grey
@@ -1194,7 +1194,7 @@ func TestAlert(t *testing.T) {
 2024-01-01T00:00:00Z,Denmark
 `,
 		"/sources/foo.yaml": `
-type: local_file
+connector: local_file
 path: data/foo.csv
 `,
 		"/models/bar.sql": `SELECT * FROM foo`,

--- a/runtime/reconcilers/alert_test.go
+++ b/runtime/reconcilers/alert_test.go
@@ -31,10 +31,10 @@ measures:
 - expression: count(*)
 `,
 		"/alerts/a1.yaml": `
-kind: alert
+type: alert
 title: Test Alert
 refs:
-- kind: MetricsView
+- type: MetricsView
   name: mv1
 watermark: inherit
 intervals:
@@ -187,10 +187,10 @@ measures:
 - expression: count(*)
 `,
 		"/alerts/a1.yaml": `
-kind: alert
+type: alert
 title: Test Alert
 refs:
-- kind: MetricsView
+- type: MetricsView
   name: mv1
 watermark: inherit
 intervals:

--- a/runtime/server/generate_metrics_view.go
+++ b/runtime/server/generate_metrics_view.go
@@ -188,7 +188,7 @@ func (s *Server) generateMetricsViewYAMLWithAI(ctx context.Context, instanceID, 
 	}
 
 	// The AI only generates metrics. We fill in the other properties using the simple logic.
-	doc.Kind = "metrics_view"
+	doc.Type = "metrics_view"
 	doc.TimeDimension = generateMetricsViewYAMLSimpleTimeDimension(tbl.Schema)
 	doc.Dimensions = generateMetricsViewYAMLSimpleDimensions(tbl.Schema)
 	if isModel {
@@ -308,7 +308,7 @@ Give me up to 10 suggested metrics using the %q SQL dialect based on the table n
 // generateMetricsViewYAMLSimple generates a simple metrics view YAML definition from a table schema.
 func generateMetricsViewYAMLSimple(connector string, tbl *drivers.Table, isDefaultConnector, isModel bool, schema *runtimev1.StructType) (string, error) {
 	doc := &metricsViewYAML{
-		Kind:          "metrics_view",
+		Type:          "metrics_view",
 		Title:         identifierToTitle(tbl.Name),
 		TimeDimension: generateMetricsViewYAMLSimpleTimeDimension(schema),
 		Dimensions:    generateMetricsViewYAMLSimpleDimensions(schema),
@@ -387,7 +387,7 @@ func generateMetricsViewYAMLSimpleMeasures(schema *runtimev1.StructType) []*metr
 // metricsViewYAML is a struct for generating a metrics view YAML file.
 // We do not use the parser's structs since they are not suitable for generating pretty output YAML.
 type metricsViewYAML struct {
-	Kind                string                      `yaml:"kind,omitempty"`
+	Type                string                      `yaml:"type,omitempty"`
 	Title               string                      `yaml:"title,omitempty"`
 	Connector           string                      `yaml:"connector,omitempty"`
 	Database            string                      `yaml:"database,omitempty"`

--- a/runtime/testruntime/testdata/ad_bids/dashboards/ad_bids_metrics_view.yaml
+++ b/runtime/testruntime/testdata/ad_bids/dashboards/ad_bids_metrics_view.yaml
@@ -1,7 +1,7 @@
 # Dashboard YAML
 # Reference documentation: https://docs.rilldata.com/reference/project-files/dashboards
 
-kind: metrics_view
+type: metrics_view
 title: Ad Bids
 model: ad_bids
 timeseries: timestamp

--- a/runtime/testruntime/testdata/ad_bids/sources/ad_bids_mini_source.yaml
+++ b/runtime/testruntime/testdata/ad_bids/sources/ad_bids_mini_source.yaml
@@ -1,2 +1,2 @@
-type: local_file
+connector: local_file
 path: data/AdBids_mini.csv

--- a/runtime/testruntime/testdata/ad_bids/sources/ad_bids_source.yaml
+++ b/runtime/testruntime/testdata/ad_bids/sources/ad_bids_source.yaml
@@ -1,2 +1,2 @@
-type: local_file
+connector: local_file
 path: data/AdBids.csv.gz

--- a/runtime/testruntime/testdata/ad_bids_2rows/sources/ad_bids_source.yaml
+++ b/runtime/testruntime/testdata/ad_bids_2rows/sources/ad_bids_source.yaml
@@ -1,2 +1,2 @@
-type: local_file
+connector: local_file
 path: data/AdBids_2rows.csv


### PR DESCRIPTION
This PR only changes user-facing usage of `kind`, such as in YAML files and log/error messages. Changing the terminology internally can be done separately.

Example usage:
```yaml
# apis/my_api.yaml
type: api
sql: SELECT 3.141
```

This PR is backwards compatible with older files that use `kind:` and also with older source files that use `type:` to specify the source connector (though only for sources defined in the `sources/` directory).