### PR TITLE
Runtime : Cast result of `date_trunc` to timestamp

### DIFF
--- a/runtime/drivers/olap.go
+++ b/runtime/drivers/olap.go
@@ -346,9 +346,9 @@ func (d Dialect) DateTruncExpr(dim *runtimev1.MetricsViewSpec_DimensionV2, grain
 
 		// TODO: Should this use date_trunc(grain, expr, tz) instead?
 		if shift == "" {
-			return fmt.Sprintf("toTimezone(date_trunc('%s', toTimezone(%s::TIMESTAMP, '%s')), '%s')", specifier, expr, tz, tz), nil
+			return fmt.Sprintf("toTimezone(date_trunc('%s', toTimezone(%s::TIMESTAMP, '%s'))::TIMESTAMP, '%s')", specifier, expr, tz, tz), nil
 		}
-		return fmt.Sprintf("toTimezone(date_trunc('%s', toTimezone(%s::TIMESTAMP, '%s') + INTERVAL %s) - INTERVAL %s, '%s')", specifier, expr, tz, shift, shift, tz), nil
+		return fmt.Sprintf("toTimezone(date_trunc('%s', toTimezone(%s::TIMESTAMP, '%s') + INTERVAL %s)::TIMESTAMP - INTERVAL %s, '%s')", specifier, expr, tz, shift, shift, tz), nil
 	case DialectPinot:
 		// TODO: Handle tz instead of ignoring it.
 		// TODO: Handle firstDayOfWeek and firstMonthOfYear. NOTE: We currently error when configuring these for Pinot in runtime/validate.go.

--- a/runtime/drivers/olap.go
+++ b/runtime/drivers/olap.go
@@ -346,9 +346,9 @@ func (d Dialect) DateTruncExpr(dim *runtimev1.MetricsViewSpec_DimensionV2, grain
 
 		// TODO: Should this use date_trunc(grain, expr, tz) instead?
 		if shift == "" {
-			return fmt.Sprintf("toTimezone(date_trunc('%s', toTimezone(%s::TIMESTAMP, '%s')), '%s')", grain, expr, tz, tz), nil
+			return fmt.Sprintf("toTimezone(date_trunc('%s', toTimezone(%s::TIMESTAMP, '%s')), '%s')", specifier, expr, tz, tz), nil
 		}
-		return fmt.Sprintf("toTimezone(date_trunc('%s', toTimezone(%s::TIMESTAMP, '%s') + INTERVAL %s) - INTERVAL %s, '%s')", grain, expr, tz, shift, shift, tz), nil
+		return fmt.Sprintf("toTimezone(date_trunc('%s', toTimezone(%s::TIMESTAMP, '%s') + INTERVAL %s) - INTERVAL %s, '%s')", specifier, expr, tz, shift, shift, tz), nil
 	case DialectPinot:
 		// TODO: Handle tz instead of ignoring it.
 		// TODO: Handle firstDayOfWeek and firstMonthOfYear. NOTE: We currently error when configuring these for Pinot in runtime/validate.go.

--- a/runtime/queries/metricsview_timeseries.go
+++ b/runtime/queries/metricsview_timeseries.go
@@ -449,7 +449,7 @@ func (q *MetricsViewTimeSeries) buildClickHouseSQL(mv *runtimev1.MetricsViewSpec
 		sql = fmt.Sprintf(
 			`
 					SELECT
-					toTimeZone(date_trunc('%[1]s', toTimeZone(%[2]s::DateTime64, '%[7]s'))::DateTime64, '%[7]s') as %[3]s,
+					toTimeZone(date_trunc('%[1]s', toTimeZone(%[2]s::TIMESTAMP, '%[7]s'))::TIMESTAMP, '%[7]s') as %[3]s,
 					%[4]s
 					FROM %[5]s
 					WHERE %[6]s
@@ -469,7 +469,7 @@ func (q *MetricsViewTimeSeries) buildClickHouseSQL(mv *runtimev1.MetricsViewSpec
 		sql = fmt.Sprintf(
 			`
 				SELECT
-					toTimeZone(date_trunc('%[1]s', toTimeZone(%[2]s::DateTime64, '%[7]s') + INTERVAL %[8]s) - (INTERVAL %[8]s), '%[7]s') as %[3]s,
+					toTimeZone(date_trunc('%[1]s', toTimeZone(%[2]s::TIMESTAMP, '%[7]s') + INTERVAL %[8]s)::TIMESTAMP - (INTERVAL %[8]s), '%[7]s') as %[3]s,
 				%[4]s
 				FROM %[5]s
 				WHERE %[6]s


### PR DESCRIPTION
We need to cast result of `date_trunc` to timestamp since `date_trunc('month`, ...) results `date`