### PR TITLE
Web: Use window.location or rel=external to navigate to /auth and /github

### DIFF
--- a/web-admin/src/client/redirect-utils.ts
+++ b/web-admin/src/client/redirect-utils.ts
@@ -16,6 +16,7 @@ export function redirectToGithubLogin(remote: string) {
 }
 
 function buildLoginUrl() {
+  // The backend requires that we always use the canonical admin URL for redirects to /auth/login.
   const u = new URL(CANONICAL_ADMIN_URL);
   u.pathname = appendPath(u.pathname, "auth/login");
   u.searchParams.set("redirect", window.location.href);

--- a/web-admin/src/client/redirect-utils.ts
+++ b/web-admin/src/client/redirect-utils.ts
@@ -1,0 +1,41 @@
+import {
+  ADMIN_URL,
+  CANONICAL_ADMIN_URL,
+} from "@rilldata/web-admin/client/http-client";
+
+export function redirectToLogin() {
+  window.location.href = buildLoginUrl();
+}
+
+export function redirectToLogout() {
+  window.location.href = buildLogoutUrl();
+}
+
+export function redirectToGithubLogin(remote: string) {
+  window.location.href = buildGithubLoginUrl(remote);
+}
+
+function buildLoginUrl() {
+  const u = new URL(CANONICAL_ADMIN_URL);
+  u.pathname = appendPath(u.pathname, "auth/login");
+  u.searchParams.set("redirect", window.location.href);
+  return u.toString();
+}
+
+function buildLogoutUrl() {
+  const u = new URL(ADMIN_URL);
+  u.pathname = appendPath(u.pathname, "auth/logout");
+  u.searchParams.set("redirect", buildLoginUrl());
+  return u.toString();
+}
+
+function buildGithubLoginUrl(remote: string) {
+  const u = new URL(ADMIN_URL);
+  u.pathname = appendPath(u.pathname, "github/auth/login");
+  u.searchParams.set("remote", remote);
+  return u.toString();
+}
+
+function appendPath(path: string, suffix: string) {
+  return `${path.replace(/\/$/, "")}/${suffix}`;
+}

--- a/web-admin/src/features/authentication/AuthRedirect.svelte
+++ b/web-admin/src/features/authentication/AuthRedirect.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
+  import { redirectToLogin } from "@rilldata/web-admin/client/redirect-utils";
   import { createAdminServiceGetCurrentUser } from "../../client";
-  import { CANONICAL_ADMIN_URL } from "../../client/http-client";
 
   const user = createAdminServiceGetCurrentUser();
 
   // redirect to login if not logged in
   $: if ($user.isSuccess && !$user.data.user) {
-    window.location.href = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.origin}`;
+    redirectToLogin();
   }
 </script>
 

--- a/web-admin/src/features/authentication/AuthRedirect.svelte
+++ b/web-admin/src/features/authentication/AuthRedirect.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
   import { createAdminServiceGetCurrentUser } from "../../client";
   import { CANONICAL_ADMIN_URL } from "../../client/http-client";
 
@@ -7,7 +6,7 @@
 
   // redirect to login if not logged in
   $: if ($user.isSuccess && !$user.data.user) {
-    goto(`${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.origin}`);
+    window.location.href = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.origin}`;
   }
 </script>
 

--- a/web-admin/src/features/authentication/AvatarButton.svelte
+++ b/web-admin/src/features/authentication/AvatarButton.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { page } from "$app/stores";
+  import { redirectToLogout } from "@rilldata/web-admin/client/redirect-utils";
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
   import { createAdminServiceGetCurrentUser } from "../../client";
-  import { ADMIN_URL, CANONICAL_ADMIN_URL } from "../../client/http-client";
   import {
     initPylonChat,
     type UserLike,
@@ -19,16 +19,6 @@
 
   function handlePylon() {
     window.Pylon("show");
-  }
-
-  function makeLogOutHref(): string {
-    // Create a login URL that redirects back to the current page
-    const loginWithRedirect = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`;
-
-    // Create the logout URL, providing the login URL as a redirect
-    const href = `${ADMIN_URL}/auth/logout?redirect=${loginWithRedirect}`;
-
-    return href;
   }
 </script>
 
@@ -99,9 +89,7 @@
       Contact Rill support
     </DropdownMenu.Item>
     <DropdownMenu.Item
-      on:click={() => {
-        window.location.href = makeLogOutHref();
-      }}
+      on:click={redirectToLogout}
       class="text-gray-800 font-normal"
     >
       Logout

--- a/web-admin/src/features/authentication/AvatarButton.svelte
+++ b/web-admin/src/features/authentication/AvatarButton.svelte
@@ -99,7 +99,9 @@
       Contact Rill support
     </DropdownMenu.Item>
     <DropdownMenu.Item
-      href={makeLogOutHref()}
+      on:click={() => {
+        window.location.href = makeLogOutHref();
+      }}
       class="text-gray-800 font-normal"
     >
       Logout

--- a/web-admin/src/features/authentication/SignIn.svelte
+++ b/web-admin/src/features/authentication/SignIn.svelte
@@ -1,10 +1,6 @@
 <script lang="ts">
+  import { redirectToLogin } from "@rilldata/web-admin/client/redirect-utils";
   import { Button } from "@rilldata/web-common/components/button";
-  import { CANONICAL_ADMIN_URL } from "../../client/http-client";
-
-  function handleSignIn() {
-    window.location.href = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`;
-  }
 </script>
 
-<Button type="primary" on:click={handleSignIn}>Log In / Sign Up</Button>
+<Button type="primary" on:click={redirectToLogin}>Log In / Sign Up</Button>

--- a/web-admin/src/features/authentication/checkUserAccess.ts
+++ b/web-admin/src/features/authentication/checkUserAccess.ts
@@ -5,7 +5,7 @@ import {
   getAdminServiceGetCurrentUserQueryKey,
   type V1GetCurrentUserResponse,
 } from "@rilldata/web-admin/client";
-import { CANONICAL_ADMIN_URL } from "@rilldata/web-admin/client/http-client";
+import { redirectToLogin } from "@rilldata/web-admin/client/redirect-utils";
 import {
   isProjectRequestAccessPage,
   withinProject,
@@ -25,7 +25,7 @@ export async function checkUserAccess() {
 
   // If not logged in, redirect to the login page
   if (!isLoggedIn) {
-    window.location.href = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`;
+    redirectToLogin();
     return true;
   } else if (
     withinProject(pageState) &&

--- a/web-admin/src/features/authentication/checkUserAccess.ts
+++ b/web-admin/src/features/authentication/checkUserAccess.ts
@@ -25,9 +25,7 @@ export async function checkUserAccess() {
 
   // If not logged in, redirect to the login page
   if (!isLoggedIn) {
-    await goto(
-      `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`,
-    );
+    window.location.href = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`;
     return true;
   } else if (
     withinProject(pageState) &&

--- a/web-admin/src/features/errors/error-utils.ts
+++ b/web-admin/src/features/errors/error-utils.ts
@@ -1,4 +1,5 @@
 import { page } from "$app/stores";
+import { redirectToLogin } from "@rilldata/web-admin/client/redirect-utils";
 import { isAdminServerQuery } from "@rilldata/web-admin/client/utils";
 import { checkUserAccess } from "@rilldata/web-admin/features/authentication/checkUserAccess";
 import {
@@ -15,7 +16,6 @@ import type { AxiosError } from "axios";
 import { get } from "svelte/store";
 import type { RpcStatus } from "../../client";
 import { getAdminServiceGetProjectQueryKey } from "../../client";
-import { CANONICAL_ADMIN_URL } from "../../client/http-client";
 import { errorStore, type ErrorStoreState } from "./error-store";
 
 export function createGlobalErrorCallback(queryClient: QueryClient) {
@@ -51,7 +51,7 @@ export function createGlobalErrorCallback(queryClient: QueryClient) {
 
     // If unauthorized to the admin server, redirect to login page
     if (isAdminServerQuery(query) && error.response?.status === 401) {
-      window.location.href = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`;
+      redirectToLogin();
       return;
     }
 

--- a/web-admin/src/features/errors/error-utils.ts
+++ b/web-admin/src/features/errors/error-utils.ts
@@ -1,4 +1,3 @@
-import { goto } from "$app/navigation";
 import { page } from "$app/stores";
 import { isAdminServerQuery } from "@rilldata/web-admin/client/utils";
 import { checkUserAccess } from "@rilldata/web-admin/features/authentication/checkUserAccess";
@@ -52,9 +51,7 @@ export function createGlobalErrorCallback(queryClient: QueryClient) {
 
     // If unauthorized to the admin server, redirect to login page
     if (isAdminServerQuery(query) && error.response?.status === 401) {
-      await goto(
-        `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`,
-      );
+      window.location.href = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.origin}${window.location.pathname}`;
       return;
     }
 

--- a/web-admin/src/routes/-/auth/device/+page.svelte
+++ b/web-admin/src/routes/-/auth/device/+page.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
   import { createAdminServiceGetCurrentUser } from "@rilldata/web-admin/client";
-  import {
-    ADMIN_URL,
-    CANONICAL_ADMIN_URL,
-  } from "@rilldata/web-admin/client/http-client";
+  import { ADMIN_URL } from "@rilldata/web-admin/client/http-client";
+  import { redirectToLogin } from "@rilldata/web-admin/client/redirect-utils";
   import CtaButton from "@rilldata/web-common/components/calls-to-action/CTAButton.svelte";
   import CtaContentContainer from "@rilldata/web-common/components/calls-to-action/CTAContentContainer.svelte";
   import CtaLayoutContainer from "@rilldata/web-common/components/calls-to-action/CTALayoutContainer.svelte";
@@ -19,8 +17,7 @@
     query: {
       onSuccess: (data) => {
         if (!data.user) {
-          let redirect = encodeURIComponent(window.location.href);
-          window.location.href = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${redirect}`;
+          redirectToLogin();
         }
       },
     },

--- a/web-admin/src/routes/-/auth/device/+page.svelte
+++ b/web-admin/src/routes/-/auth/device/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
   import { createAdminServiceGetCurrentUser } from "@rilldata/web-admin/client";
   import {
     ADMIN_URL,
@@ -21,7 +20,7 @@
       onSuccess: (data) => {
         if (!data.user) {
           let redirect = encodeURIComponent(window.location.href);
-          goto(`${CANONICAL_ADMIN_URL}/auth/login?redirect=${redirect}`);
+          window.location.href = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${redirect}`;
         }
       },
     },

--- a/web-admin/src/routes/-/github/connect/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { createAdminServiceGetCurrentUser } from "@rilldata/web-admin/client";
-  import { CANONICAL_ADMIN_URL } from "@rilldata/web-admin/client/http-client";
+  import { redirectToLogin } from "@rilldata/web-admin/client/redirect-utils";
   import CtaButton from "@rilldata/web-common/components/calls-to-action/CTAButton.svelte";
   import CtaContentContainer from "@rilldata/web-common/components/calls-to-action/CTAContentContainer.svelte";
   import CtaHeader from "@rilldata/web-common/components/calls-to-action/CTAHeader.svelte";
@@ -18,7 +18,7 @@
     query: {
       onSuccess: (data) => {
         if (!data.user) {
-          window.location.href = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.href}`;
+          redirectToLogin();
         }
       },
     },

--- a/web-admin/src/routes/-/github/connect/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
   import { createAdminServiceGetCurrentUser } from "@rilldata/web-admin/client";
   import { CANONICAL_ADMIN_URL } from "@rilldata/web-admin/client/http-client";
   import CtaButton from "@rilldata/web-common/components/calls-to-action/CTAButton.svelte";
@@ -19,9 +18,7 @@
     query: {
       onSuccess: (data) => {
         if (!data.user) {
-          goto(
-            `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.href}`,
-          );
+          window.location.href = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.href}`;
         }
       },
     },
@@ -48,7 +45,7 @@
         </CtaMessage>
       {/if}
       <div class="mt-4 w-full flex justify-center">
-        <CtaButton variant="primary" href={redirectURL}>
+        <CtaButton variant="primary" href={redirectURL} rel="external">
           Connect to GitHub
         </CtaButton>
       </div>

--- a/web-admin/src/routes/-/github/connect/request/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/request/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { createAdminServiceGetCurrentUser } from "@rilldata/web-admin/client";
-  import { CANONICAL_ADMIN_URL } from "@rilldata/web-admin/client/http-client";
+  import { redirectToLogin } from "@rilldata/web-admin/client/redirect-utils";
   import CodeBlockInline from "@rilldata/web-common/components/calls-to-action/CodeBlockInline.svelte";
   import CtaContentContainer from "@rilldata/web-common/components/calls-to-action/CTAContentContainer.svelte";
   import CtaHeader from "@rilldata/web-common/components/calls-to-action/CTAHeader.svelte";
@@ -15,7 +15,7 @@
     query: {
       onSuccess: (data) => {
         if (!data.user) {
-          window.location.href = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.href}`;
+          redirectToLogin();
         }
       },
     },

--- a/web-admin/src/routes/-/github/connect/request/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/request/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
   import { createAdminServiceGetCurrentUser } from "@rilldata/web-admin/client";
   import { CANONICAL_ADMIN_URL } from "@rilldata/web-admin/client/http-client";
   import CodeBlockInline from "@rilldata/web-common/components/calls-to-action/CodeBlockInline.svelte";
@@ -16,9 +15,7 @@
     query: {
       onSuccess: (data) => {
         if (!data.user) {
-          goto(
-            `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.href}`,
-          );
+          window.location.href = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.href}`;
         }
       },
     },

--- a/web-admin/src/routes/-/github/connect/retry-auth/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/retry-auth/+page.svelte
@@ -1,6 +1,5 @@
 <!-- This page is for cases when user authorised the github app on another github account which doesn't have access to the repo  -->
 <script lang="ts">
-  import { goto } from "$app/navigation";
   import { createAdminServiceGetCurrentUser } from "@rilldata/web-admin/client";
   import { CANONICAL_ADMIN_URL } from "@rilldata/web-admin/client/http-client";
   import CtaButton from "@rilldata/web-common/components/calls-to-action/CTAButton.svelte";
@@ -20,9 +19,7 @@
     query: {
       onSuccess: (data) => {
         if (!data.user) {
-          goto(
-            `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.href}`,
-          );
+          window.location.href = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.href}`;
         }
       },
     },
@@ -47,9 +44,11 @@
       </CtaMessage>
       <CtaButton
         variant="primary"
-        href={encodeURI(
-          CANONICAL_ADMIN_URL + "/github/auth/login?remote=" + remote,
-        )}
+        on:click={() => {
+          window.location.href = encodeURI(
+            CANONICAL_ADMIN_URL + "/github/auth/login?remote=" + remote,
+          );
+        }}
       >
         Connect to GitHub
       </CtaButton>

--- a/web-admin/src/routes/-/github/connect/retry-auth/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/retry-auth/+page.svelte
@@ -1,7 +1,10 @@
 <!-- This page is for cases when user authorised the github app on another github account which doesn't have access to the repo  -->
 <script lang="ts">
   import { createAdminServiceGetCurrentUser } from "@rilldata/web-admin/client";
-  import { CANONICAL_ADMIN_URL } from "@rilldata/web-admin/client/http-client";
+  import {
+    redirectToGithubLogin,
+    redirectToLogin,
+  } from "@rilldata/web-admin/client/redirect-utils";
   import CtaButton from "@rilldata/web-common/components/calls-to-action/CTAButton.svelte";
   import CtaContentContainer from "@rilldata/web-common/components/calls-to-action/CTAContentContainer.svelte";
   import CtaHeader from "@rilldata/web-common/components/calls-to-action/CTAHeader.svelte";
@@ -19,7 +22,7 @@
     query: {
       onSuccess: (data) => {
         if (!data.user) {
-          window.location.href = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.href}`;
+          redirectToLogin();
         }
       },
     },
@@ -44,11 +47,7 @@
       </CtaMessage>
       <CtaButton
         variant="primary"
-        on:click={() => {
-          window.location.href = encodeURI(
-            CANONICAL_ADMIN_URL + "/github/auth/login?remote=" + remote,
-          );
-        }}
+        on:click={() => redirectToGithubLogin(remote)}
       >
         Connect to GitHub
       </CtaButton>

--- a/web-admin/src/routes/-/github/connect/retry-install/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/retry-install/+page.svelte
@@ -2,7 +2,6 @@
   We can't control the repo users install the github app on and they can end up installing the app on another repo.
   This page is for showing them the message that github app is installed on another repo than they need to reinstall app on right repo.  -->
 <script lang="ts">
-  import { goto } from "$app/navigation";
   import { createAdminServiceGetCurrentUser } from "@rilldata/web-admin/client";
   import { CANONICAL_ADMIN_URL } from "@rilldata/web-admin/client/http-client";
   import CtaButton from "@rilldata/web-common/components/calls-to-action/CTAButton.svelte";
@@ -20,9 +19,7 @@
     query: {
       onSuccess: (data) => {
         if (!data.user) {
-          goto(
-            `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.href}`,
-          );
+          window.location.href = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.href}`;
         }
       },
     },
@@ -50,9 +47,11 @@
       </CtaMessage>
       <CtaButton
         variant="primary"
-        href={encodeURI(
-          CANONICAL_ADMIN_URL + "/github/connect?remote=" + remote,
-        )}
+        on:click={() => {
+          window.location.href = encodeURI(
+            CANONICAL_ADMIN_URL + "/github/connect?remote=" + remote,
+          );
+        }}
       >
         Connect to GitHub
       </CtaButton>

--- a/web-admin/src/routes/-/github/connect/retry-install/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/retry-install/+page.svelte
@@ -3,7 +3,10 @@
   This page is for showing them the message that github app is installed on another repo than they need to reinstall app on right repo.  -->
 <script lang="ts">
   import { createAdminServiceGetCurrentUser } from "@rilldata/web-admin/client";
-  import { CANONICAL_ADMIN_URL } from "@rilldata/web-admin/client/http-client";
+  import {
+    redirectToGithubLogin,
+    redirectToLogin,
+  } from "@rilldata/web-admin/client/redirect-utils";
   import CtaButton from "@rilldata/web-common/components/calls-to-action/CTAButton.svelte";
   import CtaContentContainer from "@rilldata/web-common/components/calls-to-action/CTAContentContainer.svelte";
   import CtaHeader from "@rilldata/web-common/components/calls-to-action/CTAHeader.svelte";
@@ -19,7 +22,7 @@
     query: {
       onSuccess: (data) => {
         if (!data.user) {
-          window.location.href = `${CANONICAL_ADMIN_URL}/auth/login?redirect=${window.location.href}`;
+          redirectToLogin();
         }
       },
     },
@@ -47,11 +50,7 @@
       </CtaMessage>
       <CtaButton
         variant="primary"
-        on:click={() => {
-          window.location.href = encodeURI(
-            CANONICAL_ADMIN_URL + "/github/connect?remote=" + remote,
-          );
-        }}
+        on:click={() => redirectToGithubLogin(remote)}
       >
         Connect to GitHub
       </CtaButton>

--- a/web-common/src/components/button/Button.svelte
+++ b/web-common/src/components/button/Button.svelte
@@ -29,6 +29,7 @@
   export let noStroke = false;
   export let rounded = false;
   export let href: string | null = null;
+  export let rel: string | undefined = undefined;
   export let builders: Builder[] = [];
   export let loading = false;
   export let target: string | undefined = undefined;
@@ -68,7 +69,7 @@
   form={submitForm ? form : undefined}
   aria-label={label}
   {target}
-  rel={target === "_blank" ? "noopener noreferrer" : undefined}
+  rel={target === "_blank" ? "noopener noreferrer" : rel}
   {...getAttrs(builders)}
   use:builderActions={{ builders }}
   on:click={handleClick}

--- a/web-common/src/components/calls-to-action/CTAButton.svelte
+++ b/web-common/src/components/calls-to-action/CTAButton.svelte
@@ -3,7 +3,8 @@
 
   export let variant: "primary" | "secondary" = "primary";
   export let href: string | null = null;
+  export let rel: string | undefined = undefined;
   export let disabled = false;
 </script>
 
-<Button type={variant} {href} {disabled} wide on:click><slot /></Button>
+<Button type={variant} {href} {rel} {disabled} wide on:click><slot /></Button>

--- a/web-common/src/features/authentication/LocalAvatarButton.svelte
+++ b/web-common/src/features/authentication/LocalAvatarButton.svelte
@@ -84,11 +84,11 @@
         <DropdownMenu.Item on:click={handlePylon}>
           Contact Rill support
         </DropdownMenu.Item>
-        <DropdownMenu.Item href={logoutUrl} class="text-gray-800 font-normal">
+        <DropdownMenu.Item href={logoutUrl} rel="external" class="text-gray-800 font-normal">
           Logout
         </DropdownMenu.Item>
       {:else}
-        <DropdownMenu.Item href={loginUrl} class="text-gray-800 font-normal">
+        <DropdownMenu.Item href={loginUrl} rel="external" class="text-gray-800 font-normal">
           Log in / Sign up
         </DropdownMenu.Item>
       {/if}

--- a/web-common/src/features/authentication/LocalAvatarButton.svelte
+++ b/web-common/src/features/authentication/LocalAvatarButton.svelte
@@ -84,11 +84,19 @@
         <DropdownMenu.Item on:click={handlePylon}>
           Contact Rill support
         </DropdownMenu.Item>
-        <DropdownMenu.Item href={logoutUrl} rel="external" class="text-gray-800 font-normal">
+        <DropdownMenu.Item
+          href={logoutUrl}
+          rel="external"
+          class="text-gray-800 font-normal"
+        >
           Logout
         </DropdownMenu.Item>
       {:else}
-        <DropdownMenu.Item href={loginUrl} rel="external" class="text-gray-800 font-normal">
+        <DropdownMenu.Item
+          href={loginUrl}
+          rel="external"
+          class="text-gray-800 font-normal"
+        >
           Log in / Sign up
         </DropdownMenu.Item>
       {/if}


### PR DESCRIPTION
This is necessary to prevent Svelte from doing SPA routing when navigating to the /api/auth and /api/github paths on orgs with a custom domain configured. (When a custom domain is configured, the admin service is hosted on /api of the same domain, not a different host.)
