### PR TITLE
Fix ClickHouse timestamp format for comparison offsets

### DIFF
--- a/runtime/drivers/olap.go
+++ b/runtime/drivers/olap.go
@@ -465,7 +465,7 @@ func (d Dialect) DateDiff(grain runtimev1.TimeGrain, t1, t2 time.Time) (string, 
 	unit := d.ConvertToDateTruncSpecifier(grain)
 	switch d {
 	case DialectClickHouse:
-		return fmt.Sprintf("DATEDIFF('%s', TIMESTAMP '%s', TIMESTAMP '%s')", unit, t1.Format(time.RFC3339), t2.Format(time.RFC3339)), nil
+		return fmt.Sprintf("DATEDIFF('%s', parseDateTimeBestEffort('%s'), parseDateTimeBestEffort('%s'))", unit, t1.Format(time.RFC3339), t2.Format(time.RFC3339)), nil
 	case DialectDruid:
 		return fmt.Sprintf("TIMESTAMPDIFF(%q, TIME_PARSE('%s'), TIME_PARSE('%s'))", unit, t1.Format(time.RFC3339), t2.Format(time.RFC3339)), nil
 	case DialectDuckDB:


### PR DESCRIPTION
Addresses the problem reported [here](https://rilldata.slack.com/archives/C02T907FEUB/p1730209589645439?thread_ts=1730209125.774299&cid=C02T907FEUB)