### PR TITLE
Cloud UI: Fix 401 error on the Project page due to stale JWT 

### DIFF
--- a/web-admin/src/features/dashboards/listing/selectors.ts
+++ b/web-admin/src/features/dashboards/listing/selectors.ts
@@ -1,4 +1,3 @@
-import type { V1GetProjectResponse } from "@rilldata/web-admin/client";
 import {
   createAdminServiceGetProject,
   V1DeploymentStatus,
@@ -15,11 +14,11 @@ import type { V1Resource } from "@rilldata/web-common/runtime-client";
 import {
   createRuntimeServiceListResources,
   getRuntimeServiceListResourcesQueryKey,
+  runtimeServiceListResources,
   V1ReconcileStatus,
 } from "@rilldata/web-common/runtime-client";
 import { invalidateMetricsViewData } from "@rilldata/web-common/runtime-client/invalidation";
 import type { CreateQueryResult, QueryClient } from "@tanstack/svelte-query";
-import Axios from "axios";
 import { derived } from "svelte/store";
 
 export interface DashboardListItem {
@@ -29,36 +28,19 @@ export interface DashboardListItem {
   isValid: boolean;
 }
 
-// TODO: use the creator pattern to get rid of the raw call to http endpoint
-export async function getDashboardsForProject(
-  projectData: V1GetProjectResponse,
+export async function listDashboards(
+  queryClient: QueryClient,
+  instanceId: string,
 ): Promise<V1Resource[]> {
-  // There may not be a prodDeployment if the project was hibernated
-  if (!projectData.prodDeployment) {
-    return [];
-  }
+  // Fetch all resources
+  const queryKey = getRuntimeServiceListResourcesQueryKey(instanceId);
+  const queryFn = () => runtimeServiceListResources(instanceId);
+  const resp = await queryClient.fetchQuery(queryKey, queryFn);
 
-  // Hack: in development, the runtime host is actually on port 8081
-  const runtimeHost = projectData.prodDeployment.runtimeHost.replace(
-    "localhost:9091",
-    "localhost:8081",
-  );
+  // Filter for metricsViews client-side (to reduce calls to ListResources)
+  const metricsViews = resp.resources.filter((res) => !!res.metricsView);
 
-  const axios = Axios.create({
-    baseURL: runtimeHost,
-    headers: {
-      Authorization: `Bearer ${projectData.jwt}`,
-    },
-  });
-
-  // TODO: use resource API
-  const catalogEntriesResponse = await axios.get(
-    `/v1/instances/${projectData.prodDeployment.runtimeInstanceId}/resources?kind=${ResourceKind.MetricsView}`,
-  );
-
-  const catalogEntries = catalogEntriesResponse.data?.resources as V1Resource[];
-
-  return catalogEntries.filter((e) => !!e.metricsView);
+  return metricsViews;
 }
 
 export function useDashboardsLastUpdated(

--- a/web-admin/src/features/projects/selectors.ts
+++ b/web-admin/src/features/projects/selectors.ts
@@ -36,8 +36,10 @@ export function useProjectRuntime(orgName: string, projName: string) {
   return createAdminServiceGetProject(orgName, projName, undefined, {
     query: {
       queryKey: getProjectRuntimeQueryKey(orgName, projName),
-      // Proactively refetch the JWT before it expires
-      refetchInterval: RUNTIME_ACCESS_TOKEN_DEFAULT_TTL / 2,
+      refetchInterval: RUNTIME_ACCESS_TOKEN_DEFAULT_TTL / 2, // Proactively refetch the JWT before it expires
+      refetchOnMount: true,
+      refetchOnReconnect: true,
+      refetchOnWindowFocus: true,
       select: (data) => {
         // There may not be a prodDeployment if the project was hibernated
         if (!data.prodDeployment) {

--- a/web-admin/src/features/projects/selectors.ts
+++ b/web-admin/src/features/projects/selectors.ts
@@ -36,6 +36,7 @@ export function useProjectRuntime(orgName: string, projName: string) {
   return createAdminServiceGetProject(orgName, projName, undefined, {
     query: {
       queryKey: getProjectRuntimeQueryKey(orgName, projName),
+      cacheTime: Math.min(RUNTIME_ACCESS_TOKEN_DEFAULT_TTL, 1000 * 60 * 5), // Make sure we don't keep a stale JWT in the cache
       refetchInterval: RUNTIME_ACCESS_TOKEN_DEFAULT_TTL / 2, // Proactively refetch the JWT before it expires
       refetchOnMount: true,
       refetchOnReconnect: true,

--- a/web-admin/src/features/projects/status/ProjectDeploymentStatusChip.svelte
+++ b/web-admin/src/features/projects/status/ProjectDeploymentStatusChip.svelte
@@ -4,7 +4,7 @@
     V1DeploymentStatus,
   } from "@rilldata/web-admin/client";
   import {
-    getDashboardsForProject,
+    listDashboards,
     useDashboardsStatus,
   } from "@rilldata/web-admin/features/dashboards/listing/selectors";
   import { invalidateDashboardsQueries } from "@rilldata/web-admin/features/projects/invalidations";
@@ -60,10 +60,8 @@
   }
 
   async function getDashboardsAndInvalidate() {
-    const dashboardListItems = await getDashboardsForProject($proj.data);
-    const dashboardNames = dashboardListItems.map(
-      (listing) => listing.meta.name.name,
-    );
+    const dashboards = await listDashboards(queryClient, instanceId);
+    const dashboardNames = dashboards.map((d) => d.meta.name.name);
     return invalidateDashboardsQueries(queryClient, dashboardNames);
   }
 

--- a/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
@@ -5,10 +5,9 @@
     V1DeploymentStatus,
   } from "@rilldata/web-admin/client";
   import DashboardBookmarksStateProvider from "@rilldata/web-admin/features/dashboards/DashboardBookmarksStateProvider.svelte";
-  import { getDashboardsForProject } from "@rilldata/web-admin/features/dashboards/listing/selectors";
+  import { listDashboards } from "@rilldata/web-admin/features/dashboards/listing/selectors";
   import { invalidateDashboardsQueries } from "@rilldata/web-admin/features/projects/invalidations";
   import ProjectErrored from "@rilldata/web-admin/features/projects/ProjectErrored.svelte";
-  import { useProjectRuntime } from "@rilldata/web-admin/features/projects/selectors";
   import { useProjectDeploymentStatus } from "@rilldata/web-admin/features/projects/status/selectors";
   import { Dashboard } from "@rilldata/web-common/features/dashboards";
   import DashboardThemeProvider from "@rilldata/web-common/features/dashboards/DashboardThemeProvider.svelte";
@@ -32,8 +31,6 @@
   $: dashboardName = $page.params.dashboard;
 
   const user = createAdminServiceGetCurrentUser();
-
-  $: projectRuntime = useProjectRuntime(orgName, projectName);
 
   $: projectDeploymentStatus = useProjectDeploymentStatus(orgName, projectName); // polls
   $: isProjectPending =
@@ -66,12 +63,8 @@
   }
 
   async function getDashboardsAndInvalidate() {
-    const dashboardListings = await getDashboardsForProject(
-      $projectRuntime.data,
-    );
-    const dashboardNames = dashboardListings.map(
-      (listing) => listing.meta.name.name,
-    );
+    const dashboards = await listDashboards(queryClient, instanceId);
+    const dashboardNames = dashboards.map((d) => d.meta.name.name);
     return invalidateDashboardsQueries(queryClient, dashboardNames);
   }
 

--- a/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
@@ -2,13 +2,13 @@
   import { page } from "$app/stores";
   import {
     createAdminServiceGetCurrentUser,
-    createAdminServiceGetProject,
     V1DeploymentStatus,
   } from "@rilldata/web-admin/client";
   import DashboardBookmarksStateProvider from "@rilldata/web-admin/features/dashboards/DashboardBookmarksStateProvider.svelte";
   import { getDashboardsForProject } from "@rilldata/web-admin/features/dashboards/listing/selectors";
   import { invalidateDashboardsQueries } from "@rilldata/web-admin/features/projects/invalidations";
   import ProjectErrored from "@rilldata/web-admin/features/projects/ProjectErrored.svelte";
+  import { useProjectRuntime } from "@rilldata/web-admin/features/projects/selectors";
   import { useProjectDeploymentStatus } from "@rilldata/web-admin/features/projects/status/selectors";
   import { Dashboard } from "@rilldata/web-common/features/dashboards";
   import DashboardThemeProvider from "@rilldata/web-common/features/dashboards/DashboardThemeProvider.svelte";
@@ -33,7 +33,7 @@
 
   const user = createAdminServiceGetCurrentUser();
 
-  $: project = createAdminServiceGetProject(orgName, projectName);
+  $: projectRuntime = useProjectRuntime(orgName, projectName);
 
   $: projectDeploymentStatus = useProjectDeploymentStatus(orgName, projectName); // polls
   $: isProjectPending =
@@ -66,7 +66,9 @@
   }
 
   async function getDashboardsAndInvalidate() {
-    const dashboardListings = await getDashboardsForProject($project.data);
+    const dashboardListings = await getDashboardsForProject(
+      $projectRuntime.data,
+    );
     const dashboardNames = dashboardListings.map(
       (listing) => listing.meta.name.name,
     );

--- a/web-common/src/runtime-client/RuntimeProvider.svelte
+++ b/web-common/src/runtime-client/RuntimeProvider.svelte
@@ -5,18 +5,9 @@
   export let instanceId: string;
   export let jwt: string | undefined = undefined;
 
-  $: runtime.set({
-    host: host,
-    instanceId: instanceId,
-    jwt: jwt
-      ? {
-          token: jwt,
-          receivedAt: Date.now(),
-        }
-      : undefined,
-  });
+  $: runtime.setRuntime(host, instanceId, jwt);
 </script>
 
-{#if $runtime.host !== undefined && $runtime.instanceId}
+{#if $runtime.host && $runtime.instanceId}
   <slot />
 {/if}

--- a/web-common/src/runtime-client/runtime-store.ts
+++ b/web-common/src/runtime-client/runtime-store.ts
@@ -21,6 +21,7 @@ const createRuntimeStore = () => {
 
   return {
     subscribe,
+    update,
     set, // backwards-compatibility for web-local (where there's no JWT)
     setRuntime: (host: string, instanceId: string, jwt?: string) => {
       update((current) => {

--- a/web-common/src/runtime-client/runtime-store.ts
+++ b/web-common/src/runtime-client/runtime-store.ts
@@ -13,7 +13,33 @@ export interface Runtime {
   jwt?: JWT;
 }
 
-export const runtime = writable<Runtime>({
-  host: "",
-  instanceId: "",
-});
+const createRuntimeStore = () => {
+  const { subscribe, set, update } = writable<Runtime>({
+    host: "",
+    instanceId: "",
+  });
+
+  return {
+    subscribe,
+    set, // backwards-compatibility for web-local (where there's no JWT)
+    setRuntime: (host: string, instanceId: string, jwt?: string) => {
+      update((current) => {
+        // Only update the store (particularly, the JWT `receivedAt`) if the values have changed
+        if (
+          host !== current.host ||
+          instanceId !== current.instanceId ||
+          jwt !== current.jwt?.token
+        ) {
+          return {
+            host,
+            instanceId,
+            jwt: jwt ? { token: jwt, receivedAt: Date.now() } : undefined,
+          };
+        }
+        return current;
+      });
+    },
+  };
+};
+
+export const runtime = createRuntimeStore();


### PR DESCRIPTION
Currently, re-visiting a Project page can trigger a 401 error. In the error case, a stale JWT sits in the `GetProject` Query Cache and is used in a runtime request. The 401 triggers a full-screen error page.

This PR does a few things to mitigate this, notably:
1. Adds `refetchOnMount`, `refetchOnWindowFocus`, and `refetchOnReconnect` to refetch the JWT when the user re-visits the page
2. Explicitly adds `cacheTime` to garbage-collect old JWTs
3. Removes the full-screen error page for runtime 401s on the Project page

[Bug report in Slack](https://rilldata.slack.com/archives/C01190F1R1D/p1718237032223209?thread_ts=1718235808.839709&cid=C01190F1R1D)
