### PR TITLE
fix: logged out users getting a login page for public projects

### DIFF
--- a/web-admin/src/features/navigation/TopNavigationBar.svelte
+++ b/web-admin/src/features/navigation/TopNavigationBar.svelte
@@ -94,7 +94,9 @@
 
   $: plan = createAdminServiceGetBillingSubscription(organization, {
     query: {
-      enabled: !!organization && manageOrganization && !onPublicURLPage,
+      enabled: Boolean(
+        !!organization && manageOrganization && !onPublicURLPage,
+      ),
       select: (data) => data.subscription?.plan,
     },
   });

--- a/web-admin/src/routes/+layout.ts
+++ b/web-admin/src/routes/+layout.ts
@@ -11,10 +11,7 @@ import {
   type V1OrganizationPermissions,
   type V1ProjectPermissions,
 } from "@rilldata/web-admin/client";
-import {
-  redirectToLoginIfNotLoggedIn,
-  redirectToLoginOrRequestAccess,
-} from "@rilldata/web-admin/features/authentication/checkUserAccess";
+import { redirectToLoginOrRequestAccess } from "@rilldata/web-admin/features/authentication/checkUserAccess";
 import { fetchOrganizationPermissions } from "@rilldata/web-admin/features/organizations/selectors";
 import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient.js";
 import { error, type Page } from "@sveltejs/kit";

--- a/web-admin/src/routes/+layout.ts
+++ b/web-admin/src/routes/+layout.ts
@@ -47,14 +47,6 @@ export const load = async ({ params, url, route }) => {
       if (e.response?.status !== 403) {
         throw error(e.response.status, "Error fetching organization");
       }
-      // Use without access to anything within the org will hit this, so redirect to access page here.
-      const didRedirect = await redirectToLoginIfNotLoggedIn();
-      if (!didRedirect) {
-        return {
-          organizationPermissions,
-          projectPermissions: <V1ProjectPermissions>{},
-        };
-      }
     }
   }
 


### PR DESCRIPTION
After the refactors in Billings UI PR logged out users are getting a login page for public page. There is a 403 request for org which should be ignored. Another 403 for subscription that should not be called at all.