### PR TITLE
Fix (Alerts): Handle a missing Metrics View on the Alert page

### DIFF
--- a/web-admin/src/features/alerts/metadata/AlertMetadata.svelte
+++ b/web-admin/src/features/alerts/metadata/AlertMetadata.svelte
@@ -18,7 +18,10 @@
   import { extractNotifier } from "@rilldata/web-admin/features/scheduled-reports/metadata/notifiers-utils";
   import { IconButton } from "@rilldata/web-common/components/button";
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
+  import CancelCircle from "@rilldata/web-common/components/icons/CancelCircle.svelte";
   import ThreeDot from "@rilldata/web-common/components/icons/ThreeDot.svelte";
+  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
+  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { useDashboard } from "@rilldata/web-common/features/dashboards/selectors";
   import {
     getRuntimeServiceListResourcesQueryKey,
@@ -39,6 +42,7 @@
   $: dashboard = useDashboard($runtime.instanceId, $dashboardName.data);
   $: dashboardTitle =
     $dashboard.data?.metricsView.spec.title || $dashboardName.data;
+  $: dashboardDoesNotExist = $dashboard.error?.response?.status === 404;
 
   $: alertSpec = $alertQuery.data?.resource?.alert?.spec;
 
@@ -118,9 +122,21 @@
       <div class="flex flex-col gap-y-3">
         <MetadataLabel>Dashboard</MetadataLabel>
         <MetadataValue>
-          <a href={`/${organization}/${project}/${$dashboardName.data}`}
-            >{dashboardTitle}</a
-          >
+          {#if dashboardDoesNotExist}
+            <div class="flex items-center gap-x-1">
+              {dashboardTitle}
+              <Tooltip>
+                <CancelCircle size="16px" className="text-red-500" />
+                <TooltipContent slot="tooltip-content">
+                  Dashboard does not exist
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          {:else}
+            <a href={`/${organization}/${project}/${$dashboardName.data}`}
+              >{dashboardTitle}</a
+            >
+          {/if}
         </MetadataValue>
       </div>
 

--- a/web-admin/src/features/alerts/metadata/AlertMetadata.svelte
+++ b/web-admin/src/features/alerts/metadata/AlertMetadata.svelte
@@ -125,7 +125,7 @@
           {#if dashboardDoesNotExist}
             <div class="flex items-center gap-x-1">
               {dashboardTitle}
-              <Tooltip>
+              <Tooltip distance={8}>
                 <CancelCircle size="16px" className="text-red-500" />
                 <TooltipContent slot="tooltip-content">
                   Dashboard does not exist

--- a/web-admin/src/features/errors/error-utils.ts
+++ b/web-admin/src/features/errors/error-utils.ts
@@ -3,13 +3,17 @@ import { redirectToLogin } from "@rilldata/web-admin/client/redirect-utils";
 import { isAdminServerQuery } from "@rilldata/web-admin/client/utils";
 import { checkUserAccess } from "@rilldata/web-admin/features/authentication/checkUserAccess";
 import {
+  isAlertPage,
   isMetricsExplorerPage,
   isProjectPage,
   isProjectRequestAccessPage,
   isPublicURLPage,
 } from "@rilldata/web-admin/features/navigation/nav-utils";
 import { errorEventHandler } from "@rilldata/web-common/metrics/initMetrics";
-import { isRuntimeQuery } from "@rilldata/web-common/runtime-client/is-runtime-query";
+import {
+  isGetResourceMetricsViewQuery,
+  isRuntimeQuery,
+} from "@rilldata/web-common/runtime-client/query-matcher";
 import type { Query } from "@tanstack/query-core";
 import type { QueryClient } from "@tanstack/svelte-query";
 import type { AxiosError } from "axios";
@@ -110,6 +114,18 @@ export function createGlobalErrorCallback(queryClient: QueryClient) {
       // When a JWT doesn't permit access to a metrics view, the metrics view APIs return 401s.
       // In this scenario, `GetCatalog` returns a 404. We ignore the 401s so we can show the 404.
       if (error.response?.status === 401) {
+        return;
+      }
+    }
+
+    // Special handling for some errors on the Alerts page
+    const onAlertPage = isAlertPage(get(page));
+    if (onAlertPage) {
+      // Don't block on a Metrics View 404
+      if (
+        isGetResourceMetricsViewQuery(query) &&
+        error.response?.status === 404
+      ) {
         return;
       }
     }

--- a/web-common/src/runtime-client/is-runtime-query.ts
+++ b/web-common/src/runtime-client/is-runtime-query.ts
@@ -1,6 +1,0 @@
-import type { Query } from "@tanstack/svelte-query";
-
-export function isRuntimeQuery(query: Query): boolean {
-  const [apiPath] = query.queryKey as string[];
-  return apiPath.startsWith("/v1/instances/");
-}

--- a/web-common/src/runtime-client/query-matcher.ts
+++ b/web-common/src/runtime-client/query-matcher.ts
@@ -1,4 +1,24 @@
 import type { Query } from "@tanstack/query-core";
+import { ResourceKind } from "../features/entity-management/resource-selectors";
+
+export function isRuntimeQuery(query: Query): boolean {
+  const [apiPath] = query.queryKey as string[];
+  return apiPath.startsWith("/v1/instances/");
+}
+
+export function isGetResourceMetricsViewQuery(query: Query): boolean {
+  const [apiPath, queryParams] = query.queryKey; // Renamed for clarity
+  if (
+    typeof apiPath !== "string" ||
+    typeof queryParams !== "object" ||
+    queryParams === null
+  )
+    return false;
+  return (
+    apiPath.startsWith("/v1/instances/") &&
+    queryParams["name.kind"] === ResourceKind.MetricsView
+  );
+}
 
 export enum QueryRequestType {
   MetricsViewTopList = "toplist",


### PR DESCRIPTION
For an Alert that has had its underlying Metrics View deleted, the Alert page now shows this icon & tooltip:

<img width="1426" alt="image" src="https://github.com/user-attachments/assets/8ba4fe15-82e7-4bea-b6f4-49662c996e64">

Closes https://github.com/rilldata/rill-private-issues/issues/626