### PR TITLE
Remove ReadProfiling and ReadRepo permissions from JWTs

### DIFF
--- a/admin/server/deployment.go
+++ b/admin/server/deployment.go
@@ -192,11 +192,8 @@ func (s *Server) GetDeploymentCredentials(ctx context.Context, req *adminv1.GetD
 		TTL:         ttlDuration,
 		InstancePermissions: map[string][]runtimeauth.Permission{
 			prodDepl.RuntimeInstanceID: {
-				// TODO: Remove ReadProfiling and ReadRepo (may require frontend changes)
 				runtimeauth.ReadObjects,
 				runtimeauth.ReadMetrics,
-				runtimeauth.ReadProfiling,
-				runtimeauth.ReadRepo,
 				runtimeauth.ReadAPI,
 			},
 		},
@@ -289,11 +286,8 @@ func (s *Server) GetIFrame(ctx context.Context, req *adminv1.GetIFrameRequest) (
 		TTL:         ttlDuration,
 		InstancePermissions: map[string][]runtimeauth.Permission{
 			prodDepl.RuntimeInstanceID: {
-				// TODO: Remove ReadProfiling and ReadRepo (may require frontend changes)
 				runtimeauth.ReadObjects,
 				runtimeauth.ReadMetrics,
-				runtimeauth.ReadProfiling,
-				runtimeauth.ReadRepo,
 				runtimeauth.ReadAPI,
 			},
 		},

--- a/admin/server/projects.go
+++ b/admin/server/projects.go
@@ -217,11 +217,8 @@ func (s *Server) GetProject(ctx context.Context, req *adminv1.GetProjectRequest)
 		TTL:         ttlDuration,
 		InstancePermissions: map[string][]runtimeauth.Permission{
 			depl.RuntimeInstanceID: {
-				// TODO: Remove ReadProfiling and ReadRepo (may require frontend changes)
 				runtimeauth.ReadObjects,
 				runtimeauth.ReadMetrics,
-				runtimeauth.ReadProfiling,
-				runtimeauth.ReadRepo,
 				runtimeauth.ReadAPI,
 			},
 		},

--- a/admin/server/runtime_proxy.go
+++ b/admin/server/runtime_proxy.go
@@ -74,11 +74,8 @@ func (s *Server) runtimeProxyForOrgAndProject(w http.ResponseWriter, r *http.Req
 			TTL:         runtimeAccessTokenDefaultTTL,
 			InstancePermissions: map[string][]runtimeauth.Permission{
 				depl.RuntimeInstanceID: {
-					// TODO: Remove ReadProfiling and ReadRepo (may require frontend changes)
 					runtimeauth.ReadObjects,
 					runtimeauth.ReadMetrics,
-					runtimeauth.ReadProfiling,
-					runtimeauth.ReadRepo,
 					runtimeauth.ReadAPI,
 				},
 			},


### PR DESCRIPTION
FYI, I cannot reproduce any errors relevant to removal of above permissions, did I miss something? I tested running `runtime` and `devtool-cloud`

Closes https://github.com/rilldata/rill-private-issues/issues/484