### PR TITLE
fix: line numbers being removed when there is an error in metrics/explore

### DIFF
--- a/web-common/src/components/editor/line-status/line-status-gutter.ts
+++ b/web-common/src/components/editor/line-status/line-status-gutter.ts
@@ -48,8 +48,14 @@ export const createStatusLineGutter = () =>
       // get the line statuses.
       const lineStatuses = view.state
         .field(lineStatusesStateField)
-        // remove any line statuses that are greater than the total lines
-        .filter((ls) => ls?.line && ls.line !== null && ls.line <= totalLines);
+        // remove any line statuses that are greater than the total lines or global errors with line = -1
+        .filter(
+          (ls) =>
+            ls?.line &&
+            ls.line !== null &&
+            ls.line <= totalLines &&
+            ls.line >= 0,
+        );
 
       if (!lineStatuses?.length || isEmpty) return builder.finish();
 


### PR DESCRIPTION
We added a catch all error with line=-1. But our line number gutter that displays errors does not handle this. Updating the gutter to ignore such errors to avoid a crash in the plugin.