### PR TITLE
feat: Add multiple items in a single input component

### DIFF
--- a/web-common/src/components/forms/MultiInput.svelte
+++ b/web-common/src/components/forms/MultiInput.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+  import { IconButton } from "@rilldata/web-common/components/button";
+  import InfoCircle from "@rilldata/web-common/components/icons/InfoCircle.svelte";
+
+  /**
+   * Input that allows to enter multiple items but appears within a single input box.
+   * This is a more advanced version of InputArray.svelte
+   */
+  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
+  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
+  import { AlertCircleIcon, Trash, XIcon } from "lucide-svelte";
+  import type { createForm } from "svelte-forms-lib";
+
+  export let id: string;
+  export let label = "";
+  export let description = "";
+  export let accessorKey: string;
+  export let hint = "";
+
+  export let formState: ReturnType<typeof createForm<Record<string, any>>>;
+  const { form, errors, validateField } = formState;
+  $: values = $form[id] as Record<string, string>[];
+  // There's a bug in how `svelte-forms-lib` types the `$errors` store for arrays.
+  // See: https://github.com/tjinauyeung/svelte-forms-lib/issues/154#issuecomment-1087331250
+  $: errs = ($errors[id] as unknown as Record<string, string>[]) ?? [];
+
+  let editingInput = "";
+  let focused = false;
+  function handleKeyDown(event: KeyboardEvent) {
+    if (event.key !== "Enter") return;
+
+    event.preventDefault();
+    $form[id] = $form[id].concat({ email: editingInput });
+    errs = errs.concat({ email: "" });
+    editingInput = "";
+    validateField(`${id}.${$form[id].length - 1}.${accessorKey}`);
+  }
+
+  function handleRemove(index: number) {
+    $form[id] = $form[id].filter((_, i) => i !== index);
+    errs = errs.filter?.((r, i) => i !== index);
+  }
+
+  $: hasSomeErrors = errs.some((e) => !!e[accessorKey]);
+</script>
+
+<div class="flex flex-col">
+  {#if label}
+    <div class="flex items-center gap-x-1">
+      <label for={id} class="text-gray-800 text-sm font-medium">{label}</label>
+      {#if hint}
+        <Tooltip location="right" alignment="middle" distance={8}>
+          <div class="text-gray-500" style="transform:translateY(-.5px)">
+            <InfoCircle size="13px" />
+          </div>
+          <TooltipContent maxWidth="400px" slot="tooltip-content">
+            {hint}
+          </TooltipContent>
+        </Tooltip>
+      {/if}
+      {#if description}
+        <div class="text-sm text-slate-600">{description}</div>
+      {/if}
+    </div>
+  {/if}
+  <div
+    class="flex flex-wrap gap-2 bg-white rounded-sm border border-gray-300 px-3 py-[5px] w-full"
+    class:outline={focused || hasSomeErrors}
+    class:outline-red-500={hasSomeErrors}
+    class:outline-primary-500={focused && !hasSomeErrors}
+  >
+    {#each values as _, i}
+      {@const hasError = !!errs[i]?.[accessorKey]}
+      <div
+        class="flex items-center text-gray-600 text-sm rounded-2xl border border-gray-300 bg-gray-100 pl-2 pr-1 max-w-full"
+      >
+        {#if hasError}
+          <Tooltip distance={8}>
+            <div class="w-fit h-5 overflow-hidden text-ellipsis text-red-500">
+              {values[i][accessorKey]}
+            </div>
+            <TooltipContent maxWidth="400px" slot="tooltip-content">
+              {errs[i][accessorKey]}
+            </TooltipContent>
+          </Tooltip>
+        {:else}
+          <div class="w-fit h-5 overflow-hidden text-ellipsis">
+            {values[i][accessorKey]}
+          </div>
+        {/if}
+        <IconButton disableHover on:click={() => handleRemove(i)}>
+          <XIcon size="16px" className="text-gray-500 cursor-pointer" />
+        </IconButton>
+      </div>
+    {/each}
+    <input
+      bind:value={editingInput}
+      on:keydown={handleKeyDown}
+      autocomplete="off"
+      id="{id}.{values.length}.{accessorKey}"
+      class="focus:outline-white group-hover:text-red-500 text-sm w-full"
+      on:focusin={() => (focused = true)}
+      on:focusout={() => (focused = false)}
+    />
+  </div>
+</div>

--- a/web-common/src/components/forms/MultiInput.svelte
+++ b/web-common/src/components/forms/MultiInput.svelte
@@ -43,7 +43,6 @@
   }
 
   $: hasSomeErrors = errs.some((e) => !!e[accessorKey]);
-  $: invalidValues = values.filter((_, i) => !!errs[i][accessorKey]);
 </script>
 
 <div class="flex flex-col">
@@ -108,9 +107,7 @@
   </div>
   {#if hasSomeErrors}
     <div in:slide={{ duration: 200 }} class="text-red-500 text-sm py-px">
-      Invalid {label} value{invalidValues.length > 1 ? "s" : ""}: {invalidValues
-        .map((v) => `"${v[accessorKey]}"`)
-        .join(",")}
+      {errs[0][accessorKey]}
     </div>
   {/if}
 </div>

--- a/web-common/src/components/forms/MultiInput.svelte
+++ b/web-common/src/components/forms/MultiInput.svelte
@@ -8,7 +8,7 @@
    */
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
-  import { AlertCircleIcon, Trash, XIcon } from "lucide-svelte";
+  import { XIcon } from "lucide-svelte";
   import type { createForm } from "svelte-forms-lib";
 
   export let id: string;

--- a/web-common/src/components/forms/MultiInput.svelte
+++ b/web-common/src/components/forms/MultiInput.svelte
@@ -101,7 +101,7 @@
       on:keydown={handleKeyDown}
       autocomplete="off"
       id="{id}.{values.length}.{accessorKey}"
-      class="focus:outline-white group-hover:text-red-500 text-sm w-full"
+      class="focus:outline-white group-hover:text-red-500 text-sm w-fit px-1"
       on:focusin={() => (focused = true)}
       on:focusout={() => (focused = false)}
     />

--- a/web-common/src/components/forms/MultiInput.svelte
+++ b/web-common/src/components/forms/MultiInput.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { IconButton } from "@rilldata/web-common/components/button";
   import InfoCircle from "@rilldata/web-common/components/icons/InfoCircle.svelte";
+  import { slide } from "svelte/transition";
 
   /**
    * Input that allows to enter multiple items but appears within a single input box.
@@ -42,6 +43,7 @@
   }
 
   $: hasSomeErrors = errs.some((e) => !!e[accessorKey]);
+  $: invalidValues = values.filter((_, i) => !!errs[i][accessorKey]);
 </script>
 
 <div class="flex flex-col">
@@ -73,6 +75,7 @@
       {@const hasError = !!errs[i]?.[accessorKey]}
       <div
         class="flex items-center text-gray-600 text-sm rounded-2xl border border-gray-300 bg-gray-100 pl-2 pr-1 max-w-full"
+        class:border-gray-300={hasError}
       >
         {#if hasError}
           <Tooltip distance={8}>
@@ -103,4 +106,11 @@
       on:focusout={() => (focused = false)}
     />
   </div>
+  {#if hasSomeErrors}
+    <div in:slide={{ duration: 200 }} class="text-red-500 text-sm py-px">
+      Invalid {label} value{invalidValues.length > 1 ? "s" : ""}: {invalidValues
+        .map((v) => `"${v[accessorKey]}"`)
+        .join(",")}
+    </div>
+  {/if}
 </div>

--- a/web-common/src/components/forms/__stories__/MultiInput.stories.svelte
+++ b/web-common/src/components/forms/__stories__/MultiInput.stories.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { Button } from "@rilldata/web-common/components/button";
+  import MultiInput from "@rilldata/web-common/components/forms/MultiInput.svelte";
+  import { Meta, Story } from "@storybook/addon-svelte-csf";
+  import { createForm } from "svelte-forms-lib";
+  import * as yup from "yup";
+
+  const formState = createForm({
+    initialValues: {
+      emails: [],
+    },
+    validationSchema: yup.object({
+      emails: yup.array().of(
+        yup.object().shape({
+          email: yup.string().email("Invalid email"),
+        }),
+      ),
+    }),
+    onSubmit: async (values) => {
+      console.log(values);
+    },
+  });
+
+  const { handleSubmit } = formState;
+</script>
+
+<Meta title="Multiple Input" />
+
+<Story name="Form with Multiple Input">
+  <form
+    autocomplete="off"
+    class="flex flex-col gap-y-6 w-[300px]"
+    id="multi-input-form"
+    on:submit|preventDefault={handleSubmit}
+  >
+    <MultiInput id="emails" label="Emails" accessorKey="email" {formState} />
+    <Button form="multi-input-form" submitForm type="primary">Invite</Button>
+  </form>
+</Story>


### PR DESCRIPTION
For user invite we need a single input that takes multiple items that can be deleted. This can also replace our inputs for user invite, slack users and slack channels in alerts/report forms.

<img width="342" alt="Screenshot 2024-06-28 at 12 50 00 PM" src="https://github.com/rilldata/rill/assets/3214541/0adc2120-2bf4-4607-ac85-c4c7b1eb3dad">
