### PR TITLE
fix: default timezone when timezones is not defined in yaml config

### DIFF
--- a/web-common/src/features/dashboards/time-controls/super-pill/SuperPill.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/SuperPill.svelte
@@ -10,7 +10,6 @@
   } from "@rilldata/web-common/lib/time/types";
   import type { V1TimeGrain } from "@rilldata/web-common/runtime-client";
   import { DateTime, Interval } from "luxon";
-  import { onMount } from "svelte";
   import {
     metricsExplorerStore,
     useExploreState,
@@ -132,23 +131,6 @@
 
     selectRange(baseTimeRange);
   }
-
-  // This is pulled directly from the old time controls and needs to be refactored
-  onMount(() => {
-    /**
-     * Remove the timezone selector if no timezone key is present
-     * or the available timezone list is empty. Set the default
-     * timezone to UTC in such cases.
-     *
-     */
-    if (
-      !availableTimeZones.length &&
-      $exploreState?.selectedTimezone !== "UTC"
-    ) {
-      metricsExplorerStore.setTimeZone($exploreName, "UTC");
-      localUserPreferences.set({ timeZone: "UTC" });
-    }
-  });
 
   function selectRange(range: TimeRange) {
     const defaultTimeGrain = getDefaultTimeGrain(range.start, range.end).grain;

--- a/web-common/src/features/dashboards/url-state/defaults.ts
+++ b/web-common/src/features/dashboards/url-state/defaults.ts
@@ -1,1 +1,2 @@
+export const ExploreStateDefaultTimezone = "UTC";
 export const ExploreStateDefaultChartType = "timeseries";

--- a/web-common/src/features/dashboards/url-state/getDefaultExplorePreset.ts
+++ b/web-common/src/features/dashboards/url-state/getDefaultExplorePreset.ts
@@ -1,6 +1,7 @@
 import { createAndExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
 import { getDefaultTimeGrain } from "@rilldata/web-common/features/dashboards/time-controls/time-range-utils";
 import { TDDChart } from "@rilldata/web-common/features/dashboards/time-dimension-details/types";
+import { ExploreStateDefaultTimezone } from "@rilldata/web-common/features/dashboards/url-state/defaults";
 import {
   ToURLParamTDDChartMap,
   ToURLParamTimeGrainMapMap,
@@ -54,13 +55,16 @@ export function getDefaultExplorePreset(
     ...(explore.defaultPreset ?? {}),
   };
 
-  if (
+  if (!explore.timeZones?.length) {
     // this is the old behaviour. if no timezones are configures for the explore, default it to UTC and not local IANA
-    !explore.timeZones?.length ||
+    defaultExplorePreset.timezone = ExploreStateDefaultTimezone;
+  } else if (!explore.timeZones?.includes(defaultExplorePreset.timezone!)) {
     // else if the default is not in the list of timezones
-    !explore.timeZones?.includes(defaultExplorePreset.timezone!)
-  ) {
-    defaultExplorePreset.timezone = "UTC";
+    if (explore.timeZones?.includes(ExploreStateDefaultTimezone)) {
+      defaultExplorePreset.timezone = ExploreStateDefaultTimezone;
+    } else {
+      defaultExplorePreset.timezone = explore.timeZones[0];
+    }
   }
 
   if (!defaultExplorePreset.timeGrain) {

--- a/web-common/src/features/dashboards/url-state/getDefaultExplorePreset.ts
+++ b/web-common/src/features/dashboards/url-state/getDefaultExplorePreset.ts
@@ -54,6 +54,15 @@ export function getDefaultExplorePreset(
     ...(explore.defaultPreset ?? {}),
   };
 
+  if (
+    // this is the old behaviour. if no timezones are configures for the explore, default it to UTC and not local IANA
+    !explore.timeZones?.length ||
+    // else if the default is not in the list of timezones
+    !explore.timeZones?.includes(defaultExplorePreset.timezone!)
+  ) {
+    defaultExplorePreset.timezone = "UTC";
+  }
+
   if (!defaultExplorePreset.timeGrain) {
     defaultExplorePreset.timeGrain = getDefaultPresetTimeGrain(
       defaultExplorePreset,


### PR DESCRIPTION
- Default timezone is UTC when timezones is not defined in the yaml config.
- If the localIANA is not preset in the list of timezones then default to UTC if it is in the list otherwise select the 1st timezone.