### PR TITLE
align billing cycle with sub start date

### DIFF
--- a/admin/billing/orb.go
+++ b/admin/billing/orb.go
@@ -426,8 +426,9 @@ func (o *Orb) WebhookHandlerFunc(ctx context.Context, jc jobs.Client) httputil.H
 
 func (o *Orb) createSubscription(ctx context.Context, customerID string, plan *Plan) (*Subscription, error) {
 	sub, err := o.client.Subscriptions.New(ctx, orb.SubscriptionNewParams{
-		ExternalCustomerID: orb.String(customerID),
-		PlanID:             orb.String(plan.ID),
+		ExternalCustomerID:                    orb.String(customerID),
+		PlanID:                                orb.String(plan.ID),
+		AlignBillingWithSubscriptionStartDate: orb.F(true),
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
For new subscriptions, billing cycle will be aligned to sub start date, while changing plan on same subscription (when upgrading to paid plan from trial etc) existing config will be used, so if there is any existing subscription which does not have this setting then billing cycle will align to month, do we want to force change that as well ?