### PR TITLE
Preserve alt chart type on refresh

### DIFF
--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -214,7 +214,9 @@
     {#if isInTimeDimensionView}
       <BackToOverview {metricViewName} />
       <ChartTypeSelector
-        hasComparison={Boolean(showComparison || dimensionData.length)}
+        hasComparison={Boolean(
+          showComparison || includedValuesForDimension.length,
+        )}
         {metricViewName}
         chartType={tddChartType}
       />


### PR DESCRIPTION
Fixes https://github.com/rilldata/rill-private-issues/issues/379

Moved the check from availability of compared dimension data to included values for the compared dimension