### PR TITLE
Fix 500 error on application startup

### DIFF
--- a/web-common/src/features/feature-flags.ts
+++ b/web-common/src/features/feature-flags.ts
@@ -1,12 +1,12 @@
+import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
 import type { BeforeNavigate } from "@sveltejs/kit";
 import { writable } from "svelte/store";
+import { debounce } from "../lib/create-debouncer";
 import {
   createRuntimeServiceGetInstance,
   V1InstanceFeatureFlags,
 } from "../runtime-client";
 import { runtime } from "../runtime-client/runtime-store";
-import { debounce } from "../lib/create-debouncer";
-import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
 
 class FeatureFlag {
   private state = writable(false);
@@ -59,7 +59,7 @@ class FeatureFlags {
     runtime.subscribe((runtime) => {
       if (!runtime?.instanceId) return;
 
-      createRuntimeServiceGetInstance(runtime.instanceId, {
+      createRuntimeServiceGetInstance(runtime.instanceId, undefined, {
         query: {
           select: (data) => data?.instance?.featureFlags,
           queryClient,


### PR DESCRIPTION
PR https://github.com/rilldata/rill/pull/4800 introduced a bug where the application would throw a 500 error on startup. The function `createRuntimeServiceGetInstance` was missing a parameter `params`. I've explicitly provided it as `undefined`.