### PR TITLE
Runtime: Fix for inserting NULL UUIDs from SQL Stores

### DIFF
--- a/runtime/drivers/duckdb/transporter_sqlstore_to_duckDB.go
+++ b/runtime/drivers/duckdb/transporter_sqlstore_to_duckDB.go
@@ -229,6 +229,9 @@ func CreateTableQuery(schema *runtimev1.StructType, name string) (string, error)
 
 func convert(row []driver.Value, schema *runtimev1.StructType) error {
 	for i, v := range row {
+		if v == nil {
+			continue
+		}
 		if schema.Fields[i].Type.Code == runtimev1.Type_CODE_UUID {
 			val, ok := v.([16]byte)
 			if !ok {

--- a/runtime/drivers/postgres/sql_store.go
+++ b/runtime/drivers/postgres/sql_store.go
@@ -115,11 +115,11 @@ func (r *rowIterator) Next(ctx context.Context) ([]sqldriver.Value, error) {
 	}
 
 	for i := range r.schema.Fields {
-		mapper := r.fieldMappers[i]
 		if vals[i] == nil {
 			r.row[i] = nil
 			continue
 		}
+		mapper := r.fieldMappers[i]
 		r.row[i], err = mapper.value(vals[i])
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
NOTE : Inserting null UUIDs fails in the latest version of `go-duckdb` but fixed on main. So as of now inserting null UUIDs will fail.