### PR TITLE
fix: save content method

### DIFF
--- a/web-common/src/features/entity-management/file-artifact.ts
+++ b/web-common/src/features/entity-management/file-artifact.ts
@@ -209,7 +209,7 @@ export class FileArtifact {
     await this.saveContent(get(this.editorContent) ?? "");
   };
 
-  saveContent = async (blob: string) => {
+  private saveContent = async (blob: string) => {
     const instanceId = get(runtime).instanceId;
 
     // Optimistically update the query

--- a/web-common/src/features/visual-metrics-editing/EditControls.svelte
+++ b/web-common/src/features/visual-metrics-editing/EditControls.svelte
@@ -17,13 +17,24 @@
   export let first = false;
   export let last = false;
   export let selected = false;
+  export let itemType: "measures" | "dimensions";
+  export let name: string;
 
   let type: "subtle" | "ghost";
   $: type = selected ? "subtle" : "ghost";
+
+  $: singularType = itemType.slice(0, -1);
 </script>
 
 <Tooltip distance={8} activeDelay={500}>
-  <Button {type} noStroke gray={!selected} square on:click={onEdit}>
+  <Button
+    {type}
+    noStroke
+    gray={!selected}
+    square
+    on:click={onEdit}
+    label="Edit {singularType} {name}"
+  >
     <Pen size="14px" />
   </Button>
   <TooltipContent slot="tooltip-content">
@@ -32,7 +43,14 @@
 </Tooltip>
 
 <Tooltip distance={8} activeDelay={500}>
-  <Button {type} noStroke square gray={!selected} on:click={onDelete}>
+  <Button
+    {type}
+    noStroke
+    square
+    gray={!selected}
+    on:click={onDelete}
+    label="Delete {singularType} {name}"
+  >
     <Trash2Icon size="14px" />
   </Button>
   <TooltipContent slot="tooltip-content">
@@ -41,7 +59,14 @@
 </Tooltip>
 
 <Tooltip distance={8} activeDelay={500}>
-  <Button {type} noStroke square gray={!selected} on:click={onDuplicate}>
+  <Button
+    {type}
+    noStroke
+    square
+    gray={!selected}
+    on:click={onDuplicate}
+    label="Duplicate {singularType} {name}"
+  >
     <CopyIcon size="14px" />
   </Button>
   <TooltipContent slot="tooltip-content">
@@ -56,6 +81,7 @@
     square
     gray={!selected}
     disabled={first}
+    label="Move {singularType} {name} to top"
     on:click={() => onMoveTo(true)}
   >
     <ArrowUpToLineIcon size="14px" />
@@ -72,6 +98,7 @@
     square
     gray={!selected}
     disabled={last}
+    label="Move {singularType} {name} to bottom"
     on:click={() => onMoveTo(false)}
   >
     <ArrowDownToLineIcon size="14px" />

--- a/web-common/src/features/visual-metrics-editing/MetricsTable.svelte
+++ b/web-common/src/features/visual-metrics-editing/MetricsTable.svelte
@@ -36,8 +36,6 @@
     field?: string,
   ) => void;
 
-  $: console.log(type, { items });
-
   let clientWidth: HTMLTableRowElement;
   let tbody: HTMLTableSectionElement;
   let scroll = 0;

--- a/web-common/src/features/visual-metrics-editing/MetricsTable.svelte
+++ b/web-common/src/features/visual-metrics-editing/MetricsTable.svelte
@@ -36,6 +36,8 @@
     field?: string,
   ) => void;
 
+  $: console.log(type, { items });
+
   let clientWidth: HTMLTableRowElement;
   let tbody: HTMLTableSectionElement;
   let scroll = 0;

--- a/web-common/src/features/visual-metrics-editing/MetricsTableRow.svelte
+++ b/web-common/src/features/visual-metrics-editing/MetricsTableRow.svelte
@@ -42,7 +42,7 @@
 
   $: ({ name, display_name, expression, description } = item);
 
-  $: id = name ?? display_name ?? "";
+  $: id = name || display_name || "";
 
   $: finalSelected = selected && !sidebarOpen;
 
@@ -61,6 +61,7 @@
   style:transform="translateY({translate}px)"
   class="relative text-sm"
   style:height="{rowHeight}px"
+  aria-label="{type.slice(0, -1)} {display_name || name}"
   class:editing
   class:dragging
   class:ghost
@@ -138,6 +139,8 @@
       class:selected={finalSelected}
     >
       <EditControls
+        itemType={type}
+        name={item.display_name || item.name}
         selected={finalSelected}
         first={i === 0}
         last={i === length - 1}

--- a/web-common/src/features/workspaces/VisualExploreEditing.svelte
+++ b/web-common/src/features/workspaces/VisualExploreEditing.svelte
@@ -214,7 +214,7 @@
     }
   }
 
-  async function updateProperties(
+  function updateProperties(
     newRecord: Record<string, unknown>,
     removeProperties?: Array<string | string[]>,
   ) {

--- a/web-common/src/features/workspaces/VisualMetrics.svelte
+++ b/web-common/src/features/workspaces/VisualMetrics.svelte
@@ -96,7 +96,7 @@
 
   $: totalSelected = selected.measures.size + selected.dimensions.size;
 
-  $: ({ editorContent, saveContent, getResource } = fileArtifact);
+  $: ({ editorContent, updateEditorContent, getResource } = fileArtifact);
 
   // YAML Parsing
   $: parsedDocument = parseDocument($editorContent ?? "");
@@ -320,7 +320,7 @@
     unsavedChanges = false;
   }
 
-  async function updateProperties(
+  function updateProperties(
     newRecord: Record<string, unknown>,
     removeProperties?: string[],
   ) {
@@ -338,7 +338,7 @@
       });
     }
 
-    await saveContent(parsedDocument.toString());
+    updateEditorContent(parsedDocument.toString(), false, true);
   }
 
   $: editingItem = $editingItemData
@@ -419,7 +419,7 @@
     }
   }
 
-  async function deleteItems(items: Partial<typeof selected>) {
+  function deleteItems(items: Partial<typeof selected>) {
     let deletedEditingItem = false;
 
     Object.entries(items).forEach(([type, indices]) => {
@@ -451,7 +451,7 @@
 
     selected = selected;
 
-    await saveContent(parsedDocument.toString());
+    updateEditorContent(parsedDocument.toString(), false, true);
 
     if (deletedEditingItem) {
       resetEditing();
@@ -460,7 +460,7 @@
     eventBus.emit("notification", { message: "Item deleted", type: "success" });
   }
 
-  async function duplicateItem(index: number, type: ItemType) {
+  function duplicateItem(index: number, type: ItemType) {
     const sequence = raw[type];
 
     if (!(sequence instanceof YAMLSeq)) {
@@ -496,7 +496,7 @@
 
     items.splice(index + 1, 0, newItem);
 
-    await updateProperties({ [type]: items });
+    updateProperties({ [type]: items });
 
     eventBus.emit("notification", {
       message: "Item duplicated",
@@ -513,7 +513,7 @@
       connector: rawConnector,
       database_schema: rawDatabaseSchema,
     };
-    await updateProperties(storedProperties);
+    updateProperties(storedProperties);
 
     storedProperties = currentProperties;
     tableMode = !mode;
@@ -582,7 +582,7 @@
             label="Model"
             onChange={async (newModelOrSourceName) => {
               if (!modelOrSourceOrTableName) {
-                await updateProperties({ model: newModelOrSourceName }, [
+                updateProperties({ model: newModelOrSourceName }, [
                   "table",
                   "database",
                   "connector",

--- a/web-local/tests/metrics-editor.spec.ts
+++ b/web-local/tests/metrics-editor.spec.ts
@@ -11,7 +11,7 @@ import { test } from "./utils/test";
 test.describe("Metrics editor", () => {
   useDashboardFlowTestSetup();
 
-  test("Can add measures and dimensions", async ({ page }) => {
+  test("Can add and remove measures and dimensions", async ({ page }) => {
     await gotoNavEntry(page, AD_BIDS_METRICS_PATH);
 
     await page.getByRole("button", { name: "Add new measure" }).click();
@@ -33,6 +33,30 @@ test.describe("Metrics editor", () => {
     await expect(
       page.getByText("New Dimension", { exact: true }),
     ).toBeVisible();
+
+    // Delete measure
+    await page.getByRole("row", { name: "measure New Measure" }).hover();
+    await page
+      .getByRole("button", { name: "Delete measure New Measure" })
+      .click();
+
+    await page.getByRole("button", { name: "Yes, delete" }).click();
+
+    await expect(
+      page.getByText("New Measure", { exact: true }),
+    ).not.toBeVisible();
+
+    // Delete dimension
+    await page.getByRole("row", { name: "dimension New Dimension" }).hover();
+    await page
+      .getByRole("button", { name: "Delete dimension New Dimension" })
+      .click();
+
+    await page.getByRole("button", { name: "Yes, delete" }).click();
+
+    await expect(
+      page.getByText("New Dimension", { exact: true }),
+    ).not.toBeVisible();
   });
 
   test("Metrics editor", async ({ page }) => {


### PR DESCRIPTION
Private method `saveContent` was still being used in the Visual Metrics Editing surface, preventing the UI from updating after making certain changes. Updates surface to use the `updateEditorContent` method, which has an argument for saving in the same function call.

Also adds a test and necessary selector labels.