### PR TITLE
Skip validation of measure schema if driver doesn't return a valid type

### DIFF
--- a/runtime/metricsview/executor_validate.go
+++ b/runtime/metricsview/executor_validate.go
@@ -333,7 +333,8 @@ func (e *Executor) validateSchema(ctx context.Context, res *ValidateMetricsViewR
 	for i, m := range e.metricsView.Measures {
 		typ, ok := types[m.Name]
 		if !ok {
-			return fmt.Errorf("internal: measure %q not found in schema", m.Name)
+			// Don't error: schemas are not always reliable
+			continue
 		}
 
 		switch typ.Code {


### PR DESCRIPTION
Contributes to https://github.com/rilldata/rill-private-issues/issues/1013 (but doesn't truly fix it)