### PR TITLE
Fix two casing bugs in breadcrumbs

### DIFF
--- a/web-admin/src/features/embeds/TopNavigationBarEmbed.svelte
+++ b/web-admin/src/features/embeds/TopNavigationBarEmbed.svelte
@@ -46,8 +46,11 @@
   function onSelectResource(name: string) {
     // Because the breadcrumb only returns the identifying name, we need to look up the V1ResourceName (name + kind)
     const resource = visualizations?.find(
-      (listing) => listing.meta.name.name === name,
+      (listing) => listing.meta.name.name.toLowerCase() === name,
     );
+    if (!resource) {
+      throw new Error(`Resource not found: ${name}`);
+    }
     dispatch("select-resource", resource.meta.name);
   }
 </script>

--- a/web-common/src/components/navigation/breadcrumbs/BreadcrumbItem.svelte
+++ b/web-common/src/components/navigation/breadcrumbs/BreadcrumbItem.svelte
@@ -67,7 +67,7 @@
           class="min-w-44 max-h-96 overflow-y-auto"
         >
           {#each options as [id, option] (id)}
-            {@const selected = id === current}
+            {@const selected = id === current.toLowerCase()}
             <DropdownMenu.CheckboxItem
               class="cursor-pointer"
               checked={selected}


### PR DESCRIPTION
Addresses this [bug report in Slack](https://rilldata.slack.com/archives/CTZ8XBQ85/p1727874138762379).

(As an aside, at some point, we should merge the `TopNavigationBarEmbed` component into `TopNavigationBar`.) 