### PR TITLE
Runtime : Better export limits

### DIFF
--- a/runtime/drivers/duckdb/model_executor_self_file.go
+++ b/runtime/drivers/duckdb/model_executor_self_file.go
@@ -71,8 +71,8 @@ func (e *selfToFileExecutor) Execute(ctx context.Context) (*drivers.ModelResult,
 						continue
 					}
 					if f.Size() > outputProps.FileSizeLimitBytes {
-						cancel()
 						overLimit.Store(true)
+						cancel()
 					}
 				}
 			}
@@ -94,12 +94,14 @@ func (e *selfToFileExecutor) Execute(ctx context.Context) (*drivers.ModelResult,
 	// check the size again since duckdb writes data with high throughput
 	// and it is possible that the entire file is written
 	// before we check size in background goroutine
-	f, err := os.Stat(outputProps.Path)
-	if err != nil {
-		return nil, err
-	}
-	if f.Size() > outputProps.FileSizeLimitBytes {
-		return nil, fmt.Errorf("file exceeds size limit %q", datasize.ByteSize(outputProps.FileSizeLimitBytes).HumanReadable())
+	if outputProps.FileSizeLimitBytes > 0 {
+		f, err := os.Stat(outputProps.Path)
+		if err != nil {
+			return nil, err
+		}
+		if f.Size() > outputProps.FileSizeLimitBytes {
+			return nil, fmt.Errorf("file exceeds size limit %q", datasize.ByteSize(outputProps.FileSizeLimitBytes).HumanReadable())
+		}
 	}
 
 	// Build result props

--- a/runtime/drivers/duckdb/model_executor_self_file.go
+++ b/runtime/drivers/duckdb/model_executor_self_file.go
@@ -3,7 +3,11 @@ package duckdb
 import (
 	"context"
 	"fmt"
+	"os"
+	"sync/atomic"
+	"time"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/mitchellh/mapstructure"
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/drivers/file"
@@ -47,13 +51,54 @@ func (e *selfToFileExecutor) Execute(ctx context.Context) (*drivers.ModelResult,
 		return nil, err
 	}
 
+	overLimit := atomic.Bool{}
+	if outputProps.FileSizeLimitBytes > 0 {
+		var cancel context.CancelFunc
+		// override the parent context
+		ctx, cancel = context.WithCancel(ctx)
+		defer cancel()
+		go func() {
+			ticker := time.NewTicker(time.Millisecond * 500)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					f, err := os.Stat(outputProps.Path)
+					if err != nil { // ignore error since file may not be created yet
+						continue
+					}
+					if f.Size() > outputProps.FileSizeLimitBytes {
+						cancel()
+						overLimit.Store(true)
+					}
+				}
+			}
+		}()
+	}
+
 	err = olap.Exec(ctx, &drivers.Statement{
 		Query:    sql,
 		Args:     inputProps.Args,
 		Priority: e.opts.Priority,
 	})
 	if err != nil {
+		if overLimit.Load() {
+			return nil, fmt.Errorf("file exceeds size limit %q", datasize.ByteSize(outputProps.FileSizeLimitBytes).HumanReadable())
+		}
 		return nil, fmt.Errorf("failed to execute query: %w", err)
+	}
+
+	// check the size again since duckdb writes data with high throughput
+	// and it is possible that the entire file is written
+	// before we check size in background goroutine
+	f, err := os.Stat(outputProps.Path)
+	if err != nil {
+		return nil, err
+	}
+	if f.Size() > outputProps.FileSizeLimitBytes {
+		return nil, fmt.Errorf("file exceeds size limit %q", datasize.ByteSize(outputProps.FileSizeLimitBytes).HumanReadable())
 	}
 
 	// Build result props

--- a/runtime/drivers/duckdb/model_executor_self_file.go
+++ b/runtime/drivers/duckdb/model_executor_self_file.go
@@ -51,6 +51,7 @@ func (e *selfToFileExecutor) Execute(ctx context.Context) (*drivers.ModelResult,
 		return nil, err
 	}
 
+	// Check the output file size does not exceed the configured limit.
 	overLimit := atomic.Bool{}
 	if outputProps.FileSizeLimitBytes > 0 {
 		var cancel context.CancelFunc

--- a/runtime/drivers/duckdb/olap.go
+++ b/runtime/drivers/duckdb/olap.go
@@ -744,10 +744,9 @@ func (c *connection) execWithLimits(parentCtx context.Context, stmt *drivers.Sta
 	}
 
 	// check current size
-	currentSize, _ := c.EstimateSize()
-	storageLimit -= currentSize
+	sz, _ := c.EstimateSize()
 	// current size already exceeds limit
-	if storageLimit <= 0 {
+	if sz >= storageLimit {
 		return drivers.ErrStorageLimitExceeded
 	}
 

--- a/runtime/drivers/file/model_executor.go
+++ b/runtime/drivers/file/model_executor.go
@@ -7,8 +7,9 @@ import (
 )
 
 type ModelOutputProperties struct {
-	Path   string             `mapstructure:"path"`
-	Format drivers.FileFormat `mapstructure:"format"`
+	Path               string             `mapstructure:"path"`
+	Format             drivers.FileFormat `mapstructure:"format"`
+	FileSizeLimitBytes int64              `mapstructure:"file_size_limit_bytes"`
 }
 
 func (p *ModelOutputProperties) Validate() error {

--- a/runtime/drivers/registry.go
+++ b/runtime/drivers/registry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/mitchellh/mapstructure"
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 )
@@ -71,8 +72,8 @@ type Instance struct {
 // For example, a variable "rill.stage_changes=true" would set the StageChanges field to true.
 // InstanceConfig should only be used for config that the user is allowed to change dynamically at runtime.
 type InstanceConfig struct {
-	// DownloadRowLimit is the row limit for interactive data exports. If set to 0, there is no limit.
-	DownloadRowLimit int64 `mapstructure:"rill.download_row_limit"`
+	// DownloadLimitBytes is the limit on size of exported file. If set to 0, there is no limit.
+	DownloadLimitBytes int64 `mapstructure:"rill.download_row_limit_bytes"`
 	// PivotCellLimit is the maximum number of cells allowed in a single pivot query.
 	// Note that it does not limit the UI's pivot table because it paginates the requests.
 	PivotCellLimit int64 `mapstructure:"rill.pivot_cell_limit"`
@@ -125,7 +126,7 @@ func (i *Instance) ResolveVariables() map[string]string {
 func (i *Instance) Config() (InstanceConfig, error) {
 	// Default config
 	res := InstanceConfig{
-		DownloadRowLimit:                  200_000,
+		DownloadLimitBytes:                int64(datasize.MB * 128),
 		PivotCellLimit:                    2_000_000,
 		InteractiveSQLRowLimit:            10_000,
 		StageChanges:                      true,

--- a/runtime/metricsview/executor.go
+++ b/runtime/metricsview/executor.go
@@ -30,7 +30,6 @@ type Executor struct {
 	instanceCfg drivers.InstanceConfig
 
 	watermark time.Time
-	tempDir   string
 }
 
 // NewExecutor creates a new Executor for the provided metrics view.
@@ -60,7 +59,6 @@ func NewExecutor(ctx context.Context, rt *runtime.Runtime, instanceID string, mv
 // Close releases the resources held by the Executor.
 func (e *Executor) Close() {
 	e.olapRelease()
-	_ = os.RemoveAll(e.tempDir)
 }
 
 // ValidateMetricsView validates the dimensions and measures in the executor's metrics view.

--- a/runtime/metricsview/executor_export.go
+++ b/runtime/metricsview/executor_export.go
@@ -15,7 +15,7 @@ import (
 // executeExport works by simulating a model that outputs to a file.
 // This means it creates a ModelExecutor with the provided input connector and props as input,
 // and with the "file" driver as the output connector targeting a temporary output path.
-func (e *Executor) executeExport(ctx context.Context, format drivers.FileFormat, inputConnector string, inputProps map[string]any) (res string, resErr error) {
+func (e *Executor) executeExport(ctx context.Context, format drivers.FileFormat, inputConnector string, inputProps map[string]any) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, defaultExportTimeout)
 	defer cancel()
 

--- a/runtime/metricsview/executor_rewrite_limit.go
+++ b/runtime/metricsview/executor_rewrite_limit.go
@@ -4,8 +4,8 @@ import "fmt"
 
 // rewriteQueryLimit rewrites the query limit to enforce system limits.
 // For unlimited queries, it adds a limit just above the system limit. The result reader should then error if the cap is exceeded.
-func (e *Executor) rewriteQueryLimit(qry *Query, export bool) error {
-	limitCap := e.queryLimitCap(export)
+func (e *Executor) rewriteQueryLimit(qry *Query) error {
+	limitCap := e.instanceCfg.InteractiveSQLRowLimit
 
 	// No magic if there is no cap
 	if limitCap == 0 {
@@ -25,12 +25,4 @@ func (e *Executor) rewriteQueryLimit(qry *Query, export bool) error {
 	}
 
 	return nil
-}
-
-// queryLimitCap returns the system limit for the given query type.
-func (e *Executor) queryLimitCap(export bool) int64 {
-	if export {
-		return e.instanceCfg.DownloadRowLimit
-	}
-	return e.instanceCfg.InteractiveSQLRowLimit
 }

--- a/runtime/testruntime/testruntime.go
+++ b/runtime/testruntime/testruntime.go
@@ -61,6 +61,7 @@ func New(t TestingT) *runtime.Runtime {
 		ControllerLogBufferCapacity:  10000,
 		ControllerLogBufferSizeBytes: int64(datasize.MB * 16),
 		AllowHostAccess:              true,
+		DataDir:                      t.TempDir(),
 	}
 
 	logger := zap.NewNop()


### PR DESCRIPTION
closes https://github.com/rilldata/rill-private-issues/issues/432

The excel export limit is not fully optimised. The entire export data is written into temporary files by the underlying library and the limit is only checked when writing data from these temporary files to output files. I checked and could not find any way to control these temporary files.