### PR TITLE
tweak: rill developer header sizing

### DIFF
--- a/web-common/src/app.css
+++ b/web-common/src/app.css
@@ -214,7 +214,7 @@ body {
   --monospace: 'Source Code Variable';
   margin: 0;
   padding: 0;
-  --header-height: 52px;
+  --header-height: 44px;
   --right-drawer-width: 400px;
 
   --left-sidebar-width: 400px;

--- a/web-common/src/features/project/ProjectTitle.svelte
+++ b/web-common/src/features/project/ProjectTitle.svelte
@@ -18,7 +18,7 @@
   $: ({ data: title } = $projectTitle);
 </script>
 
-<header class="pl-3 pt-4 flex-none" style:height="var(--header-height)">
+<header class="pl-3 items-center flex flex-none">
   <div class="link-wrapper">
     <a href="/" class="project-square">
       {shorthandTitle(title ?? "Rill")}
@@ -61,6 +61,9 @@
 </header>
 
 <style lang="postcss">
+  header {
+    height: var(--header-height);
+  }
   .project-square {
     @apply relative;
     @apply h-5 aspect-square grid place-items-center rounded;

--- a/web-common/src/layout/navigation/Navigation.svelte
+++ b/web-common/src/layout/navigation/Navigation.svelte
@@ -62,7 +62,7 @@
   <div class="inner" style:width="{width}px">
     <ProjectTitle {unsavedFileCount} />
 
-    <div class="p-2 w-full">
+    <div class="p-2 pt-1 w-full">
       <AddAssetButton />
     </div>
     <div class="scroll-container">

--- a/web-common/src/layout/navigation/SurfaceControlButton.svelte
+++ b/web-common/src/layout/navigation/SurfaceControlButton.svelte
@@ -43,7 +43,7 @@
 <style lang="postcss">
   button {
     @apply rounded flex justify-center items-center absolute;
-    @apply w-6 h-6 mt-[13px];
+    @apply w-6 h-6 mt-[10px];
     transition-property: left;
   }
 

--- a/web-common/src/layout/workspace/WorkspaceHeader.svelte
+++ b/web-common/src/layout/workspace/WorkspaceHeader.svelte
@@ -105,6 +105,7 @@
   input,
   label {
     @apply whitespace-pre rounded border-2 border-transparent;
+    @apply truncate;
   }
 
   input {
@@ -118,7 +119,7 @@
 
   header {
     @apply justify-between;
-    @apply flex items-center pl-4 border-b border-gray-300 overflow-hidden;
+    @apply flex items-center pl-4 py-2 border-b border-gray-300 overflow-hidden;
     height: var(--header-height);
   }
 


### PR DESCRIPTION
Before:
<img width="1189" alt="Screenshot 2024-07-24 at 7 13 35 PM" src="https://github.com/user-attachments/assets/0804ee61-ba9f-4af5-9cc2-208a65c79170">

After:
<img width="1189" alt="Screenshot 2024-07-24 at 7 12 06 PM" src="https://github.com/user-attachments/assets/220243c8-70a3-4730-bd37-6c2fee3cefbc">
