### PR TITLE
fix: refetch explore resource

### DIFF
--- a/web-common/src/features/entity-management/WatchResourcesClient.ts
+++ b/web-common/src/features/entity-management/WatchResourcesClient.ts
@@ -218,7 +218,7 @@ export class WatchResourcesClient {
             }
 
             queryClient
-              .invalidateQueries(
+              .refetchQueries(
                 getRuntimeServiceGetExploreQueryKey(this.instanceId, {
                   name: res.name.name,
                 }),


### PR DESCRIPTION
This shouldn't strictly be necessary, but this is a patch fix for the following bug:

1. Go to the Visual Explore Editing surface
2. Navigate to the upstream metrics view
3. Change a property (like the name of a dimension)
4. Navigate back to the Visual Explore Editing surface

The new name will not be reflected because the query used to create the underlying state management object (`useExploreValidSpec`) does not refetch. I believe this may be a bug related to our specific version of Svelte Query. It looks like we ran into this previously here: https://github.com/rilldata/rill/pull/2027#discussion_r1161672656