### PR TITLE
Fix hack for legacy Metrics Views

### DIFF
--- a/web-common/src/features/entity-management/file-artifacts.ts
+++ b/web-common/src/features/entity-management/file-artifacts.ts
@@ -58,7 +58,7 @@ export class FileArtifacts {
 
   updateArtifacts(resource: V1Resource) {
     resource.meta?.filePaths?.forEach((filePath) => {
-      this.getFileArtifact(filePath)?.updateAll(resource);
+      this.getFileArtifact(filePath)?.updateResource(resource);
     });
   }
 


### PR DESCRIPTION
### Context

A file specifying a legacy Metrics View generates 2 resources: a Metrics View and an Explore. However, the `FileArtifact` class (which impacts much client-side code) makes the assumption that a file is associated with 0 or 1 resource. 

In the `FileArtifact` class, for legacy Metrics View files, we've added a hack so that we ignore the generated Explore resource.

### Problem
The original hack wrongly ignored the Explore resource for Explore files placed in the `/dashboards` directory.  (Because we previously assumed that any file placed in the `/dashboards` directory was a legacy Metrics View.)

### Solution
The new hack identifies when an Explore resource is associated with a legacy Metrics View by checking to see if the file is already associated with a Metrics View. This should work because, for legacy Metrics Views, the parser first creates the Metrics View and second creates the Explore.

(In the long-run, it'd be nice if we could remove the assumption that a file generates at most 1 resource.)