### PR TITLE
fix: Empty projects page for orgs with expired trial and other billing issues

### DIFF
--- a/runtime/pkg/email/email.go
+++ b/runtime/pkg/email/email.go
@@ -496,7 +496,7 @@ func (c *Client) SendSubscriptionEnded(opts *SubscriptionEnded) error {
 		ToName:  opts.ToName,
 		Subject: fmt.Sprintf("Subscription for %s has now ended. Org is hibernated", opts.OrgName),
 		PreButton: template.HTML(fmt.Sprintf(`
-Your cancelled subscription for <b>%s</b> has and its projects are now <a href="https://docs.rilldata.com/home/FAQ#what-is-project-hibernation">hibernating</a>. We hope you enjoyed using Rill Cloud during your time with us.
+Your cancelled subscription for <b>%s</b> has ended and its projects are now <a href="https://docs.rilldata.com/home/FAQ#what-is-project-hibernation">hibernating</a>. We hope you enjoyed using Rill Cloud during your time with us.
 <br /><br />
 If you’d like to reactive your subscription and regain access, you can easily do so at any time by renewing your subscription from here:
 `, opts.OrgName)),

--- a/web-admin/src/routes/+layout.ts
+++ b/web-admin/src/routes/+layout.ts
@@ -50,7 +50,7 @@ export const load = async ({ params, url, route }) => {
   }
 
   // If no organization or project, return empty permissions
-  if (!organization || !project) {
+  if (!organization) {
     return {
       organizationPermissions: <V1OrganizationPermissions>{},
       projectPermissions: <V1ProjectPermissions>{},
@@ -68,6 +68,13 @@ export const load = async ({ params, url, route }) => {
         throw error(e.response.status, "Error fetching organization");
       }
     }
+  }
+
+  if (!project) {
+    return {
+      organizationPermissions,
+      projectPermissions: <V1ProjectPermissions>{},
+    };
   }
 
   try {

--- a/web-common/src/features/project/ProjectDeployer.ts
+++ b/web-common/src/features/project/ProjectDeployer.ts
@@ -153,10 +153,6 @@ export class ProjectDeployer {
 
     // Project does not yet exist
 
-    if (!org && this.useOrg) {
-      org = this.useOrg;
-    }
-
     let checkNextOrg = false;
     if (!org) {
       const { org: inferredOrg, checkNextOrg: inferredCheckNextOrg } =
@@ -182,6 +178,13 @@ export class ProjectDeployer {
   }
 
   private async inferOrg(rillUserOrgs: string[]) {
+    if (this.useOrg) {
+      return {
+        org: this.useOrg,
+        checkNextOrg: false,
+      };
+    }
+
     let org: string | undefined;
     let checkNextOrg = false;
     if (rillUserOrgs.length === 1) {

--- a/web-local/src/routes/(misc)/deploy/+page.svelte
+++ b/web-local/src/routes/(misc)/deploy/+page.svelte
@@ -15,9 +15,8 @@
   import type { PageData } from "./$types";
 
   export let data: PageData;
-  $: ({ orgParam } = data);
 
-  const deployer = new ProjectDeployer(orgParam);
+  const deployer = new ProjectDeployer(data.orgParam);
   const metadata = deployer.metadata;
   const user = deployer.user;
   const project = deployer.project;


### PR DESCRIPTION
- [x] For orgs with ended trial projects page is empty. It should instead show an error saying projects hibernated.
- [x] Upgrade paywall redirect doesnt automatically select the org that was upgraded.
- [x] Fix typo in cancelled subscription email.
- [x] Plan name is not fetched on every org page.