### PR TITLE
Connectors: Handle arbitrary names

### DIFF
--- a/web-common/src/features/connectors/ConnectorExplorer.svelte
+++ b/web-common/src/features/connectors/ConnectorExplorer.svelte
@@ -85,6 +85,8 @@
   }
 
   .message {
-    @apply pl-2 pr-3.5 pt-2 pb-2 text-gray-500;
+    @apply pl-2 pr-3.5 py-2;
+    @apply text-gray-500;
+    @apply text-wrap;
   }
 </style>

--- a/web-common/src/features/connectors/olap/DatabaseSchemaEntry.svelte
+++ b/web-common/src/features/connectors/olap/DatabaseSchemaEntry.svelte
@@ -56,11 +56,18 @@
   </button>
 
   {#if showTables}
-    {#if typedData && typedData.length > 0}
+    {#if connector?.errorMessage}
+      <div class="message">{connector.errorMessage}</div>
+    {:else if !connector.driver || !connector.driver.name}
+      <div class="message">Connector not found</div>
+    {:else if !typedData || typedData.length === 0}
+      <div class="message">No tables found</div>
+    {:else if typedData.length > 0}
       <ol>
         {#each typedData as tableInfo (tableInfo)}
           <TableEntry
-            connectorInstanceId={instanceId}
+            {instanceId}
+            driver={connector.driver.name}
             connector={connectorName}
             {database}
             {databaseSchema}
@@ -90,5 +97,10 @@
 
   .database-schema-entry:not(.open) .database-schema-entry-header {
     @apply bg-white;
+  }
+
+  .message {
+    @apply pl-2 pr-3.5 py-2;
+    @apply text-gray-500;
   }
 </style>

--- a/web-common/src/features/connectors/olap/TableEntry.svelte
+++ b/web-common/src/features/connectors/olap/TableEntry.svelte
@@ -14,7 +14,8 @@
     makeTablePreviewHref,
   } from "./olap-config";
 
-  export let connectorInstanceId: string;
+  export let instanceId: string;
+  export let driver: string;
   export let connector: string;
   export let database: string; // The backend interprets an empty string as the default database
   export let databaseSchema: string; // The backend interprets an empty string as the default schema
@@ -30,11 +31,18 @@
     databaseSchema,
     table,
   );
-  $: href = makeTablePreviewHref(connector, database, databaseSchema, table);
+  $: tableId = `${connector}-${fullyQualifiedTableName}`;
+  $: href = makeTablePreviewHref(
+    driver,
+    connector,
+    database,
+    databaseSchema,
+    table,
+  );
   $: open = $page.url.pathname === href;
 </script>
 
-<li aria-label={fullyQualifiedTableName} class="table-entry group" class:open>
+<li aria-label={tableId} class="table-entry group" class:open>
   <div class="table-entry-header {database ? 'pl-[58px]' : 'pl-[40px]'}">
     <TableIcon size="14px" className="shrink-0 text-gray-400" />
     <Tooltip alignment="start" location="right" distance={32}>
@@ -52,7 +60,7 @@
     </Tooltip>
     {#if hasUnsupportedDataTypes}
       <UnsupportedTypesIndicator
-        instanceId={connectorInstanceId}
+        {instanceId}
         {connector}
         {database}
         {databaseSchema}
@@ -62,9 +70,9 @@
     <DropdownMenu.Root bind:open={contextMenuOpen}>
       <DropdownMenu.Trigger asChild let:builder>
         <ContextButton
-          id="more-actions-{fullyQualifiedTableName}"
+          id="more-actions-{tableId}"
           tooltipText="More actions"
-          label="{fullyQualifiedTableName} actions menu trigger"
+          label="{tableId} actions menu trigger"
           builders={[builder]}
           suppressTooltip={contextMenuOpen}
         >
@@ -77,7 +85,13 @@
         side="right"
         sideOffset={16}
       >
-        <TableMenuItems {connector} {database} {databaseSchema} {table} />
+        <TableMenuItems
+          {driver}
+          {connector}
+          {database}
+          {databaseSchema}
+          {table}
+        />
       </DropdownMenu.Content>
     </DropdownMenu.Root>
   </div>

--- a/web-common/src/features/connectors/olap/TableEntry.svelte
+++ b/web-common/src/features/connectors/olap/TableEntry.svelte
@@ -26,7 +26,7 @@
   let showSchema = false;
 
   $: fullyQualifiedTableName = makeFullyQualifiedTableName(
-    connector,
+    driver,
     database,
     databaseSchema,
     table,

--- a/web-common/src/features/connectors/olap/TableMenuItems.svelte
+++ b/web-common/src/features/connectors/olap/TableMenuItems.svelte
@@ -21,6 +21,7 @@
 
   const { ai } = featureFlags;
 
+  export let driver: string;
   export let connector: string;
   export let database: string = "";
   export let databaseSchema: string = "";
@@ -28,7 +29,13 @@
 
   $: isModelingSupportedForCurrentOlapDriver =
     useIsModelingSupportedForCurrentOlapDriver($runtime.instanceId);
-  $: href = makeTablePreviewHref(connector, database, databaseSchema, table);
+  $: href = makeTablePreviewHref(
+    driver,
+    connector,
+    database,
+    databaseSchema,
+    table,
+  );
   $: createDashboardFromTable = useCreateDashboardFromTableUIAction(
     $runtime.instanceId,
     connector,

--- a/web-common/src/features/connectors/olap/TableWorkspaceHeader.svelte
+++ b/web-common/src/features/connectors/olap/TableWorkspaceHeader.svelte
@@ -12,7 +12,6 @@
   import { runtime } from "../../../runtime-client/runtime-store";
   import { featureFlags } from "../../feature-flags";
   import { useCreateDashboardFromTableUIAction } from "../../metrics-views/ai-generation/generateMetricsView";
-  import { makeFullyQualifiedTableName } from "./olap-config";
 
   export let connector: string;
   export let database: string = "";
@@ -20,13 +19,6 @@
   export let table: string;
 
   const { ai } = featureFlags;
-
-  $: fullyQualifiedTableName = makeFullyQualifiedTableName(
-    connector,
-    database,
-    databaseSchema,
-    table,
-  );
 
   $: createDashboardFromTable = useCreateDashboardFromTableUIAction(
     $runtime.instanceId,
@@ -48,7 +40,7 @@
   <WorkspaceHeader
     editable={false}
     showInspectorToggle={false}
-    titleInput={fullyQualifiedTableName}
+    titleInput={table}
   >
     <svelte:fragment let:width={headerWidth} slot="cta">
       {@const collapse = isHeaderWidthSmall(headerWidth)}

--- a/web-common/src/features/connectors/olap/olap-config.ts
+++ b/web-common/src/features/connectors/olap/olap-config.ts
@@ -1,5 +1,25 @@
 export const OLAP_DRIVERS_WITHOUT_MODELING = ["clickhouse", "druid", "pinot"];
 
+export function makeFullyQualifiedTableName(
+  connector: string,
+  database: string,
+  databaseSchema: string,
+  table: string,
+) {
+  switch (connector) {
+    case "clickhouse":
+      return `${databaseSchema}.${table}`;
+    case "druid":
+      return `${databaseSchema}.${table}`;
+    case "duckdb":
+      return `${database}.${databaseSchema}.${table}`;
+    case "pinot":
+      return table;
+    default:
+      throw new Error(`Unsupported OLAP connector: ${connector}`);
+  }
+}
+
 export function makeTablePreviewHref(
   driver: string,
   connectorName: string,

--- a/web-common/src/features/connectors/olap/olap-config.ts
+++ b/web-common/src/features/connectors/olap/olap-config.ts
@@ -1,12 +1,12 @@
 export const OLAP_DRIVERS_WITHOUT_MODELING = ["clickhouse", "druid", "pinot"];
 
 export function makeFullyQualifiedTableName(
-  connector: string,
+  driver: string,
   database: string,
   databaseSchema: string,
   table: string,
 ) {
-  switch (connector) {
+  switch (driver) {
     case "clickhouse":
       return `${databaseSchema}.${table}`;
     case "druid":
@@ -16,7 +16,7 @@ export function makeFullyQualifiedTableName(
     case "pinot":
       return table;
     default:
-      throw new Error(`Unsupported OLAP connector: ${connector}`);
+      throw new Error(`Unsupported OLAP connector: ${driver}`);
   }
 }
 

--- a/web-common/src/features/connectors/olap/olap-config.ts
+++ b/web-common/src/features/connectors/olap/olap-config.ts
@@ -1,43 +1,22 @@
 export const OLAP_DRIVERS_WITHOUT_MODELING = ["clickhouse", "druid", "pinot"];
 
-export function makeFullyQualifiedTableName(
-  connector: string,
-  database: string,
-  databaseSchema: string,
-  table: string,
-) {
-  switch (connector) {
-    case "clickhouse":
-      return `${databaseSchema}.${table}`;
-    case "druid":
-      return `${databaseSchema}.${table}`;
-    case "duckdb":
-      // return `${database}.${databaseSchema}.${table}`;
-      // For now, only show the table name
-      return table;
-    case "pinot":
-      return table;
-    default:
-      throw new Error(`Unsupported OLAP connector: ${connector}`);
-  }
-}
-
 export function makeTablePreviewHref(
-  connector: string,
+  driver: string,
+  connectorName: string,
   database: string,
   databaseSchema: string,
   table: string,
 ): string {
-  switch (connector) {
+  switch (driver) {
     case "clickhouse":
-      return `/connector/clickhouse/${databaseSchema}/${table}`;
+      return `/connector/clickhouse/${connectorName}/${databaseSchema}/${table}`;
     case "druid":
-      return `/connector/druid/${databaseSchema}/${table}`;
+      return `/connector/druid/${connectorName}/${databaseSchema}/${table}`;
     case "duckdb":
-      return `/connector/duckdb/${database}/${databaseSchema}/${table}`;
+      return `/connector/duckdb/${connectorName}/${database}/${databaseSchema}/${table}`;
     case "pinot":
-      return `/connector/pinot/${table}`;
+      return `/connector/pinot/${connectorName}/${table}`;
     default:
-      throw new Error(`Unsupported connector: ${connector}`);
+      throw new Error(`Unsupported connector: ${driver}`);
   }
 }

--- a/web-local/src/routes/(application)/connector/clickhouse/[name]/[database]/[table]/+page.svelte
+++ b/web-local/src/routes/(application)/connector/clickhouse/[name]/[database]/[table]/+page.svelte
@@ -7,8 +7,10 @@
 
   const { readOnly } = featureFlags;
 
+  $: name = $page.params.name;
   $: database = $page.params.database;
-  $: databaseSchema = $page.params.schema;
+  // ClickHouse does not have a database "schema" concept
+  // Rill considers the ClickHouse "database" as the "database schema"
   $: table = $page.params.table;
 
   onMount(() => {
@@ -22,4 +24,4 @@
   <title>Rill Developer | {table}</title>
 </svelte:head>
 
-<TablePreviewWorkspace connector="duckdb" {database} {databaseSchema} {table} />
+<TablePreviewWorkspace connector={name} databaseSchema={database} {table} />

--- a/web-local/src/routes/(application)/connector/druid/[name]/[schema]/[table]/+page.svelte
+++ b/web-local/src/routes/(application)/connector/druid/[name]/[schema]/[table]/+page.svelte
@@ -7,6 +7,7 @@
 
   const { readOnly } = featureFlags;
 
+  $: name = $page.params.name;
   // Druid does not have a "database" concept
   $: databaseSchema = $page.params.schema;
   $: table = $page.params.table;
@@ -22,4 +23,4 @@
   <title>Rill Developer | {table}</title>
 </svelte:head>
 
-<TablePreviewWorkspace connector="druid" {databaseSchema} {table} />
+<TablePreviewWorkspace connector={name} {databaseSchema} {table} />

--- a/web-local/src/routes/(application)/connector/duckdb/[name]/[database]/[schema]/[table]/+page.svelte
+++ b/web-local/src/routes/(application)/connector/duckdb/[name]/[database]/[schema]/[table]/+page.svelte
@@ -7,9 +7,9 @@
 
   const { readOnly } = featureFlags;
 
+  $: name = $page.params.name;
   $: database = $page.params.database;
-  // ClickHouse does not have a database "schema" concept
-  // Rill considers the ClickHouse "database" as the "database schema"
+  $: databaseSchema = $page.params.schema;
   $: table = $page.params.table;
 
   onMount(() => {
@@ -23,8 +23,4 @@
   <title>Rill Developer | {table}</title>
 </svelte:head>
 
-<TablePreviewWorkspace
-  connector="clickhouse"
-  databaseSchema={database}
-  {table}
-/>
+<TablePreviewWorkspace connector={name} {database} {databaseSchema} {table} />

--- a/web-local/src/routes/(application)/connector/pinot/[name]/[table]/+page.svelte
+++ b/web-local/src/routes/(application)/connector/pinot/[name]/[table]/+page.svelte
@@ -7,6 +7,7 @@
 
   const { readOnly } = featureFlags;
 
+  $: name = $page.params.name;
   $: table = $page.params.table;
 
   onMount(() => {
@@ -20,4 +21,4 @@
   <title>Rill Developer | {table}</title>
 </svelte:head>
 
-<TablePreviewWorkspace connector="pinot" {table} />
+<TablePreviewWorkspace connector={name} {table} />


### PR DESCRIPTION
This PR is a small refactor to handle arbitrary connector names in the UI. This sets us up to allow >1 connector per connector type/driver.


For illustration, here's a connector not named the same as its driver:

![image](https://github.com/rilldata/rill/assets/14206386/7d563e8b-2451-4115-93bb-b829a5cc769e)

