### PR TITLE
fix: array and object filter values

### DIFF
--- a/web-common/src/features/dashboards/url-state/filters/expression.cjs
+++ b/web-common/src/features/dashboards/url-state/filters/expression.cjs
@@ -7,6 +7,7 @@ function id(x) { return x[0]; }
     inPostprocessor,
     havingPostprocessor,
     andOrPostprocessor,
+    objectPostprocessor
   } from "./post-processors.ts";
 let Lexer = undefined;
 let ParserRules = [
@@ -197,6 +198,12 @@ let ParserRules = [
     {"name": "value", "symbols": ["value$subexpression$2"], "postprocess": () => false},
     {"name": "value$subexpression$3", "symbols": [/[nN]/, /[uU]/, /[lL]/, /[lL]/], "postprocess": function(d) {return d.join(""); }},
     {"name": "value", "symbols": ["value$subexpression$3"], "postprocess": () => null},
+    {"name": "value", "symbols": [{"literal":"["}, "_", "value_list", "_", {"literal":"]"}], "postprocess": ([_1, _2, list]) => list},
+    {"name": "value$ebnf$1", "symbols": []},
+    {"name": "value$ebnf$1$subexpression$1", "symbols": ["_", {"literal":","}, "_", "key_value"]},
+    {"name": "value$ebnf$1", "symbols": ["value$ebnf$1", "value$ebnf$1$subexpression$1"], "postprocess": function arrpush(d) {return d[0].concat([d[1]]);}},
+    {"name": "value", "symbols": [{"literal":"{"}, "_", "key_value", "value$ebnf$1", "_", {"literal":"}"}], "postprocess": objectPostprocessor},
+    {"name": "key_value", "symbols": ["sqstring", "_", {"literal":":"}, "_", "value"], "postprocess": ([key, _1, _2, _3, value]) => ({ [key]: value })},
     {"name": "value_list", "symbols": ["value_list", "_", {"literal":","}, "_", "value"], "postprocess": ([list, _1, _2, _3, value]) => [...list, value]},
     {"name": "value_list", "symbols": ["value"], "postprocess": ([v]) => [v]}
 ];

--- a/web-common/src/features/dashboards/url-state/filters/expression.ne
+++ b/web-common/src/features/dashboards/url-state/filters/expression.ne
@@ -11,6 +11,7 @@
     inPostprocessor,
     havingPostprocessor,
     andOrPostprocessor,
+    objectPostprocessor
   } from "./post-processors.ts";
 %}
 
@@ -46,13 +47,18 @@ compare_operator => "eq"i     {% id %}
                   | "lt"i     {% id %}
                   | "lte"i    {% id %}
 
-column     => dqstring                 {% id %}
-            | [a-zA-Z] [a-zA-Z0-9_]:*  {% ([fst, rest]) => [fst, ...rest].join("") %}
-value      => sqstring                 {% id %}
-            | int                      {% id %}
-            | decimal                  {% id %}
-            | "true"i                  {% () => true %}
-            | "false"i                 {% () => false %}
-            | "null"i                  {% () => null %}
+column     => dqstring                {% id %}
+            | [a-zA-Z] [a-zA-Z0-9_]:* {% ([fst, rest]) => [fst, ...rest].join("") %}
+
+value      => sqstring                                    {% id %}
+            | int                                         {% id %}
+            | decimal                                     {% id %}
+            | "true"i                                     {% () => true %}
+            | "false"i                                    {% () => false %}
+            | "null"i                                     {% () => null %}
+            | "[" _ value_list _ "]"                      {% ([_1, _2, list]) => list %}
+            | "{" _ key_value (_ "," _ key_value):* _ "}" {% objectPostprocessor %}
+
+key_value => sqstring _ ":" _ value    {% ([key, _1, _2, _3, value]) => ({ [key]: value }) %}
 value_list => value_list _ "," _ value {% ([list, _1, _2, _3, value]) => [...list, value] %}
             | value                    {% ([v]) => [v] %}

--- a/web-common/src/features/dashboards/url-state/filters/expression.spec.ts
+++ b/web-common/src/features/dashboards/url-state/filters/expression.spec.ts
@@ -91,6 +91,18 @@ describe("expression", () => {
           ),
         ]),
       },
+      {
+        expr: `country IN (['U\\'S','I\\nN'])`,
+        expectedExprString: `country IN (['U\\'S','I\\nN'])`,
+        expectedExprObject: createInExpression("country", [["U'S", "I\nN"]]),
+      },
+      {
+        expr: `country IN ({'US':['SF','LA'],'IN':['BLR','DLH'],'UK':'London'})`,
+        expectedExprString: `country IN ({'US':['SF','LA'],'IN':['BLR','DLH'],'UK':'London'})`,
+        expectedExprObject: createInExpression("country", [
+          { US: ["SF", "LA"], IN: ["BLR", "DLH"], UK: "London" },
+        ]),
+      },
     ];
 
     const compiledGrammar = nearley.Grammar.fromCompiled(grammar);

--- a/web-common/src/features/dashboards/url-state/filters/post-processors.ts
+++ b/web-common/src/features/dashboards/url-state/filters/post-processors.ts
@@ -34,3 +34,16 @@ export const andOrPostprocessor = ([left, right]) => {
   if (op === "AND") return createAndExpression(exprs);
   return createOrExpression(exprs);
 };
+
+export const objectPostprocessor = ([
+  _1,
+  _2,
+  keyValue,
+  otherKeyValuesMatches,
+]) => {
+  const obj = { ...keyValue };
+  otherKeyValuesMatches.forEach(([_1, _2, _3, keyValue]) => {
+    Object.assign(obj, keyValue);
+  });
+  return obj;
+};


### PR DESCRIPTION
URL filter param breaks when the dimension has array and object types. This adds support for parsing of such values.