### PR TITLE
feat: highlight SQL-in-YAML for API and MetricsView asset types

### DIFF
--- a/web-common/src/features/metrics-views/workspace/editor/MetricsEditor.svelte
+++ b/web-common/src/features/metrics-views/workspace/editor/MetricsEditor.svelte
@@ -12,7 +12,7 @@
   import { FileArtifact } from "@rilldata/web-common/features/entity-management/file-artifact";
   import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
   import { createPersistentDashboardStore } from "@rilldata/web-common/features/dashboards/stores/persistent-dashboard-state";
-  import { FileExtensionToEditorExtension } from "@rilldata/web-common/features/editor/getExtensionsForFile";
+  import { metricsPlusSQL } from "@rilldata/web-common/components/editor/presets/yamlWithJsonAndSql";
 
   export let filePath: string;
   export let metricViewName: string;
@@ -58,9 +58,9 @@
     }}
     {fileArtifact}
     extensions={[
+      metricsPlusSQL,
       placeholderElements.extension,
       yamlSchema(metricsJsonSchema),
-      FileExtensionToEditorExtension[".yaml"],
     ]}
   />
 </MetricsEditorContainer>

--- a/web-local/src/routes/(application)/files/[...file]/+page.svelte
+++ b/web-local/src/routes/(application)/files/[...file]/+page.svelte
@@ -14,6 +14,7 @@
   import MetricsWorkspace from "@rilldata/web-common/features/workspaces/MetricsWorkspace.svelte";
   import ChartWorkspace from "@rilldata/web-common/features/workspaces/ChartWorkspace.svelte";
   import CustomDashboardWorkspace from "@rilldata/web-common/features/workspaces/CustomDashboardWorkspace.svelte";
+  import { customYAMLwithJSONandSQL } from "@rilldata/web-common/components/editor/presets/yamlWithJsonAndSql";
 
   const workspaces = new Map([
     [ResourceKind.Source, SourceWorkspace],
@@ -34,6 +35,11 @@
   $: resourceKind = <ResourceKind | undefined>$name?.kind;
 
   $: workspace = workspaces.get(resourceKind);
+
+  $: extensions =
+    resourceKind === ResourceKind.API
+      ? [customYAMLwithJSONandSQL]
+      : getExtensionsForFile(filePath);
 
   onMount(() => {
     expandDirectory(filePath);
@@ -69,7 +75,7 @@
     <WorkspaceEditorContainer slot="body">
       <Editor
         {fileArtifact}
-        extensions={getExtensionsForFile(filePath)}
+        {extensions}
         bind:editor
         bind:autoSave={$autoSave}
       />


### PR DESCRIPTION
API:
<img width="772" alt="Screenshot 2024-06-24 at 5 20 14 PM" src="https://github.com/rilldata/rill/assets/120223836/ff3b3afb-961d-4c8d-a39a-8c5bb48dc1a6">


MetricsView (must be unquoted):
<img width="398" alt="Screenshot 2024-06-24 at 5 17 43 PM" src="https://github.com/rilldata/rill/assets/120223836/3024373d-a66a-48e0-bc98-df6f1c8d75a0">


Closes: #5056 