### PR TITLE
Retry when the admin or runtime service is unavailable

### DIFF
--- a/admin/client/client.go
+++ b/admin/client/client.go
@@ -19,7 +19,7 @@ const retryPolicy = `{"methodConfig": [{
 	"retryPolicy": {
 		"maxAttempts": 5,
 		"initialBackoff": ".1s",
-		"maxBackoff": "10s",
+		"maxBackoff": "5s",
 		"backoffMultiplier": 5,
 		"retryableStatusCodes": ["UNAVAILABLE"]
 	}

--- a/admin/client/client.go
+++ b/admin/client/client.go
@@ -12,6 +12,19 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+// Retry policy for requests to the admin service.
+// For details, see https://github.com/grpc/grpc/blob/master/doc/service_config.md and https://grpc.io/docs/guides/retry/.
+const retryPolicy = `{"methodConfig": [{
+	"name": [{}],
+	"retryPolicy": {
+		"maxAttempts": 5,
+		"initialBackoff": ".1s",
+		"maxBackoff": "10s",
+		"backoffMultiplier": 5,
+		"retryableStatusCodes": ["UNAVAILABLE"]
+	}
+}]}`
+
 // Client connects to an admin server.
 // It's a thin wrapper around the generated gRPC client for proto/rill/admin/v1.
 type Client struct {
@@ -29,6 +42,7 @@ func New(adminHost, bearerToken, userAgent string) (*Client, error) {
 
 	opts := []grpc.DialOption{
 		grpc.WithUserAgent(userAgent),
+		grpc.WithDefaultServiceConfig(retryPolicy),
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 	}
 

--- a/runtime/client/client.go
+++ b/runtime/client/client.go
@@ -12,6 +12,19 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+// Retry policy for requests to the runtime.
+// For details, see https://github.com/grpc/grpc/blob/master/doc/service_config.md and https://grpc.io/docs/guides/retry/.
+const retryPolicy = `{"methodConfig": [{
+	"name": [{}],
+	"retryPolicy": {
+		"maxAttempts": 5,
+		"initialBackoff": ".1s",
+		"maxBackoff": "10s",
+		"backoffMultiplier": 5,
+		"retryableStatusCodes": ["UNAVAILABLE"]
+	}
+}]}`
+
 // Client connects to a runtime server.
 // It's a thin wrapper around the generated gRPC client for proto/rill/runtime/v1.
 type Client struct {
@@ -27,6 +40,7 @@ func New(runtimeHost, bearerToken string) (*Client, error) {
 	}
 
 	opts := []grpc.DialOption{
+		grpc.WithDefaultServiceConfig(retryPolicy),
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 	}
 

--- a/runtime/client/client.go
+++ b/runtime/client/client.go
@@ -19,8 +19,8 @@ const retryPolicy = `{"methodConfig": [{
 	"retryPolicy": {
 		"maxAttempts": 5,
 		"initialBackoff": ".1s",
-		"maxBackoff": "10s",
-		"backoffMultiplier": 5,
+		"maxBackoff": "20s",
+		"backoffMultiplier": 10,
 		"retryableStatusCodes": ["UNAVAILABLE"]
 	}
 }]}`


### PR DESCRIPTION
This PR adds exponential backoff retries for admin and runtime gRPC requests that fail with an "unavailable" status code.

This will hopefully mitigate occasional errors such as this recent example:
```
repo handshake failed: rpc error: code = Unavailable desc = unexpected HTTP status code received ...
```

Closes https://github.com/rilldata/rill-private-issues/issues/787