### PR TITLE
fix: broken urls to refs in inspector

### DIFF
--- a/web-common/src/features/models/workspace/inspector/References.svelte
+++ b/web-common/src/features/models/workspace/inspector/References.svelte
@@ -69,7 +69,7 @@
           <div>
             <WithModelResultTooltip {modelHasError}>
               <a
-                href="/files{reference?.resource?.meta?.filePaths[0]}"
+                href="/files{reference?.resource?.meta?.filePaths?.[0]}"
                 class="ui-copy-muted grid justify-between gap-x-2 {query_reference_trigger} pl-4 pr-4"
                 style:grid-template-columns="auto max-content"
                 on:focus={() => {

--- a/web-common/src/features/models/workspace/inspector/References.svelte
+++ b/web-common/src/features/models/workspace/inspector/References.svelte
@@ -46,6 +46,7 @@
   );
 
   $: references = $referencedWithMetadata;
+  $: references, console.log(references);
 
   function blur() {
     eventBus.emit("highlightSelection", []);
@@ -69,9 +70,7 @@
           <div>
             <WithModelResultTooltip {modelHasError}>
               <a
-                href="/{reference?.resource?.source
-                  ? 'source'
-                  : 'model'}/{reference?.resource?.meta?.name?.name}"
+                href="/files{reference?.resource?.meta?.filePaths[0]}"
                 class="ui-copy-muted grid justify-between gap-x-2 {query_reference_trigger} pl-4 pr-4"
                 style:grid-template-columns="auto max-content"
                 on:focus={() => {

--- a/web-common/src/features/models/workspace/inspector/References.svelte
+++ b/web-common/src/features/models/workspace/inspector/References.svelte
@@ -46,7 +46,6 @@
   );
 
   $: references = $referencedWithMetadata;
-  $: references, console.log(references);
 
   function blur() {
     eventBus.emit("highlightSelection", []);


### PR DESCRIPTION
Fixes broken urls to file paths

![image](https://github.com/rilldata/rill/assets/1181922/5d3a7397-6d60-4fa7-b554-0e600054abea)
