### PR TITLE
fix: scheduled report creation in pivot for dashboards without timeseries

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-export.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-export.ts
@@ -102,6 +102,9 @@ export function getPivotExportArgs(ctx: StateManagers) {
       rows,
       columns,
     ]) => {
+      if (!validSpecStore.data?.explore || !timeControlState.ready)
+        return undefined;
+
       const enableComparison = configStore.enableComparison;
       const comparisonTime = configStore.comparisonTime;
       const pivotState = configStore.pivot;


### PR DESCRIPTION
We have a safeguard for dashboards without timeseries for every location except pivot. This PR doesnt add support for reports without timeseries but makes sure app doesnt crash.