### PR TITLE
Cancel drag events of directory/file when the native context menu is opened

### DIFF
--- a/web-common/src/features/file-explorer/NavDirectory.svelte
+++ b/web-common/src/features/file-explorer/NavDirectory.svelte
@@ -32,6 +32,7 @@
   class:bg-slate-100={isDragDropHover}
   on:mouseenter={() => navEntryDragDropStore.onMouseEnter(directory.path)}
   on:mouseleave={() => navEntryDragDropStore.onMouseLeave()}
+  on:contextmenu={() => navEntryDragDropStore.resetDrag()}
 >
   {#if directory.path !== "/"}
     <NavDirectoryEntry dir={directory} {onDelete} {onMouseDown} {onRename} />

--- a/web-common/src/features/file-explorer/nav-entry-drag-drop-store.ts
+++ b/web-common/src/features/file-explorer/nav-entry-drag-drop-store.ts
@@ -72,7 +72,7 @@ export class NavEntryDragDropStore {
     if (get(this.dragData)) return;
     const dist = Math.sqrt(
       Math.pow(left - this.initialPosition.left, 2) +
-      Math.pow(top - this.initialPosition.top, 2),
+        Math.pow(top - this.initialPosition.top, 2),
     );
     if (dist < NavEntryDragDropStore.MIN_DRAG_DISTANCE) return;
     this.dragData.set(this.newDragData);

--- a/web-common/src/features/file-explorer/nav-entry-drag-drop-store.ts
+++ b/web-common/src/features/file-explorer/nav-entry-drag-drop-store.ts
@@ -60,8 +60,7 @@ export class NavEntryDragDropStore {
       await dropSuccess(curDragData.filePath, toDir);
     }
 
-    this.newDragData = null;
-    this.dragData.set(null);
+    this.resetDrag()
   }
 
   public onMouseMove(e: MouseEvent) {
@@ -96,6 +95,11 @@ export class NavEntryDragDropStore {
       d.pop();
       return d;
     });
+  }
+
+  public resetDrag() {
+    this.newDragData = null;
+    this.dragData.set(null);
   }
 
   private getOffsets(e: MouseEvent, dragData: NavDragData) {

--- a/web-common/src/features/file-explorer/nav-entry-drag-drop-store.ts
+++ b/web-common/src/features/file-explorer/nav-entry-drag-drop-store.ts
@@ -60,7 +60,7 @@ export class NavEntryDragDropStore {
       await dropSuccess(curDragData.filePath, toDir);
     }
 
-    this.resetDrag()
+    this.resetDrag();
   }
 
   public onMouseMove(e: MouseEvent) {
@@ -72,7 +72,7 @@ export class NavEntryDragDropStore {
     if (get(this.dragData)) return;
     const dist = Math.sqrt(
       Math.pow(left - this.initialPosition.left, 2) +
-        Math.pow(top - this.initialPosition.top, 2),
+      Math.pow(top - this.initialPosition.top, 2),
     );
     if (dist < NavEntryDragDropStore.MIN_DRAG_DISTANCE) return;
     this.dragData.set(this.newDragData);


### PR DESCRIPTION
This PR removes the dangling directory/file when the native context menu is opened.

https://github.com/user-attachments/assets/e0df81d0-0036-4a2c-9d77-a784eb0ff67f

closes #5337