### PR TITLE
fix: dimension table when name and column of dimension dont match

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/DimensionTable.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionTable.svelte
@@ -33,7 +33,6 @@ TableCells – the cell contents.
     actions: { dimensionTable },
     selectors: {
       sorting: { sortMeasure },
-      dimensions: { dimensionTableColumnName },
       dimensionFilters: { isFilterExcludeMode },
       comparison: { isBeingCompared: isBeingComparedReadable },
     },
@@ -59,7 +58,7 @@ TableCells – the cell contents.
   const FILTER_COLUMN_WIDTH = config.indexWidth;
 
   $: selectedIndex = selectedValues.map((label) => {
-    return rows.findIndex((row) => row[dimensionColumnName] === label);
+    return rows.findIndex((row) => row[dimensionName] === label);
   });
 
   let rowScrollOffset = 0;
@@ -87,12 +86,10 @@ TableCells – the cell contents.
   let estimateColumnSize: number[] = [];
 
   /* Separate out dimension column */
-  $: dimensionColumnName = $dimensionTableColumnName(dimensionName);
   $: dimensionColumn = columns?.find(
-    (c) => c.name == dimensionColumnName,
+    (c) => c.name == dimensionName,
   ) as VirtualizedTableColumns;
-  $: measureColumns =
-    columns?.filter((c) => c.name !== dimensionColumnName) ?? [];
+  $: measureColumns = columns?.filter((c) => c.name !== dimensionName) ?? [];
 
   let horizontalScrolling = false;
 

--- a/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
@@ -255,7 +255,7 @@ export function prepareVirtualizedDimTableColumns(
     (m) => m.name === leaderboardMeasureName,
   );
 
-  const dimensionColumn = getDimensionColumn(dimension);
+  const dimensionColumn = dimension.name ?? "";
 
   // copy column names so we don't mutate the original
   const columnNames = [...dash.visibleMeasureKeys].filter((m) =>

--- a/web-common/src/features/dashboards/state-managers/selectors/dimension-table.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/dimension-table.ts
@@ -89,7 +89,7 @@ export const prepareDimTableRows =
 
     if (!dimension) return [];
 
-    const dimensionColumn = getDimensionColumn(dimension);
+    const dimensionColumn = dimension.name ?? "";
     const leaderboardMeasureName = activeMeasureName(dashData);
 
     // FIXME: should this really be all measures, or just visible measures?


### PR DESCRIPTION
MetricsViewAggregation API returns dimension aliased to name instead of columns. So we need to use name instead.