### PR TITLE
fix: comparison calendar not showing

### DIFF
--- a/web-common/src/components/date-picker/Calendar.svelte
+++ b/web-common/src/components/date-picker/Calendar.svelte
@@ -3,16 +3,16 @@
   import { DateTime } from "luxon";
   import { Interval } from "luxon";
 
-  type MaybeDate = DateTime<true> | DateTime<false> | undefined;
+  type MaybeDate = DateTime | undefined;
 
-  export let selection: MaybeDate | Interval<true> = undefined;
+  export let selection: MaybeDate | Interval = undefined;
   export let minDate: MaybeDate = undefined;
   export let visibleMonths = 1;
   export let selectingStart = true;
   export let firstVisibleMonth: MaybeDate = isValidDateTime(selection)
     ? selection
     : isValidInterval(selection)
-      ? selection.start
+      ? (selection.start ?? DateTime.now())
       : DateTime.now();
   export let singleDaySelection = isValidDateTime(selection);
   export let onSelectDay: (date: DateTime<true>) => void;
@@ -44,7 +44,7 @@
   }
 
   function isValidInterval(
-    value: MaybeDate | Interval<true>,
+    value: MaybeDate | Interval,
   ): value is Interval<true> {
     return Boolean(value && value instanceof Interval && value?.isValid);
   }

--- a/web-common/src/features/dashboards/time-controls/super-pill/components/CalendarPlusDateInput.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/CalendarPlusDateInput.svelte
@@ -60,14 +60,12 @@
   }}
 />
 
-<!-- {#if calendarInterval?.isValid} -->
 <Calendar
   selection={calendarInterval}
   {selectingStart}
   {firstVisibleMonth}
   onSelectDay={onValidDateInput}
 />
-<!-- {/if} -->
 
 <DropdownMenu.Separator />
 <div class="flex flex-col gap-y-2 px-2 pt-1 pb-2">

--- a/web-common/src/features/dashboards/time-controls/super-pill/components/CalendarPlusDateInput.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/CalendarPlusDateInput.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <script lang="ts">
-  export let interval: Interval<true>;
+  export let interval: Interval<true> | undefined;
   export let zone: string;
   export let firstVisibleMonth: DateTime<true>;
   export let applyRange: (range: Interval<true>) => void;
@@ -17,10 +17,11 @@
   let selectingStart = true;
   let displayError = false;
 
-  $: calendarInterval = interval.set({
-    start: interval.start.startOf("day"),
-    end: interval.end.minus({ millisecond: 1 }).startOf("day"),
-  });
+  $: calendarInterval =
+    interval?.set({
+      start: interval.start.startOf("day"),
+      end: interval.end.minus({ millisecond: 1 }).startOf("day"),
+    }) ?? Interval.invalid("Invalid interval");
 
   function onValidDateInput(date: DateTime) {
     let newInterval: Interval;
@@ -59,14 +60,14 @@
   }}
 />
 
-{#if calendarInterval.isValid}
-  <Calendar
-    selection={calendarInterval}
-    {selectingStart}
-    {firstVisibleMonth}
-    onSelectDay={onValidDateInput}
-  />
-{/if}
+<!-- {#if calendarInterval?.isValid} -->
+<Calendar
+  selection={calendarInterval}
+  {selectingStart}
+  {firstVisibleMonth}
+  onSelectDay={onValidDateInput}
+/>
+<!-- {/if} -->
 
 <DropdownMenu.Separator />
 <div class="flex flex-col gap-y-2 px-2 pt-1 pb-2">
@@ -77,7 +78,7 @@
     <DateInput
       bind:selectingStart
       bind:displayError
-      date={calendarInterval.start ?? DateTime.now()}
+      date={calendarInterval?.start ?? DateTime.now()}
       {zone}
       boundary="start"
       currentYear={firstVisibleMonth.year}
@@ -92,7 +93,7 @@
     <DateInput
       bind:selectingStart
       bind:displayError
-      date={calendarInterval.end ?? DateTime.now()}
+      date={calendarInterval?.end ?? DateTime.now()}
       {zone}
       boundary="end"
       currentYear={firstVisibleMonth.year}
@@ -106,11 +107,11 @@
     compact
     type="primary"
     on:click={() => {
-      const mapped = calendarInterval.set({
+      const mapped = calendarInterval?.set({
         end: calendarInterval.end?.plus({ day: 1 }).startOf("day"),
       });
 
-      if (mapped.isValid) {
+      if (mapped?.isValid) {
         applyRange(mapped);
       }
 

--- a/web-common/src/features/dashboards/time-controls/super-pill/components/Comparison.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/Comparison.svelte
@@ -160,7 +160,7 @@
       </div>
       {#if showSelector}
         <div class="bg-slate-50 flex flex-col w-64 px-2 py-1">
-          {#if interval?.isValid}
+          {#if !interval || interval?.isValid}
             <CalendarPlusDateInput
               {firstVisibleMonth}
               {interval}


### PR DESCRIPTION
Fixes an issue where the calendar input would not display in the Comparison Pill when `All Time` was selected.