### PR TITLE
fix: prevent opening data viewer when pivot row is expanded

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotExpandableCell.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotExpandableCell.svelte
@@ -17,7 +17,7 @@
     <span class="loading-cell" />
   {:else if assembled && row.getCanExpand()}
     <button
-      on:click={row.getToggleExpandedHandler()}
+      on:click|stopPropagation={row.getToggleExpandedHandler()}
       class="cursor-pointer p-1 -m-1 pointer-events-auto"
     >
       <div class:rotate={row.getIsExpanded()} class="transition-transform">


### PR DESCRIPTION
Fixes #6028