### PR TITLE
fix: inferred comparison time range not being made available when a default time range is present

### DIFF
--- a/web-common/src/features/dashboards/time-controls/time-control-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.ts
@@ -363,14 +363,14 @@ function getComparisonTimeRange(
   if (!timeRange || !timeRange.name || !allTimeRange) return undefined;
 
   if (!comparisonTimeRange?.name) {
-    const comparisonOption = DEFAULT_TIME_RANGES[
-      timeRange.name as TimeComparisonOption
-    ]?.defaultComparison as TimeComparisonOption;
+    const comparisonOption =
+      (DEFAULT_TIME_RANGES[timeRange.name as TimeComparisonOption]
+        ?.defaultComparison as TimeComparisonOption) ??
+      explore.timeRanges?.find((tr) => tr.range === timeRange.name)
+        ?.comparisonTimeRanges?.[0]?.offset ??
+      TimeComparisonOption.CONTIGUOUS;
     const range = getTimeComparisonParametersForComponent(
-      comparisonOption ??
-        explore.timeRanges?.find((tr) => tr.range === timeRange.name)
-          ?.comparisonTimeRanges?.[0]?.offset ??
-        TimeComparisonOption.CONTIGUOUS,
+      comparisonOption,
       allTimeRange.start,
       allTimeRange.end,
       timeRange.start,


### PR DESCRIPTION
For any time range we infer a comparison time range. But we were not assigning it to `name` of `selectedComparisonTimeRange` but just `start` and `end` in our time store. This meant that any consumer of this store was thinking it was not set at all.

One place this was seen was in alerts. With a dashboard with a default time range that can have a comparison, toggling the comparison did not update the alert creation modal. Only after selecting an option from the comparison drop down it showed up.