### PR TITLE
fix: remove z-index for leaderboard rows

### DIFF
--- a/web-common/src/components/dialog-v2/dialog-overlay.svelte
+++ b/web-common/src/components/dialog-v2/dialog-overlay.svelte
@@ -17,7 +17,7 @@
   {transition}
   {transitionConfig}
   class={cn(
-    "fixed inset-0 bg-gray-400 transition-opacity opacity-40 z-10",
+    "fixed inset-0 bg-gray-400 transition-opacity opacity-40",
     className,
   )}
   {...$$restProps}

--- a/web-common/src/components/dialog-v2/dialog-overlay.svelte
+++ b/web-common/src/components/dialog-v2/dialog-overlay.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
+  import { cn } from "@rilldata/web-common/lib/shadcn";
   import { Dialog as DialogPrimitive } from "bits-ui";
   import { fade } from "svelte/transition";
-  import { cn } from "@rilldata/web-common/lib/shadcn";
 
   type $$Props = DialogPrimitive.OverlayProps;
 
@@ -17,7 +17,7 @@
   {transition}
   {transitionConfig}
   class={cn(
-    "fixed inset-0 bg-gray-400 transition-opacity opacity-40 ",
+    "fixed inset-0 bg-gray-400 transition-opacity opacity-40 z-10",
     className,
   )}
   {...$$restProps}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
-  import { clamp } from "@rilldata/web-common/lib/clamp";
-  import LeaderboardItemFilterIcon from "./LeaderboardItemFilterIcon.svelte";
   import FormattedDataType from "@rilldata/web-common/components/data-types/FormattedDataType.svelte";
-  import { LeaderboardItemData } from "./leaderboard-utils";
-  import { getStateManagers } from "../state-managers/state-managers";
-  import { copyToClipboard } from "@rilldata/web-common/lib/actions/copy-to-clipboard";
-  import { TOOLTIP_STRING_LIMIT } from "@rilldata/web-common/layout/config";
-  import { modified } from "@rilldata/web-common/lib/actions/modified-click";
-  import LeaderboardTooltipContent from "./LeaderboardTooltipContent.svelte";
-  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
-  import { formatMeasurePercentageDifference } from "@rilldata/web-common/lib/number-formatting/percentage-formatter";
   import PercentageChange from "@rilldata/web-common/components/data-types/PercentageChange.svelte";
-  import LongBarZigZag from "./LongBarZigZag.svelte";
-  import { slide } from "svelte/transition";
   import ExternalLink from "@rilldata/web-common/components/icons/ExternalLink.svelte";
+  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
+  import { TOOLTIP_STRING_LIMIT } from "@rilldata/web-common/layout/config";
+  import { copyToClipboard } from "@rilldata/web-common/lib/actions/copy-to-clipboard";
+  import { modified } from "@rilldata/web-common/lib/actions/modified-click";
+  import { clamp } from "@rilldata/web-common/lib/clamp";
+  import { formatMeasurePercentageDifference } from "@rilldata/web-common/lib/number-formatting/percentage-formatter";
+  import { slide } from "svelte/transition";
+  import { getStateManagers } from "../state-managers/state-managers";
+  import { LeaderboardItemData } from "./leaderboard-utils";
+  import LeaderboardItemFilterIcon from "./LeaderboardItemFilterIcon.svelte";
+  import LeaderboardTooltipContent from "./LeaderboardTooltipContent.svelte";
+  import LongBarZigZag from "./LongBarZigZag.svelte";
 
   export let itemData: LeaderboardItemData;
   export let dimensionName: string;
@@ -253,7 +253,7 @@
 
 <style lang="postcss">
   td {
-    @apply text-right p-0 z-10;
+    @apply text-right p-0;
     @apply px-2  relative;
     height: 22px;
   }


### PR DESCRIPTION
When opening the Alert Dialog, parts of leaderboards are visible over the alert backdrop.
This PR removed the z-index from the leaderboard rows

Before
![image](https://github.com/user-attachments/assets/fd0e626c-0b63-4577-b002-d8aa63e168e4)

After
![image](https://github.com/user-attachments/assets/8627f072-9b61-457d-8b98-b7d17b8aca83)
