### PR TITLE
Fix: show TDD table on scrub

### DIFF
--- a/web-common/src/features/dashboards/time-series/multiple-dimension-queries.ts
+++ b/web-common/src/features/dashboards/time-series/multiple-dimension-queries.ts
@@ -308,7 +308,7 @@ export function getDimensionValueTimeSeries(
       )
         return set([]);
       if (!timeDimension || dashboardStore?.selectedScrubRange?.isScrubbing)
-        return set([]);
+        return;
 
       const { batchedTopList, batchedQueries } = batchAggregationQueries(
         ctx,


### PR DESCRIPTION
On scrubbing the TDD table would become empty. This PR now returns `undefined` instead of returning empty array so that the previous state is preserved.