### PR TITLE
Intelligent default connectors for state and partition resolvers in models

### DIFF
--- a/runtime/compilers/rillv1/parse_alert.go
+++ b/runtime/compilers/rillv1/parse_alert.go
@@ -137,7 +137,7 @@ func (p *Parser) parseAlert(node *Node) error {
 
 	if !isLegacyQuery {
 		var refs []ResourceName
-		resolver, resolverProps, refs, err = p.parseDataYAML(tmp.Data)
+		resolver, resolverProps, refs, err = p.parseDataYAML(tmp.Data, node.Connector)
 		if err != nil {
 			return fmt.Errorf(`failed to parse "data": %w`, err)
 		}

--- a/runtime/compilers/rillv1/parse_api.go
+++ b/runtime/compilers/rillv1/parse_api.go
@@ -71,7 +71,7 @@ func (p *Parser) parseAPI(node *Node) error {
 	}
 
 	// Parse the resolver and its properties from the DataYAML
-	resolver, resolverProps, resolverRefs, err := p.parseDataYAML(&tmp.DataYAML)
+	resolver, resolverProps, resolverRefs, err := p.parseDataYAML(&tmp.DataYAML, node.Connector)
 	if err != nil {
 		return err
 	}
@@ -105,8 +105,9 @@ type DataYAML struct {
 }
 
 // parseDataYAML parses a data resolver and its properties from a DataYAML.
+// The contextualConnector argument is optional; if provided and the resolver supports a connector, it becomes the default connector for the resolver.
 // It returns the resolver name, its properties, and refs found in the resolver props.
-func (p *Parser) parseDataYAML(raw *DataYAML) (string, *structpb.Struct, []ResourceName, error) {
+func (p *Parser) parseDataYAML(raw *DataYAML, contextualConnector string) (string, *structpb.Struct, []ResourceName, error) {
 	// Parse the resolver and its properties
 	var count int
 	var resolver string
@@ -120,6 +121,8 @@ func (p *Parser) parseDataYAML(raw *DataYAML) (string, *structpb.Struct, []Resou
 		resolverProps["sql"] = raw.SQL
 		if raw.Connector != "" {
 			resolverProps["connector"] = raw.Connector
+		} else if contextualConnector != "" {
+			resolverProps["connector"] = contextualConnector
 		}
 	}
 

--- a/runtime/compilers/rillv1/parse_component.go
+++ b/runtime/compilers/rillv1/parse_component.go
@@ -88,7 +88,7 @@ func (p *Parser) parseComponentYAML(tmp *ComponentYAML) (*runtimev1.ComponentSpe
 	var resolverProps *structpb.Struct
 	if tmp.Data != nil {
 		var err error
-		resolver, resolverProps, refs, err = p.parseDataYAML(tmp.Data)
+		resolver, resolverProps, refs, err = p.parseDataYAML(tmp.Data, "")
 		if err != nil {
 			return nil, nil, err
 		}

--- a/runtime/compilers/rillv1/parser_test.go
+++ b/runtime/compilers/rillv1/parser_test.go
@@ -1771,7 +1771,7 @@ metrics_sql: select * from m1
 			Paths: []string{"/apis/a1.yaml"},
 			APISpec: &runtimev1.APISpec{
 				Resolver:           "sql",
-				ResolverProperties: must(structpb.NewStruct(map[string]any{"sql": "select * from m1"})),
+				ResolverProperties: must(structpb.NewStruct(map[string]any{"connector": "duckdb", "sql": "select * from m1"})),
 			},
 		},
 		{
@@ -1838,7 +1838,7 @@ select 3
 			Refs:  []ResourceName{{Kind: ResourceKindSource, Name: "s1"}, {Kind: ResourceKindSource, Name: "s2"}},
 			APISpec: &runtimev1.APISpec{
 				Resolver:           "sql",
-				ResolverProperties: must(structpb.NewStruct(map[string]any{"sql": "select 1"})),
+				ResolverProperties: must(structpb.NewStruct(map[string]any{"connector": "duckdb", "sql": "select 1"})),
 			},
 		},
 		// m1

--- a/runtime/reconcilers/alert_test.go
+++ b/runtime/reconcilers/alert_test.go
@@ -381,7 +381,7 @@ notify:
 					IntervalsIsoDuration:   "P1D",
 					IntervalsCheckUnclosed: true,
 					Resolver:               "sql",
-					ResolverProperties:     must(structpb.NewStruct(map[string]any{"sql": "select * from bar where country <> 'Denmark'"})),
+					ResolverProperties:     must(structpb.NewStruct(map[string]any{"connector": "duckdb", "sql": "select * from bar where country <> 'Denmark'"})),
 					NotifyOnRecover:        false,
 					NotifyOnFail:           true,
 					NotifyOnError:          false,


### PR DESCRIPTION
Changes:
- If the `partitions:` resolver in a model is a `sql` resolver, it will default to the model's **input** connector
- If the `state:` resolver in a model is a `sql` resolver, it will default to the model's **output** connector