### PR TITLE
Organizations: remove old CTA to add users via CLI

### DIFF
--- a/web-admin/src/features/organizations/OrganizationHero.svelte
+++ b/web-admin/src/features/organizations/OrganizationHero.svelte
@@ -1,23 +1,7 @@
 <script lang="ts">
-  import OrganizationAccessControls from "./OrganizationAccessControls.svelte";
-  import ShareOrganizationCta from "./ShareOrganizationCTA.svelte";
-
-  export let organization: string;
   export let title: string;
 </script>
 
-<div class="flex flex-col gap-y-1">
-  <h1 class="text-sky-950 text-4xl font-light leading-10">
-    {title}
-  </h1>
-  <OrganizationAccessControls {organization}>
-    <svelte:fragment slot="manage-org-members">
-      <div class="mt-8 mb-12">
-        <ShareOrganizationCta {organization} />
-      </div>
-    </svelte:fragment>
-  </OrganizationAccessControls>
-  <span class="text-gray-500 text-base font-normal leading-normal">
-    Check out your projects below.
-  </span>
-</div>
+<h1 class="text-sky-950 text-4xl font-light leading-10">
+  {title}
+</h1>

--- a/web-admin/src/features/projects/ProjectCards.svelte
+++ b/web-admin/src/features/projects/ProjectCards.svelte
@@ -7,6 +7,10 @@
   $: projs = createAdminServiceListProjectsForOrganization(organization);
 </script>
 
+<span class="text-gray-500 text-base font-normal leading-normal">
+  Check out your projects below.
+</span>
+
 {#if $projs.data && $projs.data.projects?.length === 0}
   <p class="text-gray-500 text-xs">This organization has no projects yet.</p>
 {:else if $projs.data && $projs.data.projects?.length > 0}

--- a/web-admin/src/features/projects/ProjectCards.svelte
+++ b/web-admin/src/features/projects/ProjectCards.svelte
@@ -7,18 +7,20 @@
   $: projs = createAdminServiceListProjectsForOrganization(organization);
 </script>
 
-<span class="text-gray-500 text-base font-normal leading-normal">
-  Check out your projects below.
-</span>
+<div class="flex flex-col gap-y-4">
+  <span class="text-gray-500 text-base font-normal leading-normal">
+    Check out your projects below.
+  </span>
 
-{#if $projs.data && $projs.data.projects?.length === 0}
-  <p class="text-gray-500 text-xs">This organization has no projects yet.</p>
-{:else if $projs.data && $projs.data.projects?.length > 0}
-  <ol class="flex gap-6 flex-wrap">
-    {#each $projs.data.projects as proj}
-      <li>
-        <ProjectCard {organization} project={proj.name} />
-      </li>
-    {/each}
-  </ol>
-{/if}
+  {#if $projs.data && $projs.data.projects?.length === 0}
+    <p class="text-gray-500 text-xs">This organization has no projects yet.</p>
+  {:else if $projs.data && $projs.data.projects?.length > 0}
+    <ol class="flex gap-6 flex-wrap">
+      {#each $projs.data.projects as proj}
+        <li>
+          <ProjectCard {organization} project={proj.name} />
+        </li>
+      {/each}
+    </ol>
+  {/if}
+</div>

--- a/web-admin/src/routes/[organization]/+page.svelte
+++ b/web-admin/src/routes/[organization]/+page.svelte
@@ -47,7 +47,7 @@
         {organizationPermissions}
       />
     {:else}
-      <div class="flex flex-col gap-y-4">
+      <div class="flex flex-col gap-y-8">
         <OrganizationHero {title} />
         <ProjectCards organization={orgName} />
       </div>

--- a/web-admin/src/routes/[organization]/+page.svelte
+++ b/web-admin/src/routes/[organization]/+page.svelte
@@ -33,7 +33,7 @@
     class="mx-8 my-8 sm:my-16 sm:mx-16 lg:mx-32 lg:my-24 2xl:mx-64 mx-auto flex flex-col gap-y-4"
   >
     {#if $projs.data.projects?.length === 0}
-      <OrganizationHero organization={orgName} {title} />
+      <OrganizationHero {title} />
       <span>
         This organization has no projects yet. <a
           href="https://docs.rilldata.com/home/get-started"

--- a/web-admin/src/routes/[organization]/+page.svelte
+++ b/web-admin/src/routes/[organization]/+page.svelte
@@ -47,8 +47,8 @@
         {organizationPermissions}
       />
     {:else}
-      <OrganizationHero organization={orgName} {title} />
-      <div class="py-2 px-1.5">
+      <div class="flex flex-col gap-y-4">
+        <OrganizationHero {title} />
         <ProjectCards organization={orgName} />
       </div>
     {/if}


### PR DESCRIPTION
This CTA isn't needed now that we have a dedicated Users tab.

Before:
<img width="1488" alt="image" src="https://github.com/user-attachments/assets/c7f5d75d-aef9-4efa-9bda-b8ccad03a7d3">

After:
<img width="1341" alt="image" src="https://github.com/user-attachments/assets/a83f5212-04d3-4197-b437-40ad5866f3f5">