### PR TITLE
Added note on --allowed-origins flag

### DIFF
--- a/cli/cmd/start/start.go
+++ b/cli/cmd/start/start.go
@@ -196,7 +196,7 @@ func StartCmd(ch *cmdutil.Helper) *cobra.Command {
 	// --env was previously used for variables, but is now used to set the environment name. We maintain backwards compatibility by keeping --env as a slice var, and setting any value containing an equals sign as a variable.
 	startCmd.Flags().StringSliceVarP(&env, "env", "e", []string{}, `Environment name (default "dev")`)
 	startCmd.Flags().StringSliceVarP(&vars, "var", "v", []string{}, "Set project variables")
-	startCmd.Flags().StringSliceVarP(&allowedOrigins, "allowed-origins", "", []string{}, "add additional allowed-origins")
+	startCmd.Flags().StringSliceVarP(&allowedOrigins, "allowed-origins", "", []string{}, "Override allowed origins for CORS")
 
 	// We have deprecated the ability configure the OLAP database via the CLI. This should now be done via rill.yaml.
 	// Keeping these for backwards compatibility for a while.

--- a/docs/docs/home/get-started.md
+++ b/docs/docs/home/get-started.md
@@ -38,6 +38,11 @@ rill start my-rill-project
 
 The Rill web app runs locally at `http://localhost:9009` and will create code files in the `my-rill-project` directory.
 
+:::note
+Starting from v0.48, we have added the ability to self host the local Rill Developer application on a non-localhost endpoint. Please refer to the [rill start reference page](https://docs.rilldata.com/reference/cli/start) for more details on using the `--allowed-origins` flag. This method is not officially supported, please proceed at your own risk.
+:::
+
+
 ## Load and transform data
 
 On the welcome screen, initialize an example project or load up Rill with your own data (use local files, cloud storage and/or database connections)

--- a/docs/docs/home/get-started.md
+++ b/docs/docs/home/get-started.md
@@ -39,7 +39,7 @@ rill start my-rill-project
 The Rill web app runs locally at `http://localhost:9009` and will create code files in the `my-rill-project` directory.
 
 :::note
-Starting from v0.48, we have added the ability to self host the local Rill Developer application on a non-localhost endpoint. Please refer to the [rill start reference page](https://docs.rilldata.com/reference/cli/start) for more details on using the `--allowed-origins` flag. This method is not officially supported, please proceed at your own risk.
+Starting from v0.48, we've made changes to the CORS policy to only allow calls from the default HTTP URL by default for security purposes. If you are hosting Rill Developer on a non-localhost endpoint **(not officially supported)**, this means that they will need to pass in the appropriate CORS origins / hostname via the --allowed-origins flag when starting Rill. Please refer to the [rill start reference page](https://docs.rilldata.com/reference/cli/start) for more details on using the `--allowed-origins` flag.
 :::
 
 

--- a/docs/docs/reference/cli/org/edit.md
+++ b/docs/docs/reference/cli/org/edit.md
@@ -13,8 +13,9 @@ rill org edit [<org-name>] [flags]
 ### Flags
 
 ```
-      --org string           Organization name
-      --description string   Description
+      --org string             Organization name
+      --description string     Description
+      --billing-email string   Billing email
 ```
 
 ### Global flags

--- a/docs/docs/reference/cli/project/edit.md
+++ b/docs/docs/reference/cli/project/edit.md
@@ -18,6 +18,7 @@ rill project edit [<project-name>] [flags]
       --prod-branch string     Production branch name
       --public                 Make dashboards publicly accessible
       --path string            Project directory (default ".")
+      --subpath string         Relative path to project in the repository (for monorepos)
       --provisioner string     Project provisioner (default: current provisioner)
       --prod-ttl-seconds int   Prod deployment TTL in seconds
       --prod-version string    Rill version (default: current version)

--- a/docs/docs/reference/cli/project/project.md
+++ b/docs/docs/reference/cli/project/project.md
@@ -33,5 +33,6 @@ Manage projects
 * [rill project rename](rename.md)	 - Rename project
 * [rill project reset](reset.md)	 - Re-deploy project
 * [rill project show](show.md)	 - Show project details
+* [rill project splits](splits.md)	 - List splits for a model
 * [rill project status](status.md)	 - Project deployment status
 

--- a/docs/docs/reference/cli/project/splits.md
+++ b/docs/docs/reference/cli/project/splits.md
@@ -1,0 +1,37 @@
+---
+note: GENERATED. DO NOT EDIT.
+title: rill project splits
+---
+## rill project splits
+
+List splits for a model
+
+```
+rill project splits [<project>] <model> [flags]
+```
+
+### Flags
+
+```
+      --project string      Project Name
+      --path string         Project directory (default ".")
+      --model string        Model Name
+      --local               Target locally running Rill
+      --page-size uint32    Number of splits to return per page (default 50)
+      --page-token string   Pagination token
+```
+
+### Global flags
+
+```
+      --api-token string   Token for authenticating with the cloud API
+      --format string      Output format (options: "human", "json", "csv") (default "human")
+  -h, --help               Print usage
+      --interactive        Prompt for missing required parameters (default true)
+      --org string         Organization Name
+```
+
+### SEE ALSO
+
+* [rill project](project.md)	 - Manage projects
+

--- a/docs/docs/reference/cli/start.md
+++ b/docs/docs/reference/cli/start.md
@@ -26,7 +26,7 @@ rill start [<path>] [flags]
       --tls-key string            Path to TLS key file
   -e, --env strings               Environment name (default "dev")
   -v, --var strings               Set project variables
-      --allowed-origins strings   add additional allowed-origins
+      --allowed-origins strings   Override allowed origins for CORS
 ```
 
 ### Global flags

--- a/docs/docs/reference/cli/start.md
+++ b/docs/docs/reference/cli/start.md
@@ -13,19 +13,20 @@ rill start [<path>] [flags]
 ### Flags
 
 ```
-      --no-open             Do not open browser
-      --port int            Port for HTTP (default 9009)
-      --port-grpc int       Port for gRPC (internal) (default 49009)
-      --readonly            Show only dashboards in UI
-      --no-ui               Serve only the backend
-      --verbose             Sets the log level to debug
-      --debug               Collect additional debug info
-      --reset               Clear and re-ingest source data
-      --log-format string   Log format (options: "console", "json") (default "console")
-      --tls-cert string     Path to TLS certificate
-      --tls-key string      Path to TLS key file
-  -e, --env strings         Environment name (default "dev")
-  -v, --var strings         Set project variables
+      --no-open                   Do not open browser
+      --port int                  Port for HTTP (default 9009)
+      --port-grpc int             Port for gRPC (internal) (default 49009)
+      --readonly                  Show only dashboards in UI
+      --no-ui                     Serve only the backend
+      --verbose                   Sets the log level to debug
+      --debug                     Collect additional debug info
+      --reset                     Clear and re-ingest source data
+      --log-format string         Log format (options: "console", "json") (default "console")
+      --tls-cert string           Path to TLS certificate
+      --tls-key string            Path to TLS key file
+  -e, --env strings               Environment name (default "dev")
+  -v, --var strings               Set project variables
+      --allowed-origins strings   add additional allowed-origins
 ```
 
 ### Global flags

--- a/docs/docs/reference/cli/usergroup/remove.md
+++ b/docs/docs/reference/cli/usergroup/remove.md
@@ -4,7 +4,7 @@ title: rill usergroup remove
 ---
 ## rill usergroup remove
 
-Remove role of a user group in an organization or prodject
+Remove role of a user group in an organization or project
 
 ```
 rill usergroup remove [flags]

--- a/docs/docs/reference/cli/usergroup/usergroup.md
+++ b/docs/docs/reference/cli/usergroup/usergroup.md
@@ -23,7 +23,7 @@ Manage user groups
 * [rill usergroup delete](delete.md)	 - Delete a user group
 * [rill usergroup edit](edit.md)	 - Edit a user group
 * [rill usergroup list](list.md)	 - List user groups
-* [rill usergroup remove](remove.md)	 - Remove role of a user group in an organization or prodject
+* [rill usergroup remove](remove.md)	 - Remove role of a user group in an organization or project
 * [rill usergroup rename](rename.md)	 - Rename a user group
 * [rill usergroup set](set.md)	 - Set role to a user group in an organization or project
 * [rill usergroup show](show.md)	 - Show a user group


### PR DESCRIPTION
Added under get-started where we mention start a new rill project as a note,

added the flag to references/cli/start.md

Based on Issue: https://github.com/rilldata/rill/pull/5365
and Slack: https://rilldata.slack.com/archives/C01UFNH4W3B/p1723481208803969?thread_ts=1723461905.169519&cid=C01UFNH4W3B