### PR TITLE
nit: component background in scaffolding

### DIFF
--- a/web-common/src/features/file-explorer/new-files.ts
+++ b/web-common/src/features/file-explorer/new-files.ts
@@ -165,6 +165,7 @@ items:
         content: "First Component"
         css:
           font-size: "40px"
+          background-color: "#fff"
     width: 4
     height: 3
     x: 2


### PR DESCRIPTION
Adds a background color to the first markdown component that is created as part of the default scaffolding.