### PR TITLE
change duckdb estimated size calculations

### DIFF
--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -329,10 +329,6 @@ func (c *connection) AsNotifier(properties map[string]any) (drivers.Notifier, er
 	return nil, drivers.ErrNotNotifier
 }
 
-func (c *connection) EstimateSize() (int64, bool) {
-	return 0, false
-}
-
 func (c *connection) AcquireLongRunning(ctx context.Context) (func(), error) {
 	return nil, fmt.Errorf("not implemented")
 }

--- a/runtime/drivers/druid/druid.go
+++ b/runtime/drivers/druid/druid.go
@@ -257,10 +257,6 @@ func (c *connection) AsNotifier(properties map[string]any) (drivers.Notifier, er
 	return nil, drivers.ErrNotNotifier
 }
 
-func (c *connection) EstimateSize() (int64, bool) {
-	return 0, false
-}
-
 func (c *connection) AcquireLongRunning(ctx context.Context) (func(), error) {
 	return func() {}, nil
 }

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -840,7 +840,7 @@ func (c *connection) periodicallyEmitStats(d time.Duration) {
 	for {
 		select {
 		case <-statTicker.C:
-			estimatedDBSize, _ := c.EstimateSize()
+			estimatedDBSize := c.estimateSize(false)
 			c.activity.RecordMetric(c.ctx, "duckdb_estimated_size_bytes", float64(estimatedDBSize))
 
 			// NOTE :: running CALL pragma_database_size() while duckdb is ingesting data is causing the WAL file to explode.

--- a/runtime/drivers/duckdb/utils.go
+++ b/runtime/drivers/duckdb/utils.go
@@ -266,9 +266,5 @@ func sizeWithinStorageLimits(olap drivers.OLAPStore, size int64) bool {
 		return true
 	}
 
-	dbSizeInBytes, ok := olap.EstimateSize()
-	if ok && dbSizeInBytes+size > limit {
-		return false
-	}
-	return true
+	return olap.(*connection).estimateSize(true)+size <= limit
 }

--- a/runtime/drivers/olap.go
+++ b/runtime/drivers/olap.go
@@ -33,7 +33,6 @@ type OLAPStore interface {
 	Exec(ctx context.Context, stmt *Statement) error
 	Execute(ctx context.Context, stmt *Statement) (*Result, error)
 	InformationSchema() InformationSchema
-	EstimateSize() (int64, bool)
 
 	CreateTableAsSelect(ctx context.Context, name string, view bool, sql string, tableOpts map[string]any) error
 	InsertTableAsSelect(ctx context.Context, name, sql string, byName, inPlace bool, strategy IncrementalStrategy, uniqueKey []string) error

--- a/runtime/drivers/pinot/olap.go
+++ b/runtime/drivers/pinot/olap.go
@@ -52,9 +52,6 @@ func (c *connection) WithConnection(ctx context.Context, priority int, longRunni
 	return fmt.Errorf("pinot: WithConnection not supported")
 }
 
-func (c *connection) EstimateSize() (int64, bool) {
-	return 0, false
-}
 
 func (c *connection) Exec(ctx context.Context, stmt *drivers.Statement) error {
 	res, err := c.Execute(ctx, stmt)

--- a/runtime/drivers/pinot/olap.go
+++ b/runtime/drivers/pinot/olap.go
@@ -52,7 +52,6 @@ func (c *connection) WithConnection(ctx context.Context, priority int, longRunni
 	return fmt.Errorf("pinot: WithConnection not supported")
 }
 
-
 func (c *connection) Exec(ctx context.Context, stmt *drivers.Statement) error {
 	res, err := c.Execute(ctx, stmt)
 	if err != nil {


### PR DESCRIPTION
closes https://github.com/rilldata/rill-private-issues/issues/540

1. For emitting events it only uses the size of .db files and excludes temporary tables.
2. For other checks like size limit it calculates size of all.
3. Cleaned up OLAP interface since `EstimateSize` is not relevant for other OLAP engines and only used internally in duckDB driver.

TODO : The background goroutine in `execWithLimits` does not work since `estimateSize` does not take into account the size of new file being written into. This is already an issue and should be fixed separately. 