### PR TITLE
fix: time formating in pivot rows while loading

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-column-definition.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-column-definition.ts
@@ -147,7 +147,7 @@ function formatRowDimensionValue(
 ) {
   const dimension = rowDimensionNames?.[depth];
   if (isTimeDimension(dimension, timeConfig?.timeDimension)) {
-    if (value === "Total") return "Total";
+    if (value === "Total" || value === "LOADING_CELL") return value;
     const timeGrain = getTimeGrainFromDimension(dimension);
     const dt = addZoneOffset(
       removeLocalTimezoneOffset(new Date(value)),


### PR DESCRIPTION
The loading cell was being formatted as time as such momentarily flashing values such as `NaN` or `0NaN`. This PR prevents formatting until we have a defined value