### PR TITLE
resolve primary button collision

### DIFF
--- a/web-common/src/features/dashboards/workspace/DeployProjectCTA.svelte
+++ b/web-common/src/features/dashboards/workspace/DeployProjectCTA.svelte
@@ -1,3 +1,7 @@
+<script lang="ts" context="module">
+  export const allowPrimary = writable(false);
+</script>
+
 <script lang="ts">
   import { page } from "$app/stores";
   import {
@@ -21,7 +25,7 @@
     createLocalServiceGetCurrentUser,
     createLocalServiceGetMetadata,
   } from "@rilldata/web-common/runtime-client/local-service";
-  import { get } from "svelte/store";
+  import { get, writable } from "svelte/store";
   import { Button } from "../../../components/button";
   import Rocket from "svelte-radix/Rocket.svelte";
   import CloudIcon from "@rilldata/web-common/components/icons/CloudIcon.svelte";
@@ -37,7 +41,9 @@
       refetchOnWindowFocus: true,
     },
   });
-  $: isDeployed = !!$currentProject.data?.project;
+  $: isDeployed = true || !!$currentProject.data?.project;
+
+  $: allowPrimary.set(isDeployed || !hasValidDashboard);
 
   $: user = createLocalServiceGetCurrentUser();
   $: metadata = createLocalServiceGetMetadata();

--- a/web-common/src/features/dashboards/workspace/DeployProjectCTA.svelte
+++ b/web-common/src/features/dashboards/workspace/DeployProjectCTA.svelte
@@ -41,7 +41,7 @@
       refetchOnWindowFocus: true,
     },
   });
-  $: isDeployed = true || !!$currentProject.data?.project;
+  $: isDeployed = !!$currentProject.data?.project;
 
   $: allowPrimary.set(isDeployed || !hasValidDashboard);
 

--- a/web-common/src/features/metrics-views/GoToDashboardButton.svelte
+++ b/web-common/src/features/metrics-views/GoToDashboardButton.svelte
@@ -7,13 +7,12 @@
   import { removeLeadingSlash } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import type { V1Resource } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
-  import { useQueryClient } from "@tanstack/svelte-query";
+  import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
   import { useGetExploresForMetricsView } from "../dashboards/selectors";
   import { resourceColorMapping } from "../entity-management/resource-icon-mapping";
   import { ResourceKind } from "../entity-management/resource-selectors";
   import { createAndPreviewExplore } from "./create-and-preview-explore";
-
-  const queryClient = useQueryClient();
+  import { allowPrimary } from "../dashboards/workspace/DeployProjectCTA.svelte";
 
   export let resource: V1Resource | undefined;
 
@@ -27,7 +26,7 @@
 
 {#if dashboards?.length === 0}
   <Button
-    type="primary"
+    type={$allowPrimary ? "primary" : "secondary"}
     disabled={!resource}
     on:click={async () => {
       if (resource)

--- a/web-common/src/features/models/workspace/CreateDashboardButton.svelte
+++ b/web-common/src/features/models/workspace/CreateDashboardButton.svelte
@@ -12,6 +12,7 @@
   import { useCreateMetricsViewFromTableUIAction } from "../../metrics-views/ai-generation/generateMetricsView";
   import { useModel } from "../selectors";
   import { Wand } from "lucide-svelte";
+  import { allowPrimary } from "../../dashboards/workspace/DeployProjectCTA.svelte";
 
   export let modelName: string;
   export let hasError = false;
@@ -41,7 +42,7 @@
   <Button
     disabled={!modelIsIdle || hasError}
     on:click={createMetricsViewFromModel}
-    type="primary"
+    type={$allowPrimary ? "primary" : "secondary"}
   >
     <IconSpaceFixer pullLeft pullRight={collapse}>
       <Wand size="14px" />

--- a/web-common/src/features/sources/workspace/SourceCTAs.svelte
+++ b/web-common/src/features/sources/workspace/SourceCTAs.svelte
@@ -10,9 +10,6 @@
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
   import { removeLeadingSlash } from "../../entity-management/entity-mappers";
-  import { goto } from "$app/navigation";
-  import { Code2Icon } from "lucide-svelte";
-  import { ResourceKind } from "../../entity-management/resource-selectors";
   import {
     resourceColorMapping,
     resourceIconMapping,

--- a/web-common/src/features/sources/workspace/SourceCTAs.svelte
+++ b/web-common/src/features/sources/workspace/SourceCTAs.svelte
@@ -25,10 +25,6 @@
 
   $: ({ instanceId } = $runtime);
 
-  $: type = (
-    hasUnsavedChanges ? "primary" : "secondary"
-  ) as Button["$$prop_def"]["type"];
-
   $: modelsQuery = useModels(instanceId);
 
   $: modelsForSource = ($modelsQuery.data ?? []).filter((model) =>
@@ -67,7 +63,11 @@
   <DropdownMenu.Root>
     <DropdownMenu.Trigger asChild let:builder>
       <Tooltip distance={8}>
-        <Button builders={[builder]} label="Refresh" {type}>
+        <Button
+          builders={[builder]}
+          label="Refresh"
+          type={hasUnsavedChanges ? "primary" : "secondary"}
+        >
           <RefreshIcon size="14px" />
         </Button>
         <TooltipContent slot="tooltip-content">Refresh source</TooltipContent>

--- a/web-common/src/features/sources/workspace/SourceCTAs.svelte
+++ b/web-common/src/features/sources/workspace/SourceCTAs.svelte
@@ -5,6 +5,7 @@
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import RefreshIcon from "@rilldata/web-common/components/icons/RefreshIcon.svelte";
+  import { allowPrimary } from "../../dashboards/workspace/DeployProjectCTA.svelte";
 
   const dispatch = createEventDispatcher();
 
@@ -73,7 +74,7 @@
 <Button
   disabled={hasUnsavedChanges || hasErrors}
   on:click={() => dispatch("create-model")}
-  type="secondary"
+  type={$allowPrimary ? "primary" : "secondary"}
 >
   Create model
 </Button>

--- a/web-common/src/features/workspaces/SourceWorkspace.svelte
+++ b/web-common/src/features/workspaces/SourceWorkspace.svelte
@@ -155,6 +155,7 @@
     <svelte:fragment slot="cta">
       <div class="flex gap-x-2 items-center">
         <SourceCTAs
+          sourceName={assetName}
           hasUnsavedChanges={$hasUnsavedChanges}
           hasErrors={$hasErrors}
           {isLocalFileConnector}


### PR DESCRIPTION
Prevents collision of primary buttons in both the application and asset level headers. Also adds a dynamic Create/GoTo button for sources that matches similar buttons in other workspaces.

Consolidation of these dropdowns will come in a follow up PR.