### PR TITLE
Fix: Escape complex column names in generated measure expressions

### DIFF
--- a/runtime/server/generate_metrics_view.go
+++ b/runtime/server/generate_metrics_view.go
@@ -488,5 +488,5 @@ func safeSQLName(name string) string {
 	if alphanumericUnderscoreRegexp.MatchString(name) {
 		return name
 	}
-	return name
+	return fmt.Sprintf("\"%s\"", strings.ReplaceAll(name, "\"", "\"\""))
 }


### PR DESCRIPTION
Closes https://github.com/rilldata/rill/issues/4599