### PR TITLE
Add Pylon's new `font-src` to CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,7 +11,7 @@
       frame-ancestors *; \
       object-src 'none'; \
       connect-src https: *.usepylon.com *.posthog.com wss://*.pusher.com; \
-      font-src 'self' https://fonts.gstatic.com;
+      font-src 'self' https://fonts.gstatic.com *.usepylon.com;
       """
     Permissions-Policy = "geolocation=(),midi=(),sync-xhr=(self),microphone=(),camera=(),magnetometer=(),gyroscope=(),fullscreen=(self),payment=()"
     Referrer-Policy = "no-referrer"


### PR DESCRIPTION
Solves this console error:

<img width="808" alt="image" src="https://github.com/rilldata/rill/assets/14206386/972311dc-ed78-40a2-b996-79f347ef4849">
