### PR TITLE
Connection cache: Support acquiring a connection that was force evicted while opening while it is still opening 

### DIFF
--- a/runtime/pkg/conncache/conncache.go
+++ b/runtime/pkg/conncache/conncache.go
@@ -393,7 +393,7 @@ func (c *cacheImpl) retainEntry(key string, e *entry) {
 func (c *cacheImpl) releaseEntry(key string, e *entry) {
 	e.refs--
 	if e.refs == 0 {
-		// If opening/opening, keep entry and put in LRU. Else remove entirely.
+		// If open (or opening), keep entry and put in LRU. Else remove it from the cache entirely.
 		switch e.status {
 		case entryStatusOpening, entryStatusOpen:
 			c.lru.Add(key, e)

--- a/runtime/pkg/conncache/conncache_test.go
+++ b/runtime/pkg/conncache/conncache_test.go
@@ -179,8 +179,8 @@ func TestCloseDuringOpen(t *testing.T) {
 	// Start opening
 	go func() {
 		_, _, err := c.Acquire(context.Background(), "foo")
-		require.ErrorContains(t, err, "immediately closed")
-		require.Equal(t, int64(1), opens.Load())
+		require.NoError(t, err)
+		require.Equal(t, int64(2), opens.Load())
 	}()
 
 	// Evict it so it starts closing
@@ -298,4 +298,7 @@ func TestAcquireCloseAfterOpening(t *testing.T) {
 	_, r1, err := c.Acquire(context.Background(), "foo")
 	require.NoError(t, err)
 	r1()
+
+	// Close cache
+	require.NoError(t, c.Close(context.Background()))
 }


### PR DESCRIPTION
Imagine the following scenario:
1. We start acquiring a connection
2. We cancel the acquire before the connection finishes opening
    - We don't cancel the opening connection itself since others may be waiting for it (and is also supposed to stay open in the connection cache)
3. We force evict the connection while it is still opening
    - Since we can't close an opening connection, this marks the connection to be immediately closed once it has finished opening
4. We try to acquire the connection again while it is still opening and hasn't yet been evicted

The current connection cache will fail step 4 with `conncache: connection was immediately closed after being opened`. This happened recently in an issue where an instance was edited (triggering a controller restart and connection eviction) shortly after its runtime was restarted and still busy opening a ClickHouse connection that was taking a long time to open (around 25 seconds, maybe scaling up from zero).

This PR fixes the problem by adding a retry around step 4.