### PR TITLE
fix: disabling compare dimension in time dimension details

### DIFF
--- a/web-common/src/features/dashboards/time-controls/ComparisonSelector.svelte
+++ b/web-common/src/features/dashboards/time-controls/ComparisonSelector.svelte
@@ -86,7 +86,7 @@
         showBorderOnFocus={false}
       />
     </div>
-    <DropdownMenu.Item on:select={disableAllComparisons}>
+    <DropdownMenu.Item on:click={disableAllComparisons}>
       <span
         class:font-bold={!selectedComparisonDimension && !showTimeComparison}
       >


### PR DESCRIPTION
Enabling compare dimension in time dimension details and trying to disable by selecting `No comparison dimension` option doesnt do anything.

Attaching the correct event listener to fix this.