### PR TITLE
fix: existing projects during `rill deploy`

### DIFF
--- a/cli/cmd/project/deploy.go
+++ b/cli/cmd/project/deploy.go
@@ -165,7 +165,7 @@ func DeployWithUploadFlow(ctx context.Context, ch *cmdutil.Helper, opts *DeployO
 	// check if the project with name already exists
 	if projResp != nil {
 		if projResp.Project.GithubUrl != "" {
-			ch.PrintfError("Found existing project. But it is connected to a github repo.\nPush any changes to the repo to deploy.")
+			ch.PrintfError("Found existing project. But it is connected to a github repo.\nPush any changes to %q to deploy.\n", projResp.Project.GithubUrl)
 			return nil
 		}
 

--- a/cli/cmd/project/deploy.go
+++ b/cli/cmd/project/deploy.go
@@ -155,12 +155,20 @@ func DeployWithUploadFlow(ctx context.Context, ch *cmdutil.Helper, opts *DeployO
 		return err
 	}
 
-	// check if the project with name already exists
-	projectExists, err := projectExists(ctx, ch, ch.Org, opts.Name)
+	projResp, err := adminClient.GetProject(ctx, &adminv1.GetProjectRequest{OrganizationName: ch.Org, Name: opts.Name})
 	if err != nil {
-		return err
+		if st, ok := status.FromError(err); !ok || st.Code() != codes.NotFound {
+			return err
+		}
 	}
-	if projectExists {
+
+	// check if the project with name already exists
+	if projResp != nil {
+		if projResp.Project.GithubUrl != "" {
+			ch.PrintfError("Found existing project. But it is connected to a github repo.\nPush any changes to the repo to deploy.")
+			return nil
+		}
+
 		ch.Printer.Println("Found existing project. Starting re-upload.")
 		assetID, err := cmdutil.UploadRepo(ctx, repo, ch, ch.Org, opts.Name)
 		if err != nil {


### PR DESCRIPTION
Updating upload and github flow to have error handling when project already exists. Applies to `rill deploy` as well.
- During `rill project deploy` if project already deployed with github show an error.
- During `rill project connect-github` if project already deployed with github show an error and direct user to cloud UI to change the github.