### PR TITLE
Fix panic if `analytics_enabled: false`

### DIFF
--- a/runtime/pkg/activity/client.go
+++ b/runtime/pkg/activity/client.go
@@ -141,6 +141,9 @@ func (c *Client) RecordBehavioralLegacy(name string, extraAttrs ...attribute.Key
 	//     payload        map[string]any
 
 	data := c.resolveAttrs(context.Background(), extraAttrs)
+	if data == nil {
+		data = make(map[string]any)
+	}
 
 	if _, ok := data["install_id"]; !ok {
 		data["install_id"] = ""


### PR DESCRIPTION
Since this is not a documented feature, it hasn't been tested much before. I did some additional QA and did not find a need for other changes.

Closes https://github.com/rilldata/rill-private-issues/issues/999