### PR TITLE
fix(hacky bypass) org pagination for several commands

### DIFF
--- a/cli/cmd/auth/login.go
+++ b/cli/cmd/auth/login.go
@@ -126,7 +126,9 @@ func SelectOrgFlow(ctx context.Context, ch *cmdutil.Helper, interactive bool) er
 		return err
 	}
 
-	res, err := client.ListOrganizations(ctx, &adminv1.ListOrganizationsRequest{})
+	res, err := client.ListOrganizations(ctx, &adminv1.ListOrganizationsRequest{
+		PageSize: 1000,
+	})
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/org/org.go
+++ b/cli/cmd/org/org.go
@@ -34,7 +34,9 @@ func OrgNames(ctx context.Context, ch *cmdutil.Helper) ([]string, error) {
 		return nil, err
 	}
 
-	resp, err := c.ListOrganizations(ctx, &adminv1.ListOrganizationsRequest{})
+	resp, err := c.ListOrganizations(ctx, &adminv1.ListOrganizationsRequest{
+		PageSize: 1000,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmd/org/switch.go
+++ b/cli/cmd/org/switch.go
@@ -84,7 +84,9 @@ func SetDefaultOrg(ctx context.Context, ch *cmdutil.Helper) error {
 		return err
 	}
 
-	res, err := c.ListOrganizations(ctx, &adminv1.ListOrganizationsRequest{})
+	res, err := c.ListOrganizations(ctx, &adminv1.ListOrganizationsRequest{
+		PageSize: 1000,
+	})
 	if err != nil {
 		return fmt.Errorf("listing orgs failed: %w", err)
 	}


### PR DESCRIPTION
May be we should just set the default as 1000 since both UI and CLI use 1000 at several places.