### PR TITLE
fix: displayname returned as empty string when undefined

### DIFF
--- a/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
@@ -173,8 +173,8 @@
         tooltipText="Choose measures to display"
         onSelect={(name) => toggleMeasureVisibility(allMeasureNames, name)}
         selectableItems={$allMeasures.map(({ name, displayName }) => ({
-          name: name ?? "",
-          label: displayName ?? name ?? "",
+          name: name || "",
+          label: displayName || name || "",
         }))}
         selectedItems={visibleMeasureNames}
         onToggleSelectAll={() => {

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
@@ -68,8 +68,8 @@
         tooltipText="Choose dimensions to display"
         onSelect={(name) => toggleDimensionVisibility(allDimensionNames, name)}
         selectableItems={$allDimensions.map(({ name, displayName }) => ({
-          name: name ?? "",
-          label: displayName ?? name ?? "",
+          name: name || "",
+          label: displayName || name || "",
         }))}
         selectedItems={visibleDimensionsNames}
         onToggleSelectAll={() => {

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -307,8 +307,8 @@
         tooltipText="Choose measures to display"
         onSelect={(name) => toggleMeasureVisibility(allMeasureNames, name)}
         selectableItems={$allMeasures.map(({ name, displayName }) => ({
-          name: name ?? "",
-          label: displayName ?? name ?? "",
+          name: name || "",
+          label: displayName || name || "",
         }))}
         selectedItems={visibleMeasureNames}
         onToggleSelectAll={() => {


### PR DESCRIPTION
Nullish coalescing operator was being used, but the field is returned as an empty string when undefined. 

Closes #6224 