### PR TITLE
Allow variable creation with different target environments 

### DIFF
--- a/web-admin/src/features/projects/environment-variables/ActionsCell.svelte
+++ b/web-admin/src/features/projects/environment-variables/ActionsCell.svelte
@@ -5,12 +5,13 @@
   import { Trash2Icon, Pencil } from "lucide-svelte";
   import EditDialog from "./EditDialog.svelte";
   import DeleteDialog from "./DeleteDialog.svelte";
+  import type { VariableNames } from "./types";
 
   export let id: string;
   export let environment: string;
   export let name: string;
   export let value: string;
-  export let variableNames: string[] = [];
+  export let variableNames: VariableNames = [];
 
   let isDropdownOpen = false;
   let isEditDialogOpen = false;

--- a/web-admin/src/features/projects/environment-variables/ActivityCell.svelte
+++ b/web-admin/src/features/projects/environment-variables/ActivityCell.svelte
@@ -20,7 +20,7 @@
 </script>
 
 <Tooltip distance={8} location="top" alignment="start">
-  <div class="text-xs text-gray-500 cursor-pointer">
+  <div class="text-xs text-gray-500 cursor-pointer w-fit">
     {formattedText}
   </div>
   <TooltipContent slot="tooltip-content">

--- a/web-admin/src/features/projects/environment-variables/AddDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/AddDialog.svelte
@@ -22,7 +22,7 @@
   import { defaults, superForm } from "sveltekit-superforms";
   import { yup } from "sveltekit-superforms/adapters";
   import { object, string, array } from "yup";
-  import { EnvironmentType, type VariableNames } from "./types";
+  import { type VariableNames } from "./types";
   import Input from "@rilldata/web-common/components/forms/Input.svelte";
   import IconButton from "@rilldata/web-common/components/button/IconButton.svelte";
   import { Trash2Icon, UploadIcon } from "lucide-svelte";

--- a/web-admin/src/features/projects/environment-variables/AddDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/AddDialog.svelte
@@ -86,12 +86,18 @@
         if (!form.valid) return;
         const values = form.data;
 
-        // Omit draft variables that do not have a key
+        // Check for duplicates before proceeding
+        const duplicates = checkForExistingKeys();
+        if (duplicates > 0) {
+          // Early return without resetting the form
+          return;
+        }
+
+        // Only filter and process if there are no duplicates
         const filteredVariables = values.variables.filter(
           ({ key }) => key !== "",
         );
 
-        // Flatten the variables to match the schema
         const flatVariables = Object.fromEntries(
           filteredVariables.map(({ key, value }) => [key, value]),
         );
@@ -109,8 +115,6 @@
   async function handleUpdateProjectVariables(
     flatVariables: AdminServiceUpdateProjectVariablesBodyVariables,
   ) {
-    checkForExistingKeys();
-
     try {
       await $updateProjectVariables.mutateAsync({
         organization,
@@ -170,9 +174,7 @@
 
     const existingKeys = $form.variables.map((variable) => {
       return {
-        environment: getEnvironmentLabel(
-          getCurrentEnvironment(isDevelopment, isProduction),
-        ),
+        environment: getCurrentEnvironment(isDevelopment, isProduction),
         name: variable.key,
       };
     });

--- a/web-admin/src/features/projects/environment-variables/AddDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/AddDialog.svelte
@@ -63,12 +63,8 @@
     object({
       variables: array(
         object({
-          key: string()
-            .optional()
-            .matches(
-              /^[a-zA-Z0-9_]+$/,
-              "Key must only contain letters, numbers, and underscores.",
-            ),
+          // FIXME: after https://github.com/rilldata/rill/pull/6121
+          key: string().optional(),
           value: string().optional(),
         }),
       ),

--- a/web-admin/src/features/projects/environment-variables/AddDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/AddDialog.svelte
@@ -177,6 +177,7 @@
       };
     });
 
+    let duplicateCount = 0;
     existingKeys.forEach((key, idx) => {
       const variableEnvironment = key.environment;
       const variableKey = key.name;
@@ -184,8 +185,11 @@
       if (isDuplicateKey(variableEnvironment, variableKey, variableNames)) {
         inputErrors[idx] = true;
         isKeyAlreadyExists = true;
+        duplicateCount++;
       }
     });
+
+    return duplicateCount;
   }
 
   function handleFileUpload(event) {
@@ -359,7 +363,9 @@
             {#if isKeyAlreadyExists}
               <div class="mt-1">
                 <p class="text-xs text-red-600 font-normal">
-                  These keys already exist for this project.
+                  {Object.keys(inputErrors).length > 1
+                    ? "These keys already exist for your target environment(s)"
+                    : "This key already exists for your target environment(s)"}
                 </p>
               </div>
             {/if}

--- a/web-admin/src/features/projects/environment-variables/AddDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/AddDialog.svelte
@@ -99,6 +99,7 @@
         try {
           await handleUpdateProjectVariables(flatVariables);
           open = false;
+          handleReset();
         } catch (error) {
           console.error(error);
         }

--- a/web-admin/src/features/projects/environment-variables/AddDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/AddDialog.svelte
@@ -26,11 +26,7 @@
   import Input from "@rilldata/web-common/components/forms/Input.svelte";
   import IconButton from "@rilldata/web-common/components/button/IconButton.svelte";
   import { Trash2Icon, UploadIcon } from "lucide-svelte";
-  import {
-    getCurrentEnvironment,
-    getEnvironmentLabel,
-    isDuplicateKey,
-  } from "./utils";
+  import { getCurrentEnvironment, isDuplicateKey } from "./utils";
 
   export let open = false;
   export let variableNames: VariableNames = [];

--- a/web-admin/src/features/projects/environment-variables/AddDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/AddDialog.svelte
@@ -63,8 +63,13 @@
     object({
       variables: array(
         object({
-          // FIXME: after https://github.com/rilldata/rill/pull/6121
-          key: string().optional(),
+          key: string()
+            .optional()
+            .matches(
+              /^[a-zA-Z_][a-zA-Z0-9_.]*$/,
+              // See: https://github.com/rilldata/rill/pull/6121/files#diff-04140a6ac071a4bac716371f8b66a56c89c9d52cfbf2b05ea1e14ee8d4e301e7R12
+              "Key must start with a letter or underscore and can only contain letters, digits, underscores, and dots",
+            ),
           value: string().optional(),
         }),
       ),

--- a/web-admin/src/features/projects/environment-variables/EditDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/EditDialog.svelte
@@ -109,6 +109,7 @@
   async function handleUpdateProjectVariables(
     flatVariable: AdminServiceUpdateProjectVariablesBodyVariables,
   ) {
+    // Check if the key has changed, if so, check for existing keys
     if ($form.key !== initialValues.key) {
       checkForExistingKeys();
     }

--- a/web-admin/src/features/projects/environment-variables/EditDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/EditDialog.svelte
@@ -25,7 +25,7 @@
   import Input from "@rilldata/web-common/components/forms/Input.svelte";
   import {
     getCurrentEnvironment,
-    getEnvironmentLabel,
+    getEnvironmentType,
     isDuplicateKey,
   } from "./utils";
 
@@ -212,7 +212,7 @@
     isKeyAlreadyExists = false;
 
     const existingKey = {
-      environment: getEnvironmentLabel(
+      environment: getEnvironmentType(
         getCurrentEnvironment(isDevelopment, isProduction),
       ),
       name: $form.key,

--- a/web-admin/src/features/projects/environment-variables/EditDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/EditDialog.svelte
@@ -106,22 +106,6 @@
     },
   });
 
-  // function getCurrentEnvironment() {
-  //   if (isDevelopment && isProduction) {
-  //     return EnvironmentType.UNDEFINED;
-  //   }
-
-  //   if (isDevelopment) {
-  //     return EnvironmentType.DEVELOPMENT;
-  //   }
-
-  //   if (isProduction) {
-  //     return EnvironmentType.PRODUCTION;
-  //   }
-
-  //   return EnvironmentType.UNDEFINED;
-  // }
-
   async function handleUpdateProjectVariables(
     flatVariable: AdminServiceUpdateProjectVariablesBodyVariables,
   ) {

--- a/web-admin/src/features/projects/environment-variables/EditDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/EditDialog.svelte
@@ -23,7 +23,6 @@
   import { object, string } from "yup";
   import { EnvironmentType, type VariableNames } from "./types";
   import Input from "@rilldata/web-common/components/forms/Input.svelte";
-  import { onMount } from "svelte";
   import {
     getCurrentEnvironment,
     getEnvironmentLabel,
@@ -97,6 +96,9 @@
     async onUpdate({ form }) {
       if (!form.valid) return;
       const values = form.data;
+
+      checkForExistingKeys();
+      if (isKeyAlreadyExists) return;
 
       const flatVariable = {
         [values.key]: values.value,
@@ -248,9 +250,9 @@
     };
   }
 
-  onMount(() => {
+  $: if (open) {
     handleDialogOpen();
-  });
+  }
 </script>
 
 <Dialog
@@ -306,11 +308,6 @@
                   : ""}
                 placeholder="Key"
                 on:input={(e) => handleKeyChange(e)}
-                onBlur={() => {
-                  if ($form.key !== initialValues.key) {
-                    checkForExistingKeys();
-                  }
-                }}
               />
               <Input
                 bind:value={$form.value}
@@ -330,7 +327,7 @@
             {#if isKeyAlreadyExists}
               <div class="mt-1">
                 <p class="text-xs text-red-600 font-normal">
-                  This key already exists for this project.
+                  This key already exists for your target environment(s)
                 </p>
               </div>
             {/if}

--- a/web-admin/src/features/projects/environment-variables/EditDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/EditDialog.svelte
@@ -69,12 +69,8 @@
   const schema = yup(
     object({
       environment: string().optional(),
-      key: string()
-        .optional()
-        .matches(
-          /^[a-zA-Z0-9_]+$/,
-          "Key must only contain letters, numbers, and underscores",
-        ),
+      // FIXME: after https://github.com/rilldata/rill/pull/6121
+      key: string().optional(),
       value: string().optional(),
     }),
   );

--- a/web-admin/src/features/projects/environment-variables/EditDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/EditDialog.svelte
@@ -199,8 +199,8 @@
 
   function handleReset() {
     reset();
-    isDevelopment = true;
-    isProduction = true;
+    isDevelopment = false;
+    isProduction = false;
     inputErrors = {};
     isKeyAlreadyExists = false;
   }
@@ -240,12 +240,16 @@
     }
   }
 
-  onMount(() => {
+  function handleDialogOpen() {
     setInitialCheckboxState();
     initialEnvironment = {
       isDevelopment,
       isProduction,
     };
+  }
+
+  onMount(() => {
+    handleDialogOpen();
   });
 </script>
 

--- a/web-admin/src/features/projects/environment-variables/EditDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/EditDialog.svelte
@@ -69,8 +69,13 @@
   const schema = yup(
     object({
       environment: string().optional(),
-      // FIXME: after https://github.com/rilldata/rill/pull/6121
-      key: string().optional(),
+      key: string()
+        .optional()
+        .matches(
+          /^[a-zA-Z_][a-zA-Z0-9_.]*$/,
+          // See: https://github.com/rilldata/rill/pull/6121/files#diff-04140a6ac071a4bac716371f8b66a56c89c9d52cfbf2b05ea1e14ee8d4e301e7R12
+          "Key must start with a letter or underscore and can only contain letters, digits, underscores, and dots",
+        ),
       value: string().optional(),
     }),
   );

--- a/web-admin/src/features/projects/environment-variables/EditDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/EditDialog.svelte
@@ -105,6 +105,7 @@
       try {
         await handleUpdateProjectVariables(flatVariable);
         open = false;
+        handleReset();
       } catch (error) {
         console.error(error);
       }
@@ -198,6 +199,9 @@
 
   function handleReset() {
     reset();
+    isDevelopment = true;
+    isProduction = true;
+    inputErrors = {};
     isKeyAlreadyExists = false;
   }
 

--- a/web-admin/src/features/projects/environment-variables/EnvironmentVariablesTable.svelte
+++ b/web-admin/src/features/projects/environment-variables/EnvironmentVariablesTable.svelte
@@ -8,10 +8,11 @@
   import KeyCell from "./KeyCell.svelte";
   import ValueCell from "./ValueCell.svelte";
   import ActionsCell from "./ActionsCell.svelte";
+  import type { VariableNames } from "./types";
 
   export let data: V1ProjectVariable[];
   export let emptyText: string = "No environment variables";
-  export let variableNames: string[] = [];
+  export let variableNames: VariableNames = [];
 
   const columns: ColumnDef<V1ProjectVariable, any>[] = [
     {

--- a/web-admin/src/features/projects/environment-variables/KeyCell.svelte
+++ b/web-admin/src/features/projects/environment-variables/KeyCell.svelte
@@ -6,7 +6,7 @@
 
   // NOTE: if environment is empty, the variable is shared for all environments
   function getEnvironmentLabel(environment: string) {
-    if (environment === "") {
+    if (environment === EnvironmentType.UNDEFINED) {
       return "Development, Production";
     }
     if (environment === EnvironmentType.DEVELOPMENT) {

--- a/web-admin/src/features/projects/environment-variables/KeyCell.svelte
+++ b/web-admin/src/features/projects/environment-variables/KeyCell.svelte
@@ -5,7 +5,7 @@
   export let name: string;
 
   // NOTE: if environment is empty, the variable is shared for all environments
-  function getEnvironmentLabel(environment: string) {
+  function getEnvironmentType(environment: string) {
     if (environment === EnvironmentType.UNDEFINED) {
       return "Development, Production";
     }
@@ -18,7 +18,7 @@
     return "";
   }
 
-  $: environmentLabel = getEnvironmentLabel(environment);
+  $: environmentLabel = getEnvironmentType(environment);
 </script>
 
 <div class="flex flex-col">

--- a/web-admin/src/features/projects/environment-variables/types.ts
+++ b/web-admin/src/features/projects/environment-variables/types.ts
@@ -7,7 +7,7 @@ export enum EnvironmentType {
 
 export type EnvironmentTypes = "dev" | "prod" | "";
 
-export type EnvironmentVariable = {
-  key: string;
-  value: string;
-};
+export type VariableNames = {
+  environment: string;
+  name: string;
+}[];

--- a/web-admin/src/features/projects/environment-variables/utils.ts
+++ b/web-admin/src/features/projects/environment-variables/utils.ts
@@ -1,0 +1,39 @@
+import { EnvironmentType, type VariableNames } from "./types";
+
+// FIXME: we should rename UNDEFINED to ALL for more clarity
+// FOR NOW, we keep UNDEFINED based on the API
+export function getEnvironmentLabel(environment: string) {
+  return environment === EnvironmentType.UNDEFINED ? "all" : environment;
+}
+
+export function isDuplicateKey(
+  environment: string,
+  variableName: string,
+  variableNames: VariableNames,
+) {
+  return variableNames.some((existingVariable) => {
+    return (
+      existingVariable.environment === environment &&
+      existingVariable.name === variableName
+    );
+  });
+}
+
+export function getCurrentEnvironment(
+  isDevelopment: boolean,
+  isProduction: boolean,
+) {
+  if (isDevelopment && isProduction) {
+    return EnvironmentType.UNDEFINED;
+  }
+
+  if (isDevelopment) {
+    return EnvironmentType.DEVELOPMENT;
+  }
+
+  if (isProduction) {
+    return EnvironmentType.PRODUCTION;
+  }
+
+  return EnvironmentType.UNDEFINED;
+}

--- a/web-admin/src/features/projects/environment-variables/utils.ts
+++ b/web-admin/src/features/projects/environment-variables/utils.ts
@@ -5,7 +5,7 @@ import { EnvironmentType, type VariableNames } from "./types";
  * - Environment it belongs to ("prod" or "dev").
  * - If empty, then the value is used as the fallback for all environments.
  */
-export function getEnvironmentLabel(environment: string) {
+export function getEnvironmentType(environment: string) {
   return environment === EnvironmentType.UNDEFINED ? "" : environment;
 }
 
@@ -13,7 +13,7 @@ export function getEnvironmentLabel(environment: string) {
  * Checks if a key would create a duplicate environment variable.
  *
  * Rules for environment variables:
- * 1. A key can only be tied to one environment configuration
+ * 1. A key can be tied to multiple environment configurations, e.g. my_key[dev] & my_key[prod]
  * 2. If a key exists in all environments (UNDEFINED), it cannot be created in dev or prod
  * 3. If a key exists in dev or prod, it cannot be created in all environments
  * 4. If a key exists in dev, it cannot be created in dev but CAN be created in prod

--- a/web-admin/src/features/projects/environment-variables/utils.ts
+++ b/web-admin/src/features/projects/environment-variables/utils.ts
@@ -1,21 +1,59 @@
 import { EnvironmentType, type VariableNames } from "./types";
 
-// FIXME: we should rename UNDEFINED to ALL for more clarity
-// FOR NOW, we keep UNDEFINED based on the API
+/**
+ *
+ * - Environment it belongs to ("prod" or "dev").
+ * - If empty, then the value is used as the fallback for all environments.
+ */
 export function getEnvironmentLabel(environment: string) {
-  return environment === EnvironmentType.UNDEFINED ? "all" : environment;
+  return environment === EnvironmentType.UNDEFINED ? "" : environment;
 }
 
+/**
+ * Checks if a key would create a duplicate environment variable.
+ *
+ * Rules for environment variables:
+ * 1. A key can only be tied to one environment configuration
+ * 2. If a key exists in all environments (UNDEFINED), it cannot be created in dev or prod
+ * 3. If a key exists in dev or prod, it cannot be created in all environments
+ * 4. If a key exists in dev, it cannot be created in dev but CAN be created in prod
+ *
+ * Examples:
+ * - If test[dev] exists:
+ *   - Cannot create test[dev] (same environment)
+ *   - Cannot create test[all] (key already used)
+ *   - CAN create test[prod] (different environment)
+ * - If test[all] exists:
+ *   - Cannot create test[dev] (key used in all environments)
+ *   - Cannot create test[prod] (key used in all environments)
+ *
+ * @param environment - The target environment ("development", "production", or "undefined" for all)
+ * @param key - The environment variable key to check
+ * @param variableNames - Existing environment variables
+ * @returns true if the key would create a duplicate, false otherwise
+ */
 export function isDuplicateKey(
   environment: string,
-  variableName: string,
+  key: string,
   variableNames: VariableNames,
-) {
-  return variableNames.some((existingVariable) => {
-    return (
-      existingVariable.environment === environment &&
-      existingVariable.name === variableName
-    );
+): boolean {
+  return variableNames.some((variable) => {
+    // Only consider it a duplicate if the same key exists
+    if (variable.name === key) {
+      // If either the existing or new variable is for all environments, it's a duplicate
+      if (
+        variable.environment === EnvironmentType.UNDEFINED ||
+        environment === EnvironmentType.UNDEFINED
+      ) {
+        return true;
+      }
+
+      // If trying to create in the same environment as existing variable
+      if (variable.environment === environment) {
+        return true;
+      }
+    }
+    return false;
   });
 }
 

--- a/web-admin/src/routes/[organization]/[project]/-/settings/environment-variables/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/settings/environment-variables/+page.svelte
@@ -15,7 +15,7 @@
     EnvironmentType,
     type EnvironmentTypes,
   } from "@rilldata/web-admin/features/projects/environment-variables/types";
-  import { getEnvironmentLabel } from "@rilldata/web-admin/features/projects/environment-variables/utils";
+  import { getEnvironmentType } from "@rilldata/web-admin/features/projects/environment-variables/utils";
 
   let open = false;
   let searchText = "";
@@ -37,7 +37,7 @@
 
   $: variableNames = projectVariables.map((variable) => {
     return {
-      environment: getEnvironmentLabel(variable.environment),
+      environment: getEnvironmentType(variable.environment),
       name: variable.name,
     };
   });

--- a/web-admin/src/routes/[organization]/[project]/-/settings/environment-variables/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/settings/environment-variables/+page.svelte
@@ -15,6 +15,7 @@
     EnvironmentType,
     type EnvironmentTypes,
   } from "@rilldata/web-admin/features/projects/environment-variables/types";
+  import { getEnvironmentLabel } from "@rilldata/web-admin/features/projects/environment-variables/utils";
 
   let open = false;
   let searchText = "";
@@ -34,7 +35,12 @@
 
   $: projectVariables = $getProjectVariables.data?.variables || [];
 
-  $: variableNames = projectVariables.map((variable) => variable.name);
+  $: variableNames = projectVariables.map((variable) => {
+    return {
+      environment: getEnvironmentLabel(variable.environment),
+      name: variable.name,
+    };
+  });
 
   $: searchedVariables = projectVariables.filter((variable) =>
     variable.name.toLowerCase().includes(searchText.toLowerCase()),


### PR DESCRIPTION
closes https://github.com/rilldata/rill/issues/6150

https://www.notion.so/rilldata/Environment-Variables-management-UI-42304f145b07410d86c2a523496aa6bc

- [x] allow 1 unique variable key + environment
- [x] disallow updating existing variable in create dialog perhaps
- [x] https://rilldata.slack.com/archives/C07NUPQ02EA/p1733167795245509
- [x] A variable with the name `test` already exists for the target development

![CleanShot 2024-11-27 at 09 47 49@2x](https://github.com/user-attachments/assets/e7ab6139-6909-4e3b-a8dd-2749557a55f3)


https://github.com/user-attachments/assets/3769feac-b5d4-43b4-9046-95b8b6a9c049