### PR TITLE
fix: theme color assignment

### DIFF
--- a/web-common/src/features/themes/actions.ts
+++ b/web-common/src/features/themes/actions.ts
@@ -30,9 +30,16 @@ function updateColorVars(
   const palette = generateColorPalette(inputColor);
   // Update CSS variables
   palette.forEach((c, i) => {
+    const hsl = c.css("hsl");
+
+    root.style.setProperty(
+      `--hsl-${colorVarKind}-${TailwindColorSpacing[i]}`,
+      hsl.slice(4, -1).split(",").join(" "),
+    );
+
     root.style.setProperty(
       `--color-${colorVarKind}-${TailwindColorSpacing[i]}`,
-      c.css(),
+      hsl,
     );
   });
 }


### PR DESCRIPTION
Properly sets the required CSS variables for setting primary and secondary theme colors across the dashboard. Note the change to pill, tabs and thumb element on the time series chart.

<img width="935" alt="Screenshot 2024-11-06 at 4 21 09 PM" src="https://github.com/user-attachments/assets/2e5580d6-a0b1-4ae3-a5f6-59d20c47c6e6">
