### PR TITLE
fix: Enable search for all dimension column types

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { getDimensionType } from "@rilldata/web-common/features/dashboards/filters/dimension-filters/getDimensionType";
-
   /**
    * DimensionDisplay.svelte
    * -------------------------
@@ -9,7 +7,6 @@
    */
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
-  import { STRING_LIKES } from "@rilldata/web-common/lib/duckdb-data-types";
   import { createQueryServiceMetricsViewAggregation } from "@rilldata/web-common/runtime-client";
   import { getDimensionFilterWithSearch } from "./dimension-table-utils";
   import DimensionHeader from "./DimensionHeader.svelte";
@@ -53,12 +50,6 @@
   let searchText = "";
 
   $: instanceId = $runtime.instanceId;
-  $: dimensionType = getDimensionType(
-    instanceId,
-    $metricsViewName,
-    dimensionName,
-  );
-  $: stringLikeDimension = STRING_LIKES.has($dimensionType.data ?? "");
 
   const timeControlsStore = useTimeControlStore(stateManagers);
 
@@ -159,10 +150,9 @@
         isRowsEmpty={!tableRows.length}
         isFetching={$sortedQuery?.isFetching}
         on:search={(event) => {
-          if (stringLikeDimension) searchText = event.detail;
+          searchText = event.detail;
         }}
         on:toggle-all-search-items={() => toggleAllSearchItems()}
-        enableSearch={stringLikeDimension}
       />
     </div>
 

--- a/web-common/src/features/dashboards/dimension-table/DimensionHeader.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionHeader.svelte
@@ -27,7 +27,6 @@
   export let isFetching: boolean;
   export let areAllTableRowsSelected = false;
   export let isRowsEmpty = true;
-  export let enableSearch = true;
 
   const dispatch = createEventDispatcher();
 
@@ -180,7 +179,7 @@
           <Close />
         </button>
       </div>
-    {:else if enableSearch}
+    {:else}
       <button
         class="flex items-center gap-x-2 p-1.5 text-gray-700"
         in:fly|global={{ x: 10, duration: 300 }}

--- a/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
+++ b/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
@@ -3,9 +3,6 @@
     defaultChipColors,
     excludeChipColors,
   } from "@rilldata/web-common/components/chip/chip-types";
-  import { getDimensionType } from "@rilldata/web-common/features/dashboards/filters/dimension-filters/getDimensionType";
-  import { STRING_LIKES } from "@rilldata/web-common/lib/duckdb-data-types";
-  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import RemovableListChip from "../../../../components/chip/removable-list-chip/RemovableListChip.svelte";
   import { getFilterSearchList } from "../../selectors/index";
   import { getStateManagers } from "../../state-managers/state-managers";
@@ -20,7 +17,6 @@
     actions: {
       dimensionsFilter: { toggleDimensionFilterMode },
     },
-    metricsViewName,
   } = StateManagers;
 
   $: isInclude = !$dashboardStore.dimensionFilterExcludeMode.get(name);
@@ -30,19 +26,11 @@
   let allValues: Record<string, string[]> = {};
   let topListQuery: ReturnType<typeof getFilterSearchList> | undefined;
 
-  $: dimensionType = getDimensionType(
-    $runtime.instanceId,
-    $metricsViewName,
-    name,
-  );
-  $: stringLikeDimension = STRING_LIKES.has($dimensionType.data ?? "");
-
   $: if (isOpen) {
     topListQuery = getFilterSearchList(StateManagers, {
       dimension: name,
       searchText,
       addNull: searchText.length !== 0 && "null".includes(searchText),
-      type: $dimensionType.data,
     });
   }
 
@@ -68,7 +56,6 @@
 <RemovableListChip
   allValues={allValues[name]}
   colors={getColorForChip(isInclude)}
-  enableSearch={stringLikeDimension}
   excludeMode={!isInclude}
   label="View filter"
   name={isInclude ? label : `Exclude ${label}`}

--- a/web-common/src/features/dashboards/selectors/index.ts
+++ b/web-common/src/features/dashboards/selectors/index.ts
@@ -7,7 +7,6 @@ import {
   ResourceKind,
   useResource,
 } from "@rilldata/web-common/features/entity-management/resource-selectors";
-import { STRING_LIKES } from "@rilldata/web-common/lib/duckdb-data-types";
 import {
   RpcStatus,
   V1MetricsViewSpec,
@@ -58,12 +57,10 @@ export const getFilterSearchList = (
     dimension,
     addNull,
     searchText,
-    type,
   }: {
     dimension: string;
     addNull: boolean;
     searchText: string;
-    type: string | undefined;
   },
 ): Readable<
   QueryObserverResult<V1MetricsViewComparisonResponse, RpcStatus>
@@ -91,9 +88,7 @@ export const getFilterSearchList = (
           sort: [{ name: dimension }],
           where: addNull
             ? createInExpression(dimension, [null])
-            : STRING_LIKES.has(type ?? "")
-              ? createLikeExpression(dimension, `%${searchText}%`)
-              : undefined,
+            : createLikeExpression(dimension, `%${searchText}%`),
         },
         {
           query: {


### PR DESCRIPTION
We disabled search for non-string like dimensions as we were using `LIKE %<search>%`. But it seems like it is not needed anymore. Reverting to allowing search for all dimension types.