### PR TITLE
Hide undefined value from tooltip

### DIFF
--- a/web-common/src/features/dashboards/time-dimension-details/charts/tdd-tooltip-formatter.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/charts/tdd-tooltip-formatter.ts
@@ -53,7 +53,7 @@ function generateStackedAreaContent(
   let content = "";
   for (const key of keys) {
     const val = rest[key];
-    if (val === null || val === "NaN") continue;
+    if (val === undefined || val === null || val === "NaN") continue;
 
     let label = key;
     let keyColor = colorMap[String(key)] || "#000";


### PR DESCRIPTION
For stacked area tooltip, `undefined` was being show when the value had no data.