### PR TITLE
Runtime: handling of other time functions in metrics_sql

### DIFF
--- a/runtime/pkg/metricssql/parser.go
+++ b/runtime/pkg/metricssql/parser.go
@@ -475,7 +475,11 @@ func (t *transformer) transformDate(ctx context.Context, node *ast.FuncCallExpr)
 	types = append(types, expr.types...)
 	sb.WriteString(expr.expr)
 
-	sb.WriteString(" - ")
+	if node.FnName.L == "date_sub" {
+		sb.WriteString(" - ")
+	} else {
+		sb.WriteString(" + ")
+	}
 	sb.WriteString("INTERVAL ")
 
 	expr, err = t.transformExprNode(ctx, node.Args[1]) // handling of 1

--- a/runtime/pkg/metricssql/parser_test.go
+++ b/runtime/pkg/metricssql/parser_test.go
@@ -48,6 +48,7 @@ func TestCompiler_Compile(t *testing.T) {
 		"select distinct pub from ad_bids_metrics":                                                                                                    "SELECT DISTINCT \"publisher\" AS \"pub\" FROM \"ad_bids\"",
 		"select pub, dom, date_trunc('hour', timestamp) as day, measure_0 from ad_bids_metrics order by  date_trunc('hour', timestamp) desc limit 10": "SELECT \"publisher\" AS \"pub\", \"domain\" AS \"dom\", date_trunc('hour', timestamp) AS \"day\", count(*) AS \"measure_0\" FROM \"ad_bids\" GROUP BY \"domain\", \"publisher\", date_trunc('hour', timestamp) ORDER BY date_trunc('hour', timestamp) DESC LIMIT 10",
 		"select pub, dom from ad_bids_metrics where timestamp > now() - INTERVAL 90 DAY":                                                              "SELECT \"publisher\" AS \"pub\", \"domain\" AS \"dom\" FROM \"ad_bids\" WHERE timestamp > now() - INTERVAL 90 DAY",
+		"select pub, dom from ad_bids_metrics where timestamp > now() + INTERVAL 90 DAY":                                                              "SELECT \"publisher\" AS \"pub\", \"domain\" AS \"dom\" FROM \"ad_bids\" WHERE timestamp > now() + INTERVAL 90 DAY",
 	}
 	for inSQL, outSQL := range passTests {
 		got, _, _, err := compiler.Compile(context.Background(), inSQL)

--- a/runtime/pkg/metricssql/parser_test.go
+++ b/runtime/pkg/metricssql/parser_test.go
@@ -47,6 +47,7 @@ func TestCompiler_Compile(t *testing.T) {
 		"select publisher, domain, measure_2, measure_3 as \"click rate\" from ad_bids_mini_metrics where publisher is not null":                      "SELECT \"publisher\" AS \"publisher\", \"domain\" AS \"domain\", sum(impressions) AS \"measure_2\", sum(clicks) AS \"click rate\" FROM \"ad_bids_mini\" WHERE \"publisher\" IS NOT NULL GROUP BY \"domain\", \"publisher\"",
 		"select distinct pub from ad_bids_metrics":                                                                                                    "SELECT DISTINCT \"publisher\" AS \"pub\" FROM \"ad_bids\"",
 		"select pub, dom, date_trunc('hour', timestamp) as day, measure_0 from ad_bids_metrics order by  date_trunc('hour', timestamp) desc limit 10": "SELECT \"publisher\" AS \"pub\", \"domain\" AS \"dom\", date_trunc('hour', timestamp) AS \"day\", count(*) AS \"measure_0\" FROM \"ad_bids\" GROUP BY \"domain\", \"publisher\", date_trunc('hour', timestamp) ORDER BY date_trunc('hour', timestamp) DESC LIMIT 10",
+		"select pub, dom from ad_bids_metrics where timestamp > now() - INTERVAL 90 DAY":                                                              "SELECT \"publisher\" AS \"pub\", \"domain\" AS \"dom\" FROM \"ad_bids\" WHERE timestamp > now() - INTERVAL 90 DAY",
 	}
 	for inSQL, outSQL := range passTests {
 		got, _, _, err := compiler.Compile(context.Background(), inSQL)


### PR DESCRIPTION
Added support for `date_add`, `date_sub` and `now`