### PR TITLE
fix: autogenerate metrics indentation

### DIFF
--- a/runtime/server/generate_metrics_view.go
+++ b/runtime/server/generate_metrics_view.go
@@ -379,6 +379,7 @@ func generateMetricsViewYAMLSimpleDimensions(schema *runtimev1.StructType) []*me
 		switch f.Type.Code {
 		case runtimev1.Type_CODE_BOOL, runtimev1.Type_CODE_STRING, runtimev1.Type_CODE_BYTES, runtimev1.Type_CODE_UUID:
 			dims = append(dims, &metricsViewDimensionYAML{
+				Name:        f.Name,
 				DisplayName: identifierToDisplayName(f.Name),
 				Column:      f.Name,
 			})
@@ -447,6 +448,7 @@ type metricsViewYAML struct {
 }
 
 type metricsViewDimensionYAML struct {
+	Name        string `yaml:"name"`
 	DisplayName string `yaml:"display_name"`
 	Column      string `yaml:"column"`
 }
@@ -501,7 +503,7 @@ func insertEmptyLinesInYaml(node *yaml.Node) {
 				keyNode := node.Content[i].Content[j]
 				valueNode := node.Content[i].Content[j+1]
 
-				if keyNode.Value == "display_name" || keyNode.Value == "dimensions" || keyNode.Value == "measures" {
+				if keyNode.Value == "dimensions" || keyNode.Value == "measures" {
 					keyNode.HeadComment = "\n"
 				}
 				insertEmptyLinesInYaml(valueNode)

--- a/runtime/server/generate_metrics_view.go
+++ b/runtime/server/generate_metrics_view.go
@@ -506,6 +506,9 @@ func insertEmptyLinesInYaml(node *yaml.Node) {
 				if keyNode.Value == "dimensions" || keyNode.Value == "measures" {
 					keyNode.HeadComment = "\n"
 				}
+				if keyNode.Value == "type" {
+					valueNode.LineComment = "\n\n"
+				}
 				insertEmptyLinesInYaml(valueNode)
 			}
 		} else if node.Content[i].Kind == yaml.SequenceNode {


### PR DESCRIPTION
We are generating metrics with additional spaces. Also `name` is missing in dimensioins.
```
# Metrics view YAML
# Reference documentation: https://docs.rilldata.com/reference/project-files/dashboards

version: 1
type: metrics_view

display_name: Ad Bids
model: ad_bids
timeseries: timestamp

dimensions:
  - 
    display_name: Publisher
    column: publisher
  - 
    display_name: Domain
    column: domain

measures:
  - name: total_records
    
    display_name: Total records
    expression: COUNT(*)
    description: ""
    format_preset: humanize
  - name: bid_price_sum
    
    display_name: Sum of Bid Price
    expression: SUM(bid_price)
    description: ""
    format_preset: humanize
```

Removing the new line before display_name and adding after type instead.

After,
```
# Metrics view YAML
# Reference documentation: https://docs.rilldata.com/reference/project-files/dashboards

version: 1
type: metrics_view 

display_name: Ad Bids
model: ad_bids
timeseries: timestamp

dimensions:
  - name: publisher
    display_name: Publisher
    column: publisher
  - name: domain
    display_name: Domain
    column: domain

measures:
  - name: total_records
    display_name: Total records
    expression: COUNT(*)
    description: ""
    format_preset: humanize
  - name: bid_price_sum
    display_name: Sum of Bid Price
    expression: SUM(bid_price)
    description: ""
    format_preset: humanize
```