### PR TITLE
fix: selected measure not added to dimension table export

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/dimension-table-export-utils.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-export-utils.ts
@@ -69,6 +69,10 @@ export function getDimensionTableAggregationRequestForTime(
   }));
 
   let apiSortName = dashboardState.leaderboardMeasureName;
+  if (!dashboardState.visibleMeasureKeys.has(apiSortName)) {
+    // if selected sort measure is not visible add it to list
+    measures.push({ name: apiSortName });
+  }
   if (comparisonTimeRange) {
     // insert beside the correct measure
     measures.splice(


### PR DESCRIPTION
After our recent fix to allow hidden measures in leaderboard measure, export breaks in this scenario. While the sort column is selected as the hidden measure the list of measures is not updated.

This PR adds the selected measure even if it is hidden.