### PR TITLE
Add `ignore_paths` to `rill.yaml` validation in the runtime parser

### DIFF
--- a/runtime/compilers/rillv1/parse_rillyaml.go
+++ b/runtime/compilers/rillv1/parse_rillyaml.go
@@ -85,7 +85,11 @@ type rillYAML struct {
 	Features yaml.Node `yaml:"features"`
 	// Paths to expose over HTTP (defaults to ./public)
 	PublicPaths []string `yaml:"public_paths"`
-	// A list of mock users to test against dashboard security policies
+	// Paths to ignore when watching for changes.
+	// This is ignored in this parser because it's consumed directly by the repo driver.
+	IgnorePaths []string `yaml:"ignore_paths"`
+	// A list of mock users to test against dashboard security policies.
+	// This is ignored in this parser because it's consumed directly by the local application.
 	MockUsers []struct {
 		Email  string   `yaml:"email"`
 		Name   string   `yaml:"name"`


### PR DESCRIPTION
Previously we ignored unknown properties when parsing `rill.yaml`, but now we error for unknown properties. Since `ignore_paths` was consumed outside the parser, it was considered an unknown property.

Fixes the issue reported here: https://rilldata.slack.com/archives/CTZ8XBQ85/p1734454960845279