### PR TITLE
chore: apply vega expr to avoid eval

### DIFF
--- a/web-common/src/features/charts/render/VegaLiteRenderer.svelte
+++ b/web-common/src/features/charts/render/VegaLiteRenderer.svelte
@@ -10,6 +10,7 @@
     VisualizationSpec,
     type EmbedOptions,
   } from "svelte-vega";
+  import { expressionInterpreter } from "vega-interpreter";
   import { ExpressionFunction, VLTooltipFormatter } from "../types";
   import { VegaLiteTooltipHandler } from "./vega-tooltip";
 
@@ -43,6 +44,7 @@
     logLevel: 0, // only show errors
     width: customDashboard ? width : undefined,
     expressionFunctions,
+    expr: expressionInterpreter,
     height: chartView || !customDashboard ? undefined : height,
     loader: {
       baseURL: `${get(runtime).host}/v1/instances/${get(runtime).instanceId}/assets/`,


### PR DESCRIPTION
### Description

Apply [Vega Expr Interpreter](https://vega.github.io/vega/usage/interpreter/) to resolve the violation of the security policy `unsafe-eval`.

### Motivation

This is a follow up from https://github.com/rilldata/rill/pull/4784 and an attempt to help apply more strict CSP policies to protect rill cloud endpoints.