### PR TITLE
fix: type errors for unsafe access

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-merge-filters.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-merge-filters.ts
@@ -37,7 +37,7 @@ export function mergeFilters(
       if (likeExprMap.has(ident)) return;
       likeExprMap.set(ident, e);
     } else {
-      if (inExprMap.has(ident) || !!e.cond?.exprs?.[1].subquery) return;
+      if (inExprMap.has(ident) || !!e.cond?.exprs?.[1]?.subquery) return;
       inExprMap.set(ident, e);
     }
   });
@@ -51,7 +51,7 @@ export function mergeFilters(
       e.cond?.op === V1Operation.OPERATION_NLIKE
     )
       return;
-    if (!inExprMap.has(ident) || !!e.cond?.exprs?.[1].subquery) return;
+    if (!inExprMap.has(ident) || !!e.cond?.exprs?.[1]?.subquery) return;
 
     /**
      * We take an intersection of the values in the IN expressions.

--- a/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TimeDimensionDisplay.svelte
@@ -267,7 +267,7 @@
         </div>
       </div>
     </div>
-  {:else if comparing === "dimension" && formattedData.rowCount === 1}
+  {:else if comparing === "dimension" && formattedData?.rowCount === 1}
     <div class="w-full h-full">
       <div class="flex flex-col items-center h-full text-sm">
         <div class="text-gray-600">No search results to show</div>


### PR DESCRIPTION
Fix

`Cannot read properties of undefined (reading 'rowCount')`
`Cannot read properties of undefined (reading 'subquery')`

[Dashboard Telemetry](https://ui.rilldata.com/rilldata/internal-rill-cloud-metrics/rill_ui_telemetry?state=CgYKBFAxNEQYBSIJCgdyaWxsLVBQKg10b3RhbF9yZWNvcmRzMgdtZXNzYWdlOABIAVgBYARqDUFzaWEvQ2FsY3V0dGF4AYABAZgB%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAaIBlAEakQEICBKMARqJAQgJEgkKB21lc3NhZ2USPBI6GjhDYW5ub3QgcmVhZCBwcm9wZXJ0aWVzIG9mIHVuZGVmaW5lZCAocmVhZGluZyAnc3VicXVlcnknKRI8EjoaOENhbm5vdCByZWFkIHByb3BlcnRpZXMgb2YgdW5kZWZpbmVkIChyZWFkaW5nICdyb3dDb3VudCcpsAEA%2BAEAgAICigIHZGVmYXVsdA%3D%3D)