### PR TITLE
fix: inconsistencies with metrics view state when restored to a proto state

### DIFF
--- a/proto/rill/ui/v1/dashboard.proto
+++ b/proto/rill/ui/v1/dashboard.proto
@@ -162,7 +162,6 @@ message PivotColumnSort {
   string id = 2;
 }
 
-
 message PivotElement {
   oneof element {
     rill.runtime.v1.TimeGrain pivot_time_dimension = 1;

--- a/web-common/src/features/dashboards/proto-state/dashboard-url-state.spec.ts
+++ b/web-common/src/features/dashboards/proto-state/dashboard-url-state.spec.ts
@@ -22,7 +22,7 @@ import {
   initStateManagers,
   resetDashboardStore,
   TestTimeConstants,
-} from "@rilldata/web-common/features/dashboards/stores/dashboard-stores-test-data";
+} from "@rilldata/web-common/features/dashboards/stores/test-data/dashboard-stores-test-data";
 import DashboardTestComponent from "@rilldata/web-common/features/dashboards/stores/DashboardTestComponent.svelte";
 import {
   createAndExpression,

--- a/web-common/src/features/dashboards/proto-state/fromProto.ts
+++ b/web-common/src/features/dashboards/proto-state/fromProto.ts
@@ -170,6 +170,12 @@ export function getDashboardStateFromProto(
       chartType: chartTypeMap(dashboard.chartType),
       expandedMeasureName: dashboard.expandedMeasure,
     };
+  } else if (dashboard.activePage !== undefined) {
+    entity.tdd = {
+      pinIndex: -1,
+      chartType: TDDChart.DEFAULT,
+      expandedMeasureName: "",
+    };
   }
 
   entity.selectedTimezone = dashboard.selectedTimezone ?? "UTC";
@@ -328,11 +334,14 @@ function fromPivotProto(
     metricsView.dimensions ?? [],
     (d) => d.name,
   );
-  const mapDimension: (name: string) => PivotChipData = (name: string) => ({
-    id: name,
-    title: dimensionsMap.get(name)?.label || "Unknown",
-    type: PivotChipType.Dimension,
-  });
+  const mapDimension: (name: string) => PivotChipData = (name: string) => {
+    const dim = dimensionsMap.get(name);
+    return {
+      id: name,
+      title: dim?.label || dim?.name || "Unknown",
+      type: PivotChipType.Dimension,
+    };
+  };
   const mapTimeDimension: (grain: TimeGrain) => PivotChipData = (
     grain: TimeGrain,
   ) => ({
@@ -351,12 +360,7 @@ function fromPivotProto(
         type: PivotChipType.Time,
       };
     } else {
-      const name = dimension?.element.value as string;
-      return {
-        id: name,
-        title: dimensionsMap.get(name)?.label || "Unknown",
-        type: PivotChipType.Dimension,
-      };
+      return mapDimension(dimension?.element.value as string);
     }
   };
 
@@ -364,11 +368,14 @@ function fromPivotProto(
     metricsView.measures ?? [],
     (m) => m.name,
   );
-  const mapMeasure: (name: string) => PivotChipData = (name: string) => ({
-    id: name,
-    title: measuresMap.get(name)?.label || "Unknown",
-    type: PivotChipType.Measure,
-  });
+  const mapMeasure: (name: string) => PivotChipData = (name: string) => {
+    const mes = measuresMap.get(name);
+    return {
+      id: name,
+      title: mes?.label || mes?.name || "Unknown",
+      type: PivotChipType.Measure,
+    };
+  };
 
   let rowDimensions: PivotChipData[] = [];
   let colDimensions: PivotChipData[] = [];
@@ -408,11 +415,11 @@ function fromPivotProto(
     sorting: dashboard.pivotSort ?? [],
     columnPage: dashboard.pivotColumnPage ?? 1,
     rowPage: 1,
-    enableComparison: dashboard.pivotEnableComparison ?? false,
+    enableComparison: dashboard.pivotEnableComparison ?? true,
     activeCell: null,
     rowJoinType:
       FromProtoPivotRowJoinTypeMap[
-        dashboard.pivotRowJoinType ?? DashboardState_PivotRowJoinType.NEST
+        dashboard.pivotRowJoinType || DashboardState_PivotRowJoinType.NEST
       ],
   };
 }

--- a/web-common/src/features/dashboards/proto-state/proto.spec.ts
+++ b/web-common/src/features/dashboards/proto-state/proto.spec.ts
@@ -10,7 +10,7 @@ import {
   AD_BIDS_SCHEMA,
   AD_BIDS_WITH_BOOL_DIMENSION,
   TestTimeConstants,
-} from "@rilldata/web-common/features/dashboards/stores/dashboard-stores-test-data";
+} from "@rilldata/web-common/features/dashboards/stores/test-data/dashboard-stores-test-data";
 import {
   createAndExpression,
   createInExpression,

--- a/web-common/src/features/dashboards/proto-state/sparse-proto.spec.ts
+++ b/web-common/src/features/dashboards/proto-state/sparse-proto.spec.ts
@@ -67,7 +67,7 @@ const TestCases: {
     keys: ["activePage", "pivot"],
   },
 ];
-// mutation that reverts all mutations from the above mutations
+// list of mutations that reverts all mutations from the above test cases
 const TestCasesOppositeMutations = [
   AD_BIDS_REMOVE_PUB_DIMENSION_FILTER,
   AD_BIDS_APPLY_DOM_DIMENSION_FILTER,

--- a/web-common/src/features/dashboards/proto-state/sparse-proto.spec.ts
+++ b/web-common/src/features/dashboards/proto-state/sparse-proto.spec.ts
@@ -1,0 +1,152 @@
+import { getProtoFromDashboardState } from "@rilldata/web-common/features/dashboards/proto-state/toProto";
+import { getDefaultMetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/dashboard-store-defaults";
+import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
+import {
+  AD_BIDS_INIT,
+  AD_BIDS_NAME,
+  AD_BIDS_SCHEMA,
+  AD_BIDS_TIME_RANGE_SUMMARY,
+  getPartialDashboard,
+  resetDashboardStore,
+} from "@rilldata/web-common/features/dashboards/stores/test-data/dashboard-stores-test-data";
+import {
+  AD_BIDS_APPLY_PUB_DIMENSION_FILTER,
+  AD_BIDS_APPLY_IMP_MEASURE_FILTER,
+  AD_BIDS_OPEN_PUB_DIMENSION_TABLE,
+  AD_BIDS_OPEN_PUB_IMP_PIVOT,
+  AD_BIDS_OPEN_IMP_TDD,
+  AD_BIDS_SET_P7D_TIME_RANGE_FILTER,
+  applyMutationsToDashboard,
+  TestDashboardMutation,
+  AD_BIDS_APPLY_DOM_DIMENSION_FILTER,
+  AD_BIDS_APPLY_BP_MEASURE_FILTER,
+  AD_BIDS_SET_P4W_TIME_RANGE_FILTER,
+  AD_BIDS_OPEN_DOM_DIMENSION_TABLE,
+  AD_BIDS_OPEN_BP_TDD,
+  AD_BIDS_OPEN_DOM_BP_PIVOT,
+  AD_BIDS_REMOVE_PUB_DIMENSION_FILTER,
+  AD_BIDS_REMOVE_IMP_MEASURE_FILTER,
+} from "@rilldata/web-common/features/dashboards/stores/test-data/dashboard-stores-test-mutations";
+import { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import { initLocalUserPreferenceStore } from "@rilldata/web-common/features/dashboards/user-preferences";
+import { deepClone } from "@vitest/utils";
+import { get } from "svelte/store";
+import { beforeAll, it, describe, beforeEach, expect } from "vitest";
+
+const TestCases: {
+  title: string;
+  mutations: TestDashboardMutation[];
+  keys: (keyof MetricsExplorerEntity)[];
+}[] = [
+  {
+    title: "filters",
+    mutations: [
+      AD_BIDS_APPLY_PUB_DIMENSION_FILTER,
+      AD_BIDS_APPLY_IMP_MEASURE_FILTER,
+    ],
+    keys: ["whereFilter", "dimensionThresholdFilters"],
+  },
+  {
+    title: "time range",
+    mutations: [AD_BIDS_SET_P7D_TIME_RANGE_FILTER],
+    keys: ["selectedTimeRange", "selectedComparisonTimeRange"],
+  },
+  {
+    title: "dimension table",
+    mutations: [AD_BIDS_OPEN_PUB_DIMENSION_TABLE],
+    keys: ["activePage", "selectedDimensionName"],
+  },
+  {
+    title: "time dimension details",
+    mutations: [AD_BIDS_OPEN_IMP_TDD],
+    keys: ["activePage", "tdd"],
+  },
+  {
+    title: "pivot",
+    mutations: [AD_BIDS_OPEN_PUB_IMP_PIVOT],
+    keys: ["activePage", "pivot"],
+  },
+];
+// mutation that reverts all mutations from the above mutations
+const TestCasesOppositeMutations = [
+  AD_BIDS_REMOVE_PUB_DIMENSION_FILTER,
+  AD_BIDS_APPLY_DOM_DIMENSION_FILTER,
+  AD_BIDS_REMOVE_IMP_MEASURE_FILTER,
+  AD_BIDS_APPLY_BP_MEASURE_FILTER,
+  AD_BIDS_SET_P4W_TIME_RANGE_FILTER,
+  AD_BIDS_OPEN_DOM_DIMENSION_TABLE,
+  AD_BIDS_OPEN_BP_TDD,
+  AD_BIDS_OPEN_DOM_BP_PIVOT,
+];
+
+describe("sparse proto", () => {
+  beforeAll(() => {
+    initLocalUserPreferenceStore(AD_BIDS_NAME);
+  });
+
+  beforeEach(() => {
+    resetDashboardStore();
+  });
+
+  describe("should reset dashboard store", () => {
+    for (const { title, mutations } of TestCases) {
+      it(`from ${title}`, () => {
+        const dashboard = getDefaultMetricsExplorerEntity(
+          AD_BIDS_NAME,
+          AD_BIDS_INIT,
+          AD_BIDS_TIME_RANGE_SUMMARY,
+        );
+        const defaultProto = getProtoFromDashboardState(dashboard);
+
+        applyMutationsToDashboard(AD_BIDS_NAME, mutations);
+
+        metricsExplorerStore.syncFromUrl(
+          AD_BIDS_NAME,
+          defaultProto,
+          AD_BIDS_INIT,
+          AD_BIDS_SCHEMA,
+        );
+        assertDashboardEquals(AD_BIDS_NAME, dashboard);
+      });
+    }
+  });
+
+  describe("should reset partial dashboard store", () => {
+    for (const { title, mutations, keys } of TestCases) {
+      it(`to ${title}`, () => {
+        applyMutationsToDashboard(AD_BIDS_NAME, mutations);
+        const partialDashboard = getPartialDashboard(AD_BIDS_NAME, keys);
+        const partialProto = getProtoFromDashboardState(partialDashboard);
+
+        applyMutationsToDashboard(AD_BIDS_NAME, TestCasesOppositeMutations);
+
+        metricsExplorerStore.syncFromUrl(
+          AD_BIDS_NAME,
+          partialProto,
+          AD_BIDS_INIT,
+          AD_BIDS_SCHEMA,
+        );
+        assertDashboardEquals(AD_BIDS_NAME, {
+          ...get(metricsExplorerStore).entities[AD_BIDS_NAME],
+          ...partialDashboard,
+        });
+      });
+    }
+  });
+});
+
+function assertDashboardEquals(name: string, expected: MetricsExplorerEntity) {
+  expect(cleanDashboard(get(metricsExplorerStore).entities[name])).toEqual(
+    cleanDashboard(expected),
+  );
+}
+
+function cleanDashboard(dashboard: MetricsExplorerEntity) {
+  const newDash = deepClone(dashboard);
+  delete newDash.proto;
+  if (newDash.selectedTimeRange) {
+    delete (newDash.selectedTimeRange as any).start;
+    delete (newDash.selectedTimeRange as any).end;
+  }
+  return newDash;
+}

--- a/web-common/src/features/dashboards/proto-state/toProto.ts
+++ b/web-common/src/features/dashboards/proto-state/toProto.ts
@@ -75,7 +75,7 @@ export function getProtoFromDashboardState(
   if (metrics.whereFilter) {
     state.where = toExpressionProto(metrics.whereFilter);
   }
-  if (metrics.dimensionThresholdFilters.length) {
+  if (metrics.dimensionThresholdFilters?.length) {
     state.having = metrics.dimensionThresholdFilters.map(
       ({ name, filters }) =>
         new DashboardDimensionFilter({

--- a/web-common/src/features/dashboards/show-hide-selectors.spec.ts
+++ b/web-common/src/features/dashboards/show-hide-selectors.spec.ts
@@ -24,7 +24,7 @@ import {
   createAdBidsMirrorInStore,
   createMetricsMetaQueryMock,
   resetDashboardStore,
-} from "@rilldata/web-common/features/dashboards/stores/dashboard-stores-test-data";
+} from "@rilldata/web-common/features/dashboards/stores/test-data/dashboard-stores-test-data";
 import {
   getPersistentDashboardStore,
   initPersistentDashboardStore,

--- a/web-common/src/features/dashboards/stores/AdvancedMeasureCorrector.spec.ts
+++ b/web-common/src/features/dashboards/stores/AdvancedMeasureCorrector.spec.ts
@@ -13,7 +13,7 @@ import {
   AD_BIDS_INIT,
   AD_BIDS_PUBLISHER_DIMENSION,
   AD_BIDS_TIMESTAMP_DIMENSION,
-} from "@rilldata/web-common/features/dashboards/stores/dashboard-stores-test-data";
+} from "@rilldata/web-common/features/dashboards/stores/test-data/dashboard-stores-test-data";
 import { DashboardTimeControls } from "@rilldata/web-common/lib/time/types";
 import {
   V1MetricsViewSpec,

--- a/web-common/src/features/dashboards/stores/dashboard-store-defaults.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-store-defaults.ts
@@ -181,12 +181,15 @@ export function getDefaultMetricsExplorerEntity(
     selectedTimeRange: null,
 
     activePage: DashboardState_ActivePage.DEFAULT,
+    selectedComparisonDimension: undefined,
+    selectedDimensionName: undefined,
 
     showTimeComparison: false,
     dimensionSearchText: "",
     temporaryFilterName: null,
     tdd: {
       chartType: TDDChart.DEFAULT,
+      expandedMeasureName: "",
       pinIndex: -1,
     },
     pivot: {

--- a/web-common/src/features/dashboards/stores/dashboard-stores.spec.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.spec.ts
@@ -22,7 +22,7 @@ import {
   LAST_6_HOURS_TEST_PARSED_CONTROLS,
   resetDashboardStore,
   TestTimeConstants,
-} from "@rilldata/web-common/features/dashboards/stores/dashboard-stores-test-data";
+} from "@rilldata/web-common/features/dashboards/stores/test-data/dashboard-stores-test-data";
 import {
   createAndExpression,
   createInExpression,

--- a/web-common/src/features/dashboards/stores/test-data/dashboard-stores-test-data.ts
+++ b/web-common/src/features/dashboards/stores/test-data/dashboard-stores-test-data.ts
@@ -1,13 +1,4 @@
 import type { DashboardFetchMocks } from "@rilldata/web-common/features/dashboards/dashboard-fetch-mocks";
-import {
-  MeasureFilterOperation,
-  MeasureFilterType,
-} from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-options";
-import { PivotChipType } from "@rilldata/web-common/features/dashboards/pivot/types";
-import { toggleDimensionValueSelection } from "@rilldata/web-common/features/dashboards/state-managers/actions/dimension-filters";
-import { setPrimaryDimension } from "@rilldata/web-common/features/dashboards/state-managers/actions/dimensions";
-import { setMeasureFilter } from "@rilldata/web-common/features/dashboards/state-managers/actions/measure-filters";
-import { DashboardMutables } from "@rilldata/web-common/features/dashboards/state-managers/actions/types";
 import { createStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
 import { getDefaultMetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/dashboard-store-defaults";
 import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";

--- a/web-common/src/features/dashboards/stores/test-data/dashboard-stores-test-mutations.ts
+++ b/web-common/src/features/dashboards/stores/test-data/dashboard-stores-test-mutations.ts
@@ -1,0 +1,151 @@
+import {
+  MeasureFilterOperation,
+  MeasureFilterType,
+} from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-options";
+import { PivotChipType } from "@rilldata/web-common/features/dashboards/pivot/types";
+import {
+  removeDimensionFilter,
+  toggleDimensionValueSelection,
+} from "@rilldata/web-common/features/dashboards/state-managers/actions/dimension-filters";
+import { setPrimaryDimension } from "@rilldata/web-common/features/dashboards/state-managers/actions/dimensions";
+import {
+  removeMeasureFilter,
+  setMeasureFilter,
+} from "@rilldata/web-common/features/dashboards/state-managers/actions/measure-filters";
+import { DashboardMutables } from "@rilldata/web-common/features/dashboards/state-managers/actions/types";
+import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
+import {
+  AD_BIDS_BID_PRICE_MEASURE,
+  AD_BIDS_DOMAIN_DIMENSION,
+  AD_BIDS_IMPRESSIONS_MEASURE,
+  AD_BIDS_INIT,
+  AD_BIDS_NAME,
+  AD_BIDS_PUBLISHER_DIMENSION,
+} from "@rilldata/web-common/features/dashboards/stores/test-data/dashboard-stores-test-data";
+import { TimeRangePreset } from "@rilldata/web-common/lib/time/types";
+import { V1TimeGrain } from "@rilldata/web-common/runtime-client";
+import { get } from "svelte/store";
+
+export type TestDashboardMutation = (mut: DashboardMutables) => void;
+export const AD_BIDS_APPLY_PUB_DIMENSION_FILTER: TestDashboardMutation = (
+  mut,
+) => toggleDimensionValueSelection(mut, AD_BIDS_PUBLISHER_DIMENSION, "Google");
+export const AD_BIDS_REMOVE_PUB_DIMENSION_FILTER: TestDashboardMutation = (
+  mut,
+) => removeDimensionFilter(mut, AD_BIDS_PUBLISHER_DIMENSION);
+export const AD_BIDS_APPLY_DOM_DIMENSION_FILTER: TestDashboardMutation = (
+  mut,
+) => toggleDimensionValueSelection(mut, AD_BIDS_DOMAIN_DIMENSION, "google.com");
+
+export const AD_BIDS_APPLY_IMP_MEASURE_FILTER: TestDashboardMutation = (mut) =>
+  setMeasureFilter(mut, AD_BIDS_PUBLISHER_DIMENSION, {
+    measure: AD_BIDS_IMPRESSIONS_MEASURE,
+    type: MeasureFilterType.Value,
+    operation: MeasureFilterOperation.GreaterThan,
+    value1: "10",
+    value2: "",
+  });
+export const AD_BIDS_REMOVE_IMP_MEASURE_FILTER: TestDashboardMutation = (mut) =>
+  removeMeasureFilter(
+    mut,
+    AD_BIDS_PUBLISHER_DIMENSION,
+    AD_BIDS_IMPRESSIONS_MEASURE,
+  );
+export const AD_BIDS_APPLY_BP_MEASURE_FILTER: TestDashboardMutation = (mut) =>
+  setMeasureFilter(mut, AD_BIDS_DOMAIN_DIMENSION, {
+    measure: AD_BIDS_BID_PRICE_MEASURE,
+    type: MeasureFilterType.Value,
+    operation: MeasureFilterOperation.GreaterThan,
+    value1: "10",
+    value2: "",
+  });
+
+export const AD_BIDS_SET_P7D_TIME_RANGE_FILTER: TestDashboardMutation = () =>
+  metricsExplorerStore.selectTimeRange(
+    AD_BIDS_NAME,
+    { name: TimeRangePreset.LAST_7_DAYS } as any,
+    V1TimeGrain.TIME_GRAIN_DAY,
+    undefined,
+    AD_BIDS_INIT,
+  );
+export const AD_BIDS_SET_P4W_TIME_RANGE_FILTER: TestDashboardMutation = () =>
+  metricsExplorerStore.selectTimeRange(
+    AD_BIDS_NAME,
+    { name: TimeRangePreset.LAST_4_WEEKS } as any,
+    V1TimeGrain.TIME_GRAIN_WEEK,
+    undefined,
+    AD_BIDS_INIT,
+  );
+
+export const AD_BIDS_OPEN_PUB_DIMENSION_TABLE: TestDashboardMutation = (mut) =>
+  setPrimaryDimension(mut, AD_BIDS_PUBLISHER_DIMENSION);
+export const AD_BIDS_OPEN_DOM_DIMENSION_TABLE: TestDashboardMutation = (mut) =>
+  setPrimaryDimension(mut, AD_BIDS_DOMAIN_DIMENSION);
+
+export const AD_BIDS_OPEN_IMP_TDD: TestDashboardMutation = () =>
+  metricsExplorerStore.setExpandedMeasureName(
+    AD_BIDS_NAME,
+    AD_BIDS_IMPRESSIONS_MEASURE,
+  );
+export const AD_BIDS_OPEN_BP_TDD: TestDashboardMutation = () =>
+  metricsExplorerStore.setExpandedMeasureName(
+    AD_BIDS_NAME,
+    AD_BIDS_BID_PRICE_MEASURE,
+  );
+
+export const AD_BIDS_OPEN_PUB_IMP_PIVOT: TestDashboardMutation = () =>
+  metricsExplorerStore.createPivot(
+    AD_BIDS_NAME,
+    {
+      dimension: [
+        {
+          id: AD_BIDS_PUBLISHER_DIMENSION,
+          title: AD_BIDS_PUBLISHER_DIMENSION,
+          type: PivotChipType.Dimension,
+        },
+      ],
+    },
+    {
+      dimension: [],
+      measure: [
+        {
+          id: AD_BIDS_IMPRESSIONS_MEASURE,
+          title: AD_BIDS_IMPRESSIONS_MEASURE,
+          type: PivotChipType.Measure,
+        },
+      ],
+    },
+  );
+export const AD_BIDS_OPEN_DOM_BP_PIVOT: TestDashboardMutation = () =>
+  metricsExplorerStore.createPivot(
+    AD_BIDS_NAME,
+    {
+      dimension: [
+        {
+          id: AD_BIDS_DOMAIN_DIMENSION,
+          title: AD_BIDS_DOMAIN_DIMENSION,
+          type: PivotChipType.Dimension,
+        },
+      ],
+    },
+    {
+      dimension: [],
+      measure: [
+        {
+          id: AD_BIDS_BID_PRICE_MEASURE,
+          title: AD_BIDS_IMPRESSIONS_MEASURE,
+          type: PivotChipType.Measure,
+        },
+      ],
+    },
+  );
+
+export function applyMutationsToDashboard(
+  name: string,
+  mutations: TestDashboardMutation[],
+) {
+  const dashboard = get(metricsExplorerStore).entities[name];
+  const dashboardMutables = { dashboard } as DashboardMutables;
+
+  mutations.forEach((mutation) => mutation(dashboardMutables));
+}

--- a/web-common/src/features/dashboards/time-controls/time-control-store.spec.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.spec.ts
@@ -5,7 +5,7 @@ import {
   AD_BIDS_INIT_WITH_TIME,
   AD_BIDS_NAME,
   initStateManagers,
-} from "@rilldata/web-common/features/dashboards/stores/dashboard-stores-test-data";
+} from "@rilldata/web-common/features/dashboards/stores/test-data/dashboard-stores-test-data";
 import TimeControlsStoreTest from "@rilldata/web-common/features/dashboards/time-controls/TimeControlsStoreTest.svelte";
 import {
   TimeControlState,


### PR DESCRIPTION
Currently in certain cases restoring the dashboard back to the default state doesnt match if the store was in default state.

This makes sure dashboard state has the correct fields after restoring. Also adds a bunch of tests around this to avoid regressions.