### PR TITLE
Refactor project size limit checks

### DIFF
--- a/admin/server/auth/handlers.go
+++ b/admin/server/auth/handlers.go
@@ -122,6 +122,7 @@ func (a *Authenticator) authStart(w http.ResponseWriter, r *http.Request, signup
 func (a *Authenticator) authLoginCallback(w http.ResponseWriter, r *http.Request) {
 	// Get auth cookie
 	sess := a.cookies.Get(r, cookieName)
+
 	// Check that random state matches (for CSRF protection)
 	if r.URL.Query().Get("state") != sess.Values[cookieFieldState] {
 		http.Error(w, "invalid state parameter", http.StatusBadRequest)

--- a/cli/cmd/start/start.go
+++ b/cli/cmd/start/start.go
@@ -97,7 +97,7 @@ func StartCmd(ch *cmdutil.Helper) *cobra.Command {
 			_, err = repo.ListRecursive(cmd.Context(), "**", false)
 			if err != nil {
 				if errors.Is(err, drivers.ErrRepoListLimitExceeded) {
-					ch.PrintfError(`The project directory exceeds the limit of %d files. Please open Rill against a directory with fewer files or configure "ignore_paths" in "rill.yaml".\n`, drivers.RepoListLimit)
+					ch.PrintfError("The project directory exceeds the limit of %d files. Please open Rill against a directory with fewer files or set \"ignore_paths\" in rill.yaml.\n", drivers.RepoListLimit)
 					return nil
 				}
 				return fmt.Errorf("failed to list project files: %w", err)

--- a/runtime/drivers/admin/repo.go
+++ b/runtime/drivers/admin/repo.go
@@ -14,8 +14,6 @@ import (
 	"github.com/rilldata/rill/runtime/drivers"
 )
 
-var listFileslimit = 2000
-
 func (h *Handle) Root() string {
 	return h.projPath
 }
@@ -67,8 +65,8 @@ func (h *Handle) ListRecursive(ctx context.Context, glob string, skipDirs bool) 
 		}
 
 		// Exit if we reached the limit
-		if len(entries) == listFileslimit {
-			return fmt.Errorf("glob exceeded limit of %d matched files", listFileslimit)
+		if len(entries) == drivers.RepoListLimit {
+			return drivers.ErrRepoListLimitExceeded
 		}
 
 		// Track file (p is already relative to the FS root)

--- a/runtime/drivers/file/repo.go
+++ b/runtime/drivers/file/repo.go
@@ -14,8 +14,6 @@ import (
 	"github.com/rilldata/rill/runtime/drivers"
 )
 
-var limit = 1000
-
 // Driver implements drivers.RepoStore.
 func (c *connection) Driver() string {
 	return "file"
@@ -48,8 +46,8 @@ func (c *connection) ListRecursive(ctx context.Context, glob string, skipDirs bo
 		}
 
 		// Exit if we reached the limit
-		if len(entries) == limit {
-			return fmt.Errorf("glob exceeded limit of %d matched files", limit)
+		if len(entries) == drivers.RepoListLimit {
+			return drivers.ErrRepoListLimitExceeded
 		}
 
 		// Track file (p is already relative to the FS root)

--- a/runtime/drivers/repo.go
+++ b/runtime/drivers/repo.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"time"
@@ -47,6 +48,13 @@ type DirEntry struct {
 	Path  string
 	IsDir bool
 }
+
+// RepoListLimit is the maximum number of files that can be listed in a call to RepoStore.ListRecursive.
+// This limit is effectively a cap on the number of files in a project because `rill start` lists the project directory using a "**" glob.
+const RepoListLimit = 2000
+
+// ErrRepoListLimitExceeded should be returned when RepoListLimit is exceeded.
+var ErrRepoListLimitExceeded = fmt.Errorf("glob exceeded limit of %d matched files", RepoListLimit)
 
 // ignoredPaths is a list of paths that are ignored by the parser.
 var ignoredPaths = []string{


### PR DESCRIPTION
This PR refactors the project file listings limit checks to ensure consistent limits and skipping of ignored paths.

The refactor also fixes an issue where the project size check in `rill start` did not skip ignored paths due to a bug (missing `/` at the start of the checked path).
