### PR TITLE
Nit: Make resource tables more readable

### DIFF
--- a/web-admin/src/components/table/ResourceHeader.svelte
+++ b/web-admin/src/components/table/ResourceHeader.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import type { SvelteComponent } from "svelte";
+  import type { ComponentType, SvelteComponent } from "svelte";
   import { getContext } from "svelte";
 
   export let kind: string;
-  export let icon: typeof SvelteComponent;
+  export let icon: ComponentType<SvelteComponent>;
 
   const table = getContext("table");
 

--- a/web-admin/src/components/table/ResourceHeader.svelte
+++ b/web-admin/src/components/table/ResourceHeader.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
+  import type { Table } from "@tanstack/svelte-table";
   import type { ComponentType, SvelteComponent } from "svelte";
   import { getContext } from "svelte";
+  import type { Readable } from "svelte/store";
 
   export let kind: string;
   export let icon: ComponentType<SvelteComponent>;
 
-  const table = getContext("table");
+  const table = getContext<Readable<Table<unknown>>>("table");
 
   $: numRows = $table.getRowModel().rows.length;
 </script>

--- a/web-admin/src/components/table/ResourceHeader.svelte
+++ b/web-admin/src/components/table/ResourceHeader.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import type { SvelteComponent } from "svelte";
+  import { getContext } from "svelte";
+
+  export let kind: string;
+  export let icon: typeof SvelteComponent;
+
+  const table = getContext("table");
+
+  $: numRows = $table.getRowModel().rows.length;
+</script>
+
+<thead>
+  <tr>
+    <td>
+      <svelte:component this={icon} size={"14px"} />
+      {numRows}
+      {kind}{numRows !== 1 ? "s" : ""}
+    </td>
+  </tr>
+</thead>
+
+<!-- 
+Rounded table corners are tricky:
+- `border-radius` does not apply to table elements when `border-collapse` is `collapse`.
+- You can only apply `border-radius` to <td>, not <tr> or <table>.
+-->
+<style lang="postcss">
+  thead tr td {
+    @apply pl-[17px] pr-4 py-3 max-w-[800px] flex items-center gap-x-2 bg-slate-100;
+    @apply font-semibold text-gray-500;
+    @apply border-y;
+  }
+  thead tr td:first-child {
+    @apply border-l rounded-tl-sm;
+  }
+  thead tr td:last-child {
+    @apply border-r rounded-tr-sm;
+  }
+</style>

--- a/web-admin/src/components/table/ResourceTableEmpty.svelte
+++ b/web-admin/src/components/table/ResourceTableEmpty.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  export let kind: string;
+</script>
+
+<span class="text-gray-500"> No {kind}s found. </span>

--- a/web-admin/src/components/table/Table.svelte
+++ b/web-admin/src/components/table/Table.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
+  import type { ColumnDef, TableOptions } from "@tanstack/svelte-table";
   import {
-    type Row,
     createSvelteTable,
     flexRender,
     getCoreRowModel,
     getFilteredRowModel,
     getSortedRowModel,
+    type Row,
   } from "@tanstack/svelte-table";
-  import type { ColumnDef, TableOptions } from "@tanstack/svelte-table";
   import { createEventDispatcher, setContext } from "svelte";
   import { writable } from "svelte/store";
 
@@ -72,6 +72,8 @@
   // Whenever the input data changes, rerender the table
   $: data && rerender();
 </script>
+
+<slot name="toolbar" />
 
 <table class="w-full {maxWidth}">
   <slot name="header" />

--- a/web-admin/src/components/table/Toolbar.svelte
+++ b/web-admin/src/components/table/Toolbar.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import { beforeNavigate } from "$app/navigation";
   import { Search } from "@rilldata/web-common/components/search";
+  import type { Table } from "@tanstack/svelte-table";
   import { getContext } from "svelte";
+  import type { Readable } from "svelte/store";
 
-  const table = getContext("table");
+  const table = getContext<Readable<Table<unknown>>>("table");
 
   // Search
   let filter = "";

--- a/web-admin/src/components/table/Toolbar.svelte
+++ b/web-admin/src/components/table/Toolbar.svelte
@@ -15,8 +15,6 @@
   $: filterTable(filter);
 
   beforeNavigate(() => (filter = "")); // resets filter when changing projects
-
-  console.log("got here");
 </script>
 
 <div class="w-full max-w-[800px] flex items-center">

--- a/web-admin/src/features/alerts/listing/AlertsTable.svelte
+++ b/web-admin/src/features/alerts/listing/AlertsTable.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+  import Toolbar from "@rilldata/web-admin/components/table/Toolbar.svelte";
   import DelayedSpinner from "@rilldata/web-common/features/entity-management/DelayedSpinner.svelte";
   import type { V1Resource } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
-  import { type ColumnDef, flexRender } from "@tanstack/svelte-table";
+  import { flexRender, type ColumnDef } from "@tanstack/svelte-table";
   import Table from "../../../components/table/Table.svelte";
   import { useAlerts } from "../../alerts/selectors";
   import AlertsError from "./AlertsError.svelte";
@@ -79,6 +80,7 @@
     <NoAlertsCTA />
   {:else}
     <Table {columns} data={$alerts?.data?.resources} {columnVisibility}>
+      <Toolbar slot="toolbar" />
       <AlertsTableHeader slot="header" />
       <AlertsTableEmpty slot="empty" />
     </Table>

--- a/web-admin/src/features/alerts/listing/AlertsTable.svelte
+++ b/web-admin/src/features/alerts/listing/AlertsTable.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
+  import ResourceHeader from "@rilldata/web-admin/components/table/ResourceHeader.svelte";
+  import ResourceTableEmpty from "@rilldata/web-admin/components/table/ResourceTableEmpty.svelte";
   import Toolbar from "@rilldata/web-admin/components/table/Toolbar.svelte";
   import DelayedSpinner from "@rilldata/web-common/features/entity-management/DelayedSpinner.svelte";
   import type { V1Resource } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { flexRender, type ColumnDef } from "@tanstack/svelte-table";
+  import { BellIcon } from "lucide-svelte";
   import Table from "../../../components/table/Table.svelte";
   import { useAlerts } from "../../alerts/selectors";
   import AlertsError from "./AlertsError.svelte";
   import AlertsTableCompositeCell from "./AlertsTableCompositeCell.svelte";
-  import AlertsTableEmpty from "./AlertsTableEmpty.svelte";
-  import AlertsTableHeader from "./AlertsTableHeader.svelte";
   import NoAlertsCTA from "./NoAlertsCTA.svelte";
 
   export let organization: string;
@@ -81,8 +82,8 @@
   {:else}
     <Table {columns} data={$alerts?.data?.resources} {columnVisibility}>
       <Toolbar slot="toolbar" />
-      <AlertsTableHeader slot="header" />
-      <AlertsTableEmpty slot="empty" />
+      <ResourceHeader kind="alert" icon={BellIcon} slot="header" />
+      <ResourceTableEmpty kind="alert" slot="empty" />
     </Table>
   {/if}
 {/if}

--- a/web-admin/src/features/alerts/listing/AlertsTableCompositeCell.svelte
+++ b/web-admin/src/features/alerts/listing/AlertsTableCompositeCell.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import { BellIcon } from "lucide-svelte";
   import CancelCircleInverse from "@rilldata/web-common/components/icons/CancelCircleInverse.svelte";
   import CheckCircleOutline from "@rilldata/web-common/components/icons/CheckCircleOutline.svelte";
+  import { BellIcon } from "lucide-svelte";
+  import { timeAgo } from "../../dashboards/listing/utils";
   import ProjectAccessControls from "../../projects/ProjectAccessControls.svelte";
   import AlertOwnerBullet from "./AlertOwnerBullet.svelte";
-  import { timeAgo } from "../../dashboards/listing/utils";
 
   export let organization: string;
   export let project: string;
@@ -15,7 +15,7 @@
   export let lastTriggerErrorMessage: string | undefined;
 </script>
 
-<a href={`alerts/${id}`} class="flex flex-col gap-y-0.5 group px-4 py-[5px]">
+<a href={`alerts/${id}`} class="flex flex-col gap-y-0.5 group px-4 py-2">
   <div class="flex gap-x-2 items-center text-slate-500">
     <BellIcon size="14px" />
     <div

--- a/web-admin/src/features/alerts/listing/AlertsTableEmpty.svelte
+++ b/web-admin/src/features/alerts/listing/AlertsTableEmpty.svelte
@@ -1,1 +1,0 @@
-<span class="text-gray-500"> No alerts found. </span>

--- a/web-admin/src/features/alerts/listing/AlertsTableHeader.svelte
+++ b/web-admin/src/features/alerts/listing/AlertsTableHeader.svelte
@@ -1,85 +1,18 @@
 <script lang="ts">
-  import { Search } from "@rilldata/web-common/components/search";
-  import type { Table } from "@tanstack/table-core";
+  import { BellIcon } from "lucide-svelte";
   import { getContext } from "svelte";
-  import type { Readable } from "svelte/store";
 
-  const table = getContext<Readable<Table<any>>>("table");
-
-  // Search
-  let filter = "";
-
-  $: filterTable(filter);
-
-  function filterTable(filter: string) {
-    $table.setGlobalFilter(filter);
-  }
+  const table = getContext("table");
 
   // Number of alerts
   $: numAlerts = $table.getRowModel().rows.length;
-
-  // Sort
-  // function sortAlphabetically() {
-  //   $table.setSorting([{ id: "monocolumn", desc: false }]);
-  // }
-
-  // function sortByMostRecentlyRun() {
-  //   $table.setSorting([{ id: "lastRun", desc: true }]);
-  // }
-
-  // function sortByNextToRun() {
-  //   $table.setSorting([{ id: "monocolumn", desc: false }]);
-  // }
-
-  // let openSortMenu = false;
-  // function closeSortMenu() {
-  //   openSortMenu = false;
-  // }
 </script>
 
 <thead>
   <tr>
-    <td
-      class="pl-2 pr-4 py-2 max-w-[800px] flex items-center gap-x-2 bg-slate-100"
-    >
-      <!-- Search bar -->
-      <div class="px-2 grow">
-        <Search placeholder="Search" autofocus={false} bind:value={filter} />
-      </div>
-
-      <!-- Spacer -->
-      <div class="grow" />
-
-      <!-- filter menu button (future work) -->
-      <!-- <Button on:click={() => console.log("open filter menu")} type="secondary">
-    <span>Filter</span>
-    <CaretDownIcon />
-  </Button> -->
-
-      <!-- Number of alerts -->
-      <span class="shrink-0">{numAlerts} alert{numAlerts !== 1 ? "s" : ""}</span
-      >
-
-      <!-- Sort button -->
-      <!-- <WithTogglableFloatingElement active={openSortMenu}>
-        <Button on:click={() => (openSortMenu = true)} type="secondary">
-          <span>Sort</span>
-          <CaretDownIcon />
-        </Button>
-        <Menu
-          slot="floating-element"
-          minWidth="0px"
-          on:item-select={closeSortMenu}
-          on:click-outside={closeSortMenu}
-          on:escape={closeSortMenu}
-        >
-          <MenuItem on:select={sortAlphabetically}>Alphabetical</MenuItem>
-          <MenuItem on:select={sortByMostRecentlyRun}
-            >Most recently run</MenuItem
-          >
-          <MenuItem on:select={sortByNextToRun} disabled>Next to run</MenuItem>
-        </Menu>
-      </WithTogglableFloatingElement> -->
+    <td>
+      <BellIcon size={"14px"} />
+      {numAlerts} alert{numAlerts !== 1 ? "s" : ""}
     </td>
   </tr>
 </thead>
@@ -91,6 +24,8 @@ Rounded table corners are tricky:
 -->
 <style lang="postcss">
   thead tr td {
+    @apply pl-[17px] pr-4 py-3 max-w-[800px] flex items-center gap-x-2 bg-slate-100;
+    @apply font-semibold text-gray-500;
     @apply border-y;
   }
   thead tr td:first-child {

--- a/web-admin/src/features/alerts/listing/AlertsTableHeader.svelte
+++ b/web-admin/src/features/alerts/listing/AlertsTableHeader.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+  import type { Table } from "@tanstack/svelte-table";
   import { BellIcon } from "lucide-svelte";
   import { getContext } from "svelte";
+  import type { Readable } from "svelte/store";
 
-  const table = getContext("table");
+  const table = getContext<Readable<Table<unknown>>>("table");
 
   // Number of alerts
   $: numAlerts = $table.getRowModel().rows.length;

--- a/web-admin/src/features/dashboards/listing/DashboardsTable.svelte
+++ b/web-admin/src/features/dashboards/listing/DashboardsTable.svelte
@@ -4,11 +4,11 @@
   import { flexRender, type Row } from "@tanstack/svelte-table";
   import { createEventDispatcher } from "svelte";
   import Table from "../../../components/table/Table.svelte";
+  import Toolbar from "../../../components/table/Toolbar.svelte";
   import DashboardsError from "./DashboardsError.svelte";
   import DashboardsTableCompositeCell from "./DashboardsTableCompositeCell.svelte";
   import DashboardsTableEmpty from "./DashboardsTableEmpty.svelte";
   import DashboardsTableHeader from "./DashboardsTableHeader.svelte";
-  import DashboardsTableToolbar from "./DashboardsTableToolbar.svelte";
   import NoDashboardsCTA from "./NoDashboardsCTA.svelte";
   import { useDashboardsV2, type DashboardResource } from "./selectors";
 
@@ -105,7 +105,7 @@
       {columnVisibility}
       on:click-row={handleClickRow}
     >
-      <DashboardsTableToolbar slot="toolbar" />
+      <Toolbar slot="toolbar" />
       <DashboardsTableHeader slot="header" />
       <DashboardsTableEmpty slot="empty" />
     </Table>

--- a/web-admin/src/features/dashboards/listing/DashboardsTable.svelte
+++ b/web-admin/src/features/dashboards/listing/DashboardsTable.svelte
@@ -8,6 +8,7 @@
   import DashboardsTableCompositeCell from "./DashboardsTableCompositeCell.svelte";
   import DashboardsTableEmpty from "./DashboardsTableEmpty.svelte";
   import DashboardsTableHeader from "./DashboardsTableHeader.svelte";
+  import DashboardsTableToolbar from "./DashboardsTableToolbar.svelte";
   import NoDashboardsCTA from "./NoDashboardsCTA.svelte";
   import { useDashboardsV2, type DashboardResource } from "./selectors";
 
@@ -104,6 +105,7 @@
       {columnVisibility}
       on:click-row={handleClickRow}
     >
+      <DashboardsTableToolbar slot="toolbar" />
       <DashboardsTableHeader slot="header" />
       <DashboardsTableEmpty slot="empty" />
     </Table>

--- a/web-admin/src/features/dashboards/listing/DashboardsTable.svelte
+++ b/web-admin/src/features/dashboards/listing/DashboardsTable.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+  import ResourceHeader from "@rilldata/web-admin/components/table/ResourceHeader.svelte";
+  import ResourceTableEmpty from "@rilldata/web-admin/components/table/ResourceTableEmpty.svelte";
+  import MetricsExplorerIcon from "@rilldata/web-common/components/icons/MetricsExplorerIcon.svelte";
   import DelayedSpinner from "@rilldata/web-common/features/entity-management/DelayedSpinner.svelte";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { flexRender, type Row } from "@tanstack/svelte-table";
@@ -7,8 +10,6 @@
   import Toolbar from "../../../components/table/Toolbar.svelte";
   import DashboardsError from "./DashboardsError.svelte";
   import DashboardsTableCompositeCell from "./DashboardsTableCompositeCell.svelte";
-  import DashboardsTableEmpty from "./DashboardsTableEmpty.svelte";
-  import DashboardsTableHeader from "./DashboardsTableHeader.svelte";
   import NoDashboardsCTA from "./NoDashboardsCTA.svelte";
   import { useDashboardsV2, type DashboardResource } from "./selectors";
 
@@ -106,8 +107,12 @@
       on:click-row={handleClickRow}
     >
       <Toolbar slot="toolbar" />
-      <DashboardsTableHeader slot="header" />
-      <DashboardsTableEmpty slot="empty" />
+      <ResourceHeader
+        kind="dashboard"
+        icon={MetricsExplorerIcon}
+        slot="header"
+      />
+      <ResourceTableEmpty kind="dashboard" slot="empty" />
     </Table>
   {/if}
 {/if}

--- a/web-admin/src/features/dashboards/listing/DashboardsTableCompositeCell.svelte
+++ b/web-admin/src/features/dashboards/listing/DashboardsTableCompositeCell.svelte
@@ -30,7 +30,7 @@
 
 <svelte:element
   this={isEmbedded ? "button" : "a"}
-  class="flex flex-col gap-y-0.5 group px-4 py-[5px] w-full"
+  class="flex flex-col gap-y-0.5 group px-4 py-2 w-full"
   {href}
   role={isEmbedded ? "button" : "link"}
 >

--- a/web-admin/src/features/dashboards/listing/DashboardsTableHeader.svelte
+++ b/web-admin/src/features/dashboards/listing/DashboardsTableHeader.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import MetricsExplorerIcon from "@rilldata/web-common/components/icons/MetricsExplorerIcon.svelte";
+  import type { Table } from "@tanstack/svelte-table";
   import { getContext } from "svelte";
+  import type { Readable } from "svelte/store";
 
-  const table = getContext("table");
+  const table = getContext<Readable<Table<unknown>>>("table");
 
   // Number of dashboards
   $: numDashboards = $table.getRowModel().rows.length;

--- a/web-admin/src/features/dashboards/listing/DashboardsTableHeader.svelte
+++ b/web-admin/src/features/dashboards/listing/DashboardsTableHeader.svelte
@@ -1,88 +1,18 @@
 <script lang="ts">
-  import { beforeNavigate } from "$app/navigation";
-  import { Search } from "@rilldata/web-common/components/search";
-  import type { Table } from "@tanstack/svelte-table";
+  import MetricsExplorerIcon from "@rilldata/web-common/components/icons/MetricsExplorerIcon.svelte";
   import { getContext } from "svelte";
-  import type { Readable } from "svelte/store";
 
-  const table = getContext("table") as Readable<Table<unknown>>;
-
-  // Search
-  let filter = "";
-
-  function filterTable(filter: string) {
-    $table.setGlobalFilter(filter);
-  }
-
-  $: filterTable(filter);
-
-  beforeNavigate(() => (filter = "")); // resets filter when changing projects
+  const table = getContext("table");
 
   // Number of dashboards
   $: numDashboards = $table.getRowModel().rows.length;
-
-  // Sort
-  // function sortByTitle() {
-  //   $table.setSorting([{ id: "title", desc: false }]);
-  // }
-
-  // function sortByName() {
-  //   $table.setSorting([{ id: "name", desc: false }]);
-  // }
-
-  // function sortByLastRefreshTime() {
-  //   $table.setSorting([{ id: "lastRefreshed", desc: true }]);
-  // }
-
-  // let openSortMenu = false;
-  // function closeSortMenu() {
-  //   openSortMenu = false;
-  // }
 </script>
 
 <thead>
   <tr>
-    <td
-      class="pl-2 pr-4 py-2 max-w-[800px] flex items-center gap-x-2 bg-slate-100"
-    >
-      <!-- Search bar -->
-      <div class="px-2 grow">
-        <Search placeholder="Search" autofocus={false} bind:value={filter} />
-      </div>
-
-      <!-- Spacer -->
-      <div class="grow" />
-
-      <!-- Number of dashboards -->
-      <span>{numDashboards} dashboard{numDashboards !== 1 ? "s" : ""}</span>
-
-      <!-- Sort button -->
-      <!-- <WithTogglableFloatingElement
-        active={openSortMenu}
-        distance={4}
-        alignment="end"
-      >
-        <Button
-          on:click={() => (openSortMenu = !openSortMenu)}
-          type="secondary"
-        >
-          <span>Sort</span>
-          <CaretDownIcon />
-        </Button>
-        <Menu
-          slot="floating-element"
-          minWidth="0px"
-          on:item-select={closeSortMenu}
-          on:click-outside={closeSortMenu}
-          on:escape={closeSortMenu}
-        >
-          <MenuItem on:select={sortByTitle}>Alphabetical by title</MenuItem>
-          <MenuItem on:select={sortByName}>Alphabetical by URL</MenuItem>
-          <MenuItem on:select={sortByLastRefreshTime}
-            >Most recently refreshed</MenuItem
-          >
-        </Menu>
-      </WithTogglableFloatingElement> -->
+    <td>
+      <MetricsExplorerIcon size={"14px"} />
+      {numDashboards} dashboard{numDashboards !== 1 ? "s" : ""}
     </td>
   </tr>
 </thead>
@@ -94,6 +24,8 @@ Rounded table corners are tricky:
 -->
 <style lang="postcss">
   thead tr td {
+    @apply pl-[17px] pr-4 py-3 max-w-[800px] flex items-center gap-x-2 bg-slate-100;
+    @apply font-semibold text-gray-500;
     @apply border-y;
   }
   thead tr td:first-child {

--- a/web-admin/src/features/dashboards/listing/DashboardsTableToolbar.svelte
+++ b/web-admin/src/features/dashboards/listing/DashboardsTableToolbar.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { beforeNavigate } from "$app/navigation";
+  import { Search } from "@rilldata/web-common/components/search";
+  import { getContext } from "svelte";
+
+  const table = getContext("table");
+
+  // Search
+  let filter = "";
+
+  function filterTable(filter: string) {
+    $table.setGlobalFilter(filter);
+  }
+
+  $: filterTable(filter);
+
+  beforeNavigate(() => (filter = "")); // resets filter when changing projects
+
+  console.log("got here");
+</script>
+
+<div class="w-full max-w-[800px] flex items-center">
+  <!-- Search bar -->
+  <Search
+    placeholder="Search"
+    autofocus={false}
+    bind:value={filter}
+    background={false}
+  />
+
+  <!-- Sort button -->
+  <!-- <WithTogglableFloatingElement
+        active={openSortMenu}
+        distance={4}
+        alignment="end"
+      >
+        <Button
+          on:click={() => (openSortMenu = !openSortMenu)}
+          type="secondary"
+        >
+          <span>Sort</span>
+          <CaretDownIcon />
+        </Button>
+        <Menu
+          slot="floating-element"
+          minWidth="0px"
+          on:item-select={closeSortMenu}
+          on:click-outside={closeSortMenu}
+          on:escape={closeSortMenu}
+        >
+          <MenuItem on:select={sortByTitle}>Alphabetical by title</MenuItem>
+          <MenuItem on:select={sortByName}>Alphabetical by URL</MenuItem>
+          <MenuItem on:select={sortByLastRefreshTime}
+            >Most recently refreshed</MenuItem
+          >
+        </Menu>
+      </WithTogglableFloatingElement> -->
+</div>

--- a/web-admin/src/features/scheduled-reports/listing/ReportsTable.svelte
+++ b/web-admin/src/features/scheduled-reports/listing/ReportsTable.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+  import Toolbar from "@rilldata/web-admin/components/table/Toolbar.svelte";
   import DelayedSpinner from "@rilldata/web-common/features/entity-management/DelayedSpinner.svelte";
   import type { V1Resource } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
-  import { type ColumnDef, flexRender } from "@tanstack/svelte-table";
+  import { flexRender, type ColumnDef } from "@tanstack/svelte-table";
   import Table from "../../../components/table/Table.svelte";
   import { useReports } from "../selectors";
   import NoReportsCTA from "./NoReportsCTA.svelte";
@@ -83,6 +84,7 @@
     <NoReportsCTA />
   {:else}
     <Table {columns} data={$reports?.data?.resources} {columnVisibility}>
+      <Toolbar slot="toolbar" />
       <ReportsTableHeader slot="header" />
       <ReportsTableEmpty slot="empty" />
     </Table>

--- a/web-admin/src/features/scheduled-reports/listing/ReportsTable.svelte
+++ b/web-admin/src/features/scheduled-reports/listing/ReportsTable.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
+  import ResourceHeader from "@rilldata/web-admin/components/table/ResourceHeader.svelte";
+  import ResourceTableEmpty from "@rilldata/web-admin/components/table/ResourceTableEmpty.svelte";
   import Toolbar from "@rilldata/web-admin/components/table/Toolbar.svelte";
+  import ReportIcon from "@rilldata/web-common/components/icons/ReportIcon.svelte";
   import DelayedSpinner from "@rilldata/web-common/features/entity-management/DelayedSpinner.svelte";
   import type { V1Resource } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
@@ -9,8 +12,6 @@
   import NoReportsCTA from "./NoReportsCTA.svelte";
   import ReportsError from "./ReportsError.svelte";
   import ReportsTableCompositeCell from "./ReportsTableCompositeCell.svelte";
-  import ReportsTableEmpty from "./ReportsTableEmpty.svelte";
-  import ReportsTableHeader from "./ReportsTableHeader.svelte";
 
   export let organization: string;
   export let project: string;
@@ -85,8 +86,8 @@
   {:else}
     <Table {columns} data={$reports?.data?.resources} {columnVisibility}>
       <Toolbar slot="toolbar" />
-      <ReportsTableHeader slot="header" />
-      <ReportsTableEmpty slot="empty" />
+      <ResourceHeader kind="report" icon={ReportIcon} slot="header" />
+      <ResourceTableEmpty kind="report" slot="empty" />
     </Table>
   {/if}
 {/if}

--- a/web-admin/src/features/scheduled-reports/listing/ReportsTableCompositeCell.svelte
+++ b/web-admin/src/features/scheduled-reports/listing/ReportsTableCompositeCell.svelte
@@ -20,7 +20,7 @@
   const humanReadableFrequency = cronstrue.toString(frequency);
 </script>
 
-<a href={`reports/${id}`} class="flex flex-col gap-y-0.5 group px-4 py-[5px]">
+<a href={`reports/${id}`} class="flex flex-col gap-y-0.5 group px-4 py-2">
   <div class="flex gap-x-2 items-center">
     <ReportIcon size={"14px"} className="text-slate-500" />
     <div

--- a/web-admin/src/features/scheduled-reports/listing/ReportsTableEmpty.svelte
+++ b/web-admin/src/features/scheduled-reports/listing/ReportsTableEmpty.svelte
@@ -1,1 +1,0 @@
-<span class="text-gray-500"> No reports found. </span>

--- a/web-admin/src/features/scheduled-reports/listing/ReportsTableHeader.svelte
+++ b/web-admin/src/features/scheduled-reports/listing/ReportsTableHeader.svelte
@@ -1,86 +1,18 @@
 <script lang="ts">
-  import { Search } from "@rilldata/web-common/components/search";
-  import type { Table } from "@tanstack/svelte-table";
+  import ReportIcon from "@rilldata/web-common/components/icons/ReportIcon.svelte";
   import { getContext } from "svelte";
-  import type { Readable } from "svelte/store";
 
-  const table = getContext<Readable<Table<unknown>>>("table");
-
-  // Search
-  let filter = "";
-
-  $: filterTable(filter);
-
-  function filterTable(filter: string) {
-    $table.setGlobalFilter(filter);
-  }
+  const table = getContext("table");
 
   // Number of reports
   $: numReports = $table.getRowModel().rows.length;
-
-  // Sort
-  // function sortAlphabetically() {
-  //   $table.setSorting([{ id: "monocolumn", desc: false }]);
-  // }
-
-  // function sortByMostRecentlyRun() {
-  //   $table.setSorting([{ id: "lastRun", desc: true }]);
-  // }
-
-  // function sortByNextToRun() {
-  //   $table.setSorting([{ id: "monocolumn", desc: false }]);
-  // }
-
-  // let openSortMenu = false;
-  // function closeSortMenu() {
-  //   openSortMenu = false;
-  // }
 </script>
 
 <thead>
   <tr>
-    <td
-      class="pl-2 pr-4 py-2 max-w-[800px] flex items-center gap-x-2 bg-slate-100"
-    >
-      <!-- Search bar -->
-      <div class="px-2 grow">
-        <Search placeholder="Search" autofocus={false} bind:value={filter} />
-      </div>
-
-      <!-- Spacer -->
-      <div class="grow" />
-
-      <!-- filter menu button (future work) -->
-      <!-- <Button on:click={() => console.log("open filter menu")} type="secondary">
-    <span>Filter</span>
-    <CaretDownIcon />
-  </Button> -->
-
-      <!-- Number of reports -->
-      <span class="shrink-0"
-        >{numReports} report{numReports !== 1 ? "s" : ""}</span
-      >
-
-      <!-- Sort button -->
-      <!-- <WithTogglableFloatingElement active={openSortMenu}>
-        <Button on:click={() => (openSortMenu = true)} type="secondary">
-          <span>Sort</span>
-          <CaretDownIcon />
-        </Button>
-        <Menu
-          slot="floating-element"
-          minWidth="0px"
-          on:item-select={closeSortMenu}
-          on:click-outside={closeSortMenu}
-          on:escape={closeSortMenu}
-        >
-          <MenuItem on:select={sortAlphabetically}>Alphabetical</MenuItem>
-          <MenuItem on:select={sortByMostRecentlyRun}
-            >Most recently run</MenuItem
-          >
-          <MenuItem on:select={sortByNextToRun} disabled>Next to run</MenuItem>
-        </Menu>
-      </WithTogglableFloatingElement> -->
+    <td>
+      <ReportIcon size={"14px"} />
+      {numReports} report{numReports !== 1 ? "s" : ""}
     </td>
   </tr>
 </thead>
@@ -92,6 +24,8 @@ Rounded table corners are tricky:
 -->
 <style lang="postcss">
   thead tr td {
+    @apply pl-[17px] pr-4 py-3 max-w-[800px] flex items-center gap-x-2 bg-slate-100;
+    @apply font-semibold text-gray-500;
     @apply border-y;
   }
   thead tr td:first-child {

--- a/web-admin/src/features/scheduled-reports/listing/ReportsTableHeader.svelte
+++ b/web-admin/src/features/scheduled-reports/listing/ReportsTableHeader.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import ReportIcon from "@rilldata/web-common/components/icons/ReportIcon.svelte";
+  import type { Table } from "@tanstack/svelte-table";
   import { getContext } from "svelte";
+  import type { Readable } from "svelte/store";
 
-  const table = getContext("table");
+  const table = getContext<Readable<Table<unknown>>>("table");
 
   // Number of reports
   $: numReports = $table.getRowModel().rows.length;

--- a/web-admin/src/routes/[organization]/[project]/-/alerts/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/alerts/+page.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <ContentContainer>
-  <div class="flex flex-col items-center">
+  <div class="flex flex-col items-center gap-y-4">
     <AlertsTable {organization} {project} />
   </div>
 </ContentContainer>

--- a/web-admin/src/routes/[organization]/[project]/-/reports/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/reports/+page.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <ContentContainer>
-  <div class="flex flex-col items-center">
+  <div class="flex flex-col items-center gap-y-4">
     <ReportsTable {organization} {project} />
   </div>
 </ContentContainer>


### PR DESCRIPTION
This PR makes the resource tables a little more readable by moving the search bar out of the header and by adding padding.

The PR also factors out `ResourceHeader` and `ResourceTableEmpty` components to remove redundant code.

Before:
<img width="1397" alt="image" src="https://github.com/user-attachments/assets/a7cd9300-2811-42ea-866c-037cbedda2d7">

After:
<img width="1396" alt="image" src="https://github.com/user-attachments/assets/9b60a3be-c74b-4a9d-9ebf-c20a9e3bea57">