### PR TITLE
fix(billing): Handle errored out metrics project request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35187,6 +35187,7 @@
       }
     },
     "web-common": {
+      "version": "0.0.0",
       "devDependencies": {
         "@bufbuild/protobuf": "^1.0.0",
         "@codemirror/autocomplete": "^6.18.1",

--- a/web-admin/src/client/utils.ts
+++ b/web-admin/src/client/utils.ts
@@ -15,9 +15,15 @@ export function isAdminServerQuery(query: Query): boolean {
     "/v1/telemetry",
     "/v1/tokens",
     "/v1/users",
+    "/v1/billing",
   ];
 
   return adminApiEndpoints.some((endpoint) => apiPath.startsWith(endpoint));
+}
+
+export function isMetricsProjectQuery(query: Query): boolean {
+  const [apiPath] = query.queryKey as string[];
+  return apiPath === "/v1/billing/metrics-project-credentials";
 }
 
 export function mergedQueryStatus(

--- a/web-admin/src/client/utils.ts
+++ b/web-admin/src/client/utils.ts
@@ -21,9 +21,13 @@ export function isAdminServerQuery(query: Query): boolean {
   return adminApiEndpoints.some((endpoint) => apiPath.startsWith(endpoint));
 }
 
-export function isMetricsProjectQuery(query: Query): boolean {
+const OrgUsageAPIRegex = /v1\/instances\/.*\/api\/usage-meter/;
+export function isOrgUsageQuery(query: Query): boolean {
   const [apiPath] = query.queryKey as string[];
-  return apiPath === "/v1/billing/metrics-project-credentials";
+  return (
+    apiPath === "/v1/billing/metrics-project-credentials" ||
+    OrgUsageAPIRegex.test(apiPath)
+  );
 }
 
 export function mergedQueryStatus(

--- a/web-admin/src/features/billing/Payment.svelte
+++ b/web-admin/src/features/billing/Payment.svelte
@@ -13,6 +13,7 @@
   $: categorisedIssues = useCategorisedOrganizationBillingIssues(organization);
   $: paymentIssues = $categorisedIssues.data?.payment;
   $: neverSubscribed = $categorisedIssues.data?.neverSubscribed;
+  $: onTrial = !!$categorisedIssues.data?.trial;
 
   async function handleManagePayment() {
     window.open(
@@ -23,7 +24,7 @@
 </script>
 
 <!-- Presence of paymentCustomerId signifies that the org's payment is managed through stripe -->
-{#if !$categorisedIssues.isLoading && !neverSubscribed && $org.data?.organization?.paymentCustomerId}
+{#if !onTrial && !$categorisedIssues.isLoading && !neverSubscribed && $org.data?.organization?.paymentCustomerId}
   <SettingsContainer title="Payment Method">
     <div slot="body" class="flex flex-row items-center gap-x-1">
       {#if paymentIssues?.length}

--- a/web-admin/src/features/billing/plans/CancelledTeamPlan.svelte
+++ b/web-admin/src/features/billing/plans/CancelledTeamPlan.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { V1BillingPlan } from "@rilldata/web-admin/client";
   import ContactUs from "@rilldata/web-admin/features/billing/ContactUs.svelte";
   import PlanQuotas from "@rilldata/web-admin/features/billing/plans/PlanQuotas.svelte";
   import StartTeamPlanDialog from "@rilldata/web-admin/features/billing/plans/StartTeamPlanDialog.svelte";
@@ -9,6 +10,7 @@
   import { DateTime } from "luxon";
 
   export let organization: string;
+  export let plan: V1BillingPlan;
   export let showUpgradeDialog: boolean;
 
   $: categorisedIssues = useCategorisedOrganizationBillingIssues(organization);
@@ -26,7 +28,7 @@
   let open = showUpgradeDialog;
 </script>
 
-<SettingsContainer title="Team Plan">
+<SettingsContainer title={plan?.displayName}>
   <div slot="body">
     <div>
       <div class="flex flex-row items-center gap-x-1 text-sm">

--- a/web-admin/src/features/billing/plans/EnterprisePlan.svelte
+++ b/web-admin/src/features/billing/plans/EnterprisePlan.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
+  import type { V1BillingPlan } from "@rilldata/web-admin/client";
   import ContactUs from "@rilldata/web-admin/features/billing/ContactUs.svelte";
   import PlanQuotas from "@rilldata/web-admin/features/billing/plans/PlanQuotas.svelte";
   import SettingsContainer from "@rilldata/web-admin/features/organizations/settings/SettingsContainer.svelte";
 
   export let organization: string;
+  export let plan: V1BillingPlan;
 </script>
 
-<SettingsContainer title="Enterprise plan">
+<SettingsContainer title={plan?.displayName}>
   <div slot="body">
     <div>You’re currently on a custom contract.</div>
     <PlanQuotas {organization} />

--- a/web-admin/src/features/billing/plans/POCPlan.svelte
+++ b/web-admin/src/features/billing/plans/POCPlan.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { V1BillingPlan } from "@rilldata/web-admin/client";
   import ContactUs from "@rilldata/web-admin/features/billing/ContactUs.svelte";
   import PlanQuotas from "@rilldata/web-admin/features/billing/plans/PlanQuotas.svelte";
   import StartTeamPlanDialog from "@rilldata/web-admin/features/billing/plans/StartTeamPlanDialog.svelte";
@@ -7,11 +8,12 @@
 
   export let organization: string;
   export let hasPayment: boolean;
+  export let plan: V1BillingPlan;
 
   let open = false;
 </script>
 
-<SettingsContainer title="POC plan">
+<SettingsContainer title={plan?.displayName}>
   <div slot="body">
     <div>You’re currently on a custom contract.</div>
     <PlanQuotas {organization} />

--- a/web-admin/src/features/billing/plans/Plan.svelte
+++ b/web-admin/src/features/billing/plans/Plan.svelte
@@ -43,5 +43,5 @@
 {:else if subIsPOCPlan}
   <POCPlan {organization} {hasPayment} {plan} />
 {:else if subIsEnterprisePlan}
-  <EnterprisePlan {organization} />
+  <EnterprisePlan {organization} {plan} />
 {/if}

--- a/web-admin/src/features/billing/plans/Plan.svelte
+++ b/web-admin/src/features/billing/plans/Plan.svelte
@@ -17,6 +17,7 @@
   $: subscriptionQuery = createAdminServiceGetBillingSubscription(organization);
   $: subscription = $subscriptionQuery?.data?.subscription;
   $: hasPayment = !!$subscriptionQuery?.data?.organization?.paymentCustomerId;
+  $: plan = subscription?.plan;
 
   $: categorisedIssues = useCategorisedOrganizationBillingIssues(organization);
 
@@ -25,23 +26,22 @@
   // trial plan will have a trial issue associated with it
   $: isTrial = !!$categorisedIssues.data?.trial;
   // ended subscription will have a cancelled issue associated with it
-  $: hasEnded = !!$categorisedIssues.data?.cancelled;
-  $: subIsTeamPlan = subscription?.plan && isTeamPlan(subscription.plan);
-  $: subIsPOCPlan = subscription?.plan && isPOCPlan(subscription.plan);
-  $: subIsEnterprisePlan =
-    subscription?.plan && !isTrial && !subIsTeamPlan && !subIsPOCPlan;
+  $: subHasEnded = !!$categorisedIssues.data?.cancelled;
+  $: subIsTeamPlan = plan && isTeamPlan(plan);
+  $: subIsPOCPlan = plan && isPOCPlan(plan);
+  $: subIsEnterprisePlan = plan && !isTrial && !subIsTeamPlan && !subIsPOCPlan;
 </script>
 
 {#if neverSubbed}
   <!-- TODO: once mocks are in. Right now we just disable the routes. -->
 {:else if isTrial}
-  <TrialPlan {organization} {subscription} {showUpgradeDialog} />
-{:else if hasEnded}
-  <CancelledTeamPlan {organization} {showUpgradeDialog} />
+  <TrialPlan {organization} {subscription} {showUpgradeDialog} {plan} />
+{:else if subHasEnded}
+  <CancelledTeamPlan {organization} {showUpgradeDialog} {plan} />
 {:else if subIsTeamPlan}
-  <TeamPlan {organization} {subscription} />
+  <TeamPlan {organization} {subscription} {plan} />
 {:else if subIsPOCPlan}
-  <POCPlan {organization} {hasPayment} />
+  <POCPlan {organization} {hasPayment} {plan} />
 {:else if subIsEnterprisePlan}
   <EnterprisePlan {organization} />
 {/if}

--- a/web-admin/src/features/billing/plans/PlanQuotas.svelte
+++ b/web-admin/src/features/billing/plans/PlanQuotas.svelte
@@ -23,7 +23,7 @@
       : "Unlimited";
 
   $: usageMetrics = getOrganizationUsageMetrics(organization);
-  $: total = $usageMetrics?.data?.reduce((s, m) => s + m.size, 0) ?? 0;
+  $: totalOrgSize = $usageMetrics?.data?.reduce((s, m) => s + m.size, 0) ?? 0;
 
   $: singleProjectLimit = $organizationQuotas.data?.projects === 1;
   $: storageLimitBytesPerDeployment =
@@ -38,17 +38,22 @@
     </div>
   </div>
 
-  <div class="quota-entry">
-    <div class="quota-entry-title">Data Size</div>
-    <div>
-      {#if singleProjectLimit && storageLimitBytesPerDeployment && storageLimitBytesPerDeployment !== "-1"}
-        <Progress value={total} max={Number(storageLimitBytesPerDeployment)} />
-        {formatDataSizeQuota(total, storageLimitBytesPerDeployment)}
-      {:else}
-        <!-- TODO: once we have the dashboard support link to it -->
-      {/if}
-    </div>
-  </div>
+  {#if $usageMetrics?.data}
+    {#if singleProjectLimit && storageLimitBytesPerDeployment && storageLimitBytesPerDeployment !== "-1"}
+      <div class="quota-entry">
+        <div class="quota-entry-title">Data Size</div>
+        <div>
+          <Progress
+            value={totalOrgSize}
+            max={Number(storageLimitBytesPerDeployment)}
+          />
+          {formatDataSizeQuota(totalOrgSize, storageLimitBytesPerDeployment)}
+        </div>
+      </div>
+    {:else}
+      <!-- TODO: once we have the dashboard support link to it -->
+    {/if}
+  {/if}
 </div>
 
 <style lang="postcss">

--- a/web-admin/src/features/billing/plans/PlanQuotas.svelte
+++ b/web-admin/src/features/billing/plans/PlanQuotas.svelte
@@ -4,7 +4,7 @@
     createAdminServiceListProjectsForOrganization,
   } from "@rilldata/web-admin/client";
   import { getOrganizationUsageMetrics } from "@rilldata/web-admin/features/billing/plans/selectors";
-  import { formatDataSizeQuota } from "@rilldata/web-admin/features/billing/plans/utils";
+  import { formatUsageVsQuota } from "@rilldata/web-admin/features/billing/plans/utils";
   import { Progress } from "@rilldata/web-common/components/progress";
 
   export let organization: string;
@@ -23,7 +23,7 @@
       : "Unlimited";
 
   $: usageMetrics = getOrganizationUsageMetrics(organization);
-  $: totalOrgSize = $usageMetrics?.data?.reduce((s, m) => s + m.size, 0) ?? 0;
+  $: totalOrgUsage = $usageMetrics?.data?.reduce((s, m) => s + m.size, 0) ?? 0;
 
   $: singleProjectLimit = $organizationQuotas.data?.projects === 1;
   $: storageLimitBytesPerDeployment =
@@ -44,10 +44,10 @@
         <div class="quota-entry-title">Data Size</div>
         <div>
           <Progress
-            value={totalOrgSize}
+            value={totalOrgUsage}
             max={Number(storageLimitBytesPerDeployment)}
           />
-          {formatDataSizeQuota(totalOrgSize, storageLimitBytesPerDeployment)}
+          {formatUsageVsQuota(totalOrgUsage, storageLimitBytesPerDeployment)}
         </div>
       </div>
     {:else}

--- a/web-admin/src/features/billing/plans/TeamPlan.svelte
+++ b/web-admin/src/features/billing/plans/TeamPlan.svelte
@@ -2,6 +2,7 @@
   import {
     createAdminServiceCancelBillingSubscription,
     V1BillingIssueType,
+    type V1BillingPlan,
     type V1Subscription,
   } from "@rilldata/web-admin/client";
   import { getErrorForMutation } from "@rilldata/web-admin/client/utils";
@@ -26,6 +27,7 @@
 
   export let organization: string;
   export let subscription: V1Subscription;
+  export let plan: V1BillingPlan;
 
   $: planCanceller = createAdminServiceCancelBillingSubscription();
   async function handleCancelPlan() {
@@ -50,7 +52,7 @@
   ).toLocaleString(DateTime.DATE_MED);
 </script>
 
-<SettingsContainer title="Team plan">
+<SettingsContainer title={plan?.displayName}>
   <div slot="body">
     Next billing cycle will start on
     <b>{getNextBillingCycleDate(subscription.currentBillingCycleEndDate)}</b>.

--- a/web-admin/src/features/billing/plans/TrialPlan.svelte
+++ b/web-admin/src/features/billing/plans/TrialPlan.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {
     V1BillingIssueType,
+    type V1BillingPlan,
     type V1Subscription,
   } from "@rilldata/web-admin/client";
   import ContactUs from "@rilldata/web-admin/features/billing/ContactUs.svelte";
@@ -16,6 +17,7 @@
 
   export let organization: string;
   export let subscription: V1Subscription;
+  export let plan: V1BillingPlan;
   export let showUpgradeDialog: boolean;
 
   $: categorisedIssues = useCategorisedOrganizationBillingIssues(organization);
@@ -41,7 +43,7 @@
     }
   }
 
-  $: title = "Trial plan" + (trialEnded ? " expired" : "");
+  $: title = plan?.displayName + (trialEnded ? " expired" : "");
 
   let open = showUpgradeDialog;
   $: type = (trialEnded ? "trial-expired" : "base") as TeamPlanDialogTypes;

--- a/web-admin/src/features/billing/plans/utils.ts
+++ b/web-admin/src/features/billing/plans/utils.ts
@@ -3,20 +3,19 @@ import { formatMemorySize } from "@rilldata/web-common/lib/number-formatting/mem
 import { DateTime } from "luxon";
 import { writable } from "svelte/store";
 
-export function formatDataSizeQuota(
-  sizeInBytes: number,
+export function formatUsageVsQuota(
+  usageInBytes: number,
   storageLimitBytesPerDeployment: string,
 ): string {
-  const maxSize = Number(storageLimitBytesPerDeployment);
-  if (Number.isNaN(maxSize) || storageLimitBytesPerDeployment === "-1")
-    return "";
-  const formattedTotal = formatMemorySize(sizeInBytes);
-  const formattedMax = formatMemorySize(maxSize);
+  const quota = Number(storageLimitBytesPerDeployment);
+  if (Number.isNaN(quota) || storageLimitBytesPerDeployment === "-1") return "";
+  const formattedUsage = formatMemorySize(usageInBytes);
+  const formattedQuota = formatMemorySize(quota);
   const percent =
-    formattedTotal > formattedMax
+    formattedUsage > formattedQuota
       ? "100+"
-      : Math.round((sizeInBytes * 100) / maxSize) + "";
-  return `${formattedTotal} of ${formattedMax} (${percent}%)`;
+      : Math.round((usageInBytes * 100) / quota) + "";
+  return `${formattedUsage} of ${formattedQuota} (${percent}%)`;
 }
 
 export function isTrialPlan(plan: V1BillingPlan) {

--- a/web-admin/src/features/billing/plans/utils.ts
+++ b/web-admin/src/features/billing/plans/utils.ts
@@ -4,18 +4,18 @@ import { DateTime } from "luxon";
 import { writable } from "svelte/store";
 
 export function formatDataSizeQuota(
-  totalSizeInBytes: number,
+  sizeInBytes: number,
   storageLimitBytesPerDeployment: string,
 ): string {
   const maxSize = Number(storageLimitBytesPerDeployment);
   if (Number.isNaN(maxSize) || storageLimitBytesPerDeployment === "-1")
     return "";
-  const formattedTotal = formatMemorySize(totalSizeInBytes);
+  const formattedTotal = formatMemorySize(sizeInBytes);
   const formattedMax = formatMemorySize(maxSize);
   const percent =
     formattedTotal > formattedMax
       ? "100+"
-      : Math.round((totalSizeInBytes * 100) / maxSize) + "";
+      : Math.round((sizeInBytes * 100) / maxSize) + "";
   return `${formattedTotal} of ${formattedMax} (${percent}%)`;
 }
 
@@ -42,19 +42,6 @@ export function getSubscriptionResumedText(endDate: string) {
   }
   const resumeDate = date.plus({ day: 1 });
   return "on " + resumeDate.toLocaleString(DateTime.DATE_MED);
-}
-
-export function getPlanDisplayName(plan: V1BillingPlan) {
-  if (isTrialPlan(plan)) {
-    return "Trial Plan";
-  }
-  if (isTeamPlan(plan)) {
-    return "Team Plan";
-  }
-  if (isPOCPlan(plan)) {
-    return "POC Plan";
-  }
-  return "Enterprise Plan";
 }
 
 // Since this could be triggered in a route that could be navigated from,

--- a/web-admin/src/features/errors/error-utils.ts
+++ b/web-admin/src/features/errors/error-utils.ts
@@ -1,6 +1,9 @@
 import { page } from "$app/stores";
 import { redirectToLogin } from "@rilldata/web-admin/client/redirect-utils";
-import { isAdminServerQuery } from "@rilldata/web-admin/client/utils";
+import {
+  isAdminServerQuery,
+  isMetricsProjectQuery,
+} from "@rilldata/web-admin/client/utils";
 import { redirectToLoginOrRequestAccess } from "@rilldata/web-admin/features/authentication/checkUserAccess";
 import {
   isAlertPage,
@@ -136,6 +139,12 @@ export function createGlobalErrorCallback(queryClient: QueryClient) {
       isProjectRequestAccessPage(pageState) &&
       error.response?.status !== 403
     ) {
+      return;
+    }
+
+    // Handle case when usage metrics project is not available
+    // This is always the case on non-prod
+    if (isMetricsProjectQuery(query)) {
       return;
     }
 

--- a/web-admin/src/features/errors/error-utils.ts
+++ b/web-admin/src/features/errors/error-utils.ts
@@ -2,7 +2,7 @@ import { page } from "$app/stores";
 import { redirectToLogin } from "@rilldata/web-admin/client/redirect-utils";
 import {
   isAdminServerQuery,
-  isMetricsProjectQuery,
+  isOrgUsageQuery,
 } from "@rilldata/web-admin/client/utils";
 import { redirectToLoginOrRequestAccess } from "@rilldata/web-admin/features/authentication/checkUserAccess";
 import {
@@ -142,9 +142,9 @@ export function createGlobalErrorCallback(queryClient: QueryClient) {
       return;
     }
 
-    // Handle case when usage metrics project is not available
-    // This is always the case on non-prod
-    if (isMetricsProjectQuery(query)) {
+    // Handle case when usage metrics project is not unavailable for some reason.
+    // We shouldn't block the user in this case.
+    if (isOrgUsageQuery(query)) {
       return;
     }
 

--- a/web-admin/src/features/navigation/TopNavigationBar.svelte
+++ b/web-admin/src/features/navigation/TopNavigationBar.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { page } from "$app/stores";
-  import { getPlanDisplayName } from "@rilldata/web-admin/features/billing/plans/utils";
   import Bookmarks from "@rilldata/web-admin/features/bookmarks/Bookmarks.svelte";
   import ShareDashboardButton from "@rilldata/web-admin/features/dashboards/share/ShareDashboardButton.svelte";
   import ShareProjectPopover from "@rilldata/web-admin/features/projects/user-management/ShareProjectPopover.svelte";
@@ -103,7 +102,7 @@
     (map, { name, displayName }) =>
       map.set(name.toLowerCase(), {
         label: displayName || name,
-        pill: $plan?.data ? getPlanDisplayName($plan.data) : "",
+        pill: $plan?.data?.displayName,
       }),
     new Map<string, PathOption>(),
   );

--- a/web-common/src/features/project/ProjectDeployer.ts
+++ b/web-common/src/features/project/ProjectDeployer.ts
@@ -26,7 +26,7 @@ export class ProjectDeployer {
   public readonly metadata = createLocalServiceGetMetadata();
   public readonly user = createLocalServiceGetCurrentUser();
   public readonly project = createLocalServiceGetCurrentProject();
-  public readonly promptOrgSelection = writable(true);
+  public readonly promptOrgSelection = writable(false);
 
   public readonly org = writable("");
 


### PR DESCRIPTION
- [x] Handle the metrics project credentials request erroring out.
- [x] Use displayName in plan to keep the mapping in backend.
- [x] Show loading spinner instead of org selector during deploy.
- [x] Hide payment module for trial plans.