### PR TITLE
Fix: full width for TDD charts

### DIFF
--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -129,7 +129,10 @@
       class:flex-row={!expandedMeasureName}
       class:left-shift={extraLeftPadding}
     >
-      <div class="pt-2 flex-none" style:width="{metricsWidth}px">
+      <div
+        class="pt-2 flex-none"
+        style:width={expandedMeasureName ? "auto" : `${metricsWidth}px`}
+      >
         {#key exploreName}
           {#if !$metricTimeSeries.isLoading}
             {#if hasTimeSeries}


### PR DESCRIPTION
A regression was introduced in https://github.com/rilldata/rill/pull/6256 where the TDD charts would not be full width