### PR TITLE
fix: leaderboard column sorting behavior

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -127,6 +127,7 @@
         $sortType,
         activeMeasureName,
         dimensionName,
+        !!comparisonTimeRange,
       ),
       where: sanitiseExpression(
         mergeDimensionAndMeasureFilter(filterSet, dimensionThresholdFilters),

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -143,6 +143,7 @@
     sortType,
     activeMeasureName,
     dimensionName,
+    !!comparisonTimeRange,
   );
 
   $: sortedQuery = createQueryServiceMetricsViewAggregation(

--- a/web-common/src/features/dashboards/leaderboard/leaderboard-utils.ts
+++ b/web-common/src/features/dashboards/leaderboard/leaderboard-utils.ts
@@ -121,6 +121,7 @@ export function getSort(
   type: SortType,
   activeMeasureName: string,
   dimensionName: string,
+  timeComparison: boolean,
 ) {
   return [
     {
@@ -128,7 +129,9 @@ export function getSort(
       name:
         type === SortType.DIMENSION || !activeMeasureName
           ? dimensionName
-          : getApiSortName(activeMeasureName, type),
+          : timeComparison
+            ? getApiSortName(activeMeasureName, type)
+            : activeMeasureName || dimensionName,
     },
   ];
 }

--- a/web-common/src/features/dashboards/time-controls/comparison-pill/ComparisonPill.svelte
+++ b/web-common/src/features/dashboards/time-controls/comparison-pill/ComparisonPill.svelte
@@ -13,6 +13,7 @@
     useExploreStore,
   } from "web-common/src/features/dashboards/stores/dashboard-stores";
   import * as Elements from "../super-pill/components";
+  import { SortType } from "../../proto-state/derived-types";
 
   export let allTimeRange: TimeRange;
   export let selectedTimeRange: DashboardTimeControls | undefined;
@@ -24,6 +25,10 @@
     exploreName,
     selectors: {
       timeRangeSelectors: { timeComparisonOptionsState },
+      sorting: { sortType },
+    },
+    actions: {
+      sorting: { toggleSort },
     },
     validSpecStore,
   } = ctx;
@@ -74,6 +79,15 @@
         $exploreName,
         !showTimeComparison,
       );
+
+      if (
+        (showTimeComparison &&
+          ($sortType === SortType.DELTA_PERCENT ||
+            $sortType === SortType.DELTA_ABSOLUTE)) ||
+        (!showTimeComparison && $sortType === SortType.PERCENT)
+      ) {
+        toggleSort(SortType.VALUE);
+      }
     }}
   >
     <div class="pointer-events-none flex items-center gap-x-1.5">


### PR DESCRIPTION
- Adjusts the `getSort` function to handle situations where the `leaderboardSortType` is not compatible with time comparison state
- When toggling timeComparison, reset the `leaderboardSortType` if incompatible with new state