### PR TITLE
Use `validPercentOfTotal` as source of truth

### DIFF
--- a/web-common/src/features/dashboards/dashboard-utils.ts
+++ b/web-common/src/features/dashboards/dashboard-utils.ts
@@ -8,19 +8,27 @@ import { DashboardState_LeaderboardSortType } from "@rilldata/web-common/proto/g
 import type {
   MetricsViewSpecDimensionV2,
   MetricsViewSpecMeasureV2,
-  V1MetricsViewAggregationMeasure,
-  V1Expression,
   QueryServiceMetricsViewAggregationBody,
+  V1Expression,
+  V1MetricsViewAggregationMeasure,
 } from "@rilldata/web-common/runtime-client";
-import type { TimeControlState } from "./time-controls/time-control-store";
 import { SortType } from "./proto-state/derived-types";
+import type { TimeControlState } from "./time-controls/time-control-store";
 
 const countRegex = /count(?=[^(]*\()/i;
 const sumRegex = /sum(?=[^(]*\()/i;
+// Clickhouse has uniq and uniqExact, which are summable
+const uniqRegex = /uniq(?=[^(]*\()/i;
+const uniqExactRegex = /uniqExact(?=[^(]*\()/i;
 
 export function isSummableMeasure(measure: MetricsViewSpecMeasureV2): boolean {
   const expression = measure.expression?.toLowerCase();
-  return !!(expression?.match(countRegex) || expression?.match(sumRegex));
+  return !!(
+    expression?.match(countRegex) ||
+    expression?.match(sumRegex) ||
+    expression?.match(uniqRegex) ||
+    expression?.match(uniqExactRegex)
+  );
 }
 
 /**

--- a/web-common/src/features/dashboards/dashboard-utils.ts
+++ b/web-common/src/features/dashboards/dashboard-utils.ts
@@ -17,20 +17,14 @@ import type { TimeControlState } from "./time-controls/time-control-store";
 
 const countRegex = /count(?=[^(]*\()/i;
 const sumRegex = /sum(?=[^(]*\()/i;
-// Clickhouse has uniq and uniqExact, which are summable
-const uniqRegex = /uniq(?=[^(]*\()/i;
-const uniqExactRegex = /uniqExact(?=[^(]*\()/i;
 
 export function isSummableMeasure(measure: MetricsViewSpecMeasureV2): boolean {
   const expression = measure.expression?.toLowerCase();
-  return !!(
-    expression?.match(countRegex) ||
-    expression?.match(sumRegex) ||
-    expression?.match(uniqRegex) ||
-    expression?.match(uniqExactRegex)
+  return (
+    !!(expression?.match(countRegex) || expression?.match(sumRegex)) ||
+    Boolean(measure.validPercentOfTotal)
   );
 }
-
 /**
  * Returns a sanitized column name appropriate for use in e.g. filters.
  *


### PR DESCRIPTION
Closes https://github.com/rilldata/rill-private-issues/issues/608
Use `validPercentOfTotal` as source of truth to validate if measure is summable. Also maintain support for `sum` and `count` for legacy dashboards not having the key in their spec.