### PR TITLE
fix: query cancellation issue

### DIFF
--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -36,7 +36,6 @@
     },
 
     dashboardStore,
-    validSpecStore,
   } = StateManagers;
 
   const timeControlsStore = useTimeControlStore(StateManagers);
@@ -44,6 +43,8 @@
   const { cloudDataViewer, readOnly } = featureFlags;
 
   let exploreContainerWidth: number;
+
+  $: ({ instanceId } = $runtime);
 
   $: ({ whereFilter, dimensionThresholdFilters } = $dashboardStore);
 
@@ -55,37 +56,40 @@
   $: selectedDimension =
     selectedDimensionName && $getDimensionByName(selectedDimensionName);
   $: expandedMeasureName = $exploreState?.tdd?.expandedMeasureName;
-  $: metricTimeSeries = useModelHasTimeSeries(
-    $runtime.instanceId,
-    metricsViewName,
-  );
+  $: metricTimeSeries = useModelHasTimeSeries(instanceId, metricsViewName);
   $: hasTimeSeries = $metricTimeSeries.data;
 
   $: isRillDeveloper = $readOnly === false;
 
   // Check if the mock user (if selected) has access to the explore
-  $: explore = useExploreValidSpec($runtime.instanceId, exploreName);
+  $: explore = useExploreValidSpec(instanceId, exploreName);
 
   $: mockUserHasNoAccess =
     $selectedMockUserStore && $explore.error?.response?.status === 404;
 
   $: hidePivot = isEmbedded && $explore.data?.explore?.embedsHidePivot;
 
-  $: timeControls = $timeControlsStore;
+  $: ({
+    timeStart: start,
+    timeEnd: end,
+    showTimeComparison,
+    comparisonTimeStart,
+    comparisonTimeEnd,
+  } = $timeControlsStore);
 
   $: timeRange = {
-    start: timeControls.timeStart,
-    end: timeControls.timeEnd,
+    start,
+    end,
   };
 
-  $: comparisonTimeRange = timeControls.showTimeComparison
+  $: comparisonTimeRange = showTimeComparison
     ? {
-        start: timeControls.comparisonTimeStart,
-        end: timeControls.comparisonTimeEnd,
+        start: comparisonTimeStart,
+        end: comparisonTimeEnd,
       }
     : undefined;
 
-  $: metricsView = $validSpecStore.data?.metricsView ?? {};
+  $: metricsView = $explore.data?.metricsView ?? {};
 
   let metricsWidth = DEFAULT_TIMESERIES_WIDTH;
   let resizing = false;

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -75,6 +75,7 @@
     showTimeComparison,
     comparisonTimeStart,
     comparisonTimeEnd,
+    ready: timeControlsReady = false,
   } = $timeControlsStore);
 
   $: timeRange = {
@@ -185,7 +186,7 @@
               {timeRange}
               {comparisonTimeRange}
               activeMeasureName={$activeMeasureName}
-              timeControlsReady={!!timeControls.ready}
+              {timeControlsReady}
               {metricsView}
               visibleMeasureNames={$visibleMeasures.map(
                 ({ name }) => name ?? "",
@@ -201,7 +202,7 @@
               {timeRange}
               {comparisonTimeRange}
               {metricsView}
-              timeControlsReady={!!timeControls.ready}
+              {timeControlsReady}
             />
           {/if}
         </div>


### PR DESCRIPTION
In this [file](https://github.com/rilldata/rill/blob/main/web-admin/src/routes/%5Borganization%5D/%5Bproject%5D/%2Blayout.svelte), we're refetching the project when the application tab is refocused. 

This refetch meant we were receiving a new JWT each time. The JWT is colocated in a store that also handles the host and instanceId variables, so updating one triggers a reactive update for all of them.

In our [state managers](https://github.com/rilldata/rill/blob/main/web-common/src/features/dashboards/state-managers/state-managers.ts), the explore spec and time range summary are dependent on the runtime store.

In Leaderboards, the primary aggregation query is dependent on an array of measures and the time range, which are derived from those queries. So, on window focus, the parameters were updating and the pending query was cancelled/re-initiated.

This is a patch fix for that issue and does not address the underlying structural flaw.