### PR TITLE
fix: Misc design changes for the new deploy flow

### DIFF
--- a/runtime/pkg/email/templates/alert_fail.mjml
+++ b/runtime/pkg/email/templates/alert_fail.mjml
@@ -47,7 +47,7 @@
         </mj-text>
         
         <mj-text align="center" font-size="12px" line-height="1.5">
-          © 2023 Rill Data, Inc<br />
+          © 2024 Rill Data, Inc<br />
           18 Bartol St. • San Francisco • CA<br />
           <a href="https://www.rilldata.com/contact">Contact us</a> •
           <a href="https://bit.ly/3unvA05">Community</a> •

--- a/runtime/pkg/email/templates/alert_status.mjml
+++ b/runtime/pkg/email/templates/alert_status.mjml
@@ -47,7 +47,7 @@
         </mj-text>
         
         <mj-text align="center" font-size="12px" line-height="1.5">
-          © 2023 Rill Data, Inc<br />
+          © 2024 Rill Data, Inc<br />
           18 Bartol St. • San Francisco • CA<br />
           <a href="https://www.rilldata.com/contact">Contact us</a> •
           <a href="https://bit.ly/3unvA05">Community</a> •

--- a/runtime/pkg/email/templates/call_to_action.mjml
+++ b/runtime/pkg/email/templates/call_to_action.mjml
@@ -37,7 +37,7 @@
         <mj-spacer height="20px" />
 
         <mj-text align="center" font-size="12px" line-height="1.5">
-          © 2023 Rill Data, Inc<br />
+          © 2024 Rill Data, Inc<br />
           18 Bartol St. • San Francisco • CA<br />
           <a href="https://www.rilldata.com/contact">Contact us</a> •
           <a href="https://bit.ly/3unvA05">Community</a> •

--- a/runtime/pkg/email/templates/gen/alert_fail.html
+++ b/runtime/pkg/email/templates/gen/alert_fail.html
@@ -179,7 +179,7 @@
                     </tr>
                     <tr>
                       <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2023 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
+                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2024 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
                           <a href="https://www.rilldata.com/contact">Contact us</a> • <a href="https://bit.ly/3unvA05">Community</a> • <a href="https://www.rilldata.com/legal/privacy">Privacy Policy</a>
                         </div>
                       </td>

--- a/runtime/pkg/email/templates/gen/alert_status.html
+++ b/runtime/pkg/email/templates/gen/alert_status.html
@@ -172,7 +172,7 @@
                     </tr>
                     <tr>
                       <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2023 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
+                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2024 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
                           <a href="https://www.rilldata.com/contact">Contact us</a> • <a href="https://bit.ly/3unvA05">Community</a> • <a href="https://www.rilldata.com/legal/privacy">Privacy Policy</a>
                         </div>
                       </td>

--- a/runtime/pkg/email/templates/gen/call_to_action.html
+++ b/runtime/pkg/email/templates/gen/call_to_action.html
@@ -169,7 +169,7 @@
                     </tr>
                     <tr>
                       <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2023 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
+                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2024 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
                           <a href="https://www.rilldata.com/contact">Contact us</a> • <a href="https://bit.ly/3unvA05">Community</a> • <a href="https://www.rilldata.com/legal/privacy">Privacy Policy</a>
                         </div>
                       </td>

--- a/runtime/pkg/email/templates/gen/informational.html
+++ b/runtime/pkg/email/templates/gen/informational.html
@@ -149,7 +149,7 @@
                     </tr>
                     <tr>
                       <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2023 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
+                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2024 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
                           <a href="https://www.rilldata.com/contact">Contact us</a> • <a href="https://bit.ly/3unvA05">Community</a> • <a href="https://www.rilldata.com/legal/privacy">Privacy Policy</a>
                         </div>
                       </td>

--- a/runtime/pkg/email/templates/gen/project_access_request.html
+++ b/runtime/pkg/email/templates/gen/project_access_request.html
@@ -167,7 +167,7 @@
                     </tr>
                     <tr>
                       <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2023 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
+                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2024 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
                           <a href="https://www.rilldata.com/contact">Contact us</a> • <a href="https://bit.ly/3unvA05">Community</a> • <a href="https://www.rilldata.com/legal/privacy">Privacy Policy</a>
                         </div>
                       </td>

--- a/runtime/pkg/email/templates/gen/scheduled_report.html
+++ b/runtime/pkg/email/templates/gen/scheduled_report.html
@@ -185,7 +185,7 @@
                     </tr>
                     <tr>
                       <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2023 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
+                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2024 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
                           <a href="https://www.rilldata.com/contact">Contact us</a> • <a href="https://bit.ly/3unvA05">Community</a> • <a href="https://www.rilldata.com/legal/privacy">Privacy Policy</a>
                         </div>
                       </td>

--- a/runtime/pkg/email/templates/informational.mjml
+++ b/runtime/pkg/email/templates/informational.mjml
@@ -31,7 +31,7 @@
         <mj-spacer height="20px" />
 
         <mj-text align="center" font-size="12px" line-height="1.5">
-          © 2023 Rill Data, Inc<br />
+          © 2024 Rill Data, Inc<br />
           18 Bartol St. • San Francisco • CA<br />
           <a href="https://www.rilldata.com/contact">Contact us</a> •
           <a href="https://bit.ly/3unvA05">Community</a> •

--- a/runtime/pkg/email/templates/project_access_request.mjml
+++ b/runtime/pkg/email/templates/project_access_request.mjml
@@ -37,7 +37,7 @@
                 <mj-spacer height="20px" />
 
                 <mj-text align="center" font-size="12px" line-height="1.5">
-                    © 2023 Rill Data, Inc<br />
+                    © 2024 Rill Data, Inc<br />
                     18 Bartol St. • San Francisco • CA<br />
                     <a href="https://www.rilldata.com/contact">Contact us</a> •
                     <a href="https://bit.ly/3unvA05">Community</a> •

--- a/runtime/pkg/email/templates/scheduled_report.mjml
+++ b/runtime/pkg/email/templates/scheduled_report.mjml
@@ -45,7 +45,7 @@
         </mj-text>
         
         <mj-text align="center" font-size="12px" line-height="1.5">
-          © 2023 Rill Data, Inc<br />
+          © 2024 Rill Data, Inc<br />
           18 Bartol St. • San Francisco • CA<br />
           <a href="https://www.rilldata.com/contact">Contact us</a> •
           <a href="https://bit.ly/3unvA05">Community</a> •

--- a/web-admin/src/features/projects/github/GithubRepoSelectionDialog.svelte
+++ b/web-admin/src/features/projects/github/GithubRepoSelectionDialog.svelte
@@ -28,8 +28,8 @@
   import Spinner from "@rilldata/web-common/features/entity-management/Spinner.svelte";
   import { EntityStatus } from "@rilldata/web-common/features/entity-management/types";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
-  import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
-  import CaretUpIcon from "@rilldata/web-common/components/icons/CaretUpIcon.svelte";
+  import CaretDownFilledIcon from "@rilldata/web-common/components/icons/CaretDownFilledIcon.svelte";
+  import CaretRightFilledIcon from "@rilldata/web-common/components/icons/CaretRightFilledIcon.svelte";
   import type { AxiosError } from "axios";
 
   export let open = false;
@@ -117,7 +117,7 @@
   <DialogTrigger asChild>
     <div class="hidden"></div>
   </DialogTrigger>
-  <DialogContent>
+  <DialogContent class="translate-y-[-200px]">
     <DialogHeader>
       <div class="flex flex-row gap-x-2 items-center">
         <Github size="40px" />
@@ -152,9 +152,9 @@
         <CollapsibleTrigger asChild let:builder>
           <Button builders={[builder]} type="text">
             {#if advancedOpened}
-              <CaretUpIcon size="16px" />
+              <CaretDownFilledIcon size="12px" />
             {:else}
-              <CaretDownIcon size="16px" />
+              <CaretRightFilledIcon size="12px" />
             {/if}
             <span class="text-sm">Advanced options</span>
           </Button>

--- a/web-admin/src/features/projects/github/ProjectGithubConnection.svelte
+++ b/web-admin/src/features/projects/github/ProjectGithubConnection.svelte
@@ -30,6 +30,8 @@
     project,
   );
 
+  let hovered = false;
+
   const githubData = new GithubData();
   setGithubData(githubData);
   const userStatus = githubData.userStatus;
@@ -57,7 +59,12 @@
 </script>
 
 {#if $proj.data}
-  <div class="flex flex-col gap-y-1 max-w-[400px]">
+  <div
+    class="flex flex-col gap-y-1 max-w-[400px]"
+    on:mouseenter={() => (hovered = true)}
+    on:mouseleave={() => (hovered = false)}
+    role="region"
+  >
     <span
       class="uppercase text-gray-500 font-semibold text-[10px] leading-none"
     >
@@ -76,7 +83,11 @@
             {repoName}
           </a>
           <Button on:click={editGithubConnection} type="ghost" compact>
-            <EditIcon size="16px" />
+            <div class="min-w-4">
+              {#if hovered}
+                <EditIcon size="16px" />
+              {/if}
+            </div>
           </Button>
         </div>
         {#if subpath}

--- a/web-admin/src/features/projects/user-invite/CopyInviteLinkButton.svelte
+++ b/web-admin/src/features/projects/user-invite/CopyInviteLinkButton.svelte
@@ -17,7 +17,7 @@
   {#if copied}
     <div class="flex flex-row gap-x-1 items-center min-h-6">
       <Check size="12px" />
-      <span class="font-medium text-xs text-slate-600"> Link copied </span>
+      <span class="font-medium text-xs text-slate-600"> URL copied </span>
     </div>
   {:else}
     <Button
@@ -28,7 +28,7 @@
       compact
     >
       <Link size="12px" />
-      <span class="font-medium text-xs">Copy link</span>
+      <span class="font-medium text-xs">Copy URL</span>
     </Button>
   {/if}
 {/if}

--- a/web-admin/src/features/projects/user-invite/UserInviteButton.svelte
+++ b/web-admin/src/features/projects/user-invite/UserInviteButton.svelte
@@ -24,7 +24,7 @@
   <DropdownMenuContent class="w-[520px] p-4" side="bottom" align="end">
     <div class="flex flex-col gap-y-3">
       <div class="flex flex-row items-center">
-        <div class="text-base font-medium">Share this project</div>
+        <div class="text-sm font-medium">Share this project</div>
         <div class="grow"></div>
         <CopyInviteLinkButton {copyLink} />
       </div>

--- a/web-common/src/components/icons/CaretDownFilledIcon.svelte
+++ b/web-common/src/components/icons/CaretDownFilledIcon.svelte
@@ -1,0 +1,18 @@
+<script>
+  export let size = "1em";
+  export let color = "currentColor";
+  export let className = "";
+</script>
+
+<svg
+  height={size}
+  viewBox="0 0 24 24"
+  fill={color}
+  xmlns="http://www.w3.org/2000/svg"
+  class={className}
+>
+  <path
+    d="M11.9961 17.332L4.11108 8.51594C3.82299 8.19383 4.05162 7.68262 4.48377 7.68262H19.53C19.9625 7.68262 20.191 8.19449 19.9022 8.51645L11.9961 17.332Z"
+    fill="black"
+  />
+</svg>

--- a/web-common/src/components/icons/CaretRightFilledIcon.svelte
+++ b/web-common/src/components/icons/CaretRightFilledIcon.svelte
@@ -1,0 +1,18 @@
+<script>
+  export let size = "1em";
+  export let color = "currentColor";
+  export let className = "";
+</script>
+
+<svg
+  height={size}
+  viewBox="0 0 24 24"
+  fill={color}
+  xmlns="http://www.w3.org/2000/svg"
+  class={className}
+>
+  <path
+    d="M17.332 12.0038L8.51594 19.8888C8.19383 20.1769 7.68262 19.9483 7.68262 19.5161L7.68262 4.46989C7.68262 4.03741 8.19449 3.80891 8.51645 4.09766L17.332 12.0038Z"
+    fill="black"
+  />
+</svg>


### PR DESCRIPTION
1. Update the icons used for `Advanced Options` to match the mocks.
2. Github connection dialog should be fixed and not move around when `Advanced Options` is opened/closed.
3. Update Copyright in all emails from 2023 to 2024
4. Github edit icon should only appear when hover over the github section.
5. Adjust `Share this project` font size.
6. `Copy link` => `Copy URL` and `Link copied` => `URL copied`

Reference: https://www.notion.so/rilldata/v0-48-0-QA-26b6988933094ad1a24626ff412b66ad?pvs=4#ce94c84d67fe4630ae1f07f9cfd506bd