### PR TITLE
fix: reconnect to a different github failing with `remote already exists`

### DIFF
--- a/admin/server/assets.go
+++ b/admin/server/assets.go
@@ -322,7 +322,7 @@ func gitToFilesList(gitPath, repo, branch, subpath, token string) ([]drivers.Dir
 	var entries []drivers.DirEntry
 	err = doublestar.GlobWalk(srcProjDir, "**", func(p string, d fs.DirEntry) error {
 		// Ignore unnecessary paths
-		if drivers.IsIgnored(p, nil) {
+		if drivers.IsIgnored(path.Join("/", p), nil) {
 			return nil
 		}
 

--- a/admin/server/assets.go
+++ b/admin/server/assets.go
@@ -322,7 +322,7 @@ func gitToFilesList(gitPath, repo, branch, subpath, token string) ([]drivers.Dir
 	var entries []drivers.DirEntry
 	err = doublestar.GlobWalk(srcProjDir, "**", func(p string, d fs.DirEntry) error {
 		// Ignore unnecessary paths
-		if drivers.IsIgnored(path.Join("/", p), nil) {
+		if drivers.IsIgnored(path.Join(string(filepath.Separator), p), nil) {
 			return nil
 		}
 

--- a/admin/server/github.go
+++ b/admin/server/github.go
@@ -346,7 +346,7 @@ func (s *Server) ConnectProjectToGithub(ctx context.Context, req *adminv1.Connec
 			defer os.RemoveAll(downloadDir)
 			downloadDst := filepath.Join(downloadDir, "zipped_repo.tar.gz")
 			// extract the archive once the folder is prepped with git
-			return archive.Download(ctx, downloadURL, downloadDst, projPath, false)
+			return archive.Download(ctx, downloadURL, downloadDst, projPath, false, true)
 		}, req.Repo, req.Branch, req.Subpath, token, req.Force)
 		if err != nil {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
@@ -1053,19 +1053,6 @@ func (s *Server) pushToGit(ctx context.Context, copyData func(projPath string) e
 	}
 
 	if empty {
-		remote, err := ghRepo.Remote("origin")
-		if err != nil && !errors.Is(err, git.ErrRemoteNotFound) {
-			return err
-		}
-		// remove the remote if it already exists
-		// this could happen when previously connected to another repo and .git got added to assets
-		if remote != nil {
-			err = ghRepo.DeleteRemote("origin")
-			if err != nil {
-				return err
-			}
-		}
-
 		// we need to add a remote as the new repo if the repo was completely empty
 		_, err = ghRepo.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{repo}})
 		if err != nil {

--- a/runtime/drivers/admin/admin.go
+++ b/runtime/drivers/admin/admin.go
@@ -632,7 +632,7 @@ func (h *Handle) download() error {
 		return fmt.Errorf("download: %w", err)
 	}
 
-	err = archive.Download(ctx, h.downloadURL, downloadDst, h.projPath, true)
+	err = archive.Download(ctx, h.downloadURL, downloadDst, h.projPath, true, false)
 	if err != nil {
 		return err
 	}

--- a/runtime/pkg/archive/archive.go
+++ b/runtime/pkg/archive/archive.go
@@ -172,16 +172,15 @@ func untar(src, dest string, ignorePaths bool) error {
 			return err
 		}
 
-		// nolint:gosec // adding the '..' check here is still triggering gosec for GSC-G305
-		if strings.Contains(header.Name, "..") ||
-			(ignorePaths && drivers.IsIgnored(filepath.Join(string(filepath.Separator), header.Name), nil)) {
-			continue
-		}
-
 		// Determine the proper path for the item
 		target, err := sanitizeArchivePath(dest, header.Name)
 		if err != nil {
 			return err
+		}
+
+		// nolint:gosec // sanitizeArchivePath checks for GSC-G305 and throws error but linter cannot know this
+		if ignorePaths && drivers.IsIgnored(filepath.Join(string(filepath.Separator), header.Name), nil) {
+			continue
 		}
 
 		switch header.Typeflag {

--- a/runtime/pkg/archive/archive.go
+++ b/runtime/pkg/archive/archive.go
@@ -172,7 +172,7 @@ func untar(src, dest string, ignorePaths bool) error {
 			return err
 		}
 
-		if ignorePaths && drivers.IsIgnored(filepath.Join("/", header.Name), nil) {
+		if ignorePaths && drivers.IsIgnored(filepath.Join(string(filepath.Separator), header.Name), nil) {
 			continue
 		}
 

--- a/runtime/pkg/archive/archive.go
+++ b/runtime/pkg/archive/archive.go
@@ -172,7 +172,9 @@ func untar(src, dest string, ignorePaths bool) error {
 			return err
 		}
 
-		if ignorePaths && drivers.IsIgnored(filepath.Join(string(filepath.Separator), header.Name), nil) {
+		// nolint:gosec // adding the '..' check here is still triggering gosec for GSC-G305
+		if strings.Contains(header.Name, "..") ||
+			(ignorePaths && drivers.IsIgnored(filepath.Join(string(filepath.Separator), header.Name), nil)) {
 			continue
 		}
 


### PR DESCRIPTION
closes #6468

`.git` folder was getting added to the archive after disconnecting from github. `drivers.IsIgnored` expects a leading `/`.

Also there could already be projects with the `.git` folder. So handle this case when reconnecting to a new repo.