### PR TITLE
Runtime: Untyped component renderer

### DIFF
--- a/runtime/compilers/rillv1/data/component-template-v1.json
+++ b/runtime/compilers/rillv1/data/component-template-v1.json
@@ -3,42 +3,54 @@
     "type": "object",
     "anyOf": [
         {
-            "additionalProperties": false,
+            "type": "object",
+            "required": [
+                "line_chart"
+            ],
             "properties": {
-                "name": {
-                    "const": "line_chart"
-                },
-                "x": {
-                    "type": "string"
-                },
-                "y": {
-                    "type": "string"
+                "line_chart": {
+                    "type": "object",
+                    "required": [
+                        "x",
+                        "y"
+                    ],
+                    "properties": {
+                        "x": {
+                            "type": "string"
+                        },
+                        "y": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
                 }
             },
-            "required": [
-                "name",
-                "x",
-                "y"
-            ]
+            "additionalProperties": false
         },
         {
-            "additionalProperties": false,
+            "type": "object",
+            "required": [
+                "bar_chart"
+            ],
             "properties": {
-                "name": {
-                    "const": "bar_chart"
-                },
-                "x": {
-                    "type": "string"
-                },
-                "y": {
-                    "type": "string"
+                "bar_chart": {
+                    "type": "object",
+                    "required": [
+                        "x",
+                        "y"
+                    ],
+                    "properties": {
+                        "x": {
+                            "type": "string"
+                        },
+                        "y": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
                 }
             },
-            "required": [
-                "name",
-                "x",
-                "y"
-            ]
+            "additionalProperties": false
         }
-    ]    
+    ]
 }

--- a/runtime/compilers/rillv1/parse_component.go
+++ b/runtime/compilers/rillv1/parse_component.go
@@ -111,30 +111,25 @@ func (p *Parser) parseComponentYAML(tmp *ComponentYAML) (*runtimev1.ComponentSpe
 		renderer = "image"
 		rendererProps = must(structpb.NewStruct(map[string]any{"url": *tmp.Image}))
 	}
-	if len(tmp.Other) > 0 {
-		n += len(tmp.Other)
-		var k string
-		var v any
-		for k, v = range tmp.Other {
+	if len(tmp.Other) == 1 {
+		n++
+		var props map[string]any
+		for renderer, props = range tmp.Other {
 			break
 		}
 
-		props, ok := v.(map[string]any)
-		if !ok {
-			return nil, nil, fmt.Errorf(`expected map value for property %q`, k)
-		}
-
-		if err := componentTemplateSchema.Validate(map[string]any{k: props}); err != nil {
-			return nil, nil, fmt.Errorf(`failed to validate renderer: %w`, err)
+		if err := componentTemplateSchema.Validate(map[string]any{renderer: props}); err != nil {
+			return nil, nil, fmt.Errorf(`failed to validate renderer %q: %w`, renderer, err)
 		}
 
 		propsPB, err := structpb.NewStruct(props)
 		if err != nil {
-			return nil, nil, fmt.Errorf(`failed to convert property %q to struct: %w`, k, err)
+			return nil, nil, fmt.Errorf(`failed to convert property %q to struct: %w`, renderer, err)
 		}
 
-		renderer = k
 		rendererProps = propsPB
+	} else {
+		n += len(tmp.Other)
 	}
 
 	// Check there is exactly one renderer

--- a/runtime/compilers/rillv1/parser_test.go
+++ b/runtime/compilers/rillv1/parser_test.go
@@ -1452,6 +1452,14 @@ data:
     metrics_view: bar
 vega_lite: |%s
 `, vegaLiteSpec),
+		`components/c3.yaml`: `
+type: component
+data:
+  metrics_sql: SELECT 1
+line_chart:
+  x: time
+  y: total_sales
+`,
 		`dashboards/d1.yaml`: `
 type: dashboard
 columns: 4
@@ -1487,6 +1495,16 @@ items:
 				ResolverProperties: must(structpb.NewStruct(map[string]any{"api": "MetricsViewAggregation", "args": map[string]any{"metrics_view": "bar"}})),
 				Renderer:           "vega_lite",
 				RendererProperties: must(structpb.NewStruct(map[string]any{"spec": vegaLiteSpec})),
+			},
+		},
+		{
+			Name:  ResourceName{Kind: ResourceKindComponent, Name: "c3"},
+			Paths: []string{"/components/c3.yaml"},
+			ComponentSpec: &runtimev1.ComponentSpec{
+				Resolver:           "metrics_sql",
+				ResolverProperties: must(structpb.NewStruct(map[string]any{"sql": "SELECT 1"})),
+				Renderer:           "line_chart",
+				RendererProperties: must(structpb.NewStruct(map[string]any{"x": "time", "y": "total_sales"})),
 			},
 		},
 		{


### PR DESCRIPTION
This PR adds fallback support for a generic renderer in the component resource YAML. A map value must be provided to a generic renderer (unlike the built-in/hardcoded renderers which can accept another type, like `markdown` accepts a `string`).

Examples:
```yaml
# Output: {
#   "renderer": "line_chart",
#   "renderer_properties": {"x": "event_time", "y": "total_sales"}
# }
type: component
line_chart:
  x: event_time
  y: total_sales

# Output: {
#   "resolver": "metrics_sql",
#   "resolver_properties": {"sql": "SELECT 1"},
#   "renderer": "line_chart",
#   "renderer_properties": {"x": "event_time", "y": "total_sales"}
# }
type: component
data:
  metrics_sql: SELECT 1
line_chart:
  x: event_time
  y: total_sales

# Output: error: multiple renderers are not allowed
type: component
line_chart:
  x: event_time
  y: total_sales
bar_chart:
  x: event_time
  y: total_sales
```

Closes https://github.com/rilldata/rill/issues/5072