### PR TITLE
fix: reconnect resource watcher on project unpack

### DIFF
--- a/web-common/src/features/entity-management/ResourceWatcher.svelte
+++ b/web-common/src/features/entity-management/ResourceWatcher.svelte
@@ -23,8 +23,6 @@
     `${host}/v1/instances/${instanceId}/resources/-/watch`,
   );
 
-  const resourceClosed = resourceWatcher.closed;
-
   $: failed = $fileAttempts >= 2 || $resourceAttempts >= 2;
 
   onMount(() => {

--- a/web-common/src/features/entity-management/ResourceWatcher.svelte
+++ b/web-common/src/features/entity-management/ResourceWatcher.svelte
@@ -9,9 +9,10 @@
 
   const fileWatcher = new WatchFilesClient().client;
   const resourceWatcher = new WatchResourcesClient().client;
-  const fileAttempts = fileWatcher.retryAttempts;
-  const resourceAttempts = resourceWatcher.retryAttempts;
-  const closed = fileWatcher.closed;
+  const { retryAttempts: fileAttempts, closed: fileWatcherClosed } =
+    fileWatcher;
+  const { retryAttempts: resourceAttempts, closed: resourceWatcherClosed } =
+    fileWatcher;
 
   export let host: string;
   export let instanceId: string;
@@ -21,6 +22,8 @@
   $: resourceWatcher.watch(
     `${host}/v1/instances/${instanceId}/resources/-/watch`,
   );
+
+  const resourceClosed = resourceWatcher.closed;
 
   $: failed = $fileAttempts >= 2 || $resourceAttempts >= 2;
 
@@ -72,7 +75,7 @@
     body="Try restarting the server"
   />
 {:else}
-  {#if $closed}
+  {#if $fileWatcherClosed || $resourceWatcherClosed}
     <Banner
       banner={{
         message:

--- a/web-common/src/runtime-client/watch-request-client.ts
+++ b/web-common/src/runtime-client/watch-request-client.ts
@@ -39,7 +39,7 @@ export class WatchRequestClient<Res extends WatchResponse> {
   private url: string | undefined;
   private controller: AbortController | undefined;
   private stream: AsyncGenerator<StreamingFetchResponse<Res>> | undefined;
-  private outOfFocusThrottler = new Throttler(5000, 30000);
+  private outOfFocusThrottler = new Throttler(120000, 30000);
   public retryAttempts = writable(0);
   private reconnectTimeout: ReturnType<typeof setTimeout> | undefined;
   private retryTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -49,7 +49,10 @@ export class WatchRequestClient<Res extends WatchResponse> {
   ]);
   public closed = writable(false);
 
-  on<K extends keyof EventMap<Res>>(event: K, listener: Callback<Res, K>) {
+  public on<K extends keyof EventMap<Res>>(
+    event: K,
+    listener: Callback<Res, K>,
+  ) {
     this.listeners.get(event)?.push(listener);
   }
 
@@ -137,8 +140,8 @@ export class WatchRequestClient<Res extends WatchResponse> {
     } catch {
       clearTimeout(this.retryTimeout);
 
-      if (get(this.closed)) return;
       this.cancel();
+      if (get(this.closed)) return;
 
       this.reconnect().catch((e) => {
         throw new Error(e);


### PR DESCRIPTION
When an example project unpacks, the resource streaming endpoint closes. The application resource watcher, however, was not successfully reconnecting because the conditional check for the closed state (which ensures we don't try to reconnect when it has been intentionally closed) was not accessing the underlying store value.