### PR TITLE
use actual org name instead of req org name

### DIFF
--- a/admin/server/billing.go
+++ b/admin/server/billing.go
@@ -482,7 +482,7 @@ func (s *Server) SudoUpdateOrganizationBillingCustomer(ctx context.Context, req 
 	}
 
 	opts := &database.UpdateOrganizationOptions{
-		Name:                                req.Organization,
+		Name:                                org.Name,
 		DisplayName:                         org.DisplayName,
 		Description:                         org.Description,
 		CustomDomain:                        org.CustomDomain,


### PR DESCRIPTION
This prevents changing the case of name in case its changed while running request