### PR TITLE
Fix Vite build warnings

### DIFF
--- a/web-common/src/components/editor/line-status/highlighter.ts
+++ b/web-common/src/components/editor/line-status/highlighter.ts
@@ -3,7 +3,7 @@ import {
   Decoration,
   EditorView,
   ViewPlugin,
-  ViewUpdate,
+  type ViewUpdate,
 } from "@codemirror/view";
 import { lineStatusesStateField, updateLineStatuses } from "./state";
 

--- a/web-common/src/features/project/deploy-errors.ts
+++ b/web-common/src/features/project/deploy-errors.ts
@@ -1,4 +1,4 @@
-import { ConnectError } from "@connectrpc/connect";
+import type { ConnectError } from "@connectrpc/connect";
 
 // rpc error: code = PermissionDenied desc = does not have permission to create assets
 const RPCErrorExtractor = /rpc error: code = (.*) desc = (.*)/;


### PR DESCRIPTION
Fixes the below warnings emitted from Vite's build:

![image](https://github.com/user-attachments/assets/f195a1a1-4bae-47d1-bd55-940225a6d4fa)
