### PR TITLE
fix: alerts without an associated dashboard

### DIFF
--- a/web-admin/src/features/alerts/metadata/AlertMetadata.svelte
+++ b/web-admin/src/features/alerts/metadata/AlertMetadata.svelte
@@ -41,9 +41,7 @@
   $: dashboardName = useAlertDashboardName($runtime.instanceId, alert);
   $: dashboard = useDashboard($runtime.instanceId, $dashboardName.data);
   $: dashboardTitle =
-    $dashboard.data?.metricsView.spec.title ||
-    $dashboardName.data ||
-    $alertQuery.data?.resource?.meta?.name?.name;
+    $dashboard.data?.metricsView.spec.title || $dashboardName.data;
   $: dashboardDoesNotExist = $dashboard.error?.response?.status === 404;
 
   $: alertSpec = $alertQuery.data?.resource?.alert?.spec;
@@ -122,24 +120,31 @@
     <div class="flex flex-wrap gap-x-16 gap-y-6">
       <!-- Dashboard -->
       <div class="flex flex-col gap-y-3">
-        <MetadataLabel>Dashboard</MetadataLabel>
-        <MetadataValue>
-          {#if dashboardDoesNotExist}
-            <div class="flex items-center gap-x-1">
-              {dashboardTitle}
-              <Tooltip distance={8}>
-                <CancelCircle size="16px" className="text-red-500" />
-                <TooltipContent slot="tooltip-content">
-                  Dashboard does not exist
-                </TooltipContent>
-              </Tooltip>
-            </div>
-          {:else}
-            <a href={`/${organization}/${project}/${$dashboardName.data}`}
-              >{dashboardTitle}</a
-            >
-          {/if}
-        </MetadataValue>
+        {#if dashboardTitle}
+          <MetadataLabel>Dashboard</MetadataLabel>
+          <MetadataValue>
+            {#if dashboardDoesNotExist}
+              <div class="flex items-center gap-x-1">
+                {dashboardTitle}
+                <Tooltip distance={8}>
+                  <CancelCircle size="16px" className="text-red-500" />
+                  <TooltipContent slot="tooltip-content">
+                    Dashboard does not exist
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+            {:else}
+              <a href={`/${organization}/${project}/${$dashboardName.data}`}>
+                {dashboardTitle}
+              </a>
+            {/if}
+          </MetadataValue>
+        {:else}
+          <MetadataLabel>Name</MetadataLabel>
+          <MetadataValue>
+            {$alertQuery.data?.resource?.meta?.name?.name}
+          </MetadataValue>
+        {/if}
       </div>
 
       <!-- Split by dimension -->

--- a/web-admin/src/routes/[organization]/[project]/-/alerts/[alert]/open/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/alerts/[alert]/open/+page.svelte
@@ -19,16 +19,24 @@
   $: alert = useAlert($runtime.instanceId, alertId);
 
   let dashboardStateForAlert: ReturnType<typeof mapQueryToDashboard>;
-  $: dashboardStateForAlert = mapQueryToDashboard(
+  $: queryName =
     $alert.data?.resource?.alert?.spec?.resolverProperties?.query_name ??
-      $alert.data?.resource?.alert?.spec?.queryName ??
-      "",
+    $alert.data?.resource?.alert?.spec?.queryName ??
+    "";
+  $: queryArgsJson =
     $alert.data?.resource?.alert?.spec?.resolverProperties?.query_args_json ??
-      $alert.data?.resource?.alert?.spec?.queryArgsJson ??
-      "",
+    $alert.data?.resource?.alert?.spec?.queryArgsJson ??
+    "";
+  $: dashboardStateForAlert = mapQueryToDashboard(
+    queryName,
+    queryArgsJson,
     executionTime,
     $alert.data?.resource?.alert?.spec?.annotations ?? {},
   );
+
+  $: if ($alert.data?.resource?.alert?.spec && (!queryName || !queryArgsJson)) {
+    goto(`/${organization}/${project}/-/alerts/${alertId}`);
+  }
 
   $: if ($dashboardStateForAlert.data) {
     goto(


### PR DESCRIPTION
Alerts can be created without a dashboard through a YAML file artifact. While we do not have mocks for this, we should atleast not crash the app.

- Redirects users to alert page for emails for such alerts.
- The section in alerts page stating dashboard is removed for such alerts.