### PR TITLE
runtime-local auth support

### DIFF
--- a/admin/database/database.go
+++ b/admin/database/database.go
@@ -515,6 +515,7 @@ const (
 	AuthClientIDRillWeb     = "12345678-0000-0000-0000-000000000001"
 	AuthClientIDRillCLI     = "12345678-0000-0000-0000-000000000002"
 	AuthClientIDRillSupport = "12345678-0000-0000-0000-000000000003"
+	AuthClientIDRillLocal   = "12345678-0000-0000-0000-000000000004"
 )
 
 // DeviceAuthCodeState is an enum representing the approval state of a DeviceAuthCode

--- a/admin/database/postgres/migrations/0028.sql
+++ b/admin/database/postgres/migrations/0028.sql
@@ -1,0 +1,3 @@
+-- Hard-coded first-party auth clients
+INSERT INTO auth_clients (id, display_name)
+VALUES ('12345678-0000-0000-0000-000000000004', 'Rill Local');

--- a/admin/server/auth/pkce.go
+++ b/admin/server/auth/pkce.go
@@ -1,0 +1,178 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/rilldata/rill/cli/pkg/auth"
+)
+
+const authorizationCodeGrantType = "authorization_code"
+
+// in-memory storage for authorization codes
+// TODO use persistent storage to handle admin server restarts, but since codes expire in a minute, is it really necessary, user can just re-initiate login ?
+var authCodeDB = make(map[string]AuthorizationCode)
+
+// AuthorizationCode represents the stored information for an authorization code
+type AuthorizationCode struct {
+	ClientID            string
+	RedirectURI         string
+	UserID              string
+	Expiration          time.Time
+	CodeChallenge       string
+	CodeChallengeMethod string
+}
+
+func handlePKCE(w http.ResponseWriter, r *http.Request, clientID, userID, codeChallenge, codeChallengeMethod, redirectURI string) {
+	// Generate a unique authorization code
+	code, err := generateRandomString(16) // 16 bytes, resulting in a 32-character hex string
+	if err != nil {
+		http.Error(w, "Failed to generate authorization code", http.StatusInternalServerError)
+		return
+	}
+
+	// Set the expiration date for the authorization code (e.g., a minute from now)
+	// Note from https://www.oauth.com/oauth2-servers/authorization/the-authorization-response/
+	// The authorization code must expire shortly after it is issued. The OAuth 2.0 spec recommends a maximum lifetime of 10 minutes, but in practice, most services set the expiration much shorter, around 30-60 seconds.
+	expiration := time.Now().Add(1 * time.Minute)
+
+	authCodeDB[code] = AuthorizationCode{
+		ClientID:            clientID,
+		RedirectURI:         redirectURI,
+		UserID:              userID,
+		Expiration:          expiration,
+		CodeChallenge:       codeChallenge,
+		CodeChallengeMethod: codeChallengeMethod,
+	}
+
+	// Build the redirection URI with the authorization code as per OAuth2 spec
+	redirectWithCode := fmt.Sprintf("%s?code=%s&state=%s", redirectURI, code, r.URL.Query().Get("state"))
+
+	// Redirect the user agent to the redirect URI with the authorization code
+	http.Redirect(w, r, redirectWithCode, http.StatusFound)
+}
+
+// getAccessTokenForAuthorizationCode exchanges an authorization code for an access token
+func (a *Authenticator) getAccessTokenForAuthorizationCode(w http.ResponseWriter, r *http.Request, values url.Values) {
+	// Extract the authorization code
+	code := values.Get("code")
+	if code == "" {
+		http.Error(w, "authorization code is required", http.StatusBadRequest)
+		return
+	}
+
+	// Extract the client ID
+	clientID := values.Get("client_id")
+	if clientID == "" {
+		http.Error(w, "client ID is required", http.StatusBadRequest)
+		return
+	}
+
+	// Extract the redirect URI
+	redirectURI := values.Get("redirect_uri")
+	if redirectURI == "" {
+		http.Error(w, "redirect URI is required", http.StatusBadRequest)
+		return
+	}
+
+	// Extract the code verifier
+	codeVerifier := values.Get("code_verifier")
+	if codeVerifier == "" {
+		http.Error(w, "code verifier is required", http.StatusBadRequest)
+		return
+	}
+
+	// Validate the authorization code
+	authCode, ok := authCodeDB[code]
+	if !ok {
+		http.Error(w, "invalid authorization code, please re-initiate login", http.StatusBadRequest)
+		return
+	}
+
+	userID := authCode.UserID
+	if userID == "" {
+		http.Error(w, "no user found for authorization code", http.StatusInternalServerError)
+		return
+	}
+
+	// remove the authorization code from the database to prevent reuse
+	delete(authCodeDB, code)
+
+	// Check if the client ID matches the stored client ID
+	if authCode.ClientID != clientID {
+		http.Error(w, "invalid client ID", http.StatusBadRequest)
+		return
+	}
+
+	// Check if the redirect URI matches the stored redirect URI
+	if authCode.RedirectURI != redirectURI {
+		http.Error(w, "invalid redirect URI", http.StatusBadRequest)
+		return
+	}
+
+	// Check if the authorization code has expired
+	if time.Now().After(authCode.Expiration) {
+		http.Error(w, "authorization code has expired", http.StatusBadRequest)
+		return
+	}
+
+	// Verify the code verifier against the stored code challenge
+	if !verifyCodeChallenge(codeVerifier, authCode.CodeChallenge, authCode.CodeChallengeMethod) {
+		http.Error(w, "invalid code verifier", http.StatusBadRequest)
+		return
+	}
+
+	// Issue an access token
+	authToken, err := a.admin.IssueUserAuthToken(r.Context(), userID, authCode.ClientID, "", nil, nil)
+	if err != nil {
+		internalServerError(w, fmt.Errorf("failed to issue access token, %w", err))
+		return
+	}
+
+	resp := auth.OAuthTokenResponse{
+		AccessToken: authToken.Token().String(),
+		TokenType:   "Bearer",
+		ExpiresIn:   time.UnixMilli(0).Unix(), // never expires
+		UserID:      userID,
+	}
+	respBytes, err := json.Marshal(resp)
+	if err != nil {
+		internalServerError(w, fmt.Errorf("failed to marshal response, %w", err))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, err = w.Write(respBytes)
+	if err != nil {
+		internalServerError(w, fmt.Errorf("failed to write response, %w", err))
+		return
+	}
+}
+
+// verifyCodeChallenge validates the code verifier with the stored code challenge
+func verifyCodeChallenge(verifier, challenge, method string) bool {
+	switch method {
+	case "S256":
+		s256 := sha256.Sum256([]byte(verifier))
+		computedChallenge := base64.RawURLEncoding.EncodeToString(s256[:])
+		return computedChallenge == challenge
+	default:
+		return false
+	}
+}
+
+// Generates a random string for use as the authorization code
+func generateRandomString(n int) (string, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/cli/pkg/auth/utils.go
+++ b/cli/pkg/auth/utils.go
@@ -1,0 +1,14 @@
+package auth
+
+const (
+	FormMediaType = "application/x-www-form-urlencoded"
+	JSONMediaType = "application/json"
+)
+
+// OAuthTokenResponse contains the information returned after fetching an access token from the OAuth server.
+type OAuthTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int64  `json:"expires_in,string"`
+	TokenType   string `json:"token_type"`
+	UserID      string `json:"user_id"`
+}

--- a/cli/pkg/deviceauth/authenticator.go
+++ b/cli/pkg/deviceauth/authenticator.go
@@ -15,14 +15,10 @@ import (
 
 	"github.com/benbjohnson/clock"
 	"github.com/rilldata/rill/admin/database"
+	"github.com/rilldata/rill/cli/pkg/auth"
 )
 
 // Most parts of this file are copied from https://github.com/planetscale/cli/blob/main/internal/auth/authenticator.go
-
-const (
-	formMediaType = "application/x-www-form-urlencoded"
-	jsonMediaType = "application/json"
-)
 
 var (
 	ErrAuthenticationTimedout = fmt.Errorf("authentication timed out")
@@ -125,7 +121,7 @@ func (d *DeviceAuthenticator) VerifyDevice(ctx context.Context, redirectURL stri
 }
 
 // GetAccessTokenForDevice uses the device verification response to fetch an access token.
-func (d *DeviceAuthenticator) GetAccessTokenForDevice(ctx context.Context, v *DeviceVerification) (*OAuthTokenResponse, error) {
+func (d *DeviceAuthenticator) GetAccessTokenForDevice(ctx context.Context, v *DeviceVerification) (*auth.OAuthTokenResponse, error) {
 	for {
 		// This loop begins right after we open the user's browser to send an
 		// authentication code. We don't request a token immediately because the
@@ -154,15 +150,7 @@ func (d *DeviceAuthenticator) GetAccessTokenForDevice(ctx context.Context, v *De
 	}
 }
 
-// OAuthTokenResponse contains the information returned after fetching an access token for a device.
-type OAuthTokenResponse struct {
-	AccessToken string `json:"access_token"`
-	ExpiresIn   int64  `json:"expires_in,string"`
-	TokenType   string `json:"token_type"`
-	UserID      string `json:"user_id"`
-}
-
-func (d *DeviceAuthenticator) requestToken(ctx context.Context, deviceCode, clientID string) (*OAuthTokenResponse, error) {
+func (d *DeviceAuthenticator) requestToken(ctx context.Context, deviceCode, clientID string) (*auth.OAuthTokenResponse, error) {
 	req, err := d.newFormRequest(ctx, "auth/oauth/token", url.Values{
 		"grant_type":  []string{"urn:ietf:params:oauth:grant-type:device_code"},
 		"device_code": []string{deviceCode},
@@ -188,7 +176,7 @@ func (d *DeviceAuthenticator) requestToken(ctx context.Context, deviceCode, clie
 		return nil, nil
 	}
 
-	tokenRes := &OAuthTokenResponse{}
+	tokenRes := &auth.OAuthTokenResponse{}
 	err = json.NewDecoder(res.Body).Decode(tokenRes)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding token response: %w", err)
@@ -216,8 +204,8 @@ func (d *DeviceAuthenticator) newFormRequest(ctx context.Context, path string, p
 		return nil, err
 	}
 
-	req.Header.Set("Content-Type", formMediaType)
-	req.Header.Set("Accept", jsonMediaType)
+	req.Header.Set("Content-Type", auth.FormMediaType)
+	req.Header.Set("Accept", auth.JSONMediaType)
 	return req, nil
 }
 

--- a/cli/pkg/pkce/authenticator.go
+++ b/cli/pkg/pkce/authenticator.go
@@ -1,0 +1,177 @@
+package pkce
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/rilldata/rill/cli/pkg/auth"
+)
+
+const (
+	// characters allowed in the PKCE code verifier
+	charset             = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+	codeChallengeMethod = "S256"
+)
+
+type Authenticator struct {
+	client       *http.Client
+	baseAuthURL  string
+	redirectURL  string
+	codeVerifier string
+	clientID     string
+}
+
+func NewAuthenticator(baseAuthURL, redirectURL, clientID, state string) (*Authenticator, error) {
+	if strings.Contains(baseAuthURL, "http://localhost:9090") {
+		baseAuthURL = "http://localhost:8080"
+	}
+
+	// Generate a new code verifier
+	codeVerifier, err := generateCodeVerifier()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Authenticator{
+		client:       http.DefaultClient,
+		baseAuthURL:  baseAuthURL,
+		redirectURL:  redirectURL,
+		codeVerifier: codeVerifier,
+		clientID:     clientID,
+	}, nil
+}
+
+func (a *Authenticator) GetAuthURL(state string) string {
+	// Create the code challenge from the code verifier
+	codeChallenge := createCodeChallenge(a.codeVerifier)
+	// Create the authorization request URL
+	// Create a new URL instance from the authURL string
+	u, _ := url.Parse(a.baseAuthURL + "/auth/oauth/authorize")
+
+	// Create a new query string from the URL's query
+	q := u.Query()
+
+	// Set the client_id query parameter
+	q.Set("client_id", a.clientID)
+	// Set the redirect_uri query parameter
+	q.Set("redirect_uri", a.redirectURL)
+	// Set the response_type query parameter
+	q.Set("response_type", "code")
+	// Set the code_challenge query parameter
+	q.Set("code_challenge", codeChallenge)
+	// Set the code_challenge_method query parameter
+	q.Set("code_challenge_method", codeChallengeMethod)
+	// Set the state, will be used later to retrieve this authenticator
+	q.Set("state", state)
+
+	// Encode the query string
+	u.RawQuery = q.Encode()
+
+	// Return the URL as a string
+	return u.String()
+}
+
+func (a *Authenticator) ExchangeCodeForToken(code string) (string, error) {
+	// Create the token request
+	req, err := tokenRequest(a.baseAuthURL, code, a.clientID, a.redirectURL, a.codeVerifier)
+	if err != nil {
+		return "", err
+	}
+
+	// Send the token request
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	// Check if the response is an error
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	// TODO move OAuthTokenResponse to a common place
+	tokenResponse := &auth.OAuthTokenResponse{}
+	// Decode the response into the tokenResponse struct
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResponse); err != nil {
+		return "", err
+	}
+	println(tokenResponse.AccessToken)
+
+	// Return the access token
+	return tokenResponse.AccessToken, nil
+}
+
+func tokenRequest(baseAuthURL, code, clientID, redirectURI, codeVerifier string) (*http.Request, error) {
+	tokenURL := fmt.Sprintf("%s/auth/oauth/token", baseAuthURL)
+	payload := url.Values{
+		"grant_type":    []string{"authorization_code"},
+		"code":          []string{code},
+		"client_id":     []string{clientID},
+		"redirect_uri":  []string{redirectURI},
+		"code_verifier": []string{codeVerifier},
+	}
+	req, err := http.NewRequest(
+		http.MethodPost,
+		tokenURL,
+		strings.NewReader(payload.Encode()),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", auth.FormMediaType)
+	req.Header.Set("Accept", auth.JSONMediaType)
+	return req, nil
+}
+
+// generateCodeVerifier creates a cryptographically secure random string
+// which is between 43 and 128 characters long using the specified charset.
+func generateCodeVerifier() (string, error) {
+	// Generate a random number between 0 and 85 to extend the length of the code verifier
+	r, err := rand.Int(rand.Reader, big.NewInt(86))
+	if err != nil {
+		return "", err
+	}
+	// Define the length of the code verifier
+	// Here, we randomly choose a length between 43 and 128 characters
+	n := 43 + int(r.Int64())
+
+	// Create a byte slice of length n to store the characters of our code verifier
+	b := make([]byte, n)
+	// Temp slice to read random numbers into
+	temp := make([]byte, n)
+	if _, err := rand.Read(temp); err != nil {
+		return "", err
+	}
+
+	// Assign a valid character from charset for each byte in b
+	for i := 0; i < n; i++ {
+		b[i] = charset[temp[i]%byte(len(charset))]
+	}
+
+	return string(b), nil
+}
+
+// createCodeChallenge takes a codeVerifier and returns its SHA256 hash
+// encoded in Base64 URL encoding without padding, which is the code challenge.
+func createCodeChallenge(codeVerifier string) string {
+	// Create a new SHA256 hash instance
+	hasher := sha256.New()
+
+	// Write the codeVerifier to the hasher
+	hasher.Write([]byte(codeVerifier))
+
+	// Compute the SHA256 hash
+	hash := hasher.Sum(nil)
+
+	// Base64 URL encode the hash
+	return base64.RawURLEncoding.EncodeToString(hash)
+}

--- a/cli/pkg/pkce/authenticator.go
+++ b/cli/pkg/pkce/authenticator.go
@@ -103,7 +103,6 @@ func (a *Authenticator) ExchangeCodeForToken(code string) (string, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&tokenResponse); err != nil {
 		return "", err
 	}
-	println(tokenResponse.AccessToken)
 
 	// Return the access token
 	return tokenResponse.AccessToken, nil

--- a/cli/pkg/pkce/authenticator_test.go
+++ b/cli/pkg/pkce/authenticator_test.go
@@ -1,0 +1,20 @@
+package pkce
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_generateCodeVerifier(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		code, err := generateCodeVerifier()
+		require.NoError(t, err)
+		require.NotEmpty(t, code)
+		require.GreaterOrEqual(t, len(code), 43)
+		require.LessOrEqual(t, len(code), 128)
+		// only contains A-Z, a-z, 0-9, and the punctuation characters -._~ (hyphen, period, underscore, and tilde)
+		for _, c := range code {
+			require.Contains(t, charset, string(c))
+		}
+	}
+}


### PR DESCRIPTION
- Support login using PKCE auth flow https://www.oauth.com/oauth2-servers/pkce/ without need for any secrets at local runtime
- After login access token is persisted locally in `~/.rill/credentials.yaml`
- Next up will be to use this token to deploy project using local UI