### PR TITLE
tweak: resource table column sizing

### DIFF
--- a/web-admin/src/features/projects/status/ProjectResourcesTable.svelte
+++ b/web-admin/src/features/projects/status/ProjectResourcesTable.svelte
@@ -42,6 +42,9 @@
           message: row.original.meta.reconcileError,
           status: row.original.meta.reconcileStatus,
         }),
+      meta: {
+        marginLeft: "1",
+      },
     },
     {
       accessorFn: (row) => row.meta.stateUpdatedOn,
@@ -65,5 +68,5 @@
 <BasicTable
   {data}
   {columns}
-  columnLayout="minmax(95px, 120px) minmax(100px, 1fr) 54px minmax(80px, 210px) minmax(80px, 210px) "
+  columnLayout="minmax(95px, 108px) minmax(100px, 3fr) 48px minmax(80px, 2fr) minmax(100px, 2fr) "
 />

--- a/web-admin/src/features/projects/status/RefreshCell.svelte
+++ b/web-admin/src/features/projects/status/RefreshCell.svelte
@@ -29,7 +29,7 @@
 
 {#if dateTime.isValid}
   <Tooltip distance={8} location="top" suppress={clientWidth > 180}>
-    <div bind:clientWidth class=" w-full">
+    <div bind:clientWidth class="truncate w-full">
       {formattedDate}
     </div>
     <TooltipContent slot="tooltip-content">

--- a/web-admin/src/features/projects/status/ResourceErrorMessage.svelte
+++ b/web-admin/src/features/projects/status/ResourceErrorMessage.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <div class="container">
-  {#if status === V1ReconcileStatus.RECONCILE_STATUS_PENDING || status === V1ReconcileStatus.RECONCILE_STATUS_RUNNING}}
+  {#if status === V1ReconcileStatus.RECONCILE_STATUS_PENDING || status === V1ReconcileStatus.RECONCILE_STATUS_RUNNING}
     <LoadingSpinner size="18px" />
   {:else if message}
     <Tooltip distance={8}>

--- a/web-common/src/components/table/BasicTable.svelte
+++ b/web-common/src/components/table/BasicTable.svelte
@@ -79,16 +79,19 @@
           this={header.column.getCanSort() ? "button" : "div"}
           role="columnheader"
           tabindex="0"
-          class="pl-4 py-2 font-semibold text-gray-500 text-left flex flex-row items-center gap-x-1 truncate"
+          class="pl-{header.column.columnDef.meta?.marginLeft ||
+            '4'} py-2 font-semibold text-gray-500 text-left flex flex-row items-center gap-x-1 truncate"
           on:click={header.column.getToggleSortingHandler()}
         >
           {#if !header.isPlaceholder}
-            <svelte:component
-              this={flexRender(
-                header.column.columnDef.header,
-                header.getContext(),
-              )}
-            />
+            <span class="truncate">
+              <svelte:component
+                this={flexRender(
+                  header.column.columnDef.header,
+                  header.getContext(),
+                )}
+              />
+            </span>
             {#if header.column.getIsSorted().toString() === "asc"}
               <span>
                 <ArrowDown flip size="12px" />
@@ -107,7 +110,10 @@
   {#each rows as row (row.id)}
     <div class="row {rowPadding}">
       {#each row.getVisibleCells() as cell (cell.id)}
-        <div class="pl-4 pr-1 flex items-center truncate">
+        <div
+          class="pl-{cell.column.columnDef.meta?.marginLeft ||
+            '4'} pr-1 flex items-center truncate"
+        >
           <svelte:component
             this={flexRender(cell.column.columnDef.cell, cell.getContext())}
           />


### PR DESCRIPTION
https://rilldata.slack.com/archives/C02T907FEUB/p1736947978246939

- Removes extraneous `}` character in `ResourceErrorMessage`
- Updates column sizings to gain a little more space where needed
- Adds `truncate` class to header cell
- Adds `truncate` class to date strings