### PR TITLE
feat: Enable variables in component filter

### DIFF
--- a/web-common/src/features/canvas-dashboards/Component.svelte
+++ b/web-common/src/features/canvas-dashboards/Component.svelte
@@ -115,7 +115,6 @@
           {renderer}
           {input}
           {output}
-          {rendererProperties}
           {resolverProperties}
           {componentName}
         />

--- a/web-common/src/features/templates/TemplateRenderer.svelte
+++ b/web-common/src/features/templates/TemplateRenderer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Chart from "@rilldata/web-common/features/canvas-dashboards/Chart.svelte";
+  import { useVariableInputParams } from "@rilldata/web-common/features/canvas-dashboards/variables-store";
   import Image from "@rilldata/web-common/features/templates/image/Image.svelte";
   import KPITemplate from "@rilldata/web-common/features/templates/kpi/KPITemplate.svelte";
   import Markdown from "@rilldata/web-common/features/templates/markdown/Markdown.svelte";
@@ -8,32 +9,49 @@
   import TableTemplate from "@rilldata/web-common/features/templates/table/TableTemplate.svelte";
 
   import {
+    createQueryServiceResolveComponent,
     V1ComponentSpecRendererProperties,
     V1ComponentSpecResolverProperties,
     V1ComponentVariable,
   } from "@rilldata/web-common/runtime-client";
+  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
+  import { getContext } from "svelte";
 
   export let chartView: boolean;
   export let renderer: string;
   export let componentName: string;
   export let input: V1ComponentVariable[] | undefined;
   export let output: V1ComponentVariable | undefined;
-  export let rendererProperties: V1ComponentSpecRendererProperties;
   export let resolverProperties: V1ComponentSpecResolverProperties | undefined;
+
+  const dashboardName = getContext("rill::canvas-dashboard:name") as string;
+
+  $: inputVariableParams = useVariableInputParams(dashboardName, input);
+  $: componentQuery = createQueryServiceResolveComponent(
+    $runtime.instanceId,
+    componentName,
+    { args: $inputVariableParams },
+  );
+  $: componentData = $componentQuery?.data;
+  $: rendererProperties =
+    componentData?.rendererProperties as V1ComponentSpecRendererProperties;
+  $: data = componentData?.data;
 </script>
 
-{#if renderer === "kpi"}
-  <KPITemplate {rendererProperties} />
-{:else if renderer === "table"}
-  <TableTemplate {rendererProperties} />
-{:else if renderer === "markdown"}
-  <Markdown {rendererProperties} />
-{:else if renderer === "image"}
-  <Image {rendererProperties} />
-{:else if renderer === "select"}
-  <Select {componentName} {input} {output} {rendererProperties} />
-{:else if renderer === "switch"}
-  <Switch {output} {rendererProperties} />
-{:else if resolverProperties}
-  <Chart {chartView} {input} {componentName} />
+{#if rendererProperties}
+  {#if renderer === "kpi"}
+    <KPITemplate {rendererProperties} />
+  {:else if renderer === "table"}
+    <TableTemplate {rendererProperties} />
+  {:else if renderer === "markdown"}
+    <Markdown {rendererProperties} />
+  {:else if renderer === "image"}
+    <Image {rendererProperties} />
+  {:else if renderer === "select"}
+    <Select {data} {componentName} {output} {rendererProperties} />
+  {:else if renderer === "switch"}
+    <Switch {output} {rendererProperties} />
+  {:else if resolverProperties}
+    <Chart {componentName} {chartView} {input} />
+  {/if}
 {/if}

--- a/web-common/src/features/templates/select/Select.svelte
+++ b/web-common/src/features/templates/select/Select.svelte
@@ -3,40 +3,30 @@
   import {
     dashboardVariablesStore,
     useVariable,
-    useVariableInputParams,
   } from "@rilldata/web-common/features/canvas-dashboards/variables-store";
   import { SelectProperties } from "@rilldata/web-common/features/templates/types";
 
   import {
-    createQueryServiceResolveComponent,
     V1ComponentSpecRendererProperties,
     V1ComponentVariable,
   } from "@rilldata/web-common/runtime-client";
-  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { getContext } from "svelte";
 
   const MAX_OPTIONS = 250;
   $: dashboardName = getContext("rill::canvas-dashboard:name") as string;
 
   export let componentName: string;
+  export let data: any[] | undefined;
   export let rendererProperties: V1ComponentSpecRendererProperties;
-  export let input: V1ComponentVariable[] | undefined;
   export let output: V1ComponentVariable | undefined;
 
   $: outputVariableName = output?.name || "";
   $: outputVariableValue = useVariable(dashboardName, outputVariableName);
   $: selectProperties = rendererProperties as SelectProperties;
-  $: inputVariableParams = useVariableInputParams(dashboardName, input);
 
   $: value = (value || $outputVariableValue || output?.defaultValue) as string;
 
-  $: componentDataQuery = createQueryServiceResolveComponent(
-    $runtime.instanceId,
-    componentName,
-    { args: $inputVariableParams },
-  );
-
-  $: selectOptions = ($componentDataQuery?.data?.data || [])
+  $: selectOptions = (data || [])
     .map((v) => ({
       value: String(v[selectProperties.valueField]),
       label: String(


### PR DESCRIPTION
Support variable reference in filters of canvas components.

Can be tested with

```
kind: component

input:
 - name: selection
   type: string
   value: Instacart

kpi:
  metrics_view: Bids_Sample_Dash
  time_range: P7D
  filter: advertiser_name='{{ .args.selection }}'
  measure: measure_2
  comparison_range: P3D
```