### PR TITLE
fix: handle inlineComponents

### DIFF
--- a/web-common/src/features/custom-dashboards/CustomDashboardPreview.svelte
+++ b/web-common/src/features/custom-dashboards/CustomDashboardPreview.svelte
@@ -198,6 +198,7 @@
       top={interacting ? finalDrag[1] : Number(component.y) * gridCell}
       left={interacting ? finalDrag[0] : Number(component.x) * gridCell}
       on:change={handleChange}
+      on:delete
     />
   {/each}
 </DashboardWrapper>

--- a/web-common/src/features/custom-dashboards/PreviewElement.svelte
+++ b/web-common/src/features/custom-dashboards/PreviewElement.svelte
@@ -88,26 +88,40 @@
       >
         Go to {componentName}.yaml
       </ContextMenu.Item>
+      <ContextMenu.Item on:click={dispatch("delete", { index: i })}
+        >Delete from dashboard</ContextMenu.Item
+      >
     </ContextMenu.Content>
   </ContextMenu.Root>
 {:else if componentName}
-  <Component
-    {instanceId}
-    {i}
-    {localZIndex}
-    {interacting}
-    {componentName}
-    {padding}
-    {radius}
-    {scale}
-    {selected}
-    fontSize={component.fontSize}
-    height={finalHeight}
-    left={finalLeft}
-    top={finalTop}
-    width={finalWidth}
-    on:change
-    on:contextmenu
-    on:mousedown={handleMouseDown}
-  />
+  <ContextMenu.Root>
+    <ContextMenu.Trigger asChild let:builder>
+      <Component
+        {instanceId}
+        {i}
+        {localZIndex}
+        {interacting}
+        {componentName}
+        {padding}
+        {radius}
+        {scale}
+        {selected}
+        fontSize={component.fontSize}
+        builders={[builder]}
+        height={finalHeight}
+        left={finalLeft}
+        top={finalTop}
+        width={finalWidth}
+        on:change
+        on:contextmenu
+        on:mousedown={handleMouseDown}
+      />
+    </ContextMenu.Trigger>
+
+    <ContextMenu.Content class="z-[100]">
+      <ContextMenu.Item on:click={dispatch("delete", { index: i })}
+        >Delete from dashboard</ContextMenu.Item
+      >
+    </ContextMenu.Content>
+  </ContextMenu.Root>
 {/if}

--- a/web-common/src/features/custom-dashboards/PreviewElement.svelte
+++ b/web-common/src/features/custom-dashboards/PreviewElement.svelte
@@ -88,7 +88,7 @@
       >
         Go to {componentName}.yaml
       </ContextMenu.Item>
-      <ContextMenu.Item on:click={dispatch("delete", { index: i })}
+      <ContextMenu.Item on:click={() => dispatch("delete", { index: i })}
         >Delete from dashboard</ContextMenu.Item
       >
     </ContextMenu.Content>
@@ -119,7 +119,7 @@
     </ContextMenu.Trigger>
 
     <ContextMenu.Content class="z-[100]">
-      <ContextMenu.Item on:click={dispatch("delete", { index: i })}
+      <ContextMenu.Item on:click={() => dispatch("delete", { index: i })}
         >Delete from dashboard</ContextMenu.Item
       >
     </ContextMenu.Content>

--- a/web-common/src/features/custom-dashboards/PreviewElement.svelte
+++ b/web-common/src/features/custom-dashboards/PreviewElement.svelte
@@ -28,6 +28,7 @@
   let localZIndex = 0;
 
   $: componentName = component?.component;
+  $: inlineComponent = component?.definedInDashboard;
 
   $: finalLeft = width < 0 ? left + width : left;
   $: finalTop = height < 0 ? top + height : top;
@@ -54,7 +55,7 @@
   }
 </script>
 
-{#if componentName}
+{#if componentName && !inlineComponent}
   <ContextMenu.Root>
     <ContextMenu.Trigger asChild let:builder>
       <Component
@@ -80,16 +81,33 @@
     </ContextMenu.Trigger>
 
     <ContextMenu.Content class="z-[100]">
-      <ContextMenu.Item>Copy</ContextMenu.Item>
-      <ContextMenu.Item>Delete</ContextMenu.Item>
       <ContextMenu.Item
         on:click={async () => {
-          await goto(`/files/charts/${componentName}`);
+          await goto(`/files/charts/${componentName}.yaml`);
         }}
       >
         Go to {componentName}.yaml
       </ContextMenu.Item>
-      <ContextMenu.Item>Show details</ContextMenu.Item>
     </ContextMenu.Content>
   </ContextMenu.Root>
+{:else if componentName}
+  <Component
+    {instanceId}
+    {i}
+    {localZIndex}
+    {interacting}
+    {componentName}
+    {padding}
+    {radius}
+    {scale}
+    {selected}
+    fontSize={component.fontSize}
+    height={finalHeight}
+    left={finalLeft}
+    top={finalTop}
+    width={finalWidth}
+    on:change
+    on:contextmenu
+    on:mousedown={handleMouseDown}
+  />
 {/if}

--- a/web-local/src/routes/(application)/custom-dashboards/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/custom-dashboards/[name]/+page.svelte
@@ -194,6 +194,15 @@
     await updateChartFile(new CustomEvent("update", { detail: yaml }));
   }
 
+  async function handleDeleteEvent(
+    e: CustomEvent<{
+      index: number;
+    }>,
+  ) {
+    if (!e.detail.index) return;
+    await deleteChart(e.detail.index);
+  }
+
   async function deleteChart(index: number) {
     const items = parsedDocument.get("items");
 
@@ -333,6 +342,7 @@
         bind:selectedChartName
         bind:selectedIndex
         on:update={handlePreviewUpdate}
+        on:delete={handleDeleteEvent}
       />
     {/if}
   </div>

--- a/web-local/src/routes/(application)/custom-dashboards/[name]/+page.svelte
+++ b/web-local/src/routes/(application)/custom-dashboards/[name]/+page.svelte
@@ -50,6 +50,7 @@
   let fileArtifact: FileArtifact;
   let filePath: string;
   let customDashboardName: string;
+  let selectedChartFileArtifact: FileArtifact | undefined;
   let selectedView = "split";
   let showGrid = true;
   let showChartEditor = false;
@@ -96,17 +97,26 @@
 
   $: parsedDocument = parseDocument(yaml);
 
-  $: selectedChartFileArtifact = fileArtifacts.findFileArtifact(
-    ResourceKind.Component,
-    selectedChartName ?? "",
-  );
-  $: selectedChartFilePath = selectedChartFileArtifact?.path;
   $: resourceQuery = fileArtifact.getResource(queryClient, instanceId);
-
   $: spec = $resourceQuery.data?.dashboard?.spec ?? spec;
 
   $: ({ items = [], columns = 20, gap = 4 } = spec);
-
+  $: if (
+    items.filter(
+      (item) =>
+        !item.definedInDashboard && item.component === selectedChartName,
+    ).length
+  ) {
+    selectedChartFileArtifact = fileArtifacts.findFileArtifact(
+      ResourceKind.Component,
+      selectedChartName ?? "",
+    );
+  } else {
+    selectedChartName = null;
+    selectedChartFileArtifact = undefined;
+    showChartEditor = false;
+  }
+  $: selectedChartFilePath = selectedChartFileArtifact?.path;
   $: editorWidth = editorPercentage * containerWidth;
   $: chartEditorHeight = chartEditorPercentage * containerHeight;
 


### PR DESCRIPTION
* Don't try to show external yaml for components inline
* Handle closing and clearing second editor when moving in/out of selected state
* Removed placeholder right-click context options
* Don't render right-click menu for components defined inline

TODO:
* We are still updating and fetching the dashboard.yaml on a component click without changes.