### PR TITLE
slack alert viewable by all project users

### DIFF
--- a/docs/docs/explore/alerts/slack.md
+++ b/docs/docs/explore/alerts/slack.md
@@ -25,6 +25,10 @@ Sending notifications to a specific channel (public or private) requires the [`c
 The application will also need to be added to the channel for the notification to be sent.
 :::
 
+:::warning
+Any alert configured to be sent to a Slack channel will be viewable by all project viewers. 
+:::
+
 ### Direct messages
 
 Sending notifications via a direct message requires the [`chat:write`](https://api.slack.com/scopes/chat:write), [`users:read`](https://api.slack.com/scopes/users:read), and [`users:read.email`](https://api.slack.com/scopes/users:read.email) scopes. 

--- a/runtime/security.go
+++ b/runtime/security.go
@@ -374,6 +374,10 @@ func (p *securityEngine) builtInAlertSecurityRule(spec *runtimev1.AlertSpec, cla
 					return allowAccessRule
 				}
 			}
+			// Note - A hack to allow slack channel users to access the alert. This also means that any alert configured with a slack channel will be viewable by any user part of the project and will appear in their alert list.
+			if len(props.Channels) > 0 {
+				return allowAccessRule
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/rilldata/rill-private-issues/issues/505 

A hack to allow slack channel users to access the alert. This also means that any alert configured with a slack channel will be viewable by any user part of the project and will appear in their alert list.