### PR TITLE
fix: Slack notification being enabled even if notifier is not configured for project

### DIFF
--- a/web-common/src/features/scheduled-reports/utils.ts
+++ b/web-common/src/features/scheduled-reports/utils.ts
@@ -91,7 +91,7 @@ export function extractNotificationV2(
   }
 
   return {
-    enableSlackNotification: isEdit ? !!slackNotifier : true,
+    enableSlackNotification: isEdit ? !!slackNotifier : false,
     slackChannels,
     slackUsers,
 


### PR DESCRIPTION
We check if the slack notifier is configure for project or not for showing slack controls. But the boolean controlling enable/disable is always set to true.

Making the default to false similar to how we do in alerts.