### PR TITLE
Fix: file renames

### DIFF
--- a/web-common/src/features/canvas-components/ComponentsHeader.svelte
+++ b/web-common/src/features/canvas-components/ComponentsHeader.svelte
@@ -3,7 +3,6 @@
   import { Button } from "@rilldata/web-common/components/button";
   import PanelCTA from "@rilldata/web-common/components/panel/PanelCTA.svelte";
   import GenerateVegaSpecPrompt from "@rilldata/web-common/features/canvas-components/prompt/GenerateVegaSpecPrompt.svelte";
-  import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts";
   import {
     extractFileName,
     splitFolderAndFileName,
@@ -27,7 +26,6 @@
       newTitle,
       filePath,
       componentName,
-      fileArtifacts.getNamesForKind(ResourceKind.Component),
     );
 
     if (newRoute) await goto(newRoute);

--- a/web-common/src/features/editor/FileWorkspaceHeader.svelte
+++ b/web-common/src/features/editor/FileWorkspaceHeader.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { splitFolderAndFileName } from "@rilldata/web-common/features/entity-management/file-path-utils";
-  import { useFileNamesInDirectory } from "@rilldata/web-common/features/entity-management/file-selectors";
   import { handleEntityRename } from "@rilldata/web-common/features/entity-management/ui-actions";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { WorkspaceHeader } from "../../layout/workspace";
@@ -13,15 +12,9 @@
   export let resourceKind: ResourceKind | undefined;
 
   let fileName: string;
-  let folder: string;
 
-  $: [folder, fileName] = splitFolderAndFileName(filePath);
+  $: [, fileName] = splitFolderAndFileName(filePath);
   $: isProtectedFile = PROTECTED_FILES.includes(filePath);
-
-  $: currentDirectoryFileNamesQuery = useFileNamesInDirectory(
-    $runtime.instanceId,
-    folder,
-  );
 
   const onChangeCallback = async (newTitle: string) => {
     const route = await handleEntityRename(
@@ -29,7 +22,6 @@
       newTitle,
       filePath,
       fileName,
-      $currentDirectoryFileNamesQuery.data ?? [],
     );
     if (route) await goto(route);
   };

--- a/web-common/src/features/entity-management/file-selectors.ts
+++ b/web-common/src/features/entity-management/file-selectors.ts
@@ -1,5 +1,7 @@
 import {
   createRuntimeServiceListFiles,
+  getRuntimeServiceListFilesQueryKey,
+  runtimeServiceListFiles,
   type V1ListFilesResponse,
 } from "@rilldata/web-common/runtime-client";
 import type { QueryClient } from "@tanstack/svelte-query";
@@ -40,6 +42,28 @@ export function useFileNamesInDirectory(
       },
     },
   });
+}
+
+export async function getFileNamesInDirectory(
+  queryClient: QueryClient,
+  instanceId: string,
+  directoryPath: string,
+) {
+  // Ensure the directory path starts with a slash
+  if (!directoryPath.startsWith("/")) {
+    directoryPath = `/${directoryPath}`;
+  }
+
+  // Fetch all files in the project
+  // (For now, we fetch all files at once, rather than individual requests for each directory.)
+  const allFiles = await queryClient.fetchQuery({
+    queryKey: getRuntimeServiceListFilesQueryKey(instanceId, undefined),
+    queryFn: ({ signal }) =>
+      runtimeServiceListFiles(instanceId, undefined, signal),
+  });
+
+  // Get the file names in the given directory
+  return useFileNamesInDirectorySelector(allFiles, directoryPath);
 }
 
 export function useFileNamesInDirectorySelector(

--- a/web-common/src/features/entity-management/ui-actions.ts
+++ b/web-common/src/features/entity-management/ui-actions.ts
@@ -10,16 +10,18 @@ import {
   VALID_NAME_PATTERN,
 } from "@rilldata/web-common/features/entity-management/name-utils";
 import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
+import { queryClient } from "../../lib/svelte-query/globalQueryClient";
+import { getFileNamesInDirectory } from "./file-selectors";
 
 export async function handleEntityRename(
   instanceId: string,
   newName: string,
   existingPath: string,
   existingName: string,
-  allNames: string[],
 ) {
   const [folder] = splitFolderAndFileName(existingPath);
 
+  // Check if the new name is valid
   if (!newName.match(VALID_NAME_PATTERN)) {
     eventBus.emit("notification", {
       message: INVALID_NAME_MESSAGE,
@@ -28,7 +30,19 @@ export async function handleEntityRename(
     return;
   }
 
-  if (isDuplicateName(extractFileName(newName), existingName, allNames)) {
+  // Check if the new name is already in use
+  const fileNamesInDirectory = await getFileNamesInDirectory(
+    queryClient,
+    instanceId,
+    folder,
+  );
+  if (
+    isDuplicateName(
+      extractFileName(newName),
+      existingName,
+      fileNamesInDirectory,
+    )
+  ) {
     eventBus.emit("notification", {
       message: `Name ${newName} is already in use`,
     });
@@ -36,6 +50,7 @@ export async function handleEntityRename(
     return;
   }
 
+  // Rename the file
   try {
     const newFilePath = (folder ? `${folder}/` : "/") + newName;
 

--- a/web-common/src/features/entity-management/ui-actions.ts
+++ b/web-common/src/features/entity-management/ui-actions.ts
@@ -1,9 +1,6 @@
 import { renameFileArtifact } from "@rilldata/web-common/features/entity-management/actions";
 import { removeLeadingSlash } from "@rilldata/web-common/features/entity-management/entity-mappers";
-import {
-  extractFileName,
-  splitFolderAndFileName,
-} from "@rilldata/web-common/features/entity-management/file-path-utils";
+import { splitFolderAndFileName } from "@rilldata/web-common/features/entity-management/file-path-utils";
 import {
   INVALID_NAME_MESSAGE,
   isDuplicateName,
@@ -36,13 +33,7 @@ export async function handleEntityRename(
     instanceId,
     folder,
   );
-  if (
-    isDuplicateName(
-      extractFileName(newName),
-      existingName,
-      fileNamesInDirectory,
-    )
-  ) {
+  if (isDuplicateName(newName, existingName, fileNamesInDirectory)) {
     eventBus.emit("notification", {
       message: `Name ${newName} is already in use`,
     });

--- a/web-common/src/features/workspaces/CanvasDashboardWorkspace.svelte
+++ b/web-common/src/features/workspaces/CanvasDashboardWorkspace.svelte
@@ -7,8 +7,8 @@
   import ComponentsEditorContainer from "@rilldata/web-common/features/canvas-components/editor/ComponentsEditorContainer.svelte";
   import AddComponentMenu from "@rilldata/web-common/features/canvas/AddComponentMenu.svelte";
   import CanvasDashboardPreview from "@rilldata/web-common/features/canvas/CanvasDashboardPreview.svelte";
-  import type { Vector } from "@rilldata/web-common/features/canvas/types";
   import ViewSelector from "@rilldata/web-common/features/canvas/ViewSelector.svelte";
+  import type { Vector } from "@rilldata/web-common/features/canvas/types";
   import Editor from "@rilldata/web-common/features/editor/Editor.svelte";
   import { FileExtensionToEditorExtension } from "@rilldata/web-common/features/editor/getExtensionsForFile";
   import { getNameFromFile } from "@rilldata/web-common/features/entity-management/entity-mappers";
@@ -28,8 +28,8 @@
   import Button from "web-common/src/components/button/Button.svelte";
   import { parseDocument } from "yaml";
   import {
-    resourceIconMapping,
     resourceColorMapping,
+    resourceIconMapping,
   } from "../entity-management/resource-icon-mapping";
   import PreviewButton from "../explores/PreviewButton.svelte";
 
@@ -102,7 +102,6 @@
       newTitle,
       filePath,
       fileName,
-      fileArtifacts.getNamesForKind(ResourceKind.Canvas),
     );
     if (newRoute) await goto(newRoute);
   }

--- a/web-common/src/features/workspaces/ExploreWorkspace.svelte
+++ b/web-common/src/features/workspaces/ExploreWorkspace.svelte
@@ -3,7 +3,6 @@
   import { initLocalUserPreferenceStore } from "@rilldata/web-common/features/dashboards/user-preferences";
   import { getNameFromFile } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import type { FileArtifact } from "@rilldata/web-common/features/entity-management/file-artifact";
-  import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts";
   import {
     resourceIsLoading,
     ResourceKind,
@@ -45,7 +44,6 @@
       newTitle,
       filePath,
       fileName,
-      fileArtifacts.getNamesForKind(ResourceKind.Explore),
     );
     if (newRoute) await goto(newRoute);
   }

--- a/web-common/src/features/workspaces/MetricsWorkspace.svelte
+++ b/web-common/src/features/workspaces/MetricsWorkspace.svelte
@@ -4,7 +4,6 @@
   import { initLocalUserPreferenceStore } from "@rilldata/web-common/features/dashboards/user-preferences";
   import { getNameFromFile } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import type { FileArtifact } from "@rilldata/web-common/features/entity-management/file-artifact";
-  import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts";
   import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
   import { handleEntityRename } from "@rilldata/web-common/features/entity-management/ui-actions";
   import MetricsInspector from "@rilldata/web-common/features/metrics-views/MetricsInspector.svelte";
@@ -18,10 +17,10 @@
     useIsModelingSupportedForDefaultOlapDriver,
     useIsModelingSupportedForOlapDriver,
   } from "../connectors/olap/selectors";
+  import PreviewButton from "../explores/PreviewButton.svelte";
   import GoToDashboardButton from "../metrics-views/GoToDashboardButton.svelte";
   import { mapParseErrorsToLines } from "../metrics-views/errors";
   import VisualMetrics from "./VisualMetrics.svelte";
-  import PreviewButton from "../explores/PreviewButton.svelte";
 
   export let fileArtifact: FileArtifact;
 
@@ -69,7 +68,6 @@
       newTitle,
       filePath,
       fileName,
-      fileArtifacts.getNamesForKind(ResourceKind.MetricsView),
     );
     if (newRoute) await goto(newRoute);
   }

--- a/web-common/src/features/workspaces/ModelWorkspace.svelte
+++ b/web-common/src/features/workspaces/ModelWorkspace.svelte
@@ -3,7 +3,6 @@
   import ConnectedPreviewTable from "@rilldata/web-common/components/preview-table/ConnectedPreviewTable.svelte";
   import { getNameFromFile } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import type { FileArtifact } from "@rilldata/web-common/features/entity-management/file-artifact";
-  import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts";
   import {
     ResourceKind,
     resourceIsLoading,
@@ -70,10 +69,6 @@
       newTitle,
       filePath,
       fileName,
-      [
-        ...fileArtifacts.getNamesForKind(ResourceKind.Source),
-        ...fileArtifacts.getNamesForKind(ResourceKind.Model),
-      ],
     );
 
     if (newRoute) await goto(newRoute);

--- a/web-common/src/features/workspaces/SourceWorkspace.svelte
+++ b/web-common/src/features/workspaces/SourceWorkspace.svelte
@@ -3,7 +3,6 @@
   import ConnectedPreviewTable from "@rilldata/web-common/components/preview-table/ConnectedPreviewTable.svelte";
   import { getNameFromFile } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import type { FileArtifact } from "@rilldata/web-common/features/entity-management/file-artifact";
-  import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts";
   import {
     ResourceKind,
     resourceIsLoading,
@@ -79,10 +78,6 @@
       newTitle,
       filePath,
       fileName,
-      [
-        ...fileArtifacts.getNamesForKind(ResourceKind.Source),
-        ...fileArtifacts.getNamesForKind(ResourceKind.Model),
-      ],
     );
 
     if (newRoute) await goto(newRoute);


### PR DESCRIPTION
Currently, when a user tries to rename a file to `new_name`, we check to see if any like resources (a Model, Metrics View, etc.) named `new_name` already exist. If so, we reject the file name change. One problem with this logic is that it prevents a file rename from `model.sql` to `model.yaml`.

This PR changes the logic so that we reject name changes only if the file name already exists in the given directory. This behavior matches that of a typical code editor.

Closes https://github.com/rilldata/rill/issues/5961