### PR TITLE
set insert_distributed_sync = 1 by default for clickhouse models

### DIFF
--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -114,8 +114,6 @@ type configProperties struct {
 	SSL bool `mapstructure:"ssl"`
 	// Cluster name. Required for running distributed queries.
 	Cluster string `mapstructure:"cluster"`
-	// EnableCache controls whether to enable cache for Clickhouse queries.
-	EnableCache bool `mapstructure:"enable_cache"`
 	// LogQueries controls whether to log the raw SQL passed to OLAP.Execute.
 	LogQueries bool `mapstructure:"log_queries"`
 	// SettingsOverride override the default settings used in queries. One use case is to disable settings and set `readonly = 1` when using read-only user.

--- a/runtime/drivers/clickhouse/olap.go
+++ b/runtime/drivers/clickhouse/olap.go
@@ -113,10 +113,7 @@ func (c *connection) Execute(ctx context.Context, stmt *drivers.Statement) (res 
 	if c.config.SettingsOverride != "" {
 		stmt.Query += "\n SETTINGS " + c.config.SettingsOverride
 	} else {
-		stmt.Query += "\n SETTINGS cast_keep_nullable = 1, join_use_nulls = 1, session_timezone = 'UTC', prefer_global_in_and_join = 1"
-		if c.config.EnableCache {
-			stmt.Query += ", use_query_cache = 1"
-		}
+		stmt.Query += "\n SETTINGS cast_keep_nullable = 1, join_use_nulls = 1, session_timezone = 'UTC', prefer_global_in_and_join = 1, insert_distributed_sync = 1"
 	}
 
 	// Gather metrics only for actual queries


### PR DESCRIPTION
closes https://github.com/rilldata/rill-private-issues/issues/1057

1. We now set `insert_distributed_sync = 1` by default for clickhouse models. Based on the pros and cons listed here I do not see issues in setting this : https://github.com/ClickHouse/ClickHouse/issues/20053#issuecomment-773069116
2. Also deprecated config to enable clickhouse's internal query cache(It was added for experimentation). Can be directly set on cluster if required in future.