### PR TITLE
Avoid grabbing lock in rduckdb.localDBMonitor if local is already in sync with remote

### DIFF
--- a/runtime/pkg/rduckdb/db.go
+++ b/runtime/pkg/rduckdb/db.go
@@ -647,7 +647,7 @@ func (d *db) localDBMonitor() {
 			return
 		case <-ticker.C:
 			if !d.localDirty.Load() {
-				// all good
+				// already in sync
 				continue
 			}
 			err := d.writeSem.Acquire(d.ctx, 1)
@@ -658,7 +658,7 @@ func (d *db) localDBMonitor() {
 				continue
 			}
 			if !d.localDirty.Load() {
-				// just to be sure if a CRUD API was called in the meantime
+				// tiny optimisation if a CRUD API was called in the meantime and already synced
 				d.writeSem.Release(1)
 				continue
 			}

--- a/runtime/pkg/rduckdb/remote.go
+++ b/runtime/pkg/rduckdb/remote.go
@@ -21,7 +21,7 @@ import (
 // pullFromRemote updates local data with the latest data from remote.
 // This is not safe for concurrent calls.
 func (d *db) pullFromRemote(ctx context.Context, updateCatalog bool) error {
-	if !d.localDirty || d.remote == nil {
+	if !d.localDirty.Load() || d.remote == nil {
 		// optimisation to skip sync if write was already synced
 		if !updateCatalog {
 			// cleanup of older versions of table
@@ -235,7 +235,7 @@ func (d *db) pushToRemote(ctx context.Context, table string, oldMeta, meta *tabl
 
 	// update table meta
 	// todo :: also use etag to avoid concurrent writer conflicts
-	d.localDirty = true
+	d.localDirty.Store(true)
 	m, err := json.Marshal(meta)
 	if err != nil {
 		return fmt.Errorf("failed to marshal table metadata: %w", err)


### PR DESCRIPTION
Write lock is acquired twice in a single reconcile. One during creation of staging table and second during rename of staging table.
The lock acquisition in localDBMonitor competes with CRUD APIs leading to very large reconcile times.