### PR TITLE
fix: billing UI minor issues

### DIFF
--- a/web-admin/src/features/billing/issues/getMessageForCancelledIssue.ts
+++ b/web-admin/src/features/billing/issues/getMessageForCancelledIssue.ts
@@ -34,7 +34,7 @@ export function getMessageForCancelledIssue(cancelledSubIssue: V1BillingIssue) {
 
   return <BillingIssueMessage>{
     type: ended ? "error" : "warning",
-    title: `Your plan is canceled ${accessTimeout}.`,
+    title: `Your plan is cancelled ${accessTimeout}.`,
     description: "To maintain access, renew your plan.",
     iconType: "alert",
     cta: {

--- a/web-admin/src/features/billing/plans/CancelledTeamPlan.svelte
+++ b/web-admin/src/features/billing/plans/CancelledTeamPlan.svelte
@@ -40,7 +40,10 @@
           and your subscription has ended.
         {/if}
       </div>
-      <PlanQuotas {organization} />
+      {#if plan}
+        <!-- if there is no plan then quotas will be set to 0. It doesnt make sense to show this then -->
+        <PlanQuotas {organization} />
+      {/if}
     </div>
   </div>
   <svelte:fragment slot="contact">

--- a/web-admin/src/features/billing/plans/TeamPlan.svelte
+++ b/web-admin/src/features/billing/plans/TeamPlan.svelte
@@ -35,7 +35,7 @@
     });
     eventBus.emit("notification", {
       type: "success",
-      message: "Your Team plan was canceled",
+      message: "Your Team plan was cancelled",
     });
     void invalidateBillingInfo(organization, [
       V1BillingIssueType.BILLING_ISSUE_TYPE_SUBSCRIPTION_CANCELLED,

--- a/web-admin/src/features/billing/plans/TrialPlan.svelte
+++ b/web-admin/src/features/billing/plans/TrialPlan.svelte
@@ -58,7 +58,10 @@
         target="_blank"
         rel="noreferrer noopener">See pricing details -></a
       >
-      <PlanQuotas {organization} />
+      {#if plan}
+        <!-- if there is no plan then quotas will be set to 0. It doesnt make sense to show this then -->
+        <PlanQuotas {organization} />
+      {/if}
     </div>
   </div>
   <svelte:fragment slot="contact">

--- a/web-admin/src/features/organizations/settings/OrgNameSettings.svelte
+++ b/web-admin/src/features/organizations/settings/OrgNameSettings.svelte
@@ -119,6 +119,7 @@
       description={`Your org URL will be https://ui.rilldata.com/${sanitizeOrgName($form.name)}, to comply with our naming rules.`}
       textClass="text-sm"
       alwaysShowError
+      width="520px"
     />
     <Input
       bind:value={$form.description}
@@ -127,6 +128,7 @@
       label="Description"
       placeholder="Describe your organization"
       textClass="text-sm"
+      width="520px"
     />
   </form>
   {#if error?.message}

--- a/web-admin/src/features/organizations/settings/OrgNameSettings.svelte
+++ b/web-admin/src/features/organizations/settings/OrgNameSettings.svelte
@@ -119,7 +119,7 @@
       description={`Your org URL will be https://ui.rilldata.com/${sanitizeOrgName($form.name)}, to comply with our naming rules.`}
       textClass="text-sm"
       alwaysShowError
-      width="520px"
+      additionalClass="max-w-[520px]"
     />
     <Input
       bind:value={$form.description}
@@ -128,7 +128,7 @@
       label="Description"
       placeholder="Describe your organization"
       textClass="text-sm"
-      width="520px"
+      additionalClass="max-w-[520px]"
     />
   </form>
   {#if error?.message}

--- a/web-admin/src/routes/[organization]/-/upgrade-callback/+page.svelte
+++ b/web-admin/src/routes/[organization]/-/upgrade-callback/+page.svelte
@@ -75,7 +75,11 @@
             planName: teamPlan.name,
           },
         });
-        showWelcomeToRillDialog.set(true);
+        // if redirect is set then this page won't be active.
+        // so this will lead to pop-in of the modal before navigating away
+        if (!redirect) {
+          showWelcomeToRillDialog.set(true);
+        }
       }
       void invalidateBillingInfo(organization);
     } catch {

--- a/web-common/src/components/forms/Input.svelte
+++ b/web-common/src/components/forms/Input.svelte
@@ -36,6 +36,7 @@
   export let options:
     | { value: string; label: string; type?: string }[]
     | undefined = undefined;
+  export let additionalClass = "";
   export let onInput: (
     newValue: string,
     e: Event & {
@@ -90,7 +91,11 @@
   }
 </script>
 
-<div class="component-wrapper" class:w-full={full} style:width>
+<div
+  class="component-wrapper {additionalClass}"
+  class:w-full={full}
+  style:width
+>
   {#if label}
     <InputLabel {label} {optional} {id} {hint}>
       <slot name="mode-switch" slot="mode-switch" />

--- a/web-common/src/components/forms/Input.svelte
+++ b/web-common/src/components/forms/Input.svelte
@@ -198,7 +198,7 @@
   {/if}
 
   {#if description}
-    <div>{description}</div>
+    <div class="description">{description}</div>
   {/if}
 </div>
 
@@ -266,5 +266,9 @@
 
   .toggle:active {
     @apply bg-primary-100;
+  }
+
+  .description {
+    @apply text-xs text-gray-500;
   }
 </style>

--- a/web-common/src/features/project/DeployError.svelte
+++ b/web-common/src/features/project/DeployError.svelte
@@ -18,10 +18,12 @@
   export let adminUrl: string;
   export let isEmptyOrg: boolean;
   export let onRetry: () => void;
+  export let onBack: () => void;
 
   $: isQuotaError =
     error.type === DeployErrorType.ProjectLimitHit ||
     error.type === DeployErrorType.OrgLimitHit ||
+    error.type === DeployErrorType.TrialEnded ||
     error.type === DeployErrorType.SubscriptionEnded;
 
   $: upgradeHref = buildPlanUpgradeUrl(org, adminUrl, isEmptyOrg, $page.url);
@@ -32,8 +34,8 @@
   <p class="text-base text-gray-500 text-left w-[500px]">
     <PricingDetails extraText={error.message} />
   </p>
-  <Button type="primary" href={upgradeHref} wide on:click>Upgrade</Button>
-  <Button type="secondary" noStroke wide href="/">Back</Button>
+  <Button type="primary" href={upgradeHref} wide>Upgrade</Button>
+  <Button type="secondary" noStroke wide on:click={onBack}>Back</Button>
 {:else}
   <CancelCircleInverse size="7rem" className="text-gray-200" />
   <CTAHeader variant="bold">{error.title}</CTAHeader>

--- a/web-common/src/lib/time/ranges/iso-ranges.ts
+++ b/web-common/src/lib/time/ranges/iso-ranges.ts
@@ -187,7 +187,7 @@ function getSmallestUnit(duration: Duration) {
 }
 
 function getLargestUnit(duration: Duration, units: DurationUnit[]) {
-  for (let i = PeriodAndUnits.length - 1; i > 0; i--) {
+  for (let i = PeriodAndUnits.length - 1; i >= 0; i--) {
     const { unit } = PeriodAndUnits[i];
     if (units.includes(unit) && duration[unit]) {
       return unit;

--- a/web-local/src/routes/(misc)/deploy/+page.svelte
+++ b/web-local/src/routes/(misc)/deploy/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { goto } from "$app/navigation";
   import { getNeverSubscribedIssue } from "@rilldata/web-common/features/billing/issues";
   import TrialDetailsDialog from "@rilldata/web-common/features/billing/TrialDetailsDialog.svelte";
   import { EntityStatus } from "@rilldata/web-common/features/entity-management/types";
@@ -57,6 +58,18 @@
     return deployer.deploy(selectedOrg);
   }
 
+  function onBack() {
+    if (orgMetadata.orgs.length) {
+      promptOrgSelection.set(true);
+    } else {
+      void goto("/");
+    }
+  }
+
+  function onRetry() {
+    return deployer.deploy($org);
+  }
+
   onMount(() => {
     void deployer.loginOrDeploy();
   });
@@ -89,7 +102,8 @@
         org={$org}
         adminUrl={$metadata.data?.adminUrl ?? ""}
         {isEmptyOrg}
-        onRetry={() => {}}
+        {onRetry}
+        {onBack}
       />
     {/if}
   </CTAContentContainer>


### PR DESCRIPTION
- [x] Hide quotas when plan has ended/expired. Quotas will be set to 0 so no point in showing the quotas module.
- [x] During deploy, back button in upgrade wall should return to org selection page if org count > 1.
- [x] Fix issues with time remaining < 1 hour showing in milliseconds.
- [x] Avoid the quick pop-in of welcome dialog before navigating after upgrading during deploy.
- [x] `canceled` => `cancelled`
- [x] Update input description to match mocks.