### PR TITLE
File Explorer: Remove client-side file rename constraint

### DIFF
--- a/web-common/src/features/canvas-components/ComponentsHeader.svelte
+++ b/web-common/src/features/canvas-components/ComponentsHeader.svelte
@@ -6,7 +6,7 @@
   import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts";
   import {
     extractFileName,
-    splitFolderAndName,
+    splitFolderAndFileName,
   } from "@rilldata/web-common/features/entity-management/file-path-utils";
   import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
   import { handleEntityRename } from "@rilldata/web-common/features/entity-management/ui-actions";
@@ -17,7 +17,7 @@
   export let hasUnsavedChanges: boolean;
 
   let fileName: string;
-  $: [, fileName] = splitFolderAndName(filePath);
+  $: [, fileName] = splitFolderAndFileName(filePath);
   $: runtimeInstanceId = $runtime.instanceId;
   $: componentName = extractFileName(filePath);
 

--- a/web-common/src/features/dashboards/granular-access-policies/useMockUsers.ts
+++ b/web-common/src/features/dashboards/granular-access-policies/useMockUsers.ts
@@ -18,7 +18,6 @@ export function useMockUsers(instanceId: string) {
           const yamlObj = parseDocument(data.blob, {
             logLevel: "error",
           })?.toJS();
-          console.log({ yamlObj });
           const mockUsers =
             yamlObj?.mock_users?.filter((user: MockUser) => user?.email) || [];
           return mockUsers as Array<MockUser>;

--- a/web-common/src/features/editor/FileWorkspaceHeader.svelte
+++ b/web-common/src/features/editor/FileWorkspaceHeader.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
-  import { splitFolderAndName } from "@rilldata/web-common/features/entity-management/file-path-utils";
+  import { splitFolderAndFileName } from "@rilldata/web-common/features/entity-management/file-path-utils";
   import { useFileNamesInDirectory } from "@rilldata/web-common/features/entity-management/file-selectors";
   import { handleEntityRename } from "@rilldata/web-common/features/entity-management/ui-actions";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { WorkspaceHeader } from "../../layout/workspace";
-  import { PROTECTED_FILES } from "../file-explorer/protected-paths";
   import type { ResourceKind } from "../entity-management/resource-selectors";
+  import { PROTECTED_FILES } from "../file-explorer/protected-paths";
 
   export let filePath: string;
   export let hasUnsavedChanges: boolean;
@@ -15,7 +15,7 @@
   let fileName: string;
   let folder: string;
 
-  $: [folder, fileName] = splitFolderAndName(filePath);
+  $: [folder, fileName] = splitFolderAndFileName(filePath);
   $: isProtectedFile = PROTECTED_FILES.includes(filePath);
 
   $: currentDirectoryFileNamesQuery = useFileNamesInDirectory(

--- a/web-common/src/features/entity-management/file-artifact.ts
+++ b/web-common/src/features/entity-management/file-artifact.ts
@@ -1,6 +1,6 @@
 import {
   extractFileExtension,
-  splitFolderAndName,
+  splitFolderAndFileName,
 } from "@rilldata/web-common/features/entity-management/file-path-utils";
 import {
   ResourceKind,
@@ -84,7 +84,7 @@ export class FileArtifact {
   lastStateUpdatedOn: string | undefined;
 
   constructor(filePath: string) {
-    const [folderName, fileName] = splitFolderAndName(filePath);
+    const [folderName, fileName] = splitFolderAndFileName(filePath);
 
     this.path = filePath;
     this.folderName = folderName;

--- a/web-common/src/features/entity-management/file-path-utils.ts
+++ b/web-common/src/features/entity-management/file-path-utils.ts
@@ -21,7 +21,7 @@ export function extractFileExtension(filePath: string): string {
   return lastIndexOfDot >= 0 ? fileName.substring(lastIndexOfDot) : "";
 }
 
-export function splitFolderAndName(
+export function splitFolderAndFileName(
   filePath: string,
 ): [folder: string, fileName: string] {
   const fileName = filePath.split(FILE_PATH_SPLIT_REGEX).slice(-1)[0];

--- a/web-common/src/features/entity-management/ui-actions.ts
+++ b/web-common/src/features/entity-management/ui-actions.ts
@@ -2,7 +2,7 @@ import { renameFileArtifact } from "@rilldata/web-common/features/entity-managem
 import { removeLeadingSlash } from "@rilldata/web-common/features/entity-management/entity-mappers";
 import {
   extractFileName,
-  splitFolderAndName,
+  splitFolderAndFileName,
 } from "@rilldata/web-common/features/entity-management/file-path-utils";
 import {
   INVALID_NAME_MESSAGE,
@@ -18,7 +18,7 @@ export async function handleEntityRename(
   existingName: string,
   allNames: string[],
 ) {
-  const [folder] = splitFolderAndName(existingPath);
+  const [folder] = splitFolderAndFileName(existingPath);
 
   if (!newName.match(VALID_NAME_PATTERN)) {
     eventBus.emit("notification", {

--- a/web-common/src/features/file-explorer/FileExplorer.svelte
+++ b/web-common/src/features/file-explorer/FileExplorer.svelte
@@ -10,7 +10,7 @@
   import { removeLeadingSlash } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import {
     getTopLevelFolder,
-    splitFolderAndName,
+    splitFolderAndFileName,
   } from "@rilldata/web-common/features/entity-management/file-path-utils";
   import ForceDeleteConfirmation from "@rilldata/web-common/features/file-explorer/ForceDeleteConfirmationDialog.svelte";
   import NavEntryPortal from "@rilldata/web-common/features/file-explorer/NavEntryPortal.svelte";
@@ -123,7 +123,7 @@
     const isCurrentFile =
       $page.params.file && // handle case when user is on home page
       removeLeadingSlash(fromPath) === removeLeadingSlash($page.params.file);
-    const [, srcFile] = splitFolderAndName(fromPath);
+    const [, srcFile] = splitFolderAndFileName(fromPath);
     const newFilePath = `${toDir === "/" ? toDir : toDir + "/"}${srcFile}`;
 
     if (fromPath !== newFilePath) {

--- a/web-common/src/features/file-explorer/nav-entry-drag-drop-store.ts
+++ b/web-common/src/features/file-explorer/nav-entry-drag-drop-store.ts
@@ -1,4 +1,4 @@
-import { splitFolderAndName } from "@rilldata/web-common/features/entity-management/file-path-utils";
+import { splitFolderAndFileName } from "@rilldata/web-common/features/entity-management/file-path-utils";
 import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
 import { directoryState } from "@rilldata/web-common/features/file-explorer/directory-store";
 import { getPaddingFromPath } from "@rilldata/web-common/features/file-explorer/nav-tree-spacing";
@@ -39,7 +39,7 @@ export class NavEntryDragDropStore {
 
     this.offset = { x, y };
 
-    const [, fileName] = splitFolderAndName(dragData.filePath);
+    const [, fileName] = splitFolderAndFileName(dragData.filePath);
     this.newDragData = {
       ...dragData,
       fileName,

--- a/web-local/tests/utils/sourceHelpers.ts
+++ b/web-local/tests/utils/sourceHelpers.ts
@@ -1,7 +1,7 @@
 import { expect } from "@playwright/test";
 import {
   extractFileName,
-  splitFolderAndName,
+  splitFolderAndFileName,
 } from "@rilldata/web-common/features/entity-management/file-path-utils";
 import { asyncWait } from "@rilldata/web-common/lib/waitUtils";
 import path from "node:path";
@@ -77,7 +77,7 @@ export async function waitForSource(
   filePath: string,
   columns: Array<string>,
 ) {
-  const [, fileName] = splitFolderAndName(filePath);
+  const [, fileName] = splitFolderAndFileName(filePath);
   const name = extractFileName(fileName);
 
   await Promise.all([


### PR DESCRIPTION
Previously, client-side, we were preventing files from being re-named to the same name as any other file in the project. Now, we merely prevent files from being re-named to the same name as another file in the same directory.

Addresses [this UXQA item](https://www.notion.so/rilldata/v0-50-0-QA-114ba33c8f5780bd897ecb99547ed623?pvs=4#119ba33c8f5780b082aafc64283468e3) 