### PR TITLE
fix: explore state on rill developer not reset with explicit name on edit

### DIFF
--- a/web-common/src/features/entity-management/infer-resource-kind.ts
+++ b/web-common/src/features/entity-management/infer-resource-kind.ts
@@ -39,9 +39,15 @@ export function inferResourceKind(
   return null;
 }
 
+const resourceNameRegex = /name\s*:\s*(\w+)/i;
+export function findResourceNameInYAML(text: string) {
+  const match = text.match(resourceNameRegex);
+  return match?.length === 2 ? match[1].toLowerCase() : null;
+}
+
+const resourceKindRegex = /type\s*:\s*(\w+)/i;
 function findResourceKindInYAML(text: string): ResourceKind | null {
-  const regex = /type\s*:\s*(\w+)/i;
-  const match = text.match(regex);
+  const match = text.match(resourceKindRegex);
 
   if (match) {
     const shortName = match[1].toLowerCase();

--- a/web-common/src/features/entity-management/infer-resource-kind.ts
+++ b/web-common/src/features/entity-management/infer-resource-kind.ts
@@ -39,12 +39,6 @@ export function inferResourceKind(
   return null;
 }
 
-const resourceNameRegex = /name\s*:\s*(\w+)/i;
-export function findResourceNameInYAML(text: string) {
-  const match = text.match(resourceNameRegex);
-  return match?.length === 2 ? match[1].toLowerCase() : null;
-}
-
 const resourceKindRegex = /type\s*:\s*(\w+)/i;
 function findResourceKindInYAML(text: string): ResourceKind | null {
   const match = text.match(resourceKindRegex);

--- a/web-common/src/features/explores/ExploreEditor.svelte
+++ b/web-common/src/features/explores/ExploreEditor.svelte
@@ -5,6 +5,7 @@
   import { createPersistentDashboardStore } from "@rilldata/web-common/features/dashboards/stores/persistent-dashboard-state";
   import Editor from "@rilldata/web-common/features/editor/Editor.svelte";
   import { FileArtifact } from "@rilldata/web-common/features/entity-management/file-artifact";
+  import { findResourceNameInYAML } from "@rilldata/web-common/features/entity-management/infer-resource-kind";
   import { mapParseErrorsToLines } from "@rilldata/web-common/features/metrics-views/errors";
   import type { V1ParseError } from "@rilldata/web-common/runtime-client";
   import { yaml } from "../../components/editor/presets/yaml";
@@ -35,10 +36,12 @@
     bind:autoSave
     bind:editor
     onSave={(content) => {
+      const name = findResourceNameInYAML(content) ?? exploreName;
+      console.log(name);
       // Remove the explorer entity so that everything is reset to defaults next time user navigates to it
-      metricsExplorerStore.remove(exploreName);
+      metricsExplorerStore.remove(name);
       // Reset local persisted dashboard state for the metrics view
-      createPersistentDashboardStore(exploreName).reset();
+      createPersistentDashboardStore(name).reset();
 
       if (!content?.length) {
         setLineStatuses([], editor);

--- a/web-common/src/features/explores/ExploreEditor.svelte
+++ b/web-common/src/features/explores/ExploreEditor.svelte
@@ -5,7 +5,6 @@
   import { createPersistentDashboardStore } from "@rilldata/web-common/features/dashboards/stores/persistent-dashboard-state";
   import Editor from "@rilldata/web-common/features/editor/Editor.svelte";
   import { FileArtifact } from "@rilldata/web-common/features/entity-management/file-artifact";
-  import { findResourceNameInYAML } from "@rilldata/web-common/features/entity-management/infer-resource-kind";
   import { mapParseErrorsToLines } from "@rilldata/web-common/features/metrics-views/errors";
   import type { V1ParseError } from "@rilldata/web-common/runtime-client";
   import { yaml } from "../../components/editor/presets/yaml";
@@ -36,12 +35,10 @@
     bind:autoSave
     bind:editor
     onSave={(content) => {
-      const name = findResourceNameInYAML(content) ?? exploreName;
-      console.log(name);
       // Remove the explorer entity so that everything is reset to defaults next time user navigates to it
-      metricsExplorerStore.remove(name);
+      metricsExplorerStore.remove(exploreName);
       // Reset local persisted dashboard state for the metrics view
-      createPersistentDashboardStore(name).reset();
+      createPersistentDashboardStore(exploreName).reset();
 
       if (!content?.length) {
         setLineStatuses([], editor);

--- a/web-common/src/features/workspaces/ExploreWorkspace.svelte
+++ b/web-common/src/features/workspaces/ExploreWorkspace.svelte
@@ -19,11 +19,11 @@
     hasUnsavedChanges,
     autoSave,
     path: filePath,
-
+    resourceName,
     fileName,
   } = fileArtifact);
 
-  $: exploreName = getNameFromFile(filePath);
+  $: exploreName = $resourceName?.name ?? getNameFromFile(filePath);
 
   $: initLocalUserPreferenceStore(exploreName);
 


### PR DESCRIPTION
Editing an explore should reset the preview state to experience any change made. We were resetting using the explore name inferred from file path. If the explore contained an explicit name then it would fail to reset.