### PR TITLE
fix: Hide scheduled report button for dashboards with no timestamp column

### DIFF
--- a/web-common/src/features/exports/ExportMenu.svelte
+++ b/web-common/src/features/exports/ExportMenu.svelte
@@ -79,7 +79,7 @@
       Export as XLSX
     </DropdownMenu.Item>
 
-    {#if includeScheduledReport}
+    {#if includeScheduledReport && queryArgs}
       <DropdownMenu.Item on:click={() => (showScheduledReportDialog = true)}>
         Create scheduled report...
       </DropdownMenu.Item>


### PR DESCRIPTION
When the dashboard has no timestamp column configured reports dont work well. We should hide the button since the dialog is not opened anyway.