### PR TITLE
feat: navigate to visual explore editor

### DIFF
--- a/web-common/src/features/metrics-views/create-and-preview-explore.ts
+++ b/web-common/src/features/metrics-views/create-and-preview-explore.ts
@@ -25,13 +25,5 @@ export async function createAndPreviewExplore(
   const name = get(resource).data?.meta?.name?.name;
   if (!name) throw new Error("Failed to create an Explore resource");
 
-  // Check if the Explore has errors
-  const hasErrors = fileArtifact.getHasErrors(queryClient, instanceId);
-
-  // Depending on the presence of errors, navigate to the Explore workspace or to the Explore Preview
-  if (get(hasErrors)) {
-    await goto(`/files${filePath}`);
-  } else {
-    await goto(`/explore/${name}`);
-  }
+  await goto(`/files${filePath}`);
 }

--- a/web-local/tests/breadcrumbs.spec.ts
+++ b/web-local/tests/breadcrumbs.spec.ts
@@ -42,8 +42,9 @@ test.describe("Breadcrumbs", () => {
 
       await page.getByText("Create explore dashboard").click();
 
-      await page.getByText("Edit").click();
-      await page.getByText("Explore dashboard").click();
+      await page.waitForURL(
+        "**/files/dashboards/AdBids_model_metrics_explore.yaml",
+      );
 
       link = page.getByRole("link", {
         name: "AdBids_model_metrics_explore",
@@ -63,17 +64,13 @@ test.describe("Breadcrumbs", () => {
       await page.getByText("Go to dashboard").click();
       await page.getByText("Create dashboard").click();
 
-      await page.getByText("Edit").click();
-      await page.getByText("Metrics view").click();
-
-      await expect(
-        page.getByRole("button", {
-          name: "2 dashboards",
-          exact: true,
-        }),
-      ).toBeVisible();
+      await page.waitForURL(
+        "**/files/dashboards/AdBids_model_metrics_explore_1.yaml",
+      );
 
       await page.getByRole("link", { name: "AdBids", exact: true }).click();
+
+      await page.waitForURL("**/files/sources/AdBids.yaml");
 
       await expect(
         page.getByRole("link", {

--- a/web-local/tests/explores/dashboard-flow-test-setup.ts
+++ b/web-local/tests/explores/dashboard-flow-test-setup.ts
@@ -2,9 +2,9 @@ import { createExploreFromModel } from "web-local/tests/utils/exploreHelpers";
 import { createAdBidsModel } from "web-local/tests/utils/dataSpecifcHelpers";
 import { test } from "../utils/test";
 
-export function useDashboardFlowTestSetup(navigate = true) {
+export function useDashboardFlowTestSetup(navigateToPreview = false) {
   test.beforeEach(async ({ page }) => {
     await createAdBidsModel(page);
-    await createExploreFromModel(page, navigate);
+    await createExploreFromModel(page, navigateToPreview);
   });
 }

--- a/web-local/tests/explores/explores.spec.ts
+++ b/web-local/tests/explores/explores.spec.ts
@@ -30,7 +30,7 @@ test.describe("explores", () => {
 
   test("Autogenerate explore from model", async ({ page }) => {
     await createAdBidsModel(page);
-    await createExploreFromModel(page, false);
+    await createExploreFromModel(page, true);
     await assertAdBidsDashboard(page);
 
     // click on publisher=Facebook leaderboard value
@@ -62,7 +62,7 @@ test.describe("explores", () => {
     const watcher = new ResourceWatcher(page);
 
     await createAdBidsModel(page);
-    await createExploreFromModel(page, false);
+    await createExploreFromModel(page, true);
 
     // Check the total records are 100k
     await expect(page.getByText("Total records 100k")).toBeVisible();

--- a/web-local/tests/explores/leaderboard-and-dim-table-sort.spec.ts
+++ b/web-local/tests/explores/leaderboard-and-dim-table-sort.spec.ts
@@ -14,7 +14,7 @@ async function assertAAboveB(locA: Locator, locB: Locator) {
 }
 
 test.describe("leaderboard and dimension table sorting", () => {
-  useDashboardFlowTestSetup(false);
+  useDashboardFlowTestSetup(true);
 
   test("leaderboard and dimension table sorting", async ({ page }) => {
     await page.waitForTimeout(1000);

--- a/web-local/tests/explores/time-controls-from-config.spec.ts
+++ b/web-local/tests/explores/time-controls-from-config.spec.ts
@@ -13,12 +13,16 @@ test.describe("time controls settings from explore preset", () => {
 
     await page.getByLabel("code").click();
 
+    await page.waitForTimeout(2000);
+
     // Set a time range that is one of the supported presets
     await watcher.updateAndWaitForExplore(
       getDashboardYaml(`time_range: "P4W"
   comparison_mode: time
 `),
     );
+
+    await page.waitForTimeout(10000);
     // Preview
     await page.getByRole("button", { name: "Preview" }).click();
 

--- a/web-local/tests/explores/visual-explore-editing.spec.ts
+++ b/web-local/tests/explores/visual-explore-editing.spec.ts
@@ -7,15 +7,12 @@ import { test } from "../utils/test";
 test.describe("visual explore editing", () => {
   test("visual explore editor runthrough", async ({ page }) => {
     await createAdBidsModel(page);
-    await createExploreFromModel(page, false);
+    await createExploreFromModel(page);
 
-    await openFileNavEntryContextMenu(
-      page,
-      "/metrics/AdBids_model_metrics.yaml",
+    await page.waitForURL(
+      "**/files/dashboards/AdBids_model_metrics_explore.yaml",
     );
 
-    await page.getByRole("button", { name: "Edit" }).click();
-    await page.getByRole("menuitem", { name: "Explore" }).click();
     await page.getByLabel("code").click();
 
     await page.getByRole("button", { name: "Subset" }).first().click();

--- a/web-local/tests/explores/visual-explore-editing.spec.ts
+++ b/web-local/tests/explores/visual-explore-editing.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from "@playwright/test";
 import { createExploreFromModel } from "web-local/tests/utils/exploreHelpers";
-import { openFileNavEntryContextMenu } from "../utils/commonHelpers";
 import { createAdBidsModel } from "../utils/dataSpecifcHelpers";
 import { test } from "../utils/test";
 

--- a/web-local/tests/metrics-editor.spec.ts
+++ b/web-local/tests/metrics-editor.spec.ts
@@ -66,7 +66,7 @@ test.describe("Metrics editor", () => {
 
     // go to the dashboard and make sure the metrics and dimensions are there.
     await gotoNavEntry(page, AD_BIDS_EXPLORE_PATH);
-    await page.waitForTimeout(3000);
+
     await page.getByRole("button", { name: "Preview" }).click();
 
     // check to see metrics make sense.

--- a/web-local/tests/utils/exploreHelpers.ts
+++ b/web-local/tests/utils/exploreHelpers.ts
@@ -18,7 +18,7 @@ export async function createExploreFromSource(
 
 export async function createExploreFromModel(
   page: Page,
-  navigateToFile = true,
+  navigateToPreview = false,
   modelPath = "/models/AdBids_model.sql",
   metricsViewPath = "/metrics/AdBids_model_metrics.yaml",
 ) {
@@ -26,8 +26,10 @@ export async function createExploreFromModel(
   await clickMenuButton(page, "Generate metrics");
   await waitForFileNavEntry(page, metricsViewPath, true);
   await page.getByText("Create explore").click();
-  if (navigateToFile) {
-    await page.getByRole("button", { name: "Edit" }).click();
-    await page.getByRole("menuitem", { name: "Explore" }).click();
+
+  if (navigateToPreview) {
+    await page.getByRole("button", { name: "Preview" }).click();
   }
+
+  await page.waitForTimeout(1000);
 }


### PR DESCRIPTION
On creation of an Explore dashboard, navigate to the visual explore editor rather than the full dashboard preview.