### PR TITLE
SvelteKit: Preload data on hover

### DIFF
--- a/web-admin/src/app.html
+++ b/web-admin/src/app.html
@@ -59,7 +59,7 @@
     />
     %sveltekit.head%
   </head>
-  <body>
+  <body data-sveltekit-preload-data="hover">
     <div>%sveltekit.body%</div>
     <div id="rill-portal"></div>
   </body>

--- a/web-local/src/app.html
+++ b/web-local/src/app.html
@@ -51,7 +51,7 @@
     <meta content="width=device-width, initial-scale=1" name="viewport" />
     %sveltekit.head%
   </head>
-  <body>
+  <body data-sveltekit-preload-data="hover">
     <div id="svelte">%sveltekit.body%</div>
     <div id="rill-portal"></div>
   </body>


### PR DESCRIPTION
Adds `data-sveltekit-preload-data="hover"` to both Rill Developer and Rill Cloud UIs. This setting triggers a route's loader function to be invoked on mouse hover. 

It's now the default on new SvelteKit projects.

See https://svelte.dev/docs/kit/link-options#data-sveltekit-preload-data