### PR TITLE
fix: force z-index for select component 

### DIFF
--- a/web-common/src/features/custom-dashboards/Component.svelte
+++ b/web-common/src/features/custom-dashboards/Component.svelte
@@ -67,7 +67,7 @@
   data-index={i}
   class="wrapper hover:cursor-pointer active:cursor-grab pointer-events-auto"
   class:!cursor-default={embed}
-  style:z-index={localZIndex}
+  style:z-index={renderer === "select" ? 100 : localZIndex}
   style:padding="{padding}px"
   style:left="{left}px"
   style:top="{top}px"


### PR DESCRIPTION
Fixes #5517

This PR removes local z-index from custom components and adds an explicit z-index for select.