### PR TITLE
broaden conditional for readonly filter chips

### DIFF
--- a/web-common/src/features/dashboards/filters/FilterChipsReadOnly.svelte
+++ b/web-common/src/features/dashboards/filters/FilterChipsReadOnly.svelte
@@ -54,7 +54,7 @@ The main feature-set component for dashboard filters
     {#each dimensionFilters as { name, label, selectedValues, isInclude } (name)}
       {@const dimension = dimensions.find((d) => d.name === name)}
       <div animate:flip={{ duration: 200 }}>
-        {#if dimension?.column}
+        {#if dimension?.column || dimension?.expression}
           <DimensionFilterReadOnlyChip
             label={label ?? name}
             values={selectedValues}


### PR DESCRIPTION
Dimensions do not necessarily always have a `column` property and may sometimes, instead, have `expression`. I believe we could safely remove this conditional entirely, though it may have been included for a reason I'm not aware of.