### PR TITLE
fix: assign default comparison

### DIFF
--- a/web-common/src/features/dashboards/time-controls/super-pill/components/Comparison.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/Comparison.svelte
@@ -38,7 +38,7 @@
         DateTime.fromJSDate(selectedComparison.start).setZone(zone),
         DateTime.fromJSDate(selectedComparison.end).setZone(zone),
       )
-    : currentInterval;
+    : undefined;
 
   $: firstVisibleMonth = interval?.start ?? DateTime.now();
 
@@ -104,7 +104,7 @@
           <p>no comparison period</p>
         {:else}
           <b class="line-clamp-1">{label}</b>
-          {#if interval.isValid}
+          {#if interval?.isValid}
             <RangeDisplay {interval} {grain} />
           {/if}
         {/if}

--- a/web-common/src/features/dashboards/time-controls/time-control-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.ts
@@ -358,11 +358,8 @@ function getComparisonTimeRange(
   timeRange: DashboardTimeControls | undefined,
   comparisonTimeRange: DashboardTimeControls | undefined,
 ) {
-  if (!comparisonTimeRange || !timeRange || !timeRange.name || !allTimeRange)
-    return undefined;
+  if (!timeRange || !timeRange.name || !allTimeRange) return undefined;
 
-  let selectedComparisonTimeRange: DashboardTimeControls | undefined =
-    undefined;
   if (!comparisonTimeRange?.name) {
     const comparisonOption = DEFAULT_TIME_RANGES[
       timeRange.name as TimeComparisonOption
@@ -379,14 +376,14 @@ function getComparisonTimeRange(
     );
 
     if (range.isComparisonRangeAvailable && range.start && range.end) {
-      selectedComparisonTimeRange = {
+      return {
         start: range.start,
         end: range.end,
         name: comparisonOption,
       };
     }
   } else if (comparisonTimeRange.name === TimeComparisonOption.CUSTOM) {
-    selectedComparisonTimeRange = comparisonTimeRange;
+    return comparisonTimeRange;
   } else {
     // variable time range of some kind.
     const comparisonOption = comparisonTimeRange.name as TimeComparisonOption;
@@ -396,13 +393,11 @@ function getComparisonTimeRange(
       comparisonOption,
     );
 
-    selectedComparisonTimeRange = {
+    return {
       ...range,
       name: comparisonOption,
     };
   }
-
-  return selectedComparisonTimeRange;
 }
 
 /**

--- a/web-common/src/features/dashboards/time-controls/time-control-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.ts
@@ -368,7 +368,8 @@ function getComparisonTimeRange(
       comparisonOption ??
         metricsView.availableTimeRanges?.find(
           (tr) => tr.range === timeRange.name,
-        )?.comparisonOffsets?.[0]?.offset,
+        )?.comparisonOffsets?.[0]?.offset ??
+        TimeComparisonOption.CONTIGUOUS,
       allTimeRange.start,
       allTimeRange.end,
       timeRange.start,


### PR DESCRIPTION
This PR updates the initial assignment of `selectedComparisonRange` so that a valid comparison, if one is available, is assigned by default