### PR TITLE
CLI: Misc. `rill env` fixes

### DIFF
--- a/cli/cmd/env/show.go
+++ b/cli/cmd/env/show.go
@@ -8,7 +8,8 @@ import (
 )
 
 func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
-	var projectName string
+	var projectPath, projectName string
+
 	showCmd := &cobra.Command{
 		Use:   "show",
 		Short: "Show credentials and other variables",
@@ -16,6 +17,14 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 			client, err := ch.Client()
 			if err != nil {
 				return err
+			}
+
+			// Find the cloud project name
+			if projectName == "" {
+				projectName, err = ch.InferProjectName(cmd.Context(), ch.Org, projectPath)
+				if err != nil {
+					return err
+				}
 			}
 
 			resp, err := client.GetProjectVariables(cmd.Context(), &adminv1.GetProjectVariablesRequest{
@@ -37,8 +46,8 @@ func ShowCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 
-	showCmd.Flags().StringVar(&projectName, "project", "", "")
-	_ = showCmd.MarkFlagRequired("project")
+	showCmd.Flags().StringVar(&projectName, "project", "", "Cloud project name (will attempt to infer from Git remote if not provided)")
+	showCmd.Flags().StringVar(&projectPath, "path", ".", "Project directory")
 
 	return showCmd
 }

--- a/cli/pkg/cmdutil/helper.go
+++ b/cli/pkg/cmdutil/helper.go
@@ -261,7 +261,7 @@ func (h *Helper) ProjectNamesByGithubURL(ctx context.Context, org, githubURL str
 	}
 
 	if len(names) == 0 {
-		return nil, fmt.Errorf("no project with githubURL %q exist in org %q", githubURL, org)
+		return nil, fmt.Errorf("no project with github URL %q exists in org %q", githubURL, org)
 	}
 
 	return names, nil

--- a/docs/docs/explore/alerts/slack.md
+++ b/docs/docs/explore/alerts/slack.md
@@ -52,7 +52,7 @@ Afterwards, if the project has already been deployed to Rill Cloud, you can `ril
 Another option to set this connector variable within your project is to use the `rill env set` command, i.e.:
 
 ```shell
-rill env set connector.slack.bot_token=<BOT_USER_OAUTH_TOKEN>
+rill env set connector.slack.bot_token <BOT_USER_OAUTH_TOKEN>
 ```
 
 Afterwards, if the project has already been deployed to Rill Cloud, you can `rill env push` to update your cloud deployment accordingly.

--- a/docs/docs/reference/cli/cli.md
+++ b/docs/docs/reference/cli/cli.md
@@ -28,6 +28,7 @@ Rill CLI
 * [rill project](project/project.md)	 - Manage projects
 * [rill service](service/service.md)	 - Manage service accounts
 * [rill start](start.md)	 - Build project and start web app
+* [rill uninstall](uninstall.md)	 - Uninstall the Rill binary
 * [rill upgrade](upgrade.md)	 - Upgrade Rill to the latest version
 * [rill user](user/user.md)	 - Manage users
 * [rill version](version.md)	 - Show Rill version

--- a/docs/docs/reference/cli/deploy.md
+++ b/docs/docs/reference/cli/deploy.md
@@ -13,15 +13,16 @@ rill deploy [flags]
 ### Flags
 
 ```
-      --path string          Path to project repository (default: current directory) (default ".")
-      --subpath string       Relative path to project in the repository (for monorepos)
-      --remote string        Remote name (default: first Git remote)
-      --org string           Org to deploy project in
-      --project string       Project name (default: Git repo name)
-      --description string   Project description
-      --public               Make dashboards publicly accessible
-      --region string        Deployment region
-      --prod-branch string   Git branch to deploy from (default: the default Git branch)
+      --path string           Path to project repository (default: current directory) (default ".")
+      --subpath string        Relative path to project in the repository (for monorepos)
+      --remote string         Remote name (default: first Git remote)
+      --org string            Org to deploy project in
+      --project string        Project name (default: Git repo name)
+      --description string    Project description
+      --public                Make dashboards publicly accessible
+      --provisioner string    Project provisioner
+      --prod-version string   Rill version (default: the latest release version) (default "latest")
+      --prod-branch string    Git branch to deploy from (default: the default Git branch)
 ```
 
 ### Global flags

--- a/docs/docs/reference/cli/env/configure.md
+++ b/docs/docs/reference/cli/env/configure.md
@@ -14,7 +14,6 @@ rill env configure [flags]
 
 ```
       --path string      Project directory (default ".")
-      --subpath string   Project path to sub directory of a larger repository
       --project string   
       --redeploy         Redeploy project
 ```

--- a/docs/docs/reference/cli/env/env.md
+++ b/docs/docs/reference/cli/env/env.md
@@ -19,6 +19,8 @@ Manage variables for a project
 
 * [rill](../cli.md)	 - Rill CLI
 * [rill env configure](configure.md)	 - Configures connector variables for all sources
+* [rill env pull](pull.md)	 - Pull cloud credentials into local .env file
+* [rill env push](push.md)	 - Push local .env contents to cloud
 * [rill env rm](rm.md)	 - Remove variable
 * [rill env set](set.md)	 - Set variable
 * [rill env show](show.md)	 - Show credentials and other variables

--- a/docs/docs/reference/cli/env/pull.md
+++ b/docs/docs/reference/cli/env/pull.md
@@ -1,24 +1,20 @@
 ---
 note: GENERATED. DO NOT EDIT.
-title: rill project describe
+title: rill env pull
 ---
-## rill project describe
+## rill env pull
 
-Retrieve detailed state for a resource
-
-### Synopsis
-
-Retrieve detailed state for a specific resource (source, model, dashboard, ...)
+Pull cloud credentials into local .env file
 
 ```
-rill project describe [<project-name>] <type> <name> [flags]
+rill env pull [flags]
 ```
 
 ### Flags
 
 ```
       --path string      Project directory (default ".")
-      --project string   Project name
+      --project string   Cloud project name (will attempt to infer from Git remote if not provided)
 ```
 
 ### Global flags
@@ -28,10 +24,9 @@ rill project describe [<project-name>] <type> <name> [flags]
       --format string      Output format (options: "human", "json", "csv") (default "human")
   -h, --help               Print usage
       --interactive        Prompt for missing required parameters (default true)
-      --org string         Organization Name
 ```
 
 ### SEE ALSO
 
-* [rill project](project.md)	 - Manage projects
+* [rill env](env.md)	 - Manage variables for a project
 

--- a/docs/docs/reference/cli/env/push.md
+++ b/docs/docs/reference/cli/env/push.md
@@ -1,24 +1,20 @@
 ---
 note: GENERATED. DO NOT EDIT.
-title: rill project describe
+title: rill env push
 ---
-## rill project describe
+## rill env push
 
-Retrieve detailed state for a resource
-
-### Synopsis
-
-Retrieve detailed state for a specific resource (source, model, dashboard, ...)
+Push local .env contents to cloud
 
 ```
-rill project describe [<project-name>] <type> <name> [flags]
+rill env push [flags]
 ```
 
 ### Flags
 
 ```
       --path string      Project directory (default ".")
-      --project string   Project name
+      --project string   Cloud project name (will attempt to infer from Git remote if not provided)
 ```
 
 ### Global flags
@@ -28,10 +24,9 @@ rill project describe [<project-name>] <type> <name> [flags]
       --format string      Output format (options: "human", "json", "csv") (default "human")
   -h, --help               Print usage
       --interactive        Prompt for missing required parameters (default true)
-      --org string         Organization Name
 ```
 
 ### SEE ALSO
 
-* [rill project](project.md)	 - Manage projects
+* [rill env](env.md)	 - Manage variables for a project
 

--- a/docs/docs/reference/cli/env/rm.md
+++ b/docs/docs/reference/cli/env/rm.md
@@ -13,7 +13,8 @@ rill env rm <key> [flags]
 ### Flags
 
 ```
-      --project string   
+      --path string      Project directory (default ".")
+      --project string   Cloud project name (will attempt to infer from Git remote if not provided)
 ```
 
 ### Global flags

--- a/docs/docs/reference/cli/env/show.md
+++ b/docs/docs/reference/cli/env/show.md
@@ -13,7 +13,8 @@ rill env show [flags]
 ### Flags
 
 ```
-      --project string   
+      --path string      Project directory (default ".")
+      --project string   Cloud project name (will attempt to infer from Git remote if not provided)
 ```
 
 ### Global flags

--- a/docs/docs/reference/cli/project/edit.md
+++ b/docs/docs/reference/cli/project/edit.md
@@ -18,8 +18,9 @@ rill project edit [<project-name>] [flags]
       --prod-branch string     Production branch name
       --public                 Make dashboards publicly accessible
       --path string            Project directory (default ".")
+      --provisioner string     Project provisioner (default: current provisioner)
       --prod-ttl-seconds int   Prod deployment TTL in seconds
-      --region string          Deployment region (default: current region)
+      --prod-version string    Rill version (default: current version)
 ```
 
 ### Global flags

--- a/docs/docs/reference/cli/start.md
+++ b/docs/docs/reference/cli/start.md
@@ -22,6 +22,8 @@ rill start [<path>] [flags]
       --debug               Collect additional debug info
       --reset               Clear and re-ingest source data
       --log-format string   Log format (options: "console", "json") (default "console")
+      --tls-cert string     Path to TLS certificate
+      --tls-key string      Path to TLS key file
   -e, --env strings         Environment name (default "dev")
   -v, --var strings         Set project variables
 ```

--- a/docs/docs/reference/cli/uninstall.md
+++ b/docs/docs/reference/cli/uninstall.md
@@ -1,20 +1,13 @@
 ---
 note: GENERATED. DO NOT EDIT.
-title: rill env set
+title: rill uninstall
 ---
-## rill env set
+## rill uninstall
 
-Set variable
-
-```
-rill env set <key> <value> [flags]
-```
-
-### Flags
+Uninstall the Rill binary
 
 ```
-      --path string      Project directory (default ".")
-      --project string   Cloud project name (will attempt to infer from Git remote if not provided)
+rill uninstall [flags]
 ```
 
 ### Global flags
@@ -28,5 +21,5 @@ rill env set <key> <value> [flags]
 
 ### SEE ALSO
 
-* [rill env](env.md)	 - Manage variables for a project
+* [rill](cli.md)	 - Rill CLI
 

--- a/docs/docs/reference/cli/upgrade.md
+++ b/docs/docs/reference/cli/upgrade.md
@@ -13,7 +13,8 @@ rill upgrade [flags]
 ### Flags
 
 ```
-      --nightly   Install the latest nightly build
+      --nightly          Install the latest nightly build
+      --version string   Install a specific version of Rill
 ```
 
 ### Global flags

--- a/docs/docs/reference/cli/user/add.md
+++ b/docs/docs/reference/cli/user/add.md
@@ -16,7 +16,7 @@ rill user add [flags]
       --email string     Email of the user
       --org string       Organization
       --project string   Project
-      --role string      Role of the user [admin, viewer]
+      --role string      Role of the user (options: admin, viewer)
 ```
 
 ### Global flags

--- a/docs/docs/reference/cli/user/set-role.md
+++ b/docs/docs/reference/cli/user/set-role.md
@@ -16,7 +16,7 @@ rill user set-role [flags]
       --email string     Email of the user
       --org string       Organization
       --project string   Project
-      --role string      Role of the user [admin, viewer]
+      --role string      Role of the user (options: admin, viewer)
 ```
 
 ### Global flags

--- a/docs/docs/reference/cli/user/whitelist/list.md
+++ b/docs/docs/reference/cli/user/whitelist/list.md
@@ -4,7 +4,7 @@ title: rill user whitelist list
 ---
 ## rill user whitelist list
 
-List whitelisted email domains for the org
+List whitelisted email domains for the org or project
 
 ```
 rill user whitelist list [flags]
@@ -13,7 +13,8 @@ rill user whitelist list [flags]
 ### Flags
 
 ```
-      --org string   Organization
+      --org string       Organization
+      --project string   Project
 ```
 
 ### Global flags

--- a/docs/docs/reference/cli/user/whitelist/remove.md
+++ b/docs/docs/reference/cli/user/whitelist/remove.md
@@ -4,7 +4,7 @@ title: rill user whitelist remove
 ---
 ## rill user whitelist remove
 
-Remove whitelisted email domain for the org
+Remove whitelisted email domain for the org or project
 
 ```
 rill user whitelist remove <email-domain> [flags]
@@ -13,7 +13,8 @@ rill user whitelist remove <email-domain> [flags]
 ### Flags
 
 ```
-      --org string   Organization
+      --org string       Organization
+      --project string   Project
 ```
 
 ### Global flags

--- a/docs/docs/reference/cli/user/whitelist/setup.md
+++ b/docs/docs/reference/cli/user/whitelist/setup.md
@@ -4,7 +4,7 @@ title: rill user whitelist setup
 ---
 ## rill user whitelist setup
 
-Whitelist an email domain for the org
+Whitelist an email domain for the org or project
 
 ```
 rill user whitelist setup <email-domain> [flags]
@@ -13,8 +13,9 @@ rill user whitelist setup <email-domain> [flags]
 ### Flags
 
 ```
-      --org string    Organization
-      --role string   Role of the user [admin, viewer] (default "viewer")
+      --org string       Organization
+      --project string   Project name
+      --role string      Role of the user (default "viewer")
 ```
 
 ### Global flags

--- a/docs/docs/reference/cli/user/whitelist/whitelist.md
+++ b/docs/docs/reference/cli/user/whitelist/whitelist.md
@@ -18,7 +18,7 @@ Whitelist access by email domain
 ### SEE ALSO
 
 * [rill user](../user.md)	 - Manage users
-* [rill user whitelist list](list.md)	 - List whitelisted email domains for the org
-* [rill user whitelist remove](remove.md)	 - Remove whitelisted email domain for the org
-* [rill user whitelist setup](setup.md)	 - Whitelist an email domain for the org
+* [rill user whitelist list](list.md)	 - List whitelisted email domains for the org or project
+* [rill user whitelist remove](remove.md)	 - Remove whitelisted email domain for the org or project
+* [rill user whitelist setup](setup.md)	 - Whitelist an email domain for the org or project
 

--- a/runtime/compilers/rillv1/connectors.go
+++ b/runtime/compilers/rillv1/connectors.go
@@ -53,10 +53,21 @@ type connectorAnalyzer struct {
 
 // analyze is the entrypoint for connector analysis. After running it, you can access the result.
 func (a *connectorAnalyzer) analyze(ctx context.Context) error {
-	if a.parser.RillYAML != nil && a.parser.RillYAML.OLAPConnector != "" {
-		err := a.trackConnector(a.parser.RillYAML.OLAPConnector, nil, false)
-		if err != nil {
-			return err
+	if a.parser.RillYAML != nil {
+		// Track any connectors explicitly configured in rill.yaml
+		for _, c := range a.parser.RillYAML.Connectors {
+			err := a.trackConnector(c.Name, nil, false)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Track the OLAP connector specified in rill.yaml
+		if a.parser.RillYAML.OLAPConnector != "" {
+			err := a.trackConnector(a.parser.RillYAML.OLAPConnector, nil, false)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Changes:

- In `rill env configure`, prompt for credentials for all connectors specified under `connectors:` in `rill.yaml`
- In `rill env {show,set,rm}`, infer the project name from the current Git repository if available
- Remove redeploy prompt from `rill env configure` (not needed anymore, new variables are automatically used)
- Fix typo in `rill env set` example in the docs
- Regenerate CLI docs