### PR TITLE
fix : Clickhouse driver should always use native protocol unless a DSN is set directly

### DIFF
--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -149,14 +149,11 @@ func (d driver) Open(instanceID string, config map[string]any, st *storage.Clien
 			host = fmt.Sprintf("%s:%d", conf.Host, conf.Port)
 		}
 		opts.Addr = []string{host}
+		opts.Protocol = clickhouse.Native
 		if conf.SSL {
-			opts.Protocol = clickhouse.HTTP
 			opts.TLS = &tls.Config{
-				MinVersion:         tls.VersionTLS12,
-				InsecureSkipVerify: false,
+				MinVersion: tls.VersionTLS12,
 			}
-		} else {
-			opts.Protocol = clickhouse.Native
 		}
 
 		// username password


### PR DESCRIPTION
In my testing on local, running a query 100 times that returns 30K rows, native worked ~30% faster.

Also fixes https://github.com/rilldata/rill-private-issues/issues/1013 
The HTTP protocol does not return column types if empty results whereas native protocol does (Issue is already open in clickhouse).


