### PR TITLE
fix: devtool start fails with config is a directory error

### DIFF
--- a/cli/cmd/devtool/data/cloud-deps.docker-compose.yml
+++ b/cli/cmd/devtool/data/cloud-deps.docker-compose.yml
@@ -63,4 +63,4 @@ services:
     image: stripe/stripe-cli:v1.21.11
     command: listen --forward-to http://host.docker.internal:8080/payment/webhook --config /etc/stripe-config.toml
     volumes:
-      - ../../../../dev-cloud-state/stripe-config.toml:/etc/stripe-config.toml:ro
+      - ../../../../dev-cloud-state/stripe-config.toml:/etc/stripe-config.toml


### PR DESCRIPTION
Mounting with ro converts file to directory. 
Could be a docker bug but I think`ro` indicates that host path is to be mounted as a directory.