### PR TITLE
fix: temporary mutual exclusivity of time and dimension comparison

### DIFF
--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -479,6 +479,7 @@ const metricViewReducers = {
   displayTimeComparison(name: string, showTimeComparison: boolean) {
     updateMetricsExplorerByName(name, (metricsExplorer) => {
       metricsExplorer.showTimeComparison = showTimeComparison;
+      metricsExplorer.selectedComparisonDimension = undefined;
     });
   },
 


### PR DESCRIPTION
Turning on time comparison was not turning off dimension breakdown.