### PR TITLE
fix: javascript error telemetry not firing anymore

### DIFF
--- a/web-admin/src/routes/+layout.svelte
+++ b/web-admin/src/routes/+layout.svelte
@@ -26,10 +26,18 @@
 
   clearViewedAsUserAfterNavigate(queryClient);
 
-  initCloudMetrics();
+  let removeJavascriptListeners: () => void;
+  initCloudMetrics()
+    .then(() => {
+      removeJavascriptListeners =
+        errorEventHandler.addJavascriptErrorListeners();
+    })
+    .catch(console.error);
   initPylonWidget();
 
-  onMount(() => errorEventHandler?.addJavascriptErrorListeners());
+  onMount(() => {
+    return () => removeJavascriptListeners();
+  });
 
   $: isEmbed = $page.url.pathname === "/-/embed";
 </script>

--- a/web-common/src/features/entity-management/ResourceWatcher.svelte
+++ b/web-common/src/features/entity-management/ResourceWatcher.svelte
@@ -2,7 +2,6 @@
   import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts";
   import { WatchFilesClient } from "@rilldata/web-common/features/entity-management/WatchFilesClient";
   import { WatchResourcesClient } from "@rilldata/web-common/features/entity-management/WatchResourcesClient";
-  import { errorEventHandler } from "@rilldata/web-common/metrics/initMetrics";
   import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
   import { onMount } from "svelte";
   import ErrorPage from "@rilldata/web-common/components/ErrorPage.svelte";
@@ -24,14 +23,11 @@
   $: failed = $fileAttempts >= 2 || $resourceAttempts >= 2;
 
   onMount(() => {
-    const stopJavascriptErrorListeners =
-      errorEventHandler?.addJavascriptErrorListeners();
     void fileArtifacts.init(queryClient, instanceId);
 
     return () => {
       fileWatcher.close();
       resourceWatcher.close();
-      stopJavascriptErrorListeners?.();
     };
   });
 

--- a/web-local/src/routes/+layout.svelte
+++ b/web-local/src/routes/+layout.svelte
@@ -28,9 +28,12 @@
     query: Query,
   ) => errorEventHandler?.requestErrorEventHandler(error, query);
 
+  let removeJavascriptListeners: () => void;
+
   onMount(async () => {
     const config = await runtimeServiceGetConfig();
     await initMetrics(config);
+    removeJavascriptListeners = errorEventHandler.addJavascriptErrorListeners();
 
     featureFlags.set(false, "adminServer");
     featureFlags.set(config.readonly, "readOnly");
@@ -39,6 +42,14 @@
       version: config.version,
       commitHash: config.build_commit,
     });
+  });
+
+  /**
+   * Async mount doesnt support an unsubscribe method.
+   * So we need this to make sure javascript listeners for error handler is removed.
+   */
+  onMount(() => {
+    return () => removeJavascriptListeners?.();
   });
 
   $: ({ host, instanceId } = $runtime);


### PR DESCRIPTION
Moving initialisation of javascript error telemetry to the same place where it is created.