### PR TITLE
.env auto deploy doc updates

### DIFF
--- a/docs/docs/build/connect/multiple-connectors.md
+++ b/docs/docs/build/connect/multiple-connectors.md
@@ -5,7 +5,7 @@ sidebar_label: Multiple Connectors
 sidebar_position: 20
 ---
 
-Sometimes, you will need to set up multiple connectors of the same type in one project with different connection strings (DSN) or configurations for sources. A common example would be that you have a need for multiple [Snowflake](/reference/connectors/snowflake.md) sources that point to different databases and schemas. Therefore, when [deploying your project to Rill Cloud](/deploy/deploy-dashboard/#deploying-a-project-via-the-ui), you will want to specify multiple `snowflake.connector.dsn` connection strings, one corresponding to each unique "connection" you desire (with different connection parameters).
+Sometimes, you will need to set up multiple connectors of the same type in one project with different connection strings (DSN) or configurations for sources. A common example would be that you have a need for multiple [Snowflake](/reference/connectors/snowflake.md) sources that point to different databases and schemas. Therefore, when [deploying your project to Rill Cloud](/deploy/deploy-dashboard/#deploying-a-project-from-rill-developer), you will want to specify multiple `snowflake.connector.dsn` connection strings, one corresponding to each unique "connection" you desire (with different connection parameters).
 
 ## Defining multiple connectors in `rill.yaml`
 
@@ -51,7 +51,7 @@ sql: "select * from table_B"
 
 ## Setting credentials for each connector when deploying to Rill Cloud
 
-Finally, when deploying the project to Rill Cloud, you will want to follow the same steps to [set the credentials](/deploy/deploy-credentials#configure-environmental-variables-and-credentials-on-rill-cloud) for each connector.
+Finally, when deploying the project to Rill Cloud, you will want to follow the same steps to [set the credentials](/deploy/deploy-credentials#configure-environmental-variables-and-credentials-for-rill-cloud) for each connector.
 
 If using `rill env configure`, you should be prompted to input the correct `connector.<connector_name>.dsn` connection strings.
 

--- a/docs/docs/build/credentials/credentials.md
+++ b/docs/docs/build/credentials/credentials.md
@@ -1,6 +1,6 @@
 ---
 title: Configure connector credentials
-sidebar_label: Configure Credentials
+sidebar_label: Configure Local Credentials
 sidebar_position: 00
 ---
 
@@ -8,8 +8,8 @@ Rill requires credentials to connect to remote data sources such as private buck
 
 At a high level, configuring credentials and credentials management in Rill can be broken down into three categories:
 - Setting credentials for Rill Developer
-- [Setting credentials for a Rill Cloud project](/manage/project-management/variables-and-credentials)
-- Pushing and pulling credentials to / from Rill Cloud
+- [Setting credentials for a Rill Cloud project](/deploy/deploy-credentials)
+- [Pushing and pulling credentials to / from Rill Cloud](/manage/project-management/variables-and-credentials)
 
 ## Setting credentials for Rill Developer
 
@@ -17,7 +17,7 @@ When reading from a source (or using a different OLAP engine), Rill will attempt
 1. Credentials that have been configured in your local environment via the CLI (for [AWS](../../reference/connectors/s3.md#local-credentials) / [Azure](../../reference/connectors/azure.md#local-credentials) / [Google Cloud](../../reference/connectors/gcs#rill-developer-local-credentials))
 2. Credentials that have been passed in directly through the connection string or DSN (typically for databases - see [Source YAML](../../reference/project-files/sources.md) and [Connector YAML](../../reference/project-files/connectors.md) for more details)
 3. Credentials that have been passed in as a [variable](../../deploy/templating.md) when starting Rill Developer via `rill start --env key=value`
-4. Credentials that have been specified in your *`<RILL_PROJECT_HOME>/.env`* file
+4. Credentials that have been specified in your *`<RILL_PROJECT_HOME>/.env`* file, see  [credential naming schema](#credentials-naming-schema) for more information.
 
 For more details, please refer to the corresponding [connector](../../reference/connectors/connectors.md) or [OLAP engine](../../reference/olap-engines/olap-engines.md) page.
 
@@ -52,14 +52,13 @@ It's never a good idea to commit sensitive information to Git and goes against s
 
 ## Deploying to Rill Cloud 
 
-:::tip Ready to Deploy?
-Please see our [deploy credentials page](/deploy/deploy-credentials#configure-environmental-variables-and-credentials-on-rill-cloud) to configure your credentials on Rill Cloud.
-:::
+Please see our [deploy credentials page](/deploy/deploy-credentials#configure-environmental-variables-and-credentials-for-rill-cloud) to configure your credentials on Rill Cloud. If you have configured your credentials via the `.env` file this will be deployed with your project. If not, follow the steps to deploy then configure your credentials via the CLI running `rill env configure`.
+
 
 
 ## Pulling Credentials and Variables from a Deployed Project on Rill Cloud
 
-If you are making changes to an already deployed instance from Rill Cloud, it is possible to **sync** the credentials and variables from the Rill Cloud to your local instance of Rill Developer. 
+If you are making changes to an already deployed instance from Rill Cloud, it is possible to **pull** the credentials and variables from the Rill Cloud to your local instance of Rill Developer. If you've made any changes to the credentials, don't forget to run `rill env push` to push the variable changes to the project, or manually change these in the project's setting page.
 
 ### rill env pull
 
@@ -87,3 +86,42 @@ If a credential and/or variable has already been configured in Rill Cloud, Rill 
 
 :::
 
+
+### Credentials Naming Schema 
+
+Connector credentials are essentially a form of project variable, prefixed using the `connector.<connector_name>.<property>` syntax. For example, `connector.druid.dsn` and `connector.clickhouse.dsn` are both hardcoded project variables (that happen to correspond to the [Druid](/reference/olap-engines/druid.md) and [ClickHouse](/reference/olap-engines/clickhouse.md) OLAP engines respectively). Please see below for each source and its required properties. If you have any questions or need specifics, [contact us](../../contact)! 
+
+
+<div
+    style={{
+    width: '100%',
+    margin: 'auto',
+    padding: '20px',
+    textAlign: 'center', 
+    display: 'flex', 
+    justifyContent: 'center',
+    alignItems: 'center'
+    }}
+>
+|           **Source Name**   |        Property             |      Example         |
+| :-----------------------: | :-------------------------:  | :------------------- |
+|       **GCS**                |`GOOGLE_APPLICATION_CREDENTIALS`| `connector.gcs.google_application_credentials` |
+|                          |`GCS_BUCKET_NAME`| `connector.gcs.gcs_bucket_name` |
+| **AWS S3**                  | `AWS_ACCESS_KEY_ID`         | `connector.s3.aws_access_key_id` |
+|                          | `AWS_SECRET_ACCESS_KEY`     |`connector.s3.aws_secret_access_key` |
+|       **Azure**              |`AZURE_STORAGE_ACCOUNT`|`connector.azure.azure_storage_account`|
+|                          |`AZURE_STORAGE_KEY`|`connector.azure.azure_storage_key`|
+|                          |`AZURE_CLIENT_ID`|`connector.azure.azure_client_id`|
+|                          |`AZURE_CLIENT_SECRET`|`connector.azure.azure_client_secret`|
+|                          |`AZURE_TENANT_ID`|`connector.azure.azure_tenant_id`|
+| **Big Query**               | `GOOGLE_APPLICATION_CREDENTIALS` |`connector.bigquery.google_application_credentials` |
+|     **Snowflake**            |`DSN`|`connector.snowflake.dsn`|
+|     **ClickHouse**           |`HOST`|`connector.clickhouse.host `|
+|                          |`PORT`|`connector.clickhouse.port `|
+|                          |`USERNAME`|`connector.clickhouse.username `|
+|                          |`PASSWORD`|`connector.clickhouse.password `|
+|                          |`SSL`|`connector.clickhouse.ssl `|
+|                          |`DATABASE`|`connector.clickhouse.database `|
+...
+
+</div>

--- a/docs/docs/deploy/deploy-credentials.md
+++ b/docs/docs/deploy/deploy-credentials.md
@@ -1,12 +1,16 @@
 ---
 title: Deployment Credentials
 description: Configuring credentials for your deployed project on Rill Cloud
-sidebar_label: Deployment Credentials
-sidebar_position: 11
+sidebar_label: Configure Deployment Credentials
+sidebar_position: 10
 ---
 ## Overview
 
-When deploying a project to Rill Cloud, credentials will need to be **separately** specified and passed in for Rill Cloud to connect to and ingest data from [remote sources](/reference/connectors/connectors.md). [Local credentials](/build/credentials/#setting-credentials-for-rill-developer) will be used by Rill Developer to connect to sources from your local machine, typically for local devlopment and modeling, while [deployment credentials](/deploy/deploy-credentials#configure-environmental-variables-and-credentials-on-rill-cloud) are what is used by Rill Cloud for production workloads. For more details about using and setting deployment credentials, please see our [configuring credentials](../build/credentials/credentials.md) page and the respective [connectors](/reference/connectors/connectors.md) or [OLAP engine](/reference/olap-engines/olap-engines.md) page.
+
+When deploying a project, credentials that have been defined in your `.env` file will but automatically passed into your Rill Cloud project. However, for [remote sources](/reference/connectors/connectors.md) that are dynamically retrieving your credentials via the CLI, such as S3 and GCS, you will need to ensure that these are [defined in the .env file](/manage/project-management/variables-and-credentials#credentials-naming-schema). 
+
+
+[Local credentials](/build/credentials/#setting-credentials-for-rill-developer) are used by Rill Developer to connect to sources from your local machine, while [deployment credentials](/deploy/deploy-credentials#configure-environmental-variables-and-credentials-for-rill-cloud) are what is used by Rill Cloud for production workloads. There are a [few ways to setup credentials in Rill Developer](../build/credentials/#setting-credentials-for-rill-developer), however you will need to ensure that they are set up in your `.env` file for a seemless experience.
 
 :::info Separating development and production credentials
 
@@ -14,9 +18,14 @@ As a general best practice, it is strongly recommended to use service accounts a
 
 :::
 
-## Configure Environmental Variables and Credentials on Rill Cloud 
 
-Once you are ready to deploy or have already deployed and are experiencing issues connecting to your source, you will need to run the following command, `rill env configure`. When running this command, Rill will detect any connectors that are being used by the project and prompt you to fill in the required fields. When completed, this will be pushed to your Rill Cloud Deployment and automatically refresh the required objects. 
+## Configure Environmental Variables and Credentials for Rill Cloud 
+
+If you have defined your connector's credentials in your `.env` file, these will be deployed along with your project. You should see the credentials in [your project's settings page.](/manage/project-management/variables-and-credentials#modifying-variables-and-credentials-via-the-settings-page)
+
+![img](/img/tutorials/admin/env-var-ui.png)
+
+If not, after deploying to Rill Cloud, you can run the following in the CLI to configure all of your required credentials: `rill env configure`. When running this command, Rill will detect any connectors that are being used by the project and prompt you to fill in the required fields. When completed, this will be pushed to your Rill Cloud Deployment and automatically refresh the required objects. Once completed, you will see these in your project's environmental variables settings page. 
 
 
 ```bash

--- a/docs/docs/deploy/deploy-dashboard/_category_.yml
+++ b/docs/docs/deploy/deploy-dashboard/_category_.yml
@@ -1,4 +1,4 @@
-position: 00
+position: 11
 label: Deploy Dashboards
 collapsible: true
 collapsed: true

--- a/docs/docs/deploy/deploy-dashboard/deploy-dashboard.md
+++ b/docs/docs/deploy/deploy-dashboard/deploy-dashboard.md
@@ -12,7 +12,7 @@ sidebar_position: 00
 Deploying dashboards from Rill Developer allows you to share dashboards with other users, leverage [Rill Cloud capabilities](../../explore/dashboard-101), [embed Rill](/integrate/embedding.md) into other applications, and more!
 
 :::tip Configure credentials
-Cloud datastores will typically require service keys to access data. Make sure to create the necessary key for your service account and then run ```rill env configure``` with the correct credentials. For more details, please refer to our [connector documentation](/build/credentials/credentials.md).
+Cloud datastores will typically require service keys to access data. Make sure to you create the necessary key for your service account and either add these credetials to your `.env` file directly or deploy your project and then run ```rill env configure``` with the correct credentials. For more details, please refer to our [connector documentation](/build/credentials/credentials.md).
 :::
 
 The flow diagram below shows two options for deploying an existing project. 
@@ -39,8 +39,8 @@ graph LR;
     A--2. Push changes to GitHub-->C;
 ```
     
-## Deploying a project via the UI
-Starting from **v0.48**, we have introduced the possibility to push dashboards _directly from Rill Developer's UI to Rill Cloud_. On the dashboard page, you can select the `Deploy` button and follow the steps to deploy to Rill Cloud.
+## Deploying a project from Rill Developer
+Starting from **v0.48**, we have introduced the possibility to push dashboards _directly from Rill Developer to Rill Cloud_. On the dashboard page, you can select the `Deploy` button and follow the steps to deploy to Rill Cloud.
 
 <img src = '/img/deploy/existing-project/deploy-ui.gif' class='rounded-gif' />
 <br />

--- a/docs/docs/explore/alerts/slack.md
+++ b/docs/docs/explore/alerts/slack.md
@@ -39,7 +39,7 @@ The last two scopes are required to find the user's ID by email.
 
 ## Enabling the Slack integration in your project
 
-Once the Slack integration has been set up, the Slack destination will need to be enabled on a per project basis (note - alerts can only be configured on projects deployed to Rill Cloud). This requires the `connector.slack.bot_token` connector variable to be set, which can be configured in Rill through a fashion very similar to [setting credentials](/deploy/deploy-credentials#configure-environmental-variables-and-credentials-on-rill-cloud) for other connectors. Please use one of the available options below.
+Once the Slack integration has been set up, the Slack destination will need to be enabled on a per project basis (note - alerts can only be configured on projects deployed to Rill Cloud). This requires the `connector.slack.bot_token` connector variable to be set, which can be configured in Rill through a fashion very similar to [setting credentials](/deploy/deploy-credentials#configure-environmental-variables-and-credentials-for-rill-cloud) for other connectors. Please use one of the available options below.
 
 ### Updating the `.env` file directly
 

--- a/docs/docs/home/FAQ.md
+++ b/docs/docs/home/FAQ.md
@@ -82,7 +82,7 @@ You need to [deploy your dashboard to Rill Cloud](https://docs.rilldata.com/depl
 Rill Cloud is where your deployed Rill project exists and can be shared to your colleagues, or end-users. For more information, please review [our documentation](https://docs.rilldata.com/concepts/developerVsCloud#rill-cloud).
 
 ### How do I deploy to Rill Cloud?
-You can deploy your project directly from the UI by selecting [the Deploy button](https://docs.rilldata.com/deploy/existing-project/#deploying-a-project-via-the-ui).
+You can deploy your project directly from the UI by selecting [the Deploy button](/deploy/deploy-dashboard/#deploying-a-project-from-rill-developer).
 
 <img src = '/img/deploy/existing-project/deploy-ui.gif' class='rounded-gif' />
 <br />

--- a/docs/docs/manage/project-management/variables-and-credentials.md
+++ b/docs/docs/manage/project-management/variables-and-credentials.md
@@ -4,13 +4,16 @@ sidebar_label: Variables and Credentials
 sidebar_position: 50
 ---
 
-The credentials in a deployed Rill Cloud projects can be managed on the Settings page or via the CLI. If you have yet to deploy your credentials, please follow the steps in our [deploy credentials page](/deploy/deploy-credentials#configure-environmental-variables-and-credentials-on-rill-cloud). 
+The credentials in a deployed Rill Cloud projects can be managed on the Settings page or via the CLI. If you have yet to deploy your credentials, please follow the steps in our [deploy credentials page](/deploy/deploy-credentials#configure-environmental-variables-and-credentials-for-rill-cloud). 
 
 ## Modifying Variables and Credentials via the Settings Page
+Upon deployment via Rill Developer, if you have populated your .env file, the contents will be visible as seen below. If there are no environmantal variables defined, please run `rill env configure` from your local CLI and Rill will automatically detect the sources that are used in your project and request the credentials. Once completed, the variables should be visible and editable from Rill Cloud. If you'd like to manually add the credentals, please see [our naming convention](#credentials-naming-schema) to get started. 
 
 ![img](/img/tutorials/admin/env-var-ui.png)
 
-### Adding / Editing Environmental Variables
+### Adding and Editing Environmental Variables / Importing a `.env` file
+Once your environmantal variables are added to Rill Cloud, they can be modfied as needed.
+
 ![img](/img/manage/var-and-creds/add-variable.png)
 
 :::tip Can't find the .env file?
@@ -20,7 +23,7 @@ Keyboard shortcut: Command + Shift + .
 
 ## Pushing and pulling credentials to / from Rill Cloud via the CLI
 
-If you have a project deployed to Rill Cloud, Rill provides the ability to **sync** the credentials between your local instance of Rill Developer and Rill cloud. This provides the ability to quickly reuse existing credentials, if configured, instead of having to manually input credentials each time. This can be accomplished by leveraging the `rill env push` and `rill env pull` CLI commands respectively.
+If you'd prefer to use the CLI to managed your credentials, this can be done by running the `rill env pull` to pull your deployed Rill Cloud project's variables locally, or `rill env push` to updated Rill Cloud project's variables.
 
 :::tip Avoid committing sensitive information to Git
 
@@ -57,7 +60,8 @@ Please note when you run `rill env pull`, Rill will *automatically override any 
 
 ### Credentials Naming Schema 
 
-Connector credentials are essentially a form of project variable, prefixed using the `connector.<connector_name>.<property>` syntax. For example, `connector.druid.dsn` and `connector.clickhouse.dsn` are both hardcoded project variables (that happen to correspond to the [Druid](/reference/olap-engines/druid.md) and [ClickHouse](/reference/olap-engines/clickhouse.md) OLAP engines respectively). Please see below for each source and its required properties. 
+Connector credentials are essentially a form of project variable, prefixed using the `connector.<connector_name>.<property>` syntax. For example, `connector.druid.dsn` and `connector.clickhouse.dsn` are both hardcoded project variables (that happen to correspond to the [Druid](/reference/olap-engines/druid.md) and [ClickHouse](/reference/olap-engines/clickhouse.md) OLAP engines respectively). Please see below for each source and its required properties. If you have any questions or need specifics, [contact us](../../contact)! 
+
 
 
 <div

--- a/docs/docs/reference/project-files/sources.md
+++ b/docs/docs/reference/project-files/sources.md
@@ -103,7 +103,7 @@ Files that are *nested at any level* under your native `sources` directory will 
 
 **`database_url`**
  — Postgres connection string that should be used. Refer to Postgres [documentation](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING) for more details _(optional)_.
-  - If not specified in the source YAML, the `connector.postgres.database_url` connection string will need to be set when [deploying the project to Rill Cloud](/deploy/deploy-credentials#configure-environmental-variables-and-credentials-on-rill-cloud).
+  - If not specified in the source YAML, the `connector.postgres.database_url` connection string will need to be set when [deploying the project to Rill Cloud](/deploy/deploy-credentials#configure-environmental-variables-and-credentials-for-rill-cloud).
 
 **`duckdb`** – Specifies the raw parameters to inject into the DuckDB [`read_csv`](https://duckdb.org/docs/data/csv/overview.html), [`read_json`](https://duckdb.org/docs/data/json/overview.html) or [`read_parquet`](https://duckdb.org/docs/data/parquet/overview) statement that Rill generates internally _(optional)_. 
 
@@ -126,4 +126,4 @@ duckdb:
 ```
 
 **`dsn`** - Used to set the Snowflake connection string. For more information, refer to our [Snowflake connector page](/reference/connectors/snowflake.md) and the official [Go Snowflake Driver](https://pkg.go.dev/github.com/snowflakedb/gosnowflake#hdr-Connection_String) documentation _(optional)_.
-  - If not specified in the source YAML, the `connector.snowflake.dsn` connection string will need to be set when [deploying the project to Rill Cloud](/deploy/deploy-credentials#configure-environmental-variables-and-credentials-on-rill-cloud).
+  - If not specified in the source YAML, the `connector.snowflake.dsn` connection string will need to be set when [deploying the project to Rill Cloud](/deploy/deploy-credentials#configure-environmental-variables-and-credentials-for-rill-cloud).


### PR DESCRIPTION
Build/ configure local credentials

setting up creds for RD, 4 options,
mention to use .env when deploying to RC

Deploy/configure deployment credentials
More details on differnece between local creds and RC creds,
env is deployed with, else youll need to deploy then define creds using rill env configure

Manage/project-management/ configure environmental variables and credentials


fix references to these docs ++ nit
