### PR TITLE
Fix: time comparison tooltip for stacked area

### DIFF
--- a/web-common/src/features/charts/templates/stacked-area.ts
+++ b/web-common/src/features/charts/templates/stacked-area.ts
@@ -41,13 +41,11 @@ export function buildStackedArea(
   ];
 
   const multiValueTooltipChannel: TooltipValue[] | undefined =
-    nominalField?.values?.map((value) => {
-      return {
-        field: value === null ? "null" : sanitizeValueForVega(value),
-        type: "quantitative",
-        formatType: "measureFormatter",
-      };
-    });
+    nominalField?.values?.map((value) => ({
+      field: sanitizeValueForVega(value),
+      type: "quantitative",
+      formatType: "measureFormatter",
+    }));
 
   if (multiValueTooltipChannel?.length) {
     multiValueTooltipChannel.unshift({

--- a/web-common/src/features/dashboards/time-dimension-details/charts/utils.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/charts/utils.ts
@@ -53,7 +53,7 @@ export function getVegaSpecForTDD(
       {
         name: "key",
         label: "Comparing",
-        values: [expandedMeasureName, `comparison\\.${expandedMeasureName}`],
+        values: [expandedMeasureName, `comparison.${expandedMeasureName}`],
       },
     ];
 


### PR DESCRIPTION
https://github.com/rilldata/rill/pull/4778 broke time comparison tooltip for stacked area. The comparison measure variable was being sanitized two times.