### PR TITLE
Azure: Fix panic from nil iterator being returned without an error

### DIFF
--- a/runtime/drivers/gcs/object_store.go
+++ b/runtime/drivers/gcs/object_store.go
@@ -84,8 +84,8 @@ func (c *Connection) DownloadFiles(ctx context.Context, props map[string]any) (d
 
 	iter, err := rillblob.NewIterator(ctx, bucketObj, opts, c.logger)
 	if err != nil {
-		apiError := &googleapi.Error{}
 		// in cases when no creds are passed
+		apiError := &googleapi.Error{}
 		if errors.As(err, &apiError) && apiError.Code == http.StatusUnauthorized {
 			return nil, drivers.NewPermissionDeniedError(fmt.Sprintf("can't access remote err: %v", apiError))
 		}
@@ -97,12 +97,8 @@ func (c *Connection) DownloadFiles(ctx context.Context, props map[string]any) (d
 			return nil, drivers.NewPermissionDeniedError(fmt.Sprintf("can't access remote err: %v", retrieveError))
 		}
 
-		anonIt, anonErr := rillblob.NewIterator(ctx, bucketObj, opts, c.logger)
-		if anonErr == nil {
-			iter = anonIt
-			err = nil
-		}
+		return nil, err
 	}
 
-	return iter, err
+	return iter, nil
 }

--- a/runtime/drivers/s3/object_store.go
+++ b/runtime/drivers/s3/object_store.go
@@ -160,15 +160,15 @@ func (c *Connection) DownloadFiles(ctx context.Context, src map[string]any) (dri
 
 			anonIt, anonErr := rillblob.NewIterator(ctx, bucketObj, opts, c.logger)
 			if anonErr == nil {
-				it = anonIt
-				err = nil
+				return anonIt, nil
 			}
 		}
 
 		// check again
-		if errors.As(err, &failureErr) && (failureErr.StatusCode() == http.StatusForbidden || failureErr.StatusCode() == http.StatusBadRequest) {
+		if failureErr.StatusCode() == http.StatusForbidden || failureErr.StatusCode() == http.StatusBadRequest {
 			return nil, drivers.NewPermissionDeniedError(fmt.Sprintf("can't access remote err: %v", failureErr))
 		}
+		return nil, err
 	}
 
 	return it, err


### PR DESCRIPTION
Fixes the issue raised by [this alert](https://rilldata.slack.com/archives/C05TXA7QSTY/p1727868844887949).