### PR TITLE
return initial authentication error for object stores

### DIFF
--- a/runtime/drivers/azure/object_store.go
+++ b/runtime/drivers/azure/object_store.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rilldata/rill/runtime/drivers"
 	rillblob "github.com/rilldata/rill/runtime/drivers/blob"
 	"github.com/rilldata/rill/runtime/pkg/globutil"
+	"go.uber.org/zap"
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/azureblob"
 	"gocloud.dev/gcerrors"
@@ -133,7 +134,7 @@ func (c *Connection) DownloadFiles(ctx context.Context, props map[string]any) (d
 		var respErr *azcore.ResponseError
 		if gcerrors.Code(err) == gcerrors.Unknown ||
 			(errors.As(err, &respErr) && respErr.RawResponse.StatusCode == http.StatusForbidden && (respErr.ErrorCode == "AuthorizationPermissionMismatch" || respErr.ErrorCode == "AuthenticationFailed")) {
-			c.logger.Warn("Azure Blob Storage account does not have permission to list blobs. Falling back to anonymous access.")
+			c.logger.Warn("Azure Blob Storage account does not have permission to list blobs. Falling back to anonymous access.", zap.Error(err))
 
 			client, err = c.createAnonymousClient(conf)
 			if err != nil {

--- a/runtime/drivers/gcs/object_store.go
+++ b/runtime/drivers/gcs/object_store.go
@@ -96,6 +96,12 @@ func (c *Connection) DownloadFiles(ctx context.Context, props map[string]any) (d
 		if errors.As(err, &retrieveError) && (retrieveError.Response.StatusCode == http.StatusUnauthorized || retrieveError.Response.StatusCode == http.StatusBadRequest) {
 			return nil, drivers.NewPermissionDeniedError(fmt.Sprintf("can't access remote err: %v", retrieveError))
 		}
+
+		anonIt, anonErr := rillblob.NewIterator(ctx, bucketObj, opts, c.logger)
+		if anonErr == nil {
+			iter = anonIt
+			err = nil
+		}
 	}
 
 	return iter, err

--- a/runtime/drivers/s3/object_store.go
+++ b/runtime/drivers/s3/object_store.go
@@ -158,7 +158,11 @@ func (c *Connection) DownloadFiles(ctx context.Context, src map[string]any) (dri
 				return nil, fmt.Errorf("failed to open bucket %q, %w", conf.url.Host, bucketErr)
 			}
 
-			it, err = rillblob.NewIterator(ctx, bucketObj, opts, c.logger)
+			anonIt, anonErr := rillblob.NewIterator(ctx, bucketObj, opts, c.logger)
+			if anonErr == nil {
+				it = anonIt
+				err = nil
+			}
 		}
 
 		// check again


### PR DESCRIPTION
For object stores we first try with provided credentials and then with no credentials (to check for public buckets).
The returned error should always be the first error which can give better hints about missing keys/incorrect keys etc.