### PR TITLE
docs / metrics view locale_d3 example

### DIFF
--- a/docs/docs/reference/project-files/metrics-view.md
+++ b/docs/docs/reference/project-files/metrics-view.md
@@ -51,6 +51,10 @@ In your Rill project directory, create a metrics view, `<metrics_view>.yaml`, fi
     - **Example**: to show a measure using fixed point formatting with 2 digits after the decimal point, your measure specification would include: `format_d3: ".2f"`.
     - **Example**: to show a measure using grouped thousands with two significant digits, your measure specification would include: `format_d3: ",.2r"`.
   - **`format_d3_locale`** — locale configuration passed through to D3, enabling changing the currency symbol among other things. For details, see the docs for D3's [`formatLocale`](https://d3js.org/d3-format#formatLocale). _(optional)_
+
+```yaml
+
+```
   - **`format_preset`** — controls the formatting of this measure according to option specified below. Measures <u>cannot</u> have both `format_preset` and `format_d3` entries. _(optional; if neither `format_preset` nor `format_d3` is supplied, measures will be formatted with the `humanize` preset)_
     - `humanize` — round off numbers in an opinionated way to thousands (K), millions (M), billions (B), etc.
     - `none` — raw output

--- a/docs/docs/reference/project-files/metrics-view.md
+++ b/docs/docs/reference/project-files/metrics-view.md
@@ -53,7 +53,10 @@ In your Rill project directory, create a metrics view, `<metrics_view>.yaml`, fi
   - **`format_d3_locale`** — locale configuration passed through to D3, enabling changing the currency symbol among other things. For details, see the docs for D3's [`formatLocale`](https://d3js.org/d3-format#formatLocale). _(optional)_
 
 ```yaml
-
+  format_d3: "$,"
+  format_d3_locale: 
+    grouping: [3, 2]
+    currency: ["₹", ""]
 ```
   - **`format_preset`** — controls the formatting of this measure according to option specified below. Measures <u>cannot</u> have both `format_preset` and `format_d3` entries. _(optional; if neither `format_preset` nor `format_d3` is supplied, measures will be formatted with the `humanize` preset)_
     - `humanize` — round off numbers in an opinionated way to thousands (K), millions (M), billions (B), etc.


### PR DESCRIPTION
Not sure if necessary but based on Dhiraj showcase, might need some examples, we link the website but would be nice to able to reference one example via rill docs 

```
    format_d3: "$,"
    format_d3_locale: 
      grouping: [3, 2]
      currency: ["₹", ""]
```