### PR TITLE
fix : patch for memory leaks in arrow parquet buffered writer 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -419,10 +419,11 @@ require (
 
 exclude modernc.org/sqlite v1.18.1
 
-// Adds changes from the two PRs :
+// Adds changes from the following PRs :
 // https://github.com/apache/arrow/pull/41638
 // https://github.com/apache/arrow/pull/42003
-replace github.com/apache/arrow/go/v15 v15.0.2 => github.com/rilldata/arrow/go/v15 v15.0.0-20241221060748-f48dd933c1b0
+// https://github.com/apache/arrow/pull/41698
+replace github.com/apache/arrow/go/v15 v15.0.2 => github.com/rilldata/arrow/go/v15 v15.0.0-20250102090621-2b8f541ea250
 
 // security vulnerability in dgrijalva/jwt-go
 replace github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt v3.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2112,8 +2112,8 @@ github.com/richardlehane/mscfb v1.0.4/go.mod h1:YzVpcZg9czvAuhk9T+a3avCpcFPMUWm7
 github.com/richardlehane/msoleps v1.0.1/go.mod h1:BWev5JBpU9Ko2WAgmZEuiz4/u3ZYTKbjLycmwiWUfWg=
 github.com/richardlehane/msoleps v1.0.3 h1:aznSZzrwYRl3rLKRT3gUk9am7T/mLNSnJINvN0AQoVM=
 github.com/richardlehane/msoleps v1.0.3/go.mod h1:BWev5JBpU9Ko2WAgmZEuiz4/u3ZYTKbjLycmwiWUfWg=
-github.com/rilldata/arrow/go/v15 v15.0.0-20241221060748-f48dd933c1b0 h1:yHHJrkQkIXT1XtXl2BuAMF4A4a69DOJO6rzCcNhdoWg=
-github.com/rilldata/arrow/go/v15 v15.0.0-20241221060748-f48dd933c1b0/go.mod h1:DGXsR3ajT524njufqf95822i+KTh+yea1jass9YXgjA=
+github.com/rilldata/arrow/go/v15 v15.0.0-20250102090621-2b8f541ea250 h1:ZN01YfdGL/MdI4Ky1eXMKB0HstCD0Ihdjtu9fhDO6PI=
+github.com/rilldata/arrow/go/v15 v15.0.0-20250102090621-2b8f541ea250/go.mod h1:DGXsR3ajT524njufqf95822i+KTh+yea1jass9YXgjA=
 github.com/riverqueue/river v0.11.4 h1:NMRsODhRgFztf080RMCjI377jldLXsx41E2r7+c0lPE=
 github.com/riverqueue/river v0.11.4/go.mod h1:HvgBkqon7lYKm9Su4lVOnn1qx8Q4FnSMJjf5auVial4=
 github.com/riverqueue/river/riverdriver v0.11.4 h1:kBg68vfTnRuSwsgcZ7UbKC4ocZ+KSCGnuZw/GwMMMP4=


### PR DESCRIPTION
Based on the PR description the leak is small and it seems unlikely to cause OOMes but best to add the patch.