### PR TITLE
Refactor admin service config in local app and CLI

### DIFF
--- a/cli/cmd/admin/ping.go
+++ b/cli/cmd/admin/ping.go
@@ -14,7 +14,7 @@ func PingCmd(ch *cmdutil.Helper) *cobra.Command {
 		Short: "Ping",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Must set here to avoid flag parser overriding it globally
-			ch.AdminURL = adminURL
+			ch.AdminURLOverride = adminURL
 
 			client, err := ch.Client()
 			if err != nil {

--- a/cli/cmd/auth/logout.go
+++ b/cli/cmd/auth/logout.go
@@ -36,6 +36,10 @@ func LogoutCmd(ch *cmdutil.Helper) *cobra.Command {
 }
 
 func Logout(ctx context.Context, ch *cmdutil.Helper) error {
+	if !ch.IsAuthenticated() {
+		return nil
+	}
+
 	client, err := ch.Client()
 	if err != nil {
 		return err
@@ -69,7 +73,10 @@ func Logout(ctx context.Context, ch *cmdutil.Helper) error {
 		return err
 	}
 
-	ch.AdminTokenDefault = ""
+	err = ch.ReloadAdminConfig()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/cli/cmd/deploy/deploy.go
+++ b/cli/cmd/deploy/deploy.go
@@ -295,7 +295,7 @@ func DeployFlow(ctx context.Context, ch *cmdutil.Helper, opts *Options) error {
 	}
 
 	if localProjectPath != "" {
-		err = dotrillcloud.SetAll(localProjectPath, ch.AdminURL, &dotrillcloud.Config{
+		err = dotrillcloud.SetAll(localProjectPath, ch.AdminURL(), &dotrillcloud.Config{
 			ProjectID: res.Project.Id,
 		})
 		if err != nil {
@@ -440,7 +440,7 @@ func deployWithUploadFlow(ctx context.Context, ch *cmdutil.Helper, opts *Options
 		return fmt.Errorf("create project failed with error %w", err)
 	}
 
-	err = dotrillcloud.SetAll(localProjectPath, ch.AdminURL, &dotrillcloud.Config{
+	err = dotrillcloud.SetAll(localProjectPath, ch.AdminURL(), &dotrillcloud.Config{
 		ProjectID: res.Project.Id,
 	})
 	if err != nil {
@@ -533,16 +533,18 @@ func setDefaultOrg(ctx context.Context, c *client.Client, ch *cmdutil.Helper) er
 }
 
 func loginWithTelemetryAndGithubRedirect(ctx context.Context, ch *cmdutil.Helper, remote string) error {
-	authURL := ch.AdminURL
+	// NOTE: This is temporary until we migrate to a server that can host HTTP and gRPC on the same port.
+	authURL := ch.AdminURL()
 	if strings.Contains(authURL, "http://localhost:9090") {
 		authURL = "http://localhost:8080"
 	}
+
 	var qry map[string]string
 	if remote != "" {
 		qry = map[string]string{"remote": remote}
 	}
 
-	redirectURL, err := urlutil.WithQuery(urlutil.MustJoinURL(authURL, "/github/post-auth-redirect"), qry)
+	redirectURL, err := urlutil.WithQuery(urlutil.MustJoinURL(authURL, "github", "post-auth-redirect"), qry)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/devtool/switch-env.go
+++ b/cli/cmd/devtool/switch-env.go
@@ -29,7 +29,7 @@ func SwitchEnvCmd(ch *cmdutil.Helper) *cobra.Command {
 				return fmt.Errorf("can't switch environment when assuming another user (run `rill sudo user unassume` and try again)")
 			}
 
-			fromEnv, err := adminenv.Infer(ch.AdminURL)
+			fromEnv, err := adminenv.Infer(ch.AdminURL())
 			if err != nil {
 				return err
 			}
@@ -78,14 +78,17 @@ func switchEnv(ch *cmdutil.Helper, fromEnv, toEnv string) error {
 	if err != nil {
 		return err
 	}
-	ch.AdminTokenDefault = toToken // Also set the cfg's token to the one we just got
 
 	toURL := adminenv.AdminURL(toEnv)
 	err = dotrill.SetDefaultAdminURL(toURL)
 	if err != nil {
 		return err
 	}
-	ch.AdminURL = toURL
+
+	err = ch.ReloadAdminConfig()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -93,7 +96,7 @@ func switchEnv(ch *cmdutil.Helper, fromEnv, toEnv string) error {
 // switchEnvToDevTemporarily switches the CLI to the "dev" environment (if not already there),
 // and then switches it back and returns when the context is cancelled.
 func switchEnvToDevTemporarily(ctx context.Context, ch *cmdutil.Helper) {
-	env, err := adminenv.Infer(ch.AdminURL)
+	env, err := adminenv.Infer(ch.AdminURL())
 	if err != nil {
 		logWarn.Printf("Did not switch CLI to dev environment: failed to infer environment (error: %v)\n", err)
 		return
@@ -128,7 +131,7 @@ func switchEnvToDevTemporarily(ctx context.Context, ch *cmdutil.Helper) {
 		// Since dev environments are frequently reset, clear the token if it's invalid
 		_ = dotrill.SetAccessToken("")
 		_ = dotrill.SetDefaultOrg("")
-		ch.AdminTokenDefault = ""
+		_ = ch.ReloadAdminConfig()
 	}
 
 	// Wait for ctx cancellation, then switch back to the previous environment before returning.

--- a/cli/cmd/devtool/switch-env.go
+++ b/cli/cmd/devtool/switch-env.go
@@ -130,8 +130,10 @@ func switchEnvToDevTemporarily(ctx context.Context, ch *cmdutil.Helper) {
 	} else {
 		// Since dev environments are frequently reset, clear the token if it's invalid
 		_ = dotrill.SetAccessToken("")
-		_ = dotrill.SetDefaultOrg("")
 		_ = ch.ReloadAdminConfig()
+
+		_ = dotrill.SetDefaultOrg("")
+		ch.Org = ""
 	}
 
 	// Wait for ctx cancellation, then switch back to the previous environment before returning.

--- a/cli/cmd/org/org_test.go
+++ b/cli/cmd/org/org_test.go
@@ -67,7 +67,7 @@ func TestOrganizationWorkflow(t *testing.T) {
 	p.OverrideDataOutput(&buf)
 
 	helper := &cmdutil.Helper{
-		AdminURL:          "http://localhost:9090",
+		AdminURLDefault:   "http://localhost:9090",
 		AdminTokenDefault: adminAuthToken.Token().String(),
 		Printer:           p,
 	}

--- a/cli/cmd/project/delete.go
+++ b/cli/cmd/project/delete.go
@@ -60,17 +60,12 @@ func DeleteCmd(ch *cmdutil.Helper) *cobra.Command {
 				return err
 			}
 
-			var deployedID string
-			rc, err := dotrillcloud.GetAll(path, ch.AdminURL)
+			rc, err := dotrillcloud.GetAll(path, ch.AdminURL())
 			if err != nil {
 				return err
 			}
-			if rc != nil {
-				deployedID = rc.ProjectID
-			}
-
-			if delResp.Id == deployedID {
-				err = dotrillcloud.Delete(path, ch.AdminURL)
+			if rc != nil && rc.ProjectID == delResp.Id {
+				err = dotrillcloud.Delete(path, ch.AdminURL())
 				if err != nil {
 					return err
 				}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -38,10 +38,6 @@ func init() {
 	cobra.EnableCommandSorting = false
 }
 
-// defaultAdminURL is the default admin server URL.
-// Users can override it with the "--api-url" flag or by setting "api-url" in ~/.rill/config.yaml.
-const defaultAdminURL = "https://admin.rilldata.com"
-
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
 	Use:   "rill <command>",
@@ -76,37 +72,19 @@ func Execute(ctx context.Context, ver cmdutil.Version) {
 }
 
 func runCmd(ctx context.Context, ver cmdutil.Version) error {
-	// Load admin token from .rill (may later be overridden by flag --api-token)
-	adminTokenDefault, err := dotrill.GetAccessToken()
-	if err != nil {
-		return fmt.Errorf("could not parse access token from ~/.rill: %w", err)
-	}
-
-	// Load admin URL from .rill (override with --api-url)
-	adminURL, err := dotrill.GetDefaultAdminURL()
-	if err != nil {
-		return fmt.Errorf("could not parse default api URL from ~/.rill: %w", err)
-	}
-	if adminURL == "" {
-		adminURL = defaultAdminURL
-	}
-
-	// Load default org from .rill
-	defaultOrg, err := dotrill.GetDefaultOrg()
-	if err != nil {
-		return fmt.Errorf("could not parse default org from ~/.rill: %w", err)
-	}
-
 	// Create cmdutil Helper
 	ch := &cmdutil.Helper{
-		Printer:           printer.NewPrinter(printer.FormatHuman),
-		Version:           ver,
-		AdminURL:          adminURL,
-		AdminTokenDefault: adminTokenDefault,
-		Org:               defaultOrg,
-		Interactive:       true,
+		Printer:     printer.NewPrinter(printer.FormatHuman),
+		Version:     ver,
+		Interactive: true,
 	}
 	defer ch.Close()
+
+	// Load base admin config from ~/.rill
+	err := ch.ReloadAdminConfig()
+	if err != nil {
+		return err
+	}
 
 	// Check version
 	err = update.CheckVersion(ctx, ver.Number)
@@ -132,7 +110,7 @@ func runCmd(ctx context.Context, ver cmdutil.Version) error {
 	rootCmd.PersistentFlags().BoolP("help", "h", false, "Print usage") // Overrides message for help
 	rootCmd.PersistentFlags().BoolVar(&ch.Interactive, "interactive", true, "Prompt for missing required parameters")
 	rootCmd.PersistentFlags().Var(&ch.Printer.Format, "format", `Output format (options: "human", "json", "csv")`)
-	rootCmd.PersistentFlags().StringVar(&ch.AdminURL, "api-url", ch.AdminURL, "Base URL for the cloud API")
+	rootCmd.PersistentFlags().StringVar(&ch.AdminURLOverride, "api-url", ch.AdminURLOverride, "Base URL for the cloud API")
 	if !ch.IsDev() {
 		if err := rootCmd.PersistentFlags().MarkHidden("api-url"); err != nil {
 			panic(err)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -86,6 +86,13 @@ func runCmd(ctx context.Context, ver cmdutil.Version) error {
 		return err
 	}
 
+	// Load default org
+	defaultOrg, err := dotrill.GetDefaultOrg()
+	if err != nil {
+		return fmt.Errorf("could not parse default org from ~/.rill: %w", err)
+	}
+	ch.Org = defaultOrg
+
 	// Check version
 	err = update.CheckVersion(ctx, ver.Number)
 	if err != nil {

--- a/cli/cmd/service/service_test.go
+++ b/cli/cmd/service/service_test.go
@@ -67,7 +67,7 @@ func TestServiceWorkflow(t *testing.T) {
 	p.OverrideDataOutput(&buf)
 
 	helper := &cmdutil.Helper{
-		AdminURL:          "http://localhost:9090",
+		AdminURLDefault:   "http://localhost:9090",
 		AdminTokenDefault: adminAuthToken.Token().String(),
 		Org:               "myorg",
 		Printer:           p,

--- a/cli/cmd/start/start.go
+++ b/cli/cmd/start/start.go
@@ -147,7 +147,7 @@ func StartCmd(ch *cmdutil.Helper) *cobra.Command {
 			allowedOrigins = append(allowedOrigins, localURL)
 
 			app, err := local.NewApp(cmd.Context(), &local.AppOptions{
-				Version:        ch.Version,
+				Ch:             ch,
 				Verbose:        verbose,
 				Debug:          debug,
 				Reset:          reset,
@@ -157,10 +157,6 @@ func StartCmd(ch *cmdutil.Helper) *cobra.Command {
 				ProjectPath:    projectPath,
 				LogFormat:      parsedLogFormat,
 				Variables:      varsMap,
-				Activity:       ch.Telemetry(cmd.Context()),
-				AdminURL:       ch.AdminURL,
-				AdminToken:     ch.AdminToken(),
-				CMDHelper:      ch,
 				LocalURL:       localURL,
 				AllowedOrigins: allowedOrigins,
 			})

--- a/cli/cmd/sudo/user/assume.go
+++ b/cli/cmd/sudo/user/assume.go
@@ -53,8 +53,11 @@ func AssumeCmd(ch *cmdutil.Helper) *cobra.Command {
 				return err
 			}
 
-			// set the default token to the one we just got
-			ch.AdminTokenDefault = res.Token
+			// Load new token
+			err = ch.ReloadAdminConfig()
+			if err != nil {
+				return err
+			}
 
 			// Select org for new user
 			err = auth.SelectOrgFlow(ctx, ch, true)

--- a/cli/cmd/sudo/user/open.go
+++ b/cli/cmd/sudo/user/open.go
@@ -16,17 +16,18 @@ func OpenCmd(ch *cmdutil.Helper) *cobra.Command {
 		Args:  cobra.NoArgs,
 		Short: "Open browser as the current user",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			authURL := ch.AdminURL
+			// NOTE: This is temporary until we migrate to a server that can host HTTP and gRPC on the same port.
+			authURL := ch.AdminURL()
 			if strings.Contains(authURL, "http://localhost:9090") {
 				authURL = "http://localhost:8080"
 			}
 
-			withTokenURI, err := url.JoinPath(authURL, "auth/with-token")
+			withTokenURI, err := url.JoinPath(authURL, "auth", "with-token")
 			if err != nil {
 				return err
 			}
 
-			qry := map[string]string{"token": ch.AdminTokenDefault}
+			qry := map[string]string{"token": ch.AdminToken()}
 			withTokenURL, err := urlutil.WithQuery(withTokenURI, qry)
 			if err != nil {
 				return err

--- a/cli/cmd/user/user_test.go
+++ b/cli/cmd/user/user_test.go
@@ -66,7 +66,7 @@ func TestUserWorkflow(t *testing.T) {
 	p := printer.NewPrinter(printer.FormatHuman)
 	p.OverrideDataOutput(&buf)
 	helper := &cmdutil.Helper{
-		AdminURL:          "http://localhost:9090",
+		AdminURLDefault:   "http://localhost:9090",
 		AdminTokenDefault: adminAuthToken.Token().String(),
 		Printer:           p,
 	}

--- a/cli/pkg/cmdutil/helper.go
+++ b/cli/pkg/cmdutil/helper.go
@@ -113,8 +113,14 @@ func (h *Helper) AdminURL() string {
 }
 
 func (h *Helper) Client() (*client.Client, error) {
-	// We allow the admin token and URL to be changed (e.g. during login or env switching).
-	// We compute and cache a hash of these values to detect changes.
+	// The admin token and URL may have changed (e.g. if the user did a separate login or env switch).
+	// Reload the admin config from disk to get the latest values.
+	err := h.ReloadAdminConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	// Compute and cache a hash of the admin config values to detect changes.
 	// If the hash has changed, we should close the existing client.
 	hash := hashStr(h.AdminToken(), h.AdminURL())
 	if h.adminClient != nil && h.adminClientHash != hash {

--- a/cli/pkg/cmdutil/helper.go
+++ b/cli/pkg/cmdutil/helper.go
@@ -34,11 +34,11 @@ type Helper struct {
 	*printer.Printer
 	Version            Version
 	Interactive        bool
+	Org                string
 	AdminURLDefault    string
 	AdminURLOverride   string
 	AdminTokenDefault  string
 	AdminTokenOverride string
-	Org                string
 
 	adminClient        *client.Client
 	adminClientHash    string
@@ -92,14 +92,8 @@ func (h *Helper) ReloadAdminConfig() error {
 		adminURL = defaultAdminURL
 	}
 
-	org, err := dotrill.GetDefaultOrg()
-	if err != nil {
-		return fmt.Errorf("could not parse default org from ~/.rill: %w", err)
-	}
-
 	h.AdminURLDefault = adminURL
 	h.AdminTokenDefault = adminToken
-	h.Org = org
 
 	return nil
 }

--- a/cli/pkg/local/app.go
+++ b/cli/pkg/local/app.go
@@ -61,22 +61,19 @@ type App struct {
 	Instance              *drivers.Instance
 	Logger                *zap.SugaredLogger
 	BaseLogger            *zap.Logger
-	Version               cmdutil.Version
 	Verbose               bool
 	Debug                 bool
 	ProjectPath           string
+	ch                    *cmdutil.Helper
 	observabilityShutdown observability.ShutdownFunc
 	loggerCleanUp         func()
-	activity              *activity.Client
-	adminURL              string
 	pkceAuthenticators    map[string]*pkce.Authenticator // map of state to pkce authenticators
-	ch                    *cmdutil.Helper
 	localURL              string
 	allowedOrigins        []string
 }
 
 type AppOptions struct {
-	Version        cmdutil.Version
+	Ch             *cmdutil.Helper
 	Verbose        bool
 	Debug          bool
 	Reset          bool
@@ -86,10 +83,6 @@ type AppOptions struct {
 	ProjectPath    string
 	LogFormat      LogFormat
 	Variables      map[string]string
-	Activity       *activity.Client
-	AdminURL       string
-	AdminToken     string
-	CMDHelper      *cmdutil.Helper
 	LocalURL       string
 	AllowedOrigins []string
 }
@@ -104,7 +97,7 @@ func NewApp(ctx context.Context, opts *AppOptions) (*App, error) {
 		MetricsExporter: observability.PrometheusExporter,
 		TracesExporter:  observability.NoopExporter,
 		ServiceName:     "rill-local",
-		ServiceVersion:  opts.Version.String(),
+		ServiceVersion:  opts.Ch.Version.String(),
 	})
 	if err != nil {
 		return nil, err
@@ -175,7 +168,7 @@ func NewApp(ctx context.Context, opts *AppOptions) (*App, error) {
 		ControllerLogBufferCapacity:  10000,
 		ControllerLogBufferSizeBytes: int64(datasize.MB * 16),
 	}
-	rt, err := runtime.New(ctx, rtOpts, logger, opts.Activity, email.New(sender))
+	rt, err := runtime.New(ctx, rtOpts, logger, opts.Ch.Telemetry(ctx), email.New(sender))
 	if err != nil {
 		return nil, err
 	}
@@ -252,8 +245,8 @@ func NewApp(ctx context.Context, opts *AppOptions) (*App, error) {
 		Name: "admin",
 		Type: "admin",
 		Config: map[string]string{
-			"admin_url":    opts.AdminURL,
-			"access_token": opts.AdminToken,
+			"admin_url":    opts.Ch.AdminURL(),
+			"access_token": opts.Ch.AdminToken(),
 		},
 	}
 	connectors = append(connectors, aiConnector)
@@ -291,16 +284,13 @@ func NewApp(ctx context.Context, opts *AppOptions) (*App, error) {
 		Instance:              inst,
 		Logger:                sugarLogger,
 		BaseLogger:            logger,
-		Version:               opts.Version,
 		Verbose:               opts.Verbose,
 		Debug:                 opts.Debug,
 		ProjectPath:           projectPath,
+		ch:                    opts.Ch,
 		observabilityShutdown: shutdown,
 		loggerCleanUp:         cleanupFn,
-		activity:              opts.Activity,
-		adminURL:              opts.AdminURL,
 		pkceAuthenticators:    make(map[string]*pkce.Authenticator),
-		ch:                    opts.CMDHelper,
 		localURL:              opts.LocalURL,
 		allowedOrigins:        opts.AllowedOrigins,
 	}
@@ -348,10 +338,10 @@ func (a *App) Serve(httpPort, grpcPort int, enableUI, openBrowser, readonly bool
 		InstallID:        installID,
 		ProjectPath:      a.ProjectPath,
 		UserID:           userID,
-		Version:          a.Version.Number,
-		BuildCommit:      a.Version.Commit,
-		BuildTime:        a.Version.Timestamp,
-		IsDev:            a.Version.IsDev(),
+		Version:          a.ch.Version.Number,
+		BuildCommit:      a.ch.Version.Commit,
+		BuildTime:        a.ch.Version.Timestamp,
+		IsDev:            a.ch.Version.IsDev(),
 		AnalyticsEnabled: enabled,
 		Readonly:         readonly,
 	}
@@ -383,7 +373,7 @@ func (a *App) Serve(httpPort, grpcPort int, enableUI, openBrowser, readonly bool
 		AllowedOrigins:  a.allowedOrigins,
 		ServePrometheus: true,
 	}
-	runtimeServer, err := runtimeserver.NewServer(ctx, opts, a.Runtime, runtimeServerLogger, ratelimit.NewNoop(), a.activity)
+	runtimeServer, err := runtimeserver.NewServer(ctx, opts, a.Runtime, runtimeServerLogger, ratelimit.NewNoop(), a.ch.Telemetry(ctx))
 	if err != nil {
 		return err
 	}
@@ -488,7 +478,7 @@ func (a *App) emitStartEvent(ctx context.Context) error {
 		connectorNames = append(connectorNames, connector.Name)
 	}
 
-	a.activity.RecordBehavioralLegacy(activity.BehavioralEventAppStart, attribute.StringSlice("connectors", connectorNames), attribute.String("olap_connector", a.Instance.OLAPConnector))
+	a.ch.Telemetry(ctx).RecordBehavioralLegacy(activity.BehavioralEventAppStart, attribute.StringSlice("connectors", connectorNames), attribute.String("olap_connector", a.Instance.OLAPConnector))
 
 	return nil
 }

--- a/cli/pkg/pkce/authenticator.go
+++ b/cli/pkg/pkce/authenticator.go
@@ -31,6 +31,7 @@ type Authenticator struct {
 }
 
 func NewAuthenticator(baseAuthURL, redirectURL, clientID, origin string) (*Authenticator, error) {
+	// NOTE: This is temporary until we migrate to a server that can host HTTP and gRPC on the same port.
 	if strings.Contains(baseAuthURL, "http://localhost:9090") {
 		baseAuthURL = "http://localhost:8080"
 	}


### PR DESCRIPTION
This PR refactors the way the various admin service config (such as the access token, admin URL, current cloud project) is loaded throughout the local app and CLI.

Among other things, it fixes an issue where the access token used by the local APIs was not updated when the user ran `rill login`.