### PR TITLE
Fix (Embeds): two navigation bugs due to the MetricsView-Explore split

### DIFF
--- a/web-admin/src/features/embeds/TopNavigationBarEmbed.svelte
+++ b/web-admin/src/features/embeds/TopNavigationBarEmbed.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import BreadcrumbItem from "@rilldata/web-common/components/navigation/breadcrumbs/BreadcrumbItem.svelte";
-  import { useValidVisualizations } from "@rilldata/web-common/features/dashboards/selectors";
+  import { useValidDashboards } from "@rilldata/web-common/features/dashboards/selectors";
   import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
   import type {
     V1Resource,
@@ -21,23 +21,23 @@
     activeResource.kind === ResourceKind.MetricsView.toString();
 
   // Dashboard breadcrumb
-  $: visualizationsQuery = useValidVisualizations(instanceId);
-  $: ({ data: visualizations } = $visualizationsQuery);
+  $: dashboardsQuery = useValidDashboards(instanceId);
+  $: ({ data: dashboards } = $dashboardsQuery);
   let currentResource: V1Resource;
-  $: currentResource = visualizations?.find(
+  $: currentResource = dashboards?.find(
     (listing) => listing.meta.name.name === activeResource?.name,
   );
   $: currentResourceName = currentResource?.meta?.name?.name;
 
-  $: breadcrumbOptions = visualizations?.reduce(
-    (map, { meta, metricsView, canvas }) => {
+  $: breadcrumbOptions = dashboards?.reduce(
+    (map, { meta, explore, canvas }) => {
       const name = meta.name.name;
-      const isMetricsExplorer = !!metricsView;
+      const isExplore = !!explore;
       return map.set(name.toLowerCase(), {
         label:
-          (isMetricsExplorer
-            ? metricsView?.state?.validSpec?.title
-            : canvas?.spec?.title) || name,
+          (isExplore
+            ? explore?.state?.validSpec?.title
+            : canvas?.state?.validSpec?.title) || name,
       });
     },
     new Map(),
@@ -45,7 +45,7 @@
 
   function onSelectResource(name: string) {
     // Because the breadcrumb only returns the identifying name, we need to look up the V1ResourceName (name + kind)
-    const resource = visualizations?.find(
+    const resource = dashboards?.find(
       (listing) => listing.meta.name.name.toLowerCase() === name,
     );
     if (!resource) {

--- a/web-admin/src/routes/-/embed/+page.svelte
+++ b/web-admin/src/routes/-/embed/+page.svelte
@@ -54,17 +54,19 @@
 
   {#if !activeResource}
     <ContentContainer>
-      <div class="flex flex-col items-center">
+      <div class="flex flex-col items-center gap-y-4">
         <DashboardsTable isEmbedded on:select-resource={handleSelectResource} />
       </div>
     </ContentContainer>
   {/if}
 {/if}
 
-{#if activeResource?.kind === ResourceKind.Explore.toString()}
-  <ExploreEmbed {instanceId} exploreName={activeResource.name} />
-{:else if activeResource?.kind === ResourceKind.Canvas.toString()}
-  <CanvasEmbed {instanceId} canvasName={activeResource.name} />
-{:else}
-  <UnsupportedKind />
+{#if activeResource}
+  {#if activeResource?.kind === ResourceKind.Explore.toString()}
+    <ExploreEmbed {instanceId} exploreName={activeResource.name} />
+  {:else if activeResource?.kind === ResourceKind.Canvas.toString()}
+    <CanvasEmbed {instanceId} canvasName={activeResource.name} />
+  {:else}
+    <UnsupportedKind />
+  {/if}
 {/if}

--- a/web-common/src/features/dashboards/selectors.ts
+++ b/web-common/src/features/dashboards/selectors.ts
@@ -64,7 +64,7 @@ export function useValidDashboards(instanceId: string) {
           // Filter for valid Explores and Canvases
           return data?.resources?.filter(
             (res) =>
-              !!res.explore?.state?.validSpec || res.canvas?.state?.validSpec,
+              !!res.explore?.state?.validSpec || !!res.canvas?.state?.validSpec,
           );
         },
       },

--- a/web-common/src/features/dashboards/selectors.ts
+++ b/web-common/src/features/dashboards/selectors.ts
@@ -10,8 +10,8 @@ import type {
   V1Expression,
   V1GetResourceResponse,
   V1MetricsViewSpec,
-  V1Resource,
   V1MetricsViewTimeRangeResponse,
+  V1Resource,
 } from "@rilldata/web-common/runtime-client";
 import {
   createQueryServiceMetricsViewTimeRange,
@@ -54,16 +54,17 @@ export function useValidCanvases(instanceId: string) {
   );
 }
 
-export function useValidVisualizations(instanceId: string) {
+export function useValidDashboards(instanceId: string) {
   return createRuntimeServiceListResources(
     instanceId,
     undefined, // TODO: it'd be nice if we could provide multiple kinds here
     {
       query: {
         select: (data) => {
-          // Filter for valid Metrics Explorers and all Custom Dashboards (which don't yet have a valid/invalid state)
+          // Filter for valid Explores and Canvases
           return data?.resources?.filter(
-            (res) => !!res.metricsView?.state?.validSpec || res.canvas,
+            (res) =>
+              !!res.explore?.state?.validSpec || res.canvas?.state?.validSpec,
           );
         },
       },


### PR DESCRIPTION
This PR solves two bugs for embeds with `navigation: true`:
1. List Explores not Metrics Views in the breadcrumb's dropdown menu
2. Don't show the `UnsupportedKind` component below the table of dashboards