### PR TITLE
feat: support locale formatting using d3 locale

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,6 +8923,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "dev": true
+    },
     "node_modules/@types/d3-scale": {
       "version": "4.0.8",
       "dev": true,
@@ -35220,6 +35226,7 @@
         "@testing-library/svelte": "^4.0.0",
         "@types/chroma-js": "^2.4.3",
         "@types/codemirror": "^5.60.15",
+        "@types/d3-format": "^3.0.4",
         "@types/d3-time-format": "^4.0.3",
         "@types/dompurify": "^3.0.5",
         "@types/luxon": "^3.4.2",

--- a/web-common/package.json
+++ b/web-common/package.json
@@ -47,6 +47,7 @@
     "@testing-library/svelte": "^4.0.0",
     "@types/chroma-js": "^2.4.3",
     "@types/codemirror": "^5.60.15",
+    "@types/d3-format": "^3.0.4",
     "@types/d3-time-format": "^4.0.3",
     "@types/dompurify": "^3.0.5",
     "@types/luxon": "^3.4.2",

--- a/web-common/src/features/metrics-views/editor/metrics-schema.json
+++ b/web-common/src/features/metrics-views/editor/metrics-schema.json
@@ -123,6 +123,35 @@
             "type": "string",
             "description": "Controls the formatting of this measure using a d3-format string."
           },
+          "format_d3_locale": {
+            "type": "object",
+            "description": "Defines a custom locale for d3-format.",
+            "properties": {
+              "decimal": { "type": "string", "description": "The decimal point (e.g., \".\")." },
+              "thousands": { "type": "string", "description": "The group separator (e.g., \",\")." },
+              "grouping": {
+                "type": "array",
+                "items": { "type": "integer" },
+                "description": "The array of group sizes (e.g., [3]), cycled as needed."
+              },
+              "currency": {
+                "type": "array",
+                "items": { "type": "string" },
+                "minItems": 2,
+                "maxItems": 2,
+                "description": "The currency prefix and suffix (e.g., [\"$\", \"\"])."
+              },
+              "numerals": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Optional array of ten strings to replace the numerals 0-9."
+              },
+              "percent": { "type": "string", "description": "Optional symbol to replace the percent suffix." },
+              "minus": { "type": "string", "description": "Optional minus sign (defaults to \"−\")." },
+              "nan": { "type": "string", "description": "Optional value for not-a-number (defaults to \"NaN\")." }
+            },
+            "required": ["decimal", "thousands", "grouping", "currency"]
+          },
           "ignore": {
             "type": "boolean",
             "description": "If true, hides the measure from the dashboard."

--- a/web-common/src/lib/number-formatting/utils/d3-format-utils.ts
+++ b/web-common/src/lib/number-formatting/utils/d3-format-utils.ts
@@ -1,0 +1,36 @@
+import type { MetricsViewSpecMeasureV2FormatD3Locale } from "@rilldata/web-common/runtime-client";
+
+export function isValidD3Locale(
+  config: MetricsViewSpecMeasureV2FormatD3Locale | undefined,
+): boolean {
+  if (!config) return false;
+  if (config.thousands && config.grouping && config.currency) {
+    // thousands is a string
+    if (typeof config.thousands !== "string") return false;
+    // grouping is an array of numbers
+    if (!Array.isArray(config.grouping)) return false;
+    // currency is an array of 2 strings
+    if (!Array.isArray(config.currency) || config.currency.length !== 2)
+      return false;
+
+    return true;
+  }
+  return false;
+}
+
+export function currencyHumanizer(
+  currency: [string, string],
+  humanizedValue: string,
+): string {
+  const [prefix, suffix] = currency;
+  // Replace the "$" symbol with the appropriate currency prefix/suffix
+  return `${prefix}${humanizedValue.replace(/\$/g, "")}${suffix}`;
+}
+
+/**
+ * Parse the currency symbol from a d3 format string.
+ * For d3 the currency symbol is always "$" in the format string
+ */
+export function includesCurrencySymbol(formatString: string): boolean {
+  return formatString.includes("$");
+}


### PR DESCRIPTION
Integrate `format_d3_locale` in the UI. This enables support for all currencies, grouping, thousands string, decimal string etc.

Usage details here 

https://d3js.org/d3-format#formatLocale