### PR TITLE
navigation tweaks

### DIFF
--- a/web-common/src/components/button/ContextButton.svelte
+++ b/web-common/src/components/button/ContextButton.svelte
@@ -18,8 +18,8 @@
   <button
     {...getAttrs(builders)}
     aria-label={label}
-    class="group-hover:opacity-100"
-    class:!group-hover:opacity-100={suppressTooltip}
+    class="group-hover:block"
+    class:!group-hover:block={suppressTooltip}
     {id}
     on:click|preventDefault|stopPropagation
     use:builderActions={{ builders }}
@@ -35,7 +35,7 @@
   button {
     @apply h-full aspect-square p-1.5;
     @apply flex justify-center items-center;
-    @apply text-gray-500 opacity-0;
+    @apply text-gray-500 hidden;
     @apply transition-transform duration-100;
   }
 

--- a/web-common/src/features/connectors/ConnectorEntry.svelte
+++ b/web-common/src/features/connectors/ConnectorEntry.svelte
@@ -65,7 +65,7 @@
 
   .connector-entry-header {
     @apply flex gap-x-1 items-center;
-    @apply w-full p-1;
+    @apply w-full px-2 py-1;
     @apply sticky top-0 z-10 bg-white;
   }
 

--- a/web-common/src/features/connectors/ConnectorExplorer.svelte
+++ b/web-common/src/features/connectors/ConnectorExplorer.svelte
@@ -1,19 +1,10 @@
 <script lang="ts">
   import { slide } from "svelte/transition";
-  import CaretDownIcon from "../../components/icons/CaretDownIcon.svelte";
-  import Resizer from "../../layout/Resizer.svelte";
   import { LIST_SLIDE_DURATION as duration } from "../../layout/config";
   import { createRuntimeServiceAnalyzeConnectors } from "../../runtime-client";
   import { runtime } from "../../runtime-client/runtime-store";
   import ConnectorEntry from "./ConnectorEntry.svelte";
   import { connectorExplorerStore } from "./connector-explorer-store";
-
-  export let containerHeight: number;
-
-  const MIN_HEIGHT = 31; // The height of the "Connectors" header
-
-  let initialHeight = containerHeight / 2;
-  let sectionHeight = initialHeight;
 
   $: showConnectors = $connectorExplorerStore.showConnectors;
 
@@ -32,69 +23,31 @@
   $: ({ data, error } = $connectors);
 </script>
 
-<section style:min-height="{MIN_HEIGHT}px" style:height="{sectionHeight}px">
-  <Resizer
-    bind:dimension={sectionHeight}
-    direction="NS"
-    side="top"
-    min={10}
-    basis={showConnectors ? initialHeight : MIN_HEIGHT}
-    max={containerHeight * 0.9}
-  />
-  <button on:click={connectorExplorerStore.toggleExplorer}>
-    <h3>Connectors</h3>
-    <CaretDownIcon
-      className="transform transition-transform {showConnectors
-        ? 'rotate-0'
-        : '-rotate-180'}"
-    />
-  </button>
-  {#if showConnectors}
-    <div class="wrapper">
-      {#if error}
+{#if showConnectors}
+  <div class="wrapper">
+    {#if error}
+      <span class="message">
+        {error.message}
+      </span>
+    {:else if data?.connectors}
+      {#if data.connectors.length === 0}
         <span class="message">
-          {error.message}
+          No connectors found. Add data to get started!
         </span>
-      {:else if data?.connectors}
-        {#if data.connectors.length === 0}
-          <span class="message"
-            >No connectors found. Add data to get started!</span
-          >
-        {:else}
-          <ol transition:slide={{ duration }}>
-            {#each data.connectors as connector (connector.name)}
-              <ConnectorEntry {connector} />
-            {/each}
-          </ol>
-        {/if}
+      {:else}
+        <ol transition:slide={{ duration }}>
+          {#each data.connectors as connector (connector.name)}
+            <ConnectorEntry {connector} />
+          {/each}
+        </ol>
       {/if}
-    </div>
-  {/if}
-</section>
+    {/if}
+  </div>
+{/if}
 
 <style lang="postcss">
-  section {
-    @apply shrink-0;
-    @apply flex flex-col relative;
-    @apply border-t border-t-gray-200;
-  }
-
-  button {
-    @apply flex justify-between items-center w-full;
-    @apply pl-2 pr-3.5 py-2;
-    @apply text-gray-500;
-  }
-
-  button:hover {
-    @apply bg-slate-100;
-  }
-
-  h3 {
-    @apply font-semibold text-[10px] uppercase;
-  }
-
   .wrapper {
-    @apply overflow-auto;
+    @apply overflow-auto px-0 pb-4;
   }
 
   .message {

--- a/web-common/src/features/connectors/olap/TableEntry.svelte
+++ b/web-common/src/features/connectors/olap/TableEntry.svelte
@@ -42,15 +42,16 @@
 </script>
 
 <li aria-label={tableId} class="table-entry group" class:open>
-  <div class="table-entry-header {database ? 'pl-[58px]' : 'pl-[40px]'}">
-    <button on:click={() => (showSchema = !showSchema)}>
-      <CaretDownIcon
-        className="transform transition-transform text-gray-400 {showSchema
-          ? 'rotate-0'
-          : '-rotate-90'}"
-        size="14px"
-      />
-    </button>
+  <button
+    on:click={() => (showSchema = !showSchema)}
+    class="table-entry-header {database ? 'pl-[58px]' : 'pl-[40px]'}"
+  >
+    <CaretDownIcon
+      className="flex-none transform transition-transform text-gray-400 {!showSchema &&
+        '-rotate-90'}"
+      size="14px"
+    />
+
     <a class="clickable-text" {href}>
       <TableIcon size="14px" className="shrink-0 text-gray-400" />
       <span class="truncate">
@@ -87,7 +88,7 @@
         <TableMenuItems {connector} {database} {databaseSchema} {table} />
       </DropdownMenu.Content>
     </DropdownMenu.Root>
-  </div>
+  </button>
 
   {#if showSchema}
     <TableSchema {connector} {database} {databaseSchema} {table} />

--- a/web-common/src/features/connectors/olap/TableSchema.svelte
+++ b/web-common/src/features/connectors/olap/TableSchema.svelte
@@ -40,9 +40,9 @@
             {column.name}
           </TooltipContent>
         </Tooltip>
-        <span class="uppercase text-gray-700"
-          >{prettyPrintType(column.type ?? "")}</span
-        >
+        <span class="uppercase text-gray-700">
+          {prettyPrintType(column.type ?? "")}
+        </span>
       </li>
     {/each}
   {/if}

--- a/web-common/src/layout/config.ts
+++ b/web-common/src/layout/config.ts
@@ -7,6 +7,8 @@ import { cubicOut as easing } from "svelte/easing";
 
 export const DEFAULT_INSPECTOR_WIDTH = 360;
 export const DEFAULT_NAV_WIDTH = 240;
+export const MIN_NAV_WIDTH = 180;
+export const MAX_NAV_WIDTH = 360;
 export const DEFAULT_PREVIEW_TABLE_HEIGHT = 400;
 
 /** parameters used in the column profile view & elsewhere */

--- a/web-common/src/layout/navigation/Footer.svelte
+++ b/web-common/src/layout/navigation/Footer.svelte
@@ -28,7 +28,7 @@
 <div
   class="flex flex-col pt-3 pb-3 gap-y-1 bg-gray-50 border-t border-gray-200 sticky bottom-0"
 >
-  {#each lineItems as lineItem}
+  {#each lineItems as lineItem, i (i)}
     <a href={lineItem.href} target="_blank" rel="noreferrer noopener"
       ><div
         class="flex flex-row items-center px-4 py-1 gap-x-2 text-gray-700 font-normal hover:bg-gray-200"
@@ -50,7 +50,7 @@
     >
   {/each}
   <div
-    class="px-4 py-1 text-gray-600 flex flex-row gap-x-2"
+    class="px-4 py-1 text-gray-600 flex flex-row w-full gap-x-2 truncate line-clamp-1"
     style:font-size="10px"
   >
     <span class="text-gray-400">
@@ -79,10 +79,12 @@
         </div>
       </Tooltip>
     </span>
-    version {$appBuildMetaStore.version
-      ? $appBuildMetaStore.version
-      : "unknown (built from source)"}{$appBuildMetaStore.commitHash
-      ? ` – ${$appBuildMetaStore.commitHash}`
-      : ""}
+    <span class="truncate">
+      version {$appBuildMetaStore.version
+        ? $appBuildMetaStore.version
+        : "unknown (built from source)"}{$appBuildMetaStore.commitHash
+        ? ` – ${$appBuildMetaStore.commitHash}`
+        : ""}
+    </span>
   </div>
 </div>

--- a/web-common/src/layout/navigation/Navigation.svelte
+++ b/web-common/src/layout/navigation/Navigation.svelte
@@ -16,14 +16,27 @@
   import AddAssetButton from "../../features/entity-management/AddAssetButton.svelte";
   import FileExplorer from "../../features/file-explorer/FileExplorer.svelte";
   import Resizer from "../Resizer.svelte";
-  import { DEFAULT_NAV_WIDTH } from "../config";
+  import { DEFAULT_NAV_WIDTH, MAX_NAV_WIDTH, MIN_NAV_WIDTH } from "../config";
   import Footer from "./Footer.svelte";
   import SurfaceControlButton from "./SurfaceControlButton.svelte";
+  import { connectorExplorerStore } from "@rilldata/web-common/features/connectors/connector-explorer-store";
+  import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
+
+  const DEFAULT_PERCENTAGE = 0.4;
 
   let width = DEFAULT_NAV_WIDTH;
   let previousWidth: number;
   let resizing = false;
-  let navWrapperHeight: number;
+  let resizingConnector = false;
+  let connectorHeightPercentage = DEFAULT_PERCENTAGE;
+  let contentRect = new DOMRectReadOnly(0, 0, 0, 0);
+  let connectorWrapper: HTMLDivElement;
+
+  $: navWrapperHeight = contentRect.height;
+
+  $: showConnectors = $connectorExplorerStore.showConnectors;
+
+  $: connectorSectionHeight = navWrapperHeight * connectorHeightPercentage;
 
   $: ({ unsavedFiles } = fileArtifacts);
   $: ({ size: unsavedFileCount } = $unsavedFiles);
@@ -43,7 +56,16 @@
   }
 </script>
 
-<svelte:window on:resize={handleResize} />
+<svelte:window
+  on:resize={handleResize}
+  on:keydown={(e) => {
+    const isMac = window.navigator.userAgent.includes("Macintosh");
+
+    if (e[isMac ? "metaKey" : "ctrlkey"] && e.key === "b") {
+      navigationOpen.toggle();
+    }
+  }}
+/>
 
 <nav
   class="sidebar"
@@ -52,9 +74,9 @@
   style:width="{width}px"
 >
   <Resizer
-    min={DEFAULT_NAV_WIDTH}
+    min={MIN_NAV_WIDTH}
     basis={DEFAULT_NAV_WIDTH}
-    max={440}
+    max={MAX_NAV_WIDTH}
     bind:dimension={width}
     bind:resizing
     side="right"
@@ -64,11 +86,70 @@
       <AddAssetButton />
     </div>
     <div class="scroll-container">
-      <div class="nav-wrapper" bind:clientHeight={navWrapperHeight}>
-        <FileExplorer hasUnsaved={unsavedFileCount > 0} />
-        <div class="grow" />
+      <div class="nav-wrapper" bind:contentRect>
+        <section class="size-full overflow-y-auto pb-4">
+          <FileExplorer hasUnsaved={unsavedFileCount > 0} />
+        </section>
+
         {#if navWrapperHeight}
-          <ConnectorExplorer containerHeight={navWrapperHeight} />
+          <section class="connector-section">
+            {#if showConnectors}
+              <Resizer
+                dimension={connectorSectionHeight}
+                onUpdate={(height) => {
+                  connectorHeightPercentage = height / navWrapperHeight;
+                }}
+                direction="NS"
+                side="top"
+                min={0}
+                basis={navWrapperHeight * DEFAULT_PERCENTAGE}
+                max={navWrapperHeight * 0.9}
+                bind:resizing={resizingConnector}
+              />
+            {/if}
+
+            <button
+              on:click={() => {
+                const open = showConnectors;
+
+                if (!open) connectorExplorerStore.toggleExplorer();
+
+                connectorWrapper.animate(
+                  [
+                    {
+                      height: `${open ? connectorSectionHeight : 0}px`,
+                    },
+                    {
+                      height: `${open ? 0 : connectorSectionHeight}px`,
+                    },
+                  ],
+                  {
+                    duration: 200,
+                    easing: "ease-out",
+                  },
+                ).onfinish = () => {
+                  if (open) connectorExplorerStore.toggleExplorer();
+                };
+              }}
+            >
+              <CaretDownIcon
+                size="14px"
+                className="text-gray-400 transition-transform {!showConnectors &&
+                  '-rotate-90'}"
+              />
+              <h3>Connectors</h3>
+            </button>
+
+            <div
+              class="connector-wrapper"
+              bind:this={connectorWrapper}
+              style:height="{showConnectors ? connectorSectionHeight : 0}px"
+            >
+              {#if showConnectors}
+                <ConnectorExplorer />
+              {/if}
+            </div>
+          </section>
         {/if}
       </div>
     </div>
@@ -80,13 +161,14 @@
   {resizing}
   navWidth={width}
   navOpen={$navigationOpen}
-  on:click={navigationOpen.toggle}
+  onClick={navigationOpen.toggle}
 />
 
 <style lang="postcss">
   .sidebar {
     @apply flex flex-col flex-none relative overflow-hidden;
     @apply h-full border-r z-0;
+    @apply select-none;
     transition-property: width;
     will-change: width;
   }
@@ -97,7 +179,7 @@
   }
 
   .nav-wrapper {
-    @apply flex flex-col h-full w-full gap-y-2;
+    @apply flex flex-col size-full;
   }
 
   .scroll-container {
@@ -106,11 +188,34 @@
   }
 
   .sidebar:not(.resizing) {
-    transition-duration: 400ms;
+    transition-duration: 300ms;
     transition-timing-function: ease-in-out;
   }
 
   .hide {
     width: 0px !important;
+  }
+
+  .connector-section {
+    @apply flex flex-col flex-none h-fit;
+    @apply border-t border-t-gray-200 relative;
+  }
+
+  .connector-wrapper {
+    @apply overflow-y-auto;
+  }
+
+  button {
+    @apply flex gap-x-1 items-center w-full;
+    @apply pl-2 pr-3.5 py-1.5 cursor-pointer;
+    @apply text-gray-500;
+  }
+
+  button:hover {
+    @apply bg-slate-100;
+  }
+
+  h3 {
+    @apply font-semibold text-[10px] uppercase;
   }
 </style>

--- a/web-common/src/layout/navigation/SurfaceControlButton.svelte
+++ b/web-common/src/layout/navigation/SurfaceControlButton.svelte
@@ -2,64 +2,54 @@
   import Button from "@rilldata/web-common/components/button/Button.svelte";
   import HideSidebar from "@rilldata/web-common/components/icons/HideSidebar.svelte";
   import SurfaceView from "@rilldata/web-common/components/icons/SurfaceView.svelte";
-  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
-  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
 
   export let navWidth: number;
   export let navOpen: boolean;
   export let resizing: boolean;
   export let show = true;
-
-  let active = false;
+  export let onClick: () => void;
 
   $: label = navOpen ? "Close sidebar" : "Show sidebar";
 </script>
 
-<button
+<span
   class="text-gray-500"
   class:resizing
   class:opacity-0={!show}
   class:shift={!navOpen}
   style:left="{navWidth - 32}px"
   aria-label={label}
+  title={label}
 >
   <Button
     type={navOpen ? "secondary" : "ghost"}
     gray={!navOpen}
     selected={navOpen}
     square
-    on:click
-    on:mousedown={() => {
-      active = false;
-    }}
+    on:click={onClick}
   >
-    <Tooltip location="bottom" alignment="start" distance={12} bind:active>
-      {#if navOpen}
-        <HideSidebar side="left" open={navOpen} size="18px" />
-      {:else}
-        <SurfaceView size="16px" mode={"hamburger"} />
-      {/if}
-      <TooltipContent slot="tooltip-content">
-        {label}
-      </TooltipContent>
-    </Tooltip>
+    {#if navOpen}
+      <HideSidebar side="left" open={navOpen} size="18px" />
+    {:else}
+      <SurfaceView size="16px" mode={"hamburger"} />
+    {/if}
   </Button>
-</button>
+</span>
 
 <style lang="postcss">
-  button {
+  span {
     @apply rounded flex justify-center items-center absolute;
     @apply z-50;
     @apply w-6 h-6 mt-[10px];
     transition-property: left;
   }
 
-  button:hover {
+  span:hover {
     @apply bg-gray-300;
   }
 
-  button:not(.resizing) {
-    transition-duration: 400ms;
+  span:not(.resizing) {
+    transition-duration: 300ms;
     transition-timing-function: ease-in-out;
   }
 

--- a/web-local/tests/file-explorer.spec.ts
+++ b/web-local/tests/file-explorer.spec.ts
@@ -16,6 +16,7 @@ test.describe("File Explorer", () => {
       ).toBeVisible();
 
       // Rename the file
+      await page.getByRole("listitem", { name: "/untitled_file" }).hover();
       await page.getByLabel("/untitled_file actions menu").click();
       await page.getByRole("menuitem", { name: "Rename..." }).click();
       await page.getByLabel("File name").click();
@@ -39,6 +40,7 @@ test.describe("File Explorer", () => {
       ).toBeVisible();
 
       // Delete the file
+      await page.getByRole("listitem", { name: "/README.md" }).hover();
       await page.getByLabel("/README.md actions menu").click();
       await page.getByRole("menuitem", { name: "Delete" }).click();
       await expect(
@@ -91,7 +93,11 @@ test.describe("File Explorer", () => {
         }),
       ).toBeVisible();
 
+      await page.waitForTimeout(2000);
       // Delete the folder
+      await page
+        .getByRole("button", { name: "my-directory", exact: true })
+        .hover();
       await page.getByLabel("my-directory actions menu").click();
       await page.getByRole("menuitem", { name: "Delete" }).click();
       await page.getByRole("button", { name: "Delete" }).click();


### PR DESCRIPTION
- Sets both a smaller min and max width for the Navigation sidebar
- Adds VSCode-like key bindings for toggling the sidebar
- Changes the styling of the context menu trigger so that file names show a few more characters
- Changes the sizing behavior of the Connectors panel to better match similar elements in VSCode
- Removes troublesome(!) tooltip from SurfaceControlButton
- Changes the click target for TableEntry to match other similar UI elements
- Updates a few styles to better match Figma
- Changes Connectors panel caret to match other elements

<img width="259" alt="Screenshot 2024-10-09 at 8 36 34 PM" src="https://github.com/user-attachments/assets/d3cf9d6f-b965-4961-93ad-8a20ed9d3cb5">
