### PR TITLE
fix: select bg and titles

### DIFF
--- a/web-common/src/components/forms/Select.svelte
+++ b/web-common/src/components/forms/Select.svelte
@@ -19,11 +19,12 @@
   export let optional: boolean = false;
   export let tooltip: string = "";
   export let width: number | null = null;
+  export let className: string = "";
 
   $: selected = options.find((option) => option.value === value);
 </script>
 
-<div class="flex flex-col gap-y-2">
+<div class="flex flex-col gap-y-2 {className}">
   {#if label?.length}
     <label for={id} class="text-sm flex items-center gap-x-1">
       <span class="text-gray-800 font-medium">

--- a/web-common/src/features/canvas/Component.svelte
+++ b/web-common/src/features/canvas/Component.svelte
@@ -97,17 +97,17 @@
       class:shadow-lg={interacting}
       style:border-radius="{radius}px"
     >
+      {#if title || subtitle}
+        <div class="w-full h-fit flex flex-col pb-2">
+          {#if title}
+            <h1 class="text-slate-900">{title}</h1>
+          {/if}
+          {#if subtitle}
+            <h2 class="text-slate-600 leading-none">{subtitle}</h2>
+          {/if}
+        </div>
+      {/if}
       {#if renderer === "vega_lite" && rendererProperties?.spec && resolverProperties}
-        {#if title || subtitle}
-          <div class="w-full h-fit flex flex-col gap-y-1 px-8 py-4">
-            {#if title}
-              <h1>{title}</h1>
-            {/if}
-            {#if subtitle}
-              <h2>{subtitle}</h2>
-            {/if}
-          </div>
-        {/if}
         <Chart {componentName} {chartView} {input} />
       {:else if renderer && rendererProperties}
         <TemplateRenderer
@@ -129,12 +129,12 @@
   }
 
   h1 {
-    font-size: 24px;
-    font-weight: 700;
+    font-size: 18px;
+    font-weight: 600;
   }
 
   h2 {
-    font-size: 18px;
-    font-weight: 500;
+    font-size: 14px;
+    font-weight: 400;
   }
 </style>

--- a/web-common/src/features/templates/select/Select.svelte
+++ b/web-common/src/features/templates/select/Select.svelte
@@ -36,7 +36,7 @@
     .slice(0, MAX_OPTIONS);
 </script>
 
-<div class="m-1 p-1">
+<div>
   <Select
     on:change={(e) =>
       canvasVariablesStore.updateVariable(
@@ -50,5 +50,6 @@
     label={selectProperties.label || ""}
     options={selectOptions}
     placeholder={selectProperties.placeholder || ""}
+    className="bg-white"
   />
 </div>


### PR DESCRIPTION
Adjusts title spacing and weights.
Adds white background to the select component.

![image](https://github.com/user-attachments/assets/d491066c-f8d9-42d2-95f6-8fcc276d0df9)
![image](https://github.com/user-attachments/assets/6793bfa4-750e-4850-8be7-8124366c0ee1)
