### PR TITLE
Use ErrorPage component when runtime connection fails

### DIFF
--- a/web-common/src/components/ErrorPage.svelte
+++ b/web-common/src/components/ErrorPage.svelte
@@ -9,6 +9,7 @@
   export let statusCode: number | undefined = undefined;
   export let header: string;
   export let body: string;
+  export let fatal = false;
 </script>
 
 <CtaLayoutContainer>
@@ -24,9 +25,11 @@
     <CtaMessage>
       {body}
     </CtaMessage>
-    <CtaButton variant="primary-outline" on:click={() => goto("/")}>
-      Back to home
-    </CtaButton>
+    {#if !fatal}
+      <CtaButton variant="primary-outline" on:click={() => goto("/")}>
+        Back to home
+      </CtaButton>
+    {/if}
     <CtaNeedHelp />
   </CtaContentContainer>
 </CtaLayoutContainer>

--- a/web-common/src/features/entity-management/ResourceWatcher.svelte
+++ b/web-common/src/features/entity-management/ResourceWatcher.svelte
@@ -5,7 +5,7 @@
   import { errorEventHandler } from "@rilldata/web-common/metrics/initMetrics";
   import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
   import { onMount } from "svelte";
-  import WorkspaceError from "@rilldata/web-common/components/WorkspaceError.svelte";
+  import ErrorPage from "@rilldata/web-common/components/ErrorPage.svelte";
 
   const fileWatcher = new WatchFilesClient().client;
   const resourceWatcher = new WatchResourcesClient().client;
@@ -49,9 +49,12 @@
 <svelte:window on:visibilitychange={handleVisibilityChange} />
 
 {#if failed}
-  <div class="h-screen w-screen">
-    <WorkspaceError message="Unable to connect to runtime" />
-  </div>
+  <ErrorPage
+    fatal
+    statusCode={500}
+    header="Error connecting to runtime"
+    body="Try restarting the server"
+  />
 {:else}
   <slot />
 {/if}


### PR DESCRIPTION
This PR uses the `ErrorPage` component instead of `WorkspaceError` for handling situations where the connection to the runtime has been lost.
