### PR TITLE
fix: allows for . in dimension names

### DIFF
--- a/web-common/src/features/dashboards/url-state/filters/expression.cjs
+++ b/web-common/src/features/dashboards/url-state/filters/expression.cjs
@@ -186,7 +186,7 @@ let ParserRules = [
     {"name": "compare_operator", "symbols": ["compare_operator$subexpression$6"], "postprocess": id},
     {"name": "column", "symbols": ["sqstring"], "postprocess": id},
     {"name": "column$ebnf$1", "symbols": []},
-    {"name": "column$ebnf$1", "symbols": ["column$ebnf$1", /[a-zA-Z0-9_]/], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
+    {"name": "column$ebnf$1", "symbols": ["column$ebnf$1", /[a-zA-Z0-9_.]/], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
     {"name": "column", "symbols": [/[a-zA-Z]/, "column$ebnf$1"], "postprocess": ([fst, rest]) => [fst, ...rest].join("")},
     {"name": "value", "symbols": ["sqstring"], "postprocess": id},
     {"name": "value", "symbols": ["int"], "postprocess": id},

--- a/web-common/src/features/dashboards/url-state/filters/expression.ne
+++ b/web-common/src/features/dashboards/url-state/filters/expression.ne
@@ -47,7 +47,7 @@ compare_operator => "eq"i     {% id %}
                   | "lte"i    {% id %}
 
 column     => sqstring                 {% id %}
-            | [a-zA-Z] [a-zA-Z0-9_]:*  {% ([fst, rest]) => [fst, ...rest].join("") %}
+            | [a-zA-Z] [a-zA-Z0-9_.]:*  {% ([fst, rest]) => [fst, ...rest].join("") %}
 value      => sqstring                 {% id %}
             | int                      {% id %}
             | decimal                  {% id %}


### PR DESCRIPTION
Naive fix for allowing . in dimension names in the parser. We should look at which allowed characters we support and extend the parser syntax for it.