### PR TITLE
Runtime: Fix session usage for clickhouse http interface

### DIFF
--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -166,6 +166,7 @@ func (d driver) Open(instanceID string, config map[string]any, client *activity.
 		if conf.SSL {
 			opts.Protocol = clickhouse.HTTP
 			opts.TLS = &tls.Config{
+				MinVersion:         tls.VersionTLS12,
 				InsecureSkipVerify: false,
 			}
 		} else {

--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -166,7 +166,7 @@ func (d driver) Open(instanceID string, config map[string]any, client *activity.
 		if conf.SSL {
 			opts.Protocol = clickhouse.HTTP
 			opts.TLS = &tls.Config{
-				InsecureSkipVerify: true,
+				InsecureSkipVerify: false,
 			}
 		} else {
 			opts.Protocol = clickhouse.Native

--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -2,10 +2,11 @@ package clickhouse
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
-	"net/url"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/jmoiron/sqlx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/rilldata/rill/runtime/drivers"
@@ -13,9 +14,6 @@ import (
 	"github.com/rilldata/rill/runtime/pkg/priorityqueue"
 	"go.uber.org/zap"
 	"golang.org/x/sync/semaphore"
-
-	// import clickhouse driver
-	_ "github.com/ClickHouse/clickhouse-go/v2"
 )
 
 func init() {
@@ -149,38 +147,43 @@ func (d driver) Open(instanceID string, config map[string]any, client *activity.
 		return nil, err
 	}
 
-	var dsn string
+	// build clickhouse options
+	var opts *clickhouse.Options
 	if conf.DSN != "" {
-		dsn = conf.DSN
+		opts, err = clickhouse.ParseDSN(conf.DSN)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse DSN: %w", err)
+		}
 	} else if conf.Host != "" {
-		var dsnURL url.URL
-		dsnURL.Host = conf.Host
+		opts = &clickhouse.Options{}
+
+		// address
+		host := conf.Host
 		if conf.Port != 0 {
-			dsnURL.Host = fmt.Sprintf("%v:%v", dsnURL.Host, conf.Port)
+			host = fmt.Sprintf("%v:%v", conf.Host, conf.Port)
 		}
+		opts.Addr = append(opts.Addr, host)
 		if conf.SSL {
-			dsnURL.Scheme = "https"
-			dsnURL.RawQuery = "secure=true&skip_verify=true"
+			opts.Protocol = clickhouse.HTTP
+			opts.TLS = &tls.Config{
+				InsecureSkipVerify: true,
+			}
 		} else {
-			dsnURL.Scheme = "clickhouse"
+			opts.Protocol = clickhouse.Native
 		}
 
+		// username password
 		if conf.Password != "" {
-			dsnURL.User = url.UserPassword(conf.Username, conf.Password)
+			opts.Auth.Username = conf.Username
+			opts.Auth.Password = conf.Password
 		} else if conf.Username != "" {
-			dsnURL.User = url.User(conf.Username)
+			opts.Auth.Username = conf.Username
 		}
-
-		dsn = dsnURL.String()
 	} else {
 		return nil, fmt.Errorf("clickhouse connection parameters not set. Set `dsn` or individual properties")
 	}
 
-	db, err := sqlx.Open("clickhouse", dsn)
-	if err != nil {
-		return nil, err
-	}
-
+	db := sqlx.NewDb(clickhouse.OpenDB(opts), "clickhouse")
 	// very roughly approximating num queries required for a typical page load
 	// TODO: copied from druid reevaluate
 	db.SetMaxOpenConns(maxOpenConnections)
@@ -212,6 +215,7 @@ func (d driver) Open(instanceID string, config map[string]any, client *activity.
 		logger:  logger,
 		metaSem: semaphore.NewWeighted(1),
 		olapSem: priorityqueue.NewSemaphore(maxOpenConnections - 1),
+		opts:    opts,
 	}
 	return conn, nil
 }
@@ -244,6 +248,9 @@ type connection struct {
 	// This creates contention for the same connection in database/sql's pool, but its locks will handle that.
 	metaSem *semaphore.Weighted
 	olapSem *priorityqueue.Semaphore
+
+	// options used to open clickhouse connections
+	opts *clickhouse.Options
 }
 
 // Driver implements drivers.Connection.

--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -160,9 +160,9 @@ func (d driver) Open(instanceID string, config map[string]any, client *activity.
 		// address
 		host := conf.Host
 		if conf.Port != 0 {
-			host = fmt.Sprintf("%v:%v", conf.Host, conf.Port)
+			host = fmt.Sprintf("%s:%d", conf.Host, conf.Port)
 		}
-		opts.Addr = append(opts.Addr, host)
+		opts.Addr = []string{host}
 		if conf.SSL {
 			opts.Protocol = clickhouse.HTTP
 			opts.TLS = &tls.Config{

--- a/runtime/drivers/clickhouse/context.go
+++ b/runtime/drivers/clickhouse/context.go
@@ -2,7 +2,10 @@ package clickhouse
 
 import (
 	"context"
+	"maps"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -22,4 +25,16 @@ func connFromContext(ctx context.Context) *sqlx.Conn {
 		return conn.(*sqlx.Conn)
 	}
 	return nil
+}
+
+// sessionAwareContext sets a session_id in context which is used to tie queries to a certain session.
+// This is used to use certain session aware features like temporary tables.
+func (c *connection) sessionAwareContext(ctx context.Context) context.Context {
+	if c.opts.Protocol == clickhouse.HTTP {
+		settings := maps.Clone(c.opts.Settings)
+		settings["session_id"] = uuid.New().String()
+		return clickhouse.Context(ctx, clickhouse.WithSettings(settings))
+	}
+	// native protocol already has session context
+	return ctx
 }

--- a/runtime/drivers/clickhouse/olap.go
+++ b/runtime/drivers/clickhouse/olap.go
@@ -46,8 +46,8 @@ func (c *connection) WithConnection(ctx context.Context, priority int, longRunni
 	defer func() { _ = release() }()
 
 	// Call fn with connection embedded in context
-	wrappedCtx := contextWithConn(ctx, conn)
-	ensuredCtx := contextWithConn(context.Background(), conn)
+	wrappedCtx := c.sessionAwareContext(contextWithConn(ctx, conn))
+	ensuredCtx := c.sessionAwareContext(contextWithConn(context.Background(), conn))
 	return fn(wrappedCtx, ensuredCtx, conn.Conn)
 }
 


### PR DESCRIPTION
Clickhouse http interface requires a `session_id` to be passed to tie queries to a certain session.