### PR TITLE
Support custom domains in `web-admin`

### DIFF
--- a/web-admin/src/client/http-client.ts
+++ b/web-admin/src/client/http-client.ts
@@ -1,8 +1,26 @@
 import type { AxiosRequestConfig } from "axios";
 import Axios from "axios";
 
-export const ADMIN_URL =
+/**
+ * The canonical URL of the admin server.
+ * It does not change when the frontend is running on a custom domain.
+ */
+export const CANONICAL_ADMIN_URL =
   import.meta.env.RILL_UI_PUBLIC_RILL_ADMIN_URL || "http://localhost:8080";
+
+/**
+ * The URL of the admin server.
+ *
+ * By convention, if the frontend detects that it is running on a custom domain,
+ * instead of using the canonical admin URL, it should contact the admin server on /api on the same domain.
+ *
+ * The only exceptions to this rule are for /auth/login redirects (not other /auth endpoints) and for /github redirects,
+ * which should always use the canonical admin URL.
+ */
+export const ADMIN_URL =
+  urlExtractSLD(window.location.origin) === urlExtractSLD(CANONICAL_ADMIN_URL)
+    ? CANONICAL_ADMIN_URL
+    : urlRewritePath(window.location.origin, "/api");
 
 export const AXIOS_INSTANCE = Axios.create({
   baseURL: ADMIN_URL,
@@ -16,3 +34,25 @@ export const httpClient = async <T>(config: AxiosRequestConfig): Promise<T> => {
 };
 
 export default httpClient;
+
+/**
+ * extractSLD extracts the second-level domain from the given URL.
+ * For example, "www.example.com" returns "example.com" and "localhost:8080" returns "localhost".
+ */
+function urlExtractSLD(url: string): string {
+  const parsed = new URL(url);
+  const parts = parsed.hostname.split(".");
+  if (parts.length <= 2) {
+    return parts.join(".");
+  }
+  return parts.slice(-2).join(".");
+}
+
+/**
+ * urlRewritePath rewrites the path of the given URL.
+ */
+function urlRewritePath(url: string, path: string): string {
+  const parsed = new URL(url);
+  parsed.pathname = path;
+  return parsed.toString();
+}

--- a/web-admin/src/client/http-client.ts
+++ b/web-admin/src/client/http-client.ts
@@ -18,7 +18,8 @@ export const CANONICAL_ADMIN_URL =
  * which should always use the canonical admin URL.
  */
 export const ADMIN_URL =
-  typeof window === "undefined" || urlExtractSLD(window.location.origin) === urlExtractSLD(CANONICAL_ADMIN_URL)
+  typeof window === "undefined" ||
+  urlExtractSLD(window.location.origin) === urlExtractSLD(CANONICAL_ADMIN_URL)
     ? CANONICAL_ADMIN_URL
     : urlRewritePath(window.location.origin, "/api");
 

--- a/web-admin/src/client/http-client.ts
+++ b/web-admin/src/client/http-client.ts
@@ -18,7 +18,7 @@ export const CANONICAL_ADMIN_URL =
  * which should always use the canonical admin URL.
  */
 export const ADMIN_URL =
-  urlExtractSLD(window.location.origin) === urlExtractSLD(CANONICAL_ADMIN_URL)
+  typeof window === "undefined" || urlExtractSLD(window.location.origin) === urlExtractSLD(CANONICAL_ADMIN_URL)
     ? CANONICAL_ADMIN_URL
     : urlRewritePath(window.location.origin, "/api");
 

--- a/web-admin/src/client/http-client.ts
+++ b/web-admin/src/client/http-client.ts
@@ -22,19 +22,6 @@ export const ADMIN_URL =
     ? CANONICAL_ADMIN_URL
     : urlRewritePath(window.location.origin, "/api");
 
-export const AXIOS_INSTANCE = Axios.create({
-  baseURL: ADMIN_URL,
-  withCredentials: true,
-});
-
-// TODO: use the new client?
-export const httpClient = async <T>(config: AxiosRequestConfig): Promise<T> => {
-  const { data } = await AXIOS_INSTANCE(config);
-  return data;
-};
-
-export default httpClient;
-
 /**
  * extractSLD extracts the second-level domain from the given URL.
  * For example, "www.example.com" returns "example.com" and "localhost:8080" returns "localhost".
@@ -56,3 +43,16 @@ function urlRewritePath(url: string, path: string): string {
   parsed.pathname = path;
   return parsed.toString();
 }
+
+export const AXIOS_INSTANCE = Axios.create({
+  baseURL: ADMIN_URL,
+  withCredentials: true,
+});
+
+// TODO: use the new client?
+export const httpClient = async <T>(config: AxiosRequestConfig): Promise<T> => {
+  const { data } = await AXIOS_INSTANCE(config);
+  return data;
+};
+
+export default httpClient;

--- a/web-admin/src/features/authentication/AuthRedirect.svelte
+++ b/web-admin/src/features/authentication/AuthRedirect.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { createAdminServiceGetCurrentUser } from "../../client";
-  import { ADMIN_URL } from "../../client/http-client";
+  import { CANONICAL_ADMIN_URL } from "../../client/http-client";
 
   const user = createAdminServiceGetCurrentUser();
 
   // redirect to login if not logged in
   $: if ($user.isSuccess && !$user.data.user) {
-    goto(`${ADMIN_URL}/auth/login?redirect=${window.origin}`);
+    goto(`${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.origin}`);
   }
 </script>
 

--- a/web-admin/src/features/authentication/AvatarButton.svelte
+++ b/web-admin/src/features/authentication/AvatarButton.svelte
@@ -2,7 +2,7 @@
   import { page } from "$app/stores";
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
   import { createAdminServiceGetCurrentUser } from "../../client";
-  import { ADMIN_URL } from "../../client/http-client";
+  import { ADMIN_URL, CANONICAL_ADMIN_URL } from "../../client/http-client";
   import {
     initPylonChat,
     type UserLike,
@@ -23,7 +23,7 @@
 
   function makeLogOutHref(): string {
     // Create a login URL that redirects back to the current page
-    const loginWithRedirect = `${ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`;
+    const loginWithRedirect = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`;
 
     // Create the logout URL, providing the login URL as a redirect
     const href = `${ADMIN_URL}/auth/logout?redirect=${loginWithRedirect}`;

--- a/web-admin/src/features/authentication/SignIn.svelte
+++ b/web-admin/src/features/authentication/SignIn.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { Button } from "@rilldata/web-common/components/button";
-  import { ADMIN_URL } from "../../client/http-client";
+  import { CANONICAL_ADMIN_URL } from "../../client/http-client";
 
   function handleSignIn() {
-    window.location.href = `${ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`;
+    window.location.href = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`;
   }
 </script>
 

--- a/web-admin/src/features/authentication/checkUserAccess.ts
+++ b/web-admin/src/features/authentication/checkUserAccess.ts
@@ -5,7 +5,7 @@ import {
   getAdminServiceGetCurrentUserQueryKey,
   type V1GetCurrentUserResponse,
 } from "@rilldata/web-admin/client";
-import { ADMIN_URL } from "@rilldata/web-admin/client/http-client";
+import { CANONICAL_ADMIN_URL } from "@rilldata/web-admin/client/http-client";
 import {
   isProjectRequestAccessPage,
   withinProject,
@@ -26,7 +26,7 @@ export async function checkUserAccess() {
   // If not logged in, redirect to the login page
   if (!isLoggedIn) {
     await goto(
-      `${ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`,
+      `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`,
     );
     return true;
   } else if (

--- a/web-admin/src/features/errors/error-utils.ts
+++ b/web-admin/src/features/errors/error-utils.ts
@@ -16,7 +16,7 @@ import type { AxiosError } from "axios";
 import { get } from "svelte/store";
 import type { RpcStatus } from "../../client";
 import { getAdminServiceGetProjectQueryKey } from "../../client";
-import { ADMIN_URL } from "../../client/http-client";
+import { CANONICAL_ADMIN_URL } from "../../client/http-client";
 import { errorStore, type ErrorStoreState } from "./error-store";
 
 export function createGlobalErrorCallback(queryClient: QueryClient) {
@@ -53,7 +53,7 @@ export function createGlobalErrorCallback(queryClient: QueryClient) {
     // If unauthorized to the admin server, redirect to login page
     if (isAdminServerQuery(query) && error.response?.status === 401) {
       await goto(
-        `${ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`,
+        `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`,
       );
       return;
     }

--- a/web-admin/src/features/organizations/active-org/OrganizationRedirect.svelte
+++ b/web-admin/src/features/organizations/active-org/OrganizationRedirect.svelte
@@ -2,19 +2,35 @@
   import { goto } from "$app/navigation";
   import {
     adminServiceGetCurrentUser,
+    adminServiceGetOrganizationNameForDomain,
     adminServiceListOrganizations,
   } from "@rilldata/web-admin/client";
   import { onMount } from "svelte";
   import { getActiveOrgLocalStorageKey } from "./local-storage";
+  import { ADMIN_URL, CANONICAL_ADMIN_URL } from "../../../client/http-client";
 
   let showWelcomeMessage = false;
 
   onMount(async () => {
+    // Scenario 1: If running on a custom domain, redirect to the org for the custom domain.
+    if (ADMIN_URL !== CANONICAL_ADMIN_URL) {
+      try {
+        const res = await adminServiceGetOrganizationNameForDomain(
+          window.location.hostname,
+        );
+        await goto(`/${res.name}`);
+        return;
+      } catch (e) {
+        console.error("Failed to get organization for custom domain", e);
+        // Fall back to the default behavior
+      }
+    }
+
     // Get the activeOrg local storage key for the current user
     const userId = (await adminServiceGetCurrentUser())?.user?.id;
     const activeOrgLocalStorageKey = getActiveOrgLocalStorageKey(userId);
 
-    // Scenario 1: User has an activeOrg in localStorage
+    // Scenario 2: User has an activeOrg in localStorage
     const activeOrg = localStorage.getItem(activeOrgLocalStorageKey);
     if (activeOrg) {
       await goto(`/${activeOrg}`);
@@ -23,14 +39,14 @@
 
     const orgs = (await adminServiceListOrganizations()).organizations;
 
-    // Scenario 2: User has no activeOrg in localStorage, but does belong to an org
+    // Scenario 3: User has no activeOrg in localStorage, but does belong to an org
     if (orgs.length > 0) {
       localStorage.setItem(activeOrgLocalStorageKey, orgs[0].name);
       await goto(`/${orgs[0].name}`);
       return;
     }
 
-    // Scenario 3: User does not belong to an org
+    // Scenario 4: User does not belong to an org
     showWelcomeMessage = true;
   });
 </script>

--- a/web-admin/src/routes/-/auth/device/+page.svelte
+++ b/web-admin/src/routes/-/auth/device/+page.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { createAdminServiceGetCurrentUser } from "@rilldata/web-admin/client";
-  import { ADMIN_URL } from "@rilldata/web-admin/client/http-client";
+  import {
+    ADMIN_URL,
+    CANONICAL_ADMIN_URL,
+  } from "@rilldata/web-admin/client/http-client";
   import CtaButton from "@rilldata/web-common/components/calls-to-action/CTAButton.svelte";
   import CtaContentContainer from "@rilldata/web-common/components/calls-to-action/CTAContentContainer.svelte";
   import CtaLayoutContainer from "@rilldata/web-common/components/calls-to-action/CTALayoutContainer.svelte";
@@ -18,7 +21,7 @@
       onSuccess: (data) => {
         if (!data.user) {
           let redirect = encodeURIComponent(window.location.href);
-          goto(`${ADMIN_URL}/auth/login?redirect=${redirect}`);
+          goto(`${CANONICAL_ADMIN_URL}/auth/login?redirect=${redirect}`);
         }
       },
     },

--- a/web-admin/src/routes/-/github/connect/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { createAdminServiceGetCurrentUser } from "@rilldata/web-admin/client";
-  import { ADMIN_URL } from "@rilldata/web-admin/client/http-client";
+  import { CANONICAL_ADMIN_URL } from "@rilldata/web-admin/client/http-client";
   import CtaButton from "@rilldata/web-common/components/calls-to-action/CTAButton.svelte";
   import CtaContentContainer from "@rilldata/web-common/components/calls-to-action/CTAContentContainer.svelte";
   import CtaHeader from "@rilldata/web-common/components/calls-to-action/CTAHeader.svelte";
@@ -19,7 +19,9 @@
     query: {
       onSuccess: (data) => {
         if (!data.user) {
-          goto(`${ADMIN_URL}/auth/login?redirect=${window.location.href}`);
+          goto(
+            `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.href}`,
+          );
         }
       },
     },

--- a/web-admin/src/routes/-/github/connect/request/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/request/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { createAdminServiceGetCurrentUser } from "@rilldata/web-admin/client";
-  import { ADMIN_URL } from "@rilldata/web-admin/client/http-client";
+  import { CANONICAL_ADMIN_URL } from "@rilldata/web-admin/client/http-client";
   import CodeBlockInline from "@rilldata/web-common/components/calls-to-action/CodeBlockInline.svelte";
   import CtaContentContainer from "@rilldata/web-common/components/calls-to-action/CTAContentContainer.svelte";
   import CtaHeader from "@rilldata/web-common/components/calls-to-action/CTAHeader.svelte";
@@ -16,7 +16,9 @@
     query: {
       onSuccess: (data) => {
         if (!data.user) {
-          goto(`${ADMIN_URL}/auth/login?redirect=${window.location.href}`);
+          goto(
+            `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.href}`,
+          );
         }
       },
     },

--- a/web-admin/src/routes/-/github/connect/retry-auth/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/retry-auth/+page.svelte
@@ -2,7 +2,7 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { createAdminServiceGetCurrentUser } from "@rilldata/web-admin/client";
-  import { ADMIN_URL } from "@rilldata/web-admin/client/http-client";
+  import { CANONICAL_ADMIN_URL } from "@rilldata/web-admin/client/http-client";
   import CtaButton from "@rilldata/web-common/components/calls-to-action/CTAButton.svelte";
   import CtaContentContainer from "@rilldata/web-common/components/calls-to-action/CTAContentContainer.svelte";
   import CtaHeader from "@rilldata/web-common/components/calls-to-action/CTAHeader.svelte";
@@ -20,7 +20,9 @@
     query: {
       onSuccess: (data) => {
         if (!data.user) {
-          goto(`${ADMIN_URL}/auth/login?redirect=${window.location.href}`);
+          goto(
+            `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.href}`,
+          );
         }
       },
     },
@@ -45,7 +47,9 @@
       </CtaMessage>
       <CtaButton
         variant="primary"
-        href={encodeURI(ADMIN_URL + "/github/auth/login?remote=" + remote)}
+        href={encodeURI(
+          CANONICAL_ADMIN_URL + "/github/auth/login?remote=" + remote,
+        )}
       >
         Connect to GitHub
       </CtaButton>

--- a/web-admin/src/routes/-/github/connect/retry-install/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/retry-install/+page.svelte
@@ -4,7 +4,7 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { createAdminServiceGetCurrentUser } from "@rilldata/web-admin/client";
-  import { ADMIN_URL } from "@rilldata/web-admin/client/http-client";
+  import { CANONICAL_ADMIN_URL } from "@rilldata/web-admin/client/http-client";
   import CtaButton from "@rilldata/web-common/components/calls-to-action/CTAButton.svelte";
   import CtaContentContainer from "@rilldata/web-common/components/calls-to-action/CTAContentContainer.svelte";
   import CtaHeader from "@rilldata/web-common/components/calls-to-action/CTAHeader.svelte";
@@ -20,7 +20,9 @@
     query: {
       onSuccess: (data) => {
         if (!data.user) {
-          goto(`${ADMIN_URL}/auth/login?redirect=${window.location.href}`);
+          goto(
+            `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.href}`,
+          );
         }
       },
     },
@@ -48,7 +50,9 @@
       </CtaMessage>
       <CtaButton
         variant="primary"
-        href={encodeURI(ADMIN_URL + "/github/connect?remote=" + remote)}
+        href={encodeURI(
+          CANONICAL_ADMIN_URL + "/github/connect?remote=" + remote,
+        )}
       >
         Connect to GitHub
       </CtaButton>


### PR DESCRIPTION
This PR implements the necessary frontend changes to support custom domains.

Namely, if it detects that it runs on a custom domain, it will use `/api` on the current host to contact the `admin` service instead of using the canonical `admin` service endpoint. The only exception to this rule is for the `/auth/login` and `/github/*` endpoints, which must always be called on the canonical `admin` service endpoint.

See further details in the backend PR: https://github.com/rilldata/rill/pull/5498.

Contributes to https://github.com/rilldata/rill/issues/5476.