### PR TITLE
Connectors: persist the state of the Connector Explorer to local storage

### DIFF
--- a/web-common/src/features/connectors/ConnectorEntry.svelte
+++ b/web-common/src/features/connectors/ConnectorEntry.svelte
@@ -13,7 +13,7 @@
   export let connector: V1AnalyzedConnector;
 
   $: connectorName = connector?.name as string;
-  $: showConnector = connectorExplorerStore.getItemState(connectorName);
+  $: expanded = connectorExplorerStore.getItem(connectorName);
   $: ({ instanceId } = $runtime);
   $: instance = createRuntimeServiceGetInstance(instanceId, {
     sensitive: true,
@@ -32,7 +32,7 @@
         on:click={() => connectorExplorerStore.toggleItem(connectorName)}
       >
         <CaretDownIcon
-          className="transform transition-transform text-gray-400 {$showConnector
+          className="transform transition-transform text-gray-400 {$expanded
             ? 'rotate-0'
             : '-rotate-90'}"
           size="14px"
@@ -51,7 +51,7 @@
           <Tag height={16}>OLAP</Tag>
         {/if}
       </button>
-      {#if $showConnector}
+      {#if $expanded}
         <DatabaseExplorer {instanceId} {connector} />
       {/if}
     </li>

--- a/web-common/src/features/connectors/ConnectorEntry.svelte
+++ b/web-common/src/features/connectors/ConnectorEntry.svelte
@@ -6,13 +6,15 @@
     createRuntimeServiceGetInstance,
   } from "../../runtime-client";
   import { runtime } from "../../runtime-client/runtime-store";
+  import { connectorExplorerStore } from "./connector-explorer-store";
   import { connectorIconMapping } from "./connector-icon-mapping";
   import DatabaseExplorer from "./olap/DatabaseExplorer.svelte";
 
   export let connector: V1AnalyzedConnector;
 
-  let showDatabases = true;
-
+  $: connectorName = connector?.name as string;
+  $: showConnector =
+    $connectorExplorerStore.connectors[connectorName].showConnector;
   $: ({ instanceId } = $runtime);
   $: instance = createRuntimeServiceGetInstance(instanceId, {
     sensitive: true,
@@ -28,10 +30,10 @@
     <li aria-label={connector.name} class="connector-entry">
       <button
         class="connector-entry-header"
-        on:click={() => (showDatabases = !showDatabases)}
+        on:click={() => connectorExplorerStore.toggleConnector(connectorName)}
       >
         <CaretDownIcon
-          className="transform transition-transform text-gray-400 {showDatabases
+          className="transform transition-transform text-gray-400 {showConnector
             ? 'rotate-0'
             : '-rotate-90'}"
           size="14px"
@@ -50,7 +52,7 @@
           <Tag height={16}>OLAP</Tag>
         {/if}
       </button>
-      {#if showDatabases}
+      {#if showConnector}
         <DatabaseExplorer {instanceId} {connector} />
       {/if}
     </li>

--- a/web-common/src/features/connectors/ConnectorEntry.svelte
+++ b/web-common/src/features/connectors/ConnectorEntry.svelte
@@ -13,8 +13,7 @@
   export let connector: V1AnalyzedConnector;
 
   $: connectorName = connector?.name as string;
-  $: showConnector =
-    $connectorExplorerStore.connectors[connectorName].showConnector;
+  $: showConnector = connectorExplorerStore.getItemState(connectorName);
   $: ({ instanceId } = $runtime);
   $: instance = createRuntimeServiceGetInstance(instanceId, {
     sensitive: true,
@@ -30,10 +29,10 @@
     <li aria-label={connector.name} class="connector-entry">
       <button
         class="connector-entry-header"
-        on:click={() => connectorExplorerStore.toggleConnector(connectorName)}
+        on:click={() => connectorExplorerStore.toggleItem(connectorName)}
       >
         <CaretDownIcon
-          className="transform transition-transform text-gray-400 {showConnector
+          className="transform transition-transform text-gray-400 {$showConnector
             ? 'rotate-0'
             : '-rotate-90'}"
           size="14px"
@@ -52,7 +51,7 @@
           <Tag height={16}>OLAP</Tag>
         {/if}
       </button>
-      {#if showConnector}
+      {#if $showConnector}
         <DatabaseExplorer {instanceId} {connector} />
       {/if}
     </li>

--- a/web-common/src/features/connectors/ConnectorExplorer.svelte
+++ b/web-common/src/features/connectors/ConnectorExplorer.svelte
@@ -6,14 +6,16 @@
   import { createRuntimeServiceAnalyzeConnectors } from "../../runtime-client";
   import { runtime } from "../../runtime-client/runtime-store";
   import ConnectorEntry from "./ConnectorEntry.svelte";
+  import { connectorExplorerStore } from "./connector-explorer-store";
 
   export let containerHeight: number;
 
   const MIN_HEIGHT = 31; // The height of the "Connectors" header
 
-  let showConnectors = true;
   let initialHeight = containerHeight / 2;
   let sectionHeight = initialHeight;
+
+  $: showConnectors = $connectorExplorerStore.showConnectors;
 
   $: connectors = createRuntimeServiceAnalyzeConnectors($runtime.instanceId, {
     query: {
@@ -39,11 +41,7 @@
     basis={showConnectors ? initialHeight : MIN_HEIGHT}
     max={containerHeight * 0.9}
   />
-  <button
-    on:click={() => {
-      showConnectors = !showConnectors;
-    }}
-  >
+  <button on:click={connectorExplorerStore.toggleExplorer}>
     <h3>Connectors</h3>
     <CaretDownIcon
       className="transform transition-transform {showConnectors

--- a/web-common/src/features/connectors/connector-explorer-store.ts
+++ b/web-common/src/features/connectors/connector-explorer-store.ts
@@ -89,6 +89,7 @@ function createConnectorExplorerStore() {
         };
       }),
 
+    // Not used yet. Currently, the reconciler does not track connector renames.
     renameItem: (
       oldConnector: string,
       newConnector: string,

--- a/web-common/src/features/connectors/connector-explorer-store.ts
+++ b/web-common/src/features/connectors/connector-explorer-store.ts
@@ -26,7 +26,7 @@ function createConnectorExplorerStore() {
   }
 
   function getDefaultState(
-    connector: string,
+    connector: string, // Included for API consistency, but not used in this function
     database?: string,
     schema?: string,
   ): boolean {

--- a/web-common/src/features/connectors/connector-explorer-store.ts
+++ b/web-common/src/features/connectors/connector-explorer-store.ts
@@ -1,0 +1,127 @@
+import { localStorageStore } from "@rilldata/web-common/lib/store-utils";
+
+interface ConnectorExplorerState {
+  showConnectors: boolean;
+  connectors: Record<
+    string,
+    {
+      showConnector: boolean;
+      databases: Record<
+        string,
+        {
+          showDatabase: boolean;
+          databaseSchemas: Record<
+            string,
+            {
+              showDatabaseSchema: boolean;
+            }
+          >;
+        }
+      >;
+    }
+  >;
+}
+
+const initialState: ConnectorExplorerState = {
+  showConnectors: true,
+  connectors: {},
+};
+
+function createConnectorExplorerStore() {
+  const { subscribe, update } = localStorageStore<ConnectorExplorerState>(
+    "connector-explorer-state",
+    initialState,
+  );
+
+  return {
+    subscribe,
+    toggleExplorer: () =>
+      update((state) => ({ ...state, showConnectors: !state.showConnectors })),
+    toggleConnector: (connectorName: string) =>
+      update((state) => {
+        const connector = state.connectors[connectorName] || {
+          showConnector: true,
+          databases: {},
+        };
+        return {
+          ...state,
+          connectors: {
+            ...state.connectors,
+            [connectorName]: {
+              ...connector,
+              showConnector: !connector.showConnector,
+            },
+          },
+        };
+      }),
+    toggleDatabase: (connectorName: string, databaseName: string) =>
+      update((state) => {
+        const connector = state.connectors[connectorName] || {
+          showConnector: true,
+          databases: {},
+        };
+        const database = connector.databases[databaseName] || {
+          showDatabase: true,
+          databaseSchemas: {},
+        };
+        return {
+          ...state,
+          connectors: {
+            ...state.connectors,
+            [connectorName]: {
+              ...connector,
+              databases: {
+                ...connector.databases,
+                [databaseName]: {
+                  ...database,
+                  showDatabase: !database.showDatabase,
+                },
+              },
+            },
+          },
+        };
+      }),
+    toggleSchema: (
+      connectorName: string,
+      databaseName: string,
+      schemaName: string,
+    ) =>
+      update((state) => {
+        const connector = state.connectors[connectorName] || {
+          showConnector: true,
+          databases: {},
+        };
+        const database = connector.databases[databaseName] || {
+          showDatabase: true,
+          databaseSchemas: {},
+        };
+        const schema = database.databaseSchemas[schemaName] || {
+          showDatabaseSchema: true,
+        };
+        return {
+          ...state,
+          connectors: {
+            ...state.connectors,
+            [connectorName]: {
+              ...connector,
+              databases: {
+                ...connector.databases,
+                [databaseName]: {
+                  ...database,
+                  databaseSchemas: {
+                    ...database.databaseSchemas,
+                    [schemaName]: {
+                      ...schema,
+                      showDatabaseSchema: !schema.showDatabaseSchema,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        };
+      }),
+  };
+}
+
+export const connectorExplorerStore = createConnectorExplorerStore();

--- a/web-common/src/features/connectors/olap/DatabaseEntry.svelte
+++ b/web-common/src/features/connectors/olap/DatabaseEntry.svelte
@@ -4,6 +4,7 @@
   import CaretDownIcon from "../../../components/icons/CaretDownIcon.svelte";
   import { LIST_SLIDE_DURATION as duration } from "../../../layout/config";
   import { V1AnalyzedConnector } from "../../../runtime-client";
+  import { connectorExplorerStore } from "../connector-explorer-store";
   import DatabaseSchemaEntry from "./DatabaseSchemaEntry.svelte";
   import { useDatabaseSchemas } from "./selectors";
 
@@ -11,8 +12,10 @@
   export let connector: V1AnalyzedConnector;
   export let database: string;
 
-  let showDatabaseSchemas = true;
-
+  $: connectorName = connector?.name as string;
+  $: showDatabase =
+    $connectorExplorerStore.connectors[connectorName].databases[database]
+      .showDatabase;
   $: databaseSchemasQuery = useDatabaseSchemas(
     instanceId,
     connector?.name as string,
@@ -25,11 +28,12 @@
   {#if database}
     <button
       class="database-entry-header"
-      class:open={showDatabaseSchemas}
-      on:click={() => (showDatabaseSchemas = !showDatabaseSchemas)}
+      class:open={showDatabase}
+      on:click={() =>
+        connectorExplorerStore.toggleDatabase(connectorName, database)}
     >
       <CaretDownIcon
-        className="transform transition-transform text-gray-400 {showDatabaseSchemas
+        className="transform transition-transform text-gray-400 {showDatabase
           ? 'rotate-0'
           : '-rotate-90'}"
         size="14px"
@@ -42,7 +46,7 @@
   {/if}
 
   <ol transition:slide={{ duration }}>
-    {#if showDatabaseSchemas}
+    {#if showDatabase}
       {#if error}
         <span class="message">Error: {error.response.data.message}</span>
       {:else if isLoading}

--- a/web-common/src/features/connectors/olap/DatabaseEntry.svelte
+++ b/web-common/src/features/connectors/olap/DatabaseEntry.svelte
@@ -13,10 +13,8 @@
   export let database: string;
 
   $: connectorName = connector?.name as string;
-  $: showDatabase = connectorExplorerStore.getItemState(
-    connectorName,
-    database,
-  );
+  $: expanded = connectorExplorerStore.getItem(connectorName, database);
+  $: console.log(connectorName, database, "expanded", $expanded);
   $: databaseSchemasQuery = useDatabaseSchemas(
     instanceId,
     connector?.name as string,
@@ -29,12 +27,12 @@
   {#if database}
     <button
       class="database-entry-header"
-      class:open={$showDatabase}
+      class:open={$expanded}
       on:click={() =>
         connectorExplorerStore.toggleItem(connectorName, database)}
     >
       <CaretDownIcon
-        className="transform transition-transform text-gray-400 {$showDatabase
+        className="transform transition-transform text-gray-400 {$expanded
           ? 'rotate-0'
           : '-rotate-90'}"
         size="14px"
@@ -47,7 +45,7 @@
   {/if}
 
   <ol transition:slide={{ duration }}>
-    {#if $showDatabase}
+    {#if $expanded}
       {#if error}
         <span class="message">Error: {error.response.data.message}</span>
       {:else if isLoading}

--- a/web-common/src/features/connectors/olap/DatabaseEntry.svelte
+++ b/web-common/src/features/connectors/olap/DatabaseEntry.svelte
@@ -13,9 +13,10 @@
   export let database: string;
 
   $: connectorName = connector?.name as string;
-  $: showDatabase =
-    $connectorExplorerStore.connectors[connectorName].databases[database]
-      .showDatabase;
+  $: showDatabase = connectorExplorerStore.getItemState(
+    connectorName,
+    database,
+  );
   $: databaseSchemasQuery = useDatabaseSchemas(
     instanceId,
     connector?.name as string,
@@ -28,12 +29,12 @@
   {#if database}
     <button
       class="database-entry-header"
-      class:open={showDatabase}
+      class:open={$showDatabase}
       on:click={() =>
-        connectorExplorerStore.toggleDatabase(connectorName, database)}
+        connectorExplorerStore.toggleItem(connectorName, database)}
     >
       <CaretDownIcon
-        className="transform transition-transform text-gray-400 {showDatabase
+        className="transform transition-transform text-gray-400 {$showDatabase
           ? 'rotate-0'
           : '-rotate-90'}"
         size="14px"
@@ -46,7 +47,7 @@
   {/if}
 
   <ol transition:slide={{ duration }}>
-    {#if showDatabase}
+    {#if $showDatabase}
       {#if error}
         <span class="message">Error: {error.response.data.message}</span>
       {:else if isLoading}

--- a/web-common/src/features/connectors/olap/DatabaseEntry.svelte
+++ b/web-common/src/features/connectors/olap/DatabaseEntry.svelte
@@ -14,7 +14,6 @@
 
   $: connectorName = connector?.name as string;
   $: expanded = connectorExplorerStore.getItem(connectorName, database);
-  $: console.log(connectorName, database, "expanded", $expanded);
   $: databaseSchemasQuery = useDatabaseSchemas(
     instanceId,
     connector?.name as string,

--- a/web-common/src/features/connectors/olap/DatabaseSchemaEntry.svelte
+++ b/web-common/src/features/connectors/olap/DatabaseSchemaEntry.svelte
@@ -2,6 +2,7 @@
   import { Database, Folder } from "lucide-svelte";
   import CaretDownIcon from "../../../components/icons/CaretDownIcon.svelte";
   import { V1AnalyzedConnector } from "../../../runtime-client";
+  import { connectorExplorerStore } from "../connector-explorer-store";
   import TableEntry from "./TableEntry.svelte";
   import { useTables } from "./selectors";
 
@@ -10,9 +11,10 @@
   export let database: string;
   export let databaseSchema: string;
 
-  let showTables = true;
-
   $: connectorName = connector?.name as string;
+  $: showDatabaseSchema =
+    $connectorExplorerStore.connectors[connectorName].databases[database]
+      .databaseSchemas[databaseSchema].showDatabaseSchema;
   $: tablesQuery = useTables(
     instanceId,
     connectorName,
@@ -34,11 +36,16 @@
 <li aria-label={`${database}.${databaseSchema}`} class="database-schema-entry">
   <button
     class="database-schema-entry-header {database ? 'pl-[40px]' : 'pl-[22px]'}"
-    class:open={showTables}
-    on:click={() => (showTables = !showTables)}
+    class:open={showDatabaseSchema}
+    on:click={() =>
+      connectorExplorerStore.toggleSchema(
+        connectorName,
+        database,
+        databaseSchema,
+      )}
   >
     <CaretDownIcon
-      className="transform transition-transform text-gray-400 {showTables
+      className="transform transition-transform text-gray-400 {showDatabaseSchema
         ? 'rotate-0'
         : '-rotate-90'}"
       size="14px"
@@ -56,7 +63,7 @@
     </span>
   </button>
 
-  {#if showTables}
+  {#if showDatabaseSchema}
     {#if connector?.errorMessage}
       <div class="message">{connector.errorMessage}</div>
     {:else if !connector.driver || !connector.driver.name}

--- a/web-common/src/features/connectors/olap/DatabaseSchemaEntry.svelte
+++ b/web-common/src/features/connectors/olap/DatabaseSchemaEntry.svelte
@@ -12,9 +12,11 @@
   export let databaseSchema: string;
 
   $: connectorName = connector?.name as string;
-  $: showDatabaseSchema =
-    $connectorExplorerStore.connectors[connectorName].databases[database]
-      .databaseSchemas[databaseSchema].showDatabaseSchema;
+  $: showDatabaseSchema = connectorExplorerStore.getItemState(
+    connectorName,
+    database,
+    databaseSchema,
+  );
   $: tablesQuery = useTables(
     instanceId,
     connectorName,
@@ -36,16 +38,16 @@
 <li aria-label={`${database}.${databaseSchema}`} class="database-schema-entry">
   <button
     class="database-schema-entry-header {database ? 'pl-[40px]' : 'pl-[22px]'}"
-    class:open={showDatabaseSchema}
+    class:open={$showDatabaseSchema}
     on:click={() =>
-      connectorExplorerStore.toggleSchema(
+      connectorExplorerStore.toggleItem(
         connectorName,
         database,
         databaseSchema,
       )}
   >
     <CaretDownIcon
-      className="transform transition-transform text-gray-400 {showDatabaseSchema
+      className="transform transition-transform text-gray-400 {$showDatabaseSchema
         ? 'rotate-0'
         : '-rotate-90'}"
       size="14px"
@@ -63,7 +65,7 @@
     </span>
   </button>
 
-  {#if showDatabaseSchema}
+  {#if $showDatabaseSchema}
     {#if connector?.errorMessage}
       <div class="message">{connector.errorMessage}</div>
     {:else if !connector.driver || !connector.driver.name}

--- a/web-common/src/features/connectors/olap/DatabaseSchemaEntry.svelte
+++ b/web-common/src/features/connectors/olap/DatabaseSchemaEntry.svelte
@@ -12,7 +12,7 @@
   export let databaseSchema: string;
 
   $: connectorName = connector?.name as string;
-  $: showDatabaseSchema = connectorExplorerStore.getItemState(
+  $: expanded = connectorExplorerStore.getItem(
     connectorName,
     database,
     databaseSchema,
@@ -38,7 +38,7 @@
 <li aria-label={`${database}.${databaseSchema}`} class="database-schema-entry">
   <button
     class="database-schema-entry-header {database ? 'pl-[40px]' : 'pl-[22px]'}"
-    class:open={$showDatabaseSchema}
+    class:open={$expanded}
     on:click={() =>
       connectorExplorerStore.toggleItem(
         connectorName,
@@ -47,7 +47,7 @@
       )}
   >
     <CaretDownIcon
-      className="transform transition-transform text-gray-400 {$showDatabaseSchema
+      className="transform transition-transform text-gray-400 {$expanded
         ? 'rotate-0'
         : '-rotate-90'}"
       size="14px"
@@ -65,7 +65,7 @@
     </span>
   </button>
 
-  {#if $showDatabaseSchema}
+  {#if $expanded}
     {#if connector?.errorMessage}
       <div class="message">{connector.errorMessage}</div>
     {:else if !connector.driver || !connector.driver.name}

--- a/web-common/src/features/entity-management/WatchResourcesClient.ts
+++ b/web-common/src/features/entity-management/WatchResourcesClient.ts
@@ -22,6 +22,7 @@ import { isProfilingQuery } from "@rilldata/web-common/runtime-client/query-matc
 import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
 import { WatchRequestClient } from "@rilldata/web-common/runtime-client/watch-request-client";
 import { get } from "svelte/store";
+import { connectorExplorerStore } from "../connectors/connector-explorer-store";
 import { getConnectorNameForResource } from "../connectors/utils";
 
 const MainResourceKinds: {
@@ -210,6 +211,9 @@ export class WatchResourcesClient {
         void queryClient.cancelQueries({
           predicate: (query) => invalidationForMetricsViewData(query, name),
         });
+        break;
+      case ResourceKind.Connector:
+        connectorExplorerStore.deleteItem(name);
         break;
     }
   }


### PR DESCRIPTION
This PR saves the state of the Connector Explorer in local storage under the key `connector-explorer-state`. Closes https://github.com/rilldata/rill/issues/5327.

For example, the state of this explorer...
<img width="240" alt="image" src="https://github.com/user-attachments/assets/aa9911f3-91a6-4870-9225-ba50406401a7">

... is persisted like:
```json
{
  "showConnectors": true,
  "expandedItems": {
    "clickhouse": true,
    "clickhouse|default": false,
    "clickhouse|other": true,
    "clickhouse|test_database": false
    "duckdb": true,
    "duckdb|main_db": true,
    "duckdb|main_db|main": true,
  }
}
```