### PR TITLE
use timestamp col with tz for auth code expiration

### DIFF
--- a/admin/database/postgres/migrations/0033.sql
+++ b/admin/database/postgres/migrations/0033.sql
@@ -1,0 +1,1 @@
+ALTER TABLE authorization_codes ALTER COLUMN expires_on TYPE TIMESTAMPTZ;


### PR DESCRIPTION
Overlooked and used `TIMESTAMP` for `expires_on` earlier. This was causing issue with dev env where timezone is behind UTC and auth code would just expire. Won't cause any migration issue on prod as tz is already UTC and anyways we just delete auth codes after use so table should be just empty.