### PR TITLE
Fix: Explicitly load the Snowflake `database/sql` driver

### DIFF
--- a/runtime/drivers/snowflake/snowflake.go
+++ b/runtime/drivers/snowflake/snowflake.go
@@ -8,6 +8,9 @@ import (
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/pkg/activity"
 	"go.uber.org/zap"
+
+	// Load database/sql driver
+	_ "github.com/snowflakedb/gosnowflake"
 )
 
 func init() {


### PR DESCRIPTION
Seems like previously it was loaded "by accident" through an unrelated import of the package.
