### PR TITLE
Cast operands in `LIKE` and `ILIKE` filters to `TEXT` on ClickHouse

### DIFF
--- a/runtime/drivers/olap.go
+++ b/runtime/drivers/olap.go
@@ -240,6 +240,11 @@ func (d Dialect) SupportsILike() bool {
 	return d != DialectDruid && d != DialectPinot
 }
 
+// RequiresCastForLike returns true if the dialect requires an expression used in a LIKE or ILIKE condition to explicitly be cast to type TEXT.
+func (d Dialect) RequiresCastForLike() bool {
+	return d == DialectClickHouse
+}
+
 // EscapeTable returns an esacped fully qualified table name
 func (d Dialect) EscapeTable(db, schema, table string) string {
 	var sb strings.Builder

--- a/runtime/metricsview/astexpr.go
+++ b/runtime/metricsview/astexpr.go
@@ -36,6 +36,8 @@ type sqlExprBuilder struct {
 	args         []any
 }
 
+// writeExpression writes the SQL expression for the given expression.
+// The output is guaranteed to be wrapped in parentheses.
 func (b *sqlExprBuilder) writeExpression(e *Expression) error {
 	if e == nil {
 		return nil
@@ -281,6 +283,8 @@ func (b *sqlExprBuilder) writeBinaryConditionInner(left, right *Expression, left
 		return fmt.Errorf("invalid binary condition operator %q", op)
 	}
 
+	b.writeString("(")
+
 	if leftOverride != "" {
 		b.writeParenthesizedString(leftOverride)
 	} else {
@@ -289,10 +293,10 @@ func (b *sqlExprBuilder) writeBinaryConditionInner(left, right *Expression, left
 			return err
 		}
 	}
-	// Special cases:
-	// "dim = NULL" should be written as "dim IS NULL"
-	// dim != NULL" should be written as "dim IS NOT NULL"
 	if hasNilValue(right) {
+		// Special cases:
+		// "dim = NULL" should be written as "dim IS NULL"
+		// "dim != NULL" should be written as "dim IS NOT NULL"
 		if op == OperatorEq {
 			b.writeString(" IS NULL")
 			return nil
@@ -306,13 +310,14 @@ func (b *sqlExprBuilder) writeBinaryConditionInner(left, right *Expression, left
 	if err != nil {
 		return err
 	}
+
+	b.writeString(")")
+
 	return nil
 }
 
 func (b *sqlExprBuilder) writeILikeCondition(left, right *Expression, leftOverride string, not bool) error {
-	if not {
-		b.writeByte('(')
-	}
+	b.writeByte('(')
 
 	if b.ast.dialect.SupportsILike() {
 		// Output: <left> [NOT] ILIKE <right>
@@ -326,6 +331,10 @@ func (b *sqlExprBuilder) writeILikeCondition(left, right *Expression, leftOverri
 			}
 		}
 
+		if b.ast.dialect.RequiresCastForLike() {
+			b.writeString("::TEXT")
+		}
+
 		if not {
 			b.writeString(" NOT ILIKE ")
 		} else {
@@ -335,6 +344,10 @@ func (b *sqlExprBuilder) writeILikeCondition(left, right *Expression, leftOverri
 		err := b.writeExpression(right)
 		if err != nil {
 			return err
+		}
+
+		if b.ast.dialect.RequiresCastForLike() {
+			b.writeString("::TEXT")
 		}
 	} else {
 		// Output: LOWER(<left>) [NOT] LIKE LOWER(<right>)
@@ -348,6 +361,9 @@ func (b *sqlExprBuilder) writeILikeCondition(left, right *Expression, leftOverri
 				return err
 			}
 		}
+		if b.ast.dialect.RequiresCastForLike() {
+			b.writeString("::TEXT")
+		}
 		b.writeString(")")
 
 		if not {
@@ -360,6 +376,9 @@ func (b *sqlExprBuilder) writeILikeCondition(left, right *Expression, leftOverri
 		err := b.writeExpression(right)
 		if err != nil {
 			return err
+		}
+		if b.ast.dialect.RequiresCastForLike() {
+			b.writeString("::TEXT")
 		}
 		b.writeString(")")
 	}
@@ -378,10 +397,7 @@ func (b *sqlExprBuilder) writeILikeCondition(left, right *Expression, leftOverri
 		b.writeString(" IS NULL")
 	}
 
-	// Closes the parens opened at the start
-	if not {
-		b.writeByte(')')
-	}
+	b.writeByte(')')
 
 	return nil
 }
@@ -395,6 +411,8 @@ func (b *sqlExprBuilder) writeInCondition(left, right *Expression, leftOverride 
 
 		return b.writeInConditionForValues(left, leftOverride, vals, not)
 	}
+
+	b.writeByte('(')
 
 	if leftOverride != "" {
 		b.writeParenthesizedString(leftOverride)
@@ -415,6 +433,8 @@ func (b *sqlExprBuilder) writeInCondition(left, right *Expression, leftOverride 
 	if err != nil {
 		return err
 	}
+
+	b.writeByte(')')
 
 	return nil
 }
@@ -441,10 +461,7 @@ func (b *sqlExprBuilder) writeInConditionForValues(left *Expression, leftOverrid
 		return nil
 	}
 
-	wrapParens := not || (hasNull && hasNonNull)
-	if wrapParens {
-		b.writeByte('(')
-	}
+	b.writeByte('(')
 
 	if hasNonNull {
 		if leftOverride != "" {
@@ -518,9 +535,7 @@ func (b *sqlExprBuilder) writeInConditionForValues(left *Expression, leftOverrid
 		b.writeString(" IS NULL")
 	}
 
-	if wrapParens {
-		b.writeByte(')')
-	}
+	b.writeByte(')')
 
 	return nil
 }

--- a/runtime/metricsview/astexpr.go
+++ b/runtime/metricsview/astexpr.go
@@ -248,7 +248,7 @@ func (b *sqlExprBuilder) writeBinaryCondition(exprs []*Expression, op Operator) 
 		if err != nil {
 			return err
 		}
-		b.writeString(")")
+		b.writeByte(')')
 		return nil
 	}
 
@@ -283,7 +283,7 @@ func (b *sqlExprBuilder) writeBinaryConditionInner(left, right *Expression, left
 		return fmt.Errorf("invalid binary condition operator %q", op)
 	}
 
-	b.writeString("(")
+	b.writeByte('(')
 
 	if leftOverride != "" {
 		b.writeParenthesizedString(leftOverride)
@@ -298,10 +298,10 @@ func (b *sqlExprBuilder) writeBinaryConditionInner(left, right *Expression, left
 		// "dim = NULL" should be written as "dim IS NULL"
 		// "dim != NULL" should be written as "dim IS NOT NULL"
 		if op == OperatorEq {
-			b.writeString(" IS NULL")
+			b.writeString(" IS NULL)")
 			return nil
 		} else if op == OperatorNeq {
-			b.writeString(" IS NOT NULL")
+			b.writeString(" IS NOT NULL)")
 			return nil
 		}
 	}
@@ -311,7 +311,7 @@ func (b *sqlExprBuilder) writeBinaryConditionInner(left, right *Expression, left
 		return err
 	}
 
-	b.writeString(")")
+	b.writeByte(')')
 
 	return nil
 }
@@ -364,7 +364,7 @@ func (b *sqlExprBuilder) writeILikeCondition(left, right *Expression, leftOverri
 		if b.ast.dialect.RequiresCastForLike() {
 			b.writeString("::TEXT")
 		}
-		b.writeString(")")
+		b.writeByte(')')
 
 		if not {
 			b.writeString(" NOT LIKE ")
@@ -380,7 +380,7 @@ func (b *sqlExprBuilder) writeILikeCondition(left, right *Expression, leftOverri
 		if b.ast.dialect.RequiresCastForLike() {
 			b.writeString("::TEXT")
 		}
-		b.writeString(")")
+		b.writeByte(')')
 	}
 
 	// When you have "dim NOT ILIKE <val>", then NULL values are always excluded. We need to explicitly include it.

--- a/runtime/metricsview/astsql.go
+++ b/runtime/metricsview/astsql.go
@@ -169,10 +169,12 @@ func (b *sqlBuilder) writeSelect(n *SelectNode) error {
 		if wroteWhere {
 			b.out.WriteString(" AND (")
 		} else {
-			b.out.WriteString(" WHERE (")
+			b.out.WriteString(" WHERE ")
 		}
 		b.out.WriteString(n.Where.Expr)
-		b.out.WriteString(")")
+		if wroteWhere {
+			b.out.WriteString(")")
+		}
 		b.args = append(b.args, n.Where.Args...)
 	}
 

--- a/runtime/pkg/metricssql/parser_test.go
+++ b/runtime/pkg/metricssql/parser_test.go
@@ -117,7 +117,7 @@ func TestCompile(t *testing.T) {
 		},
 		{
 			"select pub, dom, measure_0 as \"click rate\" from ad_bids_metrics where (pub is not null and dom is null) or (pub = '__default__')",
-			"SELECT (\"publisher\") AS \"pub\", (\"domain\") AS \"dom\", (count(*)) AS \"measure_0\" FROM \"ad_bids\" WHERE ((((\"publisher\") IS NOT NULL AND (\"domain\") IS NULL) OR (\"publisher\") = ?)) GROUP BY 1, 2",
+			"SELECT (\"publisher\") AS \"pub\", (\"domain\") AS \"dom\", (count(*)) AS \"measure_0\" FROM \"ad_bids\" WHERE ((((\"publisher\") IS NOT NULL) AND ((\"domain\") IS NULL)) OR ((\"publisher\") = ?)) GROUP BY 1, 2",
 			mv,
 			[]any{"__default__"},
 		},


### PR DESCRIPTION
DuckDB and Druid automatically cast operands to `LIKE` to a text type, but ClickHouse does not. This PR explicitly casts the operands for `LIKE` to a text type for ClickHouse queries.

This should enable dashboards to support search against non-text dimension data types such as dates, ints, etc.