### PR TITLE
fix bug with druid sql query id

### DIFF
--- a/runtime/drivers/druid/druidsqldriver/druid_api_sql_driver.go
+++ b/runtime/drivers/druid/druidsqldriver/druid_api_sql_driver.go
@@ -42,7 +42,7 @@ var _ driver.QueryerContext = &sqlConnection{}
 
 func (c *sqlConnection) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 	dr := newDruidRequest(query, args)
-	b, err := json.Marshal(newDruidRequest(query, args))
+	b, err := json.Marshal(dr)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func (c *sqlConnection) QueryContext(ctx context.Context, query string, args []d
 	bodyReader := bytes.NewReader(b)
 
 	context.AfterFunc(ctx, func() {
-		tctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		tctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		r, err := http.NewRequestWithContext(tctx, http.MethodDelete, c.dsn+"/"+dr.Context.SQLQueryID, http.NoBody)
 		if err != nil {


### PR DESCRIPTION
Druid request was created twice so different query ids, the query id used in cancellation was different from id of actual request sent to druid. 