### PR TITLE
Runtime : Modify blob limits

### DIFF
--- a/docs/docs/build/connect/glob-patterns.md
+++ b/docs/docs/build/connect/glob-patterns.md
@@ -14,19 +14,19 @@ To ingest data using glob patterns, you include the pattern in the URI of the so
 gs://my-bucket/y=2023/m=01/*.parquet
 `
 
-By default, Rill applies certain limits when using glob patterns to ingest data. The default limits are as follows:
-- **Total size of all matching files**: 10GB
-- **Total file matches**: 1000
-- **Total files listed**: 1 million
+By default, Rill can apply certain limits when using glob patterns to ingest data. The default limits are as follows:
+- **Total size of all matching files**: 100GB
+- **Total file matches**: unlimited
+- **Total files listed**: unlimited
 
 These limits can be configured in the `.yaml` file for the source. To modify the default limits, you can update the `.yaml` file with following fields:
 - `glob.max_total_size`: The maximum total size (in bytes) of all objects. 
 - `glob.max_objects_matched`: The total file matches allowed.
 - `glob.max_objects_listed`: The total files listed to match against the glob pattern. 
 
-For example, to increase the limit on the total bytes downloaded to 100GB, you would add the following line to the `source.yaml` file:
+For example, to set the limit on the total bytes downloaded to 1GB, you would add the following line to the `source.yaml` file:
 ```yaml
-glob.max_total_size: 1073741824000
+glob.max_total_size: 1073741824
 ```
 
 ## Extract policies

--- a/docs/docs/reference/project-files/sources.md
+++ b/docs/docs/reference/project-files/sources.md
@@ -66,15 +66,15 @@ Files that are *nested at any level* under your native `sources` directory will 
 
 **`glob.max_total_size`**
  — Applicable if the URI is a glob pattern. The max allowed total size (in bytes) of all objects matching the glob pattern _(optional)_.
-  - Default value is _`10737418240 (10GB)`_
+  - Default value is _`107374182400 (100GB)`_
 
 **`glob.max_objects_matched`**
  — Applicable if the URI is a glob pattern. The max allowed number of objects matching the glob pattern _(optional)_.
-  - Default value is _`1,000`_
+  - Default value is _`unlimited`_
 
 **`glob.max_objects_listed`**
  — Applicable if the URI is a glob pattern. The max number of objects to list and match against glob pattern, not inclusive of files already excluded by the glob prefix _(optional)_.
-  - Default value is _`1,000,000`_
+  - Default value is _`unlimited`_
 
 **`timeout`**
  — The maximum time to wait for souce ingestion _(optional)_.

--- a/runtime/drivers/blob/blobdownloader.go
+++ b/runtime/drivers/blob/blobdownloader.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -62,14 +63,14 @@ type Options struct {
 // sets defaults if not set by user
 func (opts *Options) validate() {
 	if opts.GlobMaxObjectsMatched == 0 {
-		opts.GlobMaxObjectsMatched = 1000
+		opts.GlobMaxObjectsMatched = math.MaxInt
 	}
 	if opts.GlobMaxObjectsListed == 0 {
-		opts.GlobMaxObjectsListed = 1000 * 1000
+		opts.GlobMaxObjectsListed = math.MaxInt64
 	}
 	if opts.GlobMaxTotalSize == 0 {
-		// 10 GB
-		opts.GlobMaxTotalSize = 10 * 1024 * 1024 * 1024
+		// 100 GB
+		opts.GlobMaxTotalSize = 100 * 1024 * 1024 * 1024
 	}
 	if opts.GlobPageSize == 0 {
 		opts.GlobPageSize = 1000

--- a/runtime/drivers/blob/blobdownloader_test.go
+++ b/runtime/drivers/blob/blobdownloader_test.go
@@ -21,7 +21,7 @@ var filesData = map[string][]byte{
 	"2020/02/04/data.txt": []byte("test"),
 }
 
-const TenGB = 10 * 1024 * 1024
+const TenGB = 10 * 1024 * 1024 * 1024
 
 func TestFetchFileNames(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
By default no limits on files listed and files matched and 100 GB on total size.