### PR TITLE
fix: Updating errors for reconciling resources

### DIFF
--- a/web-common/src/features/entity-management/file-artifacts.ts
+++ b/web-common/src/features/entity-management/file-artifacts.ts
@@ -95,15 +95,7 @@ export class FileArtifact {
         this.getResource(queryClient, instanceId),
       ],
       ([name, projectParser, resource]) => {
-        if (
-          projectParser.isFetching ||
-          resource.isFetching ||
-          // retain old state while reconciling
-          resource.data?.meta?.reconcileStatus ===
-            V1ReconcileStatus.RECONCILE_STATUS_RUNNING ||
-          resource.data?.meta?.reconcileStatus ===
-            V1ReconcileStatus.RECONCILE_STATUS_PENDING
-        ) {
+        if (projectParser.isFetching || resource.isFetching) {
           // to avoid flicker during a re-fetch, retain the previous value
           return get(store);
         }


### PR DESCRIPTION
closes #4943 (potentially #4944 as well?)

This is a patch to make sure reconciling resources are updated and the reconciling spinner is shown. This might have regression where the left nav entry will flicker. We need to have a proper fix with debounce. We can do that after the patch release.