### PR TITLE
Connectors: Click a table to preview it

### DIFF
--- a/web-common/src/features/connectors/ConnectorEntry.svelte
+++ b/web-common/src/features/connectors/ConnectorEntry.svelte
@@ -33,6 +33,7 @@
           className="transform transition-transform text-gray-400 {showDatabases
             ? 'rotate-0'
             : '-rotate-90'}"
+          size="14px"
         />
         <div class="flex-none">
           {#if connector.driver?.name}

--- a/web-common/src/features/connectors/olap/DatabaseEntry.svelte
+++ b/web-common/src/features/connectors/olap/DatabaseEntry.svelte
@@ -32,6 +32,7 @@
         className="transform transition-transform text-gray-400 {showDatabaseSchemas
           ? 'rotate-0'
           : '-rotate-90'}"
+        size="14px"
       />
       <Database size="14px" class="shrink-0 text-gray-400" />
       <span class="truncate">

--- a/web-common/src/features/connectors/olap/DatabaseSchemaEntry.svelte
+++ b/web-common/src/features/connectors/olap/DatabaseSchemaEntry.svelte
@@ -41,6 +41,7 @@
       className="transform transition-transform text-gray-400 {showTables
         ? 'rotate-0'
         : '-rotate-90'}"
+      size="14px"
     />
     <!-- Some databases do not have a full "database -> databaseSchema -> table" hierarchy. 
       When there are only two organizational levels,the API returns "databaseSchema -> table". 
@@ -93,10 +94,6 @@
 
   button:hover {
     @apply bg-slate-100;
-  }
-
-  .database-schema-entry:not(.open) .database-schema-entry-header {
-    @apply bg-white;
   }
 
   .message {

--- a/web-common/src/features/connectors/olap/TableEntry.svelte
+++ b/web-common/src/features/connectors/olap/TableEntry.svelte
@@ -3,9 +3,8 @@
   import ContextButton from "@rilldata/web-common/components/column-profile/ContextButton.svelte";
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu/";
   import MoreHorizontal from "@rilldata/web-common/components/icons/MoreHorizontal.svelte";
+  import CaretDownIcon from "../../../components/icons/CaretDownIcon.svelte";
   import TableIcon from "../../../components/icons/TableIcon.svelte";
-  import Tooltip from "../../../components/tooltip/Tooltip.svelte";
-  import TooltipContent from "../../../components/tooltip/TooltipContent.svelte";
   import TableMenuItems from "./TableMenuItems.svelte";
   import TableSchema from "./TableSchema.svelte";
   import UnsupportedTypesIndicator from "./UnsupportedTypesIndicator.svelte";
@@ -44,20 +43,20 @@
 
 <li aria-label={tableId} class="table-entry group" class:open>
   <div class="table-entry-header {database ? 'pl-[58px]' : 'pl-[40px]'}">
-    <TableIcon size="14px" className="shrink-0 text-gray-400" />
-    <Tooltip alignment="start" location="right" distance={32}>
-      <button
-        class="clickable-text"
-        on:click={() => (showSchema = !showSchema)}
-      >
-        <span class="truncate">
-          {table}
-        </span>
-      </button>
-      <TooltipContent slot="tooltip-content">
-        {showSchema ? "Hide schema" : "Show schema"}
-      </TooltipContent>
-    </Tooltip>
+    <button on:click={() => (showSchema = !showSchema)}>
+      <CaretDownIcon
+        className="transform transition-transform text-gray-400 {showSchema
+          ? 'rotate-0'
+          : '-rotate-90'}"
+        size="14px"
+      />
+    </button>
+    <a class="clickable-text" {href}>
+      <TableIcon size="14px" className="shrink-0 text-gray-400" />
+      <span class="truncate">
+        {table}
+      </span>
+    </a>
     {#if hasUnsupportedDataTypes}
       <UnsupportedTypesIndicator
         {instanceId}
@@ -85,13 +84,7 @@
         side="right"
         sideOffset={16}
       >
-        <TableMenuItems
-          {driver}
-          {connector}
-          {database}
-          {databaseSchema}
-          {table}
-        />
+        <TableMenuItems {connector} {database} {databaseSchema} {table} />
       </DropdownMenu.Content>
     </DropdownMenu.Root>
   </div>
@@ -121,11 +114,7 @@
   }
 
   .clickable-text {
-    @apply select-none cursor-pointer;
-    @apply w-fit flex grow items-center gap-x-2 truncate;
-    @apply text-gray-900;
-  }
-  .clickable-text:hover {
-    @apply text-gray-900;
+    @apply flex grow items-center gap-x-1;
+    @apply text-gray-900 truncate;
   }
 </style>

--- a/web-common/src/features/connectors/olap/TableMenuItems.svelte
+++ b/web-common/src/features/connectors/olap/TableMenuItems.svelte
@@ -11,17 +11,14 @@
     MetricsEventSpace,
   } from "@rilldata/web-common/metrics/service/MetricsTypes";
   import { WandIcon } from "lucide-svelte";
-  import TableIcon from "../../../components/icons/TableIcon.svelte";
   import { runtime } from "../../../runtime-client/runtime-store";
   import { featureFlags } from "../../feature-flags";
   import { useCreateDashboardFromTableUIAction } from "../../metrics-views/ai-generation/generateMetricsView";
   import { createModelFromSource } from "../../sources/createModel";
-  import { makeTablePreviewHref } from "./olap-config";
   import { useIsModelingSupportedForCurrentOlapDriver } from "./selectors";
 
   const { ai } = featureFlags;
 
-  export let driver: string;
   export let connector: string;
   export let database: string = "";
   export let databaseSchema: string = "";
@@ -29,13 +26,6 @@
 
   $: isModelingSupportedForCurrentOlapDriver =
     useIsModelingSupportedForCurrentOlapDriver($runtime.instanceId);
-  $: href = makeTablePreviewHref(
-    driver,
-    connector,
-    database,
-    databaseSchema,
-    table,
-  );
   $: createDashboardFromTable = useCreateDashboardFromTableUIAction(
     $runtime.instanceId,
     connector,
@@ -69,10 +59,6 @@
   }
 </script>
 
-<NavigationMenuItem {href}>
-  <TableIcon slot="icon" />
-  Preview table
-</NavigationMenuItem>
 {#if $isModelingSupportedForCurrentOlapDriver}
   <NavigationMenuItem on:click={handleCreateModel}>
     <Model slot="icon" />

--- a/web-common/src/features/connectors/olap/TableSchema.svelte
+++ b/web-common/src/features/connectors/olap/TableSchema.svelte
@@ -28,7 +28,7 @@
     </div>
   {:else if data && data.profileColumns}
     {#each data.profileColumns as column (column)}
-      <li class="table-schema-entry {database ? 'pl-[74px]' : 'pl-[58px]'}">
+      <li class="table-schema-entry {database ? 'pl-[78px]' : 'pl-[60px]'}">
         <Tooltip distance={4}>
           <span class="font-mono truncate">{column.name}</span>
           <TooltipContent slot="tooltip-content">

--- a/web-common/src/features/file-explorer/NavDirectoryEntry.svelte
+++ b/web-common/src/features/file-explorer/NavDirectoryEntry.svelte
@@ -92,6 +92,7 @@
 >
   <CaretDownIcon
     className="flex-none text-gray-400 {expanded ? '' : 'transform -rotate-90'}"
+    size="14px"
   />
   <span class="truncate w-full" class:text-red-600={$hasErrors}>
     {dir.name}


### PR DESCRIPTION
Previously, clicking a Table entry revealed its schema. Now, clicking a Table entry navigates to the Table Preview.

[Context here](https://www.notion.so/rilldata/Improving-our-Connect-to-ClickHouse-modal-64420494ff514247b2fc60fef2267033?pvs=4#34bfe6a65fe947ca84166804fd746490)