### PR TITLE
Move Rill Developer's UI dev server to port 3001

### DIFF
--- a/cli/cmd/devtool/README.md
+++ b/cli/cmd/devtool/README.md
@@ -60,7 +60,7 @@ rill devtool dotenv upload cloud
 
 ### Local
 
-- UI: `http://localhost:3000`
+- UI: `http://localhost:3001`
 - Runtime HTTP: `http://localhost:9009`
 - Runtime gRPC: `http://localhost:49009`
 - Runtime debug: `http://localhost:6060`

--- a/cli/cmd/devtool/start.go
+++ b/cli/cmd/devtool/start.go
@@ -691,7 +691,7 @@ func (s local) runUI(ctx context.Context) (err error) {
 }
 
 func (s local) awaitUI(ctx context.Context) error {
-	uiURL := "http://localhost:3000"
+	uiURL := "http://localhost:3001"
 	for {
 		resp, err := http.Get(uiURL)
 		if err == nil {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "npm run build -w web-local",
     "dev": "sh -c 'npm run dev-runtime & npm run dev-web & wait'",
     "dev-web": "npm run dev -w web-local",
-    "dev-runtime": "go run cli/main.go start dev-project --no-ui --allowed-origins http://localhost:3000",
+    "dev-runtime": "go run cli/main.go start dev-project --no-ui --allowed-origins http://localhost:3001",
     "clean": "rm -rf dev-project",
     "test": "npm run test -w web-common & npm run test -w web-auth & PLAYWRIGHT_TEST=true make cli && npm run test -w web-local"
   },

--- a/web-local/package.json
+++ b/web-local/package.json
@@ -3,7 +3,7 @@
   "version": "0.15.0",
   "type": "module",
   "scripts": {
-    "dev": "vite dev",
+    "dev": "vite dev --port 3001",
     "build": "vite build",
     "install-and-build": "npm install && npm run build",
     "check": "svelte-check --tsconfig ./tsconfig.json",


### PR DESCRIPTION
Previously, both Rill Developer's UI and Rill Cloud's UI were developed on port 3000. This wasn't an issue when they were independent projects. However, now that Rill Developer is integrated with Rill Cloud, particularly for the UI-based deploy flow, it's beneficial to run development versions of both UIs simultaneously.

To resolve the port conflict, this PR:
- Moves Rill Developer UI to port 3001
- Maintains Rill Cloud UI on port 3000

This change allows for easier concurrent development and testing of both UIs.