### PR TITLE
Fix (UI deploy flow): Bump page size for `ListOrganizations`

### DIFF
--- a/cli/pkg/local/server.go
+++ b/cli/pkg/local/server.go
@@ -487,7 +487,7 @@ func (s *Server) GetCurrentUser(ctx context.Context, r *connect.Request[localv1.
 	}
 
 	// get rill user orgs
-	resp, err := c.ListOrganizations(ctx, &adminv1.ListOrganizationsRequest{})
+	resp, err := c.ListOrganizations(ctx, &adminv1.ListOrganizationsRequest{PageSize: 50})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Addresses https://rilldata.slack.com/archives/CTZ8XBQ85/p1728366139336139

Quick fix is to increase the page size from 20 (default) to 50.