### PR TITLE
fix: gap between big number and metrics chart

### DIFF
--- a/web-common/src/features/dashboards/config.ts
+++ b/web-common/src/features/dashboards/config.ts
@@ -5,7 +5,7 @@ export const MEASURE_CONFIG = {
     fullHeight: 220,
   },
   container: {
-    width: { full: 620, breakpoint: 420 },
+    width: { full: 580, breakpoint: 420 },
   },
   bigNumber: {
     widthWithChart: 140,

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -139,8 +139,6 @@
       {#if $isTimeComparisonActive}
         <col style:width="{columnWidth}px" />
         <col style:width="{columnWidth}px" />
-      {:else}
-        <col style:width="{columnWidth}px" />
       {/if}
     </colgroup>
 

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -3,13 +3,13 @@
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { createQueryServiceMetricsViewAggregation } from "@rilldata/web-common/runtime-client";
+  import { onMount } from "svelte";
   import {
     LeaderboardItemData,
     prepareLeaderboardItemData,
   } from "./leaderboard-utils";
-  import { onMount } from "svelte";
-  import LeaderboardRow from "./LeaderboardRow.svelte";
   import LeaderboardHeader from "./LeaderboardHeader.svelte";
+  import LeaderboardRow from "./LeaderboardRow.svelte";
   import LoadingRows from "./LoadingRows.svelte";
 
   const slice = 7;
@@ -116,7 +116,7 @@
   $: dimensionDescription = $getDimensionDescription(dimensionName);
 
   $: firstColumnWidth =
-    !$isTimeComparisonActive && !$isValidPercentOfTotal ? 240 : 190;
+    !$isTimeComparisonActive && !$isValidPercentOfTotal ? 240 : 164;
 
   $: columnCount = $isTimeComparisonActive ? 3 : $isValidPercentOfTotal ? 2 : 1;
 

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -5,6 +5,11 @@
   import { bisectData } from "@rilldata/web-common/components/data-graphic/utils";
   import SearchableFilterButton from "@rilldata/web-common/components/searchable-filter-menu/SearchableFilterButton.svelte";
   import { LeaderboardContextColumn } from "@rilldata/web-common/features/dashboards/leaderboard-context-column";
+  import ReplacePivotDialog from "@rilldata/web-common/features/dashboards/pivot/ReplacePivotDialog.svelte";
+  import {
+    PivotChipData,
+    PivotChipType,
+  } from "@rilldata/web-common/features/dashboards/pivot/types";
   import { useMetricsView } from "@rilldata/web-common/features/dashboards/selectors";
   import { createShowHideMeasuresStore } from "@rilldata/web-common/features/dashboards/show-hide-selectors";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
@@ -26,8 +31,8 @@
   import { adjustOffsetForZone } from "@rilldata/web-common/lib/convertTimestampPreview";
   import { getAdjustedChartTime } from "@rilldata/web-common/lib/time/ranges";
   import {
-    TimeRangePreset,
     AvailableTimeGrain,
+    TimeRangePreset,
   } from "@rilldata/web-common/lib/time/types";
   import { MetricsViewSpecMeasureV2 } from "@rilldata/web-common/runtime-client";
   import { TIME_GRAIN } from "../../../lib/time/config";
@@ -39,11 +44,6 @@
   import TimeSeriesChartContainer from "./TimeSeriesChartContainer.svelte";
   import type { DimensionDataItem } from "./multiple-dimension-queries";
   import { getOrderedStartEnd, updateChartInteractionStore } from "./utils";
-  import ReplacePivotDialog from "@rilldata/web-common/features/dashboards/pivot/ReplacePivotDialog.svelte";
-  import {
-    PivotChipData,
-    PivotChipType,
-  } from "@rilldata/web-common/features/dashboards/pivot/types";
 
   export let metricViewName: string;
   export let workspaceWidth: number;
@@ -319,7 +319,7 @@
   </div>
 
   {#if tddChartType == TDDChart.DEFAULT || !expandedMeasureName}
-    <div class="z-10 gap-x-9 flex flex-row pt-4" style:padding-left="118px">
+    <div class="z-10 gap-x-9 flex flex-row pt-4" style:padding-left="110px">
       <div class="relative w-full">
         <ChartInteractions
           {metricViewName}
@@ -363,7 +363,7 @@
           ? $isMeasureValidPercentOfTotal(measure.name)
           : false}
 
-        <div class="flex flex-row gap-x-7">
+        <div class="flex flex-row gap-x-4">
           <MeasureBigNumber
             {measure}
             value={bigNum}

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -319,7 +319,7 @@
   </div>
 
   {#if tddChartType == TDDChart.DEFAULT || !expandedMeasureName}
-    <div class="z-10 gap-x-9 flex flex-row pt-4" style:padding-left="110px">
+    <div class="z-10 gap-x-9 flex flex-row pt-4" style:padding-left="118px">
       <div class="relative w-full">
         <ChartInteractions
           {metricViewName}


### PR DESCRIPTION
The gap between the big number and the measure charts was 28px contrary to 16px suggested in the mocks