### PR TITLE
Fix: chart labels from overflow

### DIFF
--- a/web-common/src/features/dashboards/time-dimension-details/charts/ChartTypeSelector.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/charts/ChartTypeSelector.svelte
@@ -73,7 +73,7 @@
 
 <style lang="postcss">
   .chart-type-selector {
-    @apply flex ml-auto overflow-hidden mr-2;
+    @apply flex ml-auto overflow-hidden mr-4;
     @apply border border-primary-300 divide-x divide-primary-300 rounded-sm;
   }
   .chart-icon-wrapper {

--- a/web-common/src/features/dashboards/time-series/TimeSeriesChartContainer.svelte
+++ b/web-common/src/features/dashboards/time-series/TimeSeriesChartContainer.svelte
@@ -11,11 +11,9 @@ A container GraphicContext for the time series in a metrics dashboard.
   export let enableFullWidth = false;
 
   const paddingForFullWidth = 80;
-
-  $: paddingRight = enableFullWidth ? "pr-6" : "pr-2";
 </script>
 
-<div class={`max-w-full h-fit flex flex-col max-h-full ${paddingRight}`}>
+<div class="max-w-full h-fit flex flex-col max-h-full pr-2">
   <GraphicContext
     bottom={4}
     height={enableFullWidth


### PR DESCRIPTION
Current:
![image](https://github.com/rilldata/rill/assets/4402679/fdb66d3b-d8c9-41c9-aef8-0ad329ce8e86)


After:
![image](https://github.com/rilldata/rill/assets/4402679/4288f7aa-8ab8-40b7-bbfa-797644e38b6b)
