### PR TITLE
fix: do not format numbers in the dimension column

### DIFF
--- a/web-common/src/features/dashboards/time-dimension-details/TDDTable.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TDDTable.svelte
@@ -20,12 +20,12 @@
     SelectedCheckmark,
   } from "@rilldata/web-common/features/dashboards/time-dimension-details/TDDIcons";
   import { getClassForCell } from "@rilldata/web-common/features/dashboards/time-dimension-details/util";
+  import { copyToClipboard } from "@rilldata/web-common/lib/actions/copy-to-clipboard";
+  import { createMeasureValueFormatter } from "@rilldata/web-common/lib/number-formatting/format-measure-value";
+  import { MetricsViewSpecMeasureV2 } from "@rilldata/web-common/runtime-client";
   import { createEventDispatcher } from "svelte";
   import { lastKnownPosition } from "./time-dimension-data-store";
   import type { TDDComparison, TableData, TablePosition } from "./types";
-  import { createMeasureValueFormatter } from "@rilldata/web-common/lib/number-formatting/format-measure-value";
-  import { MetricsViewSpecMeasureV2 } from "@rilldata/web-common/runtime-client";
-  import { copyToClipboard } from "@rilldata/web-common/lib/actions/copy-to-clipboard";
 
   export let dimensionLabel: string;
   export let measureLabel: string;
@@ -185,7 +185,7 @@
     }
     const total =
       value.value !== undefined
-        ? isNaN(Number(value.value))
+        ? isNaN(Number(value.value)) || x == 0
           ? value.value
           : formatter(Number(value.value))
         : "...";


### PR DESCRIPTION
There was regression in a previous PR where the dimension column values in TDD were formatted as measures if they were numbers. This PR adds a check to avoid that column.