### PR TITLE
Fix initial load of Cloud dashboard

### DIFF
--- a/web-admin/src/routes/[organization]/[project]/explore/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/explore/[dashboard]/+page.svelte
@@ -7,10 +7,11 @@
   import { viewAsUserStore } from "@rilldata/web-admin/features/view-as-user/viewAsUserStore";
   import { Dashboard } from "@rilldata/web-common/features/dashboards";
   import DashboardThemeProvider from "@rilldata/web-common/features/dashboards/DashboardThemeProvider.svelte";
-  import DashboardURLStateSync from "@rilldata/web-common/features/dashboards/url-state/DashboardURLStateSync.svelte";
   import StateManagersProvider from "@rilldata/web-common/features/dashboards/state-managers/StateManagersProvider.svelte";
+  import DashboardURLStateSync from "@rilldata/web-common/features/dashboards/url-state/DashboardURLStateSync.svelte";
   import { useExplore } from "@rilldata/web-common/features/explores/selectors";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
+  import type { V1GetExploreResponse } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import type { PageData } from "./$types";
 
@@ -45,10 +46,12 @@
   $: ({ organization: orgName, project: projectName } = $page.params);
 
   $: explore = useExplore(instanceId, exploreName, {
-    refetchInterval: () => {
-      if (isDashboardReconcilingForFirstTime) {
+    refetchInterval: (data) => {
+      if (!data) {
+        return false;
+      } else if (isDashboardReconcilingForFirstTime(data)) {
         return PollIntervalWhenDashboardFirstReconciling;
-      } else if (isDashboardErrored) {
+      } else if (isDashboardErrored(data)) {
         return PollIntervalWhenDashboardErrored;
       } else {
         return false;
@@ -62,16 +65,6 @@
     !$explore.data &&
     $explore.isError &&
     $explore.error?.response?.status === 404;
-  // TODO: should these be checking metricsView or explore?
-  $: isDashboardReconcilingForFirstTime =
-    !$explore?.data?.metricsView?.metricsView?.state?.validSpec &&
-    !$explore?.data?.metricsView?.meta?.reconcileError;
-  // We check for metricsView.state.validSpec instead of meta.reconcileError. validSpec persists
-  // from previous valid dashboards, allowing display even when the current dashboard spec is invalid
-  // and a meta.reconcileError exists.
-  $: isDashboardErrored =
-    !$explore?.data?.metricsView?.metricsView?.state?.validSpec &&
-    !!$explore?.data?.metricsView?.meta?.reconcileError;
   $: metricsViewName = $explore.data?.metricsView?.meta?.name?.name;
 
   // If no dashboard is found, show a 404 page
@@ -89,6 +82,32 @@
     viewAsUserStore.set(null);
     errorStore.reset();
   });
+
+  /**
+   * The `isDashboardReconcilingForFirstTime` and `isDashboardErrored` helper functions are intentionally used instead of similarly-named variables.
+   * Using variables instead of functions would create a circular dependency that chokes Svelte's reactivity, as the values inside the `useExplore` hook would
+   * themselves be derived from the output of the `useExplore` hook.
+   */
+  function isDashboardReconcilingForFirstTime(
+    exploreResponse: V1GetExploreResponse,
+  ) {
+    if (!exploreResponse) return undefined;
+    return (
+      !exploreResponse.metricsView?.metricsView?.state?.validSpec &&
+      !exploreResponse.metricsView?.meta?.reconcileError
+    );
+  }
+
+  function isDashboardErrored(exploreResponse: V1GetExploreResponse) {
+    if (!exploreResponse) return undefined;
+    // We only consider a dashboard errored (from the end-user perspective) when BOTH a reconcile error exists AND a validSpec does not exist.
+    // If there's any validSpec (which can persist from a previous, non-current spec), then we serve that version of the dashboard to the user,
+    // so the user does not see an error state.
+    return (
+      !exploreResponse.metricsView?.metricsView?.state?.validSpec &&
+      !!exploreResponse.metricsView?.meta?.reconcileError
+    );
+  }
 </script>
 
 <svelte:head>
@@ -96,9 +115,9 @@
 </svelte:head>
 
 {#if $explore.isSuccess}
-  {#if isDashboardReconcilingForFirstTime}
+  {#if isDashboardReconcilingForFirstTime($explore.data)}
     <DashboardBuilding />
-  {:else if isDashboardErrored}
+  {:else if isDashboardErrored($explore.data)}
     <DashboardErrored organization={orgName} project={projectName} />
   {:else if metricsViewName}
     {#key exploreName}


### PR DESCRIPTION
Upon merging PR https://github.com/rilldata/rill/pull/6410, I've noticed a bug where the dashboard hangs on initial load. 

Here's the video of a failed e2e test from the [Cloud e2e test PR](https://github.com/rilldata/rill/pull/6244):

https://github.com/user-attachments/assets/aae7f040-b434-413b-9bb7-dc5693a026c9

The problem appears to be a circular reference that leads to issues with Svelte reactivity. See the code comment above the new `isDashboardReconcilingForFirstTime()` function for more detail. 