### PR TITLE
fix(Welcome screen): Avoid race condition after unpacking an empty project

### DIFF
--- a/web-common/src/features/sources/modal/FileDrop.svelte
+++ b/web-common/src/features/sources/modal/FileDrop.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
+  import { goto, invalidate } from "$app/navigation";
   import Overlay from "@rilldata/web-common/components/overlay/Overlay.svelte";
   import { getFilePathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import { EntityType } from "@rilldata/web-common/features/entity-management/types";
@@ -42,6 +42,11 @@
               displayName: EMPTY_PROJECT_TITLE,
             },
           });
+
+          // Race condition: invalidate("init") must be called before we navigate to
+          // `/files/${newFilePath}`. invalidate("init") is also called in the
+          // `WatchFilesClient`, but there it's not guaranteed to get invoked before we need it.
+          await invalidate("init");
         }
 
         const yaml = compileLocalFileSourceYAML(filePath);

--- a/web-common/src/features/sources/modal/LocalSourceUpload.svelte
+++ b/web-common/src/features/sources/modal/LocalSourceUpload.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
+  import { goto, invalidate } from "$app/navigation";
   import { Button } from "@rilldata/web-common/components/button";
   import { getFilePathFromNameAndType } from "@rilldata/web-common/features/entity-management/entity-mappers";
   import { EntityType } from "@rilldata/web-common/features/entity-management/types";
@@ -42,6 +42,11 @@
               displayName: EMPTY_PROJECT_TITLE,
             },
           });
+
+          // Race condition: invalidate("init") must be called before we navigate to
+          // `/files/${newFilePath}`. invalidate("init") is also called in the
+          // `WatchFilesClient`, but there it's not guaranteed to get invoked before we need it.
+          await invalidate("init");
         }
 
         const yaml = compileLocalFileSourceYAML(filePath);

--- a/web-common/src/features/sources/modal/submitAddDataForm.ts
+++ b/web-common/src/features/sources/modal/submitAddDataForm.ts
@@ -1,4 +1,4 @@
-import { goto } from "$app/navigation";
+import { goto, invalidate } from "$app/navigation";
 import { getScreenNameFromPage } from "@rilldata/web-common/features/file-explorer/telemetry";
 import { checkSourceImported } from "@rilldata/web-common/features/sources/source-imported-utils";
 import type { QueryClient } from "@tanstack/query-core";
@@ -58,6 +58,11 @@ export async function submitAddDataForm(
     await runtimeServiceUnpackEmpty(instanceId, {
       displayName: EMPTY_PROJECT_TITLE,
     });
+
+    // Race condition: invalidate("init") must be called before we navigate to
+    // `/files/${newFilePath}`. invalidate("init") is also called in the
+    // `WatchFilesClient`, but there it's not guaranteed to get invoked before we need it.
+    await invalidate("init");
   }
 
   // Convert the form values to Source YAML


### PR DESCRIPTION
On the Welcome screen, a race condition was sometimes preventing navigation to the user's first source file. See code comment for more detail.

Partially addresses https://github.com/rilldata/rill-private-issues/issues/991