### PR TITLE
feat: support for search in pivot data store

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotTable.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTable.svelte
@@ -37,7 +37,7 @@
   import { onMount } from "svelte";
   import type { Readable } from "svelte/motion";
   import { derived } from "svelte/store";
-  import { getPivotConfig } from "./pivot-data-store";
+  import { getPivotConfig } from "./pivot-data-config";
   import type { PivotDataRow, PivotDataStore } from "./types";
 
   // Distance threshold (in pixels) for triggering data fetch

--- a/web-common/src/features/dashboards/pivot/pivot-data-config.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-data-config.ts
@@ -1,0 +1,142 @@
+import { mergeMeasureFilters } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
+import { allDimensions } from "@rilldata/web-common/features/dashboards/state-managers/selectors/dimensions";
+import { allMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
+import type { StateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
+import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
+import { timeControlStateSelector } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
+import type { TimeRangeString } from "@rilldata/web-common/lib/time/types";
+import { type Readable, derived } from "svelte/store";
+import { canEnablePivotComparison, getPivotConfigKey } from "./pivot-utils";
+import {
+  COMPARISON_DELTA,
+  COMPARISON_PERCENT,
+  PivotChipType,
+  type PivotDataStoreConfig,
+  type PivotTimeConfig,
+} from "./types";
+
+let lastKey: string | undefined = undefined;
+
+/**
+ * Extract out config relevant to pivot from dashboard and meta store
+ */
+export function getPivotConfig(
+  ctx: StateManagers,
+): Readable<PivotDataStoreConfig> {
+  return derived(
+    [ctx.validSpecStore, ctx.timeRangeSummaryStore, ctx.dashboardStore],
+    ([validSpec, timeRangeSummary, dashboardStore]) => {
+      if (
+        !validSpec?.data?.metricsView ||
+        !validSpec?.data?.explore ||
+        timeRangeSummary.isFetching
+      ) {
+        return {
+          measureNames: [],
+          rowDimensionNames: [],
+          colDimensionNames: [],
+          allMeasures: [],
+          allDimensions: [],
+          whereFilter: dashboardStore.whereFilter,
+          pivot: dashboardStore.pivot,
+          time: {} as PivotTimeConfig,
+          comparisonTime: undefined,
+          enableComparison: false,
+        };
+      }
+
+      const { metricsView, explore } = validSpec.data;
+
+      // This indirection makes sure only one update of dashboard store triggers this
+      const timeControl = timeControlStateSelector([
+        metricsView,
+        explore,
+        timeRangeSummary,
+        dashboardStore,
+      ]);
+
+      const time: PivotTimeConfig = {
+        timeStart: timeControl.timeStart,
+        timeEnd: timeControl.timeEnd,
+        timeZone: dashboardStore?.selectedTimezone || "UTC",
+        timeDimension: metricsView.timeDimension || "",
+      };
+
+      const enableComparison =
+        canEnablePivotComparison(
+          dashboardStore.pivot,
+          timeControl.comparisonTimeStart,
+        ) && !!timeControl.showTimeComparison;
+
+      let comparisonTime: TimeRangeString | undefined = undefined;
+      if (enableComparison) {
+        comparisonTime = {
+          start: timeControl.comparisonTimeStart,
+          end: timeControl.comparisonTimeEnd,
+        };
+      }
+
+      const measureNames = dashboardStore.pivot.columns.measure.flatMap((m) => {
+        const measureName = m.id;
+        const group = [measureName];
+
+        if (enableComparison) {
+          group.push(
+            `${measureName}${COMPARISON_DELTA}`,
+            `${measureName}${COMPARISON_PERCENT}`,
+          );
+        }
+        return group;
+      });
+
+      // This is temporary until we have a better way to handle time grains
+      const rowDimensionNames = dashboardStore.pivot.rows.dimension.map((d) => {
+        if (d.type === PivotChipType.Time) {
+          return `${time.timeDimension}_rill_${d.id}`;
+        }
+        return d.id;
+      });
+
+      const colDimensionNames = dashboardStore.pivot.columns.dimension.map(
+        (d) => {
+          if (d.type === PivotChipType.Time) {
+            return `${time.timeDimension}_rill_${d.id}`;
+          }
+          return d.id;
+        },
+      );
+
+      const config: PivotDataStoreConfig = {
+        measureNames,
+        rowDimensionNames,
+        colDimensionNames,
+        allMeasures: allMeasures({
+          validMetricsView: metricsView,
+          validExplore: explore,
+        }),
+        allDimensions: allDimensions({
+          validMetricsView: metricsView,
+          validExplore: explore,
+        }),
+        whereFilter: mergeMeasureFilters(dashboardStore),
+        pivot: dashboardStore.pivot,
+        enableComparison,
+        comparisonTime,
+        time,
+      };
+
+      const currentKey = getPivotConfigKey(config);
+
+      if (lastKey !== currentKey) {
+        // Reset rowPage when pivot config changes
+        lastKey = currentKey;
+        if (config.pivot.rowPage !== 1) {
+          metricsExplorerStore.setPivotRowPage(dashboardStore.name, 1);
+          config.pivot.rowPage = 1;
+        }
+      }
+
+      return config;
+    },
+  );
+}

--- a/web-common/src/features/dashboards/pivot/pivot-data-config.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-data-config.ts
@@ -2,7 +2,10 @@ import { mergeMeasureFilters } from "@rilldata/web-common/features/dashboards/fi
 import { allDimensions } from "@rilldata/web-common/features/dashboards/state-managers/selectors/dimensions";
 import { allMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
 import type { StateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
-import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
+import {
+  dimensionSearchText,
+  metricsExplorerStore,
+} from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
 import { timeControlStateSelector } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import type { TimeRangeString } from "@rilldata/web-common/lib/time/types";
 import { type Readable, derived } from "svelte/store";
@@ -24,8 +27,13 @@ export function getPivotConfig(
   ctx: StateManagers,
 ): Readable<PivotDataStoreConfig> {
   return derived(
-    [ctx.validSpecStore, ctx.timeRangeSummaryStore, ctx.dashboardStore],
-    ([validSpec, timeRangeSummary, dashboardStore]) => {
+    [
+      ctx.validSpecStore,
+      ctx.timeRangeSummaryStore,
+      ctx.dashboardStore,
+      dimensionSearchText,
+    ],
+    ([validSpec, timeRangeSummary, dashboardStore, searchText]) => {
       if (
         !validSpec?.data?.metricsView ||
         !validSpec?.data?.explore ||
@@ -42,6 +50,7 @@ export function getPivotConfig(
           time: {} as PivotTimeConfig,
           comparisonTime: undefined,
           enableComparison: false,
+          searchText,
         };
       }
 
@@ -123,6 +132,7 @@ export function getPivotConfig(
         enableComparison,
         comparisonTime,
         time,
+        searchText,
       };
 
       const currentKey = getPivotConfigKey(config);

--- a/web-common/src/features/dashboards/pivot/pivot-data-store.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-data-store.ts
@@ -1,12 +1,8 @@
-import { mergeMeasureFilters } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
+import { getPivotConfig } from "@rilldata/web-common/features/dashboards/pivot/pivot-data-config";
 import { mergeFilters } from "@rilldata/web-common/features/dashboards/pivot/pivot-merge-filters";
 import { memoizeMetricsStore } from "@rilldata/web-common/features/dashboards/state-managers/memoize-metrics-store";
-import { allDimensions } from "@rilldata/web-common/features/dashboards/state-managers/selectors/dimensions";
-import { allMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
 import type { StateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
-import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
 import { createAndExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
-import { timeControlStateSelector } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import type { TimeRangeString } from "@rilldata/web-common/lib/time/types";
 import type {
   V1MetricsViewAggregationResponse,
@@ -40,7 +36,6 @@ import {
   reduceTableCellDataIntoRows,
 } from "./pivot-table-transformations";
 import {
-  canEnablePivotComparison,
   getErrorFromResponses,
   getErrorState,
   getFilterForPivotTable,
@@ -54,141 +49,11 @@ import {
   isTimeDimension,
 } from "./pivot-utils";
 import {
-  COMPARISON_DELTA,
-  COMPARISON_PERCENT,
-  PivotChipType,
   type PivotDataRow,
   type PivotDataStore,
   type PivotDataStoreConfig,
   type PivotFilter,
-  type PivotTimeConfig,
 } from "./types";
-
-let lastKey: string | undefined = undefined;
-
-/**
- * Extract out config relevant to pivot from dashboard and meta store
- */
-export function getPivotConfig(
-  ctx: StateManagers,
-): Readable<PivotDataStoreConfig> {
-  return derived(
-    [ctx.validSpecStore, ctx.timeRangeSummaryStore, ctx.dashboardStore],
-    ([validSpec, timeRangeSummary, dashboardStore]) => {
-      if (
-        !validSpec?.data?.metricsView ||
-        !validSpec?.data?.explore ||
-        timeRangeSummary.isFetching
-      ) {
-        return {
-          measureNames: [],
-          rowDimensionNames: [],
-          colDimensionNames: [],
-          allMeasures: [],
-          allDimensions: [],
-          whereFilter: dashboardStore.whereFilter,
-          pivot: dashboardStore.pivot,
-          time: {} as PivotTimeConfig,
-          comparisonTime: undefined,
-          enableComparison: false,
-        };
-      }
-
-      const { metricsView, explore } = validSpec.data;
-
-      // This indirection makes sure only one update of dashboard store triggers this
-      const timeControl = timeControlStateSelector([
-        metricsView,
-        explore,
-        timeRangeSummary,
-        dashboardStore,
-      ]);
-
-      const time: PivotTimeConfig = {
-        timeStart: timeControl.timeStart,
-        timeEnd: timeControl.timeEnd,
-        timeZone: dashboardStore?.selectedTimezone || "UTC",
-        timeDimension: metricsView.timeDimension || "",
-      };
-
-      const enableComparison =
-        canEnablePivotComparison(
-          dashboardStore.pivot,
-          timeControl.comparisonTimeStart,
-        ) && !!timeControl.showTimeComparison;
-
-      let comparisonTime: TimeRangeString | undefined = undefined;
-      if (enableComparison) {
-        comparisonTime = {
-          start: timeControl.comparisonTimeStart,
-          end: timeControl.comparisonTimeEnd,
-        };
-      }
-
-      const measureNames = dashboardStore.pivot.columns.measure.flatMap((m) => {
-        const measureName = m.id;
-        const group = [measureName];
-
-        if (enableComparison) {
-          group.push(
-            `${measureName}${COMPARISON_DELTA}`,
-            `${measureName}${COMPARISON_PERCENT}`,
-          );
-        }
-        return group;
-      });
-
-      // This is temporary until we have a better way to handle time grains
-      const rowDimensionNames = dashboardStore.pivot.rows.dimension.map((d) => {
-        if (d.type === PivotChipType.Time) {
-          return `${time.timeDimension}_rill_${d.id}`;
-        }
-        return d.id;
-      });
-
-      const colDimensionNames = dashboardStore.pivot.columns.dimension.map(
-        (d) => {
-          if (d.type === PivotChipType.Time) {
-            return `${time.timeDimension}_rill_${d.id}`;
-          }
-          return d.id;
-        },
-      );
-
-      const config: PivotDataStoreConfig = {
-        measureNames,
-        rowDimensionNames,
-        colDimensionNames,
-        allMeasures: allMeasures({
-          validMetricsView: metricsView,
-          validExplore: explore,
-        }),
-        allDimensions: allDimensions({
-          validMetricsView: metricsView,
-          validExplore: explore,
-        }),
-        whereFilter: mergeMeasureFilters(dashboardStore),
-        pivot: dashboardStore.pivot,
-        enableComparison,
-        comparisonTime,
-        time,
-      };
-
-      const currentKey = getPivotConfigKey(config);
-
-      if (lastKey !== currentKey) {
-        // Reset rowPage when pivot config changes
-        lastKey = currentKey;
-        if (config.pivot.rowPage !== 1) {
-          metricsExplorerStore.setPivotRowPage(dashboardStore.name, 1);
-          config.pivot.rowPage = 1;
-        }
-      }
-
-      return config;
-    },
-  );
-}
 
 /**
  * Returns a query for cell data for the initial table.

--- a/web-common/src/features/dashboards/pivot/pivot-export.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-export.ts
@@ -14,7 +14,7 @@ import {
 import { derived, get } from "svelte/store";
 import { runtime } from "../../../runtime-client/runtime-store";
 import type { StateManagers } from "../state-managers/state-managers";
-import { getPivotConfig } from "./pivot-data-store";
+import { getPivotConfig } from "./pivot-data-config";
 import { prepareMeasureForComparison } from "./pivot-utils";
 import {
   COMPARISON_DELTA,

--- a/web-common/src/features/dashboards/pivot/types.ts
+++ b/web-common/src/features/dashboards/pivot/types.ts
@@ -100,6 +100,7 @@ export interface PivotDataStoreConfig {
   time: PivotTimeConfig;
   enableComparison: boolean;
   comparisonTime: TimeRangeString | undefined;
+  searchText: string | undefined;
 }
 
 export interface PivotAxesData {

--- a/web-common/src/features/templates/table/selector.ts
+++ b/web-common/src/features/templates/table/selector.ts
@@ -85,6 +85,7 @@ export function getTableConfig(
         allMeasures: metricsView.data?.measures || [],
         allDimensions: metricsView.data?.dimensions || [],
         whereFilter: createAndExpression([]),
+        searchText: "",
         pivot: pivotState,
         enableComparison,
         comparisonTime: {


### PR DESCRIPTION
Adds support for searchText as a parameter for the pivot data store.
Also moves the pivot config in it's own file.

We can also integrate the search to existing pivot UI but we would need to think through some UX consideration as search can only be applied to a single dimension.