### PR TITLE
Fix: Empty data on exclusive filters on pivot

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotDisplay.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotDisplay.svelte
@@ -12,6 +12,9 @@
   let showPanels = true;
 
   $: pivotDataStore = usePivotDataStore(stateManagers);
+
+  $: isFetching = $pivotDataStore.isFetching;
+  $: assembled = $pivotDataStore.assembled;
 </script>
 
 <div class="layout">
@@ -22,10 +25,10 @@
     {#if showPanels}
       <PivotHeader />
     {/if}
-    <PivotToolbar isFetching={$pivotDataStore.isFetching} bind:showPanels />
+    <PivotToolbar {isFetching} bind:showPanels />
     <div class="table-view">
       {#if !$pivotDataStore?.data || $pivotDataStore?.data?.length === 0}
-        <PivotEmpty isFetching={$pivotDataStore?.isFetching} />
+        <PivotEmpty {assembled} {isFetching} />
       {:else}
         <PivotTable {pivotDataStore} />
       {/if}

--- a/web-common/src/features/dashboards/pivot/PivotEmpty.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotEmpty.svelte
@@ -6,6 +6,7 @@
   import EmptyTableIcon from "./EmptyTableIcon.svelte";
 
   export let isFetching = false;
+  export let assembled = false;
 
   const stateManagers = getStateManagers();
   const {
@@ -45,6 +46,11 @@
         rel="noopener"
         href="https://docs.rilldata.com/explore/filters/pivot">docs</a
       >.
+    </div>
+  {:else if assembled}
+    <EmptyTableIcon />
+    <div class="text-gray-600 text-base">
+      No data to show for the selected filters.
     </div>
   {:else}
     <EmptyTableIcon />

--- a/web-common/src/features/dashboards/pivot/pivot-data-store.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-data-store.ts
@@ -426,6 +426,23 @@ function createPivotDataStore(ctx: StateManagers): PivotDataStore {
               });
             }
 
+            /**
+             * If there are no axes values, return an empty table
+             */
+            if (
+              rowDimensionAxes?.data?.[anchorDimension]?.length === 0 ||
+              totalsRowResponse?.data?.data?.length === 0
+            ) {
+              return axesSet({
+                isFetching: false,
+                data: [],
+                columnDef: [],
+                assembled: true,
+                totalColumns: 0,
+                totalsRowData: displayTotalsRow ? [] : undefined,
+              });
+            }
+
             const totalsRowData = getTotalsRow(
               config,
               columnDimensionAxes?.data,


### PR DESCRIPTION
On adding mutually exclusive filters on a pivot table, the table would crash and be in a perpetual loading state. This PR fixes it and adds a message if there is no result to display.