### PR TITLE
fix: component titles and select

### DIFF
--- a/web-common/src/features/canvas-dashboards/Component.svelte
+++ b/web-common/src/features/canvas-dashboards/Component.svelte
@@ -100,10 +100,10 @@
       {#if title || subtitle}
         <div class="w-full h-fit flex flex-col gap-y-1">
           {#if title}
-            <h1>{title}</h1>
+            <h1 class="text-slate-900">{title}</h1>
           {/if}
           {#if subtitle}
-            <h2>{subtitle}</h2>
+            <h2 class="text-slate-600">{subtitle}</h2>
           {/if}
         </div>
       {/if}
@@ -130,12 +130,12 @@
   }
 
   h1 {
-    font-size: 24px;
-    font-weight: 700;
+    font-size: 18px;
+    font-weight: 600;
   }
 
   h2 {
-    font-size: 18px;
-    font-weight: 500;
+    font-size: 14px;
+    font-weight: 400;
   }
 </style>

--- a/web-common/src/features/canvas-dashboards/Component.svelte
+++ b/web-common/src/features/canvas-dashboards/Component.svelte
@@ -97,17 +97,17 @@
       class:shadow-lg={interacting}
       style:border-radius="{radius}px"
     >
+      {#if title || subtitle}
+        <div class="w-full h-fit flex flex-col gap-y-1">
+          {#if title}
+            <h1>{title}</h1>
+          {/if}
+          {#if subtitle}
+            <h2>{subtitle}</h2>
+          {/if}
+        </div>
+      {/if}
       {#if renderer === "vega_lite" && rendererProperties?.spec && resolverProperties}
-        {#if title || subtitle}
-          <div class="w-full h-fit flex flex-col gap-y-1 px-8 py-4">
-            {#if title}
-              <h1>{title}</h1>
-            {/if}
-            {#if subtitle}
-              <h2>{subtitle}</h2>
-            {/if}
-          </div>
-        {/if}
         <Chart {componentName} {chartView} {input} />
       {:else if renderer && rendererProperties}
         <TemplateRenderer

--- a/web-common/src/features/templates/select/Select.svelte
+++ b/web-common/src/features/templates/select/Select.svelte
@@ -48,7 +48,6 @@
 
 <div>
   <Select
-    className="bg-white"
     on:change={(e) =>
       dashboardVariablesStore.updateVariable(
         dashboardName,
@@ -58,6 +57,7 @@
     bind:value
     detach
     id={componentName}
+    className={"bg-white"}
     tooltip={selectProperties.tooltip || ""}
     label={selectProperties.label || ""}
     options={selectOptions}

--- a/web-common/src/features/templates/select/Select.svelte
+++ b/web-common/src/features/templates/select/Select.svelte
@@ -46,8 +46,9 @@
     .slice(0, MAX_OPTIONS);
 </script>
 
-<div class="m-1 p-1">
+<div>
   <Select
+    className="bg-white"
     on:change={(e) =>
       dashboardVariablesStore.updateVariable(
         dashboardName,


### PR DESCRIPTION
- enforces white background for select component and removes padding so that the popover aligns.
- aligns component template titles