### PR TITLE
send plan update email, plan display name logic

### DIFF
--- a/admin/billing.go
+++ b/admin/billing.go
@@ -171,7 +171,7 @@ func (s *Service) RepairOrganizationBilling(ctx context.Context, org *database.O
 			TrialEndDate: sub.TrialEndDate,
 		})
 		if err != nil {
-			s.Logger.Named("billing").Error("failed to send trial started email", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.Error(err))
+			s.Logger.Named("billing").Error("failed to send trial started email", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.String("billing_email", org.BillingEmail), zap.Error(err))
 		}
 	} else {
 		s.Logger.Named("billing").Warn("subscription already exists for org", zap.String("org_id", org.ID), zap.String("org_name", org.Name))

--- a/admin/billing/README.MD
+++ b/admin/billing/README.MD
@@ -64,9 +64,9 @@ On first project deployment, org will automatically moved to trial plan having 3
 By default, each user across lifetime is restricted to 2 trials. This is **not** checked for superusers and if needed can be increased for any user using `rill sudo quota set --user <email> --trial-orgs <num>`
 
 ### Avoiding trial and restrictive quotas
-Immediately after org creation or at any time in the future, superusers can use `rill sudo org set-internal-plan` to set the org to internal plan which will have unlimited quotas and no trial.
+Immediately after org creation or at any time in the future, superusers can use `rill sudo org set-internal-plan <org-name>` to set the org to internal plan which will have unlimited quotas and no trial.
 
-If creating org through cli you can just use `rill org create <org-name> && rill sudo org set-internal-plan`.
+If creating org through cli you can just use `rill org create <org-name> && rill sudo org set-internal-plan <org-name>`.
 
 ### Continuing with Trial plan and upgrade
 To continue with trial plan, user can upgrade to Teams plan after entering payment details and address in billing portal. In test-mode, use any of the various test cards listed [here](https://docs.stripe.com/testing#cards)

--- a/admin/billing/README.MD
+++ b/admin/billing/README.MD
@@ -104,7 +104,7 @@ If needed, billing issues can be deleted using `rill sudo billing delete-issue -
 
 ## Local dev and testing
 `rill devtool start cloud` starts the admin service with Orb and Stripe integration (except for Orb webhooks, see above for manual setup).
-All billing related background jobs like checking for trial end, hibernatino on subscription cancellation, etc. rely on end or grace end times set in respective billing issues.
+All billing related background jobs like checking for trial end, hibernation on subscription cancellation, etc. rely on end or grace end times set in respective billing issues.
 
 These times can be artificially advanced using `rill devtool subscription advance-time` to test out various billing scenarios.
 

--- a/admin/billing/orb.go
+++ b/admin/billing/orb.go
@@ -621,13 +621,11 @@ func getBillingInvoiceFromOrbInvoice(i *orb.Invoice) *Invoice {
 func getPlanDisplayName(externalID string) string {
 	switch externalID {
 	case "free_trial":
-		return "Trial"
+		return "Free trial"
 	case "team":
 		return "Team"
 	case "managed":
 		return "Managed"
-	case "poc":
-		return "POC"
 	default:
 		return "Enterprise"
 	}

--- a/admin/billing/orb.go
+++ b/admin/billing/orb.go
@@ -565,7 +565,7 @@ func (o *Orb) getBillingPlanFromOrbPlan(ctx context.Context, p *orb.Plan) (*Plan
 	billingPlan := &Plan{
 		ID:              p.ID,
 		Name:            p.ExternalPlanID,
-		DisplayName:     p.Name,
+		DisplayName:     getPlanDisplayName(p.ExternalPlanID),
 		Description:     p.Description,
 		TrialPeriodDays: trialPeriodDays,
 		Default:         metadata.Default,
@@ -615,6 +615,19 @@ func getBillingInvoiceFromOrbInvoice(i *orb.Invoice) *Invoice {
 		CreatedAt:      i.CreatedAt,
 		SubscriptionID: i.Subscription.ID,
 		Metadata:       map[string]interface{}{"issued_at": i.IssuedAt, "voided_at": i.VoidedAt, "paid_at": i.PaidAt, "payment_failed_at": i.PaymentFailedAt},
+	}
+}
+
+func getPlanDisplayName(externalID string) string {
+	switch externalID {
+	case "free_trial":
+		return "Trial"
+	case "team":
+		return "Team"
+	case "poc":
+		return "POC"
+	default:
+		return "Enterprise"
 	}
 }
 

--- a/admin/billing/orb.go
+++ b/admin/billing/orb.go
@@ -624,6 +624,8 @@ func getPlanDisplayName(externalID string) string {
 		return "Trial"
 	case "team":
 		return "Team"
+	case "managed":
+		return "Managed"
 	case "poc":
 		return "POC"
 	default:

--- a/admin/jobs/river/biller_event_handlers.go
+++ b/admin/jobs/river/biller_event_handlers.go
@@ -80,6 +80,8 @@ func (w *PaymentFailedWorker) Work(ctx context.Context, job *river.Job[PaymentFa
 		return fmt.Errorf("failed to add billing error: %w", err)
 	}
 
+	w.logger.Warn("invoice payment failed", zap.String("org_id", org.ID), zap.String("org_name", org.Name), zap.String("amount", job.Args.Amount), zap.Time("due_date", job.Args.DueDate), zap.String("invoice_id", job.Args.InvoiceID), zap.String("invoice_url", job.Args.InvoiceURL))
+
 	err = w.admin.Email.SendInvoicePaymentFailed(&email.InvoicePaymentFailed{
 		ToEmail:            org.BillingEmail,
 		ToName:             org.Name,
@@ -92,7 +94,6 @@ func (w *PaymentFailedWorker) Work(ctx context.Context, job *river.Job[PaymentFa
 	if err != nil {
 		return fmt.Errorf("failed to send invoice payment failed email for org %q: %w", org.Name, err)
 	}
-	w.logger.Warn("invoice payment failed", zap.String("org_id", org.ID), zap.String("org_name", org.Name), zap.String("amount", job.Args.Amount), zap.Time("due_date", job.Args.DueDate), zap.String("invoice_id", job.Args.InvoiceID), zap.String("invoice_url", job.Args.InvoiceURL))
 
 	return nil
 }
@@ -169,7 +170,7 @@ func (w *PaymentSuccessWorker) Work(ctx context.Context, job *river.Job[PaymentS
 	})
 	if err != nil {
 		// ignore email sending error
-		w.logger.Error("failed to send invoice payment success email", zap.String("org_id", org.ID), zap.String("org_name", org.Name), zap.String("invoice_id", job.Args.InvoiceID), zap.Error(err))
+		w.logger.Error("failed to send invoice payment success email", zap.String("org_id", org.ID), zap.String("org_name", org.Name), zap.String("invoice_id", job.Args.InvoiceID), zap.String("billing_email", org.BillingEmail), zap.Error(err))
 	}
 
 	return nil

--- a/admin/jobs/river/org_jobs.go
+++ b/admin/jobs/river/org_jobs.go
@@ -123,7 +123,7 @@ func (w *StartTrialWorker) Work(ctx context.Context, job *river.Job[StartTrialAr
 		TrialEndDate: sub.TrialEndDate,
 	})
 	if err != nil {
-		w.logger.Error("failed to send trial started email", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.Error(err))
+		w.logger.Error("failed to send trial started email", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.String("billing_email", org.BillingEmail), zap.Error(err))
 	}
 
 	return nil

--- a/admin/jobs/river/subscription_handlers.go
+++ b/admin/jobs/river/subscription_handlers.go
@@ -113,7 +113,7 @@ func (w *SubscriptionCancellationCheckWorker) subscriptionCancellationCheck(ctx 
 			OrgName: org.Name,
 		})
 		if err != nil {
-			w.logger.Error("failed to send subscription ended email", zap.String("org_id", org.ID), zap.String("org_name", org.Name), zap.Error(err))
+			w.logger.Error("failed to send subscription ended email", zap.String("org_id", org.ID), zap.String("org_name", org.Name), zap.String("billing_email", org.BillingEmail), zap.Error(err))
 		}
 
 		w.logger.Warn("projects hibernated due to subscription cancellation", zap.String("org_id", org.ID), zap.String("org_name", org.Name))

--- a/runtime/pkg/email/email.go
+++ b/runtime/pkg/email/email.go
@@ -547,3 +547,20 @@ func (c *Client) SendTrialExtended(opts *TrialExtended) error {
 		Body:    template.HTML(fmt.Sprintf("Your trial for %q has been extended and will end on %s.", opts.OrgName, opts.TrialEndDate.Format("January 2, 2006"))),
 	})
 }
+
+type PlanUpdate struct {
+	ToEmail  string
+	ToName   string
+	OrgName  string
+	PlanName string
+}
+
+func (c *Client) SendPlanUpdate(opts *PlanUpdate) error {
+	return c.SendInformational(&Informational{
+		ToEmail: opts.ToEmail,
+		ToName:  opts.ToName,
+		Subject: fmt.Sprintf("Your plan has been updated to %s", opts.PlanName),
+		Title:   fmt.Sprintf("Your plan has been updated to %s", opts.PlanName),
+		Body:    template.HTML(fmt.Sprintf("Your plan for %q has been updated to %q.", opts.OrgName, opts.PlanName)),
+	})
+}

--- a/runtime/pkg/email/email.go
+++ b/runtime/pkg/email/email.go
@@ -561,6 +561,23 @@ func (c *Client) SendPlanUpdate(opts *PlanUpdate) error {
 		ToName:  opts.ToName,
 		Subject: fmt.Sprintf("Your plan has been updated to %s", opts.PlanName),
 		Title:   fmt.Sprintf("Your plan has been updated to %s", opts.PlanName),
-		Body:    template.HTML(fmt.Sprintf("Your plan for %q has been updated to %q.", opts.OrgName, opts.PlanName)),
+		Body:    template.HTML(fmt.Sprintf("Your plan for %q has been updated to %q plan.", opts.OrgName, opts.PlanName)),
+	})
+}
+
+type SubscriptionRenewed struct {
+	ToEmail  string
+	ToName   string
+	OrgName  string
+	PlanName string
+}
+
+func (c *Client) SendSubscriptionRenewed(opts *SubscriptionRenewed) error {
+	return c.SendInformational(&Informational{
+		ToEmail: opts.ToEmail,
+		ToName:  opts.ToName,
+		Subject: fmt.Sprintf("Your subscription for %s has been renewed", opts.OrgName),
+		Title:   fmt.Sprintf("Your subscription for %s has been renewed", opts.OrgName),
+		Body:    template.HTML(fmt.Sprintf("Your subscription for %q has been renewed for %q plan.", opts.OrgName, opts.PlanName)),
 	})
 }


### PR DESCRIPTION
- Send plan update email on plan change. cc @ericpgreen2 
- Product does not want random plan names like `Legacy MMX plan` etc. to be displayed so logic for display name as per @ericokuma requirements.

@AdityaHegde plan display name logic can be removed from frontend and rather use the `display_name` field directly on the Plan object.