### PR TITLE
tweak: invalidate rather than refetch resources

### DIFF
--- a/web-common/src/features/entity-management/WatchResourcesClient.ts
+++ b/web-common/src/features/entity-management/WatchResourcesClient.ts
@@ -215,7 +215,7 @@ export class WatchResourcesClient {
   }
 
   private invalidateAllResources() {
-    return queryClient.refetchQueries({
+    return queryClient.invalidateQueries({
       predicate: (query) =>
         query.queryHash.includes(`v1/instances/${get(runtime).instanceId}`),
     });


### PR DESCRIPTION
WatchResourcesClient was calling `refetchQueries` instead of `invalidateQueries`.