### PR TITLE
fix: hide grains smaller than smallest_time_grain from pivot sidebar

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
+  import Search from "@rilldata/web-common/components/icons/Search.svelte";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
-  import PivotDrag from "./PivotDrag.svelte";
-  import { getAllowedTimeGrains } from "@rilldata/web-common/lib/time/grains";
-  import { PivotChipType } from "./types";
-  import type { PivotChipData } from "./types";
-  import Search from "@rilldata/web-common/components/icons/Search.svelte";
+  import {
+    getAllowedTimeGrains,
+    isGrainBigger,
+  } from "@rilldata/web-common/lib/time/grains";
+  import { V1TimeGrain } from "@rilldata/web-common/runtime-client";
   import { slide } from "svelte/transition";
+  import PivotDrag from "./PivotDrag.svelte";
+  import type { PivotChipData } from "./types";
+  import { PivotChipType } from "./types";
 
   const CHIP_HEIGHT = 34;
 
@@ -38,9 +42,15 @@
     .filter((m) => m.type === PivotChipType.Time)
     .concat($rows.dimension.filter((d) => d.type === PivotChipType.Time));
 
-  $: timeGrainOptions = allTimeGrains.filter(
-    (tgo) => !usedTimeGrains.some((utg) => utg.id === tgo.id),
-  );
+  $: timeGrainOptions = allTimeGrains
+    .filter((tgo) => !usedTimeGrains.some((utg) => utg.id === tgo.id))
+    .filter(
+      (tgo) =>
+        $timeControlsStore.minTimeGrain === undefined ||
+        $timeControlsStore.minTimeGrain ===
+          V1TimeGrain.TIME_GRAIN_UNSPECIFIED ||
+        !isGrainBigger($timeControlsStore.minTimeGrain, tgo.id),
+    );
 
   $: filteredMeasures = filterBasedOnSearch($measures, searchText);
   $: filteredDimensions = filterBasedOnSearch($dimensions, searchText);


### PR DESCRIPTION
Hide all grains which are smaller than the `smallest_time_grain` from the options in the pivot sidebar.