### PR TITLE
Fix: fetchWrapper duplicate json parsing

### DIFF
--- a/web-common/src/runtime-client/fetchWrapper.ts
+++ b/web-common/src/runtime-client/fetchWrapper.ts
@@ -49,7 +49,7 @@ export async function fetchWrapper({
     signal,
   });
 
-  const json = (await resp.json()) as Record<string, unknown>;
+  const json = await resp.json();
 
   if (resp.ok) return json;
 

--- a/web-common/src/runtime-client/fetchWrapper.ts
+++ b/web-common/src/runtime-client/fetchWrapper.ts
@@ -4,7 +4,7 @@ export type FetchWrapperOptions = {
   method: string;
   headers?: HeadersInit;
   params?: Record<string, unknown>;
-  data?: Record<string, unknown> | BodyInit;
+  data?: any;
   signal?: AbortSignal;
 };
 
@@ -65,7 +65,6 @@ export async function fetchWrapper({
     // Fallback error handling
     const err = new Error();
     (err as any).response = json;
-    err.message = JSON.stringify(json);
     return Promise.reject(err);
   }
 }

--- a/web-local/src/routes/(application)/chart/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/chart/[name]/+page.svelte
@@ -81,7 +81,13 @@
     resolverProperties,
   );
 
-  $: ({ isFetching: chartDataFetching, data: chartData } = $chartDataQuery);
+  $: ({
+    isFetching: chartDataFetching,
+    data: chartData,
+    error: chartError,
+  } = $chartDataQuery);
+
+  $: console.log({ chartError });
 </script>
 
 <svelte:head>
@@ -152,7 +158,8 @@
             />
           {:else}
             <p class="text-lg size-full grid place-content-center">
-              Update YAML to view chart data
+              {JSON.stringify(chartError?.response) ??
+                "Update YAML to view chart data"}
             </p>
           {/if}
         </div>

--- a/web-local/src/routes/(application)/chart/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/chart/[name]/+page.svelte
@@ -81,13 +81,7 @@
     resolverProperties,
   );
 
-  $: ({
-    isFetching: chartDataFetching,
-    data: chartData,
-    error: chartError,
-  } = $chartDataQuery);
-
-  $: console.log({ chartError });
+  $: ({ isFetching: chartDataFetching, data: chartData } = $chartDataQuery);
 </script>
 
 <svelte:head>
@@ -158,8 +152,7 @@
             />
           {:else}
             <p class="text-lg size-full grid place-content-center">
-              {JSON.stringify(chartError?.response) ??
-                "Update YAML to view chart data"}
+              Update YAML to view chart data
             </p>
           {/if}
         </div>


### PR DESCRIPTION
In certain scenarios, the  fetchWrapper tries to parse the json response multiple times, which throws. This PR reorganizes this function to avoid this duplicate call.
