### PR TITLE
fix: show loading spinner on Preview button only when navigating to the relevant route

### DIFF
--- a/web-common/src/features/metrics-views/workspace/PreviewButton.svelte
+++ b/web-common/src/features/metrics-views/workspace/PreviewButton.svelte
@@ -42,7 +42,7 @@
     href={`/${type}/${dashboardName}`}
     on:click={viewDashboard}
     type="primary"
-    loading={!!$navigating}
+    loading={!!$navigating?.to?.route}
   >
     <Play size="10px" />
     Preview

--- a/web-common/src/features/metrics-views/workspace/PreviewButton.svelte
+++ b/web-common/src/features/metrics-views/workspace/PreviewButton.svelte
@@ -28,6 +28,8 @@
       )
       .catch(console.error);
   };
+
+  $: loading = $navigating?.to?.route?.id === `/(viz)/${type}/[name]`;
 </script>
 
 <Tooltip
@@ -42,7 +44,7 @@
     href={`/${type}/${dashboardName}`}
     on:click={viewDashboard}
     type="primary"
-    loading={!!$navigating?.to?.route}
+    {loading}
   >
     <Play size="10px" />
     Preview


### PR DESCRIPTION
The spinner shows up when navigating to any url. This is an issue during login flow where we redirect to `/auth`, which can take time.

Fixing the button to only show spinner when navigating to the relevant route.