### PR TITLE
use literals in distributed engine definition in ch

### DIFF
--- a/runtime/drivers/clickhouse/olap.go
+++ b/runtime/drivers/clickhouse/olap.go
@@ -609,7 +609,7 @@ func (c *connection) createTable(ctx context.Context, name, sql string, outputPr
 		database = "currentDatabase()"
 	}
 	fmt.Fprintf(&distributed, "CREATE OR REPLACE TABLE %s %s AS %s", safeSQLName(name), onClusterClause, safelocalTableName(name))
-	fmt.Fprintf(&distributed, " ENGINE = Distributed('%s', %s, '%s'", c.config.Cluster, database, localTableName(name))
+	fmt.Fprintf(&distributed, " ENGINE = Distributed(%s, %s, %s", safeSQLString(c.config.Cluster), database, safeSQLString(localTableName(name)))
 	if outputProps.DistributedShardingKey != "" {
 		fmt.Fprintf(&distributed, ", %s", outputProps.DistributedShardingKey)
 	} else {
@@ -1191,4 +1191,8 @@ func localTableName(name string) string {
 
 func tempTableForDictionary(name string) string {
 	return name + "_dict_temp_"
+}
+
+func safeSQLString(name string) string {
+	return drivers.DialectClickHouse.EscapeStringValue(name)
 }

--- a/runtime/drivers/clickhouse/olap.go
+++ b/runtime/drivers/clickhouse/olap.go
@@ -609,7 +609,7 @@ func (c *connection) createTable(ctx context.Context, name, sql string, outputPr
 		database = "currentDatabase()"
 	}
 	fmt.Fprintf(&distributed, "CREATE OR REPLACE TABLE %s %s AS %s", safeSQLName(name), onClusterClause, safelocalTableName(name))
-	fmt.Fprintf(&distributed, " ENGINE = Distributed(%s, %s, %s", safeSQLName(c.config.Cluster), database, safelocalTableName(name))
+	fmt.Fprintf(&distributed, " ENGINE = Distributed('%s', '%s', '%s'", c.config.Cluster, database, localTableName(name))
 	if outputProps.DistributedShardingKey != "" {
 		fmt.Fprintf(&distributed, ", %s", outputProps.DistributedShardingKey)
 	} else {

--- a/runtime/drivers/clickhouse/olap.go
+++ b/runtime/drivers/clickhouse/olap.go
@@ -604,9 +604,9 @@ func (c *connection) createTable(ctx context.Context, name, sql string, outputPr
 	}
 	// create the distributed table
 	var distributed strings.Builder
-	database := c.config.Database
-	if c.config.Database == "" {
-		database = "currentDatabase()"
+	database := "currentDatabase()"
+	if c.config.Database != "" {
+		database = safeSQLString(c.config.Database)
 	}
 	fmt.Fprintf(&distributed, "CREATE OR REPLACE TABLE %s %s AS %s", safeSQLName(name), onClusterClause, safelocalTableName(name))
 	fmt.Fprintf(&distributed, " ENGINE = Distributed(%s, %s, %s", safeSQLString(c.config.Cluster), database, safeSQLString(localTableName(name)))

--- a/runtime/drivers/clickhouse/olap.go
+++ b/runtime/drivers/clickhouse/olap.go
@@ -609,7 +609,7 @@ func (c *connection) createTable(ctx context.Context, name, sql string, outputPr
 		database = "currentDatabase()"
 	}
 	fmt.Fprintf(&distributed, "CREATE OR REPLACE TABLE %s %s AS %s", safeSQLName(name), onClusterClause, safelocalTableName(name))
-	fmt.Fprintf(&distributed, " ENGINE = Distributed('%s', '%s', '%s'", c.config.Cluster, database, localTableName(name))
+	fmt.Fprintf(&distributed, " ENGINE = Distributed('%s', %s, '%s'", c.config.Cluster, database, localTableName(name))
 	if outputProps.DistributedShardingKey != "" {
 		fmt.Fprintf(&distributed, ", %s", outputProps.DistributedShardingKey)
 	} else {


### PR DESCRIPTION
otherwise it was quoting the local table name like `ENGINE = Distributed('abc', 'default', '"table_local"', rand())` and queries were failing on it saying local table not found