### PR TITLE
fix: custom compare time ranges in reports or alerts

### DIFF
--- a/web-admin/src/features/dashboards/query-mappers/utils.ts
+++ b/web-admin/src/features/dashboards/query-mappers/utils.ts
@@ -68,6 +68,14 @@ export function fillTimeRange(
         reqComparisonTimeRange.isoOffset,
         executionTime,
       );
+      // temporary fix to not lead to an uncaught error.
+      // TODO: we should a single custom label when we move to rill-time syntax
+      if (
+        dashboard.selectedComparisonTimeRange.name === TimeRangePreset.CUSTOM
+      ) {
+        dashboard.selectedComparisonTimeRange.name =
+          TimeComparisonOption.CUSTOM;
+      }
     }
 
     if (dashboard.selectedComparisonTimeRange) {


### PR DESCRIPTION
If custom compare time range is used in reports or alerts, preview link in email leads to a blank page.

Since we use different Custom label for time range and compare time range it leads to an uncaught error.