### PR TITLE
use creators id in security rule for reports

### DIFF
--- a/runtime/security.go
+++ b/runtime/security.go
@@ -46,7 +46,10 @@ func (c *SecurityClaims) UserID() string {
 	if c.UserAttributes == nil {
 		return ""
 	}
-	id, _ := c.UserAttributes["id"].(string)
+	id, _ := c.UserAttributes["creator_id"].(string)
+	if id == "" {
+		id, _ = c.UserAttributes["id"].(string)
+	}
 	return id
 }
 
@@ -367,7 +370,7 @@ func (p *securityEngine) builtInAlertSecurityRule(spec *runtimev1.AlertSpec, cla
 	// Extract attributes
 	var email, userID string
 	if len(claims.UserAttributes) != 0 {
-		userID, _ = claims.UserAttributes["id"].(string)
+		userID = claims.UserID()
 		email, _ = claims.UserAttributes["email"].(string)
 	}
 
@@ -421,7 +424,7 @@ func (p *securityEngine) builtInReportSecurityRule(spec *runtimev1.ReportSpec, c
 	// Extract attributes
 	var email, userID string
 	if len(claims.UserAttributes) != 0 {
-		userID, _ = claims.UserAttributes["id"].(string)
+		userID = claims.UserID()
 		email, _ = claims.UserAttributes["email"].(string)
 	}
 

--- a/runtime/server/auth/claims.go
+++ b/runtime/server/auth/claims.go
@@ -67,6 +67,9 @@ func (c *jwtClaims) SecurityClaims() *runtime.SecurityClaims {
 		attrs = make(map[string]any)
 	}
 	attrs["id"] = c.Subject()
+	if cid, ok := c.Attrs["creator_id"]; ok {
+		attrs["creator_id"] = cid
+	}
 
 	var rules []*runtimev1.SecurityRule
 	if len(c.Security) > 0 {


### PR DESCRIPTION
We add creator id in the jwt attributes for magic token. Now the security claims can use this to check against the owner of the report, if match then allow. Idea is that magic token should have same privileges as its creator for viewing report. 