### PR TITLE
Fix: Unfocus YAML Editor on file change

### DIFF
--- a/web-common/src/components/editor/YAMLEditor.svelte
+++ b/web-common/src/components/editor/YAMLEditor.svelte
@@ -13,6 +13,7 @@
   export let extensions: Extension[] = [];
   export let view: EditorView | undefined = undefined;
   export let whenFocused = false;
+  export let key: string;
 
   let container: HTMLElement;
 
@@ -36,6 +37,14 @@
     });
   });
 
+  $: if (key) {
+    // When the key changes, unfocus the Editor so that the update is dispatched
+    view?.contentDOM.blur();
+  }
+
+  // reactive statements to dynamically update the editor when inputs change
+  $: updateEditorContents(content);
+
   function updateEditorContents(newContent: string) {
     if (view && !view.hasFocus) {
       let curContent = view.state.doc.toString();
@@ -50,9 +59,6 @@
       }
     }
   }
-
-  // reactive statements to dynamically update the editor when inputs change
-  $: updateEditorContents(content);
 </script>
 
 <div bind:this={container} class="contents" />

--- a/web-common/src/components/editor/__stories__/YAMLEditor.stories.svelte
+++ b/web-common/src/components/editor/__stories__/YAMLEditor.stories.svelte
@@ -49,6 +49,7 @@ values:
       >
     </div>
     <YAMLEditor
+      key="key"
       {content}
       bind:view
       on:update={(event) => {

--- a/web-common/src/features/charts/editor/ChartsEditor.svelte
+++ b/web-common/src/features/charts/editor/ChartsEditor.svelte
@@ -53,6 +53,7 @@
 
 <ChartsEditorContainer error={yaml?.length ? mainError : undefined}>
   <YAMLEditor
+    key={filePath}
     bind:this={editor}
     bind:view
     content={yaml}

--- a/web-common/src/features/custom-dashboards/CustomDashboardEditor.svelte
+++ b/web-common/src/features/custom-dashboards/CustomDashboardEditor.svelte
@@ -10,6 +10,7 @@
 
   export let yaml: string;
   export let errors: V1ParseError[] = [];
+  export let filePath: string;
 
   const QUERY_DEBOUNCE_TIME = 300;
 
@@ -27,6 +28,7 @@
     bind:this={editor}
     bind:view
     content={yaml}
+    key={filePath}
     whenFocused
     on:update={(e) => debounceUpdateChartContent(e.detail.content)}
   />

--- a/web-common/src/features/generic-yaml-editor/YamlWorkspaceBody.svelte
+++ b/web-common/src/features/generic-yaml-editor/YamlWorkspaceBody.svelte
@@ -72,6 +72,7 @@
       <YAMLEditor
         bind:this={editor}
         bind:view
+        key={filePath}
         {content}
         whenFocused
         on:update={debouncedUpdate}

--- a/web-common/src/features/metrics-views/workspace/editor/MetricsEditor.svelte
+++ b/web-common/src/features/metrics-views/workspace/editor/MetricsEditor.svelte
@@ -41,6 +41,7 @@
 
 <MetricsEditorContainer error={yaml?.length ? mainError : undefined}>
   <YAMLEditor
+    key={filePath}
     bind:view
     content={yaml}
     extensions={[placeholderElements.extension, yamlSchema(metricsJsonSchema)]}

--- a/web-common/src/features/sources/editor/SourceEditor.svelte
+++ b/web-common/src/features/sources/editor/SourceEditor.svelte
@@ -12,6 +12,7 @@
   export let latest: string;
   export let hasUnsavedChanges: boolean;
   export let allErrors: V1ParseError[];
+  export let filePath: string;
 
   let view: EditorView;
 
@@ -42,6 +43,11 @@
 
 <div class="editor flex flex-col border border-gray-200 rounded h-full">
   <div class="grow flex bg-white overflow-y-auto rounded">
-    <YAMLEditor content={latest} bind:view on:update={handleUpdate} />
+    <YAMLEditor
+      content={latest}
+      bind:view
+      on:update={handleUpdate}
+      key={filePath}
+    />
   </div>
 </div>

--- a/web-local/src/routes/(application)/[type=workspace]/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/[type=workspace]/[name]/+page.svelte
@@ -330,6 +330,7 @@
         {#key assetName}
           {#if type === "source"}
             <SourceEditor
+              {filePath}
               {blob}
               {hasUnsavedChanges}
               allErrors={$allErrors}

--- a/web-local/src/routes/(application)/custom-dashboards/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/custom-dashboards/[name]/+page.svelte
@@ -233,6 +233,7 @@
         <div class="flex flex-col h-full overflow-hidden">
           <section class="size-full flex flex-col flex-shrink overflow-hidden">
             <CustomDashboardEditor
+              {filePath}
               {errors}
               {yaml}
               on:update={updateChartFile}

--- a/web-local/src/routes/(application)/dashboard/[name]/edit/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/edit/+page.svelte
@@ -61,6 +61,8 @@
   }
   $: [, fileName] = splitFolderAndName(filePath);
 
+  $: console.log({ filePath });
+
   $: instanceId = $runtime.instanceId;
   $: initLocalUserPreferenceStore(metricViewName);
   $: isModelingSupportedQuery = canModel(instanceId);
@@ -116,6 +118,8 @@
     );
     if (newRoute) await goto(newRoute);
   }
+
+  $: console.log("PAGE", { yaml });
 </script>
 
 <svelte:head>

--- a/web-local/src/routes/(application)/dashboard/[name]/edit/+page.svelte
+++ b/web-local/src/routes/(application)/dashboard/[name]/edit/+page.svelte
@@ -61,8 +61,6 @@
   }
   $: [, fileName] = splitFolderAndName(filePath);
 
-  $: console.log({ filePath });
-
   $: instanceId = $runtime.instanceId;
   $: initLocalUserPreferenceStore(metricViewName);
   $: isModelingSupportedQuery = canModel(instanceId);
@@ -118,8 +116,6 @@
     );
     if (newRoute) await goto(newRoute);
   }
-
-  $: console.log("PAGE", { yaml });
 </script>
 
 <svelte:head>


### PR DESCRIPTION
The Codemirror editor currently ignores updates that happen while the Editor is focused. This is partly a symptom of our invalidation/refetching approach where an update triggered via keystroke from within the editor is eventually received by the editor again via a prop update. Changing that behavior is an ongoing discussion. Because of that conditional, a focused editor would not update its content even when the underlying file being displayed changed.

This PR adds a `key` prop to the `YAMLEditor` that unfocuses the editor whenever the prop changes, allowing the conditional check to pass. Implementing it this way, as opposed to wrapping uses of the component in a `key` block, ensures the logic is documented/captured with the component.