### PR TITLE
fix: incorrect totals for advanced measures

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
@@ -253,7 +253,9 @@ export function prepareVirtualizedDimTableColumns(
   const dimensionColumn = getDimensionColumn(dimension);
 
   // copy column names so we don't mutate the original
-  const columnNames = [...dash.visibleMeasureKeys];
+  const columnNames = [...dash.visibleMeasureKeys].filter((m) =>
+    allMeasures.some((am) => am.name === m),
+  );
 
   // don't add context columns if sorting by dimension
   if (selectedMeasure && sortType !== SortType.DIMENSION) {

--- a/web-common/src/features/dashboards/state-managers/selectors/dashboard-queries.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/dashboard-queries.ts
@@ -1,5 +1,6 @@
 import type { ResolvedMeasureFilter } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
 import { additionalMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measure-filters";
+import { getIndependentMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
 import { sanitiseExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
 import type {
   QueryServiceMetricsViewComparisonBody,
@@ -60,7 +61,9 @@ function measuresForDimensionTable(dashData: DashboardDataSources) {
     ...selectedMeasureNames(dashData),
     ...additionalMeasures(dashData),
   ]);
-  return [...allMeasures];
+  return getIndependentMeasures(dashData.metricsSpecQueryResult.data ?? {}, [
+    ...allMeasures,
+  ]);
 }
 
 export function dimensionTableTotalQueryBody(
@@ -96,7 +99,10 @@ export function leaderboardSortedQueryBody(
   ) =>
     prepareSortedQueryBody(
       dimensionName,
-      additionalMeasures(dashData),
+      getIndependentMeasures(
+        dashData.metricsSpecQueryResult.data ?? {},
+        additionalMeasures(dashData),
+      ),
       timeControlsState(dashData),
       sortingSelectors.sortMeasure(dashData),
       sortingSelectors.sortType(dashData),

--- a/web-common/src/features/dashboards/state-managers/selectors/dimension-table.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/dimension-table.ts
@@ -50,7 +50,10 @@ export const virtualizedTableColumns =
 
     if (!dimension) return [];
 
-    const measures = visibleMeasures(dashData);
+    // temporary filter for advanced measures
+    const measures = visibleMeasures(dashData).filter(
+      (m) => !m.window && !m.requiredDimensions?.length,
+    );
 
     const measureTotals: { [key: string]: number } = {};
     if (totalsQuery?.data?.data) {

--- a/web-common/src/features/dashboards/state-managers/selectors/measures.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/measures.ts
@@ -142,6 +142,24 @@ export const getFilteredMeasuresAndDimensions = ({
   };
 };
 
+export const getIndependentMeasures = (
+  metricsViewSpec: V1MetricsViewSpec,
+  measureNames: string[],
+) => {
+  const measures = new Set<string>();
+  measureNames.forEach((measureName) => {
+    const measure = metricsViewSpec.measures?.find(
+      (m) => m.name === measureName,
+    );
+    // temporary check for window measures until the PR to move to AggregationApi is merged
+    if (!measure || measure.requiredDimensions?.length || !!measure.window)
+      return;
+    measures.add(measureName);
+    measure.referencedMeasures?.filter((refMes) => measures.add(refMes));
+  });
+  return [...measures];
+};
+
 export const measureSelectors = {
   /**
    * Get all measures in the dashboard.

--- a/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
+++ b/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
@@ -1,6 +1,9 @@
 import { measureFilterResolutionsStore } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
 import { useMetricsView } from "@rilldata/web-common/features/dashboards/selectors/index";
-import { getFilteredMeasuresAndDimensions } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
+import {
+  getFilteredMeasuresAndDimensions,
+  getIndependentMeasures,
+} from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
 import type { StateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
 import { sanitiseExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
 import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
@@ -136,10 +139,13 @@ export function createTimeSeriesDataStore(
           ? [...dashboardStore.visibleMeasureKeys]
           : [];
       }
-      const { measures: filteredMeasures, dimensions } =
-        getFilteredMeasuresAndDimensions({
-          dashboard: dashboardStore,
-        })(metricsView.data ?? {}, measures);
+      const { measures: filteredMeasures } = getFilteredMeasuresAndDimensions({
+        dashboard: dashboardStore,
+      })(metricsView.data ?? {}, measures);
+      const independentMeasures = getIndependentMeasures(
+        metricsView.data ?? {},
+        measures,
+      );
 
       const primaryTimeSeries = createMetricsViewTimeSeries(
         ctx,
@@ -148,8 +154,7 @@ export function createTimeSeriesDataStore(
       );
       const primaryTotals = createTotalsForMeasure(
         ctx,
-        filteredMeasures,
-        dimensions,
+        independentMeasures,
         false,
       );
 
@@ -160,7 +165,7 @@ export function createTimeSeriesDataStore(
       if (dashboardStore?.selectedComparisonDimension) {
         unfilteredTotals = createUnfilteredTotalsForMeasure(
           ctx,
-          filteredMeasures,
+          independentMeasures,
           dashboardStore?.selectedComparisonDimension,
         );
       }
@@ -178,8 +183,7 @@ export function createTimeSeriesDataStore(
         );
         comparisonTotals = createTotalsForMeasure(
           ctx,
-          filteredMeasures,
-          dimensions,
+          independentMeasures,
           true,
         );
       }

--- a/web-common/src/features/dashboards/time-series/totals-data-store.ts
+++ b/web-common/src/features/dashboards/time-series/totals-data-store.ts
@@ -18,7 +18,6 @@ import { derived } from "svelte/store";
 export function createTotalsForMeasure(
   ctx: StateManagers,
   measures: string[],
-  dimensions: MetricsViewSpecDimensionSelector[],
   isComparison = false,
 ): CreateQueryResult<V1MetricsViewAggregationResponse> {
   return derived(
@@ -44,17 +43,18 @@ export function createTotalsForMeasure(
         metricsViewName,
         {
           measures: measures.map((measure) => ({ name: measure })),
-          dimensions,
           where: sanitiseExpression(
             dashboard.whereFilter,
             measureFilterResolution.filter,
           ),
-          timeStart: isComparison
-            ? timeControls?.comparisonTimeStart
-            : timeControls.timeStart,
-          timeEnd: isComparison
-            ? timeControls?.comparisonTimeEnd
-            : timeControls.timeEnd,
+          timeRange: {
+            start: isComparison
+              ? timeControls?.comparisonTimeStart
+              : timeControls.timeStart,
+            end: isComparison
+              ? timeControls?.comparisonTimeEnd
+              : timeControls.timeEnd,
+          },
         },
         {
           query: {


### PR DESCRIPTION
Totals query was sending in dimensions with timestamp causing it to be aggregated by time and not actually fetching totals.

Filtering out any measure depending on a dimension in totals call. Also ignoring all advanced measures in dimension detail table temporarily.