### PR TITLE
Fix: complex values as tooltip key

### DIFF
--- a/web-common/src/features/charts/templates/stacked-area.ts
+++ b/web-common/src/features/charts/templates/stacked-area.ts
@@ -1,5 +1,9 @@
 import { ChartField } from "./build-template";
-import { multiLayerBaseSpec } from "./utils";
+import {
+  multiLayerBaseSpec,
+  sanitizeValuesForSpec,
+  sanitzeValueForVega,
+} from "./utils";
 
 /** Temporary solution for the lack of vega lite type exports */
 interface TooltipValue {
@@ -37,7 +41,7 @@ export function buildStackedArea(
   const multiValueTooltipChannel: TooltipValue[] | undefined =
     nominalField?.values?.map((value) => {
       return {
-        field: value === null ? "null" : value,
+        field: value === null ? "null" : sanitzeValueForVega(value),
         type: "quantitative",
       };
     });
@@ -62,9 +66,10 @@ export function buildStackedArea(
   };
 
   if (nominalField?.values?.length) {
+    const values = sanitizeValuesForSpec(nominalField.values);
     baseSpec.transform = [
       {
-        calculate: `indexof([${nominalField.values
+        calculate: `indexof([${values
           ?.map((v) => `'${v}'`)
           .reverse()
           .join(",")}], datum.${nominalField?.name})`,

--- a/web-common/src/features/charts/templates/utils.ts
+++ b/web-common/src/features/charts/templates/utils.ts
@@ -22,3 +22,12 @@ export function multiLayerBaseSpec() {
 
   return baseSpec;
 }
+
+export function sanitzeValueForVega(value: string | null) {
+  return value
+    ? value.replace(/[\.\-\{\}\[\]]/g, (match) => `\\${match}`)
+    : String(value);
+}
+export function sanitizeValuesForSpec(values: (string | null)[]) {
+  return values.map((value) => sanitzeValueForVega(value));
+}


### PR DESCRIPTION
Stacked area tooltips were breaking for values having special characters in them (ex- dot, dash etc.)

This PR sanitizes the value before passing them to be used in the spec.