### PR TITLE
tweak: invalid end date ux

### DIFF
--- a/web-common/src/components/date-picker/Month.svelte
+++ b/web-common/src/components/date-picker/Month.svelte
@@ -49,7 +49,7 @@
     <button
       class:hide={visibleIndex !== 0}
       class="hover:opacity-50"
-      on:click={onPan(-1)}
+      on:click={() => onPan(-1)}
     >
       <ChevronLeft size="14px" />
     </button>
@@ -62,9 +62,7 @@
     <button
       class="hover:opacity-50"
       class:hide={visibleIndex !== visibleMonths - 1}
-      on:click={() => {
-        onPan(1);
-      }}
+      on:click={() => onPan(1)}
     >
       <ChevronRight size="14px" />
     </button>

--- a/web-common/src/features/dashboards/time-controls/super-pill/components/CalendarPlusDateInput.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/CalendarPlusDateInput.svelte
@@ -25,10 +25,14 @@
   function onValidDateInput(date: DateTime) {
     let newInterval: Interval;
 
-    if (selectingStart) {
+    const selectedEndDateBeforeStart = date < calendarInterval.start;
+
+    if (selectingStart || selectedEndDateBeforeStart) {
       newInterval = calendarInterval.set({ start: date });
+      selectingStart = false;
     } else {
       newInterval = calendarInterval.set({ end: date });
+      selectingStart = true;
     }
 
     if (newInterval.isValid) {
@@ -39,10 +43,10 @@
         calendarInterval = singleDay;
       }
     }
+
     if (calendarInterval.isValid) {
       firstVisibleMonth = calendarInterval.start;
     }
-    selectingStart = !selectingStart;
   }
 </script>
 

--- a/web-common/src/features/dashboards/time-controls/super-pill/components/CalendarPlusDateInput.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/CalendarPlusDateInput.svelte
@@ -25,7 +25,8 @@
   function onValidDateInput(date: DateTime) {
     let newInterval: Interval;
 
-    const selectedEndDateBeforeStart = date < calendarInterval.start;
+    const selectedEndDateBeforeStart =
+      calendarInterval?.start && date < calendarInterval.start;
 
     if (selectingStart || selectedEndDateBeforeStart) {
       newInterval = calendarInterval.set({ start: date });


### PR DESCRIPTION
When in end date selection mode, selecting a date prior to the current start date will re-assign the start date instead of clearing the range (updating both dates). Days prior to the start date are now a lighter shade of gray and the "potential range" hover state has been updated.

<img width="257" alt="Screenshot 2024-08-28 at 5 02 42 PM" src="https://github.com/user-attachments/assets/c082e52e-fd10-48be-93e5-741b9076441a">


When in start date selection, selecting a date after the end date has a new visual cue, though the behavior is unchanged.

<img width="258" alt="Screenshot 2024-08-28 at 5 02 28 PM" src="https://github.com/user-attachments/assets/fe42cd77-1c4e-483c-a7f4-cda9be3f33d8">
