### PR TITLE
Fix error log on context cancelled in SQLStore -> DuckDB transporter

### DIFF
--- a/runtime/drivers/duckdb/transporter_sqlstore_to_duckDB.go
+++ b/runtime/drivers/duckdb/transporter_sqlstore_to_duckDB.go
@@ -43,7 +43,7 @@ func (s *sqlStoreToDuckDB) Transfer(ctx context.Context, srcProps, sinkProps map
 	}
 	defer func() {
 		err := rowIter.Close()
-		if err != nil {
+		if err != nil && !errors.Is(err, ctx.Err()) {
 			s.logger.Error("error in closing row iterator", zap.Error(err))
 		}
 	}()


### PR DESCRIPTION
Fixes [this alert](https://rilldata.slack.com/archives/C05TXA7QSTY/p1725466090360839) which was a false positive.