### PR TITLE
fix: issues with managed plan and sub/trial ended handing revert

### DIFF
--- a/web-admin/src/features/billing/Payment.svelte
+++ b/web-admin/src/features/billing/Payment.svelte
@@ -9,7 +9,7 @@
   import SettingsContainer from "@rilldata/web-admin/features/organizations/settings/SettingsContainer.svelte";
   import { Button } from "@rilldata/web-common/components/button";
   import CancelCircle from "@rilldata/web-common/components/icons/CancelCircle.svelte";
-  import { isEnterprisePlan } from "./plans/utils";
+  import { isEnterprisePlan, isManagedPlan } from "./plans/utils";
 
   export let organization: string;
   export let subscription: V1Subscription;
@@ -21,6 +21,9 @@
   $: onTrial = !!$categorisedIssues.data?.trial;
   $: onEnterprisePlan =
     subscription?.plan && isEnterprisePlan(subscription.plan);
+  $: onManagedPlan = subscription?.plan && isManagedPlan(subscription.plan);
+  $: hidePaymentModule =
+    neverSubscribed || onTrial || onEnterprisePlan || onManagedPlan;
 
   async function handleManagePayment() {
     window.open(
@@ -31,7 +34,7 @@
 </script>
 
 <!-- Presence of paymentCustomerId signifies that the org's payment is managed through stripe -->
-{#if !$categorisedIssues.isLoading && !neverSubscribed && $org.data?.organization?.paymentCustomerId && !onTrial && !onEnterprisePlan}
+{#if !$categorisedIssues.isLoading && $org.data?.organization?.paymentCustomerId && !hidePaymentModule}
   <SettingsContainer title="Payment Method">
     <div slot="body" class="flex flex-row items-center gap-x-1">
       {#if paymentIssues?.length}

--- a/web-admin/src/features/billing/plans/POCPlan.svelte
+++ b/web-admin/src/features/billing/plans/POCPlan.svelte
@@ -22,11 +22,13 @@
     <span>To make changes to your contract,</span>
     <ContactUs variant="enterprise" />
   </svelte:fragment>
-  {#if hasPayment}
-    <Button type="primary" slot="action" on:click={() => (open = true)}>
-      Start Team plan
-    </Button>
-  {/if}
+  <svelte:fragment slot="action">
+    {#if hasPayment}
+      <Button type="primary" on:click={() => (open = true)}>
+        Start Team plan
+      </Button>
+    {/if}
+  </svelte:fragment>
 </SettingsContainer>
 
 <StartTeamPlanDialog bind:open {organization} type="base" />

--- a/web-admin/src/features/billing/plans/Plan.svelte
+++ b/web-admin/src/features/billing/plans/Plan.svelte
@@ -6,7 +6,7 @@
   import TeamPlan from "@rilldata/web-admin/features/billing/plans/TeamPlan.svelte";
   import TrialPlan from "@rilldata/web-admin/features/billing/plans/TrialPlan.svelte";
   import {
-    isPOCPlan,
+    isManagedPlan,
     isTeamPlan,
   } from "@rilldata/web-admin/features/billing/plans/utils";
   import { useCategorisedOrganizationBillingIssues } from "@rilldata/web-admin/features/billing/selectors";
@@ -28,8 +28,9 @@
   // ended subscription will have a cancelled issue associated with it
   $: subHasEnded = !!$categorisedIssues.data?.cancelled;
   $: subIsTeamPlan = plan && isTeamPlan(plan);
-  $: subIsPOCPlan = plan && isPOCPlan(plan);
-  $: subIsEnterprisePlan = plan && !isTrial && !subIsTeamPlan && !subIsPOCPlan;
+  $: subIsManagedPlan = plan && isManagedPlan(plan);
+  $: subIsEnterprisePlan =
+    plan && !isTrial && !subIsTeamPlan && !subIsManagedPlan;
 </script>
 
 {#if neverSubbed}
@@ -40,7 +41,7 @@
   <CancelledTeamPlan {organization} {showUpgradeDialog} {plan} />
 {:else if subIsTeamPlan}
   <TeamPlan {organization} {subscription} {plan} />
-{:else if subIsPOCPlan}
+{:else if subIsManagedPlan}
   <POCPlan {organization} {hasPayment} {plan} />
 {:else if subIsEnterprisePlan}
   <EnterprisePlan {organization} {plan} />

--- a/web-admin/src/features/billing/plans/utils.ts
+++ b/web-admin/src/features/billing/plans/utils.ts
@@ -29,12 +29,12 @@ export function isTeamPlan(plan: V1BillingPlan) {
   return plan.planType === V1BillingPlanType.BILLING_PLAN_TYPE_TEAM;
 }
 
-export function isPOCPlan(plan: V1BillingPlan) {
+export function isManagedPlan(plan: V1BillingPlan) {
   return plan.planType === V1BillingPlanType.BILLING_PLAN_TYPE_MANAGED;
 }
 
 export function isEnterprisePlan(plan: V1BillingPlan) {
-  return !isTrialPlan(plan) && !isTeamPlan(plan) && !isPOCPlan(plan);
+  return !isTrialPlan(plan) && !isTeamPlan(plan) && !isManagedPlan(plan);
 }
 
 export function getSubscriptionResumedText(endDate: string) {

--- a/web-admin/src/routes/[organization]/-/settings/+layout.svelte
+++ b/web-admin/src/routes/[organization]/-/settings/+layout.svelte
@@ -14,7 +14,7 @@
   $: basePage = `/${organization}/-/settings`;
   $: onEnterprisePlan =
     subscription?.plan && isEnterprisePlan(subscription?.plan);
-  $: hideBillingSettings = neverSubscribed || !subscription;
+  $: hideBillingSettings = neverSubscribed;
 
   $: navItems = [
     { label: "General", route: "" },


### PR DESCRIPTION
- [x] For managed plan with payment customer id we should hide payment module. Also upgrade plan button is misplaced.
- [x] Revert the change where we hide billing settings when there is no subscription. We did this as temporary fix for un-migrated orgs. But this will hide it even when subscription or trial has ended.