### PR TITLE
Fix: No highlight dimension line on explore

### DIFF
--- a/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDisplay.svelte
@@ -13,6 +13,7 @@
   import { debounce } from "@rilldata/web-common/lib/create-debouncer";
   import { TIME_GRAIN } from "@rilldata/web-common/lib/time/config";
   import { timeFormat } from "d3-time-format";
+  import { onDestroy } from "svelte";
   import TDDHeader from "./TDDHeader.svelte";
   import TDDTable from "./TDDTable.svelte";
   import {
@@ -181,6 +182,13 @@
       toggleAllSearchItems();
     }
   }
+
+  onDestroy(() => {
+    tableInteractionStore.set({
+      dimensionValue: undefined,
+      time: undefined,
+    });
+  });
 </script>
 
 <div class="h-full w-full flex flex-col">


### PR DESCRIPTION
Fixes https://github.com/rilldata/rill-private-issues/issues/347

I can't reproduce the issue reliably so haven't tested this out but this should fix the issue. I am resetting the table highlight store once the table parent component is unmounted. 

 