### PR TITLE
fix: type error around telemetry client usage when analytics is disabled

### DIFF
--- a/web-admin/src/routes/+layout.svelte
+++ b/web-admin/src/routes/+layout.svelte
@@ -43,13 +43,13 @@
   initCloudMetrics()
     .then(() => {
       removeJavascriptListeners =
-        errorEventHandler.addJavascriptErrorListeners();
+        errorEventHandler?.addJavascriptErrorListeners();
     })
     .catch(console.error);
   initPylonWidget();
 
   onMount(() => {
-    return () => removeJavascriptListeners();
+    return () => removeJavascriptListeners?.();
   });
 
   $: isEmbed = $page.url.pathname === "/-/embed";

--- a/web-admin/src/routes/[organization]/[project]/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/+layout.svelte
@@ -142,7 +142,7 @@
 
   // Load telemetry client with relevant context
   $: if (project && $user.data?.user?.id) {
-    metricsService.loadCloudFields({
+    metricsService?.loadCloudFields({
       isDev: window.location.host.startsWith("localhost"),
       projectId: project,
       organizationId: organization,

--- a/web-common/src/features/connectors/olap/TableMenuItems.svelte
+++ b/web-common/src/features/connectors/olap/TableMenuItems.svelte
@@ -62,7 +62,7 @@
         table,
       );
       await goto(`/files${newModelPath}`);
-      await behaviourEvent.fireNavigationEvent(
+      await behaviourEvent?.fireNavigationEvent(
         newModelName,
         BehaviourEventMedium.Menu,
         MetricsEventSpace.LeftPanel,

--- a/web-common/src/features/explores/PreviewButton.svelte
+++ b/web-common/src/features/explores/PreviewButton.svelte
@@ -18,7 +18,7 @@
   const viewDashboard = () => {
     if (!href) return;
     behaviourEvent
-      .fireNavigationEvent(
+      ?.fireNavigationEvent(
         href,
         BehaviourEventMedium.Button,
         MetricsEventSpace.Workspace,

--- a/web-common/src/features/file-explorer/NavFile.svelte
+++ b/web-common/src/features/file-explorer/NavFile.svelte
@@ -77,7 +77,7 @@
   function fireTelemetry() {
     const previousScreenName = getScreenNameFromPage();
     behaviourEvent
-      .fireNavigationEvent(
+      ?.fireNavigationEvent(
         filePath,
         BehaviourEventMedium.Menu,
         MetricsEventSpace.LeftPanel,

--- a/web-common/src/features/metrics-views/MetricsViewMenuItems.svelte
+++ b/web-common/src/features/metrics-views/MetricsViewMenuItems.svelte
@@ -53,7 +53,7 @@
     if (!artifact) return;
     const previousScreenName = getScreenNameFromPage();
     await goto(`/files${artifact.path}`);
-    await behaviourEvent.fireNavigationEvent(
+    await behaviourEvent?.fireNavigationEvent(
       referenceModelName,
       BehaviourEventMedium.Menu,
       MetricsEventSpace.LeftPanel,

--- a/web-common/src/features/metrics-views/ai-generation/generateMetricsView.ts
+++ b/web-common/src/features/metrics-views/ai-generation/generateMetricsView.ts
@@ -133,7 +133,7 @@ export function useCreateMetricsViewFromTableUIAction(
       // If we're not creating an Explore, navigate to the Metrics View file
       if (!createExplore) {
         await goto(`/files${newMetricsViewFilePath}`);
-        void behaviourEvent.fireNavigationEvent(
+        void behaviourEvent?.fireNavigationEvent(
           newMetricsViewName,
           behaviourEventMedium,
           metricsEventSpace,

--- a/web-common/src/features/sources/navigation/SourceMenuItems.svelte
+++ b/web-common/src/features/sources/navigation/SourceMenuItems.svelte
@@ -93,7 +93,7 @@
         addDevLimit,
       );
       await goto(`/files${newModelPath}`);
-      await behaviourEvent.fireNavigationEvent(
+      await behaviourEvent?.fireNavigationEvent(
         newModelName,
         BehaviourEventMedium.Menu,
         MetricsEventSpace.LeftPanel,

--- a/web-common/src/features/workspaces/SourceWorkspace.svelte
+++ b/web-common/src/features/workspaces/SourceWorkspace.svelte
@@ -105,7 +105,7 @@
       addDevLimit,
     );
     await goto(`/files${newModelPath}`);
-    await behaviourEvent.fireNavigationEvent(
+    await behaviourEvent?.fireNavigationEvent(
       newModelName,
       BehaviourEventMedium.Button,
       MetricsEventSpace.RightPanel,

--- a/web-common/src/layout/navigation/navigation-utils.ts
+++ b/web-common/src/layout/navigation/navigation-utils.ts
@@ -19,7 +19,7 @@ export async function emitNavigationTelemetry(href: string, name: string) {
   const screenName = getNavURLToScreenMap(href);
 
   if (!screenName) return;
-  await behaviourEvent.fireNavigationEvent(
+  await behaviourEvent?.fireNavigationEvent(
     name,
     BehaviourEventMedium.Menu,
     MetricsEventSpace.LeftPanel,


### PR DESCRIPTION
There are some usage of the telemetry client which doesnt consider the fact that it could not be initialised. After moving dev to `disabled` this has become a lot more apparent.