### PR TITLE
Fix: Skip invalidation if no filename present

### DIFF
--- a/web-common/src/features/entity-management/resource-invalidations.ts
+++ b/web-common/src/features/entity-management/resource-invalidations.ts
@@ -95,9 +95,9 @@ async function invalidateResource(
 ) {
   if (!resource.meta) return;
   void refreshResource(queryClient, instanceId, resource);
-
+  if (!resource.meta?.filePaths?.[0]) return;
   const lastStateUpdatedOn = fileArtifacts.getFileArtifact(
-    resource.meta?.filePaths?.[0] ?? "",
+    resource.meta?.filePaths?.[0],
   ).lastStateUpdatedOn;
   if (
     resource.meta.reconcileStatus !== V1ReconcileStatus.RECONCILE_STATUS_IDLE &&


### PR DESCRIPTION
Prereq/Subset of #4901:

- Skips invalidation if the filename is not present
- This was causing a FileArtifact to be created/refetched without a valid pathname