### PR TITLE
enable TimeBoundary planning through druid context

### DIFF
--- a/runtime/drivers/druid/druidsqldriver/druid_api_sql_driver.go
+++ b/runtime/drivers/druid/druidsqldriver/druid_api_sql_driver.go
@@ -416,7 +416,8 @@ func (chc *coordinatorHTTPCheck) IsHardFailure(ctx context.Context) (bool, error
 }
 
 type DruidQueryContext struct {
-	SQLQueryID string `json:"sqlQueryId"`
+	SQLQueryID                 string `json:"sqlQueryId"`
+	EnableTimeBoundaryPlanning bool   `json:"enableTimeBoundaryPlanning"`
 }
 
 type DruidParameter struct {
@@ -448,7 +449,8 @@ func newDruidRequest(query string, args []driver.NamedValue) *DruidRequest {
 		ResultFormat:   "arrayLines",
 		Parameters:     parameters,
 		Context: DruidQueryContext{
-			SQLQueryID: uuid.New().String(),
+			SQLQueryID:                 uuid.New().String(),
+			EnableTimeBoundaryPlanning: true,
 		},
 	}
 }


### PR DESCRIPTION
So that cluster owners don't need to set this config, when driver was created ability to set context was not available through avatica driver.