### PR TITLE
fix: safe guard variable to prevent typescript errors

### DIFF
--- a/web-common/src/lib/duckdb-data-types.ts
+++ b/web-common/src/lib/duckdb-data-types.ts
@@ -71,7 +71,7 @@ export function isList(type) {
 // decimal values don't quite match a simple FLOATS.has(type) function,
 // so we need this one.
 export function isFloat(type) {
-  return FLOATS.has(type) || type.startsWith("DECIMAL");
+  return FLOATS.has(type) || type?.startsWith("DECIMAL");
 }
 
 export function isStruct(type) {

--- a/web-common/src/lib/formatters.ts
+++ b/web-common/src/lib/formatters.ts
@@ -1,3 +1,4 @@
+import { removeLocalTimezoneOffset } from "@rilldata/web-common/lib/time/timezone";
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 import {
@@ -13,7 +14,6 @@ import {
   PreviewRollupInterval,
   TIMESTAMPS,
 } from "./duckdb-data-types";
-import { removeLocalTimezoneOffset } from "@rilldata/web-common/lib/time/timezone";
 import { formatDuckdbIntervalLossless } from "./number-formatting/strategies/intervals";
 
 /** This heuristic is courtesy Dominik Moritz.
@@ -154,7 +154,7 @@ export function formatCompactInteger(n: number) {
 
 export function formatDataType(value: unknown, type: string) {
   if (value === undefined) return "";
-  if (INTEGERS.has(type) || type.startsWith("DECIMAL")) {
+  if (INTEGERS.has(type) || type?.startsWith("DECIMAL")) {
     return value;
   } else if (FLOATS.has(type)) {
     return value;
@@ -205,7 +205,7 @@ export function formatDataTypeAsDuckDbQueryString(
   if (value === null) return "null";
   if (
     INTEGERS.has(type) ||
-    type.startsWith("DECIMAL") ||
+    type?.startsWith("DECIMAL") ||
     CATEGORICALS.has(type) ||
     FLOATS.has(type)
   ) {


### PR DESCRIPTION
Fix for the below typescript error -

```
Cannot read properties of undefined (reading 'startsWith')
```

[Telemetry Dashboard](https://ui.rilldata.com/rilldata/internal-rill-cloud-metrics/rill_ui_telemetry?state=CgUKA1A0VxgFKg10b3RhbF9yZWNvcmRzMgVzdGFjazgASAFYAWAEag1Bc2lhL0NhbGN1dHRheAKAAQGYAf%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwGiAYEHGv4GCAgS%2BQYa9gYICRIHCgVzdGFjaxLoBhLlBhriBlR5cGVFcnJvcjogQ2Fubm90IHJlYWQgcHJvcGVydGllcyBvZiB1bmRlZmluZWQgKHJlYWRpbmcgJ3N0YXJ0c1dpdGgnKQogICAgYXQgUGUgKGh0dHBzOi8vdWkucmlsbGRhdGEuY29tL19hcHAvaW1tdXRhYmxlL2NodW5rcy9pbmRleC45ZDY4MWMxMi5qczoxOjQ4NTQzKQogICAgYXQgT2JqZWN0LnAgKGh0dHBzOi8vdWkucmlsbGRhdGEuY29tL19hcHAvaW1tdXRhYmxlL2NodW5rcy9pbmRleC45ZDY4MWMxMi5qczoxOjU3MTEwKQogICAgYXQgT2JqZWN0LnAgKGh0dHBzOi8vdWkucmlsbGRhdGEuY29tL19hcHAvaW1tdXRhYmxlL2NodW5rcy9pbmRleC45ZDY4MWMxMi5qczoxOjU3NTc3KQogICAgYXQgT2JqZWN0LnAgKGh0dHBzOi8vdWkucmlsbGRhdGEuY29tL19hcHAvaW1tdXRhYmxlL2NodW5rcy9pbmRleC45ZDY4MWMxMi5qczoxOjU3ODc4KQogICAgYXQganQgKGh0dHBzOi8vdWkucmlsbGRhdGEuY29tL19hcHAvaW1tdXRhYmxlL2NodW5rcy9zY2hlZHVsZXIuYzhhZTZjNGQuanM6MToxMzU0KQogICAgYXQgT2JqZWN0LnAgKGh0dHBzOi8vdWkucmlsbGRhdGEuY29tL19hcHAvaW1tdXRhYmxlL2NodW5rcy9pbmRleC45ZDY4MWMxMi5qczoxOjQ0MjA1KQogICAgYXQgT2JqZWN0LnAgKGh0dHBzOi8vdWkucmlsbGRhdGEuY29tL19hcHAvaW1tdXRhYmxlL2NodW5rcy9pbmRleC45ZDY4MWMxMi5qczoxOjQ0OTc1KQogICAgYXQgYnQgKGh0dHBzOi8vdWkucmlsbGRhdGEuY29tL19hcHAvaW1tdXRhYmxlL2NodW5rcy9zY2hlZHVsZXIuYzhhZTZjNGQuanM6MToxMDc4MSkKICAgIGF0IHl0IChodHRwczovL3VpLnJpbGxkYXRhLmNvbS9fYXBwL2ltbXV0YWJsZS9jaHVua3Mvc2NoZWR1bGVyLmM4YWU2YzRkLmpzOjE6MTA0MzQpsAEA%2BAEAgAICigIHZGVmYXVsdA%3D%3D)