### PR TITLE
fix: uncaught error in header

### DIFF
--- a/web-common/src/layout/workspace/WorkspaceHeader.svelte
+++ b/web-common/src/layout/workspace/WorkspaceHeader.svelte
@@ -29,7 +29,7 @@
   export let onTitleChange: (title: string) => void = () => {};
 
   let width: number;
-  let editing: boolean;
+  let editing = false;
 
   $: value = titleInput;
   $: workspaceLayout = workspaces.get(filePath);


### PR DESCRIPTION
Failure to initialize the `editing` variable was crashing the app when refreshing a metrics page.