### PR TITLE
Introduce ScaleDownConstraints Environment Variable for Conditional Autoscaling Down

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -29,27 +29,29 @@ type Options struct {
 	MetricsProjectOrg         string
 	MetricsProjectName        string
 	AutoscalerCron            string
+	ScaleDownConstraint       int
 }
 
 type Service struct {
-	DB               database.DB
-	Jobs             jobs.Client
-	URLs             *URLs
-	ProvisionerSet   map[string]provisioner.Provisioner
-	Email            *email.Client
-	Github           Github
-	AI               ai.Client
-	Assets           *storage.BucketHandle
-	Used             *usedFlusher
-	Logger           *zap.Logger
-	opts             *Options
-	issuer           *auth.Issuer
-	VersionNumber    string
-	VersionCommit    string
-	metricsProjectID string
-	AutoscalerCron   string
-	Biller           billing.Biller
-	PaymentProvider  payment.Provider
+	DB                  database.DB
+	Jobs                jobs.Client
+	URLs                *URLs
+	ProvisionerSet      map[string]provisioner.Provisioner
+	Email               *email.Client
+	Github              Github
+	AI                  ai.Client
+	Assets              *storage.BucketHandle
+	Used                *usedFlusher
+	Logger              *zap.Logger
+	opts                *Options
+	issuer              *auth.Issuer
+	VersionNumber       string
+	VersionCommit       string
+	metricsProjectID    string
+	AutoscalerCron      string
+	ScaleDownConstraint int
+	Biller              billing.Biller
+	PaymentProvider     payment.Provider
 }
 
 func New(ctx context.Context, opts *Options, logger *zap.Logger, issuer *auth.Issuer, emailClient *email.Client, github Github, aiClient ai.Client, assets *storage.BucketHandle, biller billing.Biller, p payment.Provider) (*Service, error) {
@@ -107,23 +109,24 @@ func New(ctx context.Context, opts *Options, logger *zap.Logger, issuer *auth.Is
 	}
 
 	return &Service{
-		DB:               db,
-		URLs:             urls,
-		ProvisionerSet:   provSet,
-		Email:            emailClient,
-		Github:           github,
-		AI:               aiClient,
-		Assets:           assets,
-		Used:             newUsedFlusher(logger, db),
-		Logger:           logger,
-		opts:             opts,
-		issuer:           issuer,
-		VersionNumber:    opts.VersionNumber,
-		VersionCommit:    opts.VersionCommit,
-		metricsProjectID: metricsProjectID,
-		AutoscalerCron:   opts.AutoscalerCron,
-		Biller:           biller,
-		PaymentProvider:  p,
+		DB:                  db,
+		URLs:                urls,
+		ProvisionerSet:      provSet,
+		Email:               emailClient,
+		Github:              github,
+		AI:                  aiClient,
+		Assets:              assets,
+		Used:                newUsedFlusher(logger, db),
+		Logger:              logger,
+		opts:                opts,
+		issuer:              issuer,
+		VersionNumber:       opts.VersionNumber,
+		VersionCommit:       opts.VersionCommit,
+		metricsProjectID:    metricsProjectID,
+		AutoscalerCron:      opts.AutoscalerCron,
+		ScaleDownConstraint: opts.ScaleDownConstraint,
+		Biller:              biller,
+		PaymentProvider:     p,
 	}, nil
 }
 

--- a/admin/worker/run_autoscaler_test.go
+++ b/admin/worker/run_autoscaler_test.go
@@ -6,23 +6,27 @@ import (
 
 func TestShouldScale(t *testing.T) {
 	tests := []struct {
-		name           string
-		originSlots    int
-		recommendSlots int
-		want           bool
-		wantReason     string
+		name                 string
+		originSlots          int
+		recommendSlots       int
+		scaleDownConstraints int
+		want                 bool
+		wantReason           string
 	}{
-		{"No scaling down", 9, 8, false, scaledown},
-		{"No scaling for small change", 50, 55, false, belowThreshold},
-		{"No scaling for less than min scaling slots", 20, 24, false, belowThreshold},
-		{"Scaling for significant change", 50, 60, true, ""},
-		{"Scaling up for small services", 6, 10, true, ""},
-		{"No scaling for the same quota", 77, 77, false, scaleMatch},
+		{"No scaling down", 9, 8, 0, false, scaledown},
+		{"No scaling down", 9, 8, 5, false, scaledown},
+		{"Scaling down under constraints", 9, 8, 10, true, ""},
+		{"Scaling down without constraints", 9, 8, -1, true, ""},
+		{"No scaling for small change", 50, 55, 0, false, belowThreshold},
+		{"No scaling for less than min scaling slots", 20, 24, 0, false, belowThreshold},
+		{"Scaling for significant change", 50, 60, 0, true, ""},
+		{"Scaling up for small services", 6, 10, 0, true, ""},
+		{"No scaling for the same quota", 77, 77, 0, false, scaleMatch},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, gotReason := shouldScale(tt.originSlots, tt.recommendSlots)
+			got, gotReason := shouldScale(tt.originSlots, tt.recommendSlots, tt.scaleDownConstraints)
 			if got != tt.want || gotReason != tt.wantReason {
 				t.Errorf("shouldScale(%d, %d) = (%v, %q); want (%v, %q)", tt.originSlots, tt.recommendSlots, got, gotReason, tt.want, tt.wantReason)
 			}

--- a/cli/cmd/admin/start.go
+++ b/cli/cmd/admin/start.go
@@ -90,6 +90,7 @@ type Config struct {
 	ActivityUISinkKafkaTopic          string `default:"" split_words:"true"`
 	MetricsProject                    string `default:"" split_words:"true"`
 	AutoscalerCron                    string `default:"CRON_TZ=America/Los_Angeles 0 0 * * 1" split_words:"true"`
+	ScaleDownConstraint               int    `default:"0" split_words:"true"`
 	OrbAPIKey                         string `split_words:"true"`
 	OrbWebhookSecret                  string `split_words:"true"`
 	StripeAPIKey                      string `split_words:"true"`
@@ -289,6 +290,7 @@ func StartCmd(ch *cmdutil.Helper) *cobra.Command {
 				MetricsProjectOrg:         metricsProjectOrg,
 				MetricsProjectName:        metricsProjectName,
 				AutoscalerCron:            conf.AutoscalerCron,
+				ScaleDownConstraint:       conf.ScaleDownConstraint,
 			}
 			adm, err := admin.New(cmd.Context(), admOpts, logger, issuer, emailClient, gh, aiClient, assetsBucket, biller, p)
 			if err != nil {


### PR DESCRIPTION
### Description:

Introduce a new environment variable, `ScaleDownConstraints`, to allow conditional autoscaling down of Rill projects based on slot usage.

**Behavior:**

- **`ScaleDownConstraints == -1`**
  - All scale-down operations are enabled (no constraints).
- **`ScaleDownConstraints == 0`**
  - All scale-down operations are disabled.
- **`ScaleDownConstraints > 0`**
  - Scale-down is allowed only for Rill projects where the current number of slots (`originSlots`) is less than or equal to `ScaleDownConstraints`.

### Motivation:

Resolve Issue: [rilldata/rill-helm-charts#161](https://github.com/rilldata/rill-helm-charts/issues/161)