### PR TITLE
Runtime: Parse inf and NaN results from Druid as floats

### DIFF
--- a/runtime/drivers/druid/druidsqldriver/druid_api_sql_driver.go
+++ b/runtime/drivers/druid/druidsqldriver/druid_api_sql_driver.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -131,6 +132,44 @@ func (c *sqlConnection) QueryContext(ctx context.Context, query string, args []d
 					switch v := v.(type) {
 					case float64:
 						return int64(v), nil
+					default:
+						return v, nil
+					}
+				}
+			case "FLOAT":
+				transformers[i] = func(v any) (any, error) {
+					switch v := v.(type) {
+					case float64:
+						return float32(v), nil
+					case string:
+						return strconv.ParseFloat(v, 32)
+					default:
+						return v, nil
+					}
+				}
+			case "DOUBLE":
+				transformers[i] = func(v any) (any, error) {
+					switch v := v.(type) {
+					case string:
+						return strconv.ParseFloat(v, 64)
+					default:
+						return v, nil
+					}
+				}
+			case "REAL":
+				transformers[i] = func(v any) (any, error) {
+					switch v := v.(type) {
+					case string:
+						return strconv.ParseFloat(v, 64)
+					default:
+						return v, nil
+					}
+				}
+			case "DECIMAL":
+				transformers[i] = func(v any) (any, error) {
+					switch v := v.(type) {
+					case string:
+						return strconv.ParseFloat(v, 64)
 					default:
 						return v, nil
 					}


### PR DESCRIPTION
Druid returns NaN and +/-Infinity results as JSON strings. This PR parses such strings into native Go floats, which can natively represent NaN and infinity. 

The runtime server already returns NaN and Infinity as `null`, so this change ensures strings will never be returned as floating point values from Druid-backed metrics queries.
