### PR TITLE
Connectors: query invalidations

### DIFF
--- a/web-common/src/features/connectors/olap/DatabaseExplorer.svelte
+++ b/web-common/src/features/connectors/olap/DatabaseExplorer.svelte
@@ -8,33 +8,30 @@
   export let instanceId: string;
   export let connector: V1AnalyzedConnector;
 
-  let dataBasesQuery: ReturnType<typeof useDatabases>;
-  $: if (connector.name) {
-    dataBasesQuery = useDatabases(instanceId, connector?.name);
-  }
+  $: connectorName = connector?.name as string;
+
+  $: dataBasesQuery = useDatabases(instanceId, connectorName);
 
   $: ({ data, error, isLoading } = $dataBasesQuery);
 </script>
 
-{#if connector && connector.name}
-  <div class="wrapper">
-    {#if error}
-      <span class="message">Error: {error.response.data.message}</span>
-    {:else if isLoading}
-      <span class="message">Loading databases...</span>
-    {:else if data}
-      {#if data.length === 0}
-        <span class="message">No databases found</span>
-      {:else}
-        <ol transition:slide={{ duration }}>
-          {#each data as database (database)}
-            <DatabaseEntry {instanceId} {connector} {database} />
-          {/each}
-        </ol>
-      {/if}
+<div class="wrapper">
+  {#if error}
+    <span class="message">Error: {error.response.data.message}</span>
+  {:else if isLoading}
+    <span class="message">Loading databases...</span>
+  {:else if data}
+    {#if data.length === 0}
+      <span class="message">No databases found</span>
+    {:else}
+      <ol transition:slide={{ duration }}>
+        {#each data as database (database)}
+          <DatabaseEntry {instanceId} {connector} {database} />
+        {/each}
+      </ol>
     {/if}
-  </div>
-{/if}
+  {/if}
+</div>
 
 <style lang="postcss">
   .wrapper {

--- a/web-common/src/features/connectors/utils.ts
+++ b/web-common/src/features/connectors/utils.ts
@@ -1,0 +1,16 @@
+import { V1Resource } from "../../runtime-client";
+import { ResourceKind } from "../entity-management/resource-selectors";
+
+export function getConnectorNameForResource(resource: V1Resource): string {
+  if (!resource.meta?.name?.kind || !resource.meta?.name?.name) return "";
+
+  if (resource.meta.name.kind === ResourceKind.Connector.toString()) {
+    return resource.meta.name.name;
+  } else if (resource.meta.name.kind === ResourceKind.Source.toString()) {
+    return resource?.source?.spec?.sinkConnector ?? "";
+  } else if (resource.meta.name.kind === ResourceKind.Model.toString()) {
+    return resource?.model?.spec?.outputConnector ?? "";
+  }
+
+  return "";
+}

--- a/web-common/src/features/entity-management/WatchResourcesClient.ts
+++ b/web-common/src/features/entity-management/WatchResourcesClient.ts
@@ -21,6 +21,7 @@ import { isProfilingQuery } from "@rilldata/web-common/runtime-client/query-matc
 import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
 import { WatchRequestClient } from "@rilldata/web-common/runtime-client/watch-request-client";
 import { get } from "svelte/store";
+import { getConnectorNameForResource } from "../connectors/utils";
 
 const MainResourceKinds: {
   [kind in ResourceKind]?: true;
@@ -144,10 +145,7 @@ export class WatchResourcesClient {
       void queryClient.invalidateQueries(
         getConnectorServiceOLAPListTablesQueryKey({
           instanceId: get(runtime).instanceId,
-          connector:
-            resource.source?.spec?.sinkConnector ??
-            resource.model?.spec?.outputConnector ??
-            "",
+          connector: getConnectorNameForResource(resource),
         }),
       );
     }

--- a/web-common/src/features/entity-management/WatchResourcesClient.ts
+++ b/web-common/src/features/entity-management/WatchResourcesClient.ts
@@ -4,6 +4,7 @@ import { ResourceKind } from "@rilldata/web-common/features/entity-management/re
 import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
 import {
   getConnectorServiceOLAPListTablesQueryKey,
+  getRuntimeServiceAnalyzeConnectorsQueryKey,
   getRuntimeServiceGetResourceQueryKey,
   getRuntimeServiceListResourcesQueryKey,
   V1ReconcileStatus,
@@ -156,6 +157,11 @@ export class WatchResourcesClient {
     const name = resource.meta?.name?.name ?? "";
     let table: string | undefined;
     switch (resource.meta.name?.kind) {
+      case ResourceKind.Connector:
+        void queryClient.invalidateQueries(
+          getRuntimeServiceAnalyzeConnectorsQueryKey(instanceId),
+        );
+        return;
       case ResourceKind.Source:
       case ResourceKind.Model:
         table =


### PR DESCRIPTION
This PR invalidates the `AnalyzeConnectors` and `OLAPListTables` APIs when a Connector changes.

One finding –
- When editing a secret in a `.env` file, sometimes the frontend does not see a `RESOURCE_EVENT_WRITE`. This is a problem because the frontend listens for this event to know when to invalidate the above APIs. Discussing with @begelundmuller, we could have the following race condition: edits to the `.env` file trigger the Controller to restart, the frontend's streaming connection is terminated and re-established, and any reconciliation events that occurred while the frontend was not subscribed to the backend are lost.