### PR TITLE
fix: hide billing settings for orgs without a sub

### DIFF
--- a/web-admin/src/routes/[organization]/-/settings/+layout.svelte
+++ b/web-admin/src/routes/[organization]/-/settings/+layout.svelte
@@ -15,7 +15,6 @@
   $: onEnterprisePlan =
     subscription?.plan && isEnterprisePlan(subscription?.plan);
   $: hideBillingSettings = neverSubscribed || !subscription;
-  $: console.log(neverSubscribed, subscription, hideBillingSettings);
 
   $: navItems = [
     { label: "General", route: "" },


### PR DESCRIPTION
We might be delayed in migrating and fresh orgs wont have `NeverSubscribed` issue. So hiding the billing tabs for orgs that do not have a subscription.

This is temporary until migration is run. This code will hide the billing settings for orgs when trial has ended or a cancelled subscription expires. So we will need to revert after migration.