### PR TITLE
Fix OLAP connector form

### DIFF
--- a/web-common/src/features/connectors/code-utils.ts
+++ b/web-common/src/features/connectors/code-utils.ts
@@ -36,6 +36,7 @@ driver: ${connector.name}`;
 
   // Compile key value pairs
   const compiledKeyValues = Object.keys(formValues)
+    .filter((key) => formValues[key] !== undefined)
     .map((key) => {
       const value = formValues[key] as string;
 

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
   import { Button } from "@rilldata/web-common/components/button";
   import InformationalField from "@rilldata/web-common/components/forms/InformationalField.svelte";
   import Input from "@rilldata/web-common/components/forms/Input.svelte";
@@ -46,7 +45,6 @@
         if (isSourceForm) {
           try {
             await submitAddDataForm(queryClient, formType, connector, values);
-            await goto(`/files/sources/${values.name}.yaml`);
             onClose();
           } catch (e) {
             rpcError = e?.response?.data;

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -4,19 +4,19 @@
   import InformationalField from "@rilldata/web-common/components/forms/InformationalField.svelte";
   import Input from "@rilldata/web-common/components/forms/Input.svelte";
   import SubmissionError from "@rilldata/web-common/components/forms/SubmissionError.svelte";
+  import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
   import {
     ConnectorDriverPropertyType,
     type RpcStatus,
     type V1ConnectorDriver,
   } from "@rilldata/web-common/runtime-client";
+  import { defaults, superForm } from "sveltekit-superforms";
+  import { yup } from "sveltekit-superforms/adapters";
   import { inferSourceName } from "../sourceUtils";
   import { humanReadableErrorMessage } from "./errors";
   import { submitAddDataForm } from "./submitAddDataForm";
   import type { AddDataFormType } from "./types";
   import { getYupSchema, toYupFriendlyKey } from "./yupSchemas";
-  import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
-  import { defaults, superForm } from "sveltekit-superforms";
-  import { yup } from "sveltekit-superforms/adapters";
 
   export let connector: V1ConnectorDriver;
   export let formType: AddDataFormType;
@@ -57,7 +57,6 @@
         // Connectors
         try {
           await submitAddDataForm(queryClient, formType, connector, values);
-          await goto(`/files/connectors/${connector.name}.yaml`);
           onClose();
         } catch (e) {
           rpcError = e?.response?.data;

--- a/web-common/src/features/sources/modal/submitAddDataForm.ts
+++ b/web-common/src/features/sources/modal/submitAddDataForm.ts
@@ -20,10 +20,7 @@ import {
   updateDotEnvWithSecrets,
   updateRillYAMLWithOlapConnector,
 } from "../../connectors/code-utils";
-import {
-  getFileAPIPathFromNameAndType,
-  getFilePathFromNameAndType,
-} from "../../entity-management/entity-mappers";
+import { getFileAPIPathFromNameAndType } from "../../entity-management/entity-mappers";
 import { fileArtifacts } from "../../entity-management/file-artifacts";
 import { getName } from "../../entity-management/name-utils";
 import { ResourceKind } from "../../entity-management/resource-selectors";
@@ -91,11 +88,12 @@ export async function submitAddDataForm(
     );
 
     // Make a new <source>.yaml file
+    const newSourceFilePath = getFileAPIPathFromNameAndType(
+      values.name as string,
+      EntityType.Table,
+    );
     await runtimeServicePutFile(instanceId, {
-      path: getFileAPIPathFromNameAndType(
-        values.name as string,
-        EntityType.Table,
-      ),
+      path: newSourceFilePath,
       blob: compileSourceYAML(rewrittenConnector, rewrittenFormValues),
       create: true,
       createOnly: false, // The modal might be opened from a YAML file with placeholder text, so the file might already exist
@@ -113,10 +111,9 @@ export async function submitAddDataForm(
       createOnly: false,
     });
 
-    await checkSourceImported(
-      queryClient,
-      getFilePathFromNameAndType(values.name as string, EntityType.Table),
-    );
+    await checkSourceImported(queryClient, newSourceFilePath);
+
+    await goto(`/files/${newSourceFilePath}`);
 
     return;
   }

--- a/web-common/src/features/sources/modal/submitAddDataForm.ts
+++ b/web-common/src/features/sources/modal/submitAddDataForm.ts
@@ -1,3 +1,4 @@
+import { goto } from "$app/navigation";
 import { getScreenNameFromPage } from "@rilldata/web-common/features/file-explorer/telemetry";
 import { checkSourceImported } from "@rilldata/web-common/features/sources/source-imported-utils";
 import type { QueryClient } from "@tanstack/query-core";
@@ -130,8 +131,12 @@ export async function submitAddDataForm(
   );
 
   // Make a new `<connector>.yaml` file
+  const newConnectorFilePath = getFileAPIPathFromNameAndType(
+    newConnectorName,
+    EntityType.Connector,
+  );
   await runtimeServicePutFile(instanceId, {
-    path: getFileAPIPathFromNameAndType(newConnectorName, EntityType.Connector),
+    path: newConnectorFilePath,
     blob: compileConnectorYAML(connector, formValues),
     create: true,
     createOnly: false,
@@ -152,4 +157,7 @@ export async function submitAddDataForm(
     create: true,
     createOnly: false,
   });
+
+  // Go to the new connector file
+  await goto(`/files/${newConnectorFilePath}`);
 }

--- a/web-common/src/features/sources/modal/yupSchemas.ts
+++ b/web-common/src/features/sources/modal/yupSchemas.ts
@@ -164,7 +164,10 @@ export const getYupSchema = {
         /^(?!https?:\/\/)[a-zA-Z0-9.-]+$/,
         "Do not prefix the host with `http(s)://`", // It will be added by the runtime
       ),
-    port: yup.number().required("Port is required"),
+    port: yup
+      .string() // Purposefully using a string input, not a numeric input
+      .matches(/^\d+$/, "Port must be a number")
+      .required("Port is required"),
     username: yup.string(),
     password: yup.string(),
     ssl: yup.boolean(),
@@ -184,7 +187,10 @@ export const getYupSchema = {
         /^(?!https?:\/\/)[a-zA-Z0-9.-]+$/,
         "Do not prefix the host with `http(s)://`", // It will be added by the runtime
       ),
-    port: yup.number().required("Port is required"),
+    port: yup
+      .string() // Purposefully using a string input, not a numeric input
+      .matches(/^\d+$/, "Port must be a number")
+      .required("Port is required"),
     username: yup.string(),
     password: yup.string(),
     ssl: yup.boolean(),
@@ -204,7 +210,10 @@ export const getYupSchema = {
         /^(?!https?:\/\/)[a-zA-Z0-9.-]+$/,
         "Do not prefix the host with `http(s)://`", // It will be added by the runtime
       ),
-    port: yup.number().required("Port is required"),
+    port: yup
+      .string() // Purposefully using a string input, not a numeric input
+      .matches(/^\d+$/, "Port must be a number")
+      .required("Port is required"),
     username: yup.string(),
     password: yup.string(),
     ssl: yup.boolean(),

--- a/web-common/src/features/sources/sourceUtils.ts
+++ b/web-common/src/features/sources/sourceUtils.ts
@@ -1,8 +1,8 @@
 import { extractFileExtension } from "@rilldata/web-common/features/entity-management/file-path-utils";
 import {
   ConnectorDriverPropertyType,
-  type V1SourceV2,
   type V1ConnectorDriver,
+  type V1SourceV2,
 } from "@rilldata/web-common/runtime-client";
 import { makeDotEnvConnectorKey } from "../connectors/code-utils";
 import { sanitizeEntityName } from "../entity-management/name-utils";
@@ -33,6 +33,7 @@ export function compileSourceYAML(
 
   // Compile key value pairs
   const compiledKeyValues = Object.keys(formValues)
+    .filter((key) => formValues[key] !== undefined)
     .filter((key) => key !== "name")
     .map((key) => {
       const value = formValues[key] as string;


### PR DESCRIPTION
This PR includes a collection of fixes for the OLAP connector forms:
- Ensures `port` isn't initialized to 0.
- Ensures Yup validation doesn't reject the `port` for being a string, not a number. (It's a string because we're using an `<input />` element with `type: string`, intentionally to avoid the `type: number` widget.)
- Removes fields with `undefined` values from the generated YAML.
- Correctly navigates to the new connector file when the connector `name` != `driver`.