### PR TITLE
fix: Avoid showing the spinner on the avatar every time the page is focused.

### DIFF
--- a/web-common/src/features/authentication/LocalAvatarButton.svelte
+++ b/web-common/src/features/authentication/LocalAvatarButton.svelte
@@ -17,7 +17,7 @@
   $: loggedIn = $user.isSuccess && $user.data?.user;
 </script>
 
-{#if ($user.isFetching || $deployValidation.isFetching) && !$user.error && !$deployValidation.error}
+{#if ($user.isLoading || $deployValidation.isLoading) && !$user.error && !$deployValidation.error}
   <div class="flex flex-row items-center h-7 mx-1.5">
     <Spinner size="16px" status={EntityStatus.Running} />
   </div>


### PR DESCRIPTION
Move from `isFetching` to `isLoading` to avoid showing a spinner every time we refetch user state.