### PR TITLE
Use humanized formatting in TDD when formatting not defined

### DIFF
--- a/web-common/src/features/dashboards/time-dimension-details/TDDTable.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TDDTable.svelte
@@ -43,6 +43,19 @@
   /** Formatter for the time axis in the table*/
   export let timeFormatter: (date: Date) => string;
 
+  /***
+   * In case there is no format defined, use the big num context
+   * so that the values are within bounds of the column. This is
+   * naive solution which should be removed later once we move to pivot
+   * UI.
+   */
+  $: hasNoFormatting = !measure.formatD3 && measure.formatPreset === "";
+
+  $: formatter = createMeasureValueFormatter<null | undefined>(
+    measure,
+    hasNoFormatting ? "big-number" : "table",
+  );
+
   const dispatch = createEventDispatcher();
 
   let pivot;
@@ -373,8 +386,6 @@
   $: cssVarStyles = `--cursor: ${
     comparing === "dimension" ? "pointer" : "default"
   }`;
-
-  $: formatter = createMeasureValueFormatter<null | undefined>(measure);
 </script>
 
 <div


### PR DESCRIPTION
We have moved to making `NONE` as the default format instead of `HUMANIZE` when there is no preset defined. 

For existing dashboards without any preset defined, this could lead to expanded measure values across the dashboard. We handle them gracefully across leaderboard, dimension table and pivot but these values were overlapping in TDD.

The lift to make the column size dynamic based on the formatted value (as done with other surfaces) is likely not a simple change.

In interest of getting the new formatting changes out for release, this is a temporary solution where we format the values in TDD similar to big number so there is no overlapping. This is only done when there is no formatting defined. 