### PR TITLE
Runtime: Clickhouse timezone fixes

### DIFF
--- a/runtime/pkg/pbutil/pbutil.go
+++ b/runtime/pkg/pbutil/pbutil.go
@@ -50,10 +50,10 @@ func ToValue(v any, t *runtimev1.Type) (*structpb.Value, error) {
 		return structpb.NewNumberValue(float64(v)), nil
 	case time.Time:
 		if t != nil && t.Code == runtimev1.Type_CODE_DATE {
-			s := v.Format(time.DateOnly)
+			s := v.In(time.UTC).Format(time.DateOnly)
 			return structpb.NewStringValue(s), nil
 		}
-		s := v.Format(time.RFC3339Nano)
+		s := v.In(time.UTC).Format(time.RFC3339Nano)
 		return structpb.NewStringValue(s), nil
 	case float32:
 		// Turning NaNs and Infs into nulls until frontend can deal with them as strings
@@ -147,10 +147,10 @@ func ToValue(v any, t *runtimev1.Type) (*structpb.Value, error) {
 		return structpb.NewNumberValue(float64(*v)), nil
 	case *time.Time:
 		if t != nil && t.Code == runtimev1.Type_CODE_DATE {
-			s := v.Format(time.DateOnly)
+			s := v.In(time.UTC).Format(time.DateOnly)
 			return structpb.NewStringValue(s), nil
 		}
-		s := v.Format(time.RFC3339Nano)
+		s := v.In(time.UTC).Format(time.RFC3339Nano)
 		return structpb.NewStringValue(s), nil
 	case *float32:
 		// Turning NaNs and Infs into nulls until frontend can deal with them as strings

--- a/runtime/queries/metricsview_aggregation.go
+++ b/runtime/queries/metricsview_aggregation.go
@@ -1984,7 +1984,8 @@ func (q *MetricsViewAggregation) buildTimestampExpr(mv *runtimev1.MetricsViewSpe
 		if dim.TimeZone == "" || dim.TimeZone == "UTC" || dim.TimeZone == "Etc/UTC" {
 			return fmt.Sprintf("date_trunc('%s', %s)", dialect.ConvertToDateTruncSpecifier(dim.TimeGrain), col), nil, nil
 		}
-		return fmt.Sprintf("toTimezone(date_trunc('%s', toTimezone(%s::TIMESTAMP, ?)), ?)", dialect.ConvertToDateTruncSpecifier(dim.TimeGrain), col), []any{dim.TimeZone, dim.TimeZone}, nil
+		// The return type of date_trunc('month', ...) is Date so need another TIMESTAMP cast
+		return fmt.Sprintf("toTimezone(date_trunc('%s', toTimezone(%s::TIMESTAMP, ?))::TIMESTAMP, ?)", dialect.ConvertToDateTruncSpecifier(dim.TimeGrain), col), []any{dim.TimeZone, dim.TimeZone}, nil
 	case drivers.DialectPinot:
 		// ToDateTime format truncates millis to secs because we don't support that, for example timeseries api does timestamppb.New(ts) which truncates to seconds
 		return fmt.Sprintf("ToDateTime(date_trunc('%s', %s, 'MILLISECONDS', ?), 'yyyy-MM-dd''T''HH:mm:ss''Z''')", dialect.ConvertToDateTruncSpecifier(dim.TimeGrain), col), []any{dim.TimeZone}, nil


### PR DESCRIPTION
My understanding is that duckdb's timezone of the returned value is always in `UTC` due to the way it is scanned here : https://github.com/marcboeker/go-duckdb/blob/e1139f74c461fc566a20d2c2c05b7bb851b1415c/rows.go#L174C10-L174C25

In case of clickhouse it depends on the timezone of column : https://github.com/ClickHouse/clickhouse-go/blob/28fd6a4954a5dbf09b7dcc0fcce597beb2dd0b58/lib/column/datetime64.go#L303

Though it is always supposed to be in `session_timezone` which is set to UTC for us but there are edge case as defined here : https://clickhouse.com/docs/en/operations/settings/settings#session_timezone
We handle it explicitly by converting all time values to UTC.