### PR TITLE
Include comparison delta and percent for export data if enableComparison

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-export.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-export.ts
@@ -87,6 +87,7 @@ export function getPivotExportArgs(ctx: StateManagers) {
       useMetricsView(ctx),
       useTimeControlStore(ctx),
       ctx.dashboardStore,
+      getPivotConfig(ctx),
       ctx.selectors.pivot.rows,
       ctx.selectors.pivot.columns,
     ],
@@ -95,16 +96,16 @@ export function getPivotExportArgs(ctx: StateManagers) {
       metricsView,
       timeControlState,
       dashboardState,
+      configStore,
       rows,
       columns,
     ]) => {
+      const enableComparison = configStore.enableComparison;
+      const comparisonTime = configStore.comparisonTime;
+
       const metricsViewSpec = metricsView.data ?? {};
       const timeRange = mapTimeRange(timeControlState, metricsViewSpec);
       if (!timeRange) return undefined;
-
-      const configStore = getPivotConfig(ctx);
-      const enableComparison = get(configStore).enableComparison;
-      const comparisonTime = get(configStore).comparisonTime;
 
       return getPivotAggregationRequest(
         metricsViewName,


### PR DESCRIPTION
- [x] use `enableComparison` flag
- [x] verify comparison data in exports
- [x] fix export sort vs. aggregate sort

closes [5295](https://github.com/rilldata/rill/issues/5295)

![CleanShot 2024-08-09 at 12 38 29@2x](https://github.com/user-attachments/assets/e07a7183-979f-42c3-90b0-26546f9d7031)

https://github.com/user-attachments/assets/b9a12cfb-17d0-4e85-9a81-c6d34153c89c
