### PR TITLE
Create public url and offer copy to clipboard cta

### DIFF
--- a/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
+++ b/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
@@ -119,14 +119,12 @@
   );
 
   function onCopy() {
-    const success = copyToClipboard(url, "URL copied to clipboard");
-    if (success) {
-      copied = true;
+    copyToClipboard(url, "URL copied to clipboard");
+    copied = true;
 
-      setTimeout(() => {
-        copied = false;
-      }, 2_000);
-    }
+    setTimeout(() => {
+      copied = false;
+    }, 2_000);
   }
 
   $: hasWhereFilter = hasDashboardWhereFilter($dashboardStore);

--- a/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
+++ b/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
@@ -60,9 +60,11 @@
     exploreFields,
   );
 
-  let token: string;
+  let url: string | null = null;
   let setExpiration = false;
   let apiError: string;
+  let popoverOpen = false;
+  let copied = false;
 
   const formId = "create-public-url-form";
 
@@ -87,7 +89,7 @@
         const values = form.data;
 
         try {
-          const { token: _token } = await $issueMagicAuthToken.mutateAsync({
+          const { url: _url } = await $issueMagicAuthToken.mutateAsync({
             organization,
             project,
             data: {
@@ -102,12 +104,8 @@
               displayName: values.title,
             },
           });
-          token = _token;
 
-          copyToClipboard(
-            `${window.location.origin}/${organization}/${project}/-/share/${token}`,
-            "URL copied to clipboard",
-          );
+          url = _url;
 
           void queryClient.invalidateQueries(
             getAdminServiceListMagicAuthTokensQueryKey(organization, project),
@@ -119,6 +117,18 @@
       },
     },
   );
+
+  async function onCopy() {
+    const success = await copyToClipboard(url, "URL copied to clipboard");
+    console.log("success", success);
+    if (success) {
+      copied = true;
+
+      setTimeout(() => {
+        copied = false;
+      }, 2_000);
+    }
+  }
 
   $: hasWhereFilter = hasDashboardWhereFilter($dashboardStore);
   $: hasDimensionThresholdFilter =
@@ -134,67 +144,64 @@
   $: ({ length: allErrorsLength } = $allErrors);
 
   $: includingTomorrowDate = DateTime.now().plus({ days: 1 }).startOf("day");
-
-  let popoverOpen = false;
 </script>
 
-{#if !token}
+{#if !url}
   <form id={formId} on:submit|preventDefault={submit} use:enhance>
-    <div class="flex flex-col gap-y-4">
-      <h3 class="text-xs text-gray-800 font-normal">
-        Create a shareable public URL for this view.
-      </h3>
+    <h3 class="text-xs text-gray-800 font-normal">
+      Create a shareable public URL for this view.
+    </h3>
 
-      <div class="flex flex-col gap-y-1">
+    {#if !url}
+      <div class="flex flex-col gap-y-1 mt-4">
         <Input
           id="name-input"
           bind:value={$form.title}
           placeholder="Label this URL"
         />
       </div>
-    </div>
 
-    <div
-      class="mt-4"
-      class:mb-4={!hasWhereFilter && !hasDimensionThresholdFilter}
-    >
-      <div class="flex items-center gap-x-2">
-        <Switch small id="has-expiration" bind:checked={setExpiration} />
-        <Label class="text-xs" for="has-expiration">Set expiration</Label>
-      </div>
-      {#if setExpiration}
-        <div class="flex items-center gap-x-1 pl-[30px]">
-          <label for="expires-at" class="text-slate-500 font-medium">
-            Access expires {new Date($form.expiresAt).toLocaleDateString(
-              "en-US",
-              { year: "numeric", month: "short", day: "numeric" },
-            )}
-          </label>
-          <Popover bind:open={popoverOpen}>
-            <PopoverTrigger>
-              <IconButton>
-                <Pencil size="14px" class="text-primary-600" />
-              </IconButton>
-            </PopoverTrigger>
-            <PopoverContent align="end" class="p-0">
-              <Calendar
-                selection={DateTime.fromISO($form.expiresAt)}
-                singleDaySelection
-                minDate={includingTomorrowDate}
-                firstVisibleMonth={DateTime.fromISO($form.expiresAt)}
-                onSelectDay={(date) => {
-                  $form.expiresAt = date.toISO();
-                  popoverOpen = false;
-                }}
-              />
-            </PopoverContent>
-          </Popover>
+      <div
+        class="mt-4"
+        class:mb-4={!hasWhereFilter && !hasDimensionThresholdFilter}
+      >
+        <div class="flex items-center gap-x-2">
+          <Switch small id="has-expiration" bind:checked={setExpiration} />
+          <Label class="text-xs" for="has-expiration">Set expiration</Label>
         </div>
-      {/if}
-    </div>
+        {#if setExpiration}
+          <div class="flex items-center gap-x-1 pl-[30px]">
+            <label for="expires-at" class="text-slate-500 font-medium">
+              Access expires {new Date($form.expiresAt).toLocaleDateString(
+                "en-US",
+                { year: "numeric", month: "short", day: "numeric" },
+              )}
+            </label>
+            <Popover bind:open={popoverOpen}>
+              <PopoverTrigger>
+                <IconButton>
+                  <Pencil size="14px" class="text-primary-600" />
+                </IconButton>
+              </PopoverTrigger>
+              <PopoverContent align="end" class="p-0">
+                <Calendar
+                  selection={DateTime.fromISO($form.expiresAt)}
+                  singleDaySelection
+                  minDate={includingTomorrowDate}
+                  firstVisibleMonth={DateTime.fromISO($form.expiresAt)}
+                  onSelectDay={(date) => {
+                    $form.expiresAt = date.toISO();
+                    popoverOpen = false;
+                  }}
+                />
+              </PopoverContent>
+            </Popover>
+          </div>
+        {/if}
+      </div>
 
-    <!-- TODO: revisit when time range lock is implemented -->
-    <!-- <div class="mt-4" class:mb-4={!hasWhereFilter}>
+      <!-- TODO: revisit when time range lock is implemented -->
+      <!-- <div class="mt-4" class:mb-4={!hasWhereFilter}>
       <div class="flex items-center gap-x-2">
         <Switch small id="lock-time-range" bind:checked={lockTimeRange} />
 
@@ -221,27 +228,28 @@
       {/if}
     </div> -->
 
-    {#if hasWhereFilter || hasDimensionThresholdFilter}
-      <hr class="border-gray-200 mt-4 mb-4" />
+      {#if hasWhereFilter || hasDimensionThresholdFilter}
+        <hr class="border-gray-200 mt-4 mb-4" />
 
-      <div class="flex flex-col gap-y-1">
-        <p class="text-xs text-gray-800 font-normal">
-          The following filters will be locked and hidden:
-        </p>
-        <div class="flex flex-row gap-1 mt-2">
-          <FilterChipsReadOnly
-            exploreName={$exploreName}
-            filters={$dashboardStore.whereFilter}
-            dimensionThresholdFilters={$dashboardStore.dimensionThresholdFilters}
-            timeRange={undefined}
-            comparisonTimeRange={undefined}
-          />
+        <div class="flex flex-col gap-y-1">
+          <p class="text-xs text-gray-800 font-normal">
+            The following filters will be locked and hidden:
+          </p>
+          <div class="flex flex-row gap-1 mt-2">
+            <FilterChipsReadOnly
+              exploreName={$exploreName}
+              filters={$dashboardStore.whereFilter}
+              dimensionThresholdFilters={$dashboardStore.dimensionThresholdFilters}
+              timeRange={undefined}
+              comparisonTimeRange={undefined}
+            />
+          </div>
         </div>
-      </div>
 
-      <p class="text-xs text-gray-800 font-normal mt-4 mb-4">
-        Measures and dimensions will be limited to current visible set.
-      </p>
+        <p class="text-xs text-gray-800 font-normal mt-4 mb-4">
+          Measures and dimensions will be limited to current visible set.
+        </p>
+      {/if}
     {/if}
 
     <Button
@@ -250,21 +258,27 @@
       form={formId}
       submitForm
     >
-      Create and copy URL
+      Create
     </Button>
 
     {#if allErrorsLength > 0}
       {#each $allErrors as error (error.path)}
-        <div class="text-red-500">{error.messages}</div>
+        <div class="text-red-500 mt-1">{error.messages}</div>
       {/each}
     {:else if apiError}
-      <div class="text-red-500">{apiError}</div>
+      <div class="text-red-500 mt-1">{apiError}</div>
     {/if}
   </form>
 {:else}
-  <!-- A successful form submission will automatically copy the link to the clipboard -->
-  <div class="flex flex-col gap-y-2">
-    <h3>Success! URL copied to clipboard.</h3>
+  <div class="flex flex-col gap-y-4">
+    <h3>
+      {copied
+        ? "Success! URL copied to clipboard."
+        : "Success! A public URL has been created."}
+    </h3>
+    <Button type="secondary" on:click={onCopy}
+      >{copied ? "Copied!" : "Copy URL"}</Button
+    >
   </div>
 {/if}
 

--- a/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
+++ b/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
@@ -118,8 +118,8 @@
     },
   );
 
-  async function onCopy() {
-    const success = await copyToClipboard(url, "URL copied to clipboard");
+  function onCopy() {
+    const success = copyToClipboard(url, "URL copied to clipboard");
     if (success) {
       copied = true;
 

--- a/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
+++ b/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
@@ -32,6 +32,7 @@
     hasDashboardDimensionThresholdFilter,
     hasDashboardWhereFilter,
   } from "./form-utils";
+  import Check from "@rilldata/web-common/components/icons/Check.svelte";
 
   const queryClient = useQueryClient();
   const StateManagers = getStateManagers();
@@ -119,7 +120,7 @@
   );
 
   function onCopy() {
-    copyToClipboard(url, "URL copied to clipboard");
+    copyToClipboard(url, "URL copied to clipboard", false);
     copied = true;
 
     setTimeout(() => {
@@ -268,13 +269,14 @@
   </form>
 {:else}
   <div class="flex flex-col gap-y-4">
-    <h3>
-      {copied
-        ? "Success! URL copied to clipboard."
-        : "Success! A public URL has been created."}
-    </h3>
-    <Button type="secondary" on:click={onCopy}
-      >{copied ? "Copied!" : "Copy URL"}</Button
+    <h3>Success! A public URL has been created.</h3>
+    <Button type="secondary" on:click={onCopy}>
+      {#if copied}
+        <Check size="16px" />
+        Copied URL
+      {:else}
+        Copy Public URL
+      {/if}</Button
     >
   </div>
 {/if}

--- a/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
+++ b/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
@@ -120,7 +120,6 @@
 
   async function onCopy() {
     const success = await copyToClipboard(url, "URL copied to clipboard");
-    console.log("success", success);
     if (success) {
       copied = true;
 

--- a/web-common/src/lib/actions/copy-to-clipboard.ts
+++ b/web-common/src/lib/actions/copy-to-clipboard.ts
@@ -20,12 +20,18 @@ function copyToClipboardAPI(value: string) {
   navigator.clipboard.writeText(value).catch(console.error);
 }
 
-export function copyToClipboard(value: string, message?: string) {
+export function copyToClipboard(
+  value: string,
+  message?: string,
+  notify: boolean = true,
+) {
   if (isClipboardApiSupported()) {
     copyToClipboardAPI(value);
-    eventBus.emit("notification", {
-      message: message || `Copied ${value} to clipboard`,
-    });
+    if (notify) {
+      eventBus.emit("notification", {
+        message: message || `Copied ${value} to clipboard`,
+      });
+    }
   } else {
     console.warn("Clipboard API not supported.");
   }

--- a/web-common/src/lib/actions/copy-to-clipboard.ts
+++ b/web-common/src/lib/actions/copy-to-clipboard.ts
@@ -16,17 +16,13 @@ export function isClipboardApiSupported(): boolean {
   return true;
 }
 
-async function copyToClipboardAPI(value: string) {
-  try {
-    await navigator.clipboard.writeText(value).catch(console.error);
-  } catch (error) {
-    console.error("Failed to copy to clipboard using Clipboard API:", error);
-  }
+function copyToClipboardAPI(value: string) {
+  navigator.clipboard.writeText(value).catch(console.error);
 }
 
-export async function copyToClipboard(value: string, message?: string) {
+export function copyToClipboard(value: string, message?: string) {
   if (isClipboardApiSupported()) {
-    await copyToClipboardAPI(value);
+    copyToClipboardAPI(value);
     eventBus.emit("notification", {
       message: message || `Copied ${value} to clipboard`,
     });

--- a/web-common/src/lib/actions/copy-to-clipboard.ts
+++ b/web-common/src/lib/actions/copy-to-clipboard.ts
@@ -1,7 +1,5 @@
 import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
 
-const IS_SAFARI = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-
 /**
  * The Clipboard API is only available in secure contexts.
  * So, a self-hosted Rill Developer instance served over HTTP (not HTTPS) will not have access to the Clipboard API.

--- a/web-common/src/lib/actions/copy-to-clipboard.ts
+++ b/web-common/src/lib/actions/copy-to-clipboard.ts
@@ -15,26 +15,12 @@ export function isClipboardApiSupported(): boolean {
     return false;
   }
 
-  if (typeof ClipboardItem === "undefined") {
-    console.warn("ClipboardItem is not supported in this environment.");
-    return false;
-  }
-
   return true;
 }
 
 async function copyToClipboardAPI(value: string) {
   try {
-    if (IS_SAFARI) {
-      const text = new ClipboardItem({
-        "text/plain": new Blob([value], { type: "text/plain" }),
-      });
-      console.log("a");
-      await navigator.clipboard.write([text]);
-    } else {
-      console.log("b");
-      await navigator.clipboard.writeText(value);
-    }
+    await navigator.clipboard.writeText(value).catch(console.error);
   } catch (error) {
     console.error("Failed to copy to clipboard using Clipboard API:", error);
   }
@@ -52,27 +38,3 @@ export async function copyToClipboard(value: string, message?: string) {
     return false;
   }
 }
-
-// REVISIT
-// // See: https://wolfgangrittner.dev/how-to-use-clipboard-api-in-safari/
-// // Related: https://developer.apple.com/forums/thread/691873
-
-// // SAFARI ERROR:
-// // Failed to copy to clipboard using Clipboard API:
-// // NotAllowedError: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.
-// function copyToClipboardSafari(value: string) {
-//   const text = new ClipboardItem({
-//     "text/plain": fetch(value)
-//       .then((response) => response.text())
-//       .then((text) => new Blob([text], { type: "text/plain" })),
-//   });
-//   navigator.clipboard.write([text]);
-// }
-
-// // See: https://wolfgangrittner.dev/how-to-use-clipboard-api-in-firefox/
-// function copyToClipboardFirefox(value: string) {
-//   fetch(value)
-//     .then((response) => response.text())
-//     .then((text) => navigator.clipboard.writeText(text))
-//     .catch(console.error);
-// }

--- a/web-common/src/lib/actions/copy-to-clipboard.ts
+++ b/web-common/src/lib/actions/copy-to-clipboard.ts
@@ -1,17 +1,78 @@
 import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
 
+const IS_SAFARI = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
 /**
  * The Clipboard API is only available in secure contexts.
  * So, a self-hosted Rill Developer instance served over HTTP (not HTTPS) will not have access to the Clipboard API.
  * See: https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
  */
 export function isClipboardApiSupported(): boolean {
-  return !!navigator.clipboard;
+  if (!navigator.clipboard) {
+    console.warn(
+      "Clipboard API is not supported in this environment. Ensure HTTPS or localhost.",
+    );
+    return false;
+  }
+
+  if (typeof ClipboardItem === "undefined") {
+    console.warn("ClipboardItem is not supported in this environment.");
+    return false;
+  }
+
+  return true;
 }
 
-export function copyToClipboard(value: string, message?: string) {
-  navigator.clipboard.writeText(value).catch(console.error);
-  eventBus.emit("notification", {
-    message: message || `Copied ${value} to clipboard`,
-  });
+async function copyToClipboardAPI(value: string) {
+  try {
+    if (IS_SAFARI) {
+      const text = new ClipboardItem({
+        "text/plain": new Blob([value], { type: "text/plain" }),
+      });
+      console.log("a");
+      await navigator.clipboard.write([text]);
+    } else {
+      console.log("b");
+      await navigator.clipboard.writeText(value);
+    }
+  } catch (error) {
+    console.error("Failed to copy to clipboard using Clipboard API:", error);
+  }
 }
+
+export async function copyToClipboard(value: string, message?: string) {
+  if (isClipboardApiSupported()) {
+    await copyToClipboardAPI(value);
+    eventBus.emit("notification", {
+      message: message || `Copied ${value} to clipboard`,
+    });
+    return true;
+  } else {
+    console.warn("Clipboard API not supported.");
+    return false;
+  }
+}
+
+// REVISIT
+// // See: https://wolfgangrittner.dev/how-to-use-clipboard-api-in-safari/
+// // Related: https://developer.apple.com/forums/thread/691873
+
+// // SAFARI ERROR:
+// // Failed to copy to clipboard using Clipboard API:
+// // NotAllowedError: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.
+// function copyToClipboardSafari(value: string) {
+//   const text = new ClipboardItem({
+//     "text/plain": fetch(value)
+//       .then((response) => response.text())
+//       .then((text) => new Blob([text], { type: "text/plain" })),
+//   });
+//   navigator.clipboard.write([text]);
+// }
+
+// // See: https://wolfgangrittner.dev/how-to-use-clipboard-api-in-firefox/
+// function copyToClipboardFirefox(value: string) {
+//   fetch(value)
+//     .then((response) => response.text())
+//     .then((text) => navigator.clipboard.writeText(text))
+//     .catch(console.error);
+// }

--- a/web-common/src/lib/actions/copy-to-clipboard.ts
+++ b/web-common/src/lib/actions/copy-to-clipboard.ts
@@ -26,9 +26,7 @@ export function copyToClipboard(value: string, message?: string) {
     eventBus.emit("notification", {
       message: message || `Copied ${value} to clipboard`,
     });
-    return true;
   } else {
     console.warn("Clipboard API not supported.");
-    return false;
   }
 }


### PR DESCRIPTION
Fix part of https://github.com/rilldata/rill-private-issues/issues/920.

Safari doesn't allow async clipboard copy unless it's directly triggered by a user interaction. Split the CTA into two separate actions: one for creation and another for copying to the clipboard.