### PR TITLE
Introducing Rill Guru on Gurubase

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ rill start my-rill-project
   <a href="https://docs.rilldata.com/home/get-started#example-projects">Example Projects</a>
   <span> · </span>
   <a href="https://discord.gg/DJ5qcsxE2m">Community</a>
+  <span> · </span>
+  <a href="https://gurubase.io/g/rill">Ask Rill Guru</a>
 </h3>
 
 ![home-demo](https://github.com/rilldata/rill/assets/1181922/1430f272-3fa4-495a-8e45-1bd6fa56f5d2)


### PR DESCRIPTION
Hello Rill team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Rill Guru](https://gurubase.io/g/rill) to Gurubase. Rill Guru uses the data from this repo and data from the [docs](https://docs.rilldata.com/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Rill Guru" on the README. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Rill Guru in Gurubase, just let me know that's totally fine.