### PR TITLE
fix: leaderboard header for no label

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -296,7 +296,7 @@
 
     <LeaderboardHeader
       {hovered}
-      displayName={displayName ?? dimensionName}
+      displayName={displayName || dimensionName}
       dimensionDescription={description}
       {dimensionName}
       {isBeingCompared}


### PR DESCRIPTION
For cases when the label of a dimension was not set, the leaderboard header was empty. This was because `<empty string> ? "id"` resolves to `<empty string>`