### PR TITLE
Fix URL decoding already decoded state

### DIFF
--- a/web-common/src/features/dashboards/proto-state/fromProto.ts
+++ b/web-common/src/features/dashboards/proto-state/fromProto.ts
@@ -78,8 +78,10 @@ export function getDashboardStateFromUrl(
   metricsView: V1MetricsViewSpec,
   schema: V1StructType,
 ): Partial<MetricsExplorerEntity> {
+  // backwards compatibility for older urls that had encoded state
+  urlState = urlState.includes("%") ? decodeURIComponent(urlState) : urlState;
   return getDashboardStateFromProto(
-    base64ToProto(decodeURIComponent(urlState)),
+    base64ToProto(urlState),
     metricsView,
     schema,
   );


### PR DESCRIPTION
closes #4530

The issue was with only `+` being present in the state that would get decoded to a space. Now we are decoding only if there is a`%` in the state.