### PR TITLE
Fix: Add chart when no items set

### DIFF
--- a/web-local/src/routes/(application)/custom-dashboards/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/custom-dashboards/[name]/+page.svelte
@@ -163,14 +163,21 @@
   }
 
   async function addChart(e: CustomEvent<{ chartName: string }>) {
-    const sequence = parsedDocument.get("items");
-    sequence.add({
+    const newChart = {
       component: e.detail.chartName,
       height: 4,
       width: 4,
       x: 0,
       y: 0,
-    });
+    };
+
+    const items = parsedDocument.get("items");
+
+    if (!items) {
+      parsedDocument.set("items", [newChart]);
+    } else {
+      items.add(newChart);
+    }
 
     yaml = parsedDocument.toString();
 


### PR DESCRIPTION
Please go the the `Preview` tab and select the appropriate sub-template:

* [Applications](?expand=1&template=applications_template.md)
* [Others](?expand=1&template=fallback_template.md)