### PR TITLE
UI: Use `type:` instead of `kind:` for resource types

### DIFF
--- a/web-admin/src/features/projects/status/ProjectResourcesTable.svelte
+++ b/web-admin/src/features/projects/status/ProjectResourcesTable.svelte
@@ -23,7 +23,7 @@
   const columns = table.createColumns([
     table.column({
       accessor: (resource) => resource.meta.name.kind,
-      header: "Kind",
+      header: "Type",
       cell: ({ value }) => {
         const prettyKind = prettyResourceKind(value);
         const color = getResourceKindTagColor(value);
@@ -80,7 +80,7 @@
     table.createViewModel(columns);
 </script>
 
-<div class="rounded-md border">
+<div class="border rounded-md">
   <Table.Root {...$tableAttrs}>
     <Table.Header>
       {#each $headerRows as headerRow}

--- a/web-common/src/features/charts/chartYaml.ts
+++ b/web-common/src/features/charts/chartYaml.ts
@@ -8,7 +8,7 @@ export function getChartYaml(
 ) {
   const doc = new Document();
   doc.commentBefore = ` Chart YAML\n Reference documentation: https://docs.rilldata.com/reference/project-files/charts`;
-  doc.set("kind", "component");
+  doc.set("type", "component");
 
   // TODO: more fields from resolverProperties
   if (resolver === "sql") {

--- a/web-common/src/features/charts/prompt/generateChart.spec.ts
+++ b/web-common/src/features/charts/prompt/generateChart.spec.ts
@@ -21,7 +21,7 @@ where publisher is not null`,
     ).toEqual(`# Chart YAML
 # Reference documentation: https://docs.rilldata.com/reference/project-files/charts
 
-kind: component
+type: component
 data:
   sql: |-
     select * from AdBids
@@ -40,7 +40,7 @@ where publisher is not null`,
     ).toEqual(`# Chart YAML
 # Reference documentation: https://docs.rilldata.com/reference/project-files/charts
 
-kind: component
+type: component
 data:
   metrics_sql: |-
     select * from AdBids

--- a/web-common/src/features/charts/prompt/generateChart.ts
+++ b/web-common/src/features/charts/prompt/generateChart.ts
@@ -4,8 +4,8 @@ import {
   parseChartYaml,
 } from "@rilldata/web-common/features/charts/chartYaml";
 import {
-  chartPromptsStore,
   ChartPromptStatus,
+  chartPromptsStore,
 } from "@rilldata/web-common/features/charts/prompt/chartPrompt";
 import { useChart } from "@rilldata/web-common/features/charts/selectors";
 import {
@@ -14,11 +14,11 @@ import {
 } from "@rilldata/web-common/features/entity-management/entity-mappers";
 import { EntityType } from "@rilldata/web-common/features/entity-management/types";
 import {
+  V1ComponentSpec,
   createRuntimeServiceGenerateRenderer,
   createRuntimeServiceGenerateResolver,
   createRuntimeServiceGetFile,
   runtimeServicePutFile,
-  V1ComponentSpec,
 } from "@rilldata/web-common/runtime-client";
 import { get } from "svelte/store";
 
@@ -84,14 +84,14 @@ export function createFullChartGenerator(instanceId: string) {
     try {
       // add an empty chart
       await runtimeServicePutFile(instanceId, filePath, {
-        blob: `kind: chart`,
+        blob: `type: component`,
       });
       chartPromptsStore.startPrompt(
         (table || metricsView) ?? "",
         newChartName,
         prompt,
       );
-      await goto(`/files//${filePath}`);
+      await goto(`/files/${filePath}`);
       const resolverResp = await get(generateResolver).mutateAsync({
         instanceId,
         data: {

--- a/web-common/src/features/entity-management/actions.ts
+++ b/web-common/src/features/entity-management/actions.ts
@@ -10,12 +10,12 @@ import {
   runtimeServiceRenameFile,
 } from "@rilldata/web-common/runtime-client";
 import { httpRequestQueue } from "@rilldata/web-common/runtime-client/http-client";
+import { get } from "svelte/store";
 import {
-  addLeadingSlash,
   FolderToResourceKind,
+  addLeadingSlash,
   removeLeadingSlash,
 } from "./entity-mappers";
-import { get } from "svelte/store";
 
 export async function renameFileArtifact(
   instanceId: string,
@@ -60,7 +60,7 @@ export async function renameFileArtifact(
       !toPath.endsWith(".sql")
     ) {
       notifications.send({
-        message: `Moving ${fromName} out of native folder. Please make sure to add "kind" key to denote the type.`,
+        message: `Moving ${fromName} out of its native folder. Make sure to specify the resource type with the "type" key.`,
       });
     }
   } catch (err) {

--- a/web-common/src/features/entity-management/file-content-utils.spec.ts
+++ b/web-common/src/features/entity-management/file-content-utils.spec.ts
@@ -31,9 +31,21 @@ describe("parseKindAndNameFromFile", () => {
       { kind: ResourceKind.MetricsView, name: "AdBids_dashboard_name" },
     ],
     [
+      "explicit kind and name for sql",
+      "sources/AdBids_model.sql",
+      `\n\n-- @type : model\n--@name:AdBids_model_name\nselect * from AdBids`,
+      { kind: ResourceKind.Model, name: "AdBids_model_name" },
+    ],
+    [
       "explicit invalid kind for yaml",
       "sources/AdBids_dashboard.yaml",
       `\n\ntype : invalid\nmodel: AdBids_model\nmeasures: []\ndimensions: []`,
+      undefined,
+    ],
+    [
+      "explicit invalid kind for sql",
+      "sources/AdBids_model.sql",
+      `\n\n-- @type : invalid\nselect * from AdBids`,
       undefined,
     ],
   ];

--- a/web-common/src/features/entity-management/file-content-utils.spec.ts
+++ b/web-common/src/features/entity-management/file-content-utils.spec.ts
@@ -15,7 +15,7 @@ describe("parseKindAndNameFromFile", () => {
     [
       "implicit kind and name for yaml",
       "sources/AdBids.yaml",
-      `type: sql\nsql: select * from read_csv('data/AdBids.csv')`,
+      `connector: sql\nsql: select * from read_csv('data/AdBids.csv')`,
       { kind: ResourceKind.Source, name: "AdBids" },
     ],
     [
@@ -27,25 +27,13 @@ describe("parseKindAndNameFromFile", () => {
     [
       "explicit kind and name for yaml",
       "sources/AdBids_dashboard.yaml",
-      `\n\nkind : metrics_view\nname:AdBids_dashboard_name\nmodel: AdBids_model\nmeasures: []\ndimensions: []`,
+      `\n\ntype : metrics_view\nname:AdBids_dashboard_name\nmodel: AdBids_model\nmeasures: []\ndimensions: []`,
       { kind: ResourceKind.MetricsView, name: "AdBids_dashboard_name" },
-    ],
-    [
-      "explicit kind and name for sql",
-      "sources/AdBids_model.sql",
-      `\n\n-- @kind : model\n--@name:AdBids_model_name\nselect * from AdBids`,
-      { kind: ResourceKind.Model, name: "AdBids_model_name" },
     ],
     [
       "explicit invalid kind for yaml",
       "sources/AdBids_dashboard.yaml",
-      `\n\nkind : invalid\nmodel: AdBids_model\nmeasures: []\ndimensions: []`,
-      undefined,
-    ],
-    [
-      "explicit invalid kind for sql",
-      "sources/AdBids_model.sql",
-      `\n\n-- @kind : invalid\nselect * from AdBids`,
+      `\n\ntype : invalid\nmodel: AdBids_model\nmeasures: []\ndimensions: []`,
       undefined,
     ],
   ];

--- a/web-common/src/features/entity-management/file-content-utils.ts
+++ b/web-common/src/features/entity-management/file-content-utils.ts
@@ -68,7 +68,7 @@ function tryParseSql(
   let kind = kindFromFolder;
   let name = nameFromFolder;
 
-  const kindMatches = /^--\s*@kind\s*:\s*(.+?)\s*$/gm.exec(fileContents);
+  const kindMatches = /^--\s*@type\s*:\s*(.+?)\s*$/gm.exec(fileContents);
   if (kindMatches?.[1]) {
     kind = ResourceShortNameToKind[kindMatches?.[1] ?? ""];
   }

--- a/web-common/src/features/entity-management/file-content-utils.ts
+++ b/web-common/src/features/entity-management/file-content-utils.ts
@@ -36,14 +36,14 @@ function tryParseYaml(
 
   try {
     const yaml = parse(fileContents);
-    if (yaml.kind) {
+    if (yaml.type) {
       kind = ResourceShortNameToKind[yaml.kind as string];
     }
     if (yaml.name) {
       name = yaml.name as string;
     }
   } catch (err) {
-    const kindMatches = /^kind\s*:\s*(.+?)\s*$/gm.exec(fileContents);
+    const kindMatches = /^type\s*:\s*(.+?)\s*$/gm.exec(fileContents);
     if (kindMatches?.[1]) {
       kind = ResourceShortNameToKind[kindMatches?.[1] ?? ""];
     }

--- a/web-common/src/features/file-explorer/new-files.ts
+++ b/web-common/src/features/file-explorer/new-files.ts
@@ -58,7 +58,7 @@ SELECT 'Hello, World!' AS Greeting`,
     baseContent: `# Dashboard YAML
 # Reference documentation: https://docs.rilldata.com/reference/project-files/dashboards
 
-kind: metrics_view
+type: metrics_view
 
 title: "Dashboard Title"
 table: example_table # Choose a table to underpin your dashboard
@@ -81,7 +81,7 @@ measures:
     baseContent: `# API YAML
 # Reference documentation: https://docs.rilldata.com/reference/project-files/apis
 
-kind: api
+type: api
 
 sql:
   select ...
@@ -93,7 +93,7 @@ sql:
     baseContent: `# Chart YAML
 # Reference documentation: https://docs.rilldata.com/reference/project-files/charts
     
-kind: component
+type: component
 
 data:
   sql: |
@@ -139,7 +139,7 @@ vega_lite: |
   [ResourceKind.Dashboard]: {
     name: "custom-dashboard",
     extension: ".yaml",
-    baseContent: `kind: dashboard
+    baseContent: `type: dashboard
 columns: 10
 gap: 2`,
   },
@@ -149,7 +149,7 @@ gap: 2`,
     baseContent: `# Theme YAML
 # Reference documentation: https://docs.rilldata.com/reference/project-files/themes
 
-kind: theme
+type: theme
 
 colors:
   primary: plum
@@ -162,7 +162,7 @@ colors:
     baseContent: `# Report YAML
 # Reference documentation: TODO
 
-kind: report
+type: report
 
 ...
 `,
@@ -173,7 +173,7 @@ kind: report
     baseContent: `# Alert YAML
 # Reference documentation: TODO
 
-kind: alert
+type: alert
 
 ...
 `,

--- a/web-common/src/features/metrics-views/metrics-internal-store.ts
+++ b/web-common/src/features/metrics-views/metrics-internal-store.ts
@@ -5,7 +5,7 @@ export function initBlankDashboardYAML(dashboardTitle: string) {
 # Dashboard YAML
 # Reference documentation: https://docs.rilldata.com/reference/project-files/dashboards
 
-kind: metrics_view
+type: metrics_view
 
 title: ""
 table: ""

--- a/web-common/src/features/sources/sourceUtils.ts
+++ b/web-common/src/features/sources/sourceUtils.ts
@@ -11,7 +11,7 @@ export function compileCreateSourceYAML(
   const topOfFile = `# Source YAML
 # Reference documentation: https://docs.rilldata.com/reference/project-files/sources
 
-kind: source`;
+type: source`;
 
   switch (connectorName) {
     case "s3":
@@ -46,11 +46,11 @@ kind: source`;
     .map(([key, value]) => `${key}: "${value}"`)
     .join("\n");
 
-  return `${topOfFile}\n\ntype: "${connectorName}"\n` + compiledKeyValues;
+  return `${topOfFile}\n\nconnector: "${connectorName}"\n` + compiledKeyValues;
 }
 
 function buildDuckDbQuery(path: string): string {
-  const extension = extractFileExtension(path as string);
+  const extension = extractFileExtension(path);
   if (extensionContainsParts(extension, [".csv", ".tsv", ".txt"])) {
     return `select * from read_csv('${path}', auto_detect=true, ignore_errors=1, header=true)`;
   } else if (extensionContainsParts(extension, [".parquet"])) {

--- a/web-local/tests/dashboards/dashboards.spec.ts
+++ b/web-local/tests/dashboards/dashboards.spec.ts
@@ -276,7 +276,7 @@ test.describe("dashboard", () => {
 
     const changeDisplayNameDoc = `# Visit https://docs.rilldata.com/reference/project-files to learn more about Rill project files.
 
-    kind: metrics_view
+    type: metrics_view
     title: "AdBids_model_dashboard_rename"
     model: "AdBids_model"
     default_time_range: ""
@@ -320,7 +320,7 @@ test.describe("dashboard", () => {
 
     const addBackTimestampColumnDoc = `# Visit https://docs.rilldata.com/reference/project-files to learn more about Rill project files.
 
-    kind: metrics_view
+    type: metrics_view
     title: "AdBids_model_dashboard_rename"
     model: "AdBids_model"
     default_time_range: ""
@@ -356,7 +356,7 @@ test.describe("dashboard", () => {
 
     const deleteOnlyMeasureDoc = `# Visit https://docs.rilldata.com/reference/project-files to learn more about Rill project files.
 
-    kind: metrics_view
+    type: metrics_view
     title: "AdBids_model_dashboard_rename"
     model: "AdBids_model"
     default_time_range: ""
@@ -385,7 +385,7 @@ test.describe("dashboard", () => {
     // Add back the total rows measure for
     const docWithIncompleteMeasure = `# Visit https://docs.rilldata.com/reference/project-files to learn more about Rill project files.
 
-    kind: metrics_view
+    type: metrics_view
     title: "AdBids_model_dashboard_rename"
     model: "AdBids_model"
     default_time_range: ""
@@ -410,7 +410,7 @@ test.describe("dashboard", () => {
 
     const docWithCompleteMeasure = `# Visit https://docs.rilldata.com/reference/project-files to learn more about Rill project files.
 
-kind: metrics_view
+type: metrics_view
 title: "AdBids_model_dashboard_rename"
 model: "AdBids_model"
 default_time_range: ""

--- a/web-local/tests/dashboards/leaderboard-context-column.spec.ts
+++ b/web-local/tests/dashboards/leaderboard-context-column.spec.ts
@@ -15,7 +15,7 @@ test.describe("leaderboard context column", () => {
     // reset metrics, and add a metric with `valid_percent_of_total: true`
     const metricsWithValidPercentOfTotal = `# Visit https://docs.rilldata.com/reference/project-files to learn more about Rill project files.
 
-  kind: metrics_view
+  type: metrics_view
   title: "AdBids_model_dashboard"
   model: "AdBids_model"
   default_time_range: ""

--- a/web-local/tests/dashboards/time-controls-from-config.spec.disabled.ts
+++ b/web-local/tests/dashboards/time-controls-from-config.spec.disabled.ts
@@ -223,7 +223,7 @@ function getDashboardYaml(defaults: string) {
   return `
 # Visit https://docs.rilldata.com/reference/project-files to learn more about Rill project files.
 
-kind: metrics_view
+type: metrics_view
 title: "AdBids_model_dashboard_rename"
 model: "AdBids_model"
 timeseries: "timestamp"

--- a/web-local/tests/sources.spec.ts
+++ b/web-local/tests/sources.spec.ts
@@ -68,7 +68,7 @@ test.describe("sources", () => {
     await createSource(page, "AdBids.csv", "/sources/AdBids.yaml");
 
     // Edit source path to a non-existent file
-    const nonExistentSource = `type: local_file
+    const nonExistentSource = `connector: local_file
 path: ${TestDataPath}/non_existent_file.csv`;
     await updateCodeEditor(page, nonExistentSource);
     await page.getByRole("button", { name: "Save and refresh" }).click();
@@ -77,7 +77,7 @@ path: ${TestDataPath}/non_existent_file.csv`;
     await expect(page.getByText("file does not exist")).toBeVisible();
 
     // Edit source path to an existent file
-    const adImpressionsSource = `type: local_file
+    const adImpressionsSource = `connector: local_file
 path: ${TestDataPath}/AdImpressions.tsv`;
     await updateCodeEditor(page, adImpressionsSource);
     await page.getByRole("button", { name: "Save and refresh" }).click();


### PR DESCRIPTION
Follows https://github.com/rilldata/rill/pull/4774 with the relevant UI changes:
- New files are generated with `type` not `kind`
- The toast message that appears when moving a file out of its native folder uses "type" not "kind"
- The project status page uses "type" not "kind"
- Updates the client-side YAML parser in `file-content-utils.ts`
- Updates tests