### PR TITLE
fix: bookmark query by doing a case insensitive query

### DIFF
--- a/admin/database/postgres/migrations/0053.sql
+++ b/admin/database/postgres/migrations/0053.sql
@@ -1,2 +1,2 @@
 DROP INDEX bookmarks_search_idx;
-CREATE INDEX bookmarks_search_idx ON bookmarks (project_id, lower(resource_name), resource_kind);
+CREATE INDEX bookmarks_search_idx ON bookmarks (project_id, resource_kind, lower(resource_name));

--- a/admin/database/postgres/migrations/0053.sql
+++ b/admin/database/postgres/migrations/0053.sql
@@ -1,0 +1,2 @@
+DROP INDEX bookmarks_search_idx;
+CREATE INDEX bookmarks_search_idx ON bookmarks (project_id, user_id, lower(resource_name), resource_kind, "default", shared);

--- a/admin/database/postgres/migrations/0053.sql
+++ b/admin/database/postgres/migrations/0053.sql
@@ -1,2 +1,2 @@
 DROP INDEX bookmarks_search_idx;
-CREATE INDEX bookmarks_search_idx ON bookmarks (project_id, user_id, lower(resource_name), resource_kind, "default", shared);
+CREATE INDEX bookmarks_search_idx ON bookmarks (project_id, lower(resource_name), resource_kind);

--- a/admin/database/postgres/postgres.go
+++ b/admin/database/postgres/postgres.go
@@ -1783,7 +1783,7 @@ func (c *connection) DeleteProjectAccessRequest(ctx context.Context, id string) 
 // FindBookmarks returns a list of bookmarks for a user per project
 func (c *connection) FindBookmarks(ctx context.Context, projectID, resourceKind, resourceName, userID string) ([]*database.Bookmark, error) {
 	var res []*database.Bookmark
-	err := c.getDB(ctx).SelectContext(ctx, &res, `SELECT * FROM bookmarks WHERE project_id = $1 and resource_kind = $2 and resource_name = $3 and (user_id = $4 or shared = true or "default" = true)`,
+	err := c.getDB(ctx).SelectContext(ctx, &res, `SELECT * FROM bookmarks WHERE project_id = $1 and resource_kind = $2 and lower(resource_name) = lower($3) and (user_id = $4 or shared = true or "default" = true)`,
 		projectID, resourceKind, resourceName, userID)
 	if err != nil {
 		return nil, parseErr("bookmarks", err)
@@ -1803,7 +1803,7 @@ func (c *connection) FindBookmark(ctx context.Context, bookmarkID string) (*data
 
 func (c *connection) FindDefaultBookmark(ctx context.Context, projectID, resourceKind, resourceName string) (*database.Bookmark, error) {
 	res := &database.Bookmark{}
-	err := c.getDB(ctx).QueryRowxContext(ctx, `SELECT * FROM bookmarks WHERE project_id = $1 and resource_kind = $2 and resource_name = $3 and "default" = true`,
+	err := c.getDB(ctx).QueryRowxContext(ctx, `SELECT * FROM bookmarks WHERE project_id = $1 and resource_kind = $2 and lower(resource_name) = lower($3) and "default" = true`,
 		projectID, resourceKind, resourceName).StructScan(res)
 	if err != nil {
 		return nil, parseErr("bookmarks", err)


### PR DESCRIPTION
Our top navigation bar uses lower case resource name so if a bookmark was created with original case and navigated to using top bar the older bookmarks were not found anymore.

Making the bookmark query case insensitive since resource name is already case insensitive in our system.