### PR TITLE
fix: preview for old metrics with explicit name

### DIFF
--- a/web-common/src/features/workspaces/MetricsWorkspace.svelte
+++ b/web-common/src/features/workspaces/MetricsWorkspace.svelte
@@ -30,13 +30,14 @@
     hasUnsavedChanges,
     autoSave,
     path: filePath,
+    resourceName,
     remoteContent,
     fileName,
   } = fileArtifact);
 
   $: workspace = workspaces.get(filePath);
 
-  $: metricsViewName = getNameFromFile(filePath);
+  $: metricsViewName = $resourceName?.name ?? getNameFromFile(filePath);
 
   $: initLocalUserPreferenceStore(metricsViewName);
 


### PR DESCRIPTION
Preview button and other actions use name from file name. We should instead use resource name similar to ExploreWorkspace.