### PR TITLE
Fix: Account for multi-OLAP paradigm when checking for OLAP modeling support

### DIFF
--- a/web-common/src/features/connectors/olap/TableMenuItems.svelte
+++ b/web-common/src/features/connectors/olap/TableMenuItems.svelte
@@ -16,7 +16,7 @@
   import { featureFlags } from "../../feature-flags";
   import { useCreateDashboardFromTableUIAction } from "../../metrics-views/ai-generation/generateMetricsView";
   import { createModelFromTable } from "./createModel";
-  import { useIsModelingSupportedForCurrentOlapDriver } from "./selectors";
+  import { useIsModelingSupportedForOlapDriver } from "./selectors";
 
   const { ai } = featureFlags;
   const queryClient = useQueryClient();
@@ -26,8 +26,10 @@
   export let databaseSchema: string = "";
   export let table: string;
 
-  $: isModelingSupportedForCurrentOlapDriver =
-    useIsModelingSupportedForCurrentOlapDriver($runtime.instanceId);
+  $: isModelingSupportedForOlapDriver = useIsModelingSupportedForOlapDriver(
+    $runtime.instanceId,
+    connector,
+  );
   $: createDashboardFromTable = useCreateDashboardFromTableUIAction(
     $runtime.instanceId,
     connector,
@@ -63,7 +65,7 @@
   }
 </script>
 
-{#if $isModelingSupportedForCurrentOlapDriver}
+{#if $isModelingSupportedForOlapDriver}
   <NavigationMenuItem on:click={handleCreateModel}>
     <Model slot="icon" />
     Create new model

--- a/web-common/src/features/entity-management/AddAssetButton.svelte
+++ b/web-common/src/features/entity-management/AddAssetButton.svelte
@@ -18,7 +18,7 @@
     createRuntimeServicePutFile,
   } from "../../runtime-client";
   import { runtime } from "../../runtime-client/runtime-store";
-  import { useIsModelingSupportedForCurrentOlapDriver } from "../connectors/olap/selectors";
+  import { useIsModelingSupportedForDefaultOlapDriver } from "../connectors/olap/selectors";
   import { featureFlags } from "../feature-flags";
   import { directoryState } from "../file-explorer/directory-store";
   import { handleEntityCreate } from "../file-explorer/new-files";
@@ -53,8 +53,8 @@
     currentDirectory,
   );
 
-  $: isModelingSupportedForCurrentOlapDriver =
-    useIsModelingSupportedForCurrentOlapDriver($runtime.instanceId);
+  $: isModelingSupportedForDefaultOlapDriver =
+    useIsModelingSupportedForDefaultOlapDriver($runtime.instanceId);
 
   async function wrapNavigation(toPath: string | undefined) {
     if (!toPath) return;
@@ -218,7 +218,7 @@
     </Button>
   </DropdownMenu.Trigger>
   <DropdownMenu.Content align="start" class="w-[240px]">
-    {#if $isModelingSupportedForCurrentOlapDriver}
+    {#if $isModelingSupportedForDefaultOlapDriver}
       <DropdownMenu.Item
         aria-label="Add Source"
         class="flex gap-x-2"

--- a/web-common/src/features/metrics-views/MetricsInspector.svelte
+++ b/web-common/src/features/metrics-views/MetricsInspector.svelte
@@ -10,6 +10,10 @@
   const queryClient = useQueryClient();
 
   export let filePath: string;
+  export let connector: string;
+  export let database: string;
+  export let databaseSchema: string;
+  export let table: string;
 
   $: fileArtifact = fileArtifacts.getFileArtifact(filePath);
   $: ({ remoteContent } = fileArtifact);
@@ -21,12 +25,6 @@
     data: resourceData,
   } = $resource);
   $: resourceReconcileError = resourceData?.meta?.reconcileError;
-
-  $: connector = $resource.data?.metricsView?.state?.validSpec?.connector ?? "";
-  $: database = $resource.data?.metricsView?.state?.validSpec?.database ?? "";
-  $: databaseSchema =
-    $resource.data?.metricsView?.state?.validSpec?.databaseSchema ?? "";
-  $: table = $resource.data?.metricsView?.state?.validSpec?.table ?? "";
 
   $: tableQuery = createConnectorServiceOLAPGetTable(
     {

--- a/web-common/src/features/metrics-views/workspace/editor/Placeholder.svelte
+++ b/web-common/src/features/metrics-views/workspace/editor/Placeholder.svelte
@@ -9,15 +9,15 @@
     runtimeServicePutFile,
   } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
-  import { useIsModelingSupportedForCurrentOlapDriver } from "../../../connectors/olap/selectors";
+  import { useIsModelingSupportedForDefaultOlapDriver } from "../../../connectors/olap/selectors";
   import { createDashboardFromTableInMetricsEditor } from "../../ai-generation/generateMetricsView";
 
   export let metricsName: string;
   export let filePath: string;
   export let view: EditorView | undefined = undefined;
 
-  $: isModelingSupportedForCurrentOlapDriver =
-    useIsModelingSupportedForCurrentOlapDriver($runtime.instanceId);
+  $: isModelingSupportedForDefaultOlapDriver =
+    useIsModelingSupportedForDefaultOlapDriver($runtime.instanceId);
   $: models = useModels($runtime.instanceId);
 
   const buttonClasses =
@@ -59,7 +59,7 @@
 </script>
 
 <div class="whitespace-normal">
-  {#if $isModelingSupportedForCurrentOlapDriver}
+  {#if $isModelingSupportedForDefaultOlapDriver}
     Auto-generate a <WithTogglableFloatingElement
       distance={8}
       inline
@@ -98,7 +98,7 @@
     on:click={async () => {
       onCreateSkeletonMetricsConfig();
     }}
-    >{#if $isModelingSupportedForCurrentOlapDriver}s{:else}S{/if}tart with a
+    >{#if $isModelingSupportedForDefaultOlapDriver}s{:else}S{/if}tart with a
     skeleton</button
   >, or just start typing.
 </div>

--- a/web-common/src/features/workspaces/MetricsWorkspace.svelte
+++ b/web-common/src/features/workspaces/MetricsWorkspace.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import LocalAvatarButton from "@rilldata/web-common/features/authentication/LocalAvatarButton.svelte";
-  import { useIsModelingSupportedForCurrentOlapDriver as canModel } from "@rilldata/web-common/features/connectors/olap/selectors";
   import { initLocalUserPreferenceStore } from "@rilldata/web-common/features/dashboards/user-preferences";
   import DeployDashboardCta from "@rilldata/web-common/features/dashboards/workspace/DeployDashboardCTA.svelte";
   import { getNameFromFile } from "@rilldata/web-common/features/entity-management/entity-mappers";
@@ -20,6 +19,10 @@
   import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import WorkspaceEditorContainer from "../../layout/workspace/WorkspaceEditorContainer.svelte";
+  import {
+    useIsModelingSupportedForDefaultOlapDriver,
+    useIsModelingSupportedForOlapDriver,
+  } from "../connectors/olap/selectors";
 
   const TOOLTIP_CTA = "Fix this error to enable your dashboard.";
 
@@ -39,14 +42,28 @@
   $: metricViewName = getNameFromFile(filePath);
 
   $: initLocalUserPreferenceStore(metricViewName);
-  $: isModelingSupportedQuery = canModel(instanceId);
-  $: isModelingSupported = $isModelingSupportedQuery;
 
   $: allErrorsQuery = fileArtifact.getAllErrors(queryClient, instanceId);
   $: allErrors = $allErrorsQuery;
   $: resourceQuery = fileArtifact.getResource(queryClient, instanceId);
   $: ({ data: resourceData, isFetching } = $resourceQuery);
   $: isResourceLoading = resourceIsLoading(resourceData);
+
+  $: connector = resourceData?.metricsView?.state?.validSpec?.connector ?? "";
+  $: database = resourceData?.metricsView?.state?.validSpec?.database ?? "";
+  $: databaseSchema =
+    resourceData?.metricsView?.state?.validSpec?.databaseSchema ?? "";
+  $: table = resourceData?.metricsView?.state?.validSpec?.table ?? "";
+
+  $: isModelingSupportedForDefaultOlapDriver =
+    useIsModelingSupportedForDefaultOlapDriver(instanceId);
+  $: isModelingSupportedForOlapDriver = useIsModelingSupportedForOlapDriver(
+    instanceId,
+    connector,
+  );
+  $: isModelingSupported = connector
+    ? $isModelingSupportedForOlapDriver
+    : $isModelingSupportedForDefaultOlapDriver;
 
   $: previewDisabled =
     !$remoteContent?.length ||
@@ -111,5 +128,12 @@
     />
   </WorkspaceEditorContainer>
 
-  <MetricsInspector {filePath} slot="inspector" />
+  <MetricsInspector
+    {filePath}
+    {connector}
+    {database}
+    {databaseSchema}
+    {table}
+    slot="inspector"
+  />
 </WorkspaceContainer>


### PR DESCRIPTION
We only support modeling for certain OLAP engines. Previously, we determined whether or not to show a modeling feature by checking the project's _default_ OLAP engine. This check didn't work in projects with multiple OLAP engines – some might support modeling, some might not.

This PR now takes into account both the default OLAP engine and, if applicable, the particular asset's OLAP engine.

[Context in Slack](https://rilldata.slack.com/archives/C02T907FEUB/p1724943962557839)