### PR TITLE
Prevent dimension names that match column names on ClickHouse if the dimension has a complex expression

### DIFF
--- a/runtime/testruntime/reconcile.go
+++ b/runtime/testruntime/reconcile.go
@@ -116,9 +116,13 @@ func RequireReconcileState(t testing.TB, rt *runtime.Runtime, id string, lenReso
 		names = append(names, fmt.Sprintf("%s/%s", r.Meta.Name.Kind, r.Meta.Name.Name))
 	}
 
-	require.Equal(t, lenParseErrs, len(parseErrs), "parse errors: %s", strings.Join(parseErrs, "\n"))
-	require.Equal(t, lenReconcileErrs, len(reconcileErrs), "reconcile errors: %s", strings.Join(reconcileErrs, "\n"))
-	if lenResources != -1 {
+	if lenParseErrs >= 0 {
+		require.Equal(t, lenParseErrs, len(parseErrs), "parse errors: %s", strings.Join(parseErrs, "\n"))
+	}
+	if lenReconcileErrs >= 0 {
+		require.Equal(t, lenReconcileErrs, len(reconcileErrs), "reconcile errors: %s", strings.Join(reconcileErrs, "\n"))
+	}
+	if lenResources >= 0 {
 		require.Equal(t, lenResources, len(rs), "resources: %s", strings.Join(names, "\n"))
 	}
 }

--- a/runtime/testruntime/testruntime.go
+++ b/runtime/testruntime/testruntime.go
@@ -82,10 +82,11 @@ func New(t TestingT) *runtime.Runtime {
 
 // InstanceOptions enables configuration of the instance options that are configurable in tests.
 type InstanceOptions struct {
-	Files        map[string]string
-	Variables    map[string]string
-	WatchRepo    bool
-	StageChanges bool
+	Files          map[string]string
+	Variables      map[string]string
+	WatchRepo      bool
+	StageChanges   bool
+	TestConnectors []string
 }
 
 // NewInstanceWithOptions creates a runtime and an instance for use in tests.
@@ -105,6 +106,11 @@ func NewInstanceWithOptions(t TestingT, opts InstanceOptions) (*runtime.Runtime,
 	vars := make(map[string]string)
 	maps.Copy(vars, opts.Variables)
 	vars["rill.stage_changes"] = strconv.FormatBool(opts.StageChanges)
+
+	for _, conn := range opts.TestConnectors {
+		connVars := Connectors[conn](t)
+		maps.Copy(vars, connVars)
+	}
 
 	tmpDir := t.TempDir()
 	inst := &drivers.Instance{

--- a/runtime/validate_test.go
+++ b/runtime/validate_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
+	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/testruntime"
 	"github.com/stretchr/testify/require"
 )
@@ -33,4 +34,124 @@ func TestValidateMetricsView(t *testing.T) {
 	require.Len(t, res.MeasureErrs, 2)
 	require.Equal(t, 1, res.MeasureErrs[0].Idx)
 	require.Equal(t, 2, res.MeasureErrs[1].Idx)
+}
+
+// ClickHouse does not support expression aliases that collide with column names.
+// Check that such metrics views are rejected.
+func TestValidateMetricsViewClickHouseNames(t *testing.T) {
+	// Start a test runtime with a simple ClickHouse model.
+	rt, instanceID := testruntime.NewInstanceWithOptions(t, testruntime.InstanceOptions{
+		TestConnectors: []string{"clickhouse"},
+		Files: map[string]string{
+			"rill.yaml": "",
+			"model.sql": `
+-- @connector: clickhouse
+select parseDateTimeBestEffort('2024-01-01T00:00:00Z') as time, 'DK' as country, 1 as val union all
+select parseDateTimeBestEffort('2024-01-02T00:00:00Z') as time, 'US' as country, 2 as val union all
+select parseDateTimeBestEffort('2024-01-03T00:00:00Z') as time, 'US' as country, 3 as val union all
+select parseDateTimeBestEffort('2024-01-04T00:00:00Z') as time, 'US' as country, 4 as val union all
+select parseDateTimeBestEffort('2024-01-05T00:00:00Z') as time, 'DK' as country, 5 as val
+`,
+		},
+	})
+
+	// Test cases of metrics view YAML partials defining dimensions and measures.
+	cases := []struct {
+		name          string
+		partial       string
+		errorContains string
+	}{
+		{
+			name: "simple",
+			partial: `
+dimensions:
+  - name: country
+    expression: country
+measures:
+  - name: val_sum
+    expression: sum(val)
+`,
+		},
+		{
+			name: "measure collides with column",
+			partial: `
+dimensions:
+  - name: country
+    expression: country
+measures:
+  - name: val
+    expression: sum(val)
+`,
+			errorContains: `invalid measure "val": measures cannot have the same name as a column`,
+		},
+		{
+			name: "dimension expression collides with column",
+			partial: `
+dimensions:
+  - name: country
+    expression: UPPER(country)
+measures:
+  - name: val_sum
+    expression: sum(val)
+		`,
+			errorContains: `invalid dimension "country": dimensions that use`,
+		},
+		{
+			name: "dimension expression collides with case insensitive column",
+			partial: `
+dimensions:
+  - name: Country
+    expression: UPPER(country)
+measures:
+  - name: val_sum
+    expression: sum(val)
+		`,
+			errorContains: `invalid dimension "Country": dimensions that use`,
+		},
+		{
+			name: "dimension column is allowed",
+			partial: `
+dimensions:
+  - name: country
+    column: country
+measures:
+  - name: val_sum
+    expression: sum(val)
+		`,
+		},
+		{
+			name: "dimension expression matching the name is allowed",
+			partial: `
+dimensions:
+  - name: country
+    expression: country
+measures:
+  - name: val_sum
+    expression: sum(val)
+		`,
+		},
+	}
+
+	// Execute the test cases
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			metricsView := `
+version: 1
+type: metrics_view
+model: model
+timeseries: time
+` + c.partial
+
+			testruntime.PutFiles(t, rt, instanceID, map[string]string{"metrics_view.yaml": metricsView})
+			testruntime.ReconcileParserAndWait(t, rt, instanceID)
+			testruntime.RequireReconcileState(t, rt, instanceID, 3, -1, 0)
+
+			r := testruntime.GetResource(t, rt, instanceID, runtime.ResourceKindMetricsView, "metrics_view")
+			if c.errorContains != "" {
+				require.Contains(t, r.Meta.ReconcileError, c.errorContains)
+			} else {
+				require.Empty(t, r.Meta.ReconcileError)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This PR adds validation that prevents a ClickHouse-backed metrics view from having dimension names that collide with an underlying column name when and only when the dimension has a custom `expression:` or `unnest: true`. This is necessary because ClickHouse eagerly substitutes aliases, and without this validation, it leads to broken references to the underlying column in other dimensions/measures and where clauses.
 
This PR essentially implements the same constraint for dimensions as this PR added for measures: https://github.com/rilldata/rill/issues/5618. See it for details.

