### PR TITLE
fix: compare time and dimension conflicts in url param

### DIFF
--- a/web-common/src/features/dashboards/url-state/convertExploreStateToPreset.ts
+++ b/web-common/src/features/dashboards/url-state/convertExploreStateToPreset.ts
@@ -95,7 +95,6 @@ function getTimeRangeFields(
   ) {
     preset.selectTimeRange = toTimeRangeParam(exploreState.selectedScrubRange);
   }
-  console.log(preset);
 
   return preset;
 }

--- a/web-common/src/features/dashboards/url-state/convertExploreStateToPreset.ts
+++ b/web-common/src/features/dashboards/url-state/convertExploreStateToPreset.ts
@@ -71,7 +71,7 @@ function getTimeRangeFields(
     timeControlsState.selectedComparisonTimeRange?.name
   ) {
     preset.compareTimeRange = toTimeRangeParam(
-      exploreState.selectedComparisonTimeRange,
+      timeControlsState.selectedComparisonTimeRange,
     );
     preset.comparisonMode =
       V1ExploreComparisonMode.EXPLORE_COMPARISON_MODE_TIME;
@@ -95,6 +95,7 @@ function getTimeRangeFields(
   ) {
     preset.selectTimeRange = toTimeRangeParam(exploreState.selectedScrubRange);
   }
+  console.log(preset);
 
   return preset;
 }

--- a/web-common/src/features/dashboards/url-state/convertPresetToExploreState.ts
+++ b/web-common/src/features/dashboards/url-state/convertPresetToExploreState.ts
@@ -146,11 +146,13 @@ function fromTimeRangesParams(
     partialExploreState.selectedTimezone = preset.timezone;
   }
 
+  let setCompareTimeRange = false;
   if (preset.compareTimeRange) {
     partialExploreState.selectedComparisonTimeRange = fromTimeRangeUrlParam(
       preset.compareTimeRange,
     );
     partialExploreState.showTimeComparison = true;
+    setCompareTimeRange = true;
     if (
       preset.comparisonMode ===
       V1ExploreComparisonMode.EXPLORE_COMPARISON_MODE_TIME
@@ -171,7 +173,9 @@ function fromTimeRangesParams(
         preset.comparisonDimension;
       if (
         preset.comparisonMode ===
-        V1ExploreComparisonMode.EXPLORE_COMPARISON_MODE_DIMENSION
+          V1ExploreComparisonMode.EXPLORE_COMPARISON_MODE_DIMENSION &&
+        // since we are setting partial explore state we need to unset time compare settings
+        !setCompareTimeRange
       ) {
         // unset compare time ranges
         partialExploreState.selectedComparisonTimeRange = undefined;


### PR DESCRIPTION
Since we use comparison mode in explore preset there could be issues when both time and dimension comparison are enabled. Since we actually support for both to be present at the same time this fixes some edge cases with it. The main one is setting both and switching between pivot and explore.