### PR TITLE
fix: missing active org update in local storage

### DIFF
--- a/web-admin/src/features/organizations/active-org/OrganizationRedirect.svelte
+++ b/web-admin/src/features/organizations/active-org/OrganizationRedirect.svelte
@@ -41,7 +41,6 @@
 
     // Scenario 3: User has no activeOrg in localStorage, but does belong to an org
     if (orgs.length > 0) {
-      localStorage.setItem(activeOrgLocalStorageKey, orgs[0].name);
       await goto(`/${orgs[0].name}`);
       return;
     }

--- a/web-admin/src/routes/[organization]/+layout.svelte
+++ b/web-admin/src/routes/[organization]/+layout.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { page } from "$app/stores";
+  import { createAdminServiceGetCurrentUser } from "@rilldata/web-admin/client";
+  import { getActiveOrgLocalStorageKey } from "@rilldata/web-admin/features/organizations/active-org/local-storage";
+
+  const user = createAdminServiceGetCurrentUser();
+  $: organization = $page.params.organization;
+
+  $: if ($user.data?.user?.id) {
+    // get active org key for the current user
+    const activeOrgLocalStorageKey = getActiveOrgLocalStorageKey(
+      $user.data?.user?.id,
+    );
+    // store the navigated org to the local storage
+    localStorage.setItem(activeOrgLocalStorageKey, organization);
+  }
+</script>
+
+<slot />


### PR DESCRIPTION
We are reading `activeOrg_<user_id>` to redirect a user when lading on cloud home page. But this is not updated anywhere. Seems like it got removed by mistake in some PR.

This will cause issues when org is deleted or is renamed. Landing on home will throw a 404.