### PR TITLE
visual metrics uxqa fixes

### DIFF
--- a/web-common/src/components/forms/Input.svelte
+++ b/web-common/src/components/forms/Input.svelte
@@ -32,9 +32,10 @@
   export let textClass = "text-xs";
   export let enableSearch = false;
   export let fields: string[] | undefined = [];
+  export let noOptionsMessage = "No valid options";
   export let options:
     | { value: string; label: string; type?: string }[]
-    | undefined = [];
+    | undefined = undefined;
   export let onInput: (
     newValue: string,
     e: Event & {
@@ -127,7 +128,7 @@
     </div>
   {/if}
 
-  {#if !options?.length}
+  {#if !options}
     <div
       class="input-wrapper {textClass}"
       style:width
@@ -204,6 +205,10 @@
       {truncate}
       {placeholder}
     />
+  {:else}
+    <div class="text-sm h-8 items-center flex text-gray-500 italic">
+      {noOptionsMessage}
+    </div>
   {/if}
 
   {#if errors && (alwaysShowError || (!focus && value))}

--- a/web-common/src/features/visual-metrics-editing/MetricsTable.svelte
+++ b/web-common/src/features/visual-metrics-editing/MetricsTable.svelte
@@ -48,6 +48,18 @@
     .map((_, i) => i)
     .filter((i) => filter(items[i], searchValue));
 
+  $: nameColumn = Math.max(180, longest.name * 8.5 + 32);
+  $: labelColumn = Math.max(180, longest.label * 7 + 50);
+
+  $: formatWidth = type === "measures" ? 140 : 0;
+
+  $: partialWidth =
+    gutterWidth + nameColumn + expressionWidth + labelColumn + formatWidth;
+
+  $: descriptionWidth = Math.max(220, wrapperWidth - partialWidth);
+
+  $: tableWidth = partialWidth + descriptionWidth;
+
   function handleDragStart(e: MouseEvent, i: number) {
     if (e.button !== 0) return;
 
@@ -100,18 +112,6 @@
         item?.column?.toLowerCase().includes(searchValue.toLowerCase()))
     );
   }
-
-  $: nameColumn = longest.name * 8.5 + 32;
-  $: labelColumn = longest.label * 7 + 50;
-
-  $: formatWidth = type === "measures" ? 140 : 0;
-
-  $: partialWidth =
-    gutterWidth + nameColumn + expressionWidth + labelColumn + formatWidth;
-
-  $: descriptionWidth = Math.max(220, wrapperWidth - partialWidth);
-
-  $: tableWidth = partialWidth + descriptionWidth;
 </script>
 
 <div

--- a/web-common/src/features/visual-metrics-editing/MetricsTableRow.svelte
+++ b/web-common/src/features/visual-metrics-editing/MetricsTableRow.svelte
@@ -85,7 +85,13 @@
   </td>
 
   <td class="source-code truncate" on:click={onCellClick} aria-label="Name">
-    <span>{name || "-"}</span>
+    {#if !name && item instanceof YAMLDimension && item.resourceName}
+      <span class="text-gray-500" title="This name was inherited automatically">
+        {item.resourceName}
+      </span>
+    {:else}
+      <span>{name || "-"}</span>
+    {/if}
   </td>
   <td on:click={onCellClick} aria-label="Label">
     <div class="text-[12px] pr-4">

--- a/web-common/src/features/visual-metrics-editing/lib.ts
+++ b/web-common/src/features/visual-metrics-editing/lib.ts
@@ -58,7 +58,7 @@ export class YAMLMeasure {
   description: string;
   valid_percent_of_total: boolean;
   format_d3: string;
-  format_preset: FormatPreset;
+  format_preset: FormatPreset | "";
 
   constructor(item?: YAMLMap<string, string>) {
     this.expression = item?.get("expression") ?? "";
@@ -71,7 +71,10 @@ export class YAMLMeasure {
         : Boolean(item?.get("valid_percent_of_total"));
     this.format_d3 = item?.get("format_d3") ?? "";
     this.format_preset =
-      (item?.get("format_preset") as unknown as FormatPreset) ?? "";
+      ((item?.get("format_preset") as unknown as FormatPreset) ??
+      this.format_d3)
+        ? ""
+        : FormatPreset.HUMANIZE;
   }
 }
 

--- a/web-common/src/features/visual-metrics-editing/lib.ts
+++ b/web-common/src/features/visual-metrics-editing/lib.ts
@@ -32,6 +32,7 @@ export class YAMLDimension {
   label: string;
   description: string;
   unnest: boolean | undefined;
+  resourceName: string;
 
   constructor(
     item?: YAMLMap<string, string>,
@@ -39,13 +40,14 @@ export class YAMLDimension {
   ) {
     this.column = item?.get("column") ?? "";
     this.expression = item?.get("expression") ?? "";
-    this.name = item?.get("name") ?? dimension?.name ?? "";
+    this.name = item?.get("name") ?? "";
     this.label = item?.get("label") ?? "";
     this.description = item?.get("description") ?? "";
     this.unnest =
       item?.get("unnest") === undefined
         ? undefined
         : item?.get("unnest") === "true";
+    this.resourceName = dimension?.name ?? "";
   }
 }
 

--- a/web-common/src/features/workspaces/MetricsWorkspace.svelte
+++ b/web-common/src/features/workspaces/MetricsWorkspace.svelte
@@ -111,13 +111,15 @@
         {metricsViewName}
       />
     {:else}
-      <VisualMetrics
-        {errors}
-        {fileArtifact}
-        switchView={() => {
-          $selectedView = "code";
-        }}
-      />
+      {#key fileArtifact}
+        <VisualMetrics
+          {errors}
+          {fileArtifact}
+          switchView={() => {
+            $selectedView = "code";
+          }}
+        />
+      {/key}
     {/if}
   </svelte:fragment>
 

--- a/web-common/src/features/workspaces/VisualMetrics.svelte
+++ b/web-common/src/features/workspaces/VisualMetrics.svelte
@@ -368,6 +368,7 @@
           truncate
           value={model}
           options={[...modelNames, ...sourceNames]}
+          placeholder="Select a model"
           label="Model or source referenced"
           onChange={(newModelName) => {
             confirmation = {
@@ -384,6 +385,7 @@
         truncate
         value={timeDimension}
         options={timeOptions}
+        placeholder="Select time column"
         label="Time column"
         hint="Column from model that will be used as primary time dimension in dashboards"
         onChange={async (value) => {
@@ -400,6 +402,7 @@
           value: label,
           label,
         }))}
+        placeholder="Select time grain"
         label="Smallest time grain"
         hint="The smallest time unit by which your charts and tables can be bucketed"
         onChange={async (value) => {

--- a/web-common/src/features/workspaces/VisualMetrics.svelte
+++ b/web-common/src/features/workspaces/VisualMetrics.svelte
@@ -391,6 +391,7 @@
         options={timeOptions}
         placeholder="Select time column"
         label="Time column"
+        noOptionsMessage="No timeseries columns in model"
         hint="Column from model that will be used as primary time dimension in dashboards"
         onChange={async (value) => {
           await updateProperty("timeseries", value);


### PR DESCRIPTION
- Sets placeholders for property dropdowns
- Sets minimum column size for `Name` and `Label`
- Updates the way inherited dimension names are pulled in and displayed
- Adds fallback when there are no valid time series columns in dataset
- Sets "humanize" as the default format_preset when adding a new measure

<img width="336" alt="Screenshot 2024-10-07 at 6 47 47 PM" src="https://github.com/user-attachments/assets/0c552023-a5f4-4a14-8c0b-6637f88ab6d8">
