### PR TITLE
feat: add copy/tooltips to TDD table

### DIFF
--- a/web-common/src/features/dashboards/pivot/RegularTable.svelte
+++ b/web-common/src/features/dashboards/pivot/RegularTable.svelte
@@ -143,7 +143,7 @@
     const value = meta?.value;
     td.setAttribute("__col", String(x));
     td.setAttribute("__row", String(y));
-    console.log({ value });
+
     if (value) td.setAttribute("title", value.toString());
 
     const maybeWidth = getColumnWidth(x);

--- a/web-common/src/features/dashboards/pivot/RegularTable.svelte
+++ b/web-common/src/features/dashboards/pivot/RegularTable.svelte
@@ -87,16 +87,6 @@
     });
 
     let data = getBodyData({ x0, x1, y0, y1 });
-    // Replace undefined with loading placeholders and nulls with null placeholder
-    data.forEach((c, i) => {
-      c.forEach((r, j) => {
-        if (r === undefined) {
-          data[i][j] = LOADING_CELL;
-        } else if (r === null) {
-          data[i][j] = NULL_CELL;
-        }
-      });
-    });
 
     const dataSlice = {
       num_rows: rowCount,
@@ -153,6 +143,7 @@
     const value = meta?.value;
     td.setAttribute("__col", String(x));
     td.setAttribute("__row", String(y));
+    console.log({ value });
     if (value) td.setAttribute("title", value.toString());
 
     const maybeWidth = getColumnWidth(x);
@@ -162,13 +153,14 @@
       td.style.maxWidth = `${maybeWidth}px`;
     }
 
-    if (
-      typeof value === "string" &&
-      (value?.includes("loading-cell") || value?.includes("null-cell"))
-    ) {
+    if (typeof value === "string") {
       td.innerHTML = value;
-    } else {
-      td.innerHTML = formatter(value as string) ?? "";
+    } else if (value === null) {
+      td.innerHTML = NULL_CELL;
+    } else if (value === undefined) {
+      td.innerHTML = LOADING_CELL;
+    } else if (typeof value === "number") {
+      td.innerHTML = formatter(value) ?? "";
     }
 
     const maybeVal = renderCell({ x, y, value, element: td });

--- a/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDisplay.svelte
@@ -54,9 +54,15 @@
   $: timeGrain = $timeControlStore.selectedTimeRange?.interval;
 
   // Get labels for table headers
-  $: measureLabel =
-    $metricsView?.data?.measures?.find((m) => m.name === expandedMeasureName)
-      ?.label ?? "";
+  // $: measureLabel =
+  //   $metricsView?.data?.measures?.find((m) => m.name === expandedMeasureName)
+  //     ?.label ?? "";
+
+  $: measure = $metricsView?.data?.measures?.find(
+    (m) => m.name === expandedMeasureName,
+  );
+
+  $: measureLabel = measure?.label ?? "";
 
   let dimensionLabel = "";
   $: if (comparing === "dimension") {
@@ -226,6 +232,7 @@
     </div>
   {:else if formattedData && comparisonCopy}
     <TDDTable
+      {measure}
       {excludeMode}
       {dimensionLabel}
       {measureLabel}

--- a/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDisplay.svelte
@@ -53,11 +53,6 @@
 
   $: timeGrain = $timeControlStore.selectedTimeRange?.interval;
 
-  // Get labels for table headers
-  // $: measureLabel =
-  //   $metricsView?.data?.measures?.find((m) => m.name === expandedMeasureName)
-  //     ?.label ?? "";
-
   $: measure = $metricsView?.data?.measures?.find(
     (m) => m.name === expandedMeasureName,
   );
@@ -230,7 +225,7 @@
         </div>
       </div>
     </div>
-  {:else if formattedData && comparisonCopy}
+  {:else if formattedData && comparisonCopy && measure}
     <TDDTable
       {measure}
       {excludeMode}

--- a/web-common/src/features/dashboards/time-dimension-details/time-dimension-data-store.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/time-dimension-data-store.ts
@@ -99,7 +99,6 @@ function prepareDimensionData(
 ): TableData | undefined {
   if (!data || !totalsData || !measure) return undefined;
 
-  // const formatter = createMeasureValueFormatter<null | undefined>(measure);
   const measureName = measure?.name as string;
   const validPercentOfTotal = measure?.validPercentOfTotal as boolean;
 

--- a/web-local/tests/dashboards/dashboards.spec.ts
+++ b/web-local/tests/dashboards/dashboards.spec.ts
@@ -508,9 +508,9 @@ dimensions:
     await page.getByRole("button", { name: "No comparison" }).nth(1).click();
     await page.getByRole("menuitem", { name: "Domain Name" }).click();
 
-    await page.getByText("google.com", { exact: true }).click();
-    await page.getByText("instagram.com").click();
-    await page.getByText("msn.com").click();
+    await page.getByText("google.com", { exact: true }).click({ force: true });
+    await page.getByText("instagram.com").click({ force: true });
+    await page.getByText("msn.com").click({ force: true });
 
     await expect(page.getByText(" Total rows 43.7k")).toBeVisible();
 


### PR DESCRIPTION
This PR is a stopgap solution to enable copying of values via the TDD table. A larger refactor is necessary to remove the use of `RegularTable`, but this is a significant lift that is not currently prioritized.

This PR moves the responsibility for formatting from the data preparation utilities to the display components.

Tooltips are displayed using the native HTML `title` attribute rather than our bespoke `Tooltip` component as using the latter is not practical with Regular Table and the tooltip approach throughout the app is in flux.

Closes: #4490