### PR TITLE
Banner nit

### DIFF
--- a/web-admin/src/features/billing/banner/BillingBannerManagerForAdmins.svelte
+++ b/web-admin/src/features/billing/banner/BillingBannerManagerForAdmins.svelte
@@ -23,7 +23,7 @@
         ? {
             cta: {
               type: "button",
-              text: message.cta.text + "->",
+              text: message.cta.text + " ->",
               onClick() {
                 return billingCTAHandler.handle(message);
               },

--- a/web-common/src/components/banner/Banner.svelte
+++ b/web-common/src/components/banner/Banner.svelte
@@ -75,7 +75,7 @@
   }
 
   .banner-cta {
-    @apply text-primary-600 cursor-pointer;
+    @apply text-primary-600 cursor-pointer font-medium;
   }
 
   .banner-message :global(a:hover) {


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/c5133c5b-27ad-40cd-9afb-b0a07c2863d3)

After
![CleanShot 2024-10-30 at 12 08 40@2x](https://github.com/user-attachments/assets/587b4f00-0c1f-4343-b588-17297ae94744)
