### PR TITLE
fix: don't fill inferred label in visual metrics sidebar

### DIFF
--- a/web-common/src/components/forms/InputLabel.svelte
+++ b/web-common/src/components/forms/InputLabel.svelte
@@ -21,7 +21,7 @@
       <div class="text-gray-500">
         <InfoCircle size="13px" />
       </div>
-      <TooltipContent maxWidth="400px" slot="tooltip-content">
+      <TooltipContent maxWidth="240px" slot="tooltip-content">
         {@html hint}
       </TooltipContent>
     </Tooltip>

--- a/web-common/src/features/visual-metrics-editing/Sidebar.svelte
+++ b/web-common/src/features/visual-metrics-editing/Sidebar.svelte
@@ -88,7 +88,7 @@
         fields: [
           {
             key: "label",
-            hint: "Used on dashboards and charts",
+            hint: "Used on dashboards and charts. Inferred from name when not provided",
 
             label: "Label",
           },
@@ -176,7 +176,7 @@
         fields: [
           {
             key: "label",
-            hint: "Used on dashboards and charts",
+            hint: "Used on dashboards and charts. Inferred from name when not provided",
 
             label: "Label",
           },

--- a/web-common/src/features/visual-metrics-editing/lib.ts
+++ b/web-common/src/features/visual-metrics-editing/lib.ts
@@ -65,7 +65,7 @@ export class YAMLMeasure {
   constructor(item?: YAMLMap<string, string>) {
     this.expression = item?.get("expression") ?? "";
     this.name = item?.get("name") ?? "";
-    this.label = item?.get("label") ?? item?.get("name") ?? "";
+    this.label = item?.get("label") ?? "";
     this.description = item?.get("description") ?? "";
     this.valid_percent_of_total =
       item?.get("valid_percent_of_total") === undefined


### PR DESCRIPTION
- Prevents the Label input in the Sidebar from being filled with a value inferred from the `name` field.
- Narrows the max width for the hint tooltip
- Updates Label input tooltip language