### PR TITLE
fix: leaderboard measure reset on a refresh if it was hidden

### DIFF
--- a/web-common/src/features/dashboards/show-hide-selectors.ts
+++ b/web-common/src/features/dashboards/show-hide-selectors.ts
@@ -105,12 +105,6 @@ function createShowHideStore<Item>(
         ...metricsExplorer[visibleFieldInStore].keys(),
       ]);
 
-      if (type === "measures") {
-        metricsExplorer.leaderboardMeasureName = firstKey[0];
-        persistentStore.updateLeaderboardMeasureName(
-          metricsExplorer.leaderboardMeasureName,
-        );
-      }
       metricsExplorer[allVisibleFieldInStore] = false;
     });
   };
@@ -119,28 +113,6 @@ function createShowHideStore<Item>(
     updateMetricsExplorerByName(metricsViewName, (metricsExplorer) => {
       if (metricsExplorer[visibleFieldInStore].has(key)) {
         metricsExplorer[visibleFieldInStore].delete(key);
-
-        /*
-         * If current leaderboard measure is hidden, set the first
-         * visible measure as the current leaderboard measure
-         */
-        if (
-          type === "measures" &&
-          metricsExplorer.leaderboardMeasureName === key
-        ) {
-          /*
-           * To maintain the order of keys, filter out the
-           * non-visible ones from the available keys
-           */
-          const firstVisible = get(derivedStore).availableKeys.find((key) =>
-            metricsExplorer[visibleFieldInStore].has(key),
-          );
-
-          metricsExplorer.leaderboardMeasureName = firstVisible ?? "";
-          persistentStore.updateLeaderboardMeasureName(
-            metricsExplorer.leaderboardMeasureName,
-          );
-        }
       } else {
         metricsExplorer[visibleFieldInStore].add(key);
       }

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -116,20 +116,6 @@ function syncMeasures(
         metricsView.measures[0].name,
       ]);
     }
-
-    // check if current leaderboard measure is visible,
-    // if not set it to first visible measure
-    if (
-      metricsExplorer.visibleMeasureKeys.size &&
-      !metricsExplorer.visibleMeasureKeys.has(
-        metricsExplorer.leaderboardMeasureName,
-      )
-    ) {
-      const firstVisibleMeasure = metricsView.measures
-        .map((measure) => measure.name)
-        .find((key) => metricsExplorer.visibleMeasureKeys.has(key));
-      metricsExplorer.leaderboardMeasureName = firstVisibleMeasure;
-    }
   }
 }
 


### PR DESCRIPTION
Currently when metrics view query is refetched we remove leaderboard measure if it is hidden. This is also triggered when the page is refereshed. This is not the intended behaviour anymore.

We also change the leaderboard measure if it was hidden. This is also not needed anymore.

More context: https://rilldata.slack.com/archives/CTCJ58H3M/p1725602517787789?thread_ts=1725586991.771069&cid=CTCJ58H3M