### PR TITLE
nit (design): Edit back-to-Explore button on the Time Dimension Detail view

### DIFF
--- a/web-common/src/features/dashboards/time-series/BackToExplore.svelte
+++ b/web-common/src/features/dashboards/time-series/BackToExplore.svelte
@@ -12,16 +12,13 @@
   }
 </script>
 
-<button
-  class="flex flex-row items-center gap-x-1"
-  on:click={() => goBackToExplore()}
->
+<button class="flex items-center" on:click={() => goBackToExplore()}>
   {#if isFetching}
     <Spinner size="16px" status={EntityStatus.Running} />
   {:else}
     <span class="ui-copy-icon">
-      <Back color="var(--color-primary-600)" size="16px" />
+      <Back size="16px" />
     </span>
-    <span class="text-primary-600 font-medium">All measures</span>
+    <span>All measures</span>
   {/if}
 </button>

--- a/web-common/src/features/dashboards/time-series/BackToExplore.svelte
+++ b/web-common/src/features/dashboards/time-series/BackToExplore.svelte
@@ -7,14 +7,14 @@
   export let exploreName: string;
   export let isFetching = false;
 
-  function goBackToOverview() {
+  function goBackToExplore() {
     metricsExplorerStore.setExpandedMeasureName(exploreName, undefined);
   }
 </script>
 
 <button
   class="flex flex-row items-center gap-x-1"
-  on:click={() => goBackToOverview()}
+  on:click={() => goBackToExplore()}
 >
   {#if isFetching}
     <Spinner size="16px" status={EntityStatus.Running} />
@@ -22,6 +22,6 @@
     <span class="ui-copy-icon">
       <Back color="var(--color-primary-600)" size="16px" />
     </span>
-    <span class="text-primary-600 font-medium">Overview</span>
+    <span class="text-primary-600 font-medium">All measures</span>
   {/if}
 </button>

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -20,7 +20,7 @@
   import TDDAlternateChart from "@rilldata/web-common/features/dashboards/time-dimension-details/charts/TDDAlternateChart.svelte";
   import { chartInteractionColumn } from "@rilldata/web-common/features/dashboards/time-dimension-details/time-dimension-data-store";
   import { TDDChart } from "@rilldata/web-common/features/dashboards/time-dimension-details/types";
-  import BackToOverview from "@rilldata/web-common/features/dashboards/time-series/BackToOverview.svelte";
+  import BackToExplore from "@rilldata/web-common/features/dashboards/time-series/BackToExplore.svelte";
   import {
     useTimeSeriesDataStore,
     type TimeSeriesDatum,
@@ -292,7 +292,7 @@
 >
   <div class:mb-6={isAlternateChart} class="flex items-center gap-x-1 px-2.5">
     {#if isInTimeDimensionView}
-      <BackToOverview {exploreName} />
+      <BackToExplore {exploreName} />
       <ChartTypeSelector
         hasComparison={Boolean(
           showComparison || includedValuesForDimension.length,


### PR DESCRIPTION
Previously:
<img width="417" alt="image" src="https://github.com/user-attachments/assets/c504ae87-06ab-4a4b-a3d8-b4f9caef6a59">

Now:
<img width="421" alt="image" src="https://github.com/user-attachments/assets/8571bf6a-4189-40a6-9289-ad4dc22cc3ac">

The purpose of this change is to match the "All dimensions" button on the Dimension Detail view
<img width="383" alt="image" src="https://github.com/user-attachments/assets/a126d11a-3b46-4019-ba6a-f7f2af2d255f">
