### PR TITLE
Deprecate the `ignore:` setting for dimensions and measures

### DIFF
--- a/docs/docs/reference/olap-engines/pinot.md
+++ b/docs/docs/reference/olap-engines/pinot.md
@@ -83,7 +83,6 @@ Multi-Valued dimensions needed to be defined in the dashboard yaml as expression
   expression: arrayToMv(RandomAirports)
   name: RandomAirports
   description: "Random Airports"
-  ignore: false
 ```
 Refer to the [Dashboard YAML](../project-files/dashboards) reference page for all dimension properties detail. 
 

--- a/docs/docs/reference/project-files/dashboards.md
+++ b/docs/docs/reference/project-files/dashboards.md
@@ -53,14 +53,12 @@ Files that are *nested at any level* under your native `dashboards` directory wi
   - **`label`** — a label for your dashboard dimension _(optional)_ 
   - **`description`** — a freeform text description of the dimension for your dashboard _(optional)_
   - **`unnest`** - if true, allows multi-valued dimension to be unnested (such as lists) and filters will automatically switch to "contains" instead of exact match _(optional)_
-  - **`ignore`** — hides the dimension _(optional)_ 
 
 **`measures`** — Used to define the numeric [aggregates](/build/dashboards/dashboards.md#measures) of columns from your data model  _(required)_.
   - **`expression`** — a combination of operators and functions for aggregations _(required)_ 
   - **`name`** — a stable identifier for the measure _(required)_
   - **`label`** — a label for your dashboard measure _(optional)_ 
   - **`description`** — a freeform text description of the dimension for your dashboard _(optional)_ 
-  - **`ignore`** — hides the measure _(optional)_ 
   - **`valid_percent_of_total`** — a boolean indicating whether percent-of-total values should be rendered for this measure _(optional)_ 
   - **`format_d3`** — controls the formatting of this measure in the dashboard using a [d3-format string](https://d3js.org/d3-format). If an invalid format string is supplied, measures will be formatted with `format_preset: humanize` (described below). Measures <u>cannot</u> have both `format_preset` and `format_d3` entries. _(optional; if neither `format_preset` nor `format_d3` is supplied, measures will be formatted with the `humanize` preset)_
     - **Example**: to show a measure using fixed point formatting with 2 digits after the decimal point, your measure specification would include: `format_d3: ".2f"`.

--- a/runtime/compilers/rillv1/parse_metrics_view.go
+++ b/runtime/compilers/rillv1/parse_metrics_view.go
@@ -38,7 +38,7 @@ type MetricsViewYAML struct {
 		Expression  string
 		Property    string // For backwards compatibility
 		Description string
-		Ignore      bool `yaml:"ignore"`
+		Ignore      bool `yaml:"ignore"` // Deprecated
 		Unnest      bool
 		URI         string
 	}
@@ -54,7 +54,7 @@ type MetricsViewYAML struct {
 		Description         string
 		FormatPreset        string `yaml:"format_preset"`
 		FormatD3            string `yaml:"format_d3"`
-		Ignore              bool   `yaml:"ignore"`
+		Ignore              bool   `yaml:"ignore"` // Deprecated
 		ValidPercentOfTotal bool   `yaml:"valid_percent_of_total"`
 	}
 	DefaultMeasures   []string `yaml:"default_measures"`


### PR DESCRIPTION
Closes https://github.com/rilldata/rill/issues/5268