### PR TITLE
Add help command grouping and org display name editing

### DIFF
--- a/cli/cmd/admin/admin.go
+++ b/cli/cmd/admin/admin.go
@@ -8,9 +8,6 @@ import (
 // AdminCmd represents the admin command
 func AdminCmd(ch *cmdutil.Helper) *cobra.Command {
 	internalGroupID := ""
-	if ch.IsDev() {
-		internalGroupID = "Internal"
-	}
 	adminCmd := &cobra.Command{
 		Use:     "admin",
 		Hidden:  !ch.IsDev(),

--- a/cli/cmd/admin/admin.go
+++ b/cli/cmd/admin/admin.go
@@ -7,10 +7,15 @@ import (
 
 // AdminCmd represents the admin command
 func AdminCmd(ch *cmdutil.Helper) *cobra.Command {
+	internalGroupID := ""
+	if ch.IsDev() {
+		internalGroupID = "Internal"
+	}
 	adminCmd := &cobra.Command{
-		Use:    "admin",
-		Hidden: !ch.IsDev(),
-		Short:  "Manage an admin server",
+		Use:     "admin",
+		Hidden:  !ch.IsDev(),
+		Short:   "Manage an admin server",
+		GroupID: internalGroupID,
 	}
 	adminCmd.AddCommand(PingCmd(ch))
 	adminCmd.AddCommand(StartCmd(ch))

--- a/cli/cmd/devtool/devtool.go
+++ b/cli/cmd/devtool/devtool.go
@@ -7,9 +7,6 @@ import (
 
 func DevtoolCmd(ch *cmdutil.Helper) *cobra.Command {
 	internalGroupID := ""
-	if ch.IsDev() {
-		internalGroupID = "Internal"
-	}
 	devtoolCmd := &cobra.Command{
 		Use:   "devtool",
 		Short: "Utilities for developing Rill",

--- a/cli/cmd/devtool/devtool.go
+++ b/cli/cmd/devtool/devtool.go
@@ -6,6 +6,10 @@ import (
 )
 
 func DevtoolCmd(ch *cmdutil.Helper) *cobra.Command {
+	internalGroupID := ""
+	if ch.IsDev() {
+		internalGroupID = "Internal"
+	}
 	devtoolCmd := &cobra.Command{
 		Use:   "devtool",
 		Short: "Utilities for developing Rill",
@@ -18,7 +22,8 @@ func DevtoolCmd(ch *cmdutil.Helper) *cobra.Command {
   rill devtool start local --reset
   rill devtool switch-env stage
   rill devtool dotenv upload cloud`,
-		Hidden: true,
+		Hidden:  true,
+		GroupID: internalGroupID,
 	}
 
 	devtoolCmd.AddCommand(StartCmd(ch))

--- a/cli/cmd/org/edit.go
+++ b/cli/cmd/org/edit.go
@@ -11,7 +11,7 @@ import (
 )
 
 func EditCmd(ch *cmdutil.Helper) *cobra.Command {
-	var orgName, description, billingEmail string
+	var orgName, displayName, description, billingEmail string
 
 	editCmd := &cobra.Command{
 		Use:   "edit [<org-name>]",
@@ -55,6 +55,22 @@ func EditCmd(ch *cmdutil.Helper) *cobra.Command {
 			org := resp.Organization
 			req := &adminv1.UpdateOrganizationRequest{
 				Name: org.Name,
+			}
+
+			if cmd.Flags().Changed("display-name") {
+				req.DisplayName = &displayName
+			} else if ch.Interactive {
+				ok, err := cmdutil.ConfirmPrompt("Do you want to update the display name", "", false)
+				if err != nil {
+					return err
+				}
+				if ok {
+					displayName, err = cmdutil.InputPrompt("Enter the display name", org.DisplayName)
+					if err != nil {
+						return err
+					}
+					req.DisplayName = &displayName
+				}
 			}
 
 			if cmd.Flags().Changed("description") {
@@ -102,6 +118,7 @@ func EditCmd(ch *cmdutil.Helper) *cobra.Command {
 	}
 	editCmd.Flags().SortFlags = false
 	editCmd.Flags().StringVar(&orgName, "org", ch.Org, "Organization name")
+	editCmd.Flags().StringVar(&displayName, "display-name", "", "Display name")
 	editCmd.Flags().StringVar(&description, "description", "", "Description")
 	editCmd.Flags().StringVar(&billingEmail, "billing-email", "", "Billing email")
 

--- a/cli/cmd/org/org_test.go
+++ b/cli/cmd/org/org_test.go
@@ -162,6 +162,20 @@ func TestOrganizationWorkflow(t *testing.T) {
 	require.Equal(t, len(orgList), 1)
 	require.Equal(t, orgList[0].Name, "new-test")
 
+	// edit organization display name
+	buf.Reset()
+	cmd = EditCmd(helper)
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--org", "new-test", "--display-name", "new-test-display", "--force"})
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	err = json.Unmarshal([]byte(buf.String()), &orgList)
+	require.NoError(t, err)
+	require.Equal(t, len(orgList), 1)
+	require.Equal(t, orgList[0].DisplayName, "new-test-display")
+
 	// Switch organization
 	buf.Reset()
 	helper.Printer.OverrideHumanOutput(&buf)
@@ -181,7 +195,8 @@ func TestOrganizationWorkflow(t *testing.T) {
 }
 
 type Org struct {
-	Name string `json:"Name"`
+	Name        string `json:"Name"`
+	DisplayName string `json:"DisplayName"`
 }
 
 // mockGithub provides a mock implementation of admin.Github.

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -130,7 +130,7 @@ func runCmd(ctx context.Context, ver cmdutil.Version) error {
 	// Command Groups
 
 	// Project commands
-	cmdutil.AddGroup(rootCmd, "Project",
+	cmdutil.AddGroup(rootCmd, "Project", false,
 		start.StartCmd(ch),
 		deploy.DeployCmd(ch),
 		project.ProjectCmd(ch),
@@ -139,7 +139,7 @@ func runCmd(ctx context.Context, ver cmdutil.Version) error {
 	)
 
 	// Organization commands
-	cmdutil.AddGroup(rootCmd, "Organization",
+	cmdutil.AddGroup(rootCmd, "Organization", false,
 		org.OrgCmd(ch),
 		user.UserCmd(ch),
 		usergroup.UsergroupCmd(ch),
@@ -148,16 +148,21 @@ func runCmd(ctx context.Context, ver cmdutil.Version) error {
 	)
 
 	// Auth commands
-	cmdutil.AddGroup(rootCmd, "Auth",
+	cmdutil.AddGroup(rootCmd, "Auth", false,
 		auth.LoginCmd(ch),
 		auth.LogoutCmd(ch),
 		whoami.WhoamiCmd(ch),
 	)
 
 	// Internal commands
-	if ch.IsDev() {
-		cmdutil.AddGroup(rootCmd, "Internal")
-	}
+	cmdutil.AddGroup(rootCmd, "Internal", !ch.IsDev(),
+		// These commands are hidden from the help menu
+		admin.AdminCmd(ch),
+		runtime.RuntimeCmd(ch),
+		devtool.DevtoolCmd(ch),
+		sudo.SudoCmd(ch),
+		verifyInstallCmd(ch),
+	)
 
 	// Additional sub-commands
 	rootCmd.AddCommand(
@@ -166,11 +171,6 @@ func runCmd(ctx context.Context, ver cmdutil.Version) error {
 		versioncmd.VersionCmd(),
 		upgrade.UpgradeCmd(ch),
 		uninstall.UninstallCmd(ch),
-		admin.AdminCmd(ch),
-		runtime.RuntimeCmd(ch),
-		devtool.DevtoolCmd(ch),
-		sudo.SudoCmd(ch),
-		verifyInstallCmd(ch),
 	)
 
 	return rootCmd.ExecuteContext(ctx)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -130,29 +130,25 @@ func runCmd(ctx context.Context, ver cmdutil.Version) error {
 	// Command Groups
 
 	// Project commands
-	cmdutil.AddGroup(
-		rootCmd, "Project",
+	cmdutil.AddGroup(rootCmd, "Project",
 		start.StartCmd(ch),
 		deploy.DeployCmd(ch),
 		project.ProjectCmd(ch),
 		publicurl.PublicURLCmd(ch),
-		service.ServiceCmd(ch),
-		runtime.RuntimeCmd(ch),
 		env.EnvCmd(ch),
 	)
 
 	// Organization commands
 	cmdutil.AddGroup(rootCmd, "Organization",
-		admin.AdminCmd(ch),
 		org.OrgCmd(ch),
 		user.UserCmd(ch),
 		usergroup.UsergroupCmd(ch),
+		service.ServiceCmd(ch),
 		billing.BillingCmd(ch),
 	)
 
-	// User commands
-	cmdutil.AddGroup(rootCmd,
-		"User",
+	// Auth commands
+	cmdutil.AddGroup(rootCmd, "Auth",
 		auth.LoginCmd(ch),
 		auth.LogoutCmd(ch),
 		whoami.WhoamiCmd(ch),
@@ -163,6 +159,8 @@ func runCmd(ctx context.Context, ver cmdutil.Version) error {
 		completionCmd,
 		docs.DocsCmd(ch, rootCmd),
 		versioncmd.VersionCmd(),
+		admin.AdminCmd(ch),
+		runtime.RuntimeCmd(ch),
 		sudo.SudoCmd(ch),
 		upgrade.UpgradeCmd(ch),
 		uninstall.UninstallCmd(ch),

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -154,18 +154,24 @@ func runCmd(ctx context.Context, ver cmdutil.Version) error {
 		whoami.WhoamiCmd(ch),
 	)
 
+	if ch.IsDev() {
+		// Internal commands - hidden from help menu
+		cmdutil.AddGroup(rootCmd, "Internal",
+			admin.AdminCmd(ch),
+			runtime.RuntimeCmd(ch),
+			devtool.DevtoolCmd(ch),
+			sudo.SudoCmd(ch),
+			verifyInstallCmd(ch),
+		)
+	}
+
 	// Additional sub-commands
 	rootCmd.AddCommand(
 		completionCmd,
 		docs.DocsCmd(ch, rootCmd),
 		versioncmd.VersionCmd(),
-		admin.AdminCmd(ch),
-		runtime.RuntimeCmd(ch),
-		sudo.SudoCmd(ch),
 		upgrade.UpgradeCmd(ch),
 		uninstall.UninstallCmd(ch),
-		devtool.DevtoolCmd(ch),
-		verifyInstallCmd(ch),
 	)
 
 	return rootCmd.ExecuteContext(ctx)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -154,16 +154,14 @@ func runCmd(ctx context.Context, ver cmdutil.Version) error {
 		whoami.WhoamiCmd(ch),
 	)
 
-	if ch.IsDev() {
-		// Internal commands - hidden from help menu
-		cmdutil.AddGroup(rootCmd, "Internal",
-			admin.AdminCmd(ch),
-			runtime.RuntimeCmd(ch),
-			devtool.DevtoolCmd(ch),
-			sudo.SudoCmd(ch),
-			verifyInstallCmd(ch),
-		)
-	}
+	// Internal commands - hidden from help menu
+	cmdutil.AddGroup(rootCmd, "Internal",
+		admin.AdminCmd(ch),
+		runtime.RuntimeCmd(ch),
+		devtool.DevtoolCmd(ch),
+		sudo.SudoCmd(ch),
+		verifyInstallCmd(ch),
+	)
 
 	// Additional sub-commands
 	rootCmd.AddCommand(

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -154,14 +154,10 @@ func runCmd(ctx context.Context, ver cmdutil.Version) error {
 		whoami.WhoamiCmd(ch),
 	)
 
-	// Internal commands - hidden from help menu
-	cmdutil.AddGroup(rootCmd, "Internal",
-		admin.AdminCmd(ch),
-		runtime.RuntimeCmd(ch),
-		devtool.DevtoolCmd(ch),
-		sudo.SudoCmd(ch),
-		verifyInstallCmd(ch),
-	)
+	// Internal commands
+	if ch.IsDev() {
+		cmdutil.AddGroup(rootCmd, "Internal")
+	}
 
 	// Additional sub-commands
 	rootCmd.AddCommand(
@@ -170,6 +166,11 @@ func runCmd(ctx context.Context, ver cmdutil.Version) error {
 		versioncmd.VersionCmd(),
 		upgrade.UpgradeCmd(ch),
 		uninstall.UninstallCmd(ch),
+		admin.AdminCmd(ch),
+		runtime.RuntimeCmd(ch),
+		devtool.DevtoolCmd(ch),
+		sudo.SudoCmd(ch),
+		verifyInstallCmd(ch),
 	)
 
 	return rootCmd.ExecuteContext(ctx)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -40,8 +40,9 @@ func init() {
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
-	Use:   "rill <command>",
-	Short: "Rill CLI",
+	Use:   "rill <command> [flags]",
+	Short: "A CLI for Rill",
+	Long:  `Work with Rill projects directly from the command line.`,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -126,31 +127,47 @@ func runCmd(ctx context.Context, ver cmdutil.Version) error {
 	rootCmd.PersistentFlags().StringVar(&ch.AdminTokenOverride, "api-token", "", "Token for authenticating with the cloud API")
 	rootCmd.Flags().BoolP("version", "v", false, "Show rill version") // Adds option to get version by passing --version or -v
 
-	// Add sub-commands
-	rootCmd.AddCommand(
+	// Command Groups
+
+	// Project commands
+	cmdutil.AddGroup(
+		rootCmd, "Project",
 		start.StartCmd(ch),
 		deploy.DeployCmd(ch),
-		env.EnvCmd(ch),
-		user.UserCmd(ch),
-		usergroup.UsergroupCmd(ch),
-		org.OrgCmd(ch),
 		project.ProjectCmd(ch),
 		publicurl.PublicURLCmd(ch),
 		service.ServiceCmd(ch),
+		runtime.RuntimeCmd(ch),
+		env.EnvCmd(ch),
+	)
+
+	// Organization commands
+	cmdutil.AddGroup(rootCmd, "Organization",
+		admin.AdminCmd(ch),
+		org.OrgCmd(ch),
+		user.UserCmd(ch),
+		usergroup.UsergroupCmd(ch),
+		billing.BillingCmd(ch),
+	)
+
+	// User commands
+	cmdutil.AddGroup(rootCmd,
+		"User",
 		auth.LoginCmd(ch),
 		auth.LogoutCmd(ch),
 		whoami.WhoamiCmd(ch),
-		docs.DocsCmd(ch, rootCmd),
+	)
+
+	// Additional sub-commands
+	rootCmd.AddCommand(
 		completionCmd,
+		docs.DocsCmd(ch, rootCmd),
 		versioncmd.VersionCmd(),
+		sudo.SudoCmd(ch),
 		upgrade.UpgradeCmd(ch),
 		uninstall.UninstallCmd(ch),
-		sudo.SudoCmd(ch),
 		devtool.DevtoolCmd(ch),
-		admin.AdminCmd(ch),
-		runtime.RuntimeCmd(ch),
 		verifyInstallCmd(ch),
-		billing.BillingCmd(ch),
 	)
 
 	return rootCmd.ExecuteContext(ctx)

--- a/cli/cmd/runtime/runtime.go
+++ b/cli/cmd/runtime/runtime.go
@@ -8,9 +8,6 @@ import (
 // RuntimeCmd represents the runtime command
 func RuntimeCmd(ch *cmdutil.Helper) *cobra.Command {
 	internalGroupID := ""
-	if ch.IsDev() {
-		internalGroupID = "Internal"
-	}
 	runtimeCmd := &cobra.Command{
 		Use:     "runtime",
 		Hidden:  !ch.IsDev(),

--- a/cli/cmd/runtime/runtime.go
+++ b/cli/cmd/runtime/runtime.go
@@ -7,10 +7,15 @@ import (
 
 // RuntimeCmd represents the runtime command
 func RuntimeCmd(ch *cmdutil.Helper) *cobra.Command {
+	internalGroupID := ""
+	if ch.IsDev() {
+		internalGroupID = "Internal"
+	}
 	runtimeCmd := &cobra.Command{
-		Use:    "runtime",
-		Hidden: !ch.IsDev(),
-		Short:  "Manage stand-alone runtimes",
+		Use:     "runtime",
+		Hidden:  !ch.IsDev(),
+		Short:   "Manage stand-alone runtimes",
+		GroupID: internalGroupID,
 	}
 	runtimeCmd.AddCommand(StartCmd(ch))
 	runtimeCmd.AddCommand(PingCmd(ch))

--- a/cli/cmd/sudo/sudo.go
+++ b/cli/cmd/sudo/sudo.go
@@ -15,10 +15,15 @@ import (
 )
 
 func SudoCmd(ch *cmdutil.Helper) *cobra.Command {
+	internalGroupID := ""
+	if ch.IsDev() {
+		internalGroupID = "Internal"
+	}
 	sudoCmd := &cobra.Command{
-		Use:    "sudo",
-		Short:  "sudo commands for superusers",
-		Hidden: true,
+		Use:     "sudo",
+		Short:   "sudo commands for superusers",
+		Hidden:  true,
+		GroupID: internalGroupID,
 	}
 	sudoCmd.AddCommand(lookupCmd(ch))
 	sudoCmd.AddCommand(org.OrgCmd(ch))

--- a/cli/cmd/sudo/sudo.go
+++ b/cli/cmd/sudo/sudo.go
@@ -16,9 +16,6 @@ import (
 
 func SudoCmd(ch *cmdutil.Helper) *cobra.Command {
 	internalGroupID := ""
-	if ch.IsDev() {
-		internalGroupID = "Internal"
-	}
 	sudoCmd := &cobra.Command{
 		Use:     "sudo",
 		Short:   "sudo commands for superusers",

--- a/cli/cmd/verify_install.go
+++ b/cli/cmd/verify_install.go
@@ -7,6 +7,10 @@ import (
 )
 
 func verifyInstallCmd(ch *cmdutil.Helper) *cobra.Command {
+	internalGroupID := ""
+	if ch.IsDev() {
+		internalGroupID = "Internal"
+	}
 	cmd := &cobra.Command{
 		Use:    "verify-install",
 		Short:  "Verify installation (called by install script)",
@@ -15,6 +19,7 @@ func verifyInstallCmd(ch *cmdutil.Helper) *cobra.Command {
 			ch.Telemetry(cmd.Context()).RecordBehavioralLegacy(activity.BehavioralEventInstallSuccess)
 			return nil
 		},
+		GroupID: internalGroupID,
 	}
 
 	return cmd

--- a/cli/cmd/verify_install.go
+++ b/cli/cmd/verify_install.go
@@ -8,9 +8,6 @@ import (
 
 func verifyInstallCmd(ch *cmdutil.Helper) *cobra.Command {
 	internalGroupID := ""
-	if ch.IsDev() {
-		internalGroupID = "Internal"
-	}
 	cmd := &cobra.Command{
 		Use:    "verify-install",
 		Short:  "Verify installation (called by install script)",

--- a/cli/pkg/cmdutil/group.go
+++ b/cli/pkg/cmdutil/group.go
@@ -3,7 +3,15 @@ package cmdutil
 import "github.com/spf13/cobra"
 
 // AddGroup adds a group of commands to the parent command.
-func AddGroup(parent *cobra.Command, title string, children ...*cobra.Command) {
+func AddGroup(parent *cobra.Command, title string, hidden bool, children ...*cobra.Command) {
+	// If the group is hidden, add the children directly to the parent.
+	if hidden {
+		for _, child := range children {
+			parent.AddCommand(child)
+		}
+		return
+	}
+
 	group := &cobra.Group{ID: title, Title: title}
 
 	// Add add the group to the parent command.

--- a/cli/pkg/cmdutil/group.go
+++ b/cli/pkg/cmdutil/group.go
@@ -1,0 +1,17 @@
+package cmdutil
+
+import "github.com/spf13/cobra"
+
+// AddGroup adds a group of commands to the parent command.
+func AddGroup(parent *cobra.Command, title string, children ...*cobra.Command) {
+	group := &cobra.Group{ID: title, Title: title}
+
+	// Add add the group to the parent command.
+	parent.AddGroup(group)
+
+	// Add the child commands to the group.
+	for _, child := range children {
+		child.GroupID = title
+		parent.AddCommand(child)
+	}
+}


### PR DESCRIPTION
**Description**

`rill org edit` now allows for the editing of the organizations "Display Name"

```sh
rill org edit
? Select org to edit demo
? Do you want to update the display name Yes
? Enter the display name new-demo
? Do you want to update the description No
? Do you want to update the billing email No
Updated organization
  NAME   CREATED AT
 ------ ---------------------
  demo   2023-06-21 04:57:34
```

```sh
rill org show
# ..snip
Name: demo
Display Name: new-demo
# ..snip
```


Updates default help with command groupings

```sh
Work with Rill projects directly from the command line.

Usage:
  rill [command]

Project
  start          Build project and start web app
  deploy         Deploy project to Rill Cloud
  project        Manage projects
  public-url     Manage public URLs
  env            Manage variables for a project

Organization
  org            Manage organisations
  user           Manage users
  usergroup      Manage user groups
  service        Manage service accounts
  billing        Billing related commands for org

Auth
  login          Authenticate with the Rill API
  logout         Logout of the Rill API
  whoami         Show current user

Internal
  admin          Manage an admin server
  runtime        Manage stand-alone runtimes
  verify-install Verify installation (called by install script)

Additional Commands:
  docs           Open docs.rilldata.com
  version        Show Rill version
  upgrade        Upgrade Rill to the latest version
  uninstall      Uninstall the Rill binary
  help           Help about any command

Flags:
      --api-token string   Token for authenticating with the cloud API
      --api-url string     Base URL for the cloud API
      --format string      Output format (options: "human", "json", "csv") (default "human")
  -h, --help               Print usage
      --interactive        Prompt for missing required parameters (default true)
  -v, --version            Show rill version

Use "rill [command] --help" for more information about a command.

```

