### PR TITLE
Fix autosave

### DIFF
--- a/web-common/src/features/editor/Editor.svelte
+++ b/web-common/src/features/editor/Editor.svelte
@@ -25,8 +25,7 @@
   let editor: EditorView;
   let container: HTMLElement;
 
-  $: latest = blob;
-  $: updateEditorContents(latest);
+  $: if (editor) updateEditorDocIfUnfocused(blob);
   $: if (editor) updateEditorExtensions(extensions);
 
   onMount(() => {
@@ -70,19 +69,22 @@
     );
   }
 
-  function updateEditorContents(newContent: string) {
-    if (editor && !editor.hasFocus) {
-      // NOTE: when changing files, we still want to update the editor
-      let curContent = editor.state.doc.toString();
-      if (newContent != curContent) {
-        editor.dispatch({
-          changes: {
-            from: 0,
-            to: curContent.length,
-            insert: newContent,
-          },
-        });
-      }
+  /**
+   * When the `blob` changes and the editor is not focused, update the editor's document.
+   * This updates the editor:
+   * - when the file is updated via an external IDE
+   * - when navigating between files
+   */
+  function updateEditorDocIfUnfocused(blob: string) {
+    let latest = editor.state.doc.toString();
+    if (!editor.hasFocus && blob !== latest) {
+      editor.dispatch({
+        changes: {
+          from: 0,
+          to: latest.length,
+          insert: blob,
+        },
+      });
     }
   }
 

--- a/web-local/src/routes/(application)/files/[...file]/+page.svelte
+++ b/web-local/src/routes/(application)/files/[...file]/+page.svelte
@@ -72,7 +72,10 @@
   });
 
   beforeNavigate((e) => {
-    if (!hasUnsavedChanges || interceptedUrl) return;
+    if (!hasUnsavedChanges || interceptedUrl) {
+      latest = undefined; // Avoids a flash of "unsaved changes" when navigating between files
+      return;
+    }
 
     e.cancel();
 
@@ -82,8 +85,8 @@
   let blob = "";
   $: blob = $fileQuery.data?.blob ?? blob;
 
-  $: latest = blob;
-  $: hasUnsavedChanges = latest !== blob;
+  let latest: string | undefined; // updated by the Editor via the binding below
+  $: hasUnsavedChanges = latest !== undefined && latest !== blob;
 
   $: pathname = $page.url.pathname;
   $: workspace = workspaces.get(pathname);


### PR DESCRIPTION
This PR proposes a way to fix the fallback `Editor`'s "autosave" functionality. The fix should also be applied to the `SourceEditor` and `ModelEditor`.

The problem with the current autosave implementation is that the `latest` in-memory file content is updated in two separate ways: 1) via the Editor, 2) via updates to the `blob` (the on-disk file content). These two update paths can be in conflict.

For example:
1. A brief pause while typing in the Editor will trigger an autosave
2. `PutFile` is called to update the file on-disk
3. Continued typing will update the `latest` file content
4. The call to `GetFile` file is ultimately invalidated and updated with the on-disk representation from step 2. Because `GetFile`'s `blob` changes, `latest` is overwritten with this new `blob`.
5. Another pause will trigger another autosave. The text saved is the `blob` (from step 2), not the most recent edits made in the Editor (from step 3).

This PR removes the direct link between `blob` and `latest`. Now, `latest` is only updated via the Editor, _not_ via changes to the `blob`. This results in a 1-way dataflow.

Closes https://github.com/rilldata/rill/issues/4878