### PR TITLE
Update .gitignore to ignore local PostgreSQL mount directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ tsc-tmp/
 /models
 /dashboards
 /sources
+/postgres
 
 # check in generated data files
 !/web-local/tests/data/*.parquet


### PR DESCRIPTION
## Changes
Small change to the `.gitignore` to ignore local PostgreSQL mount directory.

## Context
I encountered this when setting up services for the first time via `Make`

