### PR TITLE
fix : certain db level settings in duckdb can't be set again

### DIFF
--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -500,10 +499,7 @@ func (c *connection) reopenDB(ctx context.Context) error {
 	// We want to set preserve_insertion_order=false in hosted environments only (where source data is never viewed directly). Setting it reduces batch data ingestion time by ~40%.
 	// Hack: Using AllowHostAccess as a proxy indicator for a hosted environment.
 	if !c.config.AllowHostAccess {
-		bootQueries = append(bootQueries,
-			"SET preserve_insertion_order TO false",
-			fmt.Sprintf("SET secret_directory = %s", safeSQLString(filepath.Join(dataDir, ".duckdb", "secrets"))),
-		)
+		bootQueries = append(bootQueries, "SET preserve_insertion_order TO false")
 	}
 
 	// Add init SQL if provided

--- a/runtime/pkg/rduckdb/db.go
+++ b/runtime/pkg/rduckdb/db.go
@@ -743,13 +743,6 @@ func (d *db) openDBAndAttach(ctx context.Context, uri, ignoreTable string, read 
 				return err
 			}
 		}
-		if !read {
-			// disable any more configuration changes on the write handle via init queries
-			_, err = execer.ExecContext(ctx, "SET lock_configuration TO true", nil)
-			if err != nil {
-				return err
-			}
-		}
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
This is just a fix for release blocker. The permanent solution will be as follows:
1. Most of our settings are global configuration except `max_expression_depth`.
2. It seems extensions are now loaded at db level and not connection level. The following code now works:
```
	_, err = conn1.ExecContext(context.Background(), "INSTALL spatial; LOAD spatial;")
	if err != nil {
		log.Fatal(err)
	}

	row := conn2.QueryRowContext(context.Background(), "SELECT ST_Area('POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))'::GEOMETRY);")
	var area float64
	err = row.Scan(&area)
	if err != nil {
		log.Fatal(err)
	}
	log.Println(area)
```
3. Introduce two new options in `rduckdb` : 
       a. `DBInitQueries` : Runs for db handle once. Extensions, global configurations and `init_sql` in connector config will be DBInitQueries.
       b. `ConnInitQueries`: Runs for each connection. Local configurations will be `ConnInitQueries`.
4. After opening DB run `DBInitQueries`.
5. Run `ConnInitQueries` before returning a read or write connection.