### PR TITLE
Fix: collapse expanded values on measure change

### DIFF
--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -278,6 +278,7 @@ const metricViewReducers = {
   setPivotColumns(name: string, value: PivotChipData[]) {
     updateMetricsExplorerByName(name, (metricsExplorer) => {
       metricsExplorer.pivot.rowPage = 1;
+      metricsExplorer.pivot.expanded = {};
 
       const dimensions: PivotChipData[] = [];
       const measures: PivotChipData[] = [];


### PR DESCRIPTION
Temporary fix for https://rilldata.slack.com/archives/CTZ8XBQ85/p1719374514886679

We don't have support for asynchronous calls in our pivot data store. To fetch the values for a particular nested sub-table, we need to know the values of its parents. This generally works well when a user expands the table one by one. However, if we attempt to call everything at once, we need an asynchronous way to handle data in the Svelte store. This is also why implementing an "Expand All" feature would require a significant refactor. Currently, we are looking at ways to fix it so that we at least don't show incorrect data. One solution could be to collapse all expanded values when measures are changed.

A follow up for this would be to add support for asynchronous sequential calls.