### PR TITLE
fix: copy around github to better match our intent

### DIFF
--- a/web-admin/src/features/projects/github/ConnectToGithubButton.svelte
+++ b/web-admin/src/features/projects/github/ConnectToGithubButton.svelte
@@ -43,7 +43,7 @@
   <AlertDialogTrigger asChild let:builder>
     <Button builders={[builder]} type="primary" class="w-fit mt-1" {loading}>
       <Github className="w-4 h-4" fill="white" />
-      Connect to Github
+      Connect to GitHub
     </Button>
   </AlertDialogTrigger>
   <AlertDialogContent>

--- a/web-admin/src/features/projects/github/GithubRepoSelectionDialog.svelte
+++ b/web-admin/src/features/projects/github/GithubRepoSelectionDialog.svelte
@@ -122,9 +122,9 @@
       <div class="flex flex-row gap-x-2 items-center">
         <Github size="40px" />
         <div class="flex flex-col gap-y-1">
-          <DialogTitle>Select Github repository</DialogTitle>
+          <DialogTitle>Select GitHub repository</DialogTitle>
           <DialogDescription>
-            Choose a GitHub repo to house this project.
+            Choose a GitHub repo to push this project to.
           </DialogDescription>
         </div>
       </div>
@@ -144,8 +144,8 @@
           on:change={({ detail: newUrl }) => onSelectedRepoChange(newUrl)}
         />
         <span class="text-gray-500 mt-1">
-          <span class="font-semibold">Note:</span> Contents of this repo will replace
-          your current Rill project.
+          <span class="font-semibold">Note:</span> This current project will replace
+          contents of the selected repo.
         </span>
       {/if}
       <Collapsible bind:open={advancedOpened}>

--- a/web-admin/src/features/projects/github/ProjectGithubConnection.svelte
+++ b/web-admin/src/features/projects/github/ProjectGithubConnection.svelte
@@ -38,7 +38,9 @@
   const repoSelectionOpen = githubData.repoSelectionOpen;
 
   function confirmConnectToGithub() {
-    void githubData.startRepoSelection();
+    // prompt reselection repos since a new repo might be created here.
+    repoSelectionOpen.set(true);
+    void githubData.reselectRepos();
     behaviourEvent?.fireGithubIntentEvent(
       BehaviourEventAction.GithubConnectStart,
       {
@@ -68,7 +70,7 @@
     <span
       class="uppercase text-gray-500 font-semibold text-[10px] leading-none"
     >
-      Github
+      GitHub
     </span>
     <div class="flex flex-col gap-x-1">
       {#if isGithubConnected}
@@ -110,7 +112,7 @@
         {/if}
       {:else}
         <span class="mt-1">
-          Unlock the power of BI-as-code with Github-backed collaboration,
+          Unlock the power of BI-as-code with GitHub-backed collaboration,
           version control, and approval workflows.<br />
           <a href="https://docs.rilldata.com" target="_blank">Learn more</a>
         </span>

--- a/web-admin/src/routes/-/github/connect/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/+page.svelte
@@ -27,16 +27,16 @@
 </script>
 
 <svelte:head>
-  <title>Connect to Github</title>
+  <title>Connect to GitHub</title>
 </svelte:head>
 
 {#if $user.data && $user.data.user}
   <CtaLayoutContainer>
     <CtaContentContainer>
       <Github className="w-10 h-10 text-gray-900" />
-      <CtaHeader>Connect to Github</CtaHeader>
+      <CtaHeader>Connect to GitHub</CtaHeader>
       <CtaMessage>
-        Rill projects deploy continuously when you push changes to Github.
+        Rill projects deploy continuously when you push changes to GitHub.
       </CtaMessage>
       {#if remote}
         <CtaMessage>
@@ -47,7 +47,7 @@
       {/if}
       <div class="mt-4 w-full flex justify-center">
         <CtaButton variant="primary" href={redirectURL}>
-          Connect to Github
+          Connect to GitHub
         </CtaButton>
       </div>
     </CtaContentContainer>

--- a/web-admin/src/routes/-/github/connect/request/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/request/+page.svelte
@@ -24,20 +24,20 @@
 </script>
 
 <svelte:head>
-  <title>Github access requested</title>
+  <title>GitHub access requested</title>
 </svelte:head>
 
 {#if $user.data && $user.data.user}
   <CtaLayoutContainer>
     <CtaContentContainer>
       <Github className="w-10 h-10 text-gray-900" />
-      <CtaHeader>Connect to Github</CtaHeader>
+      <CtaHeader>Connect to GitHub</CtaHeader>
       <CtaMessage>
         You requested access to <GithubRepoInline githubUrl={remote} />. You can
         close this page now.
       </CtaMessage>
       <CtaMessage>
-        The CLI will keep polling until Github access has been granted by an
+        The CLI will keep polling until GitHub access has been granted by an
         admin. You can stop polling by pressing <KeyboardKey label="Control" /> +
         <KeyboardKey label="C" /> and run <CodeBlockInline code="rill deploy" />
         again once access has been granted.

--- a/web-admin/src/routes/-/github/connect/retry-auth/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/retry-auth/+page.svelte
@@ -28,16 +28,16 @@
 </script>
 
 <svelte:head>
-  <title>Could not connect to Github</title>
+  <title>Could not connect to GitHub</title>
 </svelte:head>
 
 {#if $user.data && $user.data.user}
   <CtaLayoutContainer>
     <CtaContentContainer>
       <GithubFail />
-      <CtaHeader>Could not connect to Github</CtaHeader>
+      <CtaHeader>Could not connect to GitHub</CtaHeader>
       <CtaMessage>
-        Your authorized Github account <GithubUserInline {githubUsername} />
+        Your authorized GitHub account <GithubUserInline {githubUsername} />
         does not have access to <GithubRepoInline githubUrl={remote} />.
       </CtaMessage>
       <CtaMessage>
@@ -47,7 +47,7 @@
         variant="primary"
         href={encodeURI(ADMIN_URL + "/github/auth/login?remote=" + remote)}
       >
-        Connect to Github
+        Connect to GitHub
       </CtaButton>
     </CtaContentContainer>
   </CtaLayoutContainer>

--- a/web-admin/src/routes/-/github/connect/retry-install/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/retry-install/+page.svelte
@@ -28,14 +28,14 @@
 </script>
 
 <svelte:head>
-  <title>Could not connect to Github</title>
+  <title>Could not connect to GitHub</title>
 </svelte:head>
 
 {#if $user.data && $user.data.user}
   <CtaLayoutContainer>
     <CtaContentContainer>
       <GithubFail />
-      <CtaHeader>Could not connect to Github</CtaHeader>
+      <CtaHeader>Could not connect to GitHub</CtaHeader>
       <CtaMessage>
         It looks like you did not grant access to the desired repository at <GithubRepoInline
           githubUrl={remote}
@@ -50,7 +50,7 @@
         variant="primary"
         href={encodeURI(ADMIN_URL + "/github/connect?remote=" + remote)}
       >
-        Connect to Github
+        Connect to GitHub
       </CtaButton>
     </CtaContentContainer>
   </CtaLayoutContainer>

--- a/web-admin/src/routes/-/github/connect/success/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/success/+page.svelte
@@ -17,13 +17,13 @@
 </script>
 
 <svelte:head>
-  <title>Github connected successfully</title>
+  <title>GitHub connected successfully</title>
 </svelte:head>
 
 <CtaLayoutContainer>
   <CtaContentContainer>
     <GithubSuccess />
-    <CtaHeader>Github connected successfully</CtaHeader>
+    <CtaHeader>GitHub connected successfully</CtaHeader>
     <CtaMessage>Close this page and continue setup in the Rill CLI.</CtaMessage>
   </CtaContentContainer>
 </CtaLayoutContainer>

--- a/web-common/src/features/dashboards/workspace/DeployDashboardCTA.svelte
+++ b/web-common/src/features/dashboards/workspace/DeployDashboardCTA.svelte
@@ -28,9 +28,7 @@
 
   let open = false;
   function onShowDeploy() {
-    if (isDeployed) {
-      window.open(deployPageUrl);
-    } else {
+    if (!isDeployed) {
       open = true;
     }
     void behaviourEvent?.fireDeployEvent(BehaviourEventAction.DeployIntent);


### PR DESCRIPTION
1. Update all instances of `Github` to `GitHub`.
2. Update github repo selection dialog to state that the project contents will replace target repo.
3. Show repo installation dialog during initial repo connection.
4. Clicking `Redploy` opens the deploy page twice.