### PR TITLE
fix(advanced measures): Exclude advanced measures from pivot and exclude comparison measures

### DIFF
--- a/web-common/src/features/alerts/data-tab/AlertDialogDataTab.svelte
+++ b/web-common/src/features/alerts/data-tab/AlertDialogDataTab.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import DataPreview from "@rilldata/web-common/features/alerts/data-tab/DataPreview.svelte";
   import { AlertFormValues } from "@rilldata/web-common/features/alerts/form-utils";
+  import { MetricsViewSpecMeasureType } from "@rilldata/web-common/runtime-client";
   import { createForm } from "svelte-forms-lib";
   import FormSection from "../../../components/forms/FormSection.svelte";
   import Select from "../../../components/forms/Select.svelte";
@@ -16,10 +17,16 @@
   $: metricsView = useMetricsView($runtime.instanceId, metricsViewName);
 
   $: measureOptions =
-    $metricsView.data?.measures?.map((m) => ({
-      value: m.name as string,
-      label: m.label?.length ? m.label : m.expression,
-    })) ?? [];
+    $metricsView.data?.measures
+      ?.filter(
+        (m) =>
+          !m.window &&
+          m.type !== MetricsViewSpecMeasureType.MEASURE_TYPE_TIME_COMPARISON,
+      )
+      .map((m) => ({
+        value: m.name as string,
+        label: m.label?.length ? m.label : m.expression,
+      })) ?? [];
   $: dimensionOptions = [
     {
       value: "",

--- a/web-common/src/features/dashboards/filters/FilterButton.svelte
+++ b/web-common/src/features/dashboards/filters/FilterButton.svelte
@@ -13,7 +13,7 @@
     selectors: {
       dimensions: { allDimensions },
       dimensionFilters: { dimensionHasFilter },
-      measures: { filteredBasicMeasures },
+      measures: { filteredSimpleMeasures },
       measureFilters: { measureHasFilter },
     },
     actions: {
@@ -25,7 +25,7 @@
     <SearchableFilterSelectableGroup>{
       name: "MEASURES",
       items:
-        $filteredBasicMeasures(false)
+        $filteredSimpleMeasures()
           ?.map((m) => ({
             name: m.name as string,
             label: getMeasureDisplayName(m),

--- a/web-common/src/features/dashboards/filters/FilterButton.svelte
+++ b/web-common/src/features/dashboards/filters/FilterButton.svelte
@@ -6,7 +6,6 @@
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { getDimensionDisplayName } from "@rilldata/web-common/features/dashboards/filters/getDisplayName";
-  import { filterBasicMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
   import { getStateManagers } from "../state-managers/state-managers";
   import { getMeasureDisplayName } from "./getDisplayName";
 
@@ -14,7 +13,7 @@
     selectors: {
       dimensions: { allDimensions },
       dimensionFilters: { dimensionHasFilter },
-      measures: { allMeasures },
+      measures: { filteredBasicMeasures },
       measureFilters: { measureHasFilter },
     },
     actions: {
@@ -26,7 +25,7 @@
     <SearchableFilterSelectableGroup>{
       name: "MEASURES",
       items:
-        filterBasicMeasures($allMeasures)
+        $filteredBasicMeasures(false)
           ?.map((m) => ({
             name: m.name as string,
             label: getMeasureDisplayName(m),

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
@@ -3,7 +3,6 @@
   import SearchableFilterButton from "@rilldata/web-common/components/searchable-filter-menu/SearchableFilterButton.svelte";
   import { LeaderboardContextColumn } from "@rilldata/web-common/features/dashboards/leaderboard-context-column";
   import { createShowHideDimensionsStore } from "@rilldata/web-common/features/dashboards/show-hide-selectors";
-  import { filterAdvancedMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
   import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
   import { EntityStatus } from "@rilldata/web-common/features/entity-management/types";
   import type { MetricsViewSpecMeasureV2 } from "@rilldata/web-common/runtime-client";

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
@@ -19,7 +19,7 @@
 
   const {
     selectors: {
-      measures: { filteredBasicMeasures },
+      measures: { filteredSimpleMeasures },
     },
     actions: {
       contextCol: { setContextColumn },
@@ -29,7 +29,7 @@
 
   $: metricsView = useMetricsView($runtime.instanceId, metricViewName);
 
-  $: measures = $filteredBasicMeasures(false);
+  $: measures = $filteredSimpleMeasures();
 
   let metricsExplorer: MetricsExplorerEntity;
   $: metricsExplorer = $metricsExplorerStore.entities[metricViewName];

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
@@ -3,7 +3,7 @@
   import SearchableFilterButton from "@rilldata/web-common/components/searchable-filter-menu/SearchableFilterButton.svelte";
   import { LeaderboardContextColumn } from "@rilldata/web-common/features/dashboards/leaderboard-context-column";
   import { createShowHideDimensionsStore } from "@rilldata/web-common/features/dashboards/show-hide-selectors";
-  import { filterBasicMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
+  import { filterAdvancedMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
   import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
   import { EntityStatus } from "@rilldata/web-common/features/entity-management/types";
   import type { MetricsViewSpecMeasureV2 } from "@rilldata/web-common/runtime-client";
@@ -19,6 +19,9 @@
   export let metricViewName;
 
   const {
+    selectors: {
+      measures: { filteredBasicMeasures },
+    },
     actions: {
       contextCol: { setContextColumn },
       setLeaderboardMeasureName,
@@ -27,9 +30,7 @@
 
   $: metricsView = useMetricsView($runtime.instanceId, metricViewName);
 
-  $: measures = $metricsView.data?.measures
-    ? filterBasicMeasures($metricsView.data.measures)
-    : undefined;
+  $: measures = $filteredBasicMeasures(false);
 
   let metricsExplorer: MetricsExplorerEntity;
   $: metricsExplorer = $metricsExplorerStore.entities[metricViewName];

--- a/web-common/src/features/dashboards/state-managers/selectors/measures.spec.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/measures.spec.ts
@@ -1,4 +1,4 @@
-import { getMeasuresAndDimensions } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
+import { getFilteredMeasuresAndDimensions } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
 import { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import {
   V1MetricsViewSpec,
@@ -7,7 +7,7 @@ import {
 import { describe, it, expect } from "vitest";
 
 describe("measures selectors", () => {
-  describe("getMeasuresAndDimensions", () => {
+  describe("getFilteredMeasuresAndDimensions", () => {
     const TestCases = [
       {
         title: "with unspecified grains, selected DAY",
@@ -119,7 +119,7 @@ describe("measures selectors", () => {
     for (const { title, measures, timeGrain, expected } of TestCases) {
       it(title, () => {
         expect(
-          getMeasuresAndDimensions({
+          getFilteredMeasuresAndDimensions({
             dashboard: {
               selectedTimeRange: {
                 interval: timeGrain,

--- a/web-common/src/features/dashboards/state-managers/selectors/measures.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/measures.ts
@@ -52,26 +52,24 @@ export const isMeasureValidPercentOfTotal = ({
   };
 };
 
-export const filteredBasicMeasures = ({
+export const filteredSimpleMeasures = ({
   metricsSpecQueryResult,
-  dashboard,
 }: DashboardDataSources) => {
-  return (includeComparisonMeasure: boolean) => {
-    includeComparisonMeasure =
-      includeComparisonMeasure &&
-      !!dashboard.showTimeComparison &&
-      !!dashboard.selectedComparisonTimeRange;
+  return () => {
     return (
       metricsSpecQueryResult.data?.measures?.filter(
         (m) =>
           !m.window &&
-          (includeComparisonMeasure ||
-            m.type !== MetricsViewSpecMeasureType.MEASURE_TYPE_TIME_COMPARISON),
+          m.type !== MetricsViewSpecMeasureType.MEASURE_TYPE_TIME_COMPARISON,
       ) ?? []
     );
   };
 };
 
+/**
+ * Selects measure valid for current dashboard selections.
+ * Also includes additional dimensions needed for any advanced measures.
+ */
 export const getFilteredMeasuresAndDimensions = ({
   dashboard,
 }: Pick<DashboardDataSources, "dashboard">) => {
@@ -169,7 +167,7 @@ export const measureSelectors = {
    */
   isMeasureValidPercentOfTotal,
 
-  filteredBasicMeasures,
+  filteredSimpleMeasures,
 
   getFilteredMeasuresAndDimensions,
 };

--- a/web-common/src/features/dashboards/state-managers/selectors/measures.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/measures.ts
@@ -91,6 +91,11 @@ export const getFilteredMeasuresAndDimensions = ({
       if (
         !measure ||
         measure.type === MetricsViewSpecMeasureType.MEASURE_TYPE_TIME_COMPARISON
+        // TODO: we need to send a single query for this support
+        // (measure.type ===
+        //   MetricsViewSpecMeasureType.MEASURE_TYPE_TIME_COMPARISON &&
+        //   (!dashboard.showTimeComparison ||
+        //     !dashboard.selectedComparisonTimeRange))
       )
         return;
 

--- a/web-common/src/features/dashboards/state-managers/selectors/pivot.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/pivot.ts
@@ -1,4 +1,4 @@
-import { filteredBasicMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
+import { filteredSimpleMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
 import type { DashboardDataSources } from "./types";
 import { PivotChipType } from "../../pivot/types";
 
@@ -7,7 +7,7 @@ export const pivotSelectors = {
   rows: ({ dashboard }: DashboardDataSources) => dashboard.pivot.rows,
   columns: ({ dashboard }: DashboardDataSources) => dashboard.pivot.columns,
   measures: (dashData: DashboardDataSources) => {
-    const measures = filteredBasicMeasures(dashData)(false);
+    const measures = filteredSimpleMeasures(dashData)();
     const columns = dashData.dashboard.pivot.columns;
 
     return measures

--- a/web-common/src/features/dashboards/state-managers/selectors/pivot.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/pivot.ts
@@ -1,3 +1,4 @@
+import { filteredBasicMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
 import type { DashboardDataSources } from "./types";
 import { PivotChipType } from "../../pivot/types";
 
@@ -5,9 +6,9 @@ export const pivotSelectors = {
   showPivot: ({ dashboard }: DashboardDataSources) => dashboard.pivot.active,
   rows: ({ dashboard }: DashboardDataSources) => dashboard.pivot.rows,
   columns: ({ dashboard }: DashboardDataSources) => dashboard.pivot.columns,
-  measures: ({ metricsSpecQueryResult, dashboard }: DashboardDataSources) => {
-    const measures = metricsSpecQueryResult.data?.measures ?? [];
-    const columns = dashboard.pivot.columns;
+  measures: (dashData: DashboardDataSources) => {
+    const measures = filteredBasicMeasures(dashData)(false);
+    const columns = dashData.dashboard.pivot.columns;
 
     return measures
       .filter((m) => !columns.measure.find((c) => c.id === m.name))

--- a/web-common/src/features/dashboards/stores/AdvancedMeasureCorrector.spec.ts
+++ b/web-common/src/features/dashboards/stores/AdvancedMeasureCorrector.spec.ts
@@ -1,0 +1,135 @@
+import { AdvancedMeasureCorrector } from "@rilldata/web-common/features/dashboards/stores/AdvancedMeasureCorrector";
+import { getDefaultMetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/dashboard-store-defaults";
+import {
+  AD_BIDS_ADVANCED_MEASURES,
+  AD_BIDS_IMPRESSIONS_MEASURE,
+  AD_BIDS_IMPRESSIONS_MEASURE_DAY_GRAIN,
+  AD_BIDS_IMPRESSIONS_MEASURE_NO_GRAIN,
+  AD_BIDS_IMPRESSIONS_MEASURE_WINDOW,
+  AD_BIDS_INIT,
+  AD_BIDS_PUBLISHER_DIMENSION,
+  AD_BIDS_TIMESTAMP_DIMENSION,
+} from "@rilldata/web-common/features/dashboards/stores/dashboard-stores-test-data";
+import {
+  createAndExpression,
+  createBinaryExpression,
+} from "@rilldata/web-common/features/dashboards/stores/filter-utils";
+import { DashboardTimeControls } from "@rilldata/web-common/lib/time/types";
+import {
+  V1MetricsViewSpec,
+  V1Operation,
+  V1TimeGrain,
+} from "@rilldata/web-common/runtime-client";
+import { describe, it, expect } from "vitest";
+
+describe("AdvancedMeasureCorrector", () => {
+  const MetricsView = {
+    ...AD_BIDS_INIT,
+    measures: AD_BIDS_ADVANCED_MEASURES,
+  } as V1MetricsViewSpec;
+
+  it("changing grain while in TDD for measure based on timestamp", () => {
+    const dashboard = getDefaultMetricsExplorerEntity(
+      "AdBids",
+      MetricsView,
+      undefined,
+    );
+    dashboard.tdd.expandedMeasureName = AD_BIDS_IMPRESSIONS_MEASURE_NO_GRAIN;
+
+    AdvancedMeasureCorrector.correct(dashboard, MetricsView);
+    expect(dashboard.tdd.expandedMeasureName).toEqual(
+      AD_BIDS_IMPRESSIONS_MEASURE_NO_GRAIN,
+    );
+
+    // changing selected grain doesn't impact measure with no grain dependence
+    dashboard.selectedTimeRange = {
+      interval: V1TimeGrain.TIME_GRAIN_DAY,
+    } as DashboardTimeControls;
+    AdvancedMeasureCorrector.correct(dashboard, MetricsView);
+    expect(dashboard.tdd.expandedMeasureName).toEqual(
+      AD_BIDS_IMPRESSIONS_MEASURE_NO_GRAIN,
+    );
+
+    dashboard.tdd.expandedMeasureName = AD_BIDS_IMPRESSIONS_MEASURE_DAY_GRAIN;
+    AdvancedMeasureCorrector.correct(dashboard, MetricsView);
+    expect(dashboard.tdd.expandedMeasureName).toEqual(
+      AD_BIDS_IMPRESSIONS_MEASURE_DAY_GRAIN,
+    );
+
+    // changing selected grain unsets measure with a particular grain dependence
+    dashboard.selectedTimeRange = {
+      interval: V1TimeGrain.TIME_GRAIN_WEEK,
+    } as DashboardTimeControls;
+    AdvancedMeasureCorrector.correct(dashboard, MetricsView);
+    expect(dashboard.tdd.expandedMeasureName).toEqual("");
+  });
+
+  it("metrics view spec changed converting a measure to an advanced measure", () => {
+    const dashboard = getDefaultMetricsExplorerEntity(
+      "AdBids",
+      MetricsView,
+      undefined,
+    );
+    dashboard.leaderboardMeasureName = AD_BIDS_IMPRESSIONS_MEASURE;
+    dashboard.dimensionThresholdFilters = [
+      {
+        name: AD_BIDS_PUBLISHER_DIMENSION,
+        filter: createAndExpression([
+          createBinaryExpression(
+            AD_BIDS_IMPRESSIONS_MEASURE,
+            V1Operation.OPERATION_GT,
+            10,
+          ),
+        ]),
+      },
+    ];
+
+    AdvancedMeasureCorrector.correct(dashboard, MetricsView);
+    expect(dashboard.leaderboardMeasureName).toEqual(
+      AD_BIDS_IMPRESSIONS_MEASURE,
+    );
+    expect(dashboard.dimensionThresholdFilters[0]?.filter).not.toBeUndefined();
+
+    // metrics view spec updated to make AD_BIDS_IMPRESSIONS_MEASURE an advanced measure
+    AdvancedMeasureCorrector.correct(dashboard, {
+      ...MetricsView,
+      measures: [
+        {
+          name: AD_BIDS_IMPRESSIONS_MEASURE,
+          expression: "count(*)",
+          window: {
+            partition: true,
+          },
+        },
+        {
+          name: AD_BIDS_IMPRESSIONS_MEASURE_DAY_GRAIN,
+          requiredDimensions: [
+            {
+              name: AD_BIDS_TIMESTAMP_DIMENSION,
+              timeGrain: V1TimeGrain.TIME_GRAIN_DAY,
+            },
+          ],
+        },
+        {
+          name: AD_BIDS_IMPRESSIONS_MEASURE_NO_GRAIN,
+          requiredDimensions: [
+            {
+              name: AD_BIDS_TIMESTAMP_DIMENSION,
+              timeGrain: V1TimeGrain.TIME_GRAIN_UNSPECIFIED,
+            },
+          ],
+        },
+        {
+          name: AD_BIDS_IMPRESSIONS_MEASURE_WINDOW,
+          window: {
+            partition: true,
+          },
+        },
+      ],
+    });
+    expect(dashboard.leaderboardMeasureName).toEqual(
+      AD_BIDS_IMPRESSIONS_MEASURE_NO_GRAIN,
+    );
+    expect(dashboard.dimensionThresholdFilters.length).toEqual(0);
+  });
+});

--- a/web-common/src/features/dashboards/stores/AdvancedMeasureCorrector.ts
+++ b/web-common/src/features/dashboards/stores/AdvancedMeasureCorrector.ts
@@ -1,0 +1,144 @@
+import {
+  createAndExpression,
+  filterIdentifiers,
+} from "@rilldata/web-common/features/dashboards/stores/filter-utils";
+import { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import { getMapFromArray } from "@rilldata/web-common/lib/arrayUtils";
+import { DashboardState_ActivePage } from "@rilldata/web-common/proto/gen/rill/ui/v1/dashboard_pb";
+import {
+  MetricsViewSpecMeasureType,
+  MetricsViewSpecMeasureV2,
+  V1MetricsViewSpec,
+  V1TimeGrain,
+} from "@rilldata/web-common/runtime-client";
+
+/**
+ * Single use class to correct incorrect use of advanced measures.
+ * Reason to use a class here is to avoid too many arguments in methods (especially measureMismatch).
+ */
+export class AdvancedMeasureCorrector {
+  private measuresMap: Map<string, MetricsViewSpecMeasureV2>;
+  private measuresGrains: Map<string, V1TimeGrain>;
+
+  public constructor(
+    private readonly dashboard: MetricsExplorerEntity,
+    private readonly metricsViewSpec: V1MetricsViewSpec,
+  ) {
+    this.measuresMap = getMapFromArray(
+      metricsViewSpec.measures ?? [],
+      (m) => m.name ?? "",
+    );
+    this.measuresGrains = getMapFromArray(
+      metricsViewSpec.measures ?? [],
+      (m) => m.name ?? "",
+      (m) => {
+        const d = m.requiredDimensions?.find(
+          (d) =>
+            d.timeGrain && d.timeGrain !== V1TimeGrain.TIME_GRAIN_UNSPECIFIED,
+        );
+        return d?.timeGrain ?? V1TimeGrain.TIME_GRAIN_UNSPECIFIED;
+      },
+    );
+  }
+
+  public correct() {
+    this.correctFilters();
+    this.correctLeaderboards();
+    this.correctTimeDimensionDetails();
+    this.correctPivot();
+  }
+
+  private correctFilters() {
+    this.dashboard.dimensionThresholdFilters.forEach((dimensionThreshold) => {
+      dimensionThreshold.filter =
+        filterIdentifiers(
+          dimensionThreshold.filter,
+          (_, ident) => !this.measureMismatch(ident, false, false),
+        ) ?? createAndExpression([]);
+    });
+  }
+
+  private correctLeaderboards() {
+    if (
+      !this.measureMismatch(this.dashboard.leaderboardMeasureName, true, false)
+    ) {
+      return;
+    }
+
+    this.dashboard.leaderboardMeasureName = "";
+    for (const measure of this.metricsViewSpec.measures ?? []) {
+      if (!this.measureMismatch(measure.name ?? "", true, false)) {
+        this.dashboard.leaderboardMeasureName = measure.name ?? "";
+        break;
+      }
+    }
+  }
+
+  private correctTimeDimensionDetails() {
+    if (
+      !this.measureMismatch(
+        this.dashboard.tdd.expandedMeasureName ?? "",
+        true,
+        false,
+      )
+    ) {
+      return;
+    }
+
+    this.dashboard.tdd.expandedMeasureName = "";
+    if (
+      this.dashboard.activePage ===
+      DashboardState_ActivePage.TIME_DIMENSIONAL_DETAIL
+    ) {
+      this.dashboard.activePage = DashboardState_ActivePage.DEFAULT;
+    }
+  }
+
+  private correctPivot() {
+    this.dashboard.pivot.columns.measure =
+      this.dashboard.pivot.columns.measure.filter(
+        (m) => !this.measureMismatch(m.id, true, false),
+      );
+    this.dashboard.pivot.sorting = this.dashboard.pivot.sorting.filter(
+      (s) =>
+        !this.measuresMap.has(s.id) || !this.measureMismatch(s.id, true, false),
+    );
+  }
+
+  private measureMismatch(
+    measureName: string,
+    supportsComparisonMeasure: boolean,
+    supportsWindowedMeasure: boolean,
+  ) {
+    const measure = this.measuresMap.get(measureName);
+    if (!measure) return true;
+    const grain =
+      this.measuresGrains.get(measureName) ??
+      V1TimeGrain.TIME_GRAIN_UNSPECIFIED;
+
+    switch (true) {
+      // selected grain and measure's grain mismatch
+      case grain !== V1TimeGrain.TIME_GRAIN_UNSPECIFIED &&
+        grain !== this.dashboard.selectedTimeRange?.interval:
+        return true;
+
+      // for comparison measures,
+      // if the component supports it and has no time comparison is enabled
+      // or if the component does not support it
+      case measure.type ===
+        MetricsViewSpecMeasureType.MEASURE_TYPE_TIME_COMPARISON &&
+        ((supportsComparisonMeasure &&
+          (!this.dashboard.showTimeComparison ||
+            !this.dashboard.selectedComparisonTimeRange)) ||
+          !supportsComparisonMeasure):
+        return true;
+
+      // for measures with window operations, if the component doesnt support it
+      case !!measure.window && !supportsWindowedMeasure:
+        return true;
+
+      default:
+        return false;
+    }
+  }
+}

--- a/web-common/src/features/dashboards/stores/dashboard-stores-test-data.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores-test-data.ts
@@ -39,6 +39,9 @@ export const AD_BIDS_SOURCE_NAME = "AdBids_Source";
 export const AD_BIDS_MIRROR_NAME = "AdBids_mirror";
 
 export const AD_BIDS_IMPRESSIONS_MEASURE = "impressions";
+export const AD_BIDS_IMPRESSIONS_MEASURE_NO_GRAIN = "impressions_no_grain";
+export const AD_BIDS_IMPRESSIONS_MEASURE_DAY_GRAIN = "impressions_day_grain";
+export const AD_BIDS_IMPRESSIONS_MEASURE_WINDOW = "impressions_window";
 export const AD_BIDS_BID_PRICE_MEASURE = "bid_price";
 export const AD_BIDS_PUBLISHER_COUNT_MEASURE = "publisher_count";
 export const AD_BIDS_PUBLISHER_DIMENSION = "publisher";
@@ -69,6 +72,36 @@ export const AD_BIDS_THREE_MEASURES = [
   {
     name: AD_BIDS_PUBLISHER_COUNT_MEASURE,
     expression: "count_distinct(publisher)",
+  },
+];
+export const AD_BIDS_ADVANCED_MEASURES = [
+  {
+    name: AD_BIDS_IMPRESSIONS_MEASURE,
+    expression: "count(*)",
+  },
+  {
+    name: AD_BIDS_IMPRESSIONS_MEASURE_DAY_GRAIN,
+    requiredDimensions: [
+      {
+        name: AD_BIDS_TIMESTAMP_DIMENSION,
+        timeGrain: V1TimeGrain.TIME_GRAIN_DAY,
+      },
+    ],
+  },
+  {
+    name: AD_BIDS_IMPRESSIONS_MEASURE_NO_GRAIN,
+    requiredDimensions: [
+      {
+        name: AD_BIDS_TIMESTAMP_DIMENSION,
+        timeGrain: V1TimeGrain.TIME_GRAIN_UNSPECIFIED,
+      },
+    ],
+  },
+  {
+    name: AD_BIDS_IMPRESSIONS_MEASURE_WINDOW,
+    window: {
+      partition: true,
+    },
   },
 ];
 export const AD_BIDS_INIT_DIMENSIONS = [

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -218,7 +218,7 @@ const metricViewReducers = {
       }
       metricsExplorer.dimensionFilterExcludeMode =
         includeExcludeModeFromFilters(partial.whereFilter);
-      new AdvancedMeasureCorrector(metricsExplorer, metricsView).correct();
+      AdvancedMeasureCorrector.correct(metricsExplorer, metricsView);
     });
   },
 
@@ -458,7 +458,7 @@ const metricViewReducers = {
     updateMetricsExplorerByName(name, (metricsExplorer) => {
       setDisplayComparison(metricsExplorer, true);
       metricsExplorer.selectedComparisonTimeRange = comparisonTimeRange;
-      new AdvancedMeasureCorrector(metricsExplorer, metricsViewSpec).correct();
+      AdvancedMeasureCorrector.correct(metricsExplorer, metricsViewSpec);
     });
   },
 
@@ -509,7 +509,7 @@ const metricViewReducers = {
           metricsExplorer.selectedComparisonDimension === undefined,
       );
 
-      new AdvancedMeasureCorrector(metricsExplorer, metricsViewSpec).correct();
+      AdvancedMeasureCorrector.correct(metricsExplorer, metricsViewSpec);
     });
   },
 

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -2,6 +2,7 @@ import { LeaderboardContextColumn } from "@rilldata/web-common/features/dashboar
 import { getDashboardStateFromUrl } from "@rilldata/web-common/features/dashboards/proto-state/fromProto";
 import { getProtoFromDashboardState } from "@rilldata/web-common/features/dashboards/proto-state/toProto";
 import { getWhereFilterExpressionIndex } from "@rilldata/web-common/features/dashboards/state-managers/selectors/dimension-filters";
+import { AdvancedMeasureCorrector } from "@rilldata/web-common/features/dashboards/stores/AdvancedMeasureCorrector";
 import {
   getDefaultMetricsExplorerEntity,
   restorePersistedDashboardState,
@@ -217,6 +218,7 @@ const metricViewReducers = {
       }
       metricsExplorer.dimensionFilterExcludeMode =
         includeExcludeModeFromFilters(partial.whereFilter);
+      new AdvancedMeasureCorrector(metricsExplorer, metricsView).correct();
     });
   },
 
@@ -451,10 +453,12 @@ const metricViewReducers = {
   setSelectedComparisonRange(
     name: string,
     comparisonTimeRange: DashboardTimeControls,
+    metricsViewSpec: V1MetricsViewSpec,
   ) {
     updateMetricsExplorerByName(name, (metricsExplorer) => {
       setDisplayComparison(metricsExplorer, true);
       metricsExplorer.selectedComparisonTimeRange = comparisonTimeRange;
+      new AdvancedMeasureCorrector(metricsExplorer, metricsViewSpec).correct();
     });
   },
 
@@ -484,6 +488,7 @@ const metricViewReducers = {
     timeRange: TimeRange,
     timeGrain: V1TimeGrain,
     comparisonTimeRange: DashboardTimeControls | undefined,
+    metricsViewSpec: V1MetricsViewSpec,
   ) {
     updateMetricsExplorerByName(name, (metricsExplorer) => {
       if (!timeRange.name) return;
@@ -503,6 +508,8 @@ const metricViewReducers = {
         metricsExplorer.selectedComparisonTimeRange !== undefined &&
           metricsExplorer.selectedComparisonDimension === undefined,
       );
+
+      new AdvancedMeasureCorrector(metricsExplorer, metricsViewSpec).correct();
     });
   },
 

--- a/web-common/src/features/dashboards/stores/filter-utils.ts
+++ b/web-common/src/features/dashboards/stores/filter-utils.ts
@@ -202,12 +202,6 @@ export function filterIdentifiers(
   cb: (e: V1Expression, ident: string) => boolean,
 ) {
   return filterExpressions(expr, (e) => {
-    if (
-      e.cond?.op !== V1Operation.OPERATION_IN &&
-      e.cond?.op !== V1Operation.OPERATION_NIN
-    ) {
-      return true;
-    }
     const ident = e.cond?.exprs?.[0].ident;
     if (ident === undefined) {
       return true;

--- a/web-common/src/features/dashboards/time-controls/TimeControls.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeControls.svelte
@@ -149,11 +149,15 @@
     start: Date,
     end: Date,
   ) {
-    metricsExplorerStore.setSelectedComparisonRange(metricViewName, {
-      name,
-      start,
-      end,
-    });
+    metricsExplorerStore.setSelectedComparisonRange(
+      metricViewName,
+      {
+        name,
+        start,
+        end,
+      },
+      $metricsView.data ?? {},
+    );
   }
 
   function makeTimeSeriesTimeRangeAndUpdateAppState(
@@ -170,6 +174,7 @@
       timeRange,
       timeGrain,
       comparisonTimeRange,
+      $metricsView.data ?? {},
     );
   }
 </script>

--- a/web-common/src/features/dashboards/time-controls/time-control-store.spec.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.spec.ts
@@ -176,7 +176,11 @@ describe("time-control-store", () => {
       end: undefined,
       interval: V1TimeGrain.TIME_GRAIN_HOUR,
     });
-    metricsExplorerStore.setSelectedComparisonRange(AD_BIDS_NAME, {} as any);
+    metricsExplorerStore.setSelectedComparisonRange(
+      AD_BIDS_NAME,
+      {} as any,
+      AD_BIDS_INIT_WITH_TIME,
+    );
     assertComparisonStartAndEnd(
       get(timeControlsStore),
       // Sets to default comparison
@@ -193,7 +197,11 @@ describe("time-control-store", () => {
       end: undefined,
       interval: V1TimeGrain.TIME_GRAIN_DAY,
     });
-    metricsExplorerStore.setSelectedComparisonRange(AD_BIDS_NAME, {} as any);
+    metricsExplorerStore.setSelectedComparisonRange(
+      AD_BIDS_NAME,
+      {} as any,
+      AD_BIDS_INIT_WITH_TIME,
+    );
     expect(get(timeControlsStore).showComparison).toBeFalsy();
 
     metricsExplorerStore.setSelectedTimeRange(AD_BIDS_NAME, {
@@ -202,7 +210,11 @@ describe("time-control-store", () => {
       end: undefined,
       interval: V1TimeGrain.TIME_GRAIN_DAY,
     });
-    metricsExplorerStore.setSelectedComparisonRange(AD_BIDS_NAME, {} as any);
+    metricsExplorerStore.setSelectedComparisonRange(
+      AD_BIDS_NAME,
+      {} as any,
+      AD_BIDS_INIT_WITH_TIME,
+    );
     assertComparisonStartAndEnd(
       get(timeControlsStore),
       // Sets to the one selected
@@ -242,7 +254,11 @@ describe("time-control-store", () => {
       end: undefined,
       interval: V1TimeGrain.TIME_GRAIN_HOUR,
     });
-    metricsExplorerStore.setSelectedComparisonRange(AD_BIDS_NAME, {} as any);
+    metricsExplorerStore.setSelectedComparisonRange(
+      AD_BIDS_NAME,
+      {} as any,
+      AD_BIDS_INIT_WITH_TIME,
+    );
     assertStartAndEnd(
       get(timeControlsStore),
       "2022-03-30T00:30:00.000Z",
@@ -273,9 +289,13 @@ describe("time-control-store", () => {
     );
     await waitForUpdate(timeControlsStore, "2022-01-01T00:00:00.000Z");
     metricsExplorerStore.displayTimeComparison(AD_BIDS_NAME, true);
-    metricsExplorerStore.setSelectedComparisonRange(AD_BIDS_NAME, {
-      name: TimeComparisonOption.MONTH,
-    } as any);
+    metricsExplorerStore.setSelectedComparisonRange(
+      AD_BIDS_NAME,
+      {
+        name: TimeComparisonOption.MONTH,
+      } as any,
+      AD_BIDS_INIT_WITH_TIME,
+    );
 
     metricsExplorerStore.setSelectedScrubRange(AD_BIDS_NAME, {
       name: AD_BIDS_NAME,

--- a/web-common/src/features/dashboards/time-series/ChartInteractions.svelte
+++ b/web-common/src/features/dashboards/time-series/ChartInteractions.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Button } from "@rilldata/web-common/components/button";
   import Zoom from "@rilldata/web-common/components/icons/Zoom.svelte";
+  import { useMetricsView } from "@rilldata/web-common/features/dashboards/selectors";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
   import { getOrderedStartEnd } from "@rilldata/web-common/features/dashboards/time-series/utils";
@@ -10,6 +11,7 @@
     TimeRangePreset,
   } from "@rilldata/web-common/lib/time/types";
   import type { V1TimeGrain } from "@rilldata/web-common/runtime-client";
+  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
 
   export let metricViewName: string;
   export let showComparison = false;
@@ -22,6 +24,8 @@
       charts: { canPanLeft, canPanRight, getNewPanRange },
     },
   } = StateManagers;
+
+  $: metricsView = useMetricsView($runtime.instanceId, metricViewName);
 
   function onKeyDown(e: KeyboardEvent) {
     const targetTagName = (e.target as HTMLElement).tagName;
@@ -69,6 +73,7 @@
       timeRange,
       timeGrain,
       comparisonTimeRange,
+      $metricsView.data ?? {},
     );
   }
 

--- a/web-common/src/features/dashboards/time-series/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureChart.svelte
@@ -10,7 +10,6 @@
     Grid,
   } from "@rilldata/web-common/components/data-graphic/guides";
   import { ScaleType } from "@rilldata/web-common/components/data-graphic/state";
-  import type { ScaleStore } from "@rilldata/web-common/components/data-graphic/state/types";
   import { useMetricsView } from "@rilldata/web-common/features/dashboards/selectors";
   import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
   import { tableInteractionStore } from "@rilldata/web-common/features/dashboards/time-dimension-details/time-dimension-data-store";

--- a/web-common/src/features/dashboards/time-series/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureChart.svelte
@@ -11,6 +11,7 @@
   } from "@rilldata/web-common/components/data-graphic/guides";
   import { ScaleType } from "@rilldata/web-common/components/data-graphic/state";
   import type { ScaleStore } from "@rilldata/web-common/components/data-graphic/state/types";
+  import { useMetricsView } from "@rilldata/web-common/features/dashboards/selectors";
   import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
   import { tableInteractionStore } from "@rilldata/web-common/features/dashboards/time-dimension-details/time-dimension-data-store";
   import DimensionValueMouseover from "@rilldata/web-common/features/dashboards/time-series/DimensionValueMouseover.svelte";
@@ -23,6 +24,7 @@
     MetricsViewSpecMeasureV2,
     V1TimeGrain,
   } from "@rilldata/web-common/runtime-client";
+  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { extent } from "d3-array";
   import { getContext } from "svelte";
   import { cubicOut } from "svelte/easing";
@@ -76,7 +78,7 @@
   $: numberKind = numberKindForMeasure(measure);
 
   const tweenProps = { duration: 400, easing: cubicOut };
-  const xScale = getContext(contexts.scale("x")) as ScaleStore;
+  const xScale = getContext(contexts.scale("x"));
 
   let hovered: boolean = false;
   let scrub;
@@ -163,6 +165,8 @@
   $: internalXMin = xMin || xExtentMin;
   $: internalXMax = xMax || xExtentMax;
 
+  $: metricsView = useMetricsView($runtime.instanceId, metricViewName);
+
   function inBounds(min, max, value) {
     return value >= min && value <= max;
   }
@@ -214,6 +218,7 @@
       timeRange,
       timeGrain,
       comparisonTimeRange,
+      $metricsView.data ?? {},
     );
   }
 

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -43,7 +43,10 @@
 
   const {
     selectors: {
-      measures: { isMeasureValidPercentOfTotal, getMeasuresAndDimensions },
+      measures: {
+        isMeasureValidPercentOfTotal,
+        getFilteredMeasuresAndDimensions,
+      },
       dimensionFilters: { includedDimensionValues },
     },
   } = getStateManagers();
@@ -102,7 +105,7 @@
           ? (measure) => measure.name === expandedMeasureName
           : (_, i) => $showHideMeasures.selectedItems[i],
       ) ?? [];
-    const { measures } = $getMeasuresAndDimensions(
+    const { measures } = $getFilteredMeasuresAndDimensions(
       $metricsView.data ?? {},
       renderedMeasures.map((m) => m.name ?? ""),
     );

--- a/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
+++ b/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
@@ -1,6 +1,6 @@
 import { measureFilterResolutionsStore } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
 import { useMetricsView } from "@rilldata/web-common/features/dashboards/selectors/index";
-import { getMeasuresAndDimensions } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
+import { getFilteredMeasuresAndDimensions } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
 import type { StateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
 import { sanitiseExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
 import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
@@ -137,7 +137,7 @@ export function createTimeSeriesDataStore(
           : [];
       }
       const { measures: filteredMeasures, dimensions } =
-        getMeasuresAndDimensions({
+        getFilteredMeasuresAndDimensions({
           dashboard: dashboardStore,
         })(metricsView.data ?? {}, measures);
 

--- a/web-common/src/lib/arrayUtils.ts
+++ b/web-common/src/lib/arrayUtils.ts
@@ -7,13 +7,14 @@ export function removeIfExists<T>(array: Array<T>, checker: (e: T) => boolean) {
   return false;
 }
 
-export function getMapFromArray<T, K>(
+export function getMapFromArray<T, K, V = T>(
   array: T[],
   keyGetter: (entity: T) => K,
-): Map<K, T> {
-  const map = new Map<K, T>();
+  valGetter: (entity: T) => V = (e) => e as unknown as V,
+): Map<K, V> {
+  const map = new Map<K, V>();
   for (const entity of array) {
-    map.set(keyGetter(entity), entity);
+    map.set(keyGetter(entity), valGetter(entity));
   }
   return map;
 }


### PR DESCRIPTION
Removed certain advanced measures from pivot and alerts. Also updates the dashboard state with any incorrect selections. EG: when in a TDD with a measure depending on a specific time grain and time grain is changed, active measure is cleared.

Sample dashboard,
```
# Dashboard YAML
# Reference documentation: https://docs.rilldata.com/reference/project-files/dashboards

type: metrics_view
title: Adbids Model
model: AdBids_model
timeseries: timestamp
dimensions:
  - label: Publisher
    column: publisher
  - label: Domain
    column: domain

measures:
  - name: total_records
    label: Total records
    expression: COUNT(*)
    format_preset: humanize
    valid_percent_of_total: true

  - name: bid_price
    label: Sum of Bid Price
    expression: SUM(bid_price)
    format_preset: humanize
    valid_percent_of_total: true

  - name: bid_price_lag
    label: Bid Price Lag
    expression: "bid_price - LAG(bid_price)"
    window: true
    requires: [bid_price, timestamp]
    valid_percent_of_total: true

  - name: bid_price_percent_total
    label: Bid Price Percent of Total
    expression: bid_price/SUM(bid_price)
    window:
      partition: false
    requires: [bid_price]
    format_preset: percentage
    valid_percent_of_total: true

  - name: bid_price_percent_total_diff
    type: time_comparison
    expression: (base.bid_price_percent_total - comparison.bid_price_percent_total)
    requires: [bid_price_percent_total]

  - name: bid_price_7day_rolling_avg
    expression: AVG(bid_price)
    window:
      frame: RANGE BETWEEN INTERVAL 7 DAYS PRECEDING AND CURRENT ROW
    requires:
      - name: timestamp
        time_grain: day
      - name: bid_price
```