### PR TITLE
feat: remove chart on backspace/delete

### DIFF
--- a/runtime/compilers/rillv1/parse_dashboard.go
+++ b/runtime/compilers/rillv1/parse_dashboard.go
@@ -40,11 +40,6 @@ func (p *Parser) parseDashboard(node *Node) error {
 		return fmt.Errorf("dashboards cannot have a connector")
 	}
 
-	// Ensure there's at least one item
-	if len(tmp.Items) == 0 {
-		return errors.New(`at least one item must be configured`)
-	}
-
 	// Parse items.
 	// Each item can either reference an externally defined component by name or define a component inline.
 	items := make([]*runtimev1.DashboardItem, len(tmp.Items))

--- a/web-common/src/features/custom-dashboards/CustomDashboardPreview.svelte
+++ b/web-common/src/features/custom-dashboards/CustomDashboardPreview.svelte
@@ -17,10 +17,10 @@
   export let showGrid = false;
   export let snap = false;
   export let selectedChartName: string | null;
+  export let selectedIndex: number | null = null;
 
   let contentRect: DOMRectReadOnly = new DOMRectReadOnly(0, 0, 0, 0);
   let scrollOffset = 0;
-  let selectedIndex: number | null = null;
   let changing = false;
   let startMouse: Vector = [0, 0];
   let mousePosition: Vector = [0, 0];

--- a/web-local/src/routes/(application)/custom-dashboards/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/custom-dashboards/[name]/+page.svelte
@@ -57,6 +57,7 @@
   let containerWidth: number;
   let containerHeight: number;
   let editorPercentage = 0.5;
+  let selectedIndex: number | null = null;
   let chartEditorPercentage = 0.4;
   let selectedChartName: string | null = null;
   let spec: V1DashboardSpec = {
@@ -183,11 +184,32 @@
 
     await updateChartFile(new CustomEvent("update", { detail: yaml }));
   }
+
+  async function deleteChart(index: number) {
+    const items = parsedDocument.get("items");
+
+    if (!items) return;
+
+    items.delete(index);
+
+    yaml = parsedDocument.toString();
+
+    await updateChartFile(new CustomEvent("update", { detail: yaml }));
+  }
 </script>
 
 <svelte:head>
   <title>Rill Developer | {fileName}</title>
 </svelte:head>
+
+<svelte:window
+  on:keydown={async (e) => {
+    if (e.target !== document.body || selectedIndex === null) return;
+    if (e.key === "Delete" || e.key === "Backspace") {
+      await deleteChart(selectedIndex);
+    }
+  }}
+/>
 
 <WorkspaceContainer
   bind:width={containerWidth}
@@ -308,6 +330,7 @@
         {columns}
         {showGrid}
         bind:selectedChartName
+        bind:selectedIndex
         on:update={handlePreviewUpdate}
       />
     {/if}


### PR DESCRIPTION
This PR adds a keydown listener for `Backspace` and `Delete` to the Custom Dashboards workspace that removes the currently selected component.