### PR TITLE
fix: empty pivot table on scroll

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-data-store.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-data-store.ts
@@ -430,8 +430,9 @@ function createPivotDataStore(ctx: StateManagers): PivotDataStore {
              * If there are no axes values, return an empty table
              */
             if (
-              rowDimensionAxes?.data?.[anchorDimension]?.length === 0 ||
-              totalsRowResponse?.data?.data?.length === 0
+              (rowDimensionAxes?.data?.[anchorDimension]?.length === 0 ||
+                totalsRowResponse?.data?.data?.length === 0) &&
+              rowPage === 1
             ) {
               return axesSet({
                 isFetching: false,


### PR DESCRIPTION
We get an empty table on scrolling a pivot table beyond 50 values. This PR fixes it by checking that we are on the first page when we validate for empty axes.