### PR TITLE
fix: inferred resource behavior

### DIFF
--- a/web-common/src/features/entity-management/entity-mappers.ts
+++ b/web-common/src/features/entity-management/entity-mappers.ts
@@ -124,7 +124,7 @@ export function addLeadingSlash(path: string): string {
 export const FolderNameToResourceKind: Record<string, ResourceKind> = {
   sources: ResourceKind.Source,
   models: ResourceKind.Model,
-  dashboards: ResourceKind.MetricsView,
+  // dashboards: ResourceKind.MetricsView,
   metrics: ResourceKind.MetricsView,
   // explores: ResourceKind.Explore, // This does not happen on backend
   charts: ResourceKind.Component,

--- a/web-common/src/features/entity-management/file-artifact.ts
+++ b/web-common/src/features/entity-management/file-artifact.ts
@@ -236,7 +236,13 @@ export class FileArtifact {
       this.path,
       get(this.remoteContent) ?? "",
     );
-    if (inferred) this.inferredResourceKind.set(inferred);
+
+    const curName = get(this.resourceName);
+    if (inferred) {
+      this.inferredResourceKind.set(inferred);
+    } else if (curName && curName.kind) {
+      this.inferredResourceKind.set(curName.kind as ResourceKind);
+    }
 
     this.resourceName.set(undefined);
     this.reconciling.set(false);

--- a/web-common/src/features/entity-management/file-artifact.ts
+++ b/web-common/src/features/entity-management/file-artifact.ts
@@ -106,7 +106,9 @@ export class FileArtifact {
     );
 
     this.onRemoteContentChange((content) => {
-      this.inferredResourceKind.set(inferResourceKind(this.path, content));
+      const inferred = inferResourceKind(filePath, content);
+
+      if (inferred) this.inferredResourceKind.set(inferred);
     });
   }
 
@@ -230,9 +232,11 @@ export class FileArtifact {
 
   hardDeleteResource() {
     // To avoid a workspace flicker, first infer the *intended* resource kind
-    this.inferredResourceKind.set(
-      inferResourceKind(this.path, get(this.remoteContent) ?? ""),
+    const inferred = inferResourceKind(
+      this.path,
+      get(this.remoteContent) ?? "",
     );
+    if (inferred) this.inferredResourceKind.set(inferred);
 
     this.resourceName.set(undefined);
     this.reconciling.set(false);

--- a/web-common/src/features/visual-metrics-editing/lib.ts
+++ b/web-common/src/features/visual-metrics-editing/lib.ts
@@ -1,6 +1,7 @@
 import { writable } from "svelte/store";
 import type { YAMLMap } from "yaml";
 import type { MetricsViewSpecDimensionV2 } from "@rilldata/web-common/runtime-client";
+import { FormatPreset } from "@rilldata/web-common/lib/number-formatting/humanizer-types";
 
 export const types: ItemType[] = ["measures", "dimensions"];
 
@@ -22,8 +23,6 @@ export type Confirmation = {
   index?: number;
   field?: string;
 };
-
-import { FormatPreset } from "@rilldata/web-common/lib/number-formatting/humanizer-types";
 
 export class YAMLDimension {
   column: string;

--- a/web-common/src/features/visual-metrics-editing/lib.ts
+++ b/web-common/src/features/visual-metrics-editing/lib.ts
@@ -70,9 +70,8 @@ export class YAMLMeasure {
         : Boolean(item?.get("valid_percent_of_total"));
     this.format_d3 = item?.get("format_d3") ?? "";
     this.format_preset =
-      (item?.get("format_preset") as unknown as FormatPreset) ?? this.format_d3
-        ? ""
-        : FormatPreset.HUMANIZE;
+      (item?.get("format_preset") as unknown as FormatPreset) ??
+      (this.format_d3 ? "" : FormatPreset.HUMANIZE);
   }
 }
 

--- a/web-common/src/features/visual-metrics-editing/lib.ts
+++ b/web-common/src/features/visual-metrics-editing/lib.ts
@@ -71,8 +71,7 @@ export class YAMLMeasure {
         : Boolean(item?.get("valid_percent_of_total"));
     this.format_d3 = item?.get("format_d3") ?? "";
     this.format_preset =
-      ((item?.get("format_preset") as unknown as FormatPreset) ??
-      this.format_d3)
+      (item?.get("format_preset") as unknown as FormatPreset) ?? this.format_d3
         ? ""
         : FormatPreset.HUMANIZE;
   }

--- a/web-common/src/features/workspaces/VisualMetrics.svelte
+++ b/web-common/src/features/workspaces/VisualMetrics.svelte
@@ -115,7 +115,11 @@
   $: itemGroups = {
     measures:
       raw.measures instanceof YAMLSeq
-        ? raw.measures.items.map((item) => new YAMLMeasure(item))
+        ? raw.measures.items
+            .map((item) => {
+              if (item instanceof YAMLMap) return new YAMLMeasure(item);
+            })
+            .filter(is<YAMLMeasure>)
         : [],
     dimensions:
       raw.dimensions instanceof YAMLSeq
@@ -154,9 +158,12 @@
     rawDimensions: YAMLSeq<YAMLMap<string, string>>,
     metricsViewDimensions: MetricsViewSpecDimensionV2[],
   ) {
-    return rawDimensions.items.map(
-      (item, i) => new YAMLDimension(item, metricsViewDimensions[i]),
-    );
+    return rawDimensions.items
+      .map((item, i) => {
+        if (item instanceof YAMLMap)
+          return new YAMLDimension(item, metricsViewDimensions[i]);
+      })
+      .filter(is<YAMLDimension>);
   }
 
   function stringGuard(value: unknown | undefined): string {
@@ -213,6 +220,10 @@
       value,
       label: value,
     };
+  }
+
+  function is<T>(value: unknown): value is T {
+    return Boolean(value);
   }
 
   async function reorderList(


### PR DESCRIPTION
- We cannot assume that files in the `dashboards` folder are of type MetricsView
- If a resource kind has been previously determined, do not overwrite that when it can no longer be inferred
- Adds a check to the `VisualMetrics` surface to ensure the YAML items in a sequence are of the map type
