### PR TITLE
Upgrade to DuckDB 1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/lensesio/tableprinter v0.0.0-20201125135848-89e81fc956e7
-	github.com/marcboeker/go-duckdb v1.6.4
+	github.com/marcboeker/go-duckdb v1.7.0
 	github.com/mazznoer/csscolorparser v0.1.3
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/mitchellh/mapstructure v1.5.0
@@ -338,9 +338,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-// Workaround for https://github.com/marcboeker/go-duckdb/issues/215
-replace github.com/marcboeker/go-duckdb v1.6.4 => github.com/rilldata/go-duckdb v0.0.0-20240521113010-0a4610c39d2c
 
 // Fixes a security warning. Remove when testcontainers-go v0.27.0 is released.
 replace github.com/testcontainers/testcontainers-go v0.26.0 => github.com/testcontainers/testcontainers-go v0.26.1-0.20231102155908-6aac7412c81a

--- a/go.sum
+++ b/go.sum
@@ -1679,6 +1679,8 @@ github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/marcboeker/go-duckdb v1.7.0 h1:c9DrS13ta+gqVgg9DiEW8I+PZBE85nBMLL/YMooYoUY=
+github.com/marcboeker/go-duckdb v1.7.0/go.mod h1:WtWeqqhZoTke/Nbd7V9lnBx7I2/A/q0SAq/urGzPCMs=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
@@ -1960,8 +1962,6 @@ github.com/richardlehane/msoleps v1.0.3 h1:aznSZzrwYRl3rLKRT3gUk9am7T/mLNSnJINvN
 github.com/richardlehane/msoleps v1.0.3/go.mod h1:BWev5JBpU9Ko2WAgmZEuiz4/u3ZYTKbjLycmwiWUfWg=
 github.com/rilldata/arrow/go/v14 v14.0.0-20240624035703-e234e04219ff h1:Tt67B9BQVkymWsosWgz7vyz8MXnlYzc8xbqtxYuPU1s=
 github.com/rilldata/arrow/go/v14 v14.0.0-20240624035703-e234e04219ff/go.mod h1:u3fgh3EdgN/YQ8cVQRguVW3R+seMybFg8QBQ5LU+eBY=
-github.com/rilldata/go-duckdb v0.0.0-20240521113010-0a4610c39d2c h1:kFD7bfdxkYYAT1h3HhV9sm6WHw4dmyBUxEKAuftqEdc=
-github.com/rilldata/go-duckdb v0.0.0-20240521113010-0a4610c39d2c/go.mod h1:WtWeqqhZoTke/Nbd7V9lnBx7I2/A/q0SAq/urGzPCMs=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/runtime/pkg/duckdbsql/ast_test.go
+++ b/runtime/pkg/duckdbsql/ast_test.go
@@ -203,9 +203,9 @@ with pivot_alias as (
 )
 select * from pivot_alias join unpivot_alias on pivot_alias.id=unpivot_alias.id`,
 			[]*TableRef{
-				{Name: "Users"},
-				{Name: "AdImpressions"},
 				{Name: "AdBids"},
+				{Name: "AdImpressions"},
+				{Name: "Users"},
 				{Name: "pivot_alias", LocalAlias: true},
 				{Name: "unpivot_alias", LocalAlias: true},
 			},
@@ -438,7 +438,7 @@ with
 select col1 from tbl2 join tbl3 on tbl2.id = tbl3.id
 `,
 			[]string{"AB", "AI", "tbl2", "tbl3"},
-			`WITH tbl2 AS (SELECT col1 FROM AI AS a), tbl3 AS (SELECT col1 FROM AB AS i)SELECT col1 FROM tbl2 INNER JOIN tbl3 ON ((tbl2.id = tbl3.id))`,
+			`WITH tbl2 AS (SELECT col1 FROM AB AS a), tbl3 AS (SELECT col1 FROM AI AS i)SELECT col1 FROM tbl2 INNER JOIN tbl3 ON ((tbl2.id = tbl3.id))`,
 		},
 		{
 			"table references with CTEs and unions",
@@ -449,7 +449,7 @@ with
 select col1 from tbl2 union all select col1 from tbl3 union all select col1 from "s3://data/AdBid_July.csv"
 `,
 			[]string{"A_M", "A_J", "tbl2", "tbl3", "A_Jl"},
-			`WITH tbl2 AS (SELECT col1 FROM A_J AS a), tbl3 AS (SELECT col1 FROM A_M AS i)((SELECT col1 FROM tbl2) UNION ALL (SELECT col1 FROM tbl3)) UNION ALL (SELECT col1 FROM A_Jl)`,
+			`WITH tbl2 AS (SELECT col1 FROM A_M AS a), tbl3 AS (SELECT col1 FROM A_J AS i)((SELECT col1 FROM tbl2) UNION ALL (SELECT col1 FROM tbl3)) UNION ALL (SELECT col1 FROM A_Jl)`,
 		},
 	}
 


### PR DESCRIPTION
Closes #5052

The workaround is no longer needed. [The issue](https://github.com/marcboeker/go-duckdb/issues/215) is fixed