### PR TITLE
Runtime: Cast Clickhouse DECIMALs to floats in metrics APIs

### DIFF
--- a/runtime/pkg/jsonval/jsonval.go
+++ b/runtime/pkg/jsonval/jsonval.go
@@ -57,6 +57,14 @@ func ToValue(v any, t *runtimev1.Type) (any, error) {
 		}
 		return v, nil
 	case string:
+		if t != nil && t.Code == runtimev1.Type_CODE_DECIMAL {
+			// Evil cast to float until frontend can deal with bigs:
+			v2, ok := new(big.Float).SetString(v)
+			if ok {
+				f, _ := v2.Float64()
+				return f, nil
+			}
+		}
 		return strings.ToValidUTF8(v, "�"), nil
 	case []byte:
 		if t != nil && t.Code == runtimev1.Type_CODE_UUID {

--- a/runtime/pkg/pbutil/pbutil.go
+++ b/runtime/pkg/pbutil/pbutil.go
@@ -116,6 +116,14 @@ func ToValue(v any, t *runtimev1.Type) (*structpb.Value, error) {
 			}
 		}
 	case string:
+		if t != nil && t.Code == runtimev1.Type_CODE_DECIMAL {
+			// Evil cast to float until frontend can deal with bigs:
+			v2, ok := new(big.Float).SetString(v)
+			if ok {
+				f, _ := v2.Float64()
+				return structpb.NewNumberValue(f), nil
+			}
+		}
 		return structpb.NewStringValue(strings.ToValidUTF8(v, "�")), nil
 	case net.IP:
 		return structpb.NewStringValue(v.String()), nil


### PR DESCRIPTION
In Go, ClickHouse returns `DECIMAL` types as `string`s instead of `big`s when not explicitly scanned into a different data type. This PR casts those strings to `float64`s before returning them in the metrics APIs.

Note that this is a bad practice, but something we have done historically for DuckDB numbers because the frontend can't yet handle non-float numbers.