### PR TITLE
Changing <RILL_HOME> to <RILL_PROJECT_DIRECTORY>

### DIFF
--- a/docs/docs/reference/connectors/athena.md
+++ b/docs/docs/reference/connectors/athena.md
@@ -63,7 +63,7 @@ Note that you must `cd` into the Git repository that your project was deployed f
 
 :::tip Did you know?
 
-If you've configured credentials locally already (in your `<RILL_HOME>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
+If you've configured credentials locally already (in your `<RILL_PROJECT_DIRECTORY>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
 
 :::
 

--- a/docs/docs/reference/connectors/azure.md
+++ b/docs/docs/reference/connectors/azure.md
@@ -102,6 +102,6 @@ Note that you must `cd` into the Git repository that your project was deployed f
 
 :::tip Did you know?
 
-If you've configured credentials locally already (in your `<RILL_HOME>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
+If you've configured credentials locally already (in your `<RILL_PROJECT_DIRECTORY>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
 
 :::

--- a/docs/docs/reference/connectors/bigquery.md
+++ b/docs/docs/reference/connectors/bigquery.md
@@ -48,7 +48,7 @@ Note that you must `cd` into the Git repository that your project was deployed f
 
 :::tip Did you know?
 
-If you've configured credentials locally already (in your `<RILL_HOME>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
+If you've configured credentials locally already (in your `<RILL_PROJECT_DIRECTORY>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
 
 :::
 

--- a/docs/docs/reference/connectors/gcs.md
+++ b/docs/docs/reference/connectors/gcs.md
@@ -66,7 +66,7 @@ Note that you must `cd` into the Git repository that your project was deployed f
 
 :::tip Did you know?
 
-If you've configured credentials locally already (in your `<RILL_HOME>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
+If you've configured credentials locally already (in your `<RILL_PROJECT_DIRECTORY>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
 
 :::
 

--- a/docs/docs/reference/connectors/motherduck.md
+++ b/docs/docs/reference/connectors/motherduck.md
@@ -94,6 +94,6 @@ Note that you must `cd` into the Git repository that your project was deployed f
 
 :::tip Did you know?
 
-If you've configured credentials locally already (in your `<RILL_HOME>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
+If you've configured credentials locally already (in your `<RILL_PROJECT_DIRECTORY>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
 
 :::

--- a/docs/docs/reference/connectors/mysql.md
+++ b/docs/docs/reference/connectors/mysql.md
@@ -78,6 +78,6 @@ Note that you must `cd` into the Git repository that your project was deployed f
 
 :::tip Did you know?
 
-If you've configured credentials locally already (in your `<RILL_HOME>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
+If you've configured credentials locally already (in your `<RILL_PROJECT_DIRECTORY>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
 
 :::

--- a/docs/docs/reference/connectors/postgres.md
+++ b/docs/docs/reference/connectors/postgres.md
@@ -76,6 +76,6 @@ Note that you must `cd` into the Git repository that your project was deployed f
 
 :::tip Did you know?
 
-If you've configured credentials locally already (in your `<RILL_HOME>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
+If you've configured credentials locally already (in your `<RILL_PROJECT_DIRECTORY>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
 
 :::

--- a/docs/docs/reference/connectors/redshift.md
+++ b/docs/docs/reference/connectors/redshift.md
@@ -63,7 +63,7 @@ Note that you must `cd` into the Git repository that your project was deployed f
 
 :::tip Did you know?
 
-If you've configured credentials locally already (in your `<RILL_HOME>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
+If you've configured credentials locally already (in your `<RILL_PROJECT_DIRECTORY>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
 
 :::
 

--- a/docs/docs/reference/connectors/s3.md
+++ b/docs/docs/reference/connectors/s3.md
@@ -68,7 +68,7 @@ Note that you must `cd` into the Git repository that your project was deployed f
 
 :::tip Did you know?
 
-If you've configured credentials locally already (in your `<RILL_HOME>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
+If you've configured credentials locally already (in your `<RILL_PROJECT_DIRECTORY>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
 
 :::
 

--- a/docs/docs/reference/connectors/salesforce.md
+++ b/docs/docs/reference/connectors/salesforce.md
@@ -79,6 +79,6 @@ signing.
 
 :::tip Did you know?
 
-If you've configured credentials locally already (in your `<RILL_HOME>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
+If you've configured credentials locally already (in your `<RILL_PROJECT_DIRECTORY>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
 
 :::

--- a/docs/docs/reference/connectors/snowflake.md
+++ b/docs/docs/reference/connectors/snowflake.md
@@ -62,7 +62,7 @@ Note that you must first `cd` into the Git repository that your project was depl
 
 :::tip Did you know?
 
-If you've configured credentials locally already (in your `<RILL_HOME>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
+If you've configured credentials locally already (in your `<RILL_PROJECT_DIRECTORY>/.env` file), you can use `rill env push` to [push these credentials](/build/credentials/credentials.md#rill-env-push) to your Rill Cloud project. This will allow other users to retrieve / reuse the same credentials automatically by running `rill env pull`.
 
 :::
 

--- a/docs/docs/reference/project-files/sources.md
+++ b/docs/docs/reference/project-files/sources.md
@@ -34,7 +34,7 @@ Files that are *nested at any level* under your native `sources` directory will 
   - _`duckdb`_ - use the [embedded DuckDB](../olap-engines/duckdb.md) engine to submit a DuckDB-supported native [SELECT](https://duckdb.org/docs/sql/statements/select.html) query (should be used in conjunction with the `sql` property)
 
 **`type`**
- — _Deprecated_ but preserves a legacy alias to `connector`. Can be used instead to specify the source connector, instead of the resource type (see above), **only** if the source YAML file belongs in the `<RILL_HOME>/sources/` directory (preserved primarily for backwards compatibility).
+ — _Deprecated_ but preserves a legacy alias to `connector`. Can be used instead to specify the source connector, instead of the resource type (see above), **only** if the source YAML file belongs in the `<RILL_PROJECT_DIRECTORY>/sources/` directory (preserved primarily for backwards compatibility).
 
 **`uri`**
  —  Refers to the URI of the remote connector you are using for the source. Rill also supports glob patterns as part of the URI for S3 and GCS _(required for type: http, s3, gcs)_.


### PR DESCRIPTION
Clarifying to make the callout less confusing in our docs and clear that we're not referring to a global location