### PR TITLE
feat : http to duckdb model executor

### DIFF
--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -387,8 +387,11 @@ func (c *connection) AsModelExecutor(instanceID string, opts *drivers.ModelExecu
 		if f, ok := opts.InputHandle.AsFileStore(); ok && opts.InputConnector == "local_file" {
 			return &localFileToSelfExecutor{c, f}, true
 		}
-		if opts.InputHandle.Driver() == "mysql" || opts.InputHandle.Driver() == "postgres" {
+		switch opts.InputHandle.Driver() {
+		case "mysql", "postgres":
 			return &sqlStoreToSelfExecutor{c}, true
+		case "https":
+			return &httpsToSelfExecutor{c}, true
 		}
 	}
 	if opts.InputHandle == c {

--- a/runtime/drivers/duckdb/model_executor_https_self.go
+++ b/runtime/drivers/duckdb/model_executor_https_self.go
@@ -1,0 +1,95 @@
+package duckdb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/rilldata/rill/runtime/drivers"
+)
+
+type httpsToSelfInputProps struct {
+	Path    string            `mapstructure:"path"`
+	URI     string            `mapstructure:"uri"`
+	Headers map[string]string `mapstructure:"headers"`
+	Format  string
+}
+
+func (p *httpsToSelfInputProps) resolvePath() string {
+	// Backwards compatibility for "uri" renamed to "path"
+	if p.URI != "" {
+		return p.URI
+	}
+	return p.Path
+}
+
+func (p *httpsToSelfInputProps) Validate() error {
+	if p.URI == "" && p.Path == "" {
+		return fmt.Errorf("missing property 'path'")
+	}
+	if p.URI != "" && p.Path != "" {
+		return fmt.Errorf("cannot set both 'uri' and 'path'")
+	}
+	return nil
+}
+
+type httpsToSelfExecutor struct {
+	c *connection
+}
+
+var _ drivers.ModelExecutor = &httpsToSelfExecutor{}
+
+func (e *httpsToSelfExecutor) Concurrency(desired int) (int, bool) {
+	if desired > 1 {
+		return 0, false
+	}
+	return 1, true
+}
+
+func (e *httpsToSelfExecutor) Execute(ctx context.Context, opts *drivers.ModelExecuteOptions) (*drivers.ModelResult, error) {
+	inputProps := &httpsToSelfInputProps{}
+	if err := mapstructure.WeakDecode(opts.InputProperties, inputProps); err != nil {
+		return nil, fmt.Errorf("failed to parse input properties: %w", err)
+	}
+	if err := inputProps.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid input properties: %w", err)
+	}
+
+	// Build the model executor options with updated input properties
+	clone := *opts
+	newInputProps, err := e.modelInputProperties(opts.ModelName, opts.InputConnector, inputProps)
+	if err != nil {
+		return nil, err
+	}
+	clone.InputProperties = newInputProps
+	newOpts := &clone
+
+	// execute
+	executor := &selfToSelfExecutor{c: e.c}
+	return executor.Execute(ctx, newOpts)
+}
+
+func (e *httpsToSelfExecutor) modelInputProperties(modelName, inputConnector string, inputProps *httpsToSelfInputProps) (map[string]any, error) {
+	m := &ModelInputProperties{}
+	safeSecret := safeSQLName(fmt.Sprintf("%s__%s__secret__", modelName, inputConnector))
+	if len(inputProps.Headers) != 0 {
+		m.PreExec = createSecretSQL(safeSecret, inputProps.Headers)
+	}
+	m.SQL = "SELECT * FROM " + safeSQLString(inputProps.resolvePath())
+	propsMap := make(map[string]any)
+	if err := mapstructure.Decode(m, &propsMap); err != nil {
+		return nil, err
+	}
+	fmt.Printf("propsMap: %v\n", propsMap)
+	return propsMap, nil
+}
+
+func createSecretSQL(safeName string, headers map[string]string) string {
+	var headerStrings []string
+	for key, value := range headers {
+		headerStrings = append(headerStrings, fmt.Sprintf("%s: %s", safeSQLString(key), safeSQLString(value)))
+	}
+	headersSQL := strings.Join(headerStrings, ", ")
+	return fmt.Sprintf(`CREATE OR REPLACE TEMPORARY SECRET %s (TYPE HTTP, EXTRA_HTTP_HEADERS MAP { %s })`, safeName, headersSQL)
+}

--- a/runtime/drivers/duckdb/model_executor_https_self.go
+++ b/runtime/drivers/duckdb/model_executor_https_self.go
@@ -13,7 +13,6 @@ type httpsToSelfInputProps struct {
 	Path    string            `mapstructure:"path"`
 	URI     string            `mapstructure:"uri"`
 	Headers map[string]string `mapstructure:"headers"`
-	Format  string
 }
 
 func (p *httpsToSelfInputProps) resolvePath() string {
@@ -81,7 +80,6 @@ func (e *httpsToSelfExecutor) modelInputProperties(modelName, inputConnector str
 	if err := mapstructure.Decode(m, &propsMap); err != nil {
 		return nil, err
 	}
-	fmt.Printf("propsMap: %v\n", propsMap)
 	return propsMap, nil
 }
 

--- a/runtime/drivers/duckdb/model_executor_https_self_test.go
+++ b/runtime/drivers/duckdb/model_executor_https_self_test.go
@@ -1,0 +1,103 @@
+package duckdb
+
+import (
+	"context"
+	"encoding/csv"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rilldata/rill/runtime/drivers"
+	_ "github.com/rilldata/rill/runtime/drivers/https"
+	activity "github.com/rilldata/rill/runtime/pkg/activity"
+	"github.com/rilldata/rill/runtime/storage"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// CSV Data used in the test
+var testCSVData = [][]string{
+	{"Name", "Age", "City"},
+	{"Alice", "30", "New York"},
+	{"Bob", "25", "Los Angeles"},
+	{"Charlie", "35", "Chicago"},
+}
+
+// CSV Handler function for the test server
+func csvHandler(w http.ResponseWriter, r *http.Request) {
+	apiKey := r.Header.Get("X-API-Key")
+	if apiKey != "test-key" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition", "attachment; filename=data.csv")
+
+	writer := csv.NewWriter(w)
+	defer writer.Flush()
+	for _, row := range testCSVData {
+		writer.Write(row)
+	}
+}
+
+func TestHTTPToDuckDBTransfer(t *testing.T) {
+	// Create a test server using the handler
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/data.csv" {
+			http.NotFound(w, r)
+			return
+		}
+		csvHandler(w, r)
+	}))
+	defer server.Close() // Ensure server shuts down after test
+
+	to, err := drivers.Open("duckdb", "default", map[string]any{}, storage.MustNew(t.TempDir(), nil), activity.NewNoopClient(), zap.NewNop())
+	require.NoError(t, err)
+
+	inputHandle, err := drivers.Open("https", "default", map[string]any{}, storage.MustNew(t.TempDir(), nil), activity.NewNoopClient(), zap.NewNop())
+	require.NoError(t, err)
+
+	opts := &drivers.ModelExecutorOptions{
+		InputHandle:     inputHandle,
+		InputConnector:  "https",
+		OutputHandle:    to,
+		OutputConnector: "duckdb",
+		Env: &drivers.ModelEnv{
+			AllowHostAccess: false,
+			StageChanges:    true,
+		},
+		PreliminaryInputProperties: map[string]any{
+			"path":    server.URL + "/data.csv",
+			"headers": map[string]any{"X-API-Key": "test-key"},
+		},
+		PreliminaryOutputProperties: map[string]any{
+			"table": "sink",
+		},
+	}
+
+	me, ok := to.AsModelExecutor("default", opts)
+	require.True(t, ok)
+
+	execOpts := &drivers.ModelExecuteOptions{
+		ModelExecutorOptions: opts,
+		InputProperties:      opts.PreliminaryInputProperties,
+		OutputProperties:     opts.PreliminaryOutputProperties,
+	}
+
+	_, err = me.Execute(context.Background(), execOpts)
+	require.NoError(t, err)
+
+	olap, ok := to.AsOLAP("default")
+	require.True(t, ok)
+
+	res, err := olap.Execute(context.Background(), &drivers.Statement{Query: "select count(*) from sink"})
+	require.NoError(t, err)
+	for res.Next() {
+		var count int
+		err = res.Rows.Scan(&count)
+		require.NoError(t, err)
+		require.Equal(t, 3, count)
+	}
+	require.NoError(t, res.Close())
+}

--- a/runtime/drivers/duckdb/model_executor_https_self_test.go
+++ b/runtime/drivers/duckdb/model_executor_https_self_test.go
@@ -8,11 +8,12 @@ import (
 	"testing"
 
 	"github.com/rilldata/rill/runtime/drivers"
-	_ "github.com/rilldata/rill/runtime/drivers/https"
 	activity "github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/rilldata/rill/runtime/storage"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	_ "github.com/rilldata/rill/runtime/drivers/https"
 )
 
 // CSV Data used in the test


### PR DESCRIPTION
subtask for https://github.com/rilldata/rill-private-issues/issues/854

Adds a model executor that ingests data from https to duckdb.
Sample model file
```
connector: https
path: https://storage.googleapis.com/rilldata-public/mobile-demo-funnel.parquet

output:
  connector: duckdb
```