### PR TITLE
Runtime: Use system tables and settings override

### DIFF
--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -93,6 +93,8 @@ type configProperties struct {
 	EnableCache bool `mapstructure:"enable_cache"`
 	// LogQueries controls whether to log the raw SQL passed to OLAP.Execute.
 	LogQueries bool `mapstructure:"log_queries"`
+	// SettingsOverride override the default settings used in queries. One use case is to disable settings and set `readonly = 1` when using read-only user.
+	SettingsOverride string `mapstructure:"settings_override"`
 }
 
 // Open connects to Clickhouse using std API.

--- a/runtime/drivers/clickhouse/information_schema.go
+++ b/runtime/drivers/clickhouse/information_schema.go
@@ -36,17 +36,15 @@ func (i informationSchema) All(ctx context.Context) ([]*drivers.Table, error) {
 			C.name AS COLUMNS,
 			C.type AS COLUMN_TYPE,
 			C.position AS ORDINAL_POSITION
-		FROM system.tables AS T
-		INNER JOIN system.columns AS C ON (T.database = C.database) AND (T.name = C.table)
+		FROM system.tables T
+		JOIN system.columns C ON T.database = C.database AND T.name = C.table
 		WHERE lower(T.database) NOT IN ('information_schema', 'system') 
-		ORDER BY SCHEMA ASC, NAME ASC, TABLE_TYPE ASC, ORDINAL_POSITION ASC
+		ORDER BY SCHEMA, NAME, TABLE_TYPE, ORDINAL_POSITION
 	`
 
 	rows, err := conn.QueryxContext(ctx, q)
 	if err != nil {
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 	defer rows.Close()
 
@@ -76,10 +74,10 @@ func (i informationSchema) Lookup(ctx context.Context, db, schema, name string) 
 			C.name AS COLUMNS,
 			C.type AS COLUMN_TYPE,
 			C.position AS ORDINAL_POSITION
-		FROM system.tables AS T
-		INNER JOIN system.columns AS C ON (T.database = C.database) AND (T.name = C.table)
+		FROM system.tables T
+		JOIN system.columns C ON T.database = C.database AND T.name = C.table
 		WHERE T.database = coalesce(?, currentDatabase()) AND T.name = ?
-		ORDER BY SCHEMA ASC, NAME ASC, TABLE_TYPE ASC, ORDINAL_POSITION ASC
+		ORDER BY SCHEMA, NAME, TABLE_TYPE, ORDINAL_POSITION
 	`
 	if schema == "" {
 		args = append(args, nil, name)

--- a/runtime/drivers/clickhouse/information_schema.go
+++ b/runtime/drivers/clickhouse/information_schema.go
@@ -28,23 +28,25 @@ func (i informationSchema) All(ctx context.Context) ([]*drivers.Table, error) {
 	// Given the usual way of querying table in clickhouse is `SELECT * FROM table_name` or `SELECT * FROM database.table_name`.
 	// We map clickhouse database to `database schema` and table_name to `table name`.
 	q := `
-		SELECT
-			T.table_schema AS SCHEMA,
-			T.table_schema = currentDatabase() AS is_default_schema,
-			T.table_name AS NAME,
-			T.table_type AS TABLE_TYPE, 
-			C.column_name AS COLUMNS,
-			C.data_type AS COLUMN_TYPE,
-			C.ordinal_position as ORDINAL_POSITION
-		FROM information_schema.tables T 
-		JOIN information_schema.columns C ON T.table_schema = C.table_schema AND T.table_name = C.table_name
-		WHERE lower(T.table_schema) NOT IN ('information_schema', 'system')
-		ORDER BY SCHEMA, NAME, TABLE_TYPE, ORDINAL_POSITION
+		SELECT 
+			T.database AS SCHEMA,
+			T.database = currentDatabase() AS is_default_schema,
+			T.name AS NAME,
+			if(lower(T.engine) like '%view%', 'VIEW', 'TABLE') AS TABLE_TYPE,
+			C.name AS COLUMNS,
+			C.type AS COLUMN_TYPE,
+			C.position AS ORDINAL_POSITION
+		FROM system.tables AS T
+		INNER JOIN system.columns AS C ON (T.database = C.database) AND (T.name = C.table)
+		WHERE lower(T.database) NOT IN ('information_schema', 'system') 
+		ORDER BY SCHEMA ASC, NAME ASC, TABLE_TYPE ASC, ORDINAL_POSITION ASC
 	`
 
 	rows, err := conn.QueryxContext(ctx, q)
 	if err != nil {
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
 	}
 	defer rows.Close()
 
@@ -66,18 +68,18 @@ func (i informationSchema) Lookup(ctx context.Context, db, schema, name string) 
 	var q string
 	var args []any
 	q = `
-		SELECT
-			T.table_schema AS SCHEMA,
-			T.table_schema = currentDatabase() AS is_default_schema,
-			T.table_name AS NAME,
-			T.table_type AS TABLE_TYPE, 
-			C.column_name AS COLUMNS,
-			C.data_type AS COLUMN_TYPE,
-			C.ordinal_position as ORDINAL_POSITION
-		FROM information_schema.tables T 
-		JOIN information_schema.columns C ON T.table_schema = C.table_schema AND T.table_name = C.table_name
-		WHERE T.table_schema = coalesce(?, currentDatabase()) AND T.table_name = ?
-		ORDER BY SCHEMA, NAME, TABLE_TYPE, ORDINAL_POSITION
+		SELECT 
+			T.database AS SCHEMA,
+			T.database = currentDatabase() AS is_default_schema,
+			T.name AS NAME,
+			if(lower(T.engine) like '%view%', 'VIEW', 'TABLE') AS TABLE_TYPE,
+			C.name AS COLUMNS,
+			C.type AS COLUMN_TYPE,
+			C.position AS ORDINAL_POSITION
+		FROM system.tables AS T
+		INNER JOIN system.columns AS C ON (T.database = C.database) AND (T.name = C.table)
+		WHERE T.database = coalesce(?, currentDatabase()) AND T.name = ?
+		ORDER BY SCHEMA ASC, NAME ASC, TABLE_TYPE ASC, ORDINAL_POSITION ASC
 	`
 	if schema == "" {
 		args = append(args, nil, name)

--- a/runtime/drivers/clickhouse/olap.go
+++ b/runtime/drivers/clickhouse/olap.go
@@ -107,9 +107,13 @@ func (c *connection) Execute(ctx context.Context, stmt *drivers.Statement) (res 
 		return nil, err
 	}
 
-	stmt.Query += "\n SETTINGS cast_keep_nullable = 1, join_use_nulls = 1, session_timezone = 'UTC'"
-	if c.config.EnableCache {
-		stmt.Query += ", use_query_cache = 1"
+	if c.config.SettingsOverride != "" {
+		stmt.Query += "\n SETTINGS " + c.config.SettingsOverride
+	} else {
+		stmt.Query += "\n SETTINGS cast_keep_nullable = 1, join_use_nulls = 1, session_timezone = 'UTC'"
+		if c.config.EnableCache {
+			stmt.Query += ", use_query_cache = 1"
+		}
 	}
 
 	// Gather metrics only for actual queries

--- a/runtime/testruntime/testdata/clickhouse-config.xml
+++ b/runtime/testruntime/testdata/clickhouse-config.xml
@@ -1,3 +1,6 @@
 <clickhouse>
   <timezone>UTC</timezone>
+  <access_control_improvements>
+    <select_from_information_schema_requires_grant>true</select_from_information_schema_requires_grant>
+  </access_control_improvements>
 </clickhouse>


### PR DESCRIPTION
- closes #5006
- Adds a `settings_override` to set `readonly = 1` and disable other settings in case of read only user.
