### PR TITLE
fix: math.random for eventbus

### DIFF
--- a/web-common/src/lib/event-bus/event-bus.ts
+++ b/web-common/src/lib/event-bus/event-bus.ts
@@ -5,7 +5,7 @@ class EventBus {
   private listeners: EventMap = new Map();
 
   on<Event extends T>(event: Event, callback: Listener<Event>) {
-    const key = generateUUID;
+    const key = generateUUID();
     const eventMap = this.listeners.get(event);
 
     if (!eventMap) {
@@ -33,18 +33,14 @@ class EventBus {
 
 function generateUUID(): string {
   // Generate random numbers for the UUID
-  const randomNumbers = new Array(16)
-    .fill(0)
-    .map(() => Math.floor(Math.random() * 256));
+  const randomNumbers: number[] = new Array(16).fill(0).map(() => Math.floor(Math.random() * 256));
 
   // Set the version and variant bits
   randomNumbers[6] = (randomNumbers[6] & 0x0f) | 0x40; // Version 4
   randomNumbers[8] = (randomNumbers[8] & 0x3f) | 0x80; // Variant 10
 
   // Convert to hexadecimal and format as a UUID
-  const hexDigits = Array.from(randomNumbers)
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
+  const hexDigits: string = randomNumbers.map(b => b.toString(16).padStart(2, '0')).join('');
   return `${hexDigits.slice(0, 8)}-${hexDigits.slice(8, 12)}-${hexDigits.slice(12, 16)}-${hexDigits.slice(16, 20)}-${hexDigits.slice(20, 32)}`;
 }
 

--- a/web-common/src/lib/event-bus/event-bus.ts
+++ b/web-common/src/lib/event-bus/event-bus.ts
@@ -5,7 +5,7 @@ class EventBus {
   private listeners: EventMap = new Map();
 
   on<Event extends T>(event: Event, callback: Listener<Event>) {
-    const key = crypto.randomUUID();
+    const key = generateUUID;
     const eventMap = this.listeners.get(event);
 
     if (!eventMap) {
@@ -29,6 +29,19 @@ class EventBus {
       cb(payload);
     });
   }
+}
+
+function generateUUID(): string {
+  // Generate random numbers for the UUID
+  const randomNumbers = new Array(16).fill(0).map(() => Math.floor(Math.random() * 256));
+
+  // Set the version and variant bits
+  randomNumbers[6] = (randomNumbers[6] & 0x0f) | 0x40; // Version 4
+  randomNumbers[8] = (randomNumbers[8] & 0x3f) | 0x80; // Variant 10
+
+  // Convert to hexadecimal and format as a UUID
+  const hexDigits = Array.from(randomNumbers).map(b => b.toString(16).padStart(2, '0')).join('');
+  return `${hexDigits.slice(0, 8)}-${hexDigits.slice(8, 12)}-${hexDigits.slice(12, 16)}-${hexDigits.slice(16, 20)}-${hexDigits.slice(20, 32)}`;
 }
 
 export const eventBus = new EventBus();

--- a/web-common/src/lib/event-bus/event-bus.ts
+++ b/web-common/src/lib/event-bus/event-bus.ts
@@ -33,14 +33,18 @@ class EventBus {
 
 function generateUUID(): string {
   // Generate random numbers for the UUID
-  const randomNumbers: number[] = new Array(16).fill(0).map(() => Math.floor(Math.random() * 256));
+  const randomNumbers: number[] = new Array(16)
+    .fill(0)
+    .map(() => Math.floor(Math.random() * 256));
 
   // Set the version and variant bits
   randomNumbers[6] = (randomNumbers[6] & 0x0f) | 0x40; // Version 4
   randomNumbers[8] = (randomNumbers[8] & 0x3f) | 0x80; // Variant 10
 
   // Convert to hexadecimal and format as a UUID
-  const hexDigits: string = randomNumbers.map(b => b.toString(16).padStart(2, '0')).join('');
+  const hexDigits: string = randomNumbers
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
   return `${hexDigits.slice(0, 8)}-${hexDigits.slice(8, 12)}-${hexDigits.slice(12, 16)}-${hexDigits.slice(16, 20)}-${hexDigits.slice(20, 32)}`;
 }
 

--- a/web-common/src/lib/event-bus/event-bus.ts
+++ b/web-common/src/lib/event-bus/event-bus.ts
@@ -33,14 +33,18 @@ class EventBus {
 
 function generateUUID(): string {
   // Generate random numbers for the UUID
-  const randomNumbers = new Array(16).fill(0).map(() => Math.floor(Math.random() * 256));
+  const randomNumbers = new Array(16)
+    .fill(0)
+    .map(() => Math.floor(Math.random() * 256));
 
   // Set the version and variant bits
   randomNumbers[6] = (randomNumbers[6] & 0x0f) | 0x40; // Version 4
   randomNumbers[8] = (randomNumbers[8] & 0x3f) | 0x80; // Variant 10
 
   // Convert to hexadecimal and format as a UUID
-  const hexDigits = Array.from(randomNumbers).map(b => b.toString(16).padStart(2, '0')).join('');
+  const hexDigits = Array.from(randomNumbers)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
   return `${hexDigits.slice(0, 8)}-${hexDigits.slice(8, 12)}-${hexDigits.slice(12, 16)}-${hexDigits.slice(16, 20)}-${hexDigits.slice(20, 32)}`;
 }
 


### PR DESCRIPTION
`crypto` will fail for non-https context and for other hosts then localhost. So in scenarios where someone accesses Rill Developer over http on a non-localhost hostname, such as in a virtual machine or in WSL over hostname, the event bus will fail to initialize.

Seeing as we are only using it as a key for the event bus here is a native math.random implementation. I would assume we don't need full cryptography strength on our frontend event bus keys :)