### PR TITLE
feat: Update alert criteria options to have a simpler list

### DIFF
--- a/web-common/src/features/alerts/criteria-tab/CriteriaForm.svelte
+++ b/web-common/src/features/alerts/criteria-tab/CriteriaForm.svelte
@@ -62,10 +62,11 @@
     placeholder="compare with"
     value={"Value"}
   />
+  <!-- Error is not returned as an object for criteria[index]. We instead have parsed groupErr -->
   <InputV2
     alwaysShowError
     bind:value
-    error={$errors["criteria"][index]?.value}
+    error={""}
     id="value"
     on:input={valueUpdater}
     placeholder={"0"}

--- a/web-common/src/features/alerts/criteria-tab/CriteriaForm.svelte
+++ b/web-common/src/features/alerts/criteria-tab/CriteriaForm.svelte
@@ -3,12 +3,14 @@
   import Select from "@rilldata/web-common/components/forms/Select.svelte";
   import { CriteriaOperationOptions } from "@rilldata/web-common/features/alerts/criteria-tab/operations";
   import { parseCriteriaError } from "@rilldata/web-common/features/alerts/criteria-tab/parseCriteriaError";
+  import { AlertFormValues } from "@rilldata/web-common/features/alerts/form-utils";
   import { useMetricsView } from "@rilldata/web-common/features/dashboards/selectors";
   import { debounce } from "@rilldata/web-common/lib/create-debouncer";
+  import { createForm } from "svelte-forms-lib";
   import { slide } from "svelte/transition";
   import { runtime } from "../../../runtime-client/runtime-store";
 
-  export let formState: any; // svelte-forms-lib's FormState
+  export let formState: ReturnType<typeof createForm<AlertFormValues>>;
   export let index: number;
 
   const { form, errors, validateField } = formState;

--- a/web-common/src/features/alerts/criteria-tab/operations.ts
+++ b/web-common/src/features/alerts/criteria-tab/operations.ts
@@ -20,7 +20,7 @@ export const CriteriaOperationOptions = [
   },
   {
     value: MeasureFilterOperation.NotEquals,
-    label: "does not equals",
+    label: "does not equal",
     shortLabel: "!=",
   },
 ];

--- a/web-common/src/features/alerts/criteria-tab/operations.ts
+++ b/web-common/src/features/alerts/criteria-tab/operations.ts
@@ -1,26 +1,27 @@
+import { MeasureFilterOperation } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-options";
 import { V1Operation } from "@rilldata/web-common/runtime-client";
 
 // TODO: should match measure filter. remove this once that is merged to main
 export const CriteriaOperationOptions = [
   {
-    value: V1Operation.OPERATION_LT,
-    label: "Less Than",
+    value: MeasureFilterOperation.GreaterThanOrEquals,
+    label: "greater than or equals",
+    shortLabel: ">=",
+  },
+  {
+    value: MeasureFilterOperation.LessThan,
+    label: "less than",
     shortLabel: "<",
   },
   {
-    value: V1Operation.OPERATION_LTE,
-    label: "Less Than Or Equals",
-    shortLabel: "<=",
+    value: MeasureFilterOperation.Equals,
+    label: "equals",
+    shortLabel: "=",
   },
   {
-    value: V1Operation.OPERATION_GT,
-    label: "Greater Than",
-    shortLabel: ">",
-  },
-  {
-    value: V1Operation.OPERATION_GTE,
-    label: "Greater Than Or Equals",
-    shortLabel: ">=",
+    value: MeasureFilterOperation.NotEquals,
+    label: "does not equals",
+    shortLabel: "!=",
   },
 ];
 

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterBody.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterBody.svelte
@@ -8,8 +8,8 @@
   import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
   import { MeasureFilterEntry } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry";
   import {
+    AllMeasureFilterOptions,
     MeasureFilterOperation,
-    MeasureFilterOptions,
   } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-options";
 
   export let dimensionName: string;
@@ -27,7 +27,7 @@
       case MeasureFilterOperation.LessThan:
       case MeasureFilterOperation.LessThanOrEquals:
         shortLabel =
-          MeasureFilterOptions.find(
+          AllMeasureFilterOptions.find(
             (o) =>
               // svelte-check is throwing an error here stating `filter could be undefined` so we need this
               o.value === filter?.operation ??

--- a/web-common/src/features/dashboards/filters/measure-filters/measure-filter-entry.spec.ts
+++ b/web-common/src/features/dashboards/filters/measure-filters/measure-filter-entry.spec.ts
@@ -74,6 +74,28 @@ const TestCases: [
     createBinaryExpression("imp", V1Operation.OPERATION_LTE, 10),
   ],
   [
+    "equals",
+    {
+      value1: "10",
+      value2: "",
+      measure: "imp",
+      operation: MeasureFilterOperation.Equals,
+      comparison: MeasureFilterComparisonType.None,
+    },
+    createBinaryExpression("imp", V1Operation.OPERATION_EQ, 10),
+  ],
+  [
+    "not equals",
+    {
+      value1: "10",
+      value2: "",
+      measure: "imp",
+      operation: MeasureFilterOperation.NotEquals,
+      comparison: MeasureFilterComparisonType.None,
+    },
+    createBinaryExpression("imp", V1Operation.OPERATION_NEQ, 10),
+  ],
+  [
     "between",
     {
       value1: "10",

--- a/web-common/src/features/dashboards/filters/measure-filters/measure-filter-entry.ts
+++ b/web-common/src/features/dashboards/filters/measure-filters/measure-filter-entry.ts
@@ -64,6 +64,8 @@ export function mapExprToMeasureFilter(
           : MeasureFilterOperation.NotBetween;
       break;
 
+    case V1Operation.OPERATION_EQ:
+    case V1Operation.OPERATION_NEQ:
     case V1Operation.OPERATION_GT:
     case V1Operation.OPERATION_GTE:
     case V1Operation.OPERATION_LT:
@@ -118,6 +120,8 @@ export function mapMeasureFilterToExpr(
       : DeltaAbsoluteSuffix;
 
   switch (measureFilter.operation) {
+    case MeasureFilterOperation.Equals:
+    case MeasureFilterOperation.NotEquals:
     case MeasureFilterOperation.GreaterThan:
     case MeasureFilterOperation.GreaterThanOrEquals:
     case MeasureFilterOperation.LessThan:

--- a/web-common/src/features/dashboards/filters/measure-filters/measure-filter-options.ts
+++ b/web-common/src/features/dashboards/filters/measure-filters/measure-filter-options.ts
@@ -77,3 +77,17 @@ export const MeasureFilterOptions: MeasureFilterOption[] = [
     shortLabel: "",
   },
 ];
+// Full list with options not supported in filter pills just yet.
+export const AllMeasureFilterOptions = [
+  ...MeasureFilterOptions,
+  {
+    value: MeasureFilterOperation.Equals,
+    label: "Equals",
+    shortLabel: "=",
+  },
+  {
+    value: MeasureFilterOperation.NotEquals,
+    label: "Does Not Equals",
+    shortLabel: "!=",
+  },
+];

--- a/web-common/src/features/dashboards/filters/measure-filters/measure-filter-options.ts
+++ b/web-common/src/features/dashboards/filters/measure-filters/measure-filter-options.ts
@@ -7,6 +7,8 @@ export type MeasureFilterOption = {
 };
 
 export enum MeasureFilterOperation {
+  Equals = "OPERATION_EQ",
+  NotEquals = "OPERATION_NEQ",
   GreaterThan = "OPERATION_GT",
   GreaterThanOrEquals = "OPERATION_GTE",
   LessThan = "OPERATION_LT",
@@ -21,6 +23,8 @@ export enum MeasureFilterOperation {
 }
 
 export const MeasureFilterToProtoOperation = {
+  [MeasureFilterOperation.Equals]: V1Operation.OPERATION_EQ,
+  [MeasureFilterOperation.NotEquals]: V1Operation.OPERATION_NEQ,
   [MeasureFilterOperation.GreaterThan]: V1Operation.OPERATION_GT,
   [MeasureFilterOperation.GreaterThanOrEquals]: V1Operation.OPERATION_GTE,
   [MeasureFilterOperation.LessThan]: V1Operation.OPERATION_LT,


### PR DESCRIPTION
We are updating the list of options available in alert criteria to be a simpler and smaller list.
- `greater than or equals`
- `less than`
- `equals`
- `does not equals`

Older alerts will still work and will show the correct criteria in alert page. But during edit it wont be available anymore.