### PR TITLE
fix : resolve conflict schema URL error

### DIFF
--- a/runtime/pkg/observability/observability.go
+++ b/runtime/pkg/observability/observability.go
@@ -15,7 +15,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.uber.org/zap"
 )
 


### PR DESCRIPTION
closes https://github.com/rilldata/rill/issues/6331

On a longer term we need to investigate on how this can be caught earlier. Didn't see either in prod servers or on my laptotp.