### PR TITLE
fix: metrics view casing

### DIFF
--- a/web-admin/src/features/bookmarks/Bookmarks.svelte
+++ b/web-admin/src/features/bookmarks/Bookmarks.svelte
@@ -101,6 +101,7 @@
       bookmark = detail;
     }}
     on:select={({ detail }) => selectBookmark(detail)}
+    {metricsViewName}
   />
 </DropdownMenu>
 

--- a/web-admin/src/features/bookmarks/Bookmarks.svelte
+++ b/web-admin/src/features/bookmarks/Bookmarks.svelte
@@ -24,7 +24,7 @@
   import { BookmarkIcon } from "lucide-svelte";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
 
-  $: metricsViewName = $page.params.dashboard;
+  export let metricsViewName: string;
 
   let createBookmark = false;
   let editBookmark = false;

--- a/web-admin/src/features/bookmarks/BookmarksDropdownMenuContent.svelte
+++ b/web-admin/src/features/bookmarks/BookmarksDropdownMenuContent.svelte
@@ -20,6 +20,8 @@
   import { createEventDispatcher } from "svelte";
   import HomeBookmarkPlus from "@rilldata/web-common/components/icons/HomeBookmarkPlus.svelte";
 
+  export let metricViewName: string;
+
   const dispatch = createEventDispatcher();
   const queryClient = useQueryClient();
 
@@ -33,7 +35,7 @@
     $runtime?.instanceId,
     organization,
     project,
-    $page.params.dashboard,
+    metricViewName,
   );
   $: filteredBookmarks = searchBookmarks($bookmarks.data, searchText);
 

--- a/web-admin/src/features/bookmarks/BookmarksDropdownMenuContent.svelte
+++ b/web-admin/src/features/bookmarks/BookmarksDropdownMenuContent.svelte
@@ -20,7 +20,7 @@
   import { createEventDispatcher } from "svelte";
   import HomeBookmarkPlus from "@rilldata/web-common/components/icons/HomeBookmarkPlus.svelte";
 
-  export let metricViewName: string;
+  export let metricsViewName: string;
 
   const dispatch = createEventDispatcher();
   const queryClient = useQueryClient();
@@ -35,7 +35,7 @@
     $runtime?.instanceId,
     organization,
     project,
-    metricViewName,
+    metricsViewName,
   );
   $: filteredBookmarks = searchBookmarks($bookmarks.data, searchText);
 

--- a/web-admin/src/features/navigation/TopNavigationBar.svelte
+++ b/web-admin/src/features/navigation/TopNavigationBar.svelte
@@ -176,7 +176,7 @@
         <GlobalDimensionSearch metricsViewName={dashboard} />
         {#if $user.isSuccess && $user.data.user && !onMagicLinkPage}
           <CreateAlert />
-          <Bookmarks />
+          <Bookmarks metricsViewName={dashboard} />
           <ShareDashboardButton {createMagicAuthTokens} />
         {/if}
       </StateManagersProvider>

--- a/web-admin/src/features/shareable-urls/CreateShareableURLForm.svelte
+++ b/web-admin/src/features/shareable-urls/CreateShareableURLForm.svelte
@@ -12,7 +12,7 @@
   import { yup } from "sveltekit-superforms/adapters";
   import { object, string } from "yup";
 
-  $: ({ organization, project, dashboard } = $page.params);
+  $: ({ organization, project } = $page.params);
 
   let token: string;
   let setExpiration = false;
@@ -20,6 +20,8 @@
 
   const {
     dashboardStore,
+
+    metricsViewName,
     selectors: {
       measures: { visibleMeasures },
       dimensions: { visibleDimensions },
@@ -51,7 +53,7 @@
             organization,
             project,
             data: {
-              metricsView: dashboard,
+              metricsView: $metricsViewName,
               metricsViewFilter: hasDashboardWhereFilter()
                 ? $dashboardStore.whereFilter
                 : undefined,
@@ -108,7 +110,7 @@
       {#if hasDashboardWhereFilter()}
         <div>
           <FilterChipsReadOnly
-            metricsViewName={dashboard}
+            metricsViewName={$metricsViewName}
             filters={$dashboardStore.whereFilter}
             dimensionThresholdFilters={[]}
             timeRange={undefined}

--- a/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/[dashboard]/+page.svelte
@@ -16,9 +16,11 @@
 
   $: instanceId = $runtime?.instanceId;
 
-  $: orgName = $page.params.organization;
-  $: projectName = $page.params.project;
-  $: dashboardName = $page.params.dashboard;
+  $: ({
+    organization: orgName,
+    project: projectName,
+    dashboard: dashboardName,
+  } = $page.params);
 
   const user = createAdminServiceGetCurrentUser();
 
@@ -31,7 +33,7 @@
   // from previous valid dashboards, allowing display even when the current dashboard spec is invalid
   // and a meta.reconcileError exists.
   $: isDashboardErrored = !$dashboard.data?.metricsView?.state?.validSpec;
-
+  $: metricViewName = $dashboard.data?.meta.name.name;
   // If no dashboard is found, show a 404 page
   $: if (isDashboardNotFound) {
     errorStore.set({
@@ -59,22 +61,22 @@
 {#if $dashboard.isSuccess}
   {#if isDashboardErrored}
     <ProjectErrored organization={orgName} project={projectName} />
-  {:else}
-    {#key dashboardName}
-      <StateManagersProvider metricsViewName={dashboardName}>
+  {:else if metricViewName}
+    {#key metricViewName}
+      <StateManagersProvider metricsViewName={metricViewName}>
         {#if $user.isSuccess && $user.data.user}
-          <DashboardBookmarksStateProvider metricViewName={dashboardName}>
-            <DashboardURLStateProvider metricViewName={dashboardName}>
+          <DashboardBookmarksStateProvider {metricViewName}>
+            <DashboardURLStateProvider {metricViewName}>
               <DashboardThemeProvider>
-                <Dashboard metricViewName={dashboardName} />
+                <Dashboard {metricViewName} />
               </DashboardThemeProvider>
             </DashboardURLStateProvider>
           </DashboardBookmarksStateProvider>
         {:else}
-          <DashboardStateProvider metricViewName={dashboardName}>
-            <DashboardURLStateProvider metricViewName={dashboardName}>
+          <DashboardStateProvider {metricViewName}>
+            <DashboardURLStateProvider {metricViewName}>
               <DashboardThemeProvider>
-                <Dashboard metricViewName={dashboardName} />
+                <Dashboard {metricViewName} />
               </DashboardThemeProvider>
             </DashboardURLStateProvider>
           </DashboardStateProvider>

--- a/web-common/src/features/dashboards/state-managers/StateManagersProvider.svelte
+++ b/web-common/src/features/dashboards/state-managers/StateManagersProvider.svelte
@@ -12,16 +12,11 @@
   const queryClient = useQueryClient();
   const stateManagers = createStateManagers({
     queryClient,
-    metricsViewName,
+    metricsViewName: metricsViewName,
     extraKeyPrefix:
       orgName && projectName ? `__${orgName}__${projectName}` : "",
   });
   setContext(DEFAULT_STORE_KEY, stateManagers);
-
-  $: {
-    // update metrics view name
-    stateManagers.setMetricsViewName(metricsViewName);
-  }
 </script>
 
 <slot />

--- a/web-common/src/features/dashboards/state-managers/StateManagersProvider.svelte
+++ b/web-common/src/features/dashboards/state-managers/StateManagersProvider.svelte
@@ -12,7 +12,7 @@
   const queryClient = useQueryClient();
   const stateManagers = createStateManagers({
     queryClient,
-    metricsViewName: metricsViewName,
+    metricsViewName,
     extraKeyPrefix:
       orgName && projectName ? `__${orgName}__${projectName}` : "",
   });

--- a/web-common/src/features/dashboards/state-managers/state-managers.ts
+++ b/web-common/src/features/dashboards/state-managers/state-managers.ts
@@ -44,7 +44,6 @@ export type StateManagers = {
     QueryObserverResult<V1MetricsViewTimeRangeResponse, unknown>
   >;
   queryClient: QueryClient;
-  setMetricsViewName: (s: string) => void;
   updateDashboard: DashboardCallbackExecutor;
   /**
    * A collection of Readables that can be used to select data from the dashboard.

--- a/web-common/src/features/dashboards/state-managers/state-managers.ts
+++ b/web-common/src/features/dashboards/state-managers/state-managers.ts
@@ -95,9 +95,19 @@ export function createStateManagers({
       r.instanceId,
       metricViewName,
       ResourceKind.MetricsView,
-      (data) => data.metricsView?.state?.validSpec,
+      undefined,
       queryClient,
-    ).subscribe(set);
+    ).subscribe((result) => {
+      // In case the store was created with a name that has incorrect casing
+      if (result.data?.meta?.name?.name) {
+        metricsViewNameStore.set(result.data.meta.name.name);
+      }
+
+      return set({
+        ...result,
+        data: result.data?.metricsView?.state?.validSpec,
+      });
+    });
   });
 
   const timeRangeSummaryStore: Readable<
@@ -141,9 +151,7 @@ export function createStateManagers({
     timeRangeSummaryStore,
     queryClient,
     dashboardStore,
-    setMetricsViewName: (name) => {
-      metricsViewNameStore.set(name);
-    },
+
     updateDashboard,
     /**
      * A collection of Readables that can be used to select data from the dashboard.

--- a/web-common/src/features/dashboards/stores/dashboard-stores-test-data.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores-test-data.ts
@@ -399,10 +399,11 @@ export function getOffsetByHour(time: Date) {
 export function initStateManagers(
   dashboardFetchMocks?: DashboardFetchMocks,
   resp?: V1MetricsViewSpec,
+  name?: string,
 ) {
   initAdBidsInStore();
   if (dashboardFetchMocks && resp)
-    dashboardFetchMocks.mockMetricsView(AD_BIDS_NAME, resp);
+    dashboardFetchMocks.mockMetricsView(name ?? AD_BIDS_NAME, resp);
 
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -417,7 +418,7 @@ export function initStateManagers(
   });
   const stateManagers = createStateManagers({
     queryClient,
-    metricsViewName: AD_BIDS_NAME,
+    metricsViewName: name ?? AD_BIDS_NAME,
   });
 
   return { stateManagers, queryClient };

--- a/web-common/src/features/dashboards/stores/dashboard-stores.spec.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.spec.ts
@@ -189,7 +189,7 @@ describe("dashboard-stores", () => {
         dimensionsFilter: { toggleDimensionValueSelection },
       },
     } = stateManagers;
-    stateManagers.setMetricsViewName(AD_BIDS_NO_TIMESTAMP_NAME);
+
     metricsExplorerStore.init(
       AD_BIDS_NO_TIMESTAMP_NAME,
       AD_BIDS_INIT,

--- a/web-common/src/features/dashboards/stores/dashboard-stores.spec.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.spec.ts
@@ -183,7 +183,11 @@ describe("dashboard-stores", () => {
 
   it("Should work when time range is not available", () => {
     const AD_BIDS_NO_TIMESTAMP_NAME = "AdBids_no_timestamp";
-    const { stateManagers } = initStateManagers();
+    const { stateManagers } = initStateManagers(
+      undefined,
+      undefined,
+      AD_BIDS_NO_TIMESTAMP_NAME,
+    );
     const {
       actions: {
         dimensionsFilter: { toggleDimensionValueSelection },

--- a/web-local/src/routes/(viz)/+layout.svelte
+++ b/web-local/src/routes/(viz)/+layout.svelte
@@ -45,10 +45,17 @@
     dashboardOptions,
   ];
 
-  $: currentPath = [projectTitle, dashboardName];
+  $: currentPath = [projectTitle, dashboardName.toLowerCase()];
+
+  $: currentDashboard = dashboards.find(
+    (d) => d.meta?.name?.name?.toLowerCase() === dashboardName.toLowerCase(),
+  );
+
+  $: metricsViewName = currentDashboard?.meta?.name?.name;
 </script>
 
 <div class="flex flex-col size-full">
+  {dashboardName}
   <header class="py-3 w-full bg-white flex gap-x-2 items-center px-4 border-b">
     {#if $dashboardsQuery.data}
       <Breadcrumbs {pathParts} {currentPath}>
@@ -60,9 +67,9 @@
     <span class="rounded-full px-2 border text-gray-800 bg-gray-50">
       PREVIEW
     </span>
-    {#if route.id?.includes("dashboard")}
-      <StateManagersProvider metricsViewName={dashboardName}>
-        <DashboardCtAs metricViewName={dashboardName} />
+    {#if route.id?.includes("dashboard") && metricsViewName}
+      <StateManagersProvider {metricsViewName}>
+        <DashboardCtAs metricViewName={metricsViewName} />
       </StateManagersProvider>
     {/if}
   </header>

--- a/web-local/src/routes/(viz)/+layout.svelte
+++ b/web-local/src/routes/(viz)/+layout.svelte
@@ -55,7 +55,6 @@
 </script>
 
 <div class="flex flex-col size-full">
-  {dashboardName}
   <header class="py-3 w-full bg-white flex gap-x-2 items-center px-4 border-b">
     {#if $dashboardsQuery.data}
       <Breadcrumbs {pathParts} {currentPath}>


### PR DESCRIPTION
The purpose of this PR is to make a small step toward disentangling the metricViewName used in various places across the application from the corresponding route parameter in the URL. In practice, this should not be necessary, but this is a quick fix for some upstream issues.

The literal name of a `MetricsView` may be something like `MyDashboard`. The application mostly treats this as case insensitive, so navigating to a dashboard route via `/mydashboard` (or any other variation) will still get you there. However, throughout the FE, the name being passed around sometimes maintains the casing of whatever was typed into the URL rather than the literal name. This can cause issues in places where the case sensitive name is needed (though these should be eliminated).

As such, this makes some minor changes so that the name being passed around is based off the literal name returned by the API resource call. It tries to reduce the use of $page.params to grab it within a component and instead rely on more reliable sources of truth (like prop passing or the global state manager). This was already happening in certain places, but not everywhere. Further cleanup is necessary.

