### PR TITLE
feat: baseUrl loader for vega

### DIFF
--- a/web-common/src/features/charts/render/VegaLiteRenderer.svelte
+++ b/web-common/src/features/charts/render/VegaLiteRenderer.svelte
@@ -2,6 +2,11 @@
   import CancelCircle from "@rilldata/web-common/components/icons/CancelCircle.svelte";
   import { getRillTheme } from "@rilldata/web-common/features/charts/render/vega-config";
   import {
+    JWT,
+    runtime,
+  } from "@rilldata/web-common/runtime-client/runtime-store";
+  import { get } from "svelte/store";
+  import {
     SignalListeners,
     VegaLite,
     View,
@@ -23,6 +28,7 @@
   export let viewVL: View;
 
   let contentRect = new DOMRect(0, 0, 0, 0);
+  let jwt = get(runtime).jwt;
 
   $: width = contentRect.width;
   $: height = contentRect.height * 0.95 - 80;
@@ -41,6 +47,17 @@
     width: customDashboard ? width : undefined,
     expressionFunctions,
     height: chartView || !customDashboard ? undefined : height,
+    loader: {
+      baseURL: `${get(runtime).host}/v1/instances/${get(runtime).instanceId}/assets/`,
+      ...(jwt &&
+        jwt.token && {
+          http: {
+            headers: {
+              Authorization: `Bearer ${jwt.token}`,
+            },
+          },
+        }),
+    },
   };
 
   const onError = (e: CustomEvent<{ error: Error }>) => {


### PR DESCRIPTION
Adds a dynamic base url data loader for vega. It will add JWT auth tokens for Cloud and correctly assume the correct baseUrl depending on env.

Example component
```yaml
type: component

data:
  metrics_sql:
    select id, rate from map

vega_lite: |
  {
    "width": 500,
    "height": 300,
    "data": {
      "url": "public/us-10m.json",
      "format": {
        "type": "topojson",
        "feature": "counties"
      }
    },
    "transform": [{
      "lookup": "id",
      "from": {
        "data": {
          "name": "table"
        },
        "key": "id",
        "fields": ["rate"]
      }
    }],
    "projection": {
      "type": "albersUsa"
    },
    "mark": "geoshape",
    "encoding": {
      "color": {
        "field": "rate",
        "type": "quantitative"
      }
    }
  }