### PR TITLE
Left pad parsed auth token bytes

### DIFF
--- a/admin/pkg/authtoken/authtoken.go
+++ b/admin/pkg/authtoken/authtoken.go
@@ -82,8 +82,10 @@ func FromString(s string) (*Token, error) {
 		return nil, ErrMalformed
 	}
 
-	if len(payload) != 40 {
+	if len(payload) > 40 {
 		return nil, ErrMalformed
+	} else if len(payload) < 40 {
+		payload = padLeft(payload, 40)
 	}
 
 	var id [16]byte
@@ -128,4 +130,16 @@ func unmarshalBase62(s string) ([]byte, bool) {
 		return nil, false
 	}
 	return i.Bytes(), true
+}
+
+// padLeft pads a byte slice with zeros on the left such that its length is n.
+// If the slice is already longer than n, it is returned as is.
+func padLeft(b []byte, n int) []byte {
+	if len(b) >= n {
+		return b
+	}
+
+	padded := make([]byte, n)
+	copy(padded[n-len(b):], b)
+	return padded
 }

--- a/admin/pkg/authtoken/authtoken_test.go
+++ b/admin/pkg/authtoken/authtoken_test.go
@@ -54,3 +54,47 @@ func TestValidity(t *testing.T) {
 		require.Equal(t, ErrMalformed, err)
 	}
 }
+
+func TestNull(t *testing.T) {
+	tkn := Token{
+		Type:   TypeUser,
+		ID:     uuid.UUID{},
+		Secret: [24]byte{},
+	}
+
+	str := tkn.String()
+
+	parsed, err := FromString(str)
+	require.NoError(t, err)
+	require.Equal(t, tkn.Type, parsed.Type)
+	require.Equal(t, tkn.ID, parsed.ID)
+	require.Equal(t, tkn.Secret, parsed.Secret)
+}
+
+func TestPartiallyNull(t *testing.T) {
+	secret := [24]byte{}
+	secret[23] = 0x01
+
+	tkn := Token{
+		Type:   TypeUser,
+		ID:     uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+		Secret: secret,
+	}
+
+	str := tkn.String()
+
+	parsed, err := FromString(str)
+	require.NoError(t, err)
+	require.Equal(t, tkn.Type, parsed.Type)
+	require.Equal(t, tkn.ID, parsed.ID)
+	require.Equal(t, tkn.Secret, parsed.Secret)
+}
+
+func TestMany(t *testing.T) {
+	for i := 0; i < 100000; i++ {
+		tkn := NewRandom(TypeDeployment)
+		str := tkn.String()
+		_, err := FromString(str)
+		require.NoError(t, err)
+	}
+}


### PR DESCRIPTION
Access tokens in Rill follow the format `rill_<type>_<base62(payload)>` where the payload contains the token's ID (16 bytes) and randomly generated secret (24 bytes). 

The `base62` implementation drops leading `0x00` bytes, which means that on average 1 out of every 256 tokens can't be parsed. This PR fixes this issue by left-padding the parsed payload with `0x00`.

It also adds a test that generates 100000 random tokens and tests that they parse correctly to prevent such errors from occurring again.