### PR TITLE
Fix (Public URLs): state initialization

### DIFF
--- a/web-admin/src/features/public-urls/DashboardPublicURLStateProvider.svelte
+++ b/web-admin/src/features/public-urls/DashboardPublicURLStateProvider.svelte
@@ -17,6 +17,7 @@
     readable({
       isFetching: false,
       data: token.state,
+      error: null,
     }),
   );
 </script>

--- a/web-admin/src/features/public-urls/DashboardPublicURLStateProvider.svelte
+++ b/web-admin/src/features/public-urls/DashboardPublicURLStateProvider.svelte
@@ -12,7 +12,7 @@
 
   $: initLocalUserPreferenceStore(exploreName);
 
-  const dashboardStoreReady = createDashboardStateSync(
+  $: dashboardStoreReady = createDashboardStateSync(
     getStateManagers(),
     readable({
       isFetching: false,

--- a/web-admin/src/features/public-urls/DashboardPublicURLStateProvider.svelte
+++ b/web-admin/src/features/public-urls/DashboardPublicURLStateProvider.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import type { V1MagicAuthToken } from "@rilldata/web-admin/client";
+  import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
+  import { createDashboardStateSync } from "@rilldata/web-common/features/dashboards/stores/syncDashboardState";
+  import { initLocalUserPreferenceStore } from "@rilldata/web-common/features/dashboards/user-preferences";
+  import Spinner from "@rilldata/web-common/features/entity-management/Spinner.svelte";
+  import { EntityStatus } from "@rilldata/web-common/features/entity-management/types";
+  import { readable } from "svelte/store";
+
+  export let exploreName: string;
+  export let token: V1MagicAuthToken;
+
+  $: initLocalUserPreferenceStore(exploreName);
+
+  const dashboardStoreReady = createDashboardStateSync(
+    getStateManagers(),
+    readable({
+      isFetching: false,
+      data: token.state,
+    }),
+  );
+</script>
+
+{#if $dashboardStoreReady}
+  <slot />
+{:else}
+  <div class="grid place-items-center mt-40">
+    <Spinner status={EntityStatus.Running} size="40px" />
+  </div>
+{/if}

--- a/web-admin/src/routes/[organization]/[project]/-/share/[token]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/share/[token]/+page.svelte
@@ -2,11 +2,11 @@
   import { onNavigate } from "$app/navigation";
   import { page } from "$app/stores";
   import { createAdminServiceGetProject } from "@rilldata/web-admin/client";
+  import DashboardPublicURLStateProvider from "@rilldata/web-admin/features/public-urls/DashboardPublicURLStateProvider.svelte";
   import { Dashboard } from "@rilldata/web-common/features/dashboards";
   import DashboardThemeProvider from "@rilldata/web-common/features/dashboards/DashboardThemeProvider.svelte";
   import DashboardURLStateProvider from "@rilldata/web-common/features/dashboards/proto-state/DashboardURLStateProvider.svelte";
   import StateManagersProvider from "@rilldata/web-common/features/dashboards/state-managers/StateManagersProvider.svelte";
-  import DashboardStateProvider from "@rilldata/web-common/features/dashboards/stores/DashboardStateProvider.svelte";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
   import { createRuntimeServiceGetExplore } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
@@ -52,7 +52,10 @@
       metricsViewName={explore.metricsView.meta.name.name}
       exploreName={resourceName}
     >
-      <DashboardStateProvider exploreName={resourceName}>
+      <DashboardPublicURLStateProvider
+        token={data.token}
+        exploreName={resourceName}
+      >
         <DashboardURLStateProvider
           metricsViewName={explore.metricsView.meta.name.name}
         >
@@ -63,7 +66,7 @@
             />
           </DashboardThemeProvider>
         </DashboardURLStateProvider>
-      </DashboardStateProvider>
+      </DashboardPublicURLStateProvider>
     </StateManagersProvider>
   {/if}
 {/key}


### PR DESCRIPTION
[Fixes this bug reported in Slack](https://rilldata.slack.com/archives/C01A9DYP013/p1732200296464789). Our URL state synchronization logic was mistakenly overwriting the `state` embedded in a Magic Auth Token.

This is a temporary fix that mirrors code from the Bookmarks feature. The coming [human-readable-state PR](https://github.com/rilldata/rill/pull/5675) will properly refactor how we initialize dashboard state.