### PR TITLE
Disable big number tooltip in expanded time series metrics

### DIFF
--- a/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
@@ -80,6 +80,11 @@
   }
 
   let suppressTooltip = false;
+
+  const handleExpandMeasure = () => {
+    isMeasureExpanded = !isMeasureExpanded;
+    dispatch("expand-measure");
+  };
 </script>
 
 <Tooltip
@@ -106,7 +111,7 @@
       shift: () => shiftClickHandler(hoveredValue),
       click: () => {
         suppressTooltip = true;
-        dispatch("expand-measure");
+        handleExpandMeasure();
         setTimeout(() => {
           suppressTooltip = false;
         }, 1000);

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -372,7 +372,6 @@
           <MeasureBigNumber
             {measure}
             value={bigNum}
-            isMeasureExpanded={isInTimeDimensionView}
             {showComparison}
             {comparisonValue}
             errorMessage={$timeSeriesDataStore?.error?.totals}

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -372,6 +372,7 @@
           <MeasureBigNumber
             {measure}
             value={bigNum}
+            isMeasureExpanded={isInTimeDimensionView}
             {showComparison}
             {comparisonValue}
             errorMessage={$timeSeriesDataStore?.error?.totals}


### PR DESCRIPTION
Disable the big number tooltip when switching between Overview and Measure views. Fixes #5352

See before: https://github.com/rilldata/rill/issues/5352#issue-2438372614

After

https://github.com/user-attachments/assets/725aa77e-46bf-4f9c-80d5-dc889e52e40e

