### PR TITLE
Bug: Use Custom River Error Handler

### DIFF
--- a/admin/jobs/river/org_jobs.go
+++ b/admin/jobs/river/org_jobs.go
@@ -31,7 +31,7 @@ func (w *InitOrgBillingWorker) Work(ctx context.Context, job *river.Job[InitOrgB
 			// org got deleted, ignore
 			return nil
 		}
-		w.logger.Error("failed to find organization", zap.String("org_id", job.Args.OrgID), zap.Error(err))
+		w.logger.Warn("failed to find organization", zap.String("org_id", job.Args.OrgID), zap.Error(err))
 		return err
 	}
 
@@ -39,7 +39,7 @@ func (w *InitOrgBillingWorker) Work(ctx context.Context, job *river.Job[InitOrgB
 		// rare case but if its retried, we should repair the billing as it might be in some inconsistent state
 		_, _, err = w.admin.RepairOrganizationBilling(ctx, org, false)
 		if err != nil {
-			w.logger.Error("failed to init billing for organization", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.Error(err))
+			w.logger.Warn("failed to init billing for organization", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.Error(err))
 			return err
 		}
 		return nil
@@ -47,7 +47,7 @@ func (w *InitOrgBillingWorker) Work(ctx context.Context, job *river.Job[InitOrgB
 
 	_, err = w.admin.InitOrganizationBilling(ctx, org)
 	if err != nil {
-		w.logger.Error("failed to init billing for organization", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.Error(err))
+		w.logger.Warn("failed to init billing for organization", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.Error(err))
 		return err
 	}
 	return nil
@@ -73,13 +73,13 @@ func (w *RepairOrgBillingWorker) Work(ctx context.Context, job *river.Job[Repair
 			// org got deleted, ignore
 			return nil
 		}
-		w.logger.Error("failed to find organization", zap.String("org_id", job.Args.OrgID), zap.Error(err))
+		w.logger.Warn("failed to find organization", zap.String("org_id", job.Args.OrgID), zap.Error(err))
 		return err
 	}
 
 	_, _, err = w.admin.RepairOrganizationBilling(ctx, org, true)
 	if err != nil {
-		w.logger.Error("failed to repair billing for organization", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.Error(err))
+		w.logger.Warn("failed to repair billing for organization", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.Error(err))
 		return err
 	}
 	return nil
@@ -110,7 +110,7 @@ func (w *StartTrialWorker) Work(ctx context.Context, job *river.Job[StartTrialAr
 
 	trialOrg, sub, err := w.admin.StartTrial(ctx, org)
 	if err != nil {
-		w.logger.Error("failed to start trial for organization", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.Error(err))
+		w.logger.Warn("failed to start trial for organization", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.Error(err))
 		return err
 	}
 
@@ -123,7 +123,7 @@ func (w *StartTrialWorker) Work(ctx context.Context, job *river.Job[StartTrialAr
 		TrialEndDate: sub.TrialEndDate,
 	})
 	if err != nil {
-		w.logger.Error("failed to send trial started email", zap.String("org_name", trialOrg.Name), zap.String("org_id", trialOrg.ID), zap.String("billing_email", trialOrg.BillingEmail), zap.Error(err))
+		w.logger.Warn("failed to send trial started email", zap.String("org_name", trialOrg.Name), zap.String("org_id", trialOrg.ID), zap.String("billing_email", trialOrg.BillingEmail), zap.Error(err))
 		return err
 	}
 

--- a/admin/jobs/river/org_jobs.go
+++ b/admin/jobs/river/org_jobs.go
@@ -3,6 +3,7 @@ package river
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/rilldata/rill/admin"
 	"github.com/rilldata/rill/admin/database"
@@ -31,21 +32,18 @@ func (w *InitOrgBillingWorker) Work(ctx context.Context, job *river.Job[InitOrgB
 			// org got deleted, ignore
 			return nil
 		}
-		w.logger.Warn("failed to find organization", zap.String("org_id", job.Args.OrgID), zap.Error(err))
-		return err
+		return fmt.Errorf("failed to find organization %s: %w", job.Args.OrgID, err)
 	}
 
 	// rare case but if its retried, we should repair the billing as it might be in some inconsistent state
 	_, _, err = w.admin.RepairOrganizationBilling(ctx, org, false)
 	if err != nil {
-		w.logger.Warn("failed to init billing for organization", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.Error(err))
-		return err
+		return fmt.Errorf("failed to repair billing for organization %s: %w", org.Name, err)
 	}
 
 	_, err = w.admin.InitOrganizationBilling(ctx, org)
 	if err != nil {
-		w.logger.Warn("failed to init billing for organization", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.Error(err))
-		return err
+		return fmt.Errorf("failed to init billing for organization %s: %w", org.Name, err)
 	}
 	return nil
 }
@@ -70,14 +68,12 @@ func (w *RepairOrgBillingWorker) Work(ctx context.Context, job *river.Job[Repair
 			// org got deleted, ignore
 			return nil
 		}
-		w.logger.Warn("failed to find organization", zap.String("org_id", job.Args.OrgID), zap.Error(err))
-		return err
+		return fmt.Errorf("failed to find organization %s: %w", job.Args.OrgID, err)
 	}
 
 	_, _, err = w.admin.RepairOrganizationBilling(ctx, org, true)
 	if err != nil {
-		w.logger.Warn("failed to repair billing for organization", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.Error(err))
-		return err
+		return fmt.Errorf("failed to repair billing for organization %s: %w", org.Name, err)
 	}
 	return nil
 }
@@ -107,8 +103,7 @@ func (w *StartTrialWorker) Work(ctx context.Context, job *river.Job[StartTrialAr
 
 	trialOrg, sub, err := w.admin.StartTrial(ctx, org)
 	if err != nil {
-		w.logger.Warn("failed to start trial for organization", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.Error(err))
-		return err
+		return fmt.Errorf("failed to start trial for organization %s: %w", org.Name, err)
 	}
 
 	// send trial started email
@@ -120,8 +115,7 @@ func (w *StartTrialWorker) Work(ctx context.Context, job *river.Job[StartTrialAr
 		TrialEndDate: sub.TrialEndDate,
 	})
 	if err != nil {
-		w.logger.Warn("failed to send trial started email", zap.String("org_name", trialOrg.Name), zap.String("org_id", trialOrg.ID), zap.String("billing_email", trialOrg.BillingEmail), zap.Error(err))
-		return err
+		return fmt.Errorf("failed to send trial started email for organization %s: %w", trialOrg.Name, err)
 	}
 
 	return nil

--- a/admin/jobs/river/org_jobs.go
+++ b/admin/jobs/river/org_jobs.go
@@ -110,9 +110,7 @@ func (w *StartTrialWorker) Work(ctx context.Context, job *river.Job[StartTrialAr
 
 	trialOrg, sub, err := w.admin.StartTrial(ctx, org)
 	if err != nil {
-		if job.Attempt >= job.MaxAttempts {
-			w.logger.Error("failed to start trial for organization", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.Error(err))
-		}
+		w.logger.Error("failed to start trial for organization", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.Error(err))
 		return err
 	}
 
@@ -126,6 +124,7 @@ func (w *StartTrialWorker) Work(ctx context.Context, job *river.Job[StartTrialAr
 	})
 	if err != nil {
 		w.logger.Error("failed to send trial started email", zap.String("org_name", trialOrg.Name), zap.String("org_id", trialOrg.ID), zap.String("billing_email", trialOrg.BillingEmail), zap.Error(err))
+		return err
 	}
 
 	return nil

--- a/admin/jobs/river/org_jobs.go
+++ b/admin/jobs/river/org_jobs.go
@@ -35,14 +35,11 @@ func (w *InitOrgBillingWorker) Work(ctx context.Context, job *river.Job[InitOrgB
 		return err
 	}
 
-	if job.Attempt > 1 {
-		// rare case but if its retried, we should repair the billing as it might be in some inconsistent state
-		_, _, err = w.admin.RepairOrganizationBilling(ctx, org, false)
-		if err != nil {
-			w.logger.Warn("failed to init billing for organization", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.Error(err))
-			return err
-		}
-		return nil
+	// rare case but if its retried, we should repair the billing as it might be in some inconsistent state
+	_, _, err = w.admin.RepairOrganizationBilling(ctx, org, false)
+	if err != nil {
+		w.logger.Warn("failed to init billing for organization", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.Error(err))
+		return err
 	}
 
 	_, err = w.admin.InitOrganizationBilling(ctx, org)


### PR DESCRIPTION
Allow the custom handler to manage attempts instead of worker job.

Resolves: https://github.com/rilldata/rill-private-issues/issues/1101