### PR TITLE
Remove font style declaration from `PercentageChange`

### DIFF
--- a/web-common/src/components/data-types/PercentageChange.svelte
+++ b/web-common/src/components/data-types/PercentageChange.svelte
@@ -58,7 +58,7 @@
   {isNull}
   classes="{tabularNumber
     ? 'ui-copy-number'
-    : ''} font-normal w-full {customStyle} {inTable && 'block text-right'}"
+    : ''} w-full {customStyle} {inTable && 'block text-right'}"
   {dark}
 >
   <slot name="value">


### PR DESCRIPTION
<img width="778" alt="image" src="https://github.com/rilldata/rill/assets/4402679/7ef52892-ff64-4b79-a4b2-5dbbb70a875f">

Percentage change for measure does not inherit the parent font weight because of a fixed style mentioned in `PercentageChange` which is not being used anywhere.  This PR removes that class.