### PR TITLE
fix(pivot): measure filter breaking sub table in pivot

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-merge-filters.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-merge-filters.ts
@@ -37,7 +37,7 @@ export function mergeFilters(
       if (likeExprMap.has(ident)) return;
       likeExprMap.set(ident, e);
     } else {
-      if (inExprMap.has(ident)) return;
+      if (inExprMap.has(ident) || !!e.cond?.exprs?.[1].subquery) return;
       inExprMap.set(ident, e);
     }
   });
@@ -51,7 +51,7 @@ export function mergeFilters(
       e.cond?.op === V1Operation.OPERATION_NLIKE
     )
       return;
-    if (!inExprMap.has(ident)) return;
+    if (!inExprMap.has(ident) || !!e.cond?.exprs?.[1].subquery) return;
 
     /**
      * We take an intersection of the values in the IN expressions.


### PR DESCRIPTION
When there is a measure threshold filter sub tables in pivot with multiple dimensions breaks sub tables. The query doesnt apply the filter of the sub table and shows all the dimension values. 