### PR TITLE
Rill Developer: Add option to generate an Explore Dashboard from Sources, Models, and Tables

### DIFF
--- a/web-common/src/features/canvas/AddComponentMenu.svelte
+++ b/web-common/src/features/canvas/AddComponentMenu.svelte
@@ -30,11 +30,11 @@
       .map((c) => c.meta?.name?.name ?? "") ?? [];
 
   async function handleAddComponent() {
-    const newRoute = await handleEntityCreate(ResourceKind.Component);
+    const newFilePath = await handleEntityCreate(ResourceKind.Component);
 
-    if (!newRoute) return;
+    if (!newFilePath) return;
 
-    const componentName = getNameFromFile(newRoute);
+    const componentName = getNameFromFile(newFilePath);
 
     if (componentName) {
       addComponent(componentName);

--- a/web-common/src/features/connectors/olap/TableMenuItems.svelte
+++ b/web-common/src/features/connectors/olap/TableMenuItems.svelte
@@ -11,6 +11,7 @@
   } from "@rilldata/web-common/metrics/service/MetricsTypes";
   import { useQueryClient } from "@tanstack/svelte-query";
   import { WandIcon } from "lucide-svelte";
+  import ExploreIcon from "../../../components/icons/ExploreIcon.svelte";
   import MetricsViewIcon from "../../../components/icons/MetricsViewIcon.svelte";
   import { runtime } from "../../../runtime-client/runtime-store";
   import { featureFlags } from "../../feature-flags";
@@ -37,6 +38,16 @@
     databaseSchema,
     table,
     false,
+    BehaviourEventMedium.Menu,
+    MetricsEventSpace.LeftPanel,
+  );
+  $: createExploreFromTable = useCreateMetricsViewFromTableUIAction(
+    $runtime.instanceId,
+    connector,
+    database,
+    databaseSchema,
+    table,
+    true,
     BehaviourEventMedium.Menu,
     MetricsEventSpace.LeftPanel,
   );
@@ -76,6 +87,17 @@
   <MetricsViewIcon slot="icon" />
   <div class="flex gap-x-2 items-center">
     Generate metrics
+    {#if $ai}
+      with AI
+      <WandIcon class="w-3 h-3" />
+    {/if}
+  </div>
+</NavigationMenuItem>
+
+<NavigationMenuItem on:click={createExploreFromTable}>
+  <ExploreIcon slot="icon" />
+  <div class="flex gap-x-2 items-center">
+    Generate dashboard
     {#if $ai}
       with AI
       <WandIcon class="w-3 h-3" />

--- a/web-common/src/features/connectors/olap/TableMenuItems.svelte
+++ b/web-common/src/features/connectors/olap/TableMenuItems.svelte
@@ -36,7 +36,7 @@
     database,
     databaseSchema,
     table,
-    "metrics",
+    false,
     BehaviourEventMedium.Menu,
     MetricsEventSpace.LeftPanel,
   );

--- a/web-common/src/features/connectors/olap/TableWorkspaceHeader.svelte
+++ b/web-common/src/features/connectors/olap/TableWorkspaceHeader.svelte
@@ -27,7 +27,7 @@
     database,
     databaseSchema,
     table,
-    "metrics",
+    false,
     BehaviourEventMedium.Button,
     MetricsEventSpace.RightPanel,
   );

--- a/web-common/src/features/entity-management/AddAssetButton.svelte
+++ b/web-common/src/features/entity-management/AddAssetButton.svelte
@@ -59,7 +59,7 @@
   async function wrapNavigation(toPath: string | undefined) {
     if (!toPath) return;
     const previousScreenName = getScreenNameFromPage();
-    await goto(toPath);
+    await goto(`/files${toPath}`);
     await behaviourEvent?.fireSourceTriggerEvent(
       BehaviourEventAction.Navigate,
       BehaviourEventMedium.Button,
@@ -86,24 +86,24 @@
    * Put an example Model file in the `models` directory
    */
   async function handleAddModel() {
-    const newRoute = await handleEntityCreate(ResourceKind.Model);
-    await wrapNavigation(newRoute);
+    const newFilePath = await handleEntityCreate(ResourceKind.Model);
+    await wrapNavigation(newFilePath);
   }
 
   /**
    * Put an example Metrics View file in the `metrics_views` directory
    */
   async function handleAddMetricsView() {
-    const newRoute = await handleEntityCreate(ResourceKind.MetricsView);
-    await wrapNavigation(newRoute);
+    const newFilePath = await handleEntityCreate(ResourceKind.MetricsView);
+    await wrapNavigation(newFilePath);
   }
 
   /**
    * Put an example Explore file in the `explores` directory
    */
   async function handleAddExplore() {
-    const newRoute = await handleEntityCreate(ResourceKind.Explore);
-    await wrapNavigation(newRoute);
+    const newFilePath = await handleEntityCreate(ResourceKind.Explore);
+    await wrapNavigation(newFilePath);
   }
 
   /**
@@ -162,48 +162,48 @@
    * Put an example API file in the `apis` directory
    */
   async function handleAddAPI() {
-    const newRoute = await handleEntityCreate(ResourceKind.API);
-    if (newRoute) await goto(newRoute);
+    const newFilePath = await handleEntityCreate(ResourceKind.API);
+    await wrapNavigation(newFilePath);
   }
 
   /**
    * Put an example Chart file in the `charts` directory
    */
   async function handleAddComponent() {
-    const newRoute = await handleEntityCreate(ResourceKind.Component);
-    await wrapNavigation(newRoute);
+    const newFilePath = await handleEntityCreate(ResourceKind.Component);
+    await wrapNavigation(newFilePath);
   }
 
   /**
    * Put an example Canvas file in the `canvas` directory
    */
   async function handleAddCanvasDashboard() {
-    const newRoute = await handleEntityCreate(ResourceKind.Canvas);
-    await wrapNavigation(newRoute);
+    const newFilePath = await handleEntityCreate(ResourceKind.Canvas);
+    await wrapNavigation(newFilePath);
   }
 
   /**
    * Put an example Theme file in the `themes` directory
    */
   async function handleAddTheme() {
-    const newRoute = await handleEntityCreate(ResourceKind.Theme);
-    await wrapNavigation(newRoute);
+    const newFilePath = await handleEntityCreate(ResourceKind.Theme);
+    await wrapNavigation(newFilePath);
   }
 
   /**
    * Put an example Report file in the `reports` directory
    */
   // async function handleAddReport() {
-  //   const newRoute = await handleEntityCreate(ResourceKind.Report);
-  //   if (newRoute) await goto(newRoute);
+  //   const newFilePath = await handleEntityCreate(ResourceKind.Report);
+  //   if (newFilePath) await goto(newFilePath);
   // }
 
   /**
    * Put an example Alert file in the `alerts` directory
    */
   // async function handleAddAlert() {
-  //   const newRoute = await handleEntityCreate(ResourceKind.Alert);
-  //   if (newRoute) await goto(newRoute);
+  //   const newFilePath = await handleEntityCreate(ResourceKind.Alert);
+  //   if (newFilePath) await goto(newFilePath);
   // }
 </script>
 

--- a/web-common/src/features/file-explorer/new-files.ts
+++ b/web-common/src/features/file-explorer/new-files.ts
@@ -28,7 +28,7 @@ export async function handleEntityCreate(
   });
 
   // Return the path to the new file, so we can navigate the user to it
-  return `/files/${newPath}`;
+  return `/${newPath}`;
 }
 
 export function getPathForNewResourceFile(

--- a/web-common/src/features/metrics-views/GoToDashboardButton.svelte
+++ b/web-common/src/features/metrics-views/GoToDashboardButton.svelte
@@ -23,9 +23,12 @@
   $: dashboards = $dashboardsQuery.data ?? [];
 
   async function handleCreateDashboard() {
-    const newRoute = await handleEntityCreate(ResourceKind.Explore, resource);
-    if (newRoute) {
-      await goto(newRoute);
+    const newFilePath = await handleEntityCreate(
+      ResourceKind.Explore,
+      resource,
+    );
+    if (newFilePath) {
+      await goto(`/files/${newFilePath}`);
     }
   }
 </script>

--- a/web-common/src/features/metrics-views/ai-generation/generateMetricsView.ts
+++ b/web-common/src/features/metrics-views/ai-generation/generateMetricsView.ts
@@ -5,6 +5,8 @@ import { getScreenNameFromPage } from "@rilldata/web-common/features/file-explor
 import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
 import { get } from "svelte/store";
 import { overlay } from "../../../layout/overlay-store";
+import { queryClient } from "../../../lib/svelte-query/globalQueryClient";
+import { waitUntil } from "../../../lib/waitUtils";
 import { behaviourEvent } from "../../../metrics/initMetrics";
 import type { BehaviourEventMedium } from "../../../metrics/service/BehaviourEventTypes";
 import {
@@ -20,6 +22,7 @@ import {
 import httpClient from "../../../runtime-client/http-client";
 import { getName } from "../../entity-management/name-utils";
 import { featureFlags } from "../../feature-flags";
+import { handleEntityCreate } from "../../file-explorer/new-files";
 import OptionToCancelAIGeneration from "./OptionToCancelAIGeneration.svelte";
 
 /**
@@ -52,7 +55,7 @@ export function useCreateMetricsViewFromTableUIAction(
   database: string,
   databaseSchema: string,
   tableName: string,
-  folder: string,
+  createExplore: boolean,
   behaviourEventMedium: BehaviourEventMedium,
   metricsEventSpace: MetricsEventSpace,
 ) {
@@ -64,7 +67,7 @@ export function useCreateMetricsViewFromTableUIAction(
     const abortController = new AbortController();
 
     overlay.set({
-      title: `Hang tight! ${isAiEnabled ? "AI is" : "We're"} personalizing your dashboard`,
+      title: `Hang tight! ${isAiEnabled ? "AI is" : "We're"} personalizing your ${createExplore ? "dashboard" : "metrics"}`,
       detail: {
         component: OptionToCancelAIGeneration,
         props: {
@@ -77,11 +80,11 @@ export function useCreateMetricsViewFromTableUIAction(
     });
 
     // Get a unique name
-    const newDashboardName = getName(
+    const newMetricsViewName = getName(
       `${tableName}_metrics`,
       fileArtifacts.getNamesForKind(ResourceKind.MetricsView),
     );
-    const newFilePath = `/${folder}/${newDashboardName}.yaml`;
+    const newMetricsViewFilePath = `/metrics/${newMetricsViewName}.yaml`;
 
     try {
       // First, request an AI-generated dashboard
@@ -92,7 +95,7 @@ export function useCreateMetricsViewFromTableUIAction(
           database: database,
           databaseSchema: databaseSchema,
           table: tableName,
-          path: newFilePath,
+          path: newMetricsViewFilePath,
           useAi: isAiEnabled, // AI isn't enabled during e2e tests
         },
         abortController.signal,
@@ -103,7 +106,9 @@ export function useCreateMetricsViewFromTableUIAction(
         await new Promise((resolve) => setTimeout(resolve, 1000));
 
         try {
-          await runtimeServiceGetFile(instanceId, { path: newFilePath });
+          await runtimeServiceGetFile(instanceId, {
+            path: newMetricsViewFilePath,
+          });
           // success, AI is done
           break;
         } catch {
@@ -118,21 +123,59 @@ export function useCreateMetricsViewFromTableUIAction(
           database: database,
           databaseSchema: databaseSchema,
           table: tableName,
-          path: newFilePath,
+          path: newMetricsViewFilePath,
           useAi: false,
         });
       }
 
-      // Preview
       const previousScreenName = getScreenNameFromPage();
-      await goto(`/files${newFilePath}`);
-      void behaviourEvent.fireNavigationEvent(
-        newDashboardName,
-        behaviourEventMedium,
-        metricsEventSpace,
-        previousScreenName,
-        MetricsEventScreenName.Dashboard,
-      );
+
+      if (createExplore) {
+        // Get the Metrics View to use as a base for the Explore
+        const metricsViewResource = fileArtifacts
+          .getFileArtifact(newMetricsViewFilePath)
+          .getResource(queryClient, instanceId);
+
+        // Create the Explore file
+        const newExploreFilePath = await handleEntityCreate(
+          ResourceKind.Explore,
+          get(metricsViewResource)?.data,
+        );
+        if (!newExploreFilePath) {
+          throw new Error("Failed to create an Explore file");
+        }
+
+        // Wait until the Explore is ready
+        const exploreResource = fileArtifacts
+          .getFileArtifact(newExploreFilePath)
+          .getResource(queryClient, instanceId);
+        await waitUntil(
+          () => get(exploreResource)?.data?.meta?.name?.name !== undefined,
+        );
+
+        // Navigate to the Explore Preview
+        const newExploreName = get(exploreResource)?.data?.meta?.name?.name;
+        if (!newExploreName) {
+          throw new Error("Failed to create an Explore resource");
+        }
+        await goto(`/explore/${newExploreName}`);
+        void behaviourEvent.fireNavigationEvent(
+          newExploreName,
+          behaviourEventMedium,
+          metricsEventSpace,
+          previousScreenName,
+          MetricsEventScreenName.Dashboard,
+        );
+      } else {
+        await goto(`/files${newMetricsViewFilePath}`);
+        void behaviourEvent.fireNavigationEvent(
+          newMetricsViewName,
+          behaviourEventMedium,
+          metricsEventSpace,
+          previousScreenName,
+          MetricsEventScreenName.MetricsDefinition,
+        );
+      }
     } catch (err) {
       eventBus.emit("notification", {
         message: "Failed to create a dashboard for " + tableName,

--- a/web-common/src/features/metrics-views/ai-generation/generateMetricsView.ts
+++ b/web-common/src/features/metrics-views/ai-generation/generateMetricsView.ts
@@ -178,7 +178,9 @@ export function useCreateMetricsViewFromTableUIAction(
       }
     } catch (err) {
       eventBus.emit("notification", {
-        message: "Failed to create a dashboard for " + tableName,
+        message:
+          `Failed to create ${createExplore ? "a dashboard" : "metrics"} for ` +
+          tableName,
         detail: err.response?.data?.message ?? err.message,
       });
     }

--- a/web-common/src/features/models/navigation/ModelMenuItems.svelte
+++ b/web-common/src/features/models/navigation/ModelMenuItems.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import Explore from "@rilldata/web-common/components/icons/Explore.svelte";
   import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts";
   import { featureFlags } from "@rilldata/web-common/features/feature-flags";
   import NavigationMenuItem from "@rilldata/web-common/layout/navigation/NavigationMenuItem.svelte";
@@ -7,22 +6,17 @@
   import { MetricsEventSpace } from "@rilldata/web-common/metrics/service/MetricsTypes";
   import { useQueryClient } from "@tanstack/svelte-query";
   import { WandIcon } from "lucide-svelte";
-  import { createEventDispatcher } from "svelte";
   import MetricsViewIcon from "../../../components/icons/MetricsViewIcon.svelte";
   import { V1ReconcileStatus } from "../../../runtime-client";
   import { runtime } from "../../../runtime-client/runtime-store";
   import { useCreateMetricsViewFromTableUIAction } from "../../metrics-views/ai-generation/generateMetricsView";
 
+  const { ai } = featureFlags;
+  const queryClient = useQueryClient();
+
   export let filePath: string;
 
-  const { ai } = featureFlags;
-
   $: fileArtifact = fileArtifacts.getFileArtifact(filePath);
-
-  const queryClient = useQueryClient();
-  const dispatch = createEventDispatcher();
-
-  const { customDashboards } = featureFlags;
 
   $: modelHasError = fileArtifact.getHasErrors(
     queryClient,
@@ -68,30 +62,3 @@
     {/if}
   </svelte:fragment>
 </NavigationMenuItem>
-{#if $customDashboards}
-  <NavigationMenuItem
-    disabled={disableCreateDashboard}
-    on:click={() => {
-      dispatch("generate-chart", {
-        table: $modelQuery.data?.model?.state?.resultTable,
-        connector: $modelQuery.data?.model?.state?.resultConnector,
-      });
-    }}
-  >
-    <Explore slot="icon" />
-    <div class="flex gap-x-2 items-center">
-      Generate Chart
-      {#if $ai}
-        with AI
-        <WandIcon class="w-3 h-3" />
-      {/if}
-    </div>
-    <svelte:fragment slot="description">
-      {#if $modelHasError}
-        Model has errors
-      {:else if !modelIsIdle}
-        Dependencies are being reconciled.
-      {/if}
-    </svelte:fragment>
-  </NavigationMenuItem>
-{/if}

--- a/web-common/src/features/models/navigation/ModelMenuItems.svelte
+++ b/web-common/src/features/models/navigation/ModelMenuItems.svelte
@@ -42,7 +42,7 @@
     MetricsEventSpace.LeftPanel,
   );
 
-  $: createExploreDashboardFromTable = useCreateMetricsViewFromTableUIAction(
+  $: createExploreFromTable = useCreateMetricsViewFromTableUIAction(
     $runtime.instanceId,
     connector as string,
     "",
@@ -77,7 +77,7 @@
 
 <NavigationMenuItem
   disabled={disableCreateDashboard}
-  on:click={createExploreDashboardFromTable}
+  on:click={createExploreFromTable}
 >
   <ExploreIcon slot="icon" />
   <div class="flex gap-x-2 items-center">

--- a/web-common/src/features/models/navigation/ModelMenuItems.svelte
+++ b/web-common/src/features/models/navigation/ModelMenuItems.svelte
@@ -6,6 +6,7 @@
   import { MetricsEventSpace } from "@rilldata/web-common/metrics/service/MetricsTypes";
   import { useQueryClient } from "@tanstack/svelte-query";
   import { WandIcon } from "lucide-svelte";
+  import ExploreIcon from "../../../components/icons/ExploreIcon.svelte";
   import MetricsViewIcon from "../../../components/icons/MetricsViewIcon.svelte";
   import { V1ReconcileStatus } from "../../../runtime-client";
   import { runtime } from "../../../runtime-client/runtime-store";
@@ -40,6 +41,17 @@
     BehaviourEventMedium.Menu,
     MetricsEventSpace.LeftPanel,
   );
+
+  $: createExploreDashboardFromTable = useCreateMetricsViewFromTableUIAction(
+    $runtime.instanceId,
+    connector as string,
+    "",
+    "",
+    tableName,
+    true,
+    BehaviourEventMedium.Menu,
+    MetricsEventSpace.LeftPanel,
+  );
 </script>
 
 <NavigationMenuItem
@@ -49,6 +61,27 @@
   <MetricsViewIcon slot="icon" />
   <div class="flex gap-x-2 items-center">
     Generate metrics
+    {#if $ai}
+      with AI
+      <WandIcon class="w-3 h-3" />
+    {/if}
+  </div>
+  <svelte:fragment slot="description">
+    {#if $modelHasError}
+      Model has errors
+    {:else if !modelIsIdle}
+      Dependencies are being reconciled.
+    {/if}
+  </svelte:fragment>
+</NavigationMenuItem>
+
+<NavigationMenuItem
+  disabled={disableCreateDashboard}
+  on:click={createExploreDashboardFromTable}
+>
+  <ExploreIcon slot="icon" />
+  <div class="flex gap-x-2 items-center">
+    Generate dashboard
     {#if $ai}
       with AI
       <WandIcon class="w-3 h-3" />

--- a/web-common/src/features/models/navigation/ModelMenuItems.svelte
+++ b/web-common/src/features/models/navigation/ModelMenuItems.svelte
@@ -42,7 +42,7 @@
     "",
     "",
     tableName,
-    "metrics",
+    false,
     BehaviourEventMedium.Menu,
     MetricsEventSpace.LeftPanel,
   );

--- a/web-common/src/features/models/workspace/CreateDashboardButton.svelte
+++ b/web-common/src/features/models/workspace/CreateDashboardButton.svelte
@@ -31,7 +31,7 @@
     "",
     "",
     modelName,
-    "metrics",
+    false,
     BehaviourEventMedium.Button,
     MetricsEventSpace.RightPanel,
   );

--- a/web-common/src/features/sources/modal/SourceImportedModal.svelte
+++ b/web-common/src/features/sources/modal/SourceImportedModal.svelte
@@ -35,7 +35,7 @@
   }
   $: sinkConnector = $sourceQuery?.data?.source?.spec?.sinkConnector;
 
-  $: createMetricsViewFromTable =
+  $: createExploreFromTable =
     sourcePath !== null
       ? useCreateMetricsViewFromTableUIAction(
           $runtime.instanceId,
@@ -62,9 +62,9 @@
     // This should never happen, because the button is
     // disabled when this is null, but adding this check
     // for type narrowing and just in case.
-    if (createMetricsViewFromTable === null) return;
+    if (createExploreFromTable === null) return;
     close();
-    await createMetricsViewFromTable();
+    await createExploreFromTable();
   }
 </script>
 
@@ -92,7 +92,7 @@
 
         <Button
           builders={[builder]}
-          disabled={createMetricsViewFromTable === null}
+          disabled={createExploreFromTable === null}
           on:click={generateMetrics}
           type="primary"
         >

--- a/web-common/src/features/sources/modal/SourceImportedModal.svelte
+++ b/web-common/src/features/sources/modal/SourceImportedModal.svelte
@@ -43,7 +43,7 @@
           "",
           "",
           sourceName,
-          "metrics",
+          true,
           BehaviourEventMedium.Button,
           MetricsEventSpace.Modal,
         )
@@ -96,7 +96,7 @@
           on:click={generateMetrics}
           type="primary"
         >
-          Generate metrics
+          Generate dashboard
 
           {#if $ai}
             with AI

--- a/web-common/src/features/sources/navigation/SourceMenuItems.svelte
+++ b/web-common/src/features/sources/navigation/SourceMenuItems.svelte
@@ -69,7 +69,7 @@
     MetricsEventSpace.LeftPanel,
   );
 
-  $: createExploreDashboardFromTable = useCreateMetricsViewFromTableUIAction(
+  $: createExploreFromTable = useCreateMetricsViewFromTableUIAction(
     $runtime.instanceId,
     sinkConnector as string,
     database,
@@ -164,7 +164,7 @@
 </NavigationMenuItem>
 <NavigationMenuItem
   disabled={disableCreateDashboard}
-  on:click={createExploreDashboardFromTable}
+  on:click={createExploreFromTable}
 >
   <ExploreIcon slot="icon" />
   <div class="flex gap-x-2 items-center">

--- a/web-common/src/features/sources/navigation/SourceMenuItems.svelte
+++ b/web-common/src/features/sources/navigation/SourceMenuItems.svelte
@@ -67,7 +67,7 @@
     "",
     "",
     tableName,
-    "metrics",
+    false,
     BehaviourEventMedium.Menu,
     MetricsEventSpace.LeftPanel,
   );

--- a/web-common/src/features/sources/navigation/SourceMenuItems.svelte
+++ b/web-common/src/features/sources/navigation/SourceMenuItems.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
+  import ExploreIcon from "@rilldata/web-common/components/icons/ExploreIcon.svelte";
   import Import from "@rilldata/web-common/components/icons/Import.svelte";
   import Model from "@rilldata/web-common/components/icons/Model.svelte";
   import RefreshIcon from "@rilldata/web-common/components/icons/RefreshIcon.svelte";
@@ -64,6 +65,17 @@
     databaseSchema,
     tableName,
     false,
+    BehaviourEventMedium.Menu,
+    MetricsEventSpace.LeftPanel,
+  );
+
+  $: createExploreDashboardFromTable = useCreateMetricsViewFromTableUIAction(
+    $runtime.instanceId,
+    sinkConnector as string,
+    database,
+    databaseSchema,
+    tableName,
+    true,
     BehaviourEventMedium.Menu,
     MetricsEventSpace.LeftPanel,
   );
@@ -137,6 +149,26 @@
   <MetricsViewIcon slot="icon" />
   <div class="flex gap-x-2 items-center">
     Generate metrics
+    {#if $ai}
+      with AI
+      <WandIcon class="w-3 h-3" />
+    {/if}
+  </div>
+  <svelte:fragment slot="description">
+    {#if $sourceHasError}
+      Source has errors
+    {:else if !sourceIsIdle}
+      Source is being ingested
+    {/if}
+  </svelte:fragment>
+</NavigationMenuItem>
+<NavigationMenuItem
+  disabled={disableCreateDashboard}
+  on:click={createExploreDashboardFromTable}
+>
+  <ExploreIcon slot="icon" />
+  <div class="flex gap-x-2 items-center">
+    Generate dashboard
     {#if $ai}
       with AI
       <WandIcon class="w-3 h-3" />

--- a/web-common/src/features/sources/navigation/SourceMenuItems.svelte
+++ b/web-common/src/features/sources/navigation/SourceMenuItems.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
-  import Explore from "@rilldata/web-common/components/icons/Explore.svelte";
   import Import from "@rilldata/web-common/components/icons/Import.svelte";
   import Model from "@rilldata/web-common/components/icons/Model.svelte";
   import RefreshIcon from "@rilldata/web-common/components/icons/RefreshIcon.svelte";
@@ -23,7 +22,6 @@
   import { V1ReconcileStatus } from "@rilldata/web-common/runtime-client";
   import { useQueryClient } from "@tanstack/svelte-query";
   import { WandIcon } from "lucide-svelte";
-  import { createEventDispatcher } from "svelte";
   import MetricsViewIcon from "../../../components/icons/MetricsViewIcon.svelte";
   import { runtime } from "../../../runtime-client/runtime-store";
   import { createModelFromTable } from "../../connectors/olap/createModel";
@@ -41,9 +39,7 @@
 
   $: runtimeInstanceId = $runtime.instanceId;
 
-  const dispatch = createEventDispatcher();
-
-  const { customDashboards, ai } = featureFlags;
+  const { ai } = featureFlags;
 
   $: sourceQuery = fileArtifact.getResource(queryClient, runtimeInstanceId);
   let source: V1SourceV2 | undefined;
@@ -64,8 +60,8 @@
   $: createMetricsViewFromTable = useCreateMetricsViewFromTableUIAction(
     $runtime.instanceId,
     sinkConnector as string,
-    "",
-    "",
+    database,
+    databaseSchema,
     tableName,
     false,
     BehaviourEventMedium.Menu,
@@ -154,30 +150,6 @@
     {/if}
   </svelte:fragment>
 </NavigationMenuItem>
-{#if $customDashboards}
-  <NavigationMenuItem
-    disabled={disableCreateDashboard}
-    on:click={() => {
-      dispatch("generate-chart", {
-        table: source?.state?.table,
-        connector: source?.state?.connector,
-      });
-    }}
-  >
-    <Explore slot="icon" />
-    <div class="flex gap-x-2 items-center">
-      Generate chart with AI
-      <WandIcon class="w-3 h-3" />
-    </div>
-    <svelte:fragment slot="description">
-      {#if $sourceHasError}
-        Source has errors
-      {:else if !sourceIsIdle}
-        Source is being ingested
-      {/if}
-    </svelte:fragment>
-  </NavigationMenuItem>
-{/if}
 
 <NavigationMenuItem on:click={onRefreshSource}>
   <RefreshIcon slot="icon" />

--- a/web-local/src/routes/(application)/+layout.svelte
+++ b/web-local/src/routes/(application)/+layout.svelte
@@ -4,9 +4,7 @@
   import FileDrop from "@rilldata/web-common/features/sources/modal/FileDrop.svelte";
   import SourceImportedModal from "@rilldata/web-common/features/sources/modal/SourceImportedModal.svelte";
   import { sourceImportedPath } from "@rilldata/web-common/features/sources/sources-store";
-  import BlockingOverlayContainer from "@rilldata/web-common/layout/BlockingOverlayContainer.svelte";
   import Navigation from "@rilldata/web-common/layout/navigation/Navigation.svelte";
-  import { overlay } from "@rilldata/web-common/layout/overlay-store";
 
   let showDropOverlay = false;
 
@@ -41,22 +39,6 @@
 
 {#if showDropOverlay}
   <FileDrop bind:showDropOverlay />
-{:else if $overlay !== null}
-  <BlockingOverlayContainer
-    bg="linear-gradient(to right, rgba(0,0,0,.6), rgba(0,0,0,.8))"
-  >
-    <div slot="title" class="font-bold">
-      {$overlay?.title}
-    </div>
-    <svelte:fragment slot="detail">
-      {#if $overlay?.detail}
-        <svelte:component
-          this={$overlay.detail.component}
-          {...$overlay.detail.props}
-        />
-      {/if}
-    </svelte:fragment>
-  </BlockingOverlayContainer>
 {/if}
 
 <AddDataModal />

--- a/web-local/src/routes/+layout.svelte
+++ b/web-local/src/routes/+layout.svelte
@@ -1,23 +1,27 @@
 <script lang="ts">
+  import BannerCenter from "@rilldata/web-common/components/banner/BannerCenter.svelte";
+  import NotificationCenter from "@rilldata/web-common/components/notifications/NotificationCenter.svelte";
+  import RepresentingUserBanner from "@rilldata/web-common/features/authentication/RepresentingUserBanner.svelte";
+  import ResourceWatcher from "@rilldata/web-common/features/entity-management/ResourceWatcher.svelte";
+  import { featureFlags } from "@rilldata/web-common/features/feature-flags";
   import { initPylonWidget } from "@rilldata/web-common/features/help/initPylonWidget";
   import { RillTheme } from "@rilldata/web-common/layout";
-  import { featureFlags } from "@rilldata/web-common/features/feature-flags";
+  import BlockingOverlayContainer from "@rilldata/web-common/layout/BlockingOverlayContainer.svelte";
+  import type { ApplicationBuildMetadata } from "@rilldata/web-common/layout/build-metadata";
+  import { overlay } from "@rilldata/web-common/layout/overlay-store";
+  import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
+  import {
+    errorEventHandler,
+    initMetrics,
+  } from "@rilldata/web-common/metrics/initMetrics";
   import { localServiceGetMetadata } from "@rilldata/web-common/runtime-client/local-service";
+  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { initializeNodeStoreContexts } from "@rilldata/web-local/lib/application-state-stores/initialize-node-store-contexts";
-  import { errorEventHandler } from "@rilldata/web-common/metrics/initMetrics";
   import type { Query } from "@tanstack/query-core";
   import { QueryClientProvider } from "@tanstack/svelte-query";
   import type { AxiosError } from "axios";
-  import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
-  import type { ApplicationBuildMetadata } from "@rilldata/web-common/layout/build-metadata";
-  import { initMetrics } from "@rilldata/web-common/metrics/initMetrics";
   import { getContext, onMount } from "svelte";
   import type { Writable } from "svelte/store";
-  import ResourceWatcher from "@rilldata/web-common/features/entity-management/ResourceWatcher.svelte";
-  import NotificationCenter from "@rilldata/web-common/components/notifications/NotificationCenter.svelte";
-  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
-  import RepresentingUserBanner from "@rilldata/web-common/features/authentication/RepresentingUserBanner.svelte";
-  import BannerCenter from "@rilldata/web-common/components/banner/BannerCenter.svelte";
 
   /** This function will initialize the existing node stores and will connect them
    * to the Node server.
@@ -72,6 +76,24 @@
     </ResourceWatcher>
   </QueryClientProvider>
 </RillTheme>
+
+{#if $overlay !== null}
+  <BlockingOverlayContainer
+    bg="linear-gradient(to right, rgba(0,0,0,.6), rgba(0,0,0,.8))"
+  >
+    <div slot="title" class="font-bold">
+      {$overlay?.title}
+    </div>
+    <svelte:fragment slot="detail">
+      {#if $overlay?.detail}
+        <svelte:component
+          this={$overlay.detail.component}
+          {...$overlay.detail.props}
+        />
+      {/if}
+    </svelte:fragment>
+  </BlockingOverlayContainer>
+{/if}
 
 <NotificationCenter />
 


### PR DESCRIPTION
"Generate dashboard" is a new option for Sources & Models. It does the following:
1. Creates a Metrics View file (with AI)
2. Creates a basic Explore file that references the new Metrics View
3. Navigates to the Explore Preview

This "Generate dashboard" action now is available in:
- The modal that pops up when a new Source has been ingested
- A Source's context menu in the File Explorer
- A Model's context menu in the File Explorer
- A Table's context menu in the Connector Explorer

Additionally, this PR removes "Generate chart" from the Source & Model menu items. "Generate chart" should be exclusively offered on top of Metrics Views.