### PR TITLE
Fix the generated password not being idempotent in the ClickHouse provisioner

### DIFF
--- a/admin/provisioner/clickhousestatic/provisioner.go
+++ b/admin/provisioner/clickhousestatic/provisioner.go
@@ -110,7 +110,7 @@ func (p *Provisioner) Provision(ctx context.Context, r *provisioner.Resource, op
 
 	// When creating the user, the password assignment is not idempotent (if there are two concurrent invocations, we don't know which password was used).
 	// By adding the password separately, we ensure all passwords will work.
-	// NOTE: Required ClickHouse 24.9 or later.
+	// NOTE: Requires ClickHouse 24.9 or later.
 	_, err = p.ch.ExecContext(ctx, fmt.Sprintf("ALTER USER %s ADD IDENTIFIED WITH sha256_password BY ?", user), password)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add password for clickhouse user: %w", err)

--- a/admin/provisioner/clickhousestatic/provisioner_test.go
+++ b/admin/provisioner/clickhousestatic/provisioner_test.go
@@ -17,11 +17,11 @@ import (
 	"go.uber.org/zap"
 )
 
-func Test(t *testing.T) {
+func TestClickHouseStatic(t *testing.T) {
 	// Create a test ClickHouse cluster
 	container, err := testcontainersclickhouse.Run(
 		context.Background(),
-		"clickhouse/clickhouse-server:24.6.2.17",
+		"clickhouse/clickhouse-server:24.11.1.2557",
 		// Add a user config file that enables access management for the "default" user
 		testcontainers.CustomizeRequestOption(func(req *testcontainers.GenericContainerRequest) error {
 			req.Files = append(req.Files, testcontainers.ContainerFile{


### PR DESCRIPTION
When editing the `clickhouse.yaml` file with keystroke-by-keystroke editing, provisioning calls can be rapidly cancelled and retried. This surfaced an idempotency issue where calling `CREATE USER IF NOT EXISTS` did not use the generated random password, causing the generated DSN to be invalid. This PR fixes the problem by leveraging ClickHouse's support for adding multiple passwords to one user.