### PR TITLE
return actual err status from druid resp

### DIFF
--- a/runtime/drivers/druid/druidsqldriver/druid_api_sql_driver.go
+++ b/runtime/drivers/druid/druidsqldriver/druid_api_sql_driver.go
@@ -74,6 +74,10 @@ func (c *sqlConnection) QueryContext(ctx context.Context, query string, args []d
 		return nil, err
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d, status: %s", resp.StatusCode, resp.Status)
+	}
+
 	dec := json.NewDecoder(resp.Body)
 
 	var obj any


### PR DESCRIPTION
Without this it will return non meaningful error while decoding response body