### PR TITLE
tweak redirect flow

### DIFF
--- a/web-common/src/components/card/Card.svelte
+++ b/web-common/src/components/card/Card.svelte
@@ -13,7 +13,8 @@
   class:gradient={!imageUrl}
   on:click
   on:keydown={(e) => e.key === "Enter" && e.currentTarget.click()}
-  aria-disabled={disabled && !isLoading}
+  aria-disabled={disabled}
+  class:loading={isLoading}
   style:background-image={imageUrl ? `url('${imageUrl}')` : ""}
 >
   {#if isLoading}
@@ -29,7 +30,7 @@
 <style lang="postcss">
   a {
     @apply bg-no-repeat bg-center bg-cover;
-    @apply relative;
+    @apply relative select-none;
     @apply size-60 rounded-md;
     @apply flex flex-col items-center justify-center gap-y-2;
     @apply transition duration-300 ease-out;
@@ -47,8 +48,11 @@
 
   a[aria-disabled="true"] {
     cursor: not-allowed;
-    opacity: 0.4;
     pointer-events: none;
+  }
+
+  a[aria-disabled="true"]:not(.loading) {
+    opacity: 0.4;
   }
 
   a:hover {

--- a/web-common/src/features/welcome/ProjectCards.svelte
+++ b/web-common/src/features/welcome/ProjectCards.svelte
@@ -69,6 +69,10 @@
           force: true,
         },
       });
+
+      setTimeout(() => {
+        if (window.location.search) window.location.reload();
+      }, 5000);
     } catch {
       selectedProjectName = null;
     }

--- a/web-common/src/features/welcome/ProjectCards.svelte
+++ b/web-common/src/features/welcome/ProjectCards.svelte
@@ -71,8 +71,8 @@
       });
 
       setTimeout(() => {
-        // If ?redirect=true is still in the url after 5 seconds, reload
-        if (window.location.search) window.location.reload();
+        if (window.location.search.includes("redirect=true"))
+          window.location.reload();
       }, 5000);
     } catch {
       selectedProjectName = null;

--- a/web-common/src/features/welcome/ProjectCards.svelte
+++ b/web-common/src/features/welcome/ProjectCards.svelte
@@ -71,6 +71,7 @@
       });
 
       setTimeout(() => {
+        // If ?redirect=true is still in the url after 5 seconds, reload
         if (window.location.search) window.location.reload();
       }, 5000);
     } catch {

--- a/web-common/src/runtime-client/watch-request-client.ts
+++ b/web-common/src/runtime-client/watch-request-client.ts
@@ -39,7 +39,7 @@ export class WatchRequestClient<Res extends WatchResponse> {
   private url: string | undefined;
   private controller: AbortController | undefined;
   private stream: AsyncGenerator<StreamingFetchResponse<Res>> | undefined;
-  private outOfFocusThrottler = new Throttler(120000, 30000);
+  private outOfFocusThrottler = new Throttler(120000, 20000);
   public retryAttempts = writable(0);
   private reconnectTimeout: ReturnType<typeof setTimeout> | undefined;
   private retryTimeout: ReturnType<typeof setTimeout> | undefined;


### PR DESCRIPTION
To address some concerns related to example project unpacking in certain situations, this PR makes the following changes:

- Reduce watch-request-client priority disconnect (which applies when the tab is put in the background) to 20 seconds
- Prevent multiple clicks on the same example project
- If `?redirect=true` is still in the URL after 5 seconds, reload the page