### PR TITLE
fix: measure filter short labels

### DIFF
--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterBody.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterBody.svelte
@@ -42,10 +42,7 @@
       case MeasureFilterOperation.NotEquals:
         shortLabel =
           AllMeasureFilterOperationOptions.find(
-            (o) =>
-              // svelte-check is throwing an error here stating `filter could be undefined` so we need this
-              o.value === filter?.operation ||
-              MeasureFilterOperation.GreaterThan,
+            (o) => o.value === filter?.operation,
           )?.shortLabel +
           " " +
           filter.value1 +


### PR DESCRIPTION
The short label for measure filter was not showing the correct symbol.

Before
![image](https://github.com/user-attachments/assets/5221c4cc-2951-4d64-b6bf-66cae426de70)

After
![image](https://github.com/user-attachments/assets/b8145d14-ebca-4a2b-9271-c574fbc12a6a)
