### PR TITLE
banner compatibility layout changes

### DIFF
--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -47,7 +47,7 @@
 </script>
 
 <article
-  class="flex flex-col h-screen w-full overflow-y-hidden dashboard-theme-boundary"
+  class="flex flex-col size-full overflow-y-hidden dashboard-theme-boundary"
   bind:clientWidth={exploreContainerWidth}
 >
   <div

--- a/web-common/src/layout/navigation/Navigation.svelte
+++ b/web-common/src/layout/navigation/Navigation.svelte
@@ -88,7 +88,7 @@
 <style lang="postcss">
   .sidebar {
     @apply flex flex-col flex-none relative overflow-hidden;
-    @apply h-screen border-r z-0;
+    @apply h-full border-r z-0;
     transition-property: width;
     will-change: width;
   }

--- a/web-common/src/layout/workspace/WorkspaceContainer.svelte
+++ b/web-common/src/layout/workspace/WorkspaceContainer.svelte
@@ -11,7 +11,7 @@
   $: ({ width, height } = contentRect);
 </script>
 
-<main class="flex flex-col h-screen w-full overflow-hidden" bind:contentRect>
+<main class="flex flex-col size-full overflow-hidden" bind:contentRect>
   {#if $$slots.header}
     <header class="bg-white w-full h-fit">
       <slot name="header" />

--- a/web-local/src/routes/(application)/+layout.svelte
+++ b/web-local/src/routes/(application)/+layout.svelte
@@ -26,7 +26,7 @@
 
 <main
   role="application"
-  class="index-body absolute w-screen h-screen flex overflow-hidden"
+  class="index-body relative size-full flex overflow-hidden"
   on:drag|preventDefault|stopPropagation
   on:drop|preventDefault|stopPropagation
   on:dragenter|preventDefault|stopPropagation

--- a/web-local/src/routes/(viz)/+layout.svelte
+++ b/web-local/src/routes/(viz)/+layout.svelte
@@ -54,7 +54,7 @@
   $: metricsViewName = currentDashboard?.meta?.name?.name;
 </script>
 
-<div class="flex flex-col size-full">
+<div class="flex flex-col size-full overflow-hidden">
   <header class="py-3 w-full bg-white flex gap-x-2 items-center px-4 border-b">
     {#if $dashboardsQuery.data}
       <Breadcrumbs {pathParts} {currentPath}>

--- a/web-local/src/routes/+layout.svelte
+++ b/web-local/src/routes/+layout.svelte
@@ -61,7 +61,9 @@
 <RillTheme>
   <QueryClientProvider client={queryClient}>
     <ResourceWatcher {host} {instanceId}>
-      <div class="body h-screen w-screen overflow-hidden absolute">
+      <div
+        class="body h-screen w-screen overflow-hidden absolute flex flex-col"
+      >
         <RepresentingUserBanner />
         <slot />
       </div>


### PR DESCRIPTION
We recently added the `RepresentingUserBanner` component and may use this same style of global banner elsewhere in the application. This PR changes the layout of the application so that displaying this banner no longer pushes content out of visibility.