### PR TITLE
Disable cron refreshes in dev (i.e. on localhost)

### DIFF
--- a/runtime/compilers/rillv1/parse_alert.go
+++ b/runtime/compilers/rillv1/parse_alert.go
@@ -87,7 +87,7 @@ func (p *Parser) parseAlert(node *Node) error {
 	}
 
 	// Parse refresh schedule
-	schedule, err := parseScheduleYAML(tmp.Refresh)
+	schedule, err := p.parseScheduleYAML(tmp.Refresh)
 	if err != nil {
 		return err
 	}

--- a/runtime/compilers/rillv1/parse_model.go
+++ b/runtime/compilers/rillv1/parse_model.go
@@ -43,7 +43,7 @@ func (p *Parser) parseModel(node *Node) error {
 	}
 
 	// Parse refresh schedule
-	schedule, err := parseScheduleYAML(tmp.Refresh)
+	schedule, err := p.parseScheduleYAML(tmp.Refresh)
 	if err != nil {
 		return err
 	}

--- a/runtime/compilers/rillv1/parse_report.go
+++ b/runtime/compilers/rillv1/parse_report.go
@@ -69,7 +69,7 @@ func (p *Parser) parseReport(node *Node) error {
 	}
 
 	// Parse refresh schedule
-	schedule, err := parseScheduleYAML(tmp.Refresh)
+	schedule, err := p.parseScheduleYAML(tmp.Refresh)
 	if err != nil {
 		return err
 	}

--- a/runtime/compilers/rillv1/parser.go
+++ b/runtime/compilers/rillv1/parser.go
@@ -983,6 +983,12 @@ func (p *Parser) defaultOLAPConnector() string {
 	return p.DefaultOLAPConnector
 }
 
+// isDev returns true if the parser's instance's environment is "dev".
+// Usually this means it's running on localhost with "rill start".
+func (p *Parser) isDev() bool {
+	return strings.EqualFold(p.Environment, "dev")
+}
+
 // pathIsSQL returns true if the path is a SQL file
 func pathIsSQL(path string) bool {
 	return strings.HasSuffix(path, ".sql")


### PR DESCRIPTION
This PR changes the `refresh:` YAML clause to ignore the `refresh.cron:` and `refresh.every:` properties in development (i.e. when running under `rill start` on `localhost`) unless `refresh.run_in_dev: true` is explicitly set.

Closes https://github.com/rilldata/rill-private-issues/issues/654