### PR TITLE
fix: uncaught error on root cloud page

### DIFF
--- a/web-admin/src/features/navigation/TopNavigationBar.svelte
+++ b/web-admin/src/features/navigation/TopNavigationBar.svelte
@@ -59,9 +59,10 @@
   $: alertsQuery = useAlerts(instanceId);
   $: reportsQuery = useReports(instanceId);
 
-  $: organizations = $organizationQuery.data?.organizations ?? [
-    { name: organization, id: organization },
-  ];
+  $: organizations =
+    $organizationQuery.data?.organizations ??
+    // handle case when visiting root cloud page directly (ui.rilldata.com)
+    (organization ? [{ name: organization, id: organization }] : []);
   $: projects = $projectsQuery.data?.projects ?? [];
   $: visualizations = $visualizationsQuery.data ?? [];
   $: alerts = $alertsQuery.data?.resources ?? [];


### PR DESCRIPTION
Visiting the root cloud page causes and uncaught error and leads to a crashed app.