### PR TITLE
Use autosize for vega charts

### DIFF
--- a/web-common/src/features/charts/render/VegaLiteRenderer.svelte
+++ b/web-common/src/features/charts/render/VegaLiteRenderer.svelte
@@ -51,7 +51,7 @@
 <div
   bind:contentRect
   class:bg-white={customDashboard}
-  class:px-8={customDashboard}
+  class:px-4={customDashboard}
   class:pb-2={customDashboard}
   class="overflow-hidden size-full flex flex-col items-center justify-center"
 >

--- a/web-common/src/features/charts/render/vega-config.ts
+++ b/web-common/src/features/charts/render/vega-config.ts
@@ -13,6 +13,9 @@ const gridColor = "#d1d5db"; // gray-300
 const axisLabelColor = "#4b5563"; // gray-600
 
 export const getRillTheme: () => Config = () => ({
+  autosize: {
+    type: "fit-x",
+  },
   mark: {
     tooltip: true,
   },


### PR DESCRIPTION
The legends for some charts were missing. This updates the config and reduces the X axis padding.