### PR TITLE
fix: add accessible labels for workspace toggles

### DIFF
--- a/web-common/src/layout/workspace/WorkspaceHeader.svelte
+++ b/web-common/src/layout/workspace/WorkspaceHeader.svelte
@@ -84,6 +84,7 @@
             type="secondary"
             square
             selected={$tableVisible}
+            label="Toggle table visibility"
             on:click={workspaceLayout.table.toggle}
           >
             <HideBottomPane size="18px" open={$tableVisible} />
@@ -102,6 +103,7 @@
             type="secondary"
             square
             selected={$inspectorVisible}
+            label="Toggle inspector visibility"
             on:click={workspaceLayout.inspector.toggle}
           >
             <HideSidebar open={$inspectorVisible} size="18px" />


### PR DESCRIPTION
Adds the ability to select these buttons using `page.getByLabel("Toggle table visibility")` and `page.getByLabel("Toggle inspector visibility")` when constructing Playwright tests