### PR TITLE
CLI: Uninstall command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,10 @@ tsc-tmp/
 /runtime/sql/deps
 /runtime/release
 /runtime/pkg/examples/embed/dist
-/cli/pkg/web/embed/dist
 /rill
 /cli/pkg/examples/embed/dist
+/cli/pkg/installscript/embed
+/cli/pkg/web/embed/dist
 /dev-project*
 /dev-cloud-state*
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ tsc-tmp/
 /runtime/pkg/examples/embed/dist
 /rill
 /cli/pkg/examples/embed/dist
-/cli/pkg/installscript/embed
+/cli/pkg/installscript/embed/install.sh
 /cli/pkg/web/embed/dist
 /dev-project*
 /dev-cloud-state*

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ cli.prepare:
 	mkdir -p runtime/pkg/examples/embed/dist
 	git clone --quiet https://github.com/rilldata/rill-examples.git runtime/pkg/examples/embed/dist
 	rm -rf runtime/pkg/examples/embed/dist/.git
+	cp scripts/install.sh cli/pkg/installscript/embed/install.sh
 
 .PHONY: coverage.go
 coverage.go:

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rilldata/rill/cli/cmd/service"
 	"github.com/rilldata/rill/cli/cmd/start"
 	"github.com/rilldata/rill/cli/cmd/sudo"
+	"github.com/rilldata/rill/cli/cmd/uninstall"
 	"github.com/rilldata/rill/cli/cmd/upgrade"
 	"github.com/rilldata/rill/cli/cmd/user"
 	versioncmd "github.com/rilldata/rill/cli/cmd/version"
@@ -153,6 +154,7 @@ func runCmd(ctx context.Context, ver cmdutil.Version) error {
 		completionCmd,
 		versioncmd.VersionCmd(),
 		upgrade.UpgradeCmd(ch),
+		uninstall.UninstallCmd(ch),
 		sudo.SudoCmd(ch),
 		devtool.DevtoolCmd(ch),
 		admin.AdminCmd(ch),

--- a/cli/cmd/uninstall/uninstall.go
+++ b/cli/cmd/uninstall/uninstall.go
@@ -1,0 +1,18 @@
+package uninstall
+
+import (
+	"github.com/rilldata/rill/cli/pkg/cmdutil"
+	"github.com/rilldata/rill/cli/pkg/installscript"
+	"github.com/spf13/cobra"
+)
+
+func UninstallCmd(ch *cmdutil.Helper) *cobra.Command {
+	return &cobra.Command{
+		Use:   "uninstall",
+		Short: "Uninstall the Rill binary",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return installscript.Uninstall(cmd.Context())
+		},
+	}
+}

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -1,56 +1,31 @@
 package upgrade
 
 import (
-	"io"
-	"net/http"
-	"os"
-	"os/exec"
-
 	"github.com/rilldata/rill/cli/pkg/cmdutil"
+	"github.com/rilldata/rill/cli/pkg/installscript"
 	"github.com/spf13/cobra"
 )
 
-const installScriptURL = "https://cdn.rilldata.com/install.sh"
-
 func UpgradeCmd(ch *cmdutil.Helper) *cobra.Command {
+	var version string
 	var nightly bool
 
 	upgradeCmd := &cobra.Command{
 		Use:   "upgrade",
 		Short: "Upgrade Rill to the latest version",
 		Args:  cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			// Download the install script to a temporary file
-			f, err := os.CreateTemp("", "install*.sh")
-			if err != nil {
-				return err
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if version != "" {
+				return installscript.Install(cmd.Context(), version)
 			}
-			defer os.Remove(f.Name())
-
-			resp, err := http.Get(installScriptURL)
-			if err != nil {
-				return err
-			}
-			defer resp.Body.Close()
-
-			_, err = io.Copy(f, resp.Body)
-			if err != nil {
-				return err
-			}
-			f.Close()
-
-			// Run the install script with bash
-			args := []string{f.Name()}
 			if nightly {
-				args = append(args, "--nightly")
+				return installscript.Install(cmd.Context(), "nightly")
 			}
-			cmd := exec.Command("/bin/bash", args...)
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			return cmd.Run()
+			return installscript.Install(cmd.Context(), "")
 		},
 	}
 
+	upgradeCmd.Flags().StringVar(&version, "version", "", "Install a specific version of Rill")
 	upgradeCmd.Flags().BoolVar(&nightly, "nightly", false, "Install the latest nightly build")
 
 	return upgradeCmd

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -1,6 +1,9 @@
 package upgrade
 
 import (
+	"fmt"
+
+	goversion "github.com/hashicorp/go-version"
 	"github.com/rilldata/rill/cli/pkg/cmdutil"
 	"github.com/rilldata/rill/cli/pkg/installscript"
 	"github.com/spf13/cobra"
@@ -16,11 +19,20 @@ func UpgradeCmd(ch *cmdutil.Helper) *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if version != "" {
+				// Parse the version into the canonical form
+				v, err := goversion.NewVersion(version)
+				if err != nil {
+					return fmt.Errorf("invalid version: %s", version)
+				}
+				version = "v" + v.String()
+
 				return installscript.Install(cmd.Context(), version)
 			}
+
 			if nightly {
 				return installscript.Install(cmd.Context(), "nightly")
 			}
+
 			return installscript.Install(cmd.Context(), "")
 		},
 	}

--- a/cli/cmd/upgrade/upgrade.go
+++ b/cli/cmd/upgrade/upgrade.go
@@ -1,8 +1,6 @@
 package upgrade
 
 import (
-	"fmt"
-
 	goversion "github.com/hashicorp/go-version"
 	"github.com/rilldata/rill/cli/pkg/cmdutil"
 	"github.com/rilldata/rill/cli/pkg/installscript"
@@ -22,7 +20,7 @@ func UpgradeCmd(ch *cmdutil.Helper) *cobra.Command {
 				// Parse the version into the canonical form
 				v, err := goversion.NewVersion(version)
 				if err != nil {
-					return fmt.Errorf("invalid version: %s", version)
+					return err
 				}
 				version = "v" + v.String()
 

--- a/cli/pkg/installscript/installscript.go
+++ b/cli/pkg/installscript/installscript.go
@@ -44,6 +44,7 @@ func createScriptFile() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("install script not embedded (is this a dev build?): %w", err)
 	}
+	defer in.Close()
 
 	// Write the install script to a temporary file
 	out, err := os.CreateTemp("", "install*.sh")

--- a/cli/pkg/installscript/installscript.go
+++ b/cli/pkg/installscript/installscript.go
@@ -32,7 +32,7 @@ func execScript(ctx context.Context, args ...string) error {
 
 	// Execute the script with bash
 	args = append([]string{script}, args...)
-	cmd := exec.CommandContext(ctx, "/bin/bash", args...)
+	cmd := exec.CommandContext(ctx, "/bin/sh", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/cli/pkg/installscript/installscript.go
+++ b/cli/pkg/installscript/installscript.go
@@ -1,0 +1,62 @@
+package installscript
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+)
+
+//go:embed embed/*
+var embedFS embed.FS
+
+func Install(ctx context.Context, version string) error {
+	if version != "" {
+		return execScript(ctx, "--version", version)
+	}
+	return execScript(ctx)
+}
+
+func Uninstall(ctx context.Context) error {
+	return execScript(ctx, "--uninstall")
+}
+
+func execScript(ctx context.Context, args ...string) error {
+	script, err := createScriptFile()
+	if err != nil {
+		return err
+	}
+	defer os.Remove(script)
+
+	// Execute the script with bash
+	args = append([]string{script}, args...)
+	cmd := exec.CommandContext(ctx, "/bin/bash", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func createScriptFile() (string, error) {
+	// Open the embedded install script file
+	in, err := embedFS.Open("embed/install.sh")
+	if err != nil {
+		return "", fmt.Errorf("install script not embedded (is this a dev build?): %w", err)
+	}
+
+	// Write the install script to a temporary file
+	out, err := os.CreateTemp("", "install*.sh")
+	if err != nil {
+		return "", err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	if err != nil {
+		return "", err
+	}
+
+	// Return the temp script path
+	return out.Name(), nil
+}


### PR DESCRIPTION
This PR adds a `rill uninstall` command.

It also makes two other minor changes to improve the CLI's use of the install script:
- Adds support for the `--version` flag on `rill upgrade`
- Embeds the install script directly in the binary

