### PR TITLE
fix: bg-white for KPI

### DIFF
--- a/web-common/src/features/templates/kpi/KPITemplate.svelte
+++ b/web-common/src/features/templates/kpi/KPITemplate.svelte
@@ -80,7 +80,7 @@
 
 <div
   bind:clientWidth={containerWidth}
-  class="flex flex-row h-full w-full items-center"
+  class="flex flex-row h-full w-full items-center bg-white"
 >
   {#if $measure.data && $measureValue.data}
     <MeasureBigNumber


### PR DESCRIPTION
Since we removed `bg-white` from the higher order component we enforce it on the KPI to ensure background.