### PR TITLE
fix: pivot state being removed if active page is changed

### DIFF
--- a/web-common/src/features/dashboards/proto-state/fromProto.ts
+++ b/web-common/src/features/dashboards/proto-state/fromProto.ts
@@ -212,9 +212,7 @@ export function getDashboardStateFromProto(
     entity.dashboardSortType = dashboard.leaderboardSortType;
   }
 
-  if (dashboard.pivotIsActive !== undefined) {
-    entity.pivot = fromPivotProto(dashboard, metricsView);
-  }
+  entity.pivot = fromPivotProto(dashboard, metricsView);
 
   Object.assign(entity, fromActivePageProto(dashboard));
 

--- a/web-common/src/features/dashboards/proto-state/toProto.ts
+++ b/web-common/src/features/dashboards/proto-state/toProto.ts
@@ -37,7 +37,6 @@ import {
   DashboardState,
   DashboardState_ActivePage,
   DashboardState_LeaderboardContextColumn,
-  DashboardState_PivotRowJoinType,
   DashboardTimeRange,
   PivotElement,
 } from "@rilldata/web-common/proto/gen/rill/ui/v1/dashboard_pb";
@@ -294,14 +293,8 @@ const mapPivotDimensions: (
 };
 
 function toPivotProto(pivotState: PivotState): PartialMessage<DashboardState> {
-  if (!pivotState.active)
-    return {
-      pivotIsActive: false,
-      pivotExpanded: {},
-      pivotRowJoinType: DashboardState_PivotRowJoinType.UNSPECIFIED,
-    };
   return {
-    pivotIsActive: true,
+    pivotIsActive: pivotState.active,
     pivotRowAllDimensions: pivotState.rows.dimension.map(mapPivotDimensions),
     pivotColumnAllDimensions:
       pivotState.columns.dimension.map(mapPivotDimensions),


### PR DESCRIPTION
We only save pivot state if pivot page is active. This removes the option of saving pivot state and explore state at the same time.

Since active page has a separate field we can always save pivot state.