### PR TITLE
tweak: remote content warning conditional

### DIFF
--- a/web-common/src/features/editor/Codespace.svelte
+++ b/web-common/src/features/editor/Codespace.svelte
@@ -66,7 +66,7 @@
           const local = get(localContent);
           if (editor.state.doc.toString() === newRemoteContent) return;
 
-          if (!get(localContent)) {
+          if (local === null) {
             updateEditorContent(newRemoteContent);
           } else if (local !== newRemoteContent) {
             showWarning = true;


### PR DESCRIPTION
This is likely not causing any issues, but, just to be sure, a small change so that the localContent store is only "gotten" once and the warning conditional passes only on null and not undefined or an empty string.