### PR TITLE
Fix (File Explorer): Specify more unsupported file types

### DIFF
--- a/web-common/src/features/entity-management/file-artifact.ts
+++ b/web-common/src/features/entity-management/file-artifact.ts
@@ -35,7 +35,28 @@ import {
 import { fileArtifacts } from "./file-artifacts";
 import { inferResourceKind } from "./infer-resource-kind";
 
-const UNSUPPORTED_EXTENSIONS = [".parquet", ".db", ".db.wal"];
+const UNSUPPORTED_EXTENSIONS = [
+  // Data formats
+  ".db",
+  ".db.wal",
+  ".parquet",
+  ".xls",
+  ".xlsx",
+
+  // Image formats
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".svg",
+
+  // Document formats
+  ".pdf",
+  ".doc",
+  ".docx",
+  ".ppt",
+  ".pptx",
+];
 
 export class FileArtifact {
   readonly path: string;

--- a/web-local/src/routes/(application)/files/[...file]/+page.ts
+++ b/web-local/src/routes/(application)/files/[...file]/+page.ts
@@ -15,7 +15,10 @@ export const load = async ({ params: { file } }) => {
   const fileArtifact = fileArtifacts.getFileArtifact(path);
 
   if (fileArtifact.fileTypeUnsupported) {
-    throw error(400, fileArtifact.fileExtension + " file type not supported");
+    throw error(
+      400,
+      "No renderer available for file type: " + fileArtifact.fileExtension,
+    );
   }
 
   try {


### PR DESCRIPTION
This is a quick fix to close https://github.com/rilldata/rill-private-issues/issues/629. However, we should really refactor this to explicitly state _supported_ file types rather than _unsupported_ file types.

<img width="1434" alt="image" src="https://github.com/user-attachments/assets/7e81e250-0c5a-4a1e-a69d-e77d41816a12">