### PR TITLE
fix: hide inspector from components view

### DIFF
--- a/web-common/src/features/canvas-components/ComponentsHeader.svelte
+++ b/web-common/src/features/canvas-components/ComponentsHeader.svelte
@@ -45,6 +45,8 @@
   on:change={handleNameChange}
   titleInput={fileName}
   {hasUnsavedChanges}
+  showInspectorToggle={false}
+  show
 >
   <svelte:fragment slot="cta">
     <PanelCTA side="right">

--- a/web-common/src/features/canvas-components/ComponentsHeader.svelte
+++ b/web-common/src/features/canvas-components/ComponentsHeader.svelte
@@ -46,7 +46,6 @@
   titleInput={fileName}
   {hasUnsavedChanges}
   showInspectorToggle={false}
-  show
 >
   <svelte:fragment slot="cta">
     <PanelCTA side="right">


### PR DESCRIPTION
Hides the inspector button the components editor as it currently does not do anything.