### PR TITLE
feat: estimate measure column width for pivot

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotTable.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTable.svelte
@@ -10,6 +10,7 @@
   import {
     calculateFirstColumnWidth,
     calculateMeasureWidth,
+    COLUMN_WIDTH_CONSTANTS as WIDTHS,
   } from "@rilldata/web-common/features/dashboards/pivot/pivot-column-width-utils";
   import { NUM_ROWS_PER_PAGE } from "@rilldata/web-common/features/dashboards/pivot/pivot-infinite-scroll";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
@@ -43,13 +44,6 @@
   const OVERSCAN = 60;
   const ROW_HEIGHT = 24;
   const HEADER_HEIGHT = 30;
-  const MEASURE_PADDING = 20;
-  const MIN_COL_WIDTH = 150;
-  const MAX_COL_WIDTH = 600;
-  const MAX_INIT_COL_WIDTH = 400;
-  const MIN_MEASURE_WIDTH = 70;
-  const MAX_MEAUSRE_WIDTH = 300;
-  const INIT_MEASURE_WIDTH = 100;
 
   export let pivotDataStore: PivotDataStore;
 
@@ -367,8 +361,8 @@
       <Resizer
         side="right"
         direction="EW"
-        min={MIN_COL_WIDTH}
-        max={MAX_COL_WIDTH}
+        min={WIDTHS.MIN_COL_WIDTH}
+        max={WIDTHS.MAX_COL_WIDTH}
         dimension={firstColumnWidth}
         onUpdate={(d) => (firstColumnWidth = d)}
         onMouseDown={(e) => {
@@ -388,7 +382,8 @@
     {#each measureGroups as { subHeaders }, groupIndex (groupIndex)}
       <div class="h-full z-50 flex" style:width="{totalMeasureWidth}px">
         {#each subHeaders as { column: { columnDef: { name } } }, i (name)}
-          {@const length = $measureLengths.get(name) ?? INIT_MEASURE_WIDTH}
+          {@const length =
+            $measureLengths.get(name) ?? WIDTHS.INIT_MEASURE_WIDTH}
           {@const last =
             i === subHeaders.length - 1 &&
             groupIndex === measureGroups.length - 1}
@@ -396,8 +391,8 @@
             <Resizer
               side="right"
               direction="EW"
-              min={MIN_MEASURE_WIDTH}
-              max={MAX_MEAUSRE_WIDTH}
+              min={WIDTHS.MIN_MEASURE_WIDTH}
+              max={WIDTHS.MAX_MEASURE_WIDTH}
               dimension={length}
               justify={last ? "end" : "center"}
               hang={!last}
@@ -440,7 +435,8 @@
 
       {#each measureGroups as { subHeaders }, i (i)}
         {#each subHeaders as { column: { columnDef: { name } } } (name)}
-          {@const length = $measureLengths.get(name) ?? INIT_MEASURE_WIDTH}
+          {@const length =
+            $measureLengths.get(name) ?? WIDTHS.INIT_MEASURE_WIDTH}
           <col style:width="{length}px" style:max-width="{length}px" />
         {/each}
       {/each}

--- a/web-common/src/features/dashboards/pivot/pivot-column-width-utils.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-column-width-utils.ts
@@ -1,0 +1,82 @@
+import { extractSamples } from "@rilldata/web-common/components/virtualized-table/init-widths";
+import { isTimeDimension } from "@rilldata/web-common/features/dashboards/pivot/pivot-utils";
+import type { PivotDataRow } from "@rilldata/web-common/features/dashboards/pivot/types";
+import { clamp } from "@rilldata/web-common/lib/clamp";
+
+export const MIN_COL_WIDTH = 150;
+export const MAX_COL_WIDTH = 600;
+export const MAX_INIT_COL_WIDTH = 400;
+
+export const MIN_MEASURE_WIDTH = 70;
+export const MAX_MEASURE_WIDTH = 300;
+export const INIT_MEASURE_WIDTH = 100;
+export const MEASURE_PADDING = 24;
+
+export function calculateFirstColumnWidth(
+  firstColumnName: string,
+  timeDimension: string,
+  dataRows: PivotDataRow[],
+) {
+  // Dates are displayed as shorter values
+  if (isTimeDimension(firstColumnName, timeDimension)) return MIN_COL_WIDTH;
+
+  const samples = extractSamples(
+    dataRows.map((row) => row[firstColumnName]),
+  ).filter((v): v is string => typeof v === "string");
+
+  const maxValueLength = samples.reduce((max, value) => {
+    return Math.max(max, value.length);
+  }, 0);
+
+  const finalBasis = Math.max(firstColumnName.length, maxValueLength);
+  const pixelLength = finalBasis * 8;
+  const final = clamp(MIN_COL_WIDTH, pixelLength + 16, MAX_INIT_COL_WIDTH);
+
+  return final;
+}
+
+/**
+ * For measure column if available, use the totals row data as the heuristic
+ * for determining the column width. In most cases the totals row
+ * will have the max or close. In absence of the totals row use the
+ * data rows for getting a sample
+ */
+export function calculateMeasureWidth(
+  measureName: string,
+  label: string,
+  formatter: (
+    value: string | number | null | undefined,
+  ) => string | (null | undefined),
+  totalsRow: PivotDataRow | undefined,
+  dataRows: PivotDataRow[],
+) {
+  let maxValueLength: number;
+  if (totalsRow) {
+    const value = totalsRow[measureName];
+    if (typeof value === "string" || typeof value === "number") {
+      maxValueLength = String(formatter(value)).length;
+    } else {
+      maxValueLength = 0;
+    }
+  } else {
+    const samples = extractSamples(
+      dataRows.map((row) => row[measureName]),
+    ).filter(
+      (v): v is string | number =>
+        typeof v === "string" || typeof v === "number",
+    );
+
+    maxValueLength = samples.reduce((max: number, value) => {
+      const stringLength = String(formatter(value)).length;
+      return Math.max(max, stringLength);
+    }, 0) as number;
+  }
+
+  const finalBasis = Math.max(label.length, maxValueLength);
+  const pixelLength = finalBasis * 7;
+  return clamp(
+    MIN_MEASURE_WIDTH,
+    pixelLength + MEASURE_PADDING,
+    MAX_MEASURE_WIDTH,
+  );
+}

--- a/web-common/src/features/dashboards/pivot/pivot-column-width-utils.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-column-width-utils.ts
@@ -3,14 +3,15 @@ import { isTimeDimension } from "@rilldata/web-common/features/dashboards/pivot/
 import type { PivotDataRow } from "@rilldata/web-common/features/dashboards/pivot/types";
 import { clamp } from "@rilldata/web-common/lib/clamp";
 
-export const MIN_COL_WIDTH = 150;
-export const MAX_COL_WIDTH = 600;
-export const MAX_INIT_COL_WIDTH = 400;
-
-export const MIN_MEASURE_WIDTH = 70;
-export const MAX_MEASURE_WIDTH = 300;
-export const INIT_MEASURE_WIDTH = 100;
-export const MEASURE_PADDING = 24;
+export const COLUMN_WIDTH_CONSTANTS = {
+  MIN_COL_WIDTH: 150,
+  MAX_COL_WIDTH: 600,
+  MAX_INIT_COL_WIDTH: 400,
+  MIN_MEASURE_WIDTH: 70,
+  MAX_MEASURE_WIDTH: 300,
+  INIT_MEASURE_WIDTH: 100,
+  MEASURE_PADDING: 24,
+};
 
 export function calculateFirstColumnWidth(
   firstColumnName: string,
@@ -18,7 +19,8 @@ export function calculateFirstColumnWidth(
   dataRows: PivotDataRow[],
 ) {
   // Dates are displayed as shorter values
-  if (isTimeDimension(firstColumnName, timeDimension)) return MIN_COL_WIDTH;
+  if (isTimeDimension(firstColumnName, timeDimension))
+    return COLUMN_WIDTH_CONSTANTS.MIN_COL_WIDTH;
 
   const samples = extractSamples(
     dataRows.map((row) => row[firstColumnName]),
@@ -30,7 +32,11 @@ export function calculateFirstColumnWidth(
 
   const finalBasis = Math.max(firstColumnName.length, maxValueLength);
   const pixelLength = finalBasis * 8;
-  const final = clamp(MIN_COL_WIDTH, pixelLength + 16, MAX_INIT_COL_WIDTH);
+  const final = clamp(
+    COLUMN_WIDTH_CONSTANTS.MIN_COL_WIDTH,
+    pixelLength + 16,
+    COLUMN_WIDTH_CONSTANTS.MAX_INIT_COL_WIDTH,
+  );
 
   return final;
 }
@@ -75,8 +81,8 @@ export function calculateMeasureWidth(
   const finalBasis = Math.max(label.length, maxValueLength);
   const pixelLength = finalBasis * 7;
   return clamp(
-    MIN_MEASURE_WIDTH,
-    pixelLength + MEASURE_PADDING,
-    MAX_MEASURE_WIDTH,
+    COLUMN_WIDTH_CONSTANTS.MIN_MEASURE_WIDTH,
+    pixelLength + COLUMN_WIDTH_CONSTANTS.MEASURE_PADDING,
+    COLUMN_WIDTH_CONSTANTS.MAX_MEASURE_WIDTH,
   );
 }

--- a/web-common/src/features/dashboards/pivot/pivot-column-width-utils.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-column-width-utils.ts
@@ -31,7 +31,7 @@ export function calculateFirstColumnWidth(
   }, 0);
 
   const finalBasis = Math.max(firstColumnName.length, maxValueLength);
-  const pixelLength = finalBasis * 8;
+  const pixelLength = finalBasis * 7;
   const final = clamp(
     COLUMN_WIDTH_CONSTANTS.MIN_COL_WIDTH,
     pixelLength + 16,


### PR DESCRIPTION
Use data values along with label to estimate column width for measure columns in the pivot table.

Before
![image](https://github.com/user-attachments/assets/40388c95-f821-4d14-ab32-b18897309765)


After
![image](https://github.com/user-attachments/assets/1b3dd1e0-5e43-44f3-b8f6-019724231aa2)
