### PR TITLE
fix: templated uri dimension by making a request

### DIFF
--- a/web-common/src/features/dashboards/dashboard-utils.ts
+++ b/web-common/src/features/dashboards/dashboard-utils.ts
@@ -4,6 +4,7 @@ import {
   ComparisonDeltaPreviousSuffix,
   ComparisonDeltaRelativeSuffix,
 } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry";
+import { URI_DIMENSION_SUFFIX } from "@rilldata/web-common/features/dashboards/leaderboard/leaderboard-utils";
 import { sanitiseExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
 import { DashboardState_LeaderboardSortType } from "@rilldata/web-common/proto/gen/rill/ui/v1/dashboard_pb";
 import type {
@@ -147,6 +148,17 @@ export function getComparisonRequestMeasures(
       },
     },
   ];
+}
+
+export function getURIRequestMeasure(
+  dimensionName: string,
+): V1MetricsViewAggregationMeasure {
+  return {
+    name: dimensionName + URI_DIMENSION_SUFFIX,
+    uri: {
+      dimension: dimensionName,
+    },
+  };
 }
 
 export function getBreadcrumbOptions(

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -37,7 +37,6 @@
     getSort,
     prepareLeaderboardItemData,
     type LeaderboardItemData,
-    URI_DIMENSION_SUFFIX,
   } from "./leaderboard-utils";
   import {
     LEADERBOARD_DEFAULT_COLUMN_WIDTHS,

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -14,7 +14,10 @@
     V1Operation,
   } from "@rilldata/web-common/runtime-client";
   import { onMount } from "svelte";
-  import { getComparisonRequestMeasures } from "../dashboard-utils";
+  import {
+    getComparisonRequestMeasures,
+    getURIRequestMeasure,
+  } from "../dashboard-utils";
   import { mergeDimensionAndMeasureFilter } from "../filters/measure-filters/measure-filter-utils";
   import { SortType } from "../proto-state/derived-types";
   import {
@@ -34,6 +37,7 @@
     getSort,
     prepareLeaderboardItemData,
     type LeaderboardItemData,
+    URI_DIMENSION_SUFFIX,
   } from "./leaderboard-utils";
   import {
     LEADERBOARD_DEFAULT_COLUMN_WIDTHS,
@@ -132,7 +136,8 @@
       ...(comparisonTimeRange
         ? getComparisonRequestMeasures(activeMeasureName)
         : []),
-    );
+    )
+    .concat(uri ? [getURIRequestMeasure(dimensionName)] : []);
 
   $: sort = getSort(
     sortedAscending,
@@ -316,7 +321,6 @@
             {filterExcludeMode}
             {atLeastOneActive}
             {dimensionName}
-            {uri}
             {itemData}
             {isValidPercentOfTotal}
             isTimeComparisonActive={!!comparisonTimeRange}
@@ -335,7 +339,6 @@
           {tableWidth}
           {dimensionName}
           {isBeingCompared}
-          {uri}
           {filterExcludeMode}
           {atLeastOneActive}
           {isValidPercentOfTotal}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -134,17 +134,15 @@
   $: showZigZag = barLength > tableWidth - gutterWidth;
 
   // uri template or "true" string literal or undefined
-  function makeHref(uriTemplateOrBoolean: string | null) {
+  function makeHref(uriTemplateOrBoolean: string | boolean | null) {
     if (!uriTemplateOrBoolean) {
       return undefined;
     }
 
     const uri =
-      uriTemplateOrBoolean === "true"
+      uriTemplateOrBoolean === true
         ? label
-        : uriTemplateOrBoolean
-            .replace(/\s/g, "")
-            .replace(`{{${dimensionName}}}`, label);
+        : uriTemplateOrBoolean.replace(/\s/g, "");
 
     const hasProtocol = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(uri);
 

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -134,7 +134,7 @@
   $: showZigZag = barLength > tableWidth - gutterWidth;
 
   // uri template or "true" string literal or undefined
-  function makeHref(uriTemplateOrBoolean: string | undefined) {
+  function makeHref(uriTemplateOrBoolean: string | null) {
     if (!uriTemplateOrBoolean) {
       return undefined;
     }

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -16,7 +16,6 @@
 
   export let itemData: LeaderboardItemData;
   export let dimensionName: string;
-  export let uri: string | undefined;
   export let tableWidth: number;
   export let columnWidths: {
     dimension: number;
@@ -72,7 +71,7 @@
 
   $: negativeChange = itemData.deltaAbs !== null && itemData.deltaAbs < 0;
 
-  $: href = makeHref(uri);
+  $: href = makeHref(itemData.uri);
 
   $: percentOfTotal = isSummableMeasure && pctOfTotal ? pctOfTotal : 0;
 

--- a/web-common/src/features/dashboards/leaderboard/leaderboard-utils.ts
+++ b/web-common/src/features/dashboards/leaderboard/leaderboard-utils.ts
@@ -17,6 +17,8 @@ export type LeaderboardItemData = {
    */
   dimensionValue: string;
 
+  uri: string | null;
+
   /**
    *  main value to be shown in the leaderboard
    */
@@ -59,6 +61,8 @@ export type LeaderboardItemData = {
   selectedIndex: number;
 };
 
+export const URI_DIMENSION_SUFFIX = "__rill_uri";
+
 const finiteOrNull = (v: unknown): number | null =>
   Number.isFinite(v) ? (v as number) : null;
 
@@ -81,6 +85,7 @@ export function cleanUpComparisonValue(
 
   return {
     dimensionValue: v[dimensionName],
+    uri: v[dimensionName + URI_DIMENSION_SUFFIX] || null,
     value,
     pctOfTotal: total !== null && value !== null ? value / total : null,
     prevValue: finiteOrNull(v[measureName + ComparisonDeltaPreviousSuffix]),


### PR DESCRIPTION
closes #5282

For URI dimensions we need to add a measure to get the final value after templating is done. This PR replaces the current implementation of replacing the template in frontend to backend.