### PR TITLE
DuckDB: Support configuring native secrets in DuckDB

### DIFF
--- a/runtime/compilers/rillv1/template_test.go
+++ b/runtime/compilers/rillv1/template_test.go
@@ -99,3 +99,15 @@ func TestResolve(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "SELECT partner_id FROM domain_partner_mapping WHERE domain = 'rilldata.com' AND groups IN ('admin', 'user') OR true", resolved)
 }
+
+func TestVariables(t *testing.T) {
+	template := `a={{ .vars.a }} b.a={{ .vars.b.a }} b.a={{ get .vars "b.a" }}`
+	resolved, err := ResolveTemplate(template, TemplateData{
+		Variables: map[string]string{
+			"a":   "1",
+			"b.a": "2",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "a=1 b.a=2 b.a=2", resolved)
+}

--- a/runtime/drivers/duckdb/config.go
+++ b/runtime/drivers/duckdb/config.go
@@ -41,8 +41,10 @@ type config struct {
 	MaxMemoryGBOverride int `mapstructure:"max_memory_gb_override"`
 	// ThreadsOverride sets a hard override for the "threads" DuckDB setting. Set to -1 for unlimited threads.
 	ThreadsOverride int `mapstructure:"threads_override"`
-	// BootQueries is queries to run on boot. Use ; to separate multiple queries. Common use case is to provide project specific memory and threads ratios.
+	// BootQueries is SQL to execute when initializing a new connection. It runs before any extensions are loaded or default settings are set.
 	BootQueries string `mapstructure:"boot_queries"`
+	// InitSQL is SQL to execute when initializing a new connection. It runs after extensions are loaded and and default settings are set.
+	InitSQL string `mapstructure:"init_sql"`
 	// DBFilePath is the path where the database is stored. It is inferred from the DSN (can't be provided by user).
 	DBFilePath string `mapstructure:"-"`
 	// DBStoragePath is the path where the database files are stored. It is inferred from the DSN (can't be provided by user).

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -535,8 +535,6 @@ func (c *connection) reopenDB() error {
 		"LOAD 'parquet'",
 		"INSTALL 'httpfs'",
 		"LOAD 'httpfs'",
-		"INSTALL 'aws'",
-		"LOAD 'aws'",
 		"INSTALL 'sqlite'",
 		"LOAD 'sqlite'",
 		"SET max_expression_depth TO 250",

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -535,6 +536,8 @@ func (c *connection) reopenDB() error {
 		"LOAD 'parquet'",
 		"INSTALL 'httpfs'",
 		"LOAD 'httpfs'",
+		"INSTALL 'aws'",
+		"LOAD 'aws'",
 		"INSTALL 'sqlite'",
 		"LOAD 'sqlite'",
 		"SET max_expression_depth TO 250",
@@ -546,6 +549,12 @@ func (c *connection) reopenDB() error {
 	// Hack: Using AllowHostAccess as a proxy indicator for a hosted environment.
 	if !c.config.AllowHostAccess {
 		bootQueries = append(bootQueries, "SET preserve_insertion_order TO false")
+	}
+
+	// Add init SQL if provided
+	if c.config.InitSQL != "" {
+		log.Printf("GOT INIT SQL: %s", c.config.InitSQL)
+		bootQueries = append(bootQueries, c.config.InitSQL)
 	}
 
 	// DuckDB extensions need to be loaded separately on each connection, but the built-in connection pool in database/sql doesn't enable that.

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -553,7 +552,6 @@ func (c *connection) reopenDB() error {
 
 	// Add init SQL if provided
 	if c.config.InitSQL != "" {
-		log.Printf("GOT INIT SQL: %s", c.config.InitSQL)
 		bootQueries = append(bootQueries, c.config.InitSQL)
 	}
 

--- a/scripts/embed_duckdb_ext/main.go
+++ b/scripts/embed_duckdb_ext/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 // DuckDB extensions Rill depends on
-var extensions = []string{"json", "icu", "parquet", "httpfs", "sqlite_scanner", "motherduck"}
+var extensions = []string{"json", "icu", "parquet", "httpfs", "aws", "sqlite_scanner", "motherduck"}
 
 // DuckDB platforms to download extensions for
 var platforms = []string{"linux_amd64", "linux_arm64", "osx_amd64", "osx_arm64"}

--- a/scripts/embed_duckdb_ext/main.go
+++ b/scripts/embed_duckdb_ext/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 // DuckDB extensions Rill depends on
-var extensions = []string{"json", "icu", "parquet", "httpfs", "aws", "sqlite_scanner", "motherduck"}
+var extensions = []string{"json", "icu", "parquet", "httpfs", "sqlite_scanner", "motherduck"}
 
 // DuckDB platforms to download extensions for
 var platforms = []string{"linux_amd64", "linux_arm64", "osx_amd64", "osx_arm64"}


### PR DESCRIPTION
This PR adds support for configuring native secrets in DuckDB using `init_sql` in a `duckdb.yaml` connector file.

This enables ingesting data from S3/GCS/Azure from DuckDB *models* (note that this is not needed for DuckDB *sources* due to some legacy hacks in the sources implementation that predate DuckDB's support for native secrets).

**Example:** DuckDB connector configuration that configures DuckDB to use S3 credentials from `~/.aws` on local and from Rill env variables on cloud:

```yaml
# connectors/duckdb.yaml
type: connector
driver: duckdb

init_sql: >
  CREATE OR REPLACE SECRET s3 (
    TYPE S3,
    KEY_ID '{{ .vars.connector.s3.aws_access_key_id }}',
    SECRET '{{ .vars.connector.s3.aws_secret_access_key }}',
    REGION 'eu-north-1'
  )

dev:
  init_sql: >
    CREATE OR REPLACE SECRET s3 (TYPE S3, PROVIDER CREDENTIAL_CHAIN)
```