### PR TITLE
fix: Do not mandate github login/installation for github disconnect for a project

### DIFF
--- a/web-admin/src/features/projects/github/ProjectGithubConnection.svelte
+++ b/web-admin/src/features/projects/github/ProjectGithubConnection.svelte
@@ -56,7 +56,6 @@
   }
 
   function disconnectGithubConnect() {
-    void githubData.ensureGithubAccess();
     disconnectConfirmOpen = true;
   }
 </script>


### PR DESCRIPTION
During github disconnect, we use user's token to currently github repo to push to archive. This is not necessary and we can instead use the installation token.

This PR also fixes an issue with incorrectly ignored paths.