### PR TITLE
Fix panic when renaming two resources simultaneously during incremental parsing

### DIFF
--- a/runtime/reconcilers/project_parser.go
+++ b/runtime/reconcilers/project_parser.go
@@ -445,6 +445,11 @@ func (r *ProjectParserReconciler) reconcileResourcesDiff(ctx context.Context, in
 		// Rename if possible
 		renamed := false
 		for idx, rr := range deleteResources {
+			if rr == nil {
+				// Already renamed
+				continue
+			}
+
 			var err error
 			renamed, err = r.attemptRename(ctx, inst, self, def, rr)
 			if err != nil {


### PR DESCRIPTION
This edge case has probably never happened before, but will become prevalent with metrics view and explore resources now being emitted from the same file.