### PR TITLE
fix: Custom picker focus handling

### DIFF
--- a/web-common/src/components/date-picker/Litepicker.svelte
+++ b/web-common/src/components/date-picker/Litepicker.svelte
@@ -20,6 +20,7 @@
     if (picker) {
       picker.show();
       picker.setEditingDate(0);
+      picker.scrollToSpecificDate(picker.datePicked[0]);
     }
   };
 
@@ -27,6 +28,7 @@
     if (picker) {
       picker.show();
       picker.setEditingDate(1);
+      picker.scrollToSpecificDate(picker.datePicked[1]);
     }
   };
 

--- a/web-common/src/components/date-picker/custom-picker.js
+++ b/web-common/src/components/date-picker/custom-picker.js
@@ -2,7 +2,7 @@
 import Litepicker from "litepicker";
 import { DateTime } from "./datetime";
 import { findNestedMonthItem, parseLocaleStringDate } from "./util";
-import { DateTime as LuxonDateTime } from "luxon";
+
 const style = {
   dayItem: "day-item",
   litepicker: "litepicker",

--- a/web-common/src/components/date-picker/custom-picker.js
+++ b/web-common/src/components/date-picker/custom-picker.js
@@ -2,7 +2,7 @@
 import Litepicker from "litepicker";
 import { DateTime } from "./datetime";
 import { findNestedMonthItem, parseLocaleStringDate } from "./util";
-
+import { DateTime as LuxonDateTime } from "luxon";
 const style = {
   dayItem: "day-item",
   litepicker: "litepicker",
@@ -31,18 +31,6 @@ export default class Custompicker extends Litepicker {
       if (!isNaN(maybeStartDate.valueOf())) {
         this.datePicked[0] = new DateTime(maybeStartDate);
         this.emitChanged();
-        // Only render if the blur event was not caused by clicking on a day-item
-        if (
-          !e.relatedTarget ||
-          !(
-            e.relatedTarget.classList.contains("day-item") ||
-            e.relatedTarget.classList.contains(style.buttonPreviousMonth) ||
-            e.relatedTarget.classList.contains(style.buttonNextMonth)
-          )
-        ) {
-          this.scrollToSpecificDate(this.datePicked[0]);
-          this.render();
-        }
       }
     });
 
@@ -52,18 +40,6 @@ export default class Custompicker extends Litepicker {
         this.datePicked[1] = new DateTime(maybeEndDate);
 
         this.emitChanged();
-        // Only render if the blur event was not caused by clicking on a day-item
-        if (
-          !e.relatedTarget ||
-          !(
-            e.relatedTarget.classList.contains("day-item") ||
-            e.relatedTarget.classList.contains(style.buttonPreviousMonth) ||
-            e.relatedTarget.classList.contains(style.buttonNextMonth)
-          )
-        ) {
-          this.scrollToSpecificDate(this.datePicked[1]);
-          this.render();
-        }
       }
     });
   }
@@ -72,6 +48,7 @@ export default class Custompicker extends Litepicker {
     const clonedDate = date.clone();
     clonedDate.setDate(1);
     this.calendars[0] = clonedDate.clone();
+    this.render();
   }
 
   setEditingDate(idx) {


### PR DESCRIPTION
This PR adjusts the custom picker implementation so that it properly scrolls to the relevant boundary date when selecting a text input.

This is patch fix for code that will soon be deprecated.

closes: #4899 