### PR TITLE
Deprecate `rill start --readonly`

### DIFF
--- a/cli/cmd/start/start.go
+++ b/cli/cmd/start/start.go
@@ -194,6 +194,11 @@ func StartCmd(ch *cmdutil.Helper) *cobra.Command {
 		panic(err)
 	}
 
+	// Deprecated support for "--readonly". Projects should be shared via Rill Cloud.
+	if err := startCmd.Flags().MarkHidden("readonly"); err != nil {
+		panic(err)
+	}
+
 	// We have deprecated the ability configure the OLAP database via the CLI. This should now be done via rill.yaml.
 	// Keeping these for backwards compatibility for a while.
 	startCmd.Flags().StringVar(&olapDSN, "db", local.DefaultOLAPDSN, "Database DSN")


### PR DESCRIPTION
Projects should be shared via Rill Cloud.