### PR TITLE
set instance's default olap connector as model's default output connector

### DIFF
--- a/cli/pkg/local/app.go
+++ b/cli/pkg/local/app.go
@@ -467,7 +467,7 @@ func (a *App) emitStartEvent(ctx context.Context) error {
 		connectorNames = append(connectorNames, connector.Name)
 	}
 
-	a.ch.Telemetry(ctx).RecordBehavioralLegacy(activity.BehavioralEventAppStart, attribute.StringSlice("connectors", connectorNames), attribute.String("olap_connector", a.Instance.OLAPConnector))
+	a.ch.Telemetry(ctx).RecordBehavioralLegacy(activity.BehavioralEventAppStart, attribute.StringSlice("connectors", connectorNames), attribute.String("olap_connector", a.Instance.ResolveOLAPConnector()))
 
 	return nil
 }

--- a/runtime/compilers/rillv1/parse_model.go
+++ b/runtime/compilers/rillv1/parse_model.go
@@ -141,7 +141,7 @@ func (p *Parser) parseModel(ctx context.Context, node *Node) error {
 	// Build output details
 	outputConnector := tmp.Output.Connector
 	if outputConnector == "" {
-		outputConnector = inputConnector
+		outputConnector = p.defaultOLAPConnector()
 	}
 	outputProps := tmp.Output.Properties
 

--- a/runtime/metricsview/executor_validate_test.go
+++ b/runtime/metricsview/executor_validate_test.go
@@ -49,7 +49,7 @@ func TestValidateMetricsViewClickHouseNames(t *testing.T) {
 	rt, instanceID := testruntime.NewInstanceWithOptions(t, testruntime.InstanceOptions{
 		TestConnectors: []string{"clickhouse"},
 		Files: map[string]string{
-			"rill.yaml": "",
+			"rill.yaml": "olap_connector: clickhouse",
 			"model.sql": `
 -- @connector: clickhouse
 select parseDateTimeBestEffort('2024-01-01T00:00:00Z') as time, 'DK' as country, 1 as val union all

--- a/runtime/resolvers/testdata/metrics_comparisons.yaml
+++ b/runtime/resolvers/testdata/metrics_comparisons.yaml
@@ -11,6 +11,8 @@ project_files:
       select parseDateTimeBestEffort('2024-01-03T00:00:00Z') as time, 'US' as country, 3 as val union all
       select parseDateTimeBestEffort('2024-01-04T00:00:00Z') as time, 'US' as country, 4 as val union all
       select parseDateTimeBestEffort('2024-01-05T00:00:00Z') as time, 'DK' as country, 5 as val
+    output:
+      connector: clickhouse
   clickhouse_metrics.yaml:
     type: metrics_view
     model: clickhouse_data

--- a/runtime/resolvers/testdata/metrics_sql_clickhouse.yaml
+++ b/runtime/resolvers/testdata/metrics_sql_clickhouse.yaml
@@ -1,6 +1,8 @@
 connectors:
   - clickhouse
 project_files:
+  rill.yaml:
+    olap_connector: clickhouse
   ad_bids_mini.yaml:
     type: model
     connector: clickhouse


### PR DESCRIPTION
Setting it to default OLAP connector allows us to skip setting output in models that ingests data from external sources. So the following model definition is sufficient to ingest data from postgres to duckdb.
```
connector: postgres
sql: SELECT * FROM students 
dsn: "postgresql://postgres:postgres@localhost:5432/postgres"
```