### PR TITLE
Fix use of `table:` leading to missing DAG links for sources

### DIFF
--- a/runtime/compilers/rillv1/parse_metrics_view.go
+++ b/runtime/compilers/rillv1/parse_metrics_view.go
@@ -732,6 +732,13 @@ func (p *Parser) parseMetricsView(node *Node) error {
 		// Not setting Kind because for backwards compatibility, it may actually be a source or an external table.
 		node.Refs = append(node.Refs, ResourceName{Name: tmp.Model})
 	}
+	if tmp.Table != "" {
+		// By convention, if the table name matches a source or model name we add a DAG link.
+		// We may want to remove this at some point, but the cases where it would not be desired are very rare.
+		// Not setting Kind so that inference kicks in.
+		node.Refs = append(node.Refs, ResourceName{Name: tmp.Table})
+	}
+
 	if tmp.DefaultTheme != "" {
 		node.Refs = append(node.Refs, ResourceName{Kind: ResourceKindTheme, Name: tmp.DefaultTheme})
 	}

--- a/runtime/server/generate_metrics_view.go
+++ b/runtime/server/generate_metrics_view.go
@@ -73,6 +73,8 @@ func (s *Server) GenerateMetricsViewFile(ctx context.Context, req *runtimev1.Gen
 	}
 
 	// The table may have been created by a model. Search for a model with the same name in the same connector.
+	// NOTE: If it's a source, we will also mark it as a model. The metrics view YAML supports that, and we'll anyway deprecate sources soon.
+	var isModel bool
 	ctrl, err := s.runtime.Controller(ctx, req.InstanceId)
 	if err != nil {
 		return nil, err
@@ -82,10 +84,22 @@ func (s *Server) GenerateMetricsViewFile(ctx context.Context, req *runtimev1.Gen
 		return nil, err
 	}
 	if model != nil {
+		// Check model is for this table.
 		modelState := model.GetModel().State
-		if modelState.ResultConnector != req.Connector || modelState.ResultTable != tbl.Name {
-			// The model is not for this table. Ignore it.
-			model = nil
+		if modelState.ResultConnector == req.Connector && strings.EqualFold(modelState.ResultTable, tbl.Name) {
+			isModel = true
+		}
+	} else {
+		// Check if it's a source
+		source, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindSource, Name: tbl.Name}, false)
+		if err != nil && !errors.Is(err, drivers.ErrResourceNotFound) {
+			return nil, err
+		}
+		if source != nil {
+			sourceState := source.GetSource().State
+			if sourceState.Connector == req.Connector && strings.EqualFold(sourceState.Table, tbl.Name) {
+				isModel = true
+			}
 		}
 	}
 
@@ -95,7 +109,7 @@ func (s *Server) GenerateMetricsViewFile(ctx context.Context, req *runtimev1.Gen
 	if req.UseAi {
 		// Generate
 		start := time.Now()
-		res, err := s.generateMetricsViewYAMLWithAI(ctx, req.InstanceId, olap.Dialect().String(), req.Connector, tbl, isDefaultConnector, model != nil)
+		res, err := s.generateMetricsViewYAMLWithAI(ctx, req.InstanceId, olap.Dialect().String(), req.Connector, tbl, isDefaultConnector, isModel)
 		if err != nil {
 			s.logger.Warn("failed to generate metrics view YAML using AI", zap.Error(err))
 		} else {
@@ -123,7 +137,7 @@ func (s *Server) GenerateMetricsViewFile(ctx context.Context, req *runtimev1.Gen
 
 	// If we didn't manage to generate the YAML using AI, we fall back to the simple generator
 	if data == "" {
-		data, err = generateMetricsViewYAMLSimple(req.Connector, tbl, isDefaultConnector, model != nil, tbl.Schema)
+		data, err = generateMetricsViewYAMLSimple(req.Connector, tbl, isDefaultConnector, isModel, tbl.Schema)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This is a patch that:
- Changes the metrics view generator to use `model: source_name` instead of `table: source_name` when generating a metrics view directly on a source.
- Changes the parser to create a source/model DAG link for a metrics view that uses a `table:` if the table name matches a source/model name.

This is a non-breaking change that can be rolled out quickly while we contemplate larger refactors of how metrics views are generated on sources and external tables.