### PR TITLE
postgres column encryption for sensitive data

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -16,17 +16,18 @@ import (
 )
 
 type Options struct {
-	DatabaseDriver     string
-	DatabaseDSN        string
-	ExternalURL        string
-	FrontendURL        string
-	ProvisionerSetJSON string
-	DefaultProvisioner string
-	VersionNumber      string
-	VersionCommit      string
-	MetricsProjectOrg  string
-	MetricsProjectName string
-	AutoscalerCron     string
+	DatabaseDriver            string
+	DatabaseDSN               string
+	ExternalURL               string
+	FrontendURL               string
+	ProvisionerSetJSON        string
+	DefaultProvisioner        string
+	VersionNumber             string
+	VersionCommit             string
+	MetricsProjectOrg         string
+	MetricsProjectName        string
+	AutoscalerCron            string
+	DatabaseEncryptionKeyring string
 }
 
 type Service struct {
@@ -49,9 +50,9 @@ type Service struct {
 	PaymentProvider  payment.Provider
 }
 
-func New(ctx context.Context, opts *Options, logger *zap.Logger, issuer *auth.Issuer, emailClient *email.Client, github Github, aiClient ai.Client, assets *storage.BucketHandle, biller billing.Biller, p payment.Provider, databaseEncryptionKeyring []*database.EncryptionKey) (*Service, error) {
+func New(ctx context.Context, opts *Options, logger *zap.Logger, issuer *auth.Issuer, emailClient *email.Client, github Github, aiClient ai.Client, assets *storage.BucketHandle, biller billing.Biller, p payment.Provider) (*Service, error) {
 	// Init db
-	db, err := database.Open(opts.DatabaseDriver, opts.DatabaseDSN, databaseEncryptionKeyring)
+	db, err := database.Open(opts.DatabaseDriver, opts.DatabaseDSN, opts.DatabaseEncryptionKeyring)
 	if err != nil {
 		logger.Fatal("error connecting to database", zap.Error(err))
 	}

--- a/admin/admin.go
+++ b/admin/admin.go
@@ -49,9 +49,9 @@ type Service struct {
 	PaymentProvider  payment.Provider
 }
 
-func New(ctx context.Context, opts *Options, logger *zap.Logger, issuer *auth.Issuer, emailClient *email.Client, github Github, aiClient ai.Client, assets *storage.BucketHandle, biller billing.Biller, p payment.Provider) (*Service, error) {
+func New(ctx context.Context, opts *Options, logger *zap.Logger, issuer *auth.Issuer, emailClient *email.Client, github Github, aiClient ai.Client, assets *storage.BucketHandle, biller billing.Biller, p payment.Provider, databaseEncryptionKeyring []*database.EncryptionKey) (*Service, error) {
 	// Init db
-	db, err := database.Open(opts.DatabaseDriver, opts.DatabaseDSN)
+	db, err := database.Open(opts.DatabaseDriver, opts.DatabaseDSN, databaseEncryptionKeyring)
 	if err != nil {
 		logger.Fatal("error connecting to database", zap.Error(err))
 	}

--- a/admin/admin.go
+++ b/admin/admin.go
@@ -18,6 +18,7 @@ import (
 type Options struct {
 	DatabaseDriver            string
 	DatabaseDSN               string
+	DatabaseEncryptionKeyring string
 	ExternalURL               string
 	FrontendURL               string
 	ProvisionerSetJSON        string
@@ -27,7 +28,6 @@ type Options struct {
 	MetricsProjectOrg         string
 	MetricsProjectName        string
 	AutoscalerCron            string
-	DatabaseEncryptionKeyring string
 }
 
 type Service struct {

--- a/admin/database/database.go
+++ b/admin/database/database.go
@@ -34,10 +34,6 @@ func Open(driver, dsn, encKeyringConfig string) (DB, error) {
 		return nil, fmt.Errorf("error parsing encryption keyring: %w", err)
 	}
 
-	if len(encKeyring) == 0 {
-		return nil, errors.New("encryption keyring is empty")
-	}
-
 	db, err := d.Open(dsn, encKeyring)
 	if err != nil {
 		return nil, err
@@ -939,6 +935,10 @@ type EncryptionKey struct {
 }
 
 func ParseEncryptionKeyring(keyring string) ([]*EncryptionKey, error) {
+	if keyring == "" {
+		return nil, nil
+	}
+
 	var encKeyring []*EncryptionKey
 	err := json.Unmarshal([]byte(keyring), &encKeyring)
 	if err != nil {

--- a/admin/database/database.go
+++ b/admin/database/database.go
@@ -929,6 +929,9 @@ type Asset struct {
 	CreatedOn      time.Time `db:"created_on"`
 }
 
+// EncryptionKey represents an encryption key for column-level encryption/decryption.
+// Column-level encryption provides an extra layer of security for highly sensitive columns in the database.
+// It is implemented on the application side before writes to and after reads from the database.
 type EncryptionKey struct {
 	ID     string `json:"key_id"`
 	Secret []byte `json:"key"`

--- a/admin/database/database.go
+++ b/admin/database/database.go
@@ -22,7 +22,8 @@ func Register(name string, driver Driver) {
 	Drivers[name] = driver
 }
 
-// Open opens a new database connection. encryptionKeyring is for client-side column-level encryption
+// Open opens a new database connection.
+// See ParseEncryptionKeyring for the expected format for encKeyringConfig.
 func Open(driver, dsn, encKeyringConfig string) (DB, error) {
 	d, ok := Drivers[driver]
 	if !ok {

--- a/admin/database/database.go
+++ b/admin/database/database.go
@@ -937,6 +937,9 @@ type EncryptionKey struct {
 	Secret []byte `json:"key"`
 }
 
+// ParseEncryptionKeyring parses a JSON string containing an array of EncryptionKey objects.
+// If the provided string is empty, an empty keyring is returned.
+// When using an empty keyring, columns will be read and written without applying encryption/decryption.
 func ParseEncryptionKeyring(keyring string) ([]*EncryptionKey, error) {
 	if keyring == "" {
 		return nil, nil

--- a/admin/database/database.go
+++ b/admin/database/database.go
@@ -2,6 +2,8 @@ package database
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -19,13 +21,13 @@ func Register(name string, driver Driver) {
 }
 
 // Open opens a new database connection.
-func Open(driver, dsn string) (DB, error) {
+func Open(driver, dsn string, encryptionKeyring []*EncryptionKey) (DB, error) {
 	d, ok := Drivers[driver]
 	if !ok {
 		return nil, fmt.Errorf("unknown database driver: %s", driver)
 	}
 
-	db, err := d.Open(dsn)
+	db, err := d.Open(dsn, encryptionKeyring)
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +37,7 @@ func Open(driver, dsn string) (DB, error) {
 
 // Driver is the interface for DB drivers.
 type Driver interface {
-	Open(dsn string) (DB, error)
+	Open(dsn string, encryptionKeyring []*EncryptionKey) (DB, error)
 }
 
 // DB is the interface for a database connection.
@@ -339,21 +341,22 @@ type Project struct {
 	Provisioner     string
 	// ArchiveAssetID is set when project files are managed by Rill instead of maintained in Git.
 	// If ArchiveAssetID is set all git related fields will be empty.
-	ArchiveAssetID       *string           `db:"archive_asset_id"`
-	GithubURL            *string           `db:"github_url"`
-	GithubInstallationID *int64            `db:"github_installation_id"`
-	Subpath              string            `db:"subpath"`
-	ProdVersion          string            `db:"prod_version"`
-	ProdBranch           string            `db:"prod_branch"`
-	ProdVariables        map[string]string `db:"prod_variables"`
-	ProdOLAPDriver       string            `db:"prod_olap_driver"`
-	ProdOLAPDSN          string            `db:"prod_olap_dsn"`
-	ProdSlots            int               `db:"prod_slots"`
-	ProdTTLSeconds       *int64            `db:"prod_ttl_seconds"`
-	ProdDeploymentID     *string           `db:"prod_deployment_id"`
-	Annotations          map[string]string `db:"annotations"`
-	CreatedOn            time.Time         `db:"created_on"`
-	UpdatedOn            time.Time         `db:"updated_on"`
+	ArchiveAssetID               *string           `db:"archive_asset_id"`
+	GithubURL                    *string           `db:"github_url"`
+	GithubInstallationID         *int64            `db:"github_installation_id"`
+	Subpath                      string            `db:"subpath"`
+	ProdVersion                  string            `db:"prod_version"`
+	ProdBranch                   string            `db:"prod_branch"`
+	ProdVariables                map[string]string `db:"prod_variables"`
+	ProdOLAPDriver               string            `db:"prod_olap_driver"`
+	ProdOLAPDSN                  string            `db:"prod_olap_dsn"`
+	ProdSlots                    int               `db:"prod_slots"`
+	ProdTTLSeconds               *int64            `db:"prod_ttl_seconds"`
+	ProdDeploymentID             *string           `db:"prod_deployment_id"`
+	Annotations                  map[string]string `db:"annotations"`
+	ProdVariablesEncryptionKeyID *string           `db:"prod_variables_encryption_key_id"`
+	CreatedOn                    time.Time         `db:"created_on"`
+	UpdatedOn                    time.Time         `db:"updated_on"`
 }
 
 // InsertProjectOptions defines options for inserting a new Project.
@@ -917,4 +920,34 @@ type Asset struct {
 	Path           string    `db:"path"`
 	OwnerID        string    `db:"owner_id"`
 	CreatedOn      time.Time `db:"created_on"`
+}
+
+type EncryptionKey struct {
+	ID     string `json:"key_id"`
+	Secret []byte `json:"key"`
+}
+
+// UnmarshalJSON custom method for EncryptionKey
+func (e *EncryptionKey) UnmarshalJSON(data []byte) error {
+	// Create a temporary structure to unmarshal into
+	type Alias EncryptionKey
+	aux := &struct {
+		Key string `json:"key"`
+		*Alias
+	}{
+		Alias: (*Alias)(e),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	// Decode the base64 encoded key into the Secret field
+	decodedSecret, err := base64.StdEncoding.DecodeString(aux.Key)
+	if err != nil {
+		return err
+	}
+
+	e.Secret = decodedSecret
+	return nil
 }

--- a/admin/database/postgres/migrations/0043.sql
+++ b/admin/database/postgres/migrations/0043.sql
@@ -1,1 +1,1 @@
-ALTER TABLE projects ADD COLUMN prod_variables_encryption_key_id TEXT;
+ALTER TABLE projects ADD COLUMN prod_variables_encryption_key_id TEXT NOT NULL DEFAULT '';

--- a/admin/database/postgres/migrations/0043.sql
+++ b/admin/database/postgres/migrations/0043.sql
@@ -1,0 +1,1 @@
+ALTER TABLE projects ADD COLUMN prod_variables_encryption_key_id TEXT;

--- a/admin/database/postgres/postgres.go
+++ b/admin/database/postgres/postgres.go
@@ -1985,30 +1985,31 @@ func (c *connection) encryptMap(m map[string]string) (map[string]string, string,
 
 // returns the map with decrypted values and the encryption key id used
 func (c *connection) decryptMap(m map[string]string, encKeyID string) (map[string]string, error) {
-	if encKeyID != "" {
-		var encKey *database.EncryptionKey
-		for _, key := range c.encKeyring {
-			if key.ID == encKeyID {
-				encKey = key
-				break
-			}
-		}
-		if encKey == nil {
-			return nil, fmt.Errorf("encryption key id %s not found in keyring", encKeyID)
-		}
-
-		// copy the map to avoid modifying the original map
-		vars := make(map[string]string, len(m))
-		for k, v := range m {
-			decrypted, err := decrypt(v, encKey.Secret)
-			if err != nil {
-				return nil, err
-			}
-			vars[k] = decrypted
-		}
-		return vars, nil
+	if encKeyID == "" {
+		return m, nil
 	}
-	return m, nil
+
+	var encKey *database.EncryptionKey
+	for _, key := range c.encKeyring {
+		if key.ID == encKeyID {
+			encKey = key
+			break
+		}
+	}
+	if encKey == nil {
+		return nil, fmt.Errorf("encryption key id %s not found in keyring", encKeyID)
+	}
+
+	// copy the map to avoid modifying the original map
+	vars := make(map[string]string, len(m))
+	for k, v := range m {
+		decrypted, err := decrypt(v, encKey.Secret)
+		if err != nil {
+			return nil, err
+		}
+		vars[k] = decrypted
+	}
+	return vars, nil
 }
 
 // magicAuthTokenDTO wraps database.MagicAuthToken, using the pgtype package to handly types that pgx can't read directly into their native Go types.

--- a/admin/database/postgres/postgres_test.go
+++ b/admin/database/postgres/postgres_test.go
@@ -2,7 +2,7 @@ package postgres
 
 import (
 	"context"
-	"crypto/rand"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -19,15 +19,12 @@ func TestPostgres(t *testing.T) {
 	pg := pgtestcontainer.New(t)
 	defer pg.Terminate(t)
 
-	secret := make([]byte, 32) // 32 bytes for AES-256
-	_, err := rand.Read(secret)
+	encKeyRing, err := database.NewRandomKeyring()
+	require.NoError(t, err)
+	conf, err := json.Marshal(encKeyRing)
 	require.NoError(t, err)
 
-	encKeyRing := []*database.EncryptionKey{
-		{ID: "test", Secret: secret},
-	}
-
-	db, err := database.Open("postgres", pg.DatabaseURL, encKeyRing)
+	db, err := database.Open("postgres", pg.DatabaseURL, string(conf))
 	require.NoError(t, err)
 	require.NotNil(t, db)
 

--- a/admin/database/postgres/postgres_test.go
+++ b/admin/database/postgres/postgres_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"crypto/rand"
 	"testing"
 	"time"
 
@@ -18,7 +19,15 @@ func TestPostgres(t *testing.T) {
 	pg := pgtestcontainer.New(t)
 	defer pg.Terminate(t)
 
-	db, err := database.Open("postgres", pg.DatabaseURL)
+	secret := make([]byte, 32) // 32 bytes for AES-256
+	_, err := rand.Read(secret)
+	require.NoError(t, err)
+
+	encKeyRing := []*database.EncryptionKey{
+		{ID: "test", Secret: secret},
+	}
+
+	db, err := database.Open("postgres", pg.DatabaseURL, encKeyRing)
 	require.NoError(t, err)
 	require.NotNil(t, db)
 

--- a/admin/provisioner/static_test.go
+++ b/admin/provisioner/static_test.go
@@ -2,7 +2,6 @@ package provisioner
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/c2h5oh/datasize"
@@ -18,12 +17,7 @@ func Test_staticProvisioner_Provision(t *testing.T) {
 	pg := pgtestcontainer.New(t)
 	defer pg.Terminate(t)
 
-	encKeyRing, err := database.NewRandomKeyring()
-	require.NoError(t, err)
-	conf, err := json.Marshal(encKeyRing)
-	require.NoError(t, err)
-
-	db, err := database.Open("postgres", pg.DatabaseURL, string(conf))
+	db, err := database.Open("postgres", pg.DatabaseURL, "")
 	require.NoError(t, err)
 	require.NotNil(t, db)
 	defer db.Close()

--- a/admin/provisioner/static_test.go
+++ b/admin/provisioner/static_test.go
@@ -2,6 +2,7 @@ package provisioner
 
 import (
 	"context"
+	"crypto/rand"
 	"testing"
 
 	"github.com/c2h5oh/datasize"
@@ -17,7 +18,15 @@ func Test_staticProvisioner_Provision(t *testing.T) {
 	pg := pgtestcontainer.New(t)
 	defer pg.Terminate(t)
 
-	db, err := database.Open("postgres", pg.DatabaseURL)
+	secret := make([]byte, 32) // 32 bytes for AES-256
+	_, err := rand.Read(secret)
+	require.NoError(t, err)
+
+	encKeyRing := []*database.EncryptionKey{
+		{ID: "test", Secret: secret},
+	}
+
+	db, err := database.Open("postgres", pg.DatabaseURL, encKeyRing)
 	require.NoError(t, err)
 	require.NotNil(t, db)
 	defer db.Close()

--- a/admin/server/admin_rbac_test.go
+++ b/admin/server/admin_rbac_test.go
@@ -64,6 +64,7 @@ func TestAdmin_RBAC(t *testing.T) {
 		nil,
 		billing.NewNoop(),
 		payment.NewNoop(),
+		nil,
 	)
 	require.NoError(t, err)
 

--- a/admin/server/admin_rbac_test.go
+++ b/admin/server/admin_rbac_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"net"
 	"strconv"
 	"testing"
@@ -54,20 +53,14 @@ func TestAdmin_RBAC(t *testing.T) {
 
 	provisionerSetJSON := "{\"static\":{\"type\":\"static\",\"spec\":{\"runtimes\":[{\"host\":\"http://localhost:9091\",\"slots\":50,\"data_dir\":\"\",\"audience_url\":\"http://localhost:8081\"}]}}}"
 
-	dbEncKeyring, err := database.NewRandomKeyring()
-	require.NoError(t, err)
-	encKeyringConf, err := json.Marshal(dbEncKeyring)
-	require.NoError(t, err)
-
 	service, err := admin.New(context.Background(),
 		&admin.Options{
-			DatabaseDriver:            "postgres",
-			DatabaseDSN:               pg.DatabaseURL,
-			ProvisionerSetJSON:        provisionerSetJSON,
-			DefaultProvisioner:        "static",
-			ExternalURL:               "http://localhost:9090",
-			VersionNumber:             "",
-			DatabaseEncryptionKeyring: string(encKeyringConf),
+			DatabaseDriver:     "postgres",
+			DatabaseDSN:        pg.DatabaseURL,
+			ProvisionerSetJSON: provisionerSetJSON,
+			DefaultProvisioner: "static",
+			ExternalURL:        "http://localhost:9090",
+			VersionNumber:      "",
 		},
 		logger,
 		issuer,

--- a/cli/cmd/admin/start.go
+++ b/cli/cmd/admin/start.go
@@ -279,6 +279,10 @@ func StartCmd(ch *cmdutil.Helper) *cobra.Command {
 				logger.Fatal("error loading database encryption keyring", zap.Error(err))
 			}
 
+			if len(databaseEncryptionKeyring) == 0 {
+				logger.Fatal("no encryption keys found in database encryption keyring")
+			}
+
 			// Init admin service
 			admOpts := &admin.Options{
 				DatabaseDriver:     conf.DatabaseDriver,

--- a/cli/pkg/mock/server.go
+++ b/cli/pkg/mock/server.go
@@ -50,7 +50,7 @@ func AdminService(ctx context.Context, logger *zap.Logger, databaseURL string) (
 		VersionCommit:      "",
 	}
 
-	adm, err := admin.New(ctx, admOpts, logger, issuer, emailClient, gh, ai.NewNoop(), nil, billing.NewNoop(), payment.NewNoop())
+	adm, err := admin.New(ctx, admOpts, logger, issuer, emailClient, gh, ai.NewNoop(), nil, billing.NewNoop(), payment.NewNoop(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/pkg/mock/server.go
+++ b/cli/pkg/mock/server.go
@@ -50,7 +50,7 @@ func AdminService(ctx context.Context, logger *zap.Logger, databaseURL string) (
 		VersionCommit:      "",
 	}
 
-	adm, err := admin.New(ctx, admOpts, logger, issuer, emailClient, gh, ai.NewNoop(), nil, billing.NewNoop(), payment.NewNoop(), nil)
+	adm, err := admin.New(ctx, admOpts, logger, issuer, emailClient, gh, ai.NewNoop(), nil, billing.NewNoop(), payment.NewNoop())
 	if err != nil {
 		return nil, err
 	}

--- a/scripts/generate_enc_keyring/main.go
+++ b/scripts/generate_enc_keyring/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/rilldata/rill/admin/database"
+)
+
+// This script generates a new encryption keyring for the database and prints it to stdout. Existing keyring can be provided as an argument like:
+// go run scripts/generate_enc_keyring/main.go '[{"key_id":"<>","key":"<>"},{"key_id":"key2","key":"<>"}]'
+// New key will be prepended to the existing keyring.
+func main() {
+	var encKeyring []*database.EncryptionKey
+	var err error
+	if len(os.Args) > 1 {
+		encKeyring, err = database.ParseEncryptionKeyring(os.Args[1])
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+	}
+
+	// Generate encryption keyring for db column encryption
+	newKeyRing, err := database.NewRandomKeyring()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	newKeyRing = append(newKeyRing, encKeyring...)
+
+	conf, err := json.Marshal(newKeyRing)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	fmt.Printf("RILL_ADMIN_DATABASE_ENCRYPTION_KEYRING='%s'\n", conf)
+}


### PR DESCRIPTION
Fixes https://github.com/rilldata/rill-private-issues/issues/590

Before merging this, we will need to set following admin property in helm with secret in vault, also dev .env file should be updated, otherwise admin service will fail to start  -
```
RILL_ADMIN_DATABASE_ENCRYPTION_KEYRING='[{"key_id":"<id(can use numerical order for id starting from 1)>","key":"<32-bytes-base64-encoded-secret>"}]'
```

For key rotation, new key should be prepended to the array as the first key is used for encryption. New secret can be generated using `openssl rand -base64 32`

Included a utility to generate keyring - `go run scripts/generate_enc_keyring/main.go`. It accepts prepending to existing keyring with `go run scripts/generate_enc_keyring/main.go '[{"key_id":"<>","key":"<>"},{"key_id":"key2","key":"<>"}]'`