### PR TITLE
fix: Do not add 1 to get next billing cycle start date

### DIFF
--- a/web-admin/src/features/billing/plans/selectors.ts
+++ b/web-admin/src/features/billing/plans/selectors.ts
@@ -58,8 +58,7 @@ export function getBillingUpgradeUrl(page: Page, organization: string) {
 export function getNextBillingCycleDate(curEndDateRaw: string): string {
   const curEndDate = DateTime.fromJSDate(new Date(curEndDateRaw));
   if (!curEndDate.isValid) return "Unknown";
-  const nextStartDate = curEndDate.plus({ day: 1 });
-  return nextStartDate.toLocaleString(DateTime.DATE_MED);
+  return curEndDate.toLocaleString(DateTime.DATE_MED);
 }
 
 export function getOrganizationUsageMetrics(


### PR DESCRIPTION
Billing cycle end date already has a +1. So we dont need to add to it to get the next cycle start date.

This is the frontend change similar to #6349