### PR TITLE
fix: avoid using global runtime in loader funciton

### DIFF
--- a/web-admin/src/routes/+layout.ts
+++ b/web-admin/src/routes/+layout.ts
@@ -14,9 +14,7 @@ import { redirectToLoginOrRequestAccess } from "@rilldata/web-admin/features/aut
 import { fetchOrganizationPermissions } from "@rilldata/web-admin/features/organizations/selectors";
 import { fetchProjectDeploymentDetails } from "@rilldata/web-admin/features/projects/selectors";
 import { initPosthog } from "@rilldata/web-common/lib/analytics/posthog";
-import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient.js";
 import { fixLocalhostRuntimePort } from "@rilldata/web-common/runtime-client/fix-localhost-runtime-port";
-import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
 import { error, redirect, type Page } from "@sveltejs/kit";
 
 export const load = async ({ params, url, route }) => {

--- a/web-admin/src/routes/+layout.ts
+++ b/web-admin/src/routes/+layout.ts
@@ -84,13 +84,7 @@ export const load = async ({ params, url, route }) => {
       runtime: runtimeData,
     } = await fetchProjectDeploymentDetails(organization, project, token);
 
-    await runtime.setRuntime(
-      queryClient,
-      fixLocalhostRuntimePort(runtimeData.host ?? ""),
-      runtimeData.instanceId,
-      runtimeData.jwt?.token,
-      runtimeData.jwt?.authContext,
-    );
+    runtimeData.host = fixLocalhostRuntimePort(runtimeData.host ?? "");
 
     return {
       organizationPermissions,

--- a/web-admin/src/routes/[organization]/[project]/-/share/[token]/+layout.ts
+++ b/web-admin/src/routes/[organization]/[project]/-/share/[token]/+layout.ts
@@ -13,10 +13,7 @@ export const load = async ({ params: { token }, parent }) => {
     }
 
     const { explore, metricsView, defaultExplorePreset } =
-      await fetchExploreSpec(
-        runtime.instanceId as string,
-        tokenData.token.resourceName,
-      );
+      await fetchExploreSpec(runtime, tokenData.token.resourceName);
 
     return {
       explore,

--- a/web-admin/src/routes/[organization]/[project]/explore/[dashboard]/+layout.ts
+++ b/web-admin/src/routes/[organization]/[project]/explore/[dashboard]/+layout.ts
@@ -17,7 +17,7 @@ export const load = async ({ params, depends, parent }) => {
 
   try {
     const { explore, metricsView, defaultExplorePreset } =
-      await fetchExploreSpec(runtime?.instanceId, exploreName);
+      await fetchExploreSpec(runtime, exploreName);
 
     // used to merge home bookmark to url state
     const bookmarks = await fetchBookmarks(project.id, exploreName);

--- a/web-common/src/features/explores/selectors.ts
+++ b/web-common/src/features/explores/selectors.ts
@@ -14,7 +14,6 @@ import {
   createRuntimeServiceGetExplore,
   getQueryServiceMetricsViewTimeRangeQueryKey,
   getRuntimeServiceGetExploreQueryKey,
-  queryServiceMetricsViewTimeRange,
   runtimeServiceGetExplore,
   type RpcStatus,
   type V1ExploreSpec,

--- a/web-common/src/runtime-client/http-client.ts
+++ b/web-common/src/runtime-client/http-client.ts
@@ -20,15 +20,18 @@ export const httpRequestQueue = new HttpRequestQueue();
 
 export const httpClient = async <T>(
   config: FetchWrapperOptions,
+  // used to override the global runtime in cases where it is either not initialised or is stale
+  // this could happen when switching projects with different runtimes
+  runtimeData = get(runtime),
 ): Promise<T> => {
   // Naive request interceptors
 
   // Set host
-  const host = get(runtime).host;
+  const host = runtimeData.host;
   const interceptedConfig = { ...config, baseUrl: host };
 
   // Set JWT
-  let jwt = get(runtime).jwt;
+  let jwt = runtimeData.jwt;
   if (jwt && jwt.token) {
     jwt = await maybeWaitForFreshJWT(jwt);
     interceptedConfig.headers = {

--- a/web-local/src/routes/(viz)/explore/[name]/+layout.ts
+++ b/web-local/src/routes/(viz)/explore/[name]/+layout.ts
@@ -4,15 +4,13 @@ import { error } from "@sveltejs/kit";
 import { get } from "svelte/store";
 
 export const load = async ({ params, depends }) => {
-  const { instanceId } = get(runtime);
-
   const exploreName = params.name;
 
   depends(exploreName, "explore");
 
   try {
     const { explore, metricsView, defaultExplorePreset } =
-      await fetchExploreSpec(instanceId, exploreName);
+      await fetchExploreSpec(get(runtime), exploreName);
 
     return {
       explore,


### PR DESCRIPTION
We were setting the global runtime in project's loader function and using it in explore's loader function to fetch explore spec and other data. This would cause issue with preloading routes where loader function gets called. Hovering over other projects in breadcrumbs would update the runtime causing the dashboard list to be incorrect.

Here we are making explicit calls to `httpRuntime` with a custom `Runtime` object. This should not be the final solution since changes to API is not auto generated. We should look at autogenerating these `fetch` wrappers for every API.