### PR TITLE
Make `display_name` default to humanized `name`

### DIFF
--- a/runtime/compilers/rillv1/parse_alert.go
+++ b/runtime/compilers/rillv1/parse_alert.go
@@ -277,7 +277,7 @@ func (p *Parser) parseAlert(node *Node) error {
 
 	r.AlertSpec.DisplayName = tmp.DisplayName
 	if r.AlertSpec.DisplayName == "" {
-		r.AlertSpec.DisplayName = node.Name
+		r.AlertSpec.DisplayName = ToDisplayName(node.Name)
 	}
 	if schedule != nil {
 		r.AlertSpec.RefreshSchedule = schedule

--- a/runtime/compilers/rillv1/parse_alert.go
+++ b/runtime/compilers/rillv1/parse_alert.go
@@ -276,6 +276,9 @@ func (p *Parser) parseAlert(node *Node) error {
 	// NOTE: After calling insertResource, an error must not be returned. Any validation should be done before calling it.
 
 	r.AlertSpec.DisplayName = tmp.DisplayName
+	if r.AlertSpec.DisplayName == "" {
+		r.AlertSpec.DisplayName = node.Name
+	}
 	if schedule != nil {
 		r.AlertSpec.RefreshSchedule = schedule
 	}

--- a/runtime/compilers/rillv1/parse_canvas.go
+++ b/runtime/compilers/rillv1/parse_canvas.go
@@ -110,7 +110,7 @@ func (p *Parser) parseCanvas(node *Node) error {
 
 	r.CanvasSpec.DisplayName = tmp.DisplayName
 	if r.CanvasSpec.DisplayName == "" {
-		r.CanvasSpec.DisplayName = node.Name
+		r.CanvasSpec.DisplayName = ToDisplayName(node.Name)
 	}
 	r.CanvasSpec.Columns = tmp.Columns
 	r.CanvasSpec.Gap = tmp.Gap

--- a/runtime/compilers/rillv1/parse_canvas.go
+++ b/runtime/compilers/rillv1/parse_canvas.go
@@ -109,6 +109,9 @@ func (p *Parser) parseCanvas(node *Node) error {
 	// NOTE: After calling insertResource, an error must not be returned. Any validation should be done before calling it.
 
 	r.CanvasSpec.DisplayName = tmp.DisplayName
+	if r.CanvasSpec.DisplayName == "" {
+		r.CanvasSpec.DisplayName = node.Name
+	}
 	r.CanvasSpec.Columns = tmp.Columns
 	r.CanvasSpec.Gap = tmp.Gap
 	r.CanvasSpec.Variables = variables

--- a/runtime/compilers/rillv1/parse_component.go
+++ b/runtime/compilers/rillv1/parse_component.go
@@ -63,7 +63,7 @@ func (p *Parser) parseComponent(node *Node) error {
 
 	r.ComponentSpec = spec
 	if r.ComponentSpec.DisplayName == "" {
-		r.ComponentSpec.DisplayName = node.Name
+		r.ComponentSpec.DisplayName = ToDisplayName(node.Name)
 	}
 
 	return nil

--- a/runtime/compilers/rillv1/parse_component.go
+++ b/runtime/compilers/rillv1/parse_component.go
@@ -62,6 +62,9 @@ func (p *Parser) parseComponent(node *Node) error {
 	// NOTE: After calling insertResource, an error must not be returned. Any validation should be done before calling it.
 
 	r.ComponentSpec = spec
+	if r.ComponentSpec.DisplayName == "" {
+		r.ComponentSpec.DisplayName = node.Name
+	}
 
 	return nil
 }

--- a/runtime/compilers/rillv1/parse_explore.go
+++ b/runtime/compilers/rillv1/parse_explore.go
@@ -267,7 +267,7 @@ func (p *Parser) parseExplore(node *Node) error {
 
 	r.ExploreSpec.DisplayName = tmp.DisplayName
 	if r.ExploreSpec.DisplayName == "" {
-		r.ExploreSpec.DisplayName = node.Name
+		r.ExploreSpec.DisplayName = ToDisplayName(node.Name)
 	}
 	r.ExploreSpec.Description = tmp.Description
 	r.ExploreSpec.MetricsView = tmp.MetricsView

--- a/runtime/compilers/rillv1/parse_explore.go
+++ b/runtime/compilers/rillv1/parse_explore.go
@@ -266,6 +266,9 @@ func (p *Parser) parseExplore(node *Node) error {
 	// NOTE: After calling insertResource, an error must not be returned. Any validation should be done before calling it.
 
 	r.ExploreSpec.DisplayName = tmp.DisplayName
+	if r.ExploreSpec.DisplayName == "" {
+		r.ExploreSpec.DisplayName = node.Name
+	}
 	r.ExploreSpec.Description = tmp.Description
 	r.ExploreSpec.MetricsView = tmp.MetricsView
 	r.ExploreSpec.Dimensions = dimensions

--- a/runtime/compilers/rillv1/parse_metrics_view.go
+++ b/runtime/compilers/rillv1/parse_metrics_view.go
@@ -530,6 +530,10 @@ func (p *Parser) parseMetricsView(node *Node) error {
 			dim.DisplayName = dim.Label
 		}
 
+		if dim.DisplayName == "" {
+			dim.DisplayName = dim.Name
+		}
+
 		if (dim.Column == "" && dim.Expression == "") || (dim.Column != "" && dim.Expression != "") {
 			return fmt.Errorf("exactly one of column or expression should be set for dimension: %q", dim.Name)
 		}
@@ -561,6 +565,10 @@ func (p *Parser) parseMetricsView(node *Node) error {
 		// Backwards compatibility
 		if measure.Label != "" && measure.DisplayName == "" {
 			measure.DisplayName = measure.Label
+		}
+
+		if measure.DisplayName == "" {
+			measure.DisplayName = measure.Name
 		}
 
 		lower := strings.ToLower(measure.Name)
@@ -783,6 +791,9 @@ func (p *Parser) parseMetricsView(node *Node) error {
 	spec.Table = tmp.Table
 	spec.Model = tmp.Model
 	spec.DisplayName = tmp.DisplayName
+	if spec.DisplayName == "" {
+		spec.DisplayName = node.Name
+	}
 	spec.Description = tmp.Description
 	spec.TimeDimension = tmp.TimeDimension
 	spec.WatermarkExpression = tmp.Watermark

--- a/runtime/compilers/rillv1/parse_metrics_view.go
+++ b/runtime/compilers/rillv1/parse_metrics_view.go
@@ -531,7 +531,7 @@ func (p *Parser) parseMetricsView(node *Node) error {
 		}
 
 		if dim.DisplayName == "" {
-			dim.DisplayName = dim.Name
+			dim.DisplayName = ToDisplayName(dim.Name)
 		}
 
 		if (dim.Column == "" && dim.Expression == "") || (dim.Column != "" && dim.Expression != "") {
@@ -568,7 +568,7 @@ func (p *Parser) parseMetricsView(node *Node) error {
 		}
 
 		if measure.DisplayName == "" {
-			measure.DisplayName = measure.Name
+			measure.DisplayName = ToDisplayName(measure.Name)
 		}
 
 		lower := strings.ToLower(measure.Name)
@@ -792,7 +792,7 @@ func (p *Parser) parseMetricsView(node *Node) error {
 	spec.Model = tmp.Model
 	spec.DisplayName = tmp.DisplayName
 	if spec.DisplayName == "" {
-		spec.DisplayName = node.Name
+		spec.DisplayName = ToDisplayName(node.Name)
 	}
 	spec.Description = tmp.Description
 	spec.TimeDimension = tmp.TimeDimension

--- a/runtime/compilers/rillv1/parse_report.go
+++ b/runtime/compilers/rillv1/parse_report.go
@@ -184,6 +184,9 @@ func (p *Parser) parseReport(node *Node) error {
 	// NOTE: After calling insertResource, an error must not be returned. Any validation should be done before calling it.
 
 	r.ReportSpec.DisplayName = tmp.DisplayName
+	if r.ReportSpec.DisplayName == "" {
+		r.ReportSpec.DisplayName = node.Name
+	}
 	if schedule != nil {
 		r.ReportSpec.RefreshSchedule = schedule
 	}

--- a/runtime/compilers/rillv1/parse_report.go
+++ b/runtime/compilers/rillv1/parse_report.go
@@ -185,7 +185,7 @@ func (p *Parser) parseReport(node *Node) error {
 
 	r.ReportSpec.DisplayName = tmp.DisplayName
 	if r.ReportSpec.DisplayName == "" {
-		r.ReportSpec.DisplayName = node.Name
+		r.ReportSpec.DisplayName = ToDisplayName(node.Name)
 	}
 	if schedule != nil {
 		r.ReportSpec.RefreshSchedule = schedule

--- a/runtime/compilers/rillv1/parser_test.go
+++ b/runtime/compilers/rillv1/parser_test.go
@@ -1574,6 +1574,7 @@ theme:
 			Paths: []string{"/explores/e1.yaml"},
 			Refs:  []ResourceName{{Kind: ResourceKindMetricsView, Name: "missing"}, {Kind: ResourceKindTheme, Name: "t1"}},
 			ExploreSpec: &runtimev1.ExploreSpec{
+				DisplayName:        "E1",
 				MetricsView:        "missing",
 				DimensionsSelector: &runtimev1.FieldSelector{Selector: &runtimev1.FieldSelector_All{All: true}},
 				MeasuresSelector:   &runtimev1.FieldSelector{Selector: &runtimev1.FieldSelector_All{All: true}},
@@ -1585,6 +1586,7 @@ theme:
 			Paths: []string{"/explores/e2.yaml"},
 			Refs:  []ResourceName{{Kind: ResourceKindMetricsView, Name: "missing"}},
 			ExploreSpec: &runtimev1.ExploreSpec{
+				DisplayName:        "E2",
 				MetricsView:        "missing",
 				DimensionsSelector: &runtimev1.FieldSelector{Selector: &runtimev1.FieldSelector_All{All: true}},
 				MeasuresSelector:   &runtimev1.FieldSelector{Selector: &runtimev1.FieldSelector_All{All: true}},
@@ -1670,6 +1672,7 @@ items:
 			Paths: []string{"/components/c1.yaml"},
 			Refs:  []ResourceName{{Kind: ResourceKindAPI, Name: "MetricsViewAggregation"}},
 			ComponentSpec: &runtimev1.ComponentSpec{
+				DisplayName:        "C1",
 				Resolver:           "api",
 				ResolverProperties: must(structpb.NewStruct(map[string]any{"api": "MetricsViewAggregation", "args": map[string]any{"metrics_view": "foo"}})),
 				Renderer:           "vega_lite",
@@ -1681,6 +1684,7 @@ items:
 			Paths: []string{"/components/c2.yaml"},
 			Refs:  []ResourceName{{Kind: ResourceKindAPI, Name: "MetricsViewAggregation"}},
 			ComponentSpec: &runtimev1.ComponentSpec{
+				DisplayName:        "C2",
 				Resolver:           "api",
 				ResolverProperties: must(structpb.NewStruct(map[string]any{"api": "MetricsViewAggregation", "args": map[string]any{"metrics_view": "bar"}})),
 				Renderer:           "vega_lite",
@@ -1691,6 +1695,7 @@ items:
 			Name:  ResourceName{Kind: ResourceKindComponent, Name: "c3"},
 			Paths: []string{"/components/c3.yaml"},
 			ComponentSpec: &runtimev1.ComponentSpec{
+				DisplayName:        "C3",
 				Resolver:           "metrics_sql",
 				ResolverProperties: must(structpb.NewStruct(map[string]any{"sql": "SELECT 1"})),
 				Renderer:           "line_chart",
@@ -1715,8 +1720,9 @@ items:
 				{Kind: ResourceKindComponent, Name: "d1--component-2"},
 			},
 			CanvasSpec: &runtimev1.CanvasSpec{
-				Columns: 4,
-				Gap:     3,
+				DisplayName: "D1",
+				Columns:     4,
+				Gap:         3,
 				Items: []*runtimev1.CanvasItem{
 					{Component: "c1"},
 					{Component: "c2", Width: asPtr(uint32(1)), Height: asPtr(uint32(2))},

--- a/runtime/compilers/rillv1/parser_test.go
+++ b/runtime/compilers/rillv1/parser_test.go
@@ -276,14 +276,16 @@ schema: default
 			Refs:  []ResourceName{{Kind: ResourceKindModel, Name: "m2"}},
 			Paths: []string{"/metrics/d1.yaml"},
 			MetricsViewSpec: &runtimev1.MetricsViewSpec{
-				Connector: "duckdb",
-				Model:     "m2",
+				Connector:   "duckdb",
+				Model:       "m2",
+				DisplayName: "D1",
 				Dimensions: []*runtimev1.MetricsViewSpec_DimensionV2{
-					{Name: "a", Column: "a"},
+					{Name: "a", DisplayName: "A", Column: "a"},
 				},
 				Measures: []*runtimev1.MetricsViewSpec_MeasureV2{
 					{
 						Name:           "b",
+						DisplayName:    "B",
 						Expression:     "count(*)",
 						Type:           runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE,
 						FormatD3:       "0,0",
@@ -1069,13 +1071,14 @@ security:
 			Name:  ResourceName{Kind: ResourceKindMetricsView, Name: "mv1"},
 			Paths: []string{"/mv1.yaml"},
 			MetricsViewSpec: &runtimev1.MetricsViewSpec{
-				Connector: "duckdb",
-				Table:     "t1",
+				Connector:   "duckdb",
+				Table:       "t1",
+				DisplayName: "Mv1",
 				Dimensions: []*runtimev1.MetricsViewSpec_DimensionV2{
-					{Name: "a", Column: "a"},
+					{Name: "a", DisplayName: "A", Column: "a"},
 				},
 				Measures: []*runtimev1.MetricsViewSpec_MeasureV2{
-					{Name: "b", Expression: "count(*)", Type: runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE},
+					{Name: "b", DisplayName: "B", Expression: "count(*)", Type: runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE},
 				},
 				FirstDayOfWeek: 7,
 				SecurityRules: []*runtimev1.SecurityRule{
@@ -1091,13 +1094,14 @@ security:
 			Name:  ResourceName{Kind: ResourceKindMetricsView, Name: "mv2"},
 			Paths: []string{"/mv2.yaml"},
 			MetricsViewSpec: &runtimev1.MetricsViewSpec{
-				Connector: "duckdb",
-				Table:     "t2",
+				Connector:   "duckdb",
+				Table:       "t2",
+				DisplayName: "Mv2",
 				Dimensions: []*runtimev1.MetricsViewSpec_DimensionV2{
-					{Name: "a", Column: "a"},
+					{Name: "a", DisplayName: "A", Column: "a"},
 				},
 				Measures: []*runtimev1.MetricsViewSpec_MeasureV2{
-					{Name: "b", Expression: "count(*)", Type: runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE},
+					{Name: "b", DisplayName: "B", Expression: "count(*)", Type: runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE},
 				},
 				FirstDayOfWeek: 1,
 				SecurityRules: []*runtimev1.SecurityRule{
@@ -1209,13 +1213,14 @@ security:
 			Name:  ResourceName{Kind: ResourceKindMetricsView, Name: "d1"},
 			Paths: []string{"/metrics/d1.yaml"},
 			MetricsViewSpec: &runtimev1.MetricsViewSpec{
-				Connector: "duckdb",
-				Table:     "t1",
+				Connector:   "duckdb",
+				Table:       "t1",
+				DisplayName: "D1",
 				Dimensions: []*runtimev1.MetricsViewSpec_DimensionV2{
-					{Name: "a", Column: "a"},
+					{Name: "a", DisplayName: "A", Column: "a"},
 				},
 				Measures: []*runtimev1.MetricsViewSpec_MeasureV2{
-					{Name: "b", Expression: "count(*)", Type: runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE},
+					{Name: "b", DisplayName: "B", Expression: "count(*)", Type: runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE},
 				},
 				SecurityRules: []*runtimev1.SecurityRule{
 					{Rule: &runtimev1.SecurityRule_Access{Access: &runtimev1.SecurityRuleAccess{
@@ -1497,13 +1502,14 @@ measures:
 			Refs:  nil, // NOTE: This is what we're testing – that it avoids inferring the missing "d1" as a self-reference
 			Paths: []string{"/metrics/d1.yaml"},
 			MetricsViewSpec: &runtimev1.MetricsViewSpec{
-				Connector: "duckdb",
-				Table:     "d1",
+				Connector:   "duckdb",
+				Table:       "d1",
+				DisplayName: "D1",
 				Dimensions: []*runtimev1.MetricsViewSpec_DimensionV2{
-					{Name: "a", Column: "a"},
+					{Name: "a", DisplayName: "A", Column: "a"},
 				},
 				Measures: []*runtimev1.MetricsViewSpec_MeasureV2{
-					{Name: "b", Expression: "count(*)", Type: runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE},
+					{Name: "b", DisplayName: "B", Expression: "count(*)", Type: runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE},
 				},
 			},
 		},
@@ -1901,33 +1907,38 @@ measures:
 			MetricsViewSpec: &runtimev1.MetricsViewSpec{
 				Connector:     "duckdb",
 				Table:         "t1",
+				DisplayName:   "D1",
 				TimeDimension: "t",
 				Dimensions: []*runtimev1.MetricsViewSpec_DimensionV2{
-					{Name: "foo", Column: "foo"},
+					{Name: "foo", DisplayName: "Foo", Column: "foo"},
 				},
 				Measures: []*runtimev1.MetricsViewSpec_MeasureV2{
 					{
-						Name:       "a",
-						Expression: "count(*)",
-						Type:       runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE,
+						Name:        "a",
+						DisplayName: "A",
+						Expression:  "count(*)",
+						Type:        runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE,
 					},
 					{
 						Name:               "b",
+						DisplayName:        "B",
 						Expression:         "a+1",
 						Type:               runtimev1.MetricsViewSpec_MEASURE_TYPE_DERIVED,
 						ReferencedMeasures: []string{"a"},
 					},
 					{
 						Name:               "c",
+						DisplayName:        "C",
 						Expression:         "sum(a)",
 						Type:               runtimev1.MetricsViewSpec_MEASURE_TYPE_DERIVED,
 						PerDimensions:      []*runtimev1.MetricsViewSpec_DimensionSelector{{Name: "foo"}},
 						ReferencedMeasures: []string{"a"},
 					},
 					{
-						Name:       "d",
-						Expression: "a/lag(a)",
-						Type:       runtimev1.MetricsViewSpec_MEASURE_TYPE_DERIVED,
+						Name:        "d",
+						DisplayName: "D",
+						Expression:  "a/lag(a)",
+						Type:        runtimev1.MetricsViewSpec_MEASURE_TYPE_DERIVED,
 						Window: &runtimev1.MetricsViewSpec_MeasureWindow{
 							Partition:       true,
 							OrderBy:         []*runtimev1.MetricsViewSpec_DimensionSelector{{Name: "t", TimeGrain: runtimev1.TimeGrain_TIME_GRAIN_DAY}},

--- a/runtime/compilers/rillv1/util.go
+++ b/runtime/compilers/rillv1/util.go
@@ -7,7 +7,7 @@ import (
 	"golang.org/x/text/language"
 )
 
-// toDisplayName converts a snake_case name to a display name by replacing underscores and dashes with spaces and capitalizing the first letter.
+// toDisplayName converts a snake_case name to a display name by replacing underscores and dashes with spaces and capitalizing every word.
 func ToDisplayName(name string) string {
 	// Don't transform names that start with an underscore (since it's probably internal).
 	if name != "" && name[0] == '_' {

--- a/runtime/compilers/rillv1/util.go
+++ b/runtime/compilers/rillv1/util.go
@@ -1,0 +1,25 @@
+package rillv1
+
+import (
+	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// toDisplayName converts a snake_case name to a display name by replacing underscores and dashes with spaces and capitalizing the first letter.
+func ToDisplayName(name string) string {
+	// Don't transform names that start with an underscore (since it's probably internal).
+	if name != "" && name[0] == '_' {
+		return name
+	}
+
+	// Replace underscores and dashes with spaces.
+	name = strings.ReplaceAll(name, "_", " ")
+	name = strings.ReplaceAll(name, "-", " ")
+
+	// Capitalize the first letter.
+	name = cases.Title(language.English).String(name)
+
+	return name
+}

--- a/runtime/compilers/rillv1/util_test.go
+++ b/runtime/compilers/rillv1/util_test.go
@@ -1,0 +1,27 @@
+package rillv1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToDisplayName(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{"", ""},
+		{"foo", "Foo"},
+		{"foo_bar", "Foo Bar"},
+		{"foo-bar", "Foo Bar"},
+		{"_foo", "_foo"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := ToDisplayName(test.name)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/runtime/controller_test.go
+++ b/runtime/controller_test.go
@@ -101,10 +101,11 @@ measures:
 
 	// Verify the metrics view
 	mvSpec := &runtimev1.MetricsViewSpec{
-		Connector:  "duckdb",
-		Model:      "bar",
-		Dimensions: []*runtimev1.MetricsViewSpec_DimensionV2{{Name: "a", Column: "a"}},
-		Measures:   []*runtimev1.MetricsViewSpec_MeasureV2{{Name: "b", Expression: "count(*)", Type: runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE}},
+		Connector:   "duckdb",
+		Model:       "bar",
+		Dimensions:  []*runtimev1.MetricsViewSpec_DimensionV2{{Name: "a", DisplayName: "a", Column: "a"}},
+		Measures:    []*runtimev1.MetricsViewSpec_MeasureV2{{Name: "b", DisplayName: "b", Expression: "count(*)", Type: runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE}},
+		DisplayName: "foobar",
 	}
 	testruntime.RequireResource(t, rt, id, &runtimev1.Resource{
 		Meta: &runtimev1.ResourceMeta{
@@ -118,11 +119,12 @@ measures:
 				Spec: mvSpec,
 				State: &runtimev1.MetricsViewState{
 					ValidSpec: &runtimev1.MetricsViewSpec{
-						Connector:  "duckdb",
-						Model:      "bar",
-						Table:      "bar",
-						Dimensions: []*runtimev1.MetricsViewSpec_DimensionV2{{Name: "a", Column: "a"}},
-						Measures:   []*runtimev1.MetricsViewSpec_MeasureV2{{Name: "b", Expression: "count(*)", Type: runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE}},
+						Connector:   "duckdb",
+						Table:       "bar",
+						Model:       "bar",
+						DisplayName: "foobar",
+						Dimensions:  []*runtimev1.MetricsViewSpec_DimensionV2{{Name: "a", DisplayName: "a", Column: "a"}},
+						Measures:    []*runtimev1.MetricsViewSpec_MeasureV2{{Name: "b", DisplayName: "b", Expression: "count(*)", Type: runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE}},
 					},
 				},
 			},
@@ -1464,25 +1466,30 @@ func newMetricsView(name, model string, measures, dimensions []string) (*runtime
 	}
 
 	for i, measure := range measures {
+		name := fmt.Sprintf("measure_%d", i)
 		metrics.Spec.Measures[i] = &runtimev1.MetricsViewSpec_MeasureV2{
-			Name:       fmt.Sprintf("measure_%d", i),
-			Expression: measure,
-			Type:       runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE,
+			Name:        name,
+			DisplayName: name,
+			Expression:  measure,
+			Type:        runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE,
 		}
 		metrics.State.ValidSpec.Measures[i] = &runtimev1.MetricsViewSpec_MeasureV2{
-			Name:       fmt.Sprintf("measure_%d", i),
-			Expression: measure,
-			Type:       runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE,
+			Name:        name,
+			DisplayName: name,
+			Expression:  measure,
+			Type:        runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE,
 		}
 	}
 	for i, dimension := range dimensions {
 		metrics.Spec.Dimensions[i] = &runtimev1.MetricsViewSpec_DimensionV2{
-			Name:   dimension,
-			Column: dimension,
+			Name:        dimension,
+			DisplayName: dimension,
+			Column:      dimension,
 		}
 		metrics.State.ValidSpec.Dimensions[i] = &runtimev1.MetricsViewSpec_DimensionV2{
-			Name:   dimension,
-			Column: dimension,
+			Name:        dimension,
+			DisplayName: dimension,
+			Column:      dimension,
 		}
 	}
 	metricsRes := &runtimev1.Resource{

--- a/runtime/controller_test.go
+++ b/runtime/controller_test.go
@@ -9,6 +9,7 @@ import (
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
+	"github.com/rilldata/rill/runtime/compilers/rillv1"
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/testruntime"
 	"github.com/stretchr/testify/require"
@@ -103,9 +104,9 @@ measures:
 	mvSpec := &runtimev1.MetricsViewSpec{
 		Connector:   "duckdb",
 		Model:       "bar",
-		Dimensions:  []*runtimev1.MetricsViewSpec_DimensionV2{{Name: "a", DisplayName: "a", Column: "a"}},
-		Measures:    []*runtimev1.MetricsViewSpec_MeasureV2{{Name: "b", DisplayName: "b", Expression: "count(*)", Type: runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE}},
-		DisplayName: "foobar",
+		Dimensions:  []*runtimev1.MetricsViewSpec_DimensionV2{{Name: "a", DisplayName: "A", Column: "a"}},
+		Measures:    []*runtimev1.MetricsViewSpec_MeasureV2{{Name: "b", DisplayName: "B", Expression: "count(*)", Type: runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE}},
+		DisplayName: "Foobar",
 	}
 	testruntime.RequireResource(t, rt, id, &runtimev1.Resource{
 		Meta: &runtimev1.ResourceMeta{
@@ -122,9 +123,9 @@ measures:
 						Connector:   "duckdb",
 						Table:       "bar",
 						Model:       "bar",
-						DisplayName: "foobar",
-						Dimensions:  []*runtimev1.MetricsViewSpec_DimensionV2{{Name: "a", DisplayName: "a", Column: "a"}},
-						Measures:    []*runtimev1.MetricsViewSpec_MeasureV2{{Name: "b", DisplayName: "b", Expression: "count(*)", Type: runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE}},
+						DisplayName: "Foobar",
+						Dimensions:  []*runtimev1.MetricsViewSpec_DimensionV2{{Name: "a", DisplayName: "A", Column: "a"}},
+						Measures:    []*runtimev1.MetricsViewSpec_MeasureV2{{Name: "b", DisplayName: "B", Expression: "count(*)", Type: runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE}},
 					},
 				},
 			},
@@ -698,7 +699,7 @@ path: data/foo.csv
 		"/metrics/dash.yaml": `
 version: 1
 type: metrics_view
-display_name: dash
+display_name: Dash
 model: bar3
 dimensions:
 - column: b
@@ -849,7 +850,7 @@ path: data/foo.csv
 		"/metrics/dash.yaml": `
 version: 1
 type: metrics_view
-display_name: dash
+display_name: Dash
 model: bar
 dimensions:
 - column: b
@@ -870,7 +871,7 @@ measures:
 		"/metrics/dash.yaml": `
 version: 1
 type: metrics_view
-display_name: dash
+display_name: Dash
 model: bar
 dimensions:
 - column: b
@@ -892,7 +893,7 @@ measures:
 		"/metrics/dash.yaml": `
 version: 1
 type: metrics_view
-display_name: dash
+display_name: Dash
 model: bar
 dimensions:
 - column: b
@@ -914,7 +915,7 @@ measures:
 		"/metrics/dash.yaml": `
 version: 1
 type: metrics_view
-display_name: dash
+display_name: Dash
 model: bar
 dimensions:
 - column: b
@@ -937,7 +938,7 @@ measures:
 		"/metrics/dash.yaml": `
 version: 1
 type: metrics_view
-display_name: dash
+display_name: Dash
 model: bar
 dimensions:
 - column: b
@@ -958,7 +959,7 @@ measures:
 		"/metrics/dash.yaml": `
 version: 1
 type: metrics_view
-display_name: dash
+display_name: Dash
 model: bar
 dimensions:
 - column: b
@@ -979,7 +980,7 @@ measures:
 		"/metrics/dash.yaml": `
 version: 1
 type: metrics_view
-display_name: dash
+display_name: Dash
 model: bar
 dimensions:
 - column: b
@@ -1000,7 +1001,7 @@ measures:
 		"/metrics/dash.yaml": `
 version: 1
 type: metrics_view
-display_name: dash
+display_name: Dash
 model: bar
 dimensions:
 - column: b
@@ -1046,7 +1047,7 @@ path: data/foo.csv
 		"/metrics/dash.yaml": `
 version: 1
 type: metrics_view
-display_name: dash
+display_name: Dash
 model: bar
 dimensions:
 - column: b
@@ -1138,7 +1139,7 @@ path: data/foo.csv
 		"/metrics/dash.yaml": `
 version: 1
 type: metrics_view
-display_name: dash
+display_name: Dash
 model: bar
 dimensions:
 - column: b
@@ -1274,7 +1275,7 @@ path: data/foo.csv
 		"/metrics/dash.yaml": `
 version: 1
 type: metrics_view
-display_name: dash
+display_name: Dash
 model: bar
 dimensions:
 - column: country
@@ -1449,7 +1450,7 @@ func newMetricsView(name, model string, measures, dimensions []string) (*runtime
 		Spec: &runtimev1.MetricsViewSpec{
 			Connector:   "duckdb",
 			Model:       model,
-			DisplayName: name,
+			DisplayName: rillv1.ToDisplayName(name),
 			Measures:    make([]*runtimev1.MetricsViewSpec_MeasureV2, len(measures)),
 			Dimensions:  make([]*runtimev1.MetricsViewSpec_DimensionV2, len(dimensions)),
 		},
@@ -1458,7 +1459,7 @@ func newMetricsView(name, model string, measures, dimensions []string) (*runtime
 				Connector:   "duckdb",
 				Table:       model,
 				Model:       model,
-				DisplayName: name,
+				DisplayName: rillv1.ToDisplayName(name),
 				Measures:    make([]*runtimev1.MetricsViewSpec_MeasureV2, len(measures)),
 				Dimensions:  make([]*runtimev1.MetricsViewSpec_DimensionV2, len(dimensions)),
 			},
@@ -1469,13 +1470,13 @@ func newMetricsView(name, model string, measures, dimensions []string) (*runtime
 		name := fmt.Sprintf("measure_%d", i)
 		metrics.Spec.Measures[i] = &runtimev1.MetricsViewSpec_MeasureV2{
 			Name:        name,
-			DisplayName: name,
+			DisplayName: rillv1.ToDisplayName(name),
 			Expression:  measure,
 			Type:        runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE,
 		}
 		metrics.State.ValidSpec.Measures[i] = &runtimev1.MetricsViewSpec_MeasureV2{
 			Name:        name,
-			DisplayName: name,
+			DisplayName: rillv1.ToDisplayName(name),
 			Expression:  measure,
 			Type:        runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE,
 		}
@@ -1483,12 +1484,12 @@ func newMetricsView(name, model string, measures, dimensions []string) (*runtime
 	for i, dimension := range dimensions {
 		metrics.Spec.Dimensions[i] = &runtimev1.MetricsViewSpec_DimensionV2{
 			Name:        dimension,
-			DisplayName: dimension,
+			DisplayName: rillv1.ToDisplayName(dimension),
 			Column:      dimension,
 		}
 		metrics.State.ValidSpec.Dimensions[i] = &runtimev1.MetricsViewSpec_DimensionV2{
 			Name:        dimension,
-			DisplayName: dimension,
+			DisplayName: rillv1.ToDisplayName(dimension),
 			Column:      dimension,
 		}
 	}

--- a/runtime/queries/metricsview_aggregation_test.go
+++ b/runtime/queries/metricsview_aggregation_test.go
@@ -657,7 +657,6 @@ func TestMetricsViewsAggregation_pivot_export_nolabel(t *testing.T) {
 			{
 				Name: "nolabel_pub",
 			},
-
 			{
 				Name:      "timestamp",
 				TimeGrain: runtimev1.TimeGrain_TIME_GRAIN_MONTH,
@@ -711,7 +710,6 @@ func TestMetricsViewsAggregation_pivot_export_nolabel_measure(t *testing.T) {
 			{
 				Name: "nolabel_pub",
 			},
-
 			{
 				Name:      "timestamp",
 				TimeGrain: runtimev1.TimeGrain_TIME_GRAIN_MONTH,
@@ -741,9 +739,9 @@ func TestMetricsViewsAggregation_pivot_export_nolabel_measure(t *testing.T) {
 
 	require.Equal(t, 4, len(q.Result.Schema.Fields))
 	require.Equal(t, "nolabel_pub", q.Result.Schema.Fields[0].Name)
-	require.Equal(t, "2022-01-01 00:00:00_m1", q.Result.Schema.Fields[1].Name)
-	require.Equal(t, "2022-02-01 00:00:00_m1", q.Result.Schema.Fields[2].Name)
-	require.Equal(t, "2022-03-01 00:00:00_m1", q.Result.Schema.Fields[3].Name)
+	require.Equal(t, "2022-01-01 00:00:00_M1", q.Result.Schema.Fields[1].Name)
+	require.Equal(t, "2022-02-01 00:00:00_M1", q.Result.Schema.Fields[2].Name)
+	require.Equal(t, "2022-03-01 00:00:00_M1", q.Result.Schema.Fields[3].Name)
 
 	i := 0
 	require.Equal(t, "Facebook", fieldsToString(rows[i], "nolabel_pub"))

--- a/runtime/reconcilers/alert_test.go
+++ b/runtime/reconcilers/alert_test.go
@@ -8,6 +8,7 @@ import (
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
+	"github.com/rilldata/rill/runtime/compilers/rillv1"
 	"github.com/rilldata/rill/runtime/pkg/email"
 	"github.com/rilldata/rill/runtime/testruntime"
 	"github.com/stretchr/testify/require"
@@ -26,7 +27,6 @@ SELECT '2024-01-01T00:00:00Z'::TIMESTAMP as __time, 'Denmark' as country
 		"/metrics/mv1.yaml": `
 version: 1
 type: metrics_view
-display_name: mv1
 model: bar
 timeseries: __time
 dimensions:
@@ -162,7 +162,7 @@ SELECT '2024-01-04T00:00:00Z'::TIMESTAMP as __time, 'Denmark' as country
 				Status: runtimev1.AssertionStatus_ASSERTION_STATUS_FAIL,
 				FailRow: must(structpb.NewStruct(map[string]any{
 					"country":   "Denmark",
-					"measure_0": "4",
+					"Measure 0": "4",
 				})),
 			},
 			SentNotifications: true,
@@ -187,7 +187,6 @@ SELECT '2024-01-01T00:00:00Z'::TIMESTAMP as __time, 'Denmark' as country
 		"/metrics/mv1.yaml": `
 version: 1
 type: metrics_view
-display_name: mv1
 model: bar
 timeseries: __time
 dimensions:
@@ -321,7 +320,7 @@ SELECT '2024-01-04T00:00:00Z'::TIMESTAMP as __time, 'Denmark' as country
 				Status: runtimev1.AssertionStatus_ASSERTION_STATUS_FAIL,
 				FailRow: must(structpb.NewStruct(map[string]any{
 					"country":   "Denmark",
-					"measure_0": "4",
+					"Measure 0": "4",
 				})),
 			},
 			SentNotifications: true,
@@ -472,7 +471,6 @@ SELECT '2024-01-01T00:00:00Z'::TIMESTAMP as __time, 'Denmark' as country
 		"/metrics/mv1.yaml": `
 version: 1
 type: metrics_view
-display_name: mv1
 model: bar
 timeseries: __time
 dimensions:
@@ -580,7 +578,7 @@ func newMetricsView(name, model, timeDim string, measures, dimensions []string) 
 		Spec: &runtimev1.MetricsViewSpec{
 			Connector:     "duckdb",
 			Model:         model,
-			DisplayName:   name,
+			DisplayName:   rillv1.ToDisplayName(name),
 			TimeDimension: timeDim,
 			Measures:      make([]*runtimev1.MetricsViewSpec_MeasureV2, len(measures)),
 			Dimensions:    make([]*runtimev1.MetricsViewSpec_DimensionV2, len(dimensions)),
@@ -590,7 +588,7 @@ func newMetricsView(name, model, timeDim string, measures, dimensions []string) 
 				Connector:     "duckdb",
 				Table:         model,
 				Model:         model,
-				DisplayName:   name,
+				DisplayName:   rillv1.ToDisplayName(name),
 				TimeDimension: timeDim,
 				Measures:      make([]*runtimev1.MetricsViewSpec_MeasureV2, len(measures)),
 				Dimensions:    make([]*runtimev1.MetricsViewSpec_DimensionV2, len(dimensions)),
@@ -598,25 +596,30 @@ func newMetricsView(name, model, timeDim string, measures, dimensions []string) 
 		},
 	}
 	for i, measure := range measures {
+		name := fmt.Sprintf("measure_%d", i)
 		metrics.Spec.Measures[i] = &runtimev1.MetricsViewSpec_MeasureV2{
-			Name:       fmt.Sprintf("measure_%d", i),
-			Expression: measure,
-			Type:       runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE,
+			Name:        name,
+			DisplayName: rillv1.ToDisplayName(name),
+			Expression:  measure,
+			Type:        runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE,
 		}
 		metrics.State.ValidSpec.Measures[i] = &runtimev1.MetricsViewSpec_MeasureV2{
-			Name:       fmt.Sprintf("measure_%d", i),
-			Expression: measure,
-			Type:       runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE,
+			Name:        name,
+			DisplayName: rillv1.ToDisplayName(name),
+			Expression:  measure,
+			Type:        runtimev1.MetricsViewSpec_MEASURE_TYPE_SIMPLE,
 		}
 	}
 	for i, dimension := range dimensions {
 		metrics.Spec.Dimensions[i] = &runtimev1.MetricsViewSpec_DimensionV2{
-			Name:   dimension,
-			Column: dimension,
+			Name:        dimension,
+			DisplayName: rillv1.ToDisplayName(dimension),
+			Column:      dimension,
 		}
 		metrics.State.ValidSpec.Dimensions[i] = &runtimev1.MetricsViewSpec_DimensionV2{
-			Name:   dimension,
-			Column: dimension,
+			Name:        dimension,
+			DisplayName: rillv1.ToDisplayName(dimension),
+			Column:      dimension,
 		}
 	}
 	metricsRes := &runtimev1.Resource{

--- a/runtime/testruntime/testdata/ad_bids/dashboards/ad_bids_metrics.yaml
+++ b/runtime/testruntime/testdata/ad_bids/dashboards/ad_bids_metrics.yaml
@@ -16,6 +16,7 @@ dimensions:
     property: domain
     description: ""
   - name: nolabel_pub
+    display_name: nolabel_pub
     property: publisher
   - name: space_label
     display_name: Space Label


### PR DESCRIPTION
This PR adds a default value for `display_name` for resources as well as a metrics view's dimensions and measures. The default is a humanized version of the resource's `name`. For example, if the name is `foo_bar`, the default display name becomes `Foo Bar`.