### PR TITLE
Disable vornoi for bar charts

### DIFF
--- a/web-common/src/features/charts/templates/grouped-bar.ts
+++ b/web-common/src/features/charts/templates/grouped-bar.ts
@@ -53,7 +53,6 @@ export function buildGroupedBar(
         on: "pointerover",
         clear: "pointerout",
         encodings: ["x", "color"],
-        nearest: true,
       },
     },
   ];

--- a/web-common/src/features/charts/templates/simple-bar.ts
+++ b/web-common/src/features/charts/templates/simple-bar.ts
@@ -43,7 +43,6 @@ export function buildSimpleBar(
         on: "pointerover",
         clear: "pointerout",
         encodings: ["x"],
-        nearest: true,
       },
     },
   ];


### PR DESCRIPTION
Disable vornoi selection of marks on hover for bar charts.