### PR TITLE
File explorer - Invalidation issues when source's table query has errored or is deleted

### DIFF
--- a/web-common/src/features/entity-management/file-artifacts.ts
+++ b/web-common/src/features/entity-management/file-artifacts.ts
@@ -59,9 +59,7 @@ export class FileArtifact {
         V1ReconcileStatus.RECONCILE_STATUS_RUNNING,
     );
     this.renaming = !!resource.meta?.renamedFrom;
-    this.hasTable =
-      (!!resource.model && !!resource.model.state?.table) ||
-      (!!resource.source && !!resource.source.state?.table);
+    this.hasTable = resourceHasTable(resource);
   }
 
   public updateReconciling(resource: V1Resource) {
@@ -242,12 +240,13 @@ export class FileArtifacts {
     });
   }
 
-  public hadTable(resource: V1Resource) {
-    return (
+  public tableStatusChanged(resource: V1Resource) {
+    const hadTable =
       resource.meta?.filePaths?.some((filePath) => {
         return this.artifacts[filePath].hasTable;
-      }) ?? false
-    );
+      }) ?? false;
+    const hasTable = resourceHasTable(resource);
+    return hadTable !== hasTable;
   }
 
   public wasRenaming(resource: V1Resource) {
@@ -314,6 +313,13 @@ export class FileArtifacts {
       .filter((artifact) => get(artifact.name)?.kind === kind)
       .map((artifact) => get(artifact.name)?.name ?? "");
   }
+}
+
+function resourceHasTable(resource: V1Resource) {
+  return (
+    (!!resource.model && !!resource.model.state?.table) ||
+    (!!resource.source && !!resource.source.state?.table)
+  );
 }
 
 export const fileArtifacts = new FileArtifacts();

--- a/web-common/src/features/entity-management/file-artifacts.ts
+++ b/web-common/src/features/entity-management/file-artifacts.ts
@@ -62,6 +62,7 @@ export class FileArtifact {
     );
     this.renaming = !!resource.meta?.renamedFrom;
     this.hasTable = resourceHasTable(resource);
+    this.deleted = false;
   }
 
   public updateReconciling(resource: V1Resource) {

--- a/web-common/src/features/entity-management/file-artifacts.ts
+++ b/web-common/src/features/entity-management/file-artifacts.ts
@@ -45,6 +45,8 @@ export class FileArtifact {
 
   public hasTable = false;
 
+  public deleted = false;
+
   public constructor(filePath: string) {
     this.path = filePath;
   }
@@ -75,7 +77,7 @@ export class FileArtifact {
     this.lastStateUpdatedOn = resource.meta?.stateUpdatedOn;
   }
 
-  public deleteResource() {
+  public softDeleteResource() {
     this.reconciling.set(false);
   }
 
@@ -216,7 +218,31 @@ export class FileArtifacts {
    * This is called when an artifact is deleted.
    */
   public fileDeleted(filePath: string) {
-    delete this.artifacts[filePath];
+    // 2-way delete to handle race condition with delete from file and resource watchers
+    // TODO: avoid this if `name` is undefined - event from resource will not be present
+    if (this.artifacts[filePath]?.deleted) {
+      // already marked for delete in resourceDeleted, delete from cache
+      delete this.artifacts[filePath];
+    } else if (this.artifacts[filePath]) {
+      // seeing delete for the 1st time, mark for delete
+      this.artifacts[filePath].deleted = true;
+    }
+  }
+
+  public resourceDeleted(name: V1ResourceName) {
+    const artifact = this.findFileArtifact(
+      (name.kind ?? "") as ResourceKind,
+      name.name ?? "",
+    );
+    if (!artifact) return;
+    // 2-way delete to handle race condition with delete from file and resource watchers
+    if (artifact.deleted) {
+      // already marked for delete in fileDeleted, delete from cache
+      delete this.artifacts[artifact.path];
+    } else {
+      // seeing delete for the 1st time, mark for delete
+      artifact.deleted = true;
+    }
   }
 
   public updateArtifacts(resource: V1Resource) {
@@ -261,9 +287,9 @@ export class FileArtifacts {
   /**
    * This is called when a resource is deleted either because file was deleted or it errored out.
    */
-  public deleteResource(resource: V1Resource) {
+  public softDeleteResource(resource: V1Resource) {
     resource.meta?.filePaths?.forEach((filePath) => {
-      this.artifacts[filePath]?.deleteResource();
+      this.artifacts[filePath]?.softDeleteResource();
     });
   }
 

--- a/web-common/src/features/entity-management/resource-invalidations.ts
+++ b/web-common/src/features/entity-management/resource-invalidations.ts
@@ -45,6 +45,9 @@ export function invalidateResourceResponse(
   if (!res.name?.kind || !res.resource || !UsedResourceKinds[res.name.kind])
     return;
 
+  console.log(
+    `[${res.resource.meta?.reconcileStatus}] ${res.resource.meta?.name?.kind}/${res.resource.meta?.name?.name} delete=${!!res.resource?.meta?.deletedOn}`,
+  );
   const instanceId = get(runtime).instanceId;
   if (
     MainResourceKinds[res.name.kind] &&
@@ -104,17 +107,19 @@ async function invalidateResource(
   )
     return;
 
+  console.log(fileArtifacts.tableStatusChanged(resource));
   if (
     (resource.meta.name?.kind === ResourceKind.Source ||
       resource.meta.name?.kind === ResourceKind.Model) &&
-    (fileArtifacts.wasRenaming(resource) || !fileArtifacts.hadTable(resource))
+    (fileArtifacts.wasRenaming(resource) ||
+      fileArtifacts.tableStatusChanged(resource))
   ) {
     void queryClient.invalidateQueries(
       getConnectorServiceOLAPListTablesQueryKey({
         instanceId: get(runtime).instanceId,
         connector:
-          resource.source?.state?.connector ??
-          resource.model?.state?.connector ??
+          resource.source?.spec?.sinkConnector ??
+          resource.model?.spec?.connector ??
           "",
       }),
     );

--- a/web-common/src/features/entity-management/resource-invalidations.ts
+++ b/web-common/src/features/entity-management/resource-invalidations.ts
@@ -52,9 +52,6 @@ export function invalidateResourceResponse(
     return;
   }
 
-  console.log(
-    `[${res.resource.meta?.reconcileStatus}] ${res.name?.kind}/${res.name?.name}`,
-  );
   const instanceId = get(runtime).instanceId;
   if (
     MainResourceKinds[res.name.kind] &&

--- a/web-common/src/features/sources/modal/file-upload.ts
+++ b/web-common/src/features/sources/modal/file-upload.ts
@@ -36,6 +36,7 @@ export async function* uploadTableFiles(
     ...fileArtifacts.getNamesForKind(ResourceKind.Source),
     ...fileArtifacts.getNamesForKind(ResourceKind.Model),
   ];
+  console.log(allNames);
 
   for (const validFile of validFiles) {
     // check if the file is already present. get the file and

--- a/web-common/src/features/sources/modal/file-upload.ts
+++ b/web-common/src/features/sources/modal/file-upload.ts
@@ -36,7 +36,6 @@ export async function* uploadTableFiles(
     ...fileArtifacts.getNamesForKind(ResourceKind.Source),
     ...fileArtifacts.getNamesForKind(ResourceKind.Model),
   ];
-  console.log(allNames);
 
   for (const validFile of validFiles) {
     // check if the file is already present. get the file and

--- a/web-local/src/routes/(application)/[type=workspace]/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/[type=workspace]/[name]/+page.svelte
@@ -356,7 +356,7 @@
         <WorkspaceTableContainer fade={type === "source" && hasUnsavedChanges}>
           {#if type === "source" && $allErrors[0]?.message}
             <ErrorPane {filePath} errorMessage={$allErrors[0].message} />
-          {:else}
+          {:else if !$allErrors.length}
             <ConnectedPreviewTable
               {connector}
               table={tableName ?? ""}


### PR DESCRIPTION
- [x] When a source's table query errors (can be simulated by deleting the uploaded file and refreshed) we are not properly invalidating the list of olap tables. This was because we were not checking for chance in `table` field before invalidating. We should do a refactor here after the release to decrease complexity.
- [x] When a source (or any entity for that matter) is deleted and re-added, name collision occurs. This was because we were not handling delete event from resource watcher and there could be a race condition with file watcher leading to the artifact being re-added.