### PR TITLE
fix: onboarding screen being shown again even after creating a project

### DIFF
--- a/web-common/src/features/welcome/is-project-initialized.ts
+++ b/web-common/src/features/welcome/is-project-initialized.ts
@@ -6,12 +6,13 @@ import {
   runtimeServiceUnpackEmpty,
 } from "@rilldata/web-common/runtime-client";
 import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
+import { fetchQueryWithRetry } from "@rilldata/web-common/runtime-client/fetchQueryWithRetry";
 import { EMPTY_PROJECT_TITLE } from "./constants";
 import { writable } from "svelte/store";
 
 export async function isProjectInitialized(instanceId: string) {
   try {
-    const files = await queryClient.fetchQuery<V1ListFilesResponse>({
+    const files = await fetchQueryWithRetry<V1ListFilesResponse>(queryClient, {
       queryKey: getRuntimeServiceListFilesQueryKey(instanceId, undefined),
       queryFn: ({ signal }) => {
         return runtimeServiceListFiles(instanceId, undefined, signal);
@@ -20,7 +21,7 @@ export async function isProjectInitialized(instanceId: string) {
 
     // Return true if `rill.yaml` exists, else false
     return !!files.files?.some(({ path }) => path === "/rill.yaml");
-  } catch {
+  } catch (e) {
     return false;
   }
 }

--- a/web-common/src/runtime-client/fetchQueryWithRetry.ts
+++ b/web-common/src/runtime-client/fetchQueryWithRetry.ts
@@ -1,0 +1,28 @@
+import { asyncWait } from "@rilldata/web-common/lib/waitUtils";
+import { FetchQueryOptions } from "@tanstack/query-core";
+import { QueryClient, QueryKey } from "@tanstack/svelte-query";
+
+/**
+ * A query cancellation due to a possible unmount will not retry `fetchQuery` even if `retry` is set.
+ * This wraps it with an explicit retry.
+ */
+export async function fetchQueryWithRetry<T>(
+  queryClient: QueryClient,
+  args: FetchQueryOptions<T, unknown, T, QueryKey>,
+  retryCount = 3,
+  retryDelay = 100,
+) {
+  let lastErr;
+  for (let c = 0; c < retryCount; c++) {
+    try {
+      return await queryClient.fetchQuery<T>(args);
+    } catch (e) {
+      if (c < retryCount - 1) {
+        // wait for some time before retrying
+        await asyncWait(retryDelay * (c + 1));
+      }
+      lastErr = e;
+    }
+  }
+  throw lastErr;
+}


### PR DESCRIPTION
We seem to have a fetch to files as a `queryClient.fetchQuery`. If this fails for any reason we redirect the user back to onboarding screen. In some cases the query is being cancelled which also triggers this flow. But adding a `retry` doesnt seem to be honoured when the query is cancelled.

Wrapping the fetch with a retry to fix this.