### PR TITLE
feat: create table and then insert while creating model in clickhouse

### DIFF
--- a/runtime/drivers/clickhouse/model_manager.go
+++ b/runtime/drivers/clickhouse/model_manager.go
@@ -43,8 +43,8 @@ type ModelOutputProperties struct {
 	SampleBy string `mapstructure:"sample_by"`
 	// TTL sets ttl for column and table.
 	TTL string `mapstructure:"ttl"`
-	// Settings set the table specific settings.
-	Settings string `mapstructure:"settings"`
+	// TableSettings set the table specific settings.
+	TableSettings string `mapstructure:"table_settings"`
 	// QuerySettings sets the settings clause used in insert/create table as select queries.
 	QuerySettings string `mapstructure:"query_settings"`
 }

--- a/runtime/drivers/clickhouse/olap.go
+++ b/runtime/drivers/clickhouse/olap.go
@@ -233,7 +233,9 @@ func (c *connection) CreateTableAsSelect(ctx context.Context, name string, view 
 			return err
 		}
 		defer func() {
-			_ = c.Exec(context.Background(), &drivers.Statement{Query: "DROP VIEW " + v})
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+			defer cancel()
+			_ = c.Exec(ctx, &drivers.Statement{Query: "DROP VIEW " + v})
 		}()
 		// create table with same schema as view
 		create.WriteString(" AS ")


### PR DESCRIPTION
Fixed `CreateTableAsSelect` on clickhouse cloud.

**NOTE** : Creating a view based on external systems can fail sometimes but the workaround will be to specify columns manually which is also expected to be set in most cases.