### PR TITLE
fix: remove global preventDefault calls

### DIFF
--- a/web-common/src/components/data-graphic/actions/scrub-action-factory.ts
+++ b/web-common/src/components/data-graphic/actions/scrub-action-factory.ts
@@ -206,7 +206,6 @@ export function createScrubAction({
       }
 
       function onScrubEnd(event: MouseEvent) {
-        event.preventDefault();
         node.removeEventListener(moveEvent, onScrub);
         if (!(endPredicate === undefined || endPredicate(event))) {
           reset();

--- a/web-common/src/features/file-explorer/nav-entry-drag-drop-store.ts
+++ b/web-common/src/features/file-explorer/nav-entry-drag-drop-store.ts
@@ -50,7 +50,6 @@ export class NavEntryDragDropStore {
     e: MouseEvent,
     dropSuccess: (fromPath: string, toDir: string) => Promise<void>,
   ) {
-    e.preventDefault();
     e.stopPropagation();
 
     const curDragData = get(this.dragData);


### PR DESCRIPTION
Remove calls of `preventDefault` on listeners scoped to the window object.