### PR TITLE
fix: scrub range reload from url params

### DIFF
--- a/web-common/src/features/dashboards/url-state/convertPresetToExploreState.ts
+++ b/web-common/src/features/dashboards/url-state/convertPresetToExploreState.ts
@@ -185,10 +185,11 @@ function fromTimeRangesParams(
   }
 
   if (preset.selectTimeRange) {
-    partialExploreState.selectedScrubRange = {
-      ...fromTimeRangeUrlParam(preset.selectTimeRange),
-      isScrubbing: false,
-    };
+    partialExploreState.lastDefinedScrubRange =
+      partialExploreState.selectedScrubRange = {
+        ...fromTimeRangeUrlParam(preset.selectTimeRange),
+        isScrubbing: false,
+      };
   } else {
     partialExploreState.selectedScrubRange = undefined;
   }


### PR DESCRIPTION
We were setting only `selectedScrubRange` while loading from url. But our queries check `lastDefinedScrubRange`