### PR TITLE
Fix: Await repository clone before resolving the repository root path

### DIFF
--- a/cli/pkg/cmdutil/archive.go
+++ b/cli/pkg/cmdutil/archive.go
@@ -34,7 +34,12 @@ func UploadRepo(ctx context.Context, repo drivers.RepoStore, ch *Helper, org, na
 		return "", err
 	}
 
-	err = archive.Create(ctx, entries, repo.Root(), asset.SignedUrl, asset.SigningHeaders)
+	rootPath, err := repo.Root(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get root path: %w", err)
+	}
+
+	err = archive.Create(ctx, entries, rootPath, asset.SignedUrl, asset.SigningHeaders)
 	if err != nil {
 		return "", err
 	}

--- a/runtime/connections.go
+++ b/runtime/connections.go
@@ -267,7 +267,12 @@ func (r *Runtime) ConnectorConfig(ctx context.Context, instanceID, name string) 
 			if err != nil {
 				return nil, err
 			}
-			res.setPreset("dsn", repo.Root(), true)
+			rootPath, err := repo.Root(ctx)
+			if err != nil {
+				release()
+				return nil, fmt.Errorf("failed to get root path: %w", err)
+			}
+			res.setPreset("dsn", rootPath, true)
 			release()
 		}
 	}

--- a/runtime/drivers/admin/repo.go
+++ b/runtime/drivers/admin/repo.go
@@ -14,8 +14,14 @@ import (
 	"github.com/rilldata/rill/runtime/drivers"
 )
 
-func (h *Handle) Root() string {
-	return h.projPath
+func (h *Handle) Root(ctx context.Context) (string, error) {
+	err := h.rlockEnsureCloned(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer h.repoMu.RUnlock()
+
+	return h.projPath, nil
 }
 
 func (h *Handle) CommitHash(ctx context.Context) (string, error) {

--- a/runtime/drivers/file/file_store.go
+++ b/runtime/drivers/file/file_store.go
@@ -26,7 +26,7 @@ func (c *connection) FilePaths(ctx context.Context, src map[string]any) ([]strin
 		return nil, err
 	}
 	if len(localPaths) == 0 {
-		return nil, fmt.Errorf("file does not exist at %s", conf.Path)
+		return nil, fmt.Errorf("file does not exist at %q", conf.Path)
 	}
 
 	return localPaths, nil

--- a/runtime/drivers/file/repo.go
+++ b/runtime/drivers/file/repo.go
@@ -20,8 +20,8 @@ func (c *connection) Driver() string {
 }
 
 // Root implements drivers.RepoStore.
-func (c *connection) Root() string {
-	return c.root
+func (c *connection) Root(ctx context.Context) (string, error) {
+	return c.root, nil
 }
 
 // CommitHash implements drivers.RepoStore.

--- a/runtime/drivers/repo.go
+++ b/runtime/drivers/repo.go
@@ -16,7 +16,7 @@ import (
 type RepoStore interface {
 	Driver() string
 	// Root returns directory where artifacts are stored.
-	Root() string
+	Root(ctx context.Context) (string, error)
 	CommitHash(ctx context.Context) (string, error)
 	ListRecursive(ctx context.Context, glob string, skipDirs bool) ([]DirEntry, error)
 	Get(ctx context.Context, path string) (string, error)

--- a/runtime/reconcilers/model.go
+++ b/runtime/reconcilers/model.go
@@ -1310,9 +1310,14 @@ func (r *ModelReconciler) newModelEnv(ctx context.Context) (*drivers.ModelEnv, e
 	}
 	defer release()
 
+	repoRoot, err := repo.Root(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get repo root: %w", err)
+	}
+
 	return &drivers.ModelEnv{
 		AllowHostAccess:    r.C.Runtime.AllowHostAccess(),
-		RepoRoot:           repo.Root(),
+		RepoRoot:           repoRoot,
 		StageChanges:       cfg.StageChanges,
 		DefaultMaterialize: cfg.ModelDefaultMaterialize,
 		AcquireConnector:   r.C.AcquireConn,

--- a/runtime/reconcilers/source.go
+++ b/runtime/reconcilers/source.go
@@ -360,7 +360,10 @@ func (r *SourceReconciler) ingestSource(ctx context.Context, self *runtimev1.Res
 	if err != nil {
 		return fmt.Errorf("failed to access repo: %w", err)
 	}
-	repoRoot := repo.Root()
+	repoRoot, err := repo.Root(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get repo root: %w", err)
+	}
 	release()
 
 	// Execute the data transfer


### PR DESCRIPTION
Avoids a race condition where e.g. a `local_file` source may try to read a file in the Git repo before it's cloned.