### PR TITLE
Generate both Explore and Canvas files in `/dashboards`

### DIFF
--- a/web-common/src/features/file-explorer/new-files.ts
+++ b/web-common/src/features/file-explorer/new-files.ts
@@ -80,7 +80,7 @@ const ResourceKindMap: Record<
     extension: ".yaml",
   },
   [ResourceKind.Explore]: {
-    folderName: "explore-dashboards",
+    folderName: "dashboards",
     baseName: "explore",
     extension: ".yaml",
   },
@@ -95,7 +95,7 @@ const ResourceKindMap: Record<
     extension: ".yaml",
   },
   [ResourceKind.Canvas]: {
-    folderName: "canvas-dashboards",
+    folderName: "dashboards",
     baseName: "canvas",
     extension: ".yaml",
   },

--- a/web-local/tests/explores/explores.spec.ts
+++ b/web-local/tests/explores/explores.spec.ts
@@ -25,7 +25,7 @@ test.describe("explores", () => {
     await createExploreFromSource(page);
     await waitForFileNavEntry(
       page,
-      "/explore-dashboards/AdBids_metrics_explore.yaml",
+      "/dashboards/AdBids_metrics_explore.yaml",
       true,
     );
     await page.getByRole("button", { name: "Preview" }).click();

--- a/web-local/tests/utils/dataSpecifcHelpers.ts
+++ b/web-local/tests/utils/dataSpecifcHelpers.ts
@@ -1,16 +1,16 @@
 import type { Page } from "playwright";
+import { assertLeaderboards } from "web-local/tests/utils/metricsViewHelpers";
 import {
   updateCodeEditor,
   waitForProfiling,
   wrapRetryAssertion,
 } from "./commonHelpers";
-import { assertLeaderboards } from "web-local/tests/utils/metricsViewHelpers";
 import { createModel } from "./modelHelpers";
 import { uploadFile, waitForSource } from "./sourceHelpers";
 
 export const AD_BIDS_METRICS_PATH = "/metrics/AdBids_model_metrics.yaml";
 export const AD_BIDS_EXPLORE_PATH =
-  "/explore-dashboards/AdBids_model_metrics_explore.yaml";
+  "/dashboards/AdBids_model_metrics_explore.yaml";
 
 export async function createAdBidsModel(page: Page) {
   await Promise.all([

--- a/web-local/tests/utils/exploreHelpers.ts
+++ b/web-local/tests/utils/exploreHelpers.ts
@@ -20,7 +20,7 @@ export async function createExploreFromModel(
   page: Page,
   modelPath = "/models/AdBids_model.sql",
   metricsViewPath = "/metrics/AdBids_model_metrics.yaml",
-  explorePath = "/explore-dashboards/AdBids_model_metrics_explore.yaml",
+  explorePath = "/dashboards/AdBids_model_metrics_explore.yaml",
 ) {
   await openFileNavEntryContextMenu(page, modelPath);
   await clickMenuButton(page, "Generate metrics");


### PR DESCRIPTION
By default, place Explore and Canvas files in `/dashboards`, rather than `/explore-dashboards` and `/canvas-dashboards` respectively.