### PR TITLE
Runtime: Prevent resource protos from being mutated after being read

### DIFF
--- a/runtime/reconcilers/alert.go
+++ b/runtime/reconcilers/alert.go
@@ -360,7 +360,7 @@ func (r *AlertReconciler) setTriggerFalse(ctx context.Context, n *runtimev1.Reso
 	r.C.Lock(ctx)
 	defer r.C.Unlock(ctx)
 
-	self, err := r.C.Get(ctx, n, false)
+	self, err := r.C.Get(ctx, n, true)
 	if err != nil {
 		return err
 	}

--- a/runtime/reconcilers/model.go
+++ b/runtime/reconcilers/model.go
@@ -550,7 +550,7 @@ func (r *ModelReconciler) updateTriggerFalse(ctx context.Context, n *runtimev1.R
 	r.C.Lock(ctx)
 	defer r.C.Unlock(ctx)
 
-	self, err := r.C.Get(ctx, n, false)
+	self, err := r.C.Get(ctx, n, true)
 	if err != nil {
 		return err
 	}

--- a/runtime/reconcilers/refresh_trigger.go
+++ b/runtime/reconcilers/refresh_trigger.go
@@ -146,7 +146,7 @@ func (r *RefreshTriggerReconciler) Reconcile(ctx context.Context, n *runtimev1.R
 
 	// Handle generic resource triggers
 	for _, rn := range trigger.Spec.Resources {
-		res, err := r.C.Get(ctx, rn, false)
+		res, err := r.C.Get(ctx, rn, true)
 		if err != nil {
 			// Skip triggers for non-existent resources
 			if !errors.Is(err, drivers.ErrResourceNotFound) {

--- a/runtime/reconcilers/report.go
+++ b/runtime/reconcilers/report.go
@@ -208,7 +208,7 @@ func (r *ReportReconciler) setTriggerFalse(ctx context.Context, n *runtimev1.Res
 	r.C.Lock(ctx)
 	defer r.C.Unlock(ctx)
 
-	self, err := r.C.Get(ctx, n, false)
+	self, err := r.C.Get(ctx, n, true)
 	if err != nil {
 		return err
 	}

--- a/runtime/reconcilers/source.go
+++ b/runtime/reconcilers/source.go
@@ -308,7 +308,7 @@ func (r *SourceReconciler) setTriggerFalse(ctx context.Context, n *runtimev1.Res
 	r.C.Lock(ctx)
 	defer r.C.Unlock(ctx)
 
-	self, err := r.C.Get(ctx, n, false)
+	self, err := r.C.Get(ctx, n, true)
 	if err != nil {
 		return err
 	}

--- a/runtime/testruntime/reconcile.go
+++ b/runtime/testruntime/reconcile.go
@@ -65,10 +65,9 @@ func RefreshAndWait(t testing.TB, rt *runtime.Runtime, id string, n *runtimev1.R
 	ctrl, err := rt.Controller(context.Background(), id)
 	require.NoError(t, err)
 
-	// Get spec version before refresh
-	r, err := ctrl.Get(context.Background(), n, false)
+	// Get resource before refresh
+	rPrev, err := ctrl.Get(context.Background(), n, false)
 	require.NoError(t, err)
-	prevSpecVersion := r.Meta.SpecVersion
 
 	// Create refresh trigger
 	trgName := &runtimev1.ResourceName{Kind: runtime.ResourceKindRefreshTrigger, Name: time.Now().String()}
@@ -87,8 +86,12 @@ func RefreshAndWait(t testing.TB, rt *runtime.Runtime, id string, n *runtimev1.R
 	err = ctrl.WaitUntilIdle(context.Background(), false)
 	require.NoError(t, err)
 
+	// Get resource after refresh
+	rNew, err := ctrl.Get(context.Background(), n, false)
+	require.NoError(t, err)
+
 	// Check the resource's spec version has increased
-	require.Greater(t, r.Meta.SpecVersion, prevSpecVersion)
+	require.Greater(t, rNew.Meta.SpecVersion, rPrev.Meta.SpecVersion)
 }
 
 func RequireReconcileState(t testing.TB, rt *runtime.Runtime, id string, lenResources, lenReconcileErrs, lenParseErrs int) {


### PR DESCRIPTION
Should fix [this issue reported in Slack](https://rilldata.slack.com/archives/CTCJ58H3M/p1733432211759179).