### PR TITLE
Add back reconnection to watch request client

### DIFF
--- a/web-common/src/features/sources/source-imported-utils.ts
+++ b/web-common/src/features/sources/source-imported-utils.ts
@@ -12,6 +12,7 @@ export async function checkSourceImported(
   const lastUpdatedOn =
     fileArtifacts.getFileArtifact(filePath).lastStateUpdatedOn;
   if (lastUpdatedOn) return; // For now only show for fresh sources
+
   const success = await waitForResourceUpdate(
     queryClient,
     get(runtime).instanceId,


### PR DESCRIPTION
WatchRequestClient no longer had the reconnection feature.

This causes issues during a fresh project when the controller is restarted and all the watch clients are disconnected. This can be seen by starting a fresh project and import a source, the loading spinner would be present forever since the reconciled event is never recieved.