### PR TITLE
Remove empty directories from initialized projects

### DIFF
--- a/runtime/compilers/rillv1/init.go
+++ b/runtime/compilers/rillv1/init.go
@@ -16,9 +16,9 @@ func IsInit(ctx context.Context, repo drivers.RepoStore, instanceID string) bool
 
 // InitEmpty initializes an empty project
 func InitEmpty(ctx context.Context, repo drivers.RepoStore, instanceID, title string) error {
-	mockUsersInfo := "# These are example mock users to test your security policies.\n# For more information, see the documentation: https://docs.rilldata.com/manage/security"
+	mockUsersInfo := "# These are example mock users to test your security policies.\n# Learn more: https://docs.rilldata.com/manage/security"
 	mockUsers := "mock_users:\n- email: john@yourcompany.com\n- email: jane@partnercompany.com"
-	rillYAML := fmt.Sprintf("compiler: %s\n\ntitle: %q\n\n%s\n\n%s", Version, title, mockUsersInfo, mockUsers)
+	rillYAML := fmt.Sprintf("compiler: %s\n\ntitle: %q\n\n%s\n%s", Version, title, mockUsersInfo, mockUsers)
 
 	err := repo.Put(ctx, "rill.yaml", strings.NewReader(rillYAML))
 	if err != nil {

--- a/runtime/compilers/rillv1/init.go
+++ b/runtime/compilers/rillv1/init.go
@@ -36,20 +36,5 @@ func InitEmpty(ctx context.Context, repo drivers.RepoStore, instanceID, title st
 		return err
 	}
 
-	err = repo.Put(ctx, "sources/.gitkeep", strings.NewReader(""))
-	if err != nil {
-		return err
-	}
-
-	err = repo.Put(ctx, "models/.gitkeep", strings.NewReader(""))
-	if err != nil {
-		return err
-	}
-
-	err = repo.Put(ctx, "dashboards/.gitkeep", strings.NewReader(""))
-	if err != nil {
-		return err
-	}
-
 	return nil
 }


### PR DESCRIPTION
Previously, new Rill projects were initialized with emtpy `source`, `model`, and `dashboard` directories. This PR removes those empty folders from initialized projects. Particularly, the `source` and `model` directories are not currently applicable to ClickHouse-backed projects.

[Context in Notion](https://www.notion.so/rilldata/Improving-our-Connect-to-ClickHouse-modal-64420494ff514247b2fc60fef2267033?pvs=4#3e4d8f54ad7c4fb1be10b1116cc9484e)