### PR TITLE
fix: reveal sub row dimension values in pivot without measures

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotTable.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTable.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
   import ArrowDown from "@rilldata/web-common/components/icons/ArrowDown.svelte";
+  import VirtualTooltip from "@rilldata/web-common/components/virtualized-table/VirtualTooltip.svelte";
   import { extractSamples } from "@rilldata/web-common/components/virtualized-table/init-widths";
   import { getMeasureColumnProps } from "@rilldata/web-common/features/dashboards/pivot/pivot-column-definition";
   import { NUM_ROWS_PER_PAGE } from "@rilldata/web-common/features/dashboards/pivot/pivot-infinite-scroll";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
   import Resizer from "@rilldata/web-common/layout/Resizer.svelte";
+  import { copyToClipboard } from "@rilldata/web-common/lib/actions/copy-to-clipboard";
+  import { modified } from "@rilldata/web-common/lib/actions/modified-click";
   import { clamp } from "@rilldata/web-common/lib/clamp";
   import {
     ExpandedState,
@@ -26,9 +29,6 @@
   import { getPivotConfig } from "./pivot-data-store";
   import { isTimeDimension } from "./pivot-utils";
   import type { PivotDataRow, PivotDataStore } from "./types";
-  import VirtualTooltip from "@rilldata/web-common/components/virtualized-table/VirtualTooltip.svelte";
-  import { modified } from "@rilldata/web-common/lib/actions/modified-click";
-  import { copyToClipboard } from "@rilldata/web-common/lib/actions/copy-to-clipboard";
 
   // Distance threshold (in pixels) for triggering data fetch
   const ROW_THRESHOLD = 200;
@@ -58,7 +58,7 @@
   const options: Readable<TableOptions<PivotDataRow>> = derived(
     [pivotDashboardStore, pivotDataStore],
     ([pivotConfig, pivotData]) => {
-      let tableData = pivotData.data;
+      let tableData = [...pivotData.data];
       if (pivotData.totalsRowData) {
         tableData = [pivotData.totalsRowData, ...pivotData.data];
       }


### PR DESCRIPTION
The challenge with revealing sub-rows when there are no measures is that we really don't know what should come in those sub-rows. 
Example -
Dimension 1: Country
Values: India, USA, UK

Dimension 2: Cities
Values: Delhi, New York, London

Displaying a "cross-product" to get the sub-rows would give wrong results.

In case we use the first measure as a reference, depending on the measure type avg/sum/etc we can get confusing results.

The best solution probably is to use the inline `count(*)` as a measure when there is no measure. This PR implements this approach.

Closes #4637