### PR TITLE
fix: update subscription plan names to match orb

### DIFF
--- a/cli/cmd/devtool/subscription.go
+++ b/cli/cmd/devtool/subscription.go
@@ -144,7 +144,7 @@ func AdvanceSubscriptionTimeCmd(ch *cmdutil.Helper) *cobra.Command {
 					}
 					biller := billing.NewOrb(logger, conf.OrbAPIKey, conf.OrbWebhookSecret, strings.ToLower(conf.OrbIntegratedTaxProvider))
 
-					_, err = biller.UnscheduleCancellation(ctx, orgResp.Organization.BillingCustomerId)
+					_, err = biller.UnscheduleCancellation(ctx, subResp.Subscription.Id)
 					if err != nil {
 						return err
 					}

--- a/web-admin/src/features/billing/plans/utils.ts
+++ b/web-admin/src/features/billing/plans/utils.ts
@@ -15,15 +15,15 @@ export function formatDataSizeQuota(
 }
 
 export function isTrialPlan(plan: V1BillingPlan) {
-  return plan.default && plan.trialPeriodDays;
+  return plan.name === "free_trial";
 }
 
 export function isTeamPlan(plan: V1BillingPlan) {
-  return plan.name === "Teams";
+  return plan.name === "team";
 }
 
 export function isPOCPlan(plan: V1BillingPlan) {
-  return plan.name === "Custom";
+  return plan.name === "poc";
 }
 
 export function isEnterprisePlan(plan: V1BillingPlan) {


### PR DESCRIPTION
We updated plan names on orb to be `team` and `trial_plan`. Updating UI to reflect this.

Also setting POC name to `poc`. This is not final and there could be follow up PR for this.