### PR TITLE
improved idle detection

### DIFF
--- a/web-common/src/features/entity-management/ResourceWatcher.svelte
+++ b/web-common/src/features/entity-management/ResourceWatcher.svelte
@@ -35,8 +35,8 @@
 
   function handleVisibilityChange() {
     if (document.visibilityState === "visible") {
-      fileWatcher.reconnect().catch(console.error);
-      resourceWatcher.reconnect().catch(console.error);
+      fileWatcher.heartbeat();
+      resourceWatcher.heartbeat();
     } else {
       fileWatcher.throttle(true);
       resourceWatcher.throttle(true);

--- a/web-common/src/features/entity-management/ResourceWatcher.svelte
+++ b/web-common/src/features/entity-management/ResourceWatcher.svelte
@@ -5,7 +5,7 @@
   import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
   import { onMount } from "svelte";
   import ErrorPage from "@rilldata/web-common/components/ErrorPage.svelte";
-  import InfoCircle from "@rilldata/web-common/components/icons/InfoCircle.svelte";
+  import Banner from "@rilldata/web-common/components/banner/Banner.svelte";
 
   const fileWatcher = new WatchFilesClient().client;
   const resourceWatcher = new WatchResourcesClient().client;
@@ -73,15 +73,14 @@
   />
 {:else}
   {#if $closed}
-    <div class="bg-yellow-100 py-1 w-full">
-      <div class="flex flex-row items-center mx-auto w-fit gap-x-2">
-        <InfoCircle />
-        <span>
-          Connection closed due to inactivity. Interact with the page to
-          reconnect.
-        </span>
-      </div>
-    </div>
+    <Banner
+      banner={{
+        message:
+          "Connection closed due to inactivity. Interact with the page to reconnect.",
+        type: "warning",
+        iconType: "alert",
+      }}
+    />
   {/if}
   <slot />
 {/if}

--- a/web-common/src/features/entity-management/ResourceWatcher.svelte
+++ b/web-common/src/features/entity-management/ResourceWatcher.svelte
@@ -47,8 +47,8 @@
 <svelte:window
   on:visibilitychange={handleVisibilityChange}
   on:blur={() => {
-    fileWatcher.throttle(true);
-    resourceWatcher.throttle(true);
+    fileWatcher.throttle();
+    resourceWatcher.throttle();
   }}
   on:click={() => {
     fileWatcher.heartbeat();

--- a/web-common/src/lib/throttler.ts
+++ b/web-common/src/lib/throttler.ts
@@ -2,16 +2,22 @@ export class Throttler {
   private timer: ReturnType<typeof setTimeout> | undefined;
   private callback: () => void | Promise<void>;
 
-  public constructor(private readonly timeout: number) {}
+  public constructor(
+    private readonly timeout: number,
+    private readonly priorityTimeout: number,
+  ) {}
 
-  public throttle(callback: () => void | Promise<void>) {
+  public throttle(callback: () => void | Promise<void>, prioritize = false) {
     this.cancel();
     this.callback = callback;
 
-    this.timer = setTimeout(() => {
-      this.timer = undefined;
-      this.callback();
-    }, this.timeout);
+    this.timer = setTimeout(
+      () => {
+        this.timer = undefined;
+        this.callback();
+      },
+      prioritize ? this.priorityTimeout : this.timeout,
+    );
   }
 
   public isThrottling() {

--- a/web-common/src/lib/throttler.ts
+++ b/web-common/src/lib/throttler.ts
@@ -4,19 +4,22 @@ export class Throttler {
 
   public constructor(
     private readonly timeout: number,
-    private readonly priorityTimeout: number,
+    private readonly shortTimeout: number,
   ) {}
 
-  public throttle(callback: () => void | Promise<void>, prioritize = false) {
+  public throttle(
+    callback: () => void | Promise<void>,
+    useShortTimeout = false,
+  ) {
     this.cancel();
     this.callback = callback;
 
     this.timer = setTimeout(
       () => {
         this.timer = undefined;
-        this.callback();
+        this.callback()?.catch(console.error);
       },
-      prioritize ? this.priorityTimeout : this.timeout,
+      useShortTimeout ? this.shortTimeout : this.timeout,
     );
   }
 

--- a/web-common/src/runtime-client/watch-request-client.ts
+++ b/web-common/src/runtime-client/watch-request-client.ts
@@ -39,7 +39,7 @@ export class WatchRequestClient<Res extends WatchResponse> {
   private url: string | undefined;
   private controller: AbortController | undefined;
   private stream: AsyncGenerator<StreamingFetchResponse<Res>> | undefined;
-  private outOfFocusThrottler = new Throttler(10000);
+  private outOfFocusThrottler = new Throttler(120000, 30000);
   public retryAttempts = writable(0);
   private reconnectTimeout: ReturnType<typeof setTimeout> | undefined;
   private retryTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -47,7 +47,7 @@ export class WatchRequestClient<Res extends WatchResponse> {
     ["response", []],
     ["reconnect", []],
   ]);
-  private closed = false;
+  public closed = writable(false);
 
   public on<K extends keyof EventMap<Res>>(
     event: K,
@@ -56,25 +56,34 @@ export class WatchRequestClient<Res extends WatchResponse> {
     this.listeners.get(event)?.push(listener);
   }
 
+  public heartbeat = () => {
+    if (this.closed) {
+      this.reconnect().catch(console.error);
+    }
+    this.throttle();
+  };
+
   public watch(url: string) {
     this.cancel();
     this.url = url;
+
     this.listen().catch(console.error);
+
+    // Start throttling after the first connection
+    this.throttle();
   }
 
-  public close() {
-    this.closed = true;
+  public close = () => {
+    this.closed.set(true);
     this.cancel();
-  }
+  };
 
-  public throttle() {
-    this.outOfFocusThrottler.throttle(() => {
-      this.close();
-    });
+  public throttle(priority: boolean = false) {
+    this.outOfFocusThrottler.throttle(this.close, priority);
   }
 
   public async reconnect() {
-    this.closed = false;
+    this.closed.set(false);
     clearTimeout(this.reconnectTimeout);
 
     if (this.outOfFocusThrottler.isThrottling()) {

--- a/web-common/src/runtime-client/watch-request-client.ts
+++ b/web-common/src/runtime-client/watch-request-client.ts
@@ -78,11 +78,11 @@ export class WatchRequestClient<Res extends WatchResponse> {
     this.cancel();
   };
 
-  public throttle(priority: boolean = false) {
-    this.outOfFocusThrottler.throttle(this.close, priority);
+  public throttle(prioritize: boolean = false) {
+    this.outOfFocusThrottler.throttle(this.close, prioritize);
   }
 
-  public async reconnect() {
+  private async reconnect() {
     this.closed.set(false);
     clearTimeout(this.reconnectTimeout);
 


### PR DESCRIPTION
This PR adds improved idle detection timeout that closes the resource watchers (and displays a small banner) after two minutes of inactivity (keydown or mouse click). It also adds a priority inactivity detection that closes the watchers after 30 seconds if the tab's visibility has changed.

There are a few different scenarios that we can detect and set timeouts for:

1. The tab is no longer visible
2. A blur event has happened on the page, which does not necessarily mean it's no longer visible
3. No mouse click events
4. No keydown events
5. No mouse move events
6. IdleDetection API, though this is supported only in Chrome and in HTTPS contexts