### PR TITLE
Runtime: Component renderer for "template:"

### DIFF
--- a/runtime/compilers/rillv1/data/component-template-v1.json
+++ b/runtime/compilers/rillv1/data/component-template-v1.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "anyOf": [
+        {
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "const": "line_chart"
+                },
+                "x": {
+                    "type": "string"
+                },
+                "y": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "x",
+                "y"
+            ]
+        },
+        {
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "const": "bar_chart"
+                },
+                "x": {
+                    "type": "string"
+                },
+                "y": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "x",
+                "y"
+            ]
+        }
+    ]    
+}

--- a/runtime/compilers/rillv1/parse_component.go
+++ b/runtime/compilers/rillv1/parse_component.go
@@ -17,6 +17,11 @@ var vegaLiteSpec string
 
 var vegaLiteSchema = jsonschema.MustCompileString("https://vega.github.io/schema/vega-lite/v5.json", vegaLiteSpec)
 
+//go:embed data/component-template-v1.json
+var componentTemplateSpec string
+
+var componentTemplateSchema = jsonschema.MustCompileString("https://github.com/rilldata/rill/runtime/compilers/rillv1/data/component-template-v1.json", componentTemplateSpec)
+
 type ComponentYAML struct {
 	commonYAML `yaml:",inline"` // Not accessed here, only setting it so we can use KnownFields for YAML parsing
 	Title      string           `yaml:"title"`
@@ -25,6 +30,7 @@ type ComponentYAML struct {
 	VegaLite   *string          `yaml:"vega_lite"`
 	Markdown   *string          `yaml:"markdown"`
 	Image      *string          `yaml:"image"`
+	Template   map[string]any   `yaml:"template"`
 }
 
 func (p *Parser) parseComponent(node *Node) error {
@@ -104,6 +110,16 @@ func (p *Parser) parseComponentYAML(tmp *ComponentYAML) (*runtimev1.ComponentSpe
 		n++
 		renderer = "image"
 		rendererProps = must(structpb.NewStruct(map[string]any{"url": *tmp.Image}))
+	}
+	if len(tmp.Template) > 0 {
+		n++
+
+		if err := componentTemplateSchema.Validate(tmp.Template); err != nil {
+			return nil, nil, fmt.Errorf(`failed to validate "template": %w`, err)
+		}
+
+		renderer = "template"
+		rendererProps = must(structpb.NewStruct(tmp.Template))
 	}
 
 	// Check there is exactly one renderer


### PR DESCRIPTION
- Adds support for a `template:` renderer in resources of `type: component`.
- Resources will have `spec.renderer == "template"` and `spec.rendererProperties` will contain the supplied properties.
- The template properties are validated using the JSON schema in `runtime/compilers/rillv1/data/component-template-v1.json`. It currently has validation stubs for `line_chart` and `bar_chart` templates.

Example:
```yaml
type: component

template:
  name: line_chart
  x: foo
  y: bar
```