### PR TITLE
model executor for postgres and mysql to duckdb

### DIFF
--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -387,6 +387,9 @@ func (c *connection) AsModelExecutor(instanceID string, opts *drivers.ModelExecu
 		if f, ok := opts.InputHandle.AsFileStore(); ok && opts.InputConnector == "local_file" {
 			return &localFileToSelfExecutor{c, f}, true
 		}
+		if opts.InputHandle.Driver() == "mysql" || opts.InputHandle.Driver() == "postgres" {
+			return &sqlStoreToSelfExecutor{c}, true
+		}
 	}
 	if opts.InputHandle == c {
 		if opts.OutputHandle.Driver() == "file" {

--- a/runtime/drivers/duckdb/model_executor_sqlstore_self.go
+++ b/runtime/drivers/duckdb/model_executor_sqlstore_self.go
@@ -11,6 +11,18 @@ import (
 	"github.com/rilldata/rill/runtime/drivers/postgres"
 )
 
+type sqlStoreToSelfInputProps struct {
+	SQL string `mapstructure:"sql"`
+	DSN string `mapstructure:"dsn"`
+}
+
+func (p *sqlStoreToSelfInputProps) Validate() error {
+	if p.SQL == "" {
+		return fmt.Errorf("missing property 'sql'")
+	}
+	return nil
+}
+
 type sqlStoreToSelfExecutor struct {
 	c *connection
 }
@@ -25,7 +37,7 @@ func (e *sqlStoreToSelfExecutor) Concurrency(desired int) (int, bool) {
 }
 
 func (e *sqlStoreToSelfExecutor) Execute(ctx context.Context, opts *drivers.ModelExecuteOptions) (*drivers.ModelResult, error) {
-	inputProps := &ModelInputProperties{}
+	inputProps := &sqlStoreToSelfInputProps{}
 	if err := mapstructure.WeakDecode(opts.InputProperties, inputProps); err != nil {
 		return nil, fmt.Errorf("failed to parse input properties: %w", err)
 	}
@@ -47,26 +59,45 @@ func (e *sqlStoreToSelfExecutor) Execute(ctx context.Context, opts *drivers.Mode
 	return executor.Execute(ctx, newOpts)
 }
 
-func (e *sqlStoreToSelfExecutor) modelInputProperties(modelName, inputConnector string, inputHandle drivers.Handle, inputProps *ModelInputProperties) (map[string]any, error) {
+func (e *sqlStoreToSelfExecutor) modelInputProperties(modelName, inputConnector string, inputHandle drivers.Handle, inputProps *sqlStoreToSelfInputProps) (map[string]any, error) {
 	m := &ModelInputProperties{}
 	dbName := fmt.Sprintf("%s__%s", modelName, inputConnector)
 	safeDBName := safeName(dbName)
 	userQuery, _ := strings.CutSuffix(inputProps.SQL, ";") // trim trailing semi colon
 	switch inputHandle.Driver() {
 	case "mysql":
-		var config *mysql.ConfigProperties
-		if err := mapstructure.Decode(inputHandle.Config(), &config); err != nil {
-			return nil, err
+		var dsn string
+		if inputProps.DSN != "" {
+			dsn = inputProps.DSN
+		} else {
+			// may be configured via a connector
+			var config *mysql.ConfigProperties
+			if err := mapstructure.Decode(inputHandle.Config(), &config); err != nil {
+				return nil, err
+			}
+			dsn = rewriteMySQLDSN(config.DSN)
 		}
-		dsn := rewriteMySQLDSN(config.DSN)
+		if dsn == "" {
+			return nil, fmt.Errorf("must set `dsn` for models that transfer data from `mysql` to `duckdb`")
+		}
 		m.PreExec = fmt.Sprintf("INSTALL 'MYSQL'; LOAD 'MYSQL'; ATTACH %s AS %s (TYPE mysql, READ_ONLY)", safeSQLString(dsn), safeDBName)
 		m.SQL = fmt.Sprintf("SELECT * FROM mysql_query(%s, %s)", safeSQLString(dbName), safeSQLString(userQuery))
 	case "postgres":
-		var config *postgres.ConfigProperties
-		if err := mapstructure.Decode(inputHandle.Config(), &config); err != nil {
-			return nil, err
+		var dsn string
+		if inputProps.DSN != "" {
+			dsn = inputProps.DSN
+		} else {
+			// may be configured via a connector
+			var config *postgres.ConfigProperties
+			if err := mapstructure.Decode(inputHandle.Config(), &config); err != nil {
+				return nil, err
+			}
+			dsn = config.DatabaseURL
 		}
-		m.PreExec = fmt.Sprintf("INSTALL 'POSTGRES'; LOAD 'POSTGRES'; ATTACH %s AS %s (TYPE postgres, READ_ONLY)", safeSQLString(config.DatabaseURL), safeDBName)
+		if dsn == "" {
+			return nil, fmt.Errorf("must set `dsn` for models that transfer data from `postgres` to `duckdb`")
+		}
+		m.PreExec = fmt.Sprintf("INSTALL 'POSTGRES'; LOAD 'POSTGRES'; ATTACH %s AS %s (TYPE postgres, READ_ONLY)", safeSQLString(dsn), safeDBName)
 		m.SQL = fmt.Sprintf("SELECT * FROM postgres_query(%s, %s)", safeSQLString(dbName), safeSQLString(userQuery))
 	default:
 		return nil, fmt.Errorf("internal error: unsupported external database: %s", inputHandle.Driver())

--- a/runtime/drivers/duckdb/model_executor_sqlstore_self.go
+++ b/runtime/drivers/duckdb/model_executor_sqlstore_self.go
@@ -1,0 +1,101 @@
+package duckdb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/rilldata/rill/runtime/drivers"
+)
+
+type sqlStoreToSelfInputProps struct {
+	SQL string `mapstructure:"sql"`
+	DSN string `mapstructure:"dsn"`
+}
+
+func (p *sqlStoreToSelfInputProps) Validate() error {
+	if p.SQL == "" {
+		return fmt.Errorf("missing property 'sql'")
+	}
+	if p.DSN == "" {
+		return fmt.Errorf("missing property `dsn`")
+	}
+	return nil
+}
+
+type sqlStoreToSelfExecutor struct {
+	c *connection
+}
+
+var _ drivers.ModelExecutor = &sqlStoreToSelfExecutor{}
+
+func (e *sqlStoreToSelfExecutor) Concurrency(desired int) (int, bool) {
+	if desired > 1 {
+		return 0, false
+	}
+	return 1, true
+}
+
+func (e *sqlStoreToSelfExecutor) Execute(ctx context.Context, opts *drivers.ModelExecuteOptions) (*drivers.ModelResult, error) {
+	inputProps := &sqlStoreToSelfInputProps{}
+	if err := mapstructure.WeakDecode(opts.InputProperties, inputProps); err != nil {
+		return nil, fmt.Errorf("failed to parse input properties: %w", err)
+	}
+	if err := inputProps.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid input properties: %w", err)
+	}
+
+	outputProps := &ModelOutputProperties{}
+	if err := mapstructure.WeakDecode(opts.OutputProperties, outputProps); err != nil {
+		return nil, fmt.Errorf("failed to parse output properties: %w", err)
+	}
+	if err := outputProps.Validate(opts); err != nil {
+		return nil, fmt.Errorf("invalid output properties: %w", err)
+	}
+
+	// Build the model executor options with updated input and output properties
+	clone := *opts
+
+	newInputProps, err := e.modelInputProperties(opts.InputHandle.Driver(), inputProps, outputProps)
+	if err != nil {
+		return nil, err
+	}
+	clone.InputProperties = newInputProps
+
+	newOutputProps := make(map[string]any)
+	err = mapstructure.WeakDecode(outputProps, &newOutputProps)
+	if err != nil {
+		return nil, err
+	}
+	clone.OutputProperties = newOutputProps
+	newOpts := &clone
+
+	// execute
+	executor := &selfToSelfExecutor{c: e.c}
+	return executor.Execute(ctx, newOpts)
+}
+
+func (e *sqlStoreToSelfExecutor) modelInputProperties(inputDriver string, inputProps *sqlStoreToSelfInputProps, outputProps *ModelOutputProperties) (map[string]any, error) {
+	m := &ModelInputProperties{}
+	dbName := outputProps.Table + "_external_db_"
+	safeDBName := safeName(dbName)
+	userQuery, _ := strings.CutSuffix(inputProps.SQL, ";") // trim trailing semi colon
+	switch inputDriver {
+	case "mysql":
+		dsn := rewriteMySQLDSN(inputProps.DSN)
+		m.PreExec = fmt.Sprintf("INSTALL 'MYSQL'; LOAD 'MYSQL'; ATTACH %s AS %s (TYPE mysql, READ_ONLY)", safeSQLString(dsn), safeDBName)
+		m.SQL = fmt.Sprintf("SELECT * FROM mysql_query(%s, %s)", safeSQLString(dbName), safeSQLString(userQuery))
+	case "postgres":
+		m.PreExec = fmt.Sprintf("INSTALL 'POSTGRES'; LOAD 'POSTGRES'; ATTACH %s AS %s (TYPE postgres, READ_ONLY)", safeSQLString(inputProps.DSN), safeDBName)
+		m.SQL = fmt.Sprintf("SELECT * FROM postgres_query(%s, %s)", safeSQLString(dbName), safeSQLString(userQuery))
+	default:
+		return nil, fmt.Errorf("internal error: unsupported external database: %s", inputDriver)
+	}
+	m.PostExec = fmt.Sprintf("DETACH %s", safeDBName)
+	propsMap := make(map[string]any)
+	if err := mapstructure.Decode(m, &propsMap); err != nil {
+		return nil, err
+	}
+	return propsMap, nil
+}

--- a/runtime/drivers/duckdb/model_executor_sqlstore_self.go
+++ b/runtime/drivers/duckdb/model_executor_sqlstore_self.go
@@ -57,7 +57,7 @@ func (e *sqlStoreToSelfExecutor) Execute(ctx context.Context, opts *drivers.Mode
 	// Build the model executor options with updated input and output properties
 	clone := *opts
 
-	newInputProps, err := e.modelInputProperties(opts.InputHandle.Driver(), inputProps, outputProps)
+	newInputProps, err := e.modelInputProperties(opts.ModelName, opts.InputHandle.Driver(), inputProps)
 	if err != nil {
 		return nil, err
 	}
@@ -76,9 +76,9 @@ func (e *sqlStoreToSelfExecutor) Execute(ctx context.Context, opts *drivers.Mode
 	return executor.Execute(ctx, newOpts)
 }
 
-func (e *sqlStoreToSelfExecutor) modelInputProperties(inputDriver string, inputProps *sqlStoreToSelfInputProps, outputProps *ModelOutputProperties) (map[string]any, error) {
+func (e *sqlStoreToSelfExecutor) modelInputProperties(modelName, inputDriver string, inputProps *sqlStoreToSelfInputProps) (map[string]any, error) {
 	m := &ModelInputProperties{}
-	dbName := outputProps.Table + "_external_db_"
+	dbName := modelName + "_external_db_"
 	safeDBName := safeName(dbName)
 	userQuery, _ := strings.CutSuffix(inputProps.SQL, ";") // trim trailing semi colon
 	switch inputDriver {

--- a/runtime/drivers/duckdb/model_executor_sqlstore_self.go
+++ b/runtime/drivers/duckdb/model_executor_sqlstore_self.go
@@ -102,7 +102,7 @@ func (e *sqlStoreToSelfExecutor) modelInputProperties(modelName, inputConnector 
 			dsn = config.ResolveDSN()
 		}
 		if dsn == "" {
-			return nil, fmt.Errorf("must set `dsn` for models that transfer data from `postgres` to `duckdb`")
+			return nil, fmt.Errorf("must set `database_url` or `dsn` for models that transfer data from `postgres` to `duckdb`")
 		}
 		m.PreExec = fmt.Sprintf("INSTALL 'POSTGRES'; LOAD 'POSTGRES'; ATTACH %s AS %s (TYPE postgres, READ_ONLY)", safeSQLString(dsn), safeDBName)
 		m.SQL = fmt.Sprintf("SELECT * FROM postgres_query(%s, %s)", safeSQLString(dbName), safeSQLString(userQuery))

--- a/runtime/drivers/duckdb/model_executor_sqlstore_self.go
+++ b/runtime/drivers/duckdb/model_executor_sqlstore_self.go
@@ -92,7 +92,7 @@ func (e *sqlStoreToSelfExecutor) modelInputProperties(modelName, inputConnector 
 			if err := mapstructure.Decode(inputHandle.Config(), &config); err != nil {
 				return nil, err
 			}
-			dsn = config.DatabaseURL
+			dsn = config.ResolveDSN()
 		}
 		if dsn == "" {
 			return nil, fmt.Errorf("must set `dsn` for models that transfer data from `postgres` to `duckdb`")

--- a/runtime/drivers/duckdb/transporter_postgres_to_duckDB_test.go
+++ b/runtime/drivers/duckdb/transporter_postgres_to_duckDB_test.go
@@ -1,4 +1,4 @@
-package duckdb
+package duckdb_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 
 	// Load postgres driver
 	_ "github.com/jackc/pgx/v5/stdlib"
+	_ "github.com/rilldata/rill/runtime/drivers/duckdb"
 	_ "github.com/rilldata/rill/runtime/drivers/postgres"
 )
 
@@ -61,6 +62,7 @@ func TestTransfer(t *testing.T) {
 	defer db.Close()
 
 	t.Run("AllDataTypes", func(t *testing.T) { allDataTypesTest(t, db, pg.DatabaseURL) })
+	t.Run("model_executor_postgres_to_duckDB", func(t *testing.T) { pgxToDuckDB(t, db, pg.DatabaseURL) })
 }
 
 func allDataTypesTest(t *testing.T, db *sql.DB, dbURL string) {
@@ -72,7 +74,12 @@ func allDataTypesTest(t *testing.T, db *sql.DB, dbURL string) {
 	require.NoError(t, err)
 	olap, _ := to.AsOLAP("")
 
-	tr := newDuckDBToDuckDB(to.(*connection), "postgres", zap.NewNop())
+	inputHandle, err := drivers.Open("postgres", "default", map[string]any{"database_url": dbURL}, storage.MustNew(t.TempDir(), nil), activity.NewNoopClient(), zap.NewNop())
+	require.NoError(t, err)
+
+	tr, ok := to.AsTransporter(inputHandle, to)
+	require.True(t, ok)
+
 	err = tr.Transfer(ctx, map[string]any{"sql": "select * from all_datatypes;", "db": dbURL}, map[string]any{"table": "sink"}, &drivers.TransferOptions{})
 	require.NoError(t, err)
 	res, err := olap.Execute(context.Background(), &drivers.Statement{Query: "select count(*) from sink"})
@@ -85,4 +92,81 @@ func allDataTypesTest(t *testing.T, db *sql.DB, dbURL string) {
 	}
 	require.NoError(t, res.Close())
 	require.NoError(t, to.Close())
+}
+
+func pgxToDuckDB(t *testing.T, pgdb *sql.DB, dbURL string) {
+	duckDB, err := drivers.Open("duckdb", "default", map[string]any{"data_dir": t.TempDir()}, storage.MustNew(t.TempDir(), nil), activity.NewNoopClient(), zap.NewNop())
+	require.NoError(t, err)
+
+	inputHandle, err := drivers.Open("mysql", "default", map[string]any{"dsn": dbURL}, storage.MustNew(t.TempDir(), nil), activity.NewNoopClient(), zap.NewNop())
+	require.NoError(t, err)
+
+	opts := &drivers.ModelExecutorOptions{
+		InputHandle:     inputHandle,
+		InputConnector:  "mysql",
+		OutputHandle:    duckDB,
+		OutputConnector: "duckdb",
+		Env: &drivers.ModelEnv{
+			AllowHostAccess: false,
+			StageChanges:    true,
+		},
+		PreliminaryInputProperties: map[string]any{
+			"sql": "SELECT * FROM all_datatypes;",
+			"dsn": dbURL,
+		},
+		PreliminaryOutputProperties: map[string]any{
+			"table": "sink",
+		},
+	}
+
+	me, ok := duckDB.AsModelExecutor("default", opts)
+	require.True(t, ok)
+
+	execOpts := &drivers.ModelExecuteOptions{
+		ModelExecutorOptions: opts,
+		InputProperties:      opts.PreliminaryInputProperties,
+		OutputProperties:     opts.PreliminaryOutputProperties,
+	}
+
+	_, err = me.Execute(context.Background(), execOpts)
+	require.NoError(t, err)
+
+	olap, ok := duckDB.AsOLAP("default")
+	require.True(t, ok)
+
+	res, err := olap.Execute(context.Background(), &drivers.Statement{Query: "select count(*) from sink"})
+	require.NoError(t, err)
+	for res.Next() {
+		var count int
+		err = res.Rows.Scan(&count)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+	}
+	require.NoError(t, res.Close())
+
+	// ingest some more data in postges
+	_, err = pgdb.Exec("INSERT INTO all_datatypes(uuid, created_at) VALUES (gen_random_uuid(), '2024-01-02 12:46:55');")
+	require.NoError(t, err)
+
+	// drop older data from postgres
+	_, err = pgdb.Exec("DELETE FROM all_datatypes WHERE created_at < '2024-01-01 00:00:00';")
+	require.NoError(t, err)
+
+	// incremental run
+	execOpts.IncrementalRun = true
+	execOpts.InputProperties["sql"] = "SELECT * FROM all_datatypes WHERE created_at > '2024-01-01 00:00:00';"
+	_, err = me.Execute(context.Background(), execOpts)
+	require.NoError(t, err)
+
+	res, err = olap.Execute(context.Background(), &drivers.Statement{Query: "select count(*) from sink"})
+	require.NoError(t, err)
+	for res.Next() {
+		var count int
+		err = res.Rows.Scan(&count)
+		require.NoError(t, err)
+		require.Equal(t, 2, count)
+	}
+	require.NoError(t, res.Close())
+
+	require.NoError(t, duckDB.Close())
 }

--- a/runtime/drivers/duckdb/transporter_postgres_to_duckDB_test.go
+++ b/runtime/drivers/duckdb/transporter_postgres_to_duckDB_test.go
@@ -98,7 +98,7 @@ func pgxToDuckDB(t *testing.T, pgdb *sql.DB, dbURL string) {
 	duckDB, err := drivers.Open("duckdb", "default", map[string]any{"data_dir": t.TempDir()}, storage.MustNew(t.TempDir(), nil), activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
-	inputHandle, err := drivers.Open("postgres", "default", map[string]any{"dsn": dbURL}, storage.MustNew(t.TempDir(), nil), activity.NewNoopClient(), zap.NewNop())
+	inputHandle, err := drivers.Open("postgres", "default", map[string]any{"database_url": dbURL}, storage.MustNew(t.TempDir(), nil), activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	opts := &drivers.ModelExecutorOptions{

--- a/runtime/drivers/duckdb/transporter_postgres_to_duckDB_test.go
+++ b/runtime/drivers/duckdb/transporter_postgres_to_duckDB_test.go
@@ -98,7 +98,7 @@ func pgxToDuckDB(t *testing.T, pgdb *sql.DB, dbURL string) {
 	duckDB, err := drivers.Open("duckdb", "default", map[string]any{"data_dir": t.TempDir()}, storage.MustNew(t.TempDir(), nil), activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
-	inputHandle, err := drivers.Open("mysql", "default", map[string]any{"dsn": dbURL}, storage.MustNew(t.TempDir(), nil), activity.NewNoopClient(), zap.NewNop())
+	inputHandle, err := drivers.Open("postgres", "default", map[string]any{"dsn": dbURL}, storage.MustNew(t.TempDir(), nil), activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
 
 	opts := &drivers.ModelExecutorOptions{

--- a/runtime/drivers/duckdb/transporter_postgres_to_duckDB_test.go
+++ b/runtime/drivers/duckdb/transporter_postgres_to_duckDB_test.go
@@ -103,7 +103,7 @@ func pgxToDuckDB(t *testing.T, pgdb *sql.DB, dbURL string) {
 
 	opts := &drivers.ModelExecutorOptions{
 		InputHandle:     inputHandle,
-		InputConnector:  "mysql",
+		InputConnector:  "postgres",
 		OutputHandle:    duckDB,
 		OutputConnector: "duckdb",
 		Env: &drivers.ModelEnv{

--- a/runtime/drivers/mysql/mysql.go
+++ b/runtime/drivers/mysql/mysql.go
@@ -58,6 +58,10 @@ var spec = drivers.Spec{
 
 type driver struct{}
 
+type ConfigProperties struct {
+	DSN string `mapstructure:"dsn"`
+}
+
 func (d driver) Open(instanceID string, config map[string]any, st *storage.Client, ac *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
 	if instanceID == "" {
 		return nil, errors.New("mysql driver can't be shared")

--- a/runtime/drivers/postgres/postgres.go
+++ b/runtime/drivers/postgres/postgres.go
@@ -56,6 +56,10 @@ var spec = drivers.Spec{
 
 type driver struct{}
 
+type ConfigProperties struct {
+	DatabaseURL string `mapstructure:"database_url"`
+}
+
 func (d driver) Open(instanceID string, config map[string]any, st *storage.Client, ac *activity.Client, logger *zap.Logger) (drivers.Handle, error) {
 	if instanceID == "" {
 		return nil, errors.New("postgres driver can't be shared")

--- a/runtime/drivers/postgres/postgres.go
+++ b/runtime/drivers/postgres/postgres.go
@@ -58,6 +58,14 @@ type driver struct{}
 
 type ConfigProperties struct {
 	DatabaseURL string `mapstructure:"database_url"`
+	DSN         string `mapstructure:"dsn"`
+}
+
+func (c *ConfigProperties) ResolveDSN() string {
+	if c.DSN != "" {
+		return c.DSN
+	}
+	return c.DatabaseURL
 }
 
 func (d driver) Open(instanceID string, config map[string]any, st *storage.Client, ac *activity.Client, logger *zap.Logger) (drivers.Handle, error) {


### PR DESCRIPTION
subtask for https://github.com/rilldata/rill-private-issues/issues/854

- Adds a model executor that ingests data from postgres/mysql using duckdb extension.
- Also supports incremental ingestion.

Sample model yaml that ingests from postgres.
```
connector: postgres
sql: SELECT * FROM students 
dsn: "postgresql://postgres:postgres@localhost:5432/postgres"

output:
  connector: duckdb
```  