### PR TITLE
Fix (Autogenerate Explore): ensure Metrics View exists before proceeding with Explore generation

### DIFF
--- a/web-common/src/features/metrics-views/ai-generation/generateMetricsView.ts
+++ b/web-common/src/features/metrics-views/ai-generation/generateMetricsView.ts
@@ -87,7 +87,7 @@ export function useCreateMetricsViewFromTableUIAction(
     const newMetricsViewFilePath = `/metrics/${newMetricsViewName}.yaml`;
 
     try {
-      // First, request an AI-generated dashboard
+      // First, request an AI-generated metrics view
       void runtimeServiceGenerateMetricsViewFileWithSignal(
         instanceId,
         {
@@ -130,42 +130,8 @@ export function useCreateMetricsViewFromTableUIAction(
 
       const previousScreenName = getScreenNameFromPage();
 
-      if (createExplore) {
-        // Get the Metrics View to use as a base for the Explore
-        const metricsViewResource = fileArtifacts
-          .getFileArtifact(newMetricsViewFilePath)
-          .getResource(queryClient, instanceId);
-        await waitUntil(() => get(metricsViewResource).data !== undefined);
-
-        // Create the Explore file
-        const newExploreFilePath = await handleEntityCreate(
-          ResourceKind.Explore,
-          get(metricsViewResource).data,
-        );
-        if (!newExploreFilePath) {
-          throw new Error("Failed to create an Explore file");
-        }
-
-        // Wait until the Explore is ready
-        const exploreResource = fileArtifacts
-          .getFileArtifact(newExploreFilePath)
-          .getResource(queryClient, instanceId);
-        await waitUntil(() => get(exploreResource).data !== undefined);
-
-        // Navigate to the Explore Preview
-        const newExploreName = get(exploreResource).data?.meta?.name?.name;
-        if (!newExploreName) {
-          throw new Error("Failed to create an Explore resource");
-        }
-        await goto(`/explore/${newExploreName}`);
-        void behaviourEvent.fireNavigationEvent(
-          newExploreName,
-          behaviourEventMedium,
-          metricsEventSpace,
-          previousScreenName,
-          MetricsEventScreenName.Dashboard,
-        );
-      } else {
+      // If we're not creating an Explore, navigate to the Metrics View file
+      if (!createExplore) {
         await goto(`/files${newMetricsViewFilePath}`);
         void behaviourEvent.fireNavigationEvent(
           newMetricsViewName,
@@ -174,7 +140,59 @@ export function useCreateMetricsViewFromTableUIAction(
           previousScreenName,
           MetricsEventScreenName.MetricsDefinition,
         );
+        overlay.set(null);
+        return;
       }
+
+      // If we are creating an Explore...
+
+      // Get the Metrics View to use as a base for the Explore
+      const metricsViewResource = fileArtifacts
+        .getFileArtifact(newMetricsViewFilePath)
+        .getResource(queryClient, instanceId);
+      await waitUntil(() => get(metricsViewResource).data !== undefined);
+
+      // Create the Explore file
+      const newExploreFilePath = await handleEntityCreate(
+        ResourceKind.Explore,
+        undefined,
+      );
+      if (!newExploreFilePath) {
+        throw new Error("Failed to create an Explore file");
+      }
+
+      // Wait until the Explore is ready
+      const exploreFileArtifact =
+        fileArtifacts.getFileArtifact(newExploreFilePath);
+      const exploreResource = exploreFileArtifact.getResource(
+        queryClient,
+        instanceId,
+      );
+      await waitUntil(() => get(exploreResource).data !== undefined);
+      const newExploreName = get(exploreResource).data?.meta?.name?.name;
+      if (!newExploreName) {
+        throw new Error("Failed to create an Explore resource");
+      }
+
+      // Check if the Explore has errors
+      const hasErrors = exploreFileArtifact.getHasErrors(
+        queryClient,
+        instanceId,
+      );
+
+      // Navigate to the Explore workspace or to the Explore Preview
+      if (hasErrors) {
+        await goto(`/files${newExploreFilePath}`);
+      } else {
+        await goto(`/explore/${newExploreName}`);
+      }
+      void behaviourEvent.fireNavigationEvent(
+        newExploreName,
+        behaviourEventMedium,
+        metricsEventSpace,
+        previousScreenName,
+        MetricsEventScreenName.Explore,
+      );
     } catch (err) {
       eventBus.emit("notification", {
         message:

--- a/web-common/src/features/metrics-views/ai-generation/generateMetricsView.ts
+++ b/web-common/src/features/metrics-views/ai-generation/generateMetricsView.ts
@@ -135,11 +135,12 @@ export function useCreateMetricsViewFromTableUIAction(
         const metricsViewResource = fileArtifacts
           .getFileArtifact(newMetricsViewFilePath)
           .getResource(queryClient, instanceId);
+        await waitUntil(() => get(metricsViewResource).data !== undefined);
 
         // Create the Explore file
         const newExploreFilePath = await handleEntityCreate(
           ResourceKind.Explore,
-          get(metricsViewResource)?.data,
+          get(metricsViewResource).data,
         );
         if (!newExploreFilePath) {
           throw new Error("Failed to create an Explore file");
@@ -149,12 +150,10 @@ export function useCreateMetricsViewFromTableUIAction(
         const exploreResource = fileArtifacts
           .getFileArtifact(newExploreFilePath)
           .getResource(queryClient, instanceId);
-        await waitUntil(
-          () => get(exploreResource)?.data?.meta?.name?.name !== undefined,
-        );
+        await waitUntil(() => get(exploreResource).data !== undefined);
 
         // Navigate to the Explore Preview
-        const newExploreName = get(exploreResource)?.data?.meta?.name?.name;
+        const newExploreName = get(exploreResource).data?.meta?.name?.name;
         if (!newExploreName) {
           throw new Error("Failed to create an Explore resource");
         }


### PR DESCRIPTION
- Wait for the Metrics View resource before proceeding with generating an Explore
- If the resultant Explore file has an error, navigate to the Explore editor rather than the Explore preview