### PR TITLE
fix: deploy success possibly not firing in UI based deploy flow

### DIFF
--- a/web-common/src/features/project/ProjectDeployer.ts
+++ b/web-common/src/features/project/ProjectDeployer.ts
@@ -165,7 +165,8 @@ export class ProjectDeployer {
           org: `${org}${i === 0 ? "" : "-" + i}`,
           upload: true,
         });
-        void behaviourEvent?.fireDeployEvent(
+        // wait for the telemetry to finish since the page will be redirected after a deploy success
+        await behaviourEvent?.fireDeployEvent(
           BehaviourEventAction.DeploySuccess,
         );
         return resp.frontendUrl;


### PR DESCRIPTION
Deploy success event is fired asynchronously after a deploy succeeds. Since the page is redirected to project page on cloud the telemetry might not always fire. This adds an await to make sure the telemetry gets fired.