### PR TITLE
Fix: Prevent unintended data preloading when hovering project links in the breadcrumb menu

### DIFF
--- a/web-admin/src/features/navigation/TopNavigationBar.svelte
+++ b/web-admin/src/features/navigation/TopNavigationBar.svelte
@@ -110,7 +110,8 @@
   );
 
   $: projectPaths = projects.reduce(
-    (map, { name }) => map.set(name.toLowerCase(), { label: name }),
+    (map, { name }) =>
+      map.set(name.toLowerCase(), { label: name, preloadData: false }),
     new Map<string, PathOption>(),
   );
 

--- a/web-common/src/components/dropdown-menu/DropdownMenuCheckboxItem.svelte
+++ b/web-common/src/components/dropdown-menu/DropdownMenuCheckboxItem.svelte
@@ -8,6 +8,7 @@
     // See: https://www.bits-ui.com/docs/components/dropdown-menu#dropdownmenucheckboxitem
     // Converts div to anchor tag
     href?: string;
+    preloadData?: boolean;
     showXForSelected?: boolean;
   };
   // type $$Events = DropdownMenuPrimitive.CheckboxItemEvents;
@@ -16,13 +17,19 @@
   export let checked: $$Props["checked"] = undefined;
   export let checkSize: $$Props["checkSize"] = "h-4 w-4";
   export let href: $$Props["href"] = undefined;
+  export let preloadData: $$Props["preloadData"] = true;
   export let showXForSelected: $$Props["showXForSelected"] = false;
   export { className as class };
 
   const iconColor = "#15141A";
 </script>
 
-<svelte:element this={href ? "a" : "div"} {href} rel="noopener noreferrer">
+<svelte:element
+  this={href ? "a" : "div"}
+  {href}
+  rel="noopener noreferrer"
+  data-sveltekit-preload-data={preloadData ? "hover" : "false"}
+>
   <DropdownMenuPrimitive.CheckboxItem
     bind:checked
     role="menuitem"

--- a/web-common/src/components/navigation/breadcrumbs/BreadcrumbItem.svelte
+++ b/web-common/src/components/navigation/breadcrumbs/BreadcrumbItem.svelte
@@ -85,6 +85,7 @@
                 option,
                 $page.route.id ?? "",
               )}
+              preloadData={option.preloadData}
               on:click={() => {
                 if (onSelect) {
                   onSelect(id);

--- a/web-common/src/components/navigation/breadcrumbs/types.ts
+++ b/web-common/src/components/navigation/breadcrumbs/types.ts
@@ -4,6 +4,7 @@ export type PathOption = {
   label: string;
   depth?: number;
   href?: string;
+  preloadData?: boolean;
   section?: string;
   pill?: string;
 };


### PR DESCRIPTION
### Problem
If a user is viewing the homepage of Project A, when the user hovers over Project B's name in the project breadcrumb dropdown menu, the dashboard list will change from Project A's to Project B's before navigation actually takes place.

Why:
- In the root `+layout.ts` file's loader function, we call `GetProject` to fetch a project's runtime information, _and we set the runtime information in a global store_. 
- Due to `data-sveltekit-preload-data`, this loader function is triggered when hovering over the link to Project B in the project breadcrumb's dropdown menu. The global runtime store switches from containing Project A's runtime to Project B's runtime.
- All mounted runtime queries are re-run for Project B.

### Quick-fix solution
For now, this PR disables `data-sveltekit-preload-data` for the project breadcrumb dropdown menu.

### Long-term solution
We should not have a global runtime store. Runtimes are inherently a project-level concern, so our code should reflect that. Also, at some point, we may want to show metrics from two different projects on the same page.