### PR TITLE
Increase model materialize timeout to 60 minutes

### DIFF
--- a/runtime/reconcilers/model.go
+++ b/runtime/reconcilers/model.go
@@ -23,7 +23,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const _defaultModelTimeout = 15 * time.Minute
+const _defaultModelTimeout = 60 * time.Minute
 
 func init() {
 	runtime.RegisterReconcilerInitializer(runtime.ResourceKindModel, newModelReconciler)


### PR DESCRIPTION
Now that more people materialize models and use incremental models, it makes sense for the default timeout to be the same as for source ingestion.