### PR TITLE
fix: default to 24 columns

### DIFF
--- a/web-admin/src/features/embeds/CanvasDashboardEmbed.svelte
+++ b/web-admin/src/features/embeds/CanvasDashboardEmbed.svelte
@@ -20,7 +20,7 @@
     items = [],
     columns,
     gap,
-  } = dashboard || { items: [], columns: 10, gap: 2 });
+  } = dashboard || { items: [], columns: 24, gap: 2 });
 </script>
 
 <CanvasDashboardEmbed {dashboardName} {columns} {items} {gap} />

--- a/web-admin/src/routes/[organization]/[project]/-/dashboards/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/dashboards/[dashboard]/+page.svelte
@@ -22,7 +22,7 @@
     items = [],
     columns,
     gap,
-  } = dashboard || { items: [], columns: 10, gap: 2 });
+  } = dashboard || { items: [], columns: 24, gap: 2 });
 </script>
 
 <CanvasDashboardEmbed {dashboardName} {columns} {items} {gap} />

--- a/web-common/src/features/file-explorer/new-files.ts
+++ b/web-common/src/features/file-explorer/new-files.ts
@@ -147,7 +147,7 @@ vega_lite: |
     name: "canvas-dashboard",
     extension: ".yaml",
     baseContent: `type: dashboard
-columns: 10
+columns: 24
 gap: 2
 
 items:


### PR DESCRIPTION
Defaulting to 24 columns as it's divisable by both thirds and quarters. We could go 12 as well if 24 seems to finegrain.