### PR TITLE
fix: disable alert/report queries when instanceid undefined

### DIFF
--- a/web-admin/src/features/alerts/selectors.ts
+++ b/web-admin/src/features/alerts/selectors.ts
@@ -13,7 +13,7 @@ export function useAlerts(instanceId: string, enabled = true) {
     },
     {
       query: {
-        enabled,
+        enabled: enabled && !!instanceId,
       },
     },
   );

--- a/web-admin/src/features/scheduled-reports/selectors.ts
+++ b/web-admin/src/features/scheduled-reports/selectors.ts
@@ -14,7 +14,7 @@ export function useReports(instanceId: string, enabled = true) {
     },
     {
       query: {
-        enabled,
+        enabled: enabled && !!instanceId,
       },
     },
   );


### PR DESCRIPTION
`TopNavigationBar` makes use of queries that require the project instance ID, but this components exists outside of the `RuntimeProvider` scope. As such, the instanceId may not initially be set when one arrives at an alert or report page directly.

This is a workaround fix, in my opinion, and a real fix would require a reorganization of the routes and load functions.