### PR TITLE
single quote the download url

### DIFF
--- a/cli/cmd/sudo/clone.go
+++ b/cli/cmd/sudo/clone.go
@@ -41,7 +41,7 @@ func cloneCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			fmt.Println("Clone command:")
 			if res.ArchiveDownloadUrl != "" {
-				fmt.Printf("\tcurl -o %s__%s.tar.gz %s\n\n", args[0], args[1], res.ArchiveDownloadUrl)
+				fmt.Printf("\tcurl -o %s__%s.tar.gz '%s'\n\n", args[0], args[1], res.ArchiveDownloadUrl)
 				return nil
 			}
 


### PR DESCRIPTION
otherwise shell interprets it throwing random errors