### PR TITLE
Runtime: Use jsonval to serialize resolver results

### DIFF
--- a/runtime/resolver.go
+++ b/runtime/resolver.go
@@ -5,10 +5,13 @@ import (
 	"crypto/md5"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
+	"github.com/rilldata/rill/runtime/drivers"
+	"github.com/rilldata/rill/runtime/pkg/jsonval"
 )
 
 // Resolver represents logic, such as a SQL query, that produces output data.
@@ -31,19 +34,77 @@ type Resolver interface {
 	// Validate the properties and args without running any expensive operations.
 	Validate(ctx context.Context) error
 	// ResolveInteractive resolves data for interactive use (e.g. API requests or alerts).
-	ResolveInteractive(ctx context.Context) (*ResolverResult, error)
+	ResolveInteractive(ctx context.Context) (ResolverResult, error)
 	// ResolveExport resolve data for export (e.g. downloads or reports).
 	ResolveExport(ctx context.Context, w io.Writer, opts *ResolverExportOptions) error
 }
 
 // ResolverResult is the result of a resolver's execution.
-type ResolverResult struct {
-	// Data is a JSON encoded array of objects.
-	Data []byte
+type ResolverResult interface {
 	// Schema is the schema for the Data
-	Schema *runtimev1.StructType
-	// Cache indicates whether the result can be cached.
-	Cache bool
+	Schema() *runtimev1.StructType
+	// Cache indicates whether the result can be cached
+	Cache() bool
+	// MarshalJSON is a convenience method to serialize the result to JSON.
+	MarshalJSON() ([]byte, error)
+	// Close should be called to release resources
+	Close() error
+}
+
+func NewResolverResult(result *drivers.Result, cache bool) ResolverResult {
+	return &resolverResult{
+		rows:  result,
+		cache: cache,
+	}
+}
+
+type resolverResult struct {
+	rows  *drivers.Result
+	cache bool
+}
+
+var _ ResolverResult = &resolverResult{}
+
+// Cache implements ResolverResult.
+func (r *resolverResult) Cache() bool {
+	return r.cache
+}
+
+// Close implements ResolverResult.
+func (r *resolverResult) Close() error {
+	return r.rows.Close()
+}
+
+// MarshalJSON implements ResolverResult.
+func (r *resolverResult) MarshalJSON() ([]byte, error) {
+	var out []map[string]any
+	for r.rows.Next() {
+		row := make(map[string]any)
+		err := r.rows.MapScan(row)
+		if err != nil {
+			return nil, err
+		}
+
+		ret, err := jsonval.ToValue(row, &runtimev1.Type{StructType: r.rows.Schema})
+		if err != nil {
+			return nil, err
+		}
+		row, ok := ret.(map[string]any)
+		if !ok {
+			// this should never happen
+			return nil, fmt.Errorf("Resolver.MarshalJSON unexpected type %T", ret)
+		}
+		out = append(out, row)
+	}
+	if r.rows.Err() != nil {
+		return nil, r.rows.Err()
+	}
+	return json.Marshal(out)
+}
+
+// Schema implements ResolverResult.
+func (r *resolverResult) Schema() *runtimev1.StructType {
+	return r.rows.Schema
 }
 
 // ResolverExportOptions are the options passed to a resolver's ResolveExport method.
@@ -162,13 +223,19 @@ func (r *Runtime) Resolve(ctx context.Context, opts *ResolveOptions) (ResolveRes
 		if err != nil {
 			return ResolveResult{}, err
 		}
+		defer res.Close()
+
+		data, err := res.MarshalJSON()
+		if err != nil {
+			return ResolveResult{}, err
+		}
 
 		cRes := ResolveResult{
-			Data:   res.Data,
-			Schema: res.Schema,
+			Data:   data,
+			Schema: res.Schema(),
 		}
-		if res.Cache {
-			r.queryCache.cache.Set(key, cRes, int64(len(res.Data)))
+		if res.Cache() {
+			r.queryCache.cache.Set(key, cRes, int64(len(data)))
 		}
 		return cRes, nil
 	})

--- a/runtime/resolvers/metrics.go
+++ b/runtime/resolvers/metrics.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -104,36 +103,13 @@ func (r *metricsResolver) Validate(ctx context.Context) error {
 	return r.executor.ValidateQuery(r.query)
 }
 
-func (r *metricsResolver) ResolveInteractive(ctx context.Context) (*runtime.ResolverResult, error) {
+func (r *metricsResolver) ResolveInteractive(ctx context.Context) (runtime.ResolverResult, error) {
 	res, cache, err := r.executor.Query(ctx, r.query, r.args.ExecutionTime)
 	if err != nil {
 		return nil, err
 	}
-	defer res.Close()
 
-	out := []map[string]any{}
-	for res.Next() {
-		row := make(map[string]any)
-		err = res.MapScan(row)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, row)
-	}
-	if res.Err() != nil {
-		return nil, res.Rows.Err()
-	}
-
-	data, err := json.Marshal(out)
-	if err != nil {
-		return nil, err
-	}
-
-	return &runtime.ResolverResult{
-		Data:   data,
-		Schema: res.Schema,
-		Cache:  cache,
-	}, nil
+	return runtime.NewResolverResult(res, cache), nil
 }
 
 func (r *metricsResolver) ResolveExport(ctx context.Context, w io.Writer, opts *runtime.ResolverExportOptions) error {

--- a/runtime/resolvers/sql.go
+++ b/runtime/resolvers/sql.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"time"
@@ -141,7 +140,7 @@ func (r *sqlResolver) Validate(ctx context.Context) error {
 	return err
 }
 
-func (r *sqlResolver) ResolveInteractive(ctx context.Context) (*runtime.ResolverResult, error) {
+func (r *sqlResolver) ResolveInteractive(ctx context.Context) (runtime.ResolverResult, error) {
 	// Wrap the SQL with an outer SELECT to limit the number of rows returned in interactive mode.
 	// Adding +1 to the limit so we can return a nice error message if the limit is exceeded.
 	sql := fmt.Sprintf("SELECT * FROM (%s) LIMIT %d", r.sql, r.interactiveRowLimit+1)
@@ -153,41 +152,16 @@ func (r *sqlResolver) ResolveInteractive(ctx context.Context) (*runtime.Resolver
 	if err != nil {
 		return nil, err
 	}
-	defer res.Close()
-
-	if r.interactiveRowLimit != 0 {
-		res.SetCap(r.interactiveRowLimit)
-	}
-
-	var out []map[string]any
-	for res.Next() {
-		row := make(map[string]any)
-		err = res.MapScan(row)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, row)
-	}
-	if res.Err() != nil {
-		return nil, res.Err()
-	}
-
-	data, err := json.Marshal(out)
-	if err != nil {
-		return nil, err
-	}
 
 	// This is a little hacky, but for now we only cache results from DuckDB queries that have refs.
 	var cache bool
 	if r.olap.Dialect() == drivers.DialectDuckDB {
 		cache = len(r.refs) != 0
 	}
-
-	return &runtime.ResolverResult{
-		Data:   data,
-		Schema: res.Schema,
-		Cache:  cache,
-	}, nil
+	if r.interactiveRowLimit != 0 {
+		res.SetCap(r.interactiveRowLimit)
+	}
+	return runtime.NewResolverResult(res, cache), nil
 }
 
 func (r *sqlResolver) ResolveExport(ctx context.Context, w io.Writer, opts *runtime.ResolverExportOptions) error {


### PR DESCRIPTION
Fixes issue where `duckdb.Decimal` is serialized as an object instead of a number.