### PR TITLE
fix: disable typeahead when calendar picker open

### DIFF
--- a/web-common/src/features/dashboards/time-controls/super-pill/components/Comparison.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/Comparison.svelte
@@ -88,6 +88,7 @@
       comparisonOption === TimeComparisonOption.CUSTOM && showComparison
     );
   }}
+  typeahead={!showSelector}
 >
   <DropdownMenu.Trigger asChild let:builder>
     <button

--- a/web-common/src/features/dashboards/time-controls/super-pill/components/RangePicker.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/RangePicker.svelte
@@ -36,6 +36,7 @@
     showSelector = selected === "CUSTOM";
   }}
   closeOnItemClick={false}
+  typeahead={!showSelector}
 >
   <DropdownMenu.Trigger asChild let:builder>
     <button


### PR DESCRIPTION
This PR disables the typeahead functionality of the dropdown menu when the custom calendar picker is open. This was previously causing issues with the date input.