### PR TITLE
feat : Add a `read_write_ratio` for duckdb to split resources between serving and ETL

### DIFF
--- a/runtime/drivers/duckdb/config.go
+++ b/runtime/drivers/duckdb/config.go
@@ -21,8 +21,8 @@ type config struct {
 	CPU int `mapstructure:"cpu"`
 	// MemoryLimitGB is the amount of memory available for the DB. If no ratio is set then this is split evenly between read and write.
 	MemoryLimitGB int `mapstructure:"memory_limit_gb"`
-	// ReadWriteResourceSplitRatio is the ratio of resources to allocate to the read DB. If set, CPU and MemoryLimitGB are distributed based on this ratio.
-	ReadWriteResourceSplitRatio float64 `mapstructure:"read_write_resource_split_ratio"`
+	// ReadWriteRatio is the ratio of resources to allocate to the read DB. If set, CPU and MemoryLimitGB are distributed based on this ratio.
+	ReadWriteRatio float64 `mapstructure:"read_write_ratio"`
 	// BootQueries is SQL to execute when initializing a new connection. It runs before any extensions are loaded or default settings are set.
 	BootQueries string `mapstructure:"boot_queries"`
 	// InitSQL is SQL to execute when initializing a new connection. It runs after extensions are loaded and and default settings are set.
@@ -32,7 +32,9 @@ type config struct {
 }
 
 func newConfig(cfgMap map[string]any) (*config, error) {
-	cfg := &config{}
+	cfg := &config{
+		ReadWriteRatio: 0.5,
+	}
 	err := mapstructure.WeakDecode(cfgMap, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("could not decode config: %w", err)

--- a/runtime/drivers/duckdb/config.go
+++ b/runtime/drivers/duckdb/config.go
@@ -2,7 +2,6 @@ package duckdb
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -18,14 +17,12 @@ type config struct {
 	PoolSize int `mapstructure:"pool_size"`
 	// AllowHostAccess denotes whether to limit access to the local environment and file system
 	AllowHostAccess bool `mapstructure:"allow_host_access"`
-	// CPU cores available for the read DB. If no CPUWrite is set then this is split evenly between read and write.
+	// CPU cores available for the DB. If no ratio is set then this is split evenly between read and write.
 	CPU int `mapstructure:"cpu"`
-	// MemoryLimitGB is the amount of memory available for the read DB. If no MemoryLimitGBWrite is set then this is split evenly between read and write.
+	// MemoryLimitGB is the amount of memory available for the DB. If no ratio is set then this is split evenly between read and write.
 	MemoryLimitGB int `mapstructure:"memory_limit_gb"`
-	// CPUWrite is CPU available for the DB when writing data.
-	CPUWrite int `mapstructure:"cpu_write"`
-	// MemoryLimitGBWrite is the amount of memory available for the DB when writing data.
-	MemoryLimitGBWrite int `mapstructure:"memory_limit_gb_write"`
+	// ReadWriteResourceSplitRatio is the ratio of resources to allocate to the read DB. If set, CPU and MemoryLimitGB are distributed based on this ratio.
+	ReadWriteResourceSplitRatio float64 `mapstructure:"read_write_resource_split_ratio"`
 	// BootQueries is SQL to execute when initializing a new connection. It runs before any extensions are loaded or default settings are set.
 	BootQueries string `mapstructure:"boot_queries"`
 	// InitSQL is SQL to execute when initializing a new connection. It runs after extensions are loaded and and default settings are set.
@@ -53,23 +50,11 @@ func newConfig(cfgMap map[string]any) (*config, error) {
 
 func (c *config) readSettings() map[string]string {
 	readSettings := make(map[string]string)
-	if c.MemoryLimitGB > 0 {
-		readSettings["max_memory"] = fmt.Sprintf("%dGB", c.MemoryLimitGB)
-	}
-	if c.CPU > 0 {
-		readSettings["threads"] = strconv.Itoa(c.CPU)
-	}
 	return readSettings
 }
 
 func (c *config) writeSettings() map[string]string {
 	writeSettings := make(map[string]string)
-	if c.MemoryLimitGBWrite > 0 {
-		writeSettings["max_memory"] = fmt.Sprintf("%dGB", c.MemoryLimitGBWrite)
-	}
-	if c.CPUWrite > 0 {
-		writeSettings["threads"] = strconv.Itoa(c.CPUWrite)
-	}
 	// useful for motherduck but safe to pass at initial connect
 	writeSettings["custom_user_agent"] = "rill"
 	return writeSettings

--- a/runtime/drivers/duckdb/config_test.go
+++ b/runtime/drivers/duckdb/config_test.go
@@ -22,8 +22,6 @@ func TestConfig(t *testing.T) {
 
 	cfg, err = newConfig(map[string]any{"dsn": "", "cpu": 2})
 	require.NoError(t, err)
-	require.Equal(t, "2", cfg.readSettings()["threads"])
-	require.Subset(t, cfg.writeSettings(), map[string]string{"custom_user_agent": "rill"})
 	require.Equal(t, 2, cfg.PoolSize)
 
 	cfg, err = newConfig(map[string]any{"pool_size": 10})
@@ -32,10 +30,6 @@ func TestConfig(t *testing.T) {
 
 	cfg, err = newConfig(map[string]any{"dsn": "duck.db", "memory_limit_gb": "8", "cpu": "2"})
 	require.NoError(t, err)
-	require.Equal(t, "2", cfg.readSettings()["threads"])
-	require.Equal(t, "", cfg.writeSettings()["threads"])
-	require.Equal(t, "8GB", cfg.readSettings()["max_memory"])
-	require.Equal(t, "", cfg.writeSettings()["max_memory"])
 	require.Equal(t, 2, cfg.PoolSize)
 }
 

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -512,13 +512,16 @@ func (c *connection) reopenDB(ctx context.Context) error {
 		AddSource: true,
 	}))
 	c.db, err = rduckdb.NewDB(ctx, &rduckdb.DBOptions{
-		LocalPath:      dataDir,
-		Remote:         c.remote,
-		ReadSettings:   c.config.readSettings(),
-		WriteSettings:  c.config.writeSettings(),
-		InitQueries:    bootQueries,
-		Logger:         logger,
-		OtelAttributes: []attribute.KeyValue{attribute.String("instance_id", c.instanceID)},
+		LocalPath:                   dataDir,
+		Remote:                      c.remote,
+		CPU:                         c.config.CPU,
+		MemoryLimitGB:               c.config.MemoryLimitGB,
+		ReadWriteResourceSplitRatio: c.config.ReadWriteResourceSplitRatio,
+		ReadSettings:                c.config.readSettings(),
+		WriteSettings:               c.config.writeSettings(),
+		InitQueries:                 bootQueries,
+		Logger:                      logger,
+		OtelAttributes:              []attribute.KeyValue{attribute.String("instance_id", c.instanceID)},
 	})
 	return err
 }

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -512,16 +512,16 @@ func (c *connection) reopenDB(ctx context.Context) error {
 		AddSource: true,
 	}))
 	c.db, err = rduckdb.NewDB(ctx, &rduckdb.DBOptions{
-		LocalPath:                   dataDir,
-		Remote:                      c.remote,
-		CPU:                         c.config.CPU,
-		MemoryLimitGB:               c.config.MemoryLimitGB,
-		ReadWriteResourceSplitRatio: c.config.ReadWriteResourceSplitRatio,
-		ReadSettings:                c.config.readSettings(),
-		WriteSettings:               c.config.writeSettings(),
-		InitQueries:                 bootQueries,
-		Logger:                      logger,
-		OtelAttributes:              []attribute.KeyValue{attribute.String("instance_id", c.instanceID)},
+		LocalPath:      dataDir,
+		Remote:         c.remote,
+		CPU:            c.config.CPU,
+		MemoryLimitGB:  c.config.MemoryLimitGB,
+		ReadWriteRatio: c.config.ReadWriteRatio,
+		ReadSettings:   c.config.readSettings(),
+		WriteSettings:  c.config.writeSettings(),
+		InitQueries:    bootQueries,
+		Logger:         logger,
+		OtelAttributes: []attribute.KeyValue{attribute.String("instance_id", c.instanceID)},
 	})
 	return err
 }

--- a/runtime/pkg/rduckdb/db.go
+++ b/runtime/pkg/rduckdb/db.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"math"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -21,7 +22,6 @@ import (
 	"github.com/XSAM/otelsql"
 	"github.com/jmoiron/sqlx"
 	"github.com/marcboeker/go-duckdb"
-	"github.com/mitchellh/mapstructure"
 	"go.opentelemetry.io/otel/attribute"
 	"gocloud.dev/blob"
 	"golang.org/x/sync/semaphore"
@@ -63,7 +63,12 @@ type DBOptions struct {
 	// Remote is the blob storage bucket where the database files will be stored. This is the source of truth.
 	// The local db will be eventually synced with the remote.
 	Remote *blob.Bucket
-
+	// CPU cores available for the DB. If no ratio is set then this is split evenly between read and write.
+	CPU int `mapstructure:"cpu"`
+	// MemoryLimitGB is the amount of memory available for the DB. If no ratio is set then this is split evenly between read and write.
+	MemoryLimitGB int `mapstructure:"memory_limit_gb"`
+	// ReadWriteResourceSplitRatio is the ratio of resources to allocate to the read DB. If set, CPU and MemoryLimitGB are distributed based on this ratio.
+	ReadWriteResourceSplitRatio float64 `mapstructure:"read_write_resource_split_ratio"`
 	// ReadSettings are settings applied the read duckDB handle.
 	ReadSettings map[string]string
 	// WriteSettings are settings applied the write duckDB handle.
@@ -76,27 +81,22 @@ type DBOptions struct {
 }
 
 func (d *DBOptions) ValidateSettings() error {
-	read := &settings{}
-	err := mapstructure.Decode(d.ReadSettings, read)
-	if err != nil {
-		return fmt.Errorf("read settings: %w", err)
+	if d.ReadWriteResourceSplitRatio < 0 || d.ReadWriteResourceSplitRatio >= 1 {
+		return errors.New("invalid `resource_split_ratio`. Must be between 0 and 1")
 	}
 
-	write := &settings{}
-	err = mapstructure.Decode(d.WriteSettings, write)
-	if err != nil {
-		return fmt.Errorf("write settings: %w", err)
+	if d.ReadSettings == nil {
+		d.ReadSettings = make(map[string]string)
 	}
-
-	// no memory limits defined
-	// divide memory equally between read and write
-	if read.MaxMemory == "" && write.MaxMemory == "" {
-		connector, err := duckdb.NewConnector("", nil)
+	if d.WriteSettings == nil {
+		d.WriteSettings = make(map[string]string)
+	}
+	memoryLimitBytes := int64(d.MemoryLimitGB * 1000 * 1000 * 1000)
+	if memoryLimitBytes == 0 {
+		db, err := sql.Open("duckdb", "")
 		if err != nil {
-			return fmt.Errorf("unable to create duckdb connector: %w", err)
+			return err
 		}
-		defer connector.Close()
-		db := sql.OpenDB(connector)
 		defer db.Close()
 
 		row := db.QueryRow("SELECT value FROM duckdb_settings() WHERE name = 'max_memory'")
@@ -111,87 +111,49 @@ func (d *DBOptions) ValidateSettings() error {
 			return fmt.Errorf("unable to parse max_memory: %w", err)
 		}
 
-		read.MaxMemory = fmt.Sprintf("%d bytes", int64(bytes)/2)
-		write.MaxMemory = fmt.Sprintf("%d bytes", int64(bytes)/2)
+		memoryLimitBytes = int64(bytes)
 	}
 
-	if read.MaxMemory == "" != (write.MaxMemory == "") {
-		// only one is defined
-		var mem string
-		if read.MaxMemory != "" {
-			mem = read.MaxMemory
-		} else {
-			mem = write.MaxMemory
-		}
-
-		bytes, err := humanReadableSizeToBytes(mem)
+	threads := d.CPU
+	if threads == 0 {
+		db, err := sql.Open("duckdb", "")
 		if err != nil {
-			return fmt.Errorf("unable to parse max_memory: %w", err)
+			return err
 		}
-
-		read.MaxMemory = fmt.Sprintf("%d bytes", int64(bytes)/2)
-		write.MaxMemory = fmt.Sprintf("%d bytes", int64(bytes)/2)
-	}
-
-	var readThread, writeThread int
-	if read.Threads != "" {
-		readThread, err = strconv.Atoi(read.Threads)
-		if err != nil {
-			return fmt.Errorf("unable to parse read threads: %w", err)
-		}
-	}
-	if write.Threads != "" {
-		writeThread, err = strconv.Atoi(write.Threads)
-		if err != nil {
-			return fmt.Errorf("unable to parse write threads: %w", err)
-		}
-	}
-
-	if readThread == 0 && writeThread == 0 {
-		connector, err := duckdb.NewConnector("", nil)
-		if err != nil {
-			return fmt.Errorf("unable to create duckdb connector: %w", err)
-		}
-		defer connector.Close()
-		db := sql.OpenDB(connector)
 		defer db.Close()
 
 		row := db.QueryRow("SELECT value FROM duckdb_settings() WHERE name = 'threads'")
-		var threads int
 		err = row.Scan(&threads)
 		if err != nil {
 			return fmt.Errorf("unable to get threads: %w", err)
 		}
-
-		read.Threads = strconv.Itoa((threads + 1) / 2)
-		write.Threads = strconv.Itoa(threads / 2)
 	}
 
-	if readThread == 0 != (writeThread == 0) {
-		// only one is defined
-		var threads int
-		if readThread != 0 {
-			threads = readThread
+	if d.ReadWriteResourceSplitRatio == 0 {
+		d.ReadSettings["memory_limit"] = fmt.Sprintf("%d bytes", memoryLimitBytes/2)
+		d.WriteSettings["memory_limit"] = fmt.Sprintf("%d bytes", memoryLimitBytes/2)
+		if threads < 2 {
+			d.ReadSettings["threads"] = "1"
 		} else {
-			threads = writeThread
+			d.ReadSettings["threads"] = strconv.Itoa(threads / 2)
 		}
+		d.WriteSettings["threads"] = strconv.Itoa((threads + 1) / 2)
+	} else {
+		d.ReadSettings["memory_limit"] = fmt.Sprintf("%d bytes", int64(float64(memoryLimitBytes)*d.ReadWriteResourceSplitRatio))
+		d.WriteSettings["memory_limit"] = fmt.Sprintf("%d bytes", int64(float64(memoryLimitBytes)*(1-d.ReadWriteResourceSplitRatio)))
 
-		read.Threads = strconv.Itoa((threads + 1) / 2)
-		if threads <= 3 {
-			write.Threads = "1"
+		readThreads := math.Floor(float64(threads) * d.ReadWriteResourceSplitRatio)
+		if readThreads <= 1 {
+			d.ReadSettings["threads"] = "1"
 		} else {
-			write.Threads = strconv.Itoa(threads / 2)
+			d.ReadSettings["threads"] = strconv.Itoa(int(readThreads))
 		}
-	}
-
-	err = mapstructure.WeakDecode(read, &d.ReadSettings)
-	if err != nil {
-		return fmt.Errorf("failed to update read settings: %w", err)
-	}
-
-	err = mapstructure.WeakDecode(write, &d.WriteSettings)
-	if err != nil {
-		return fmt.Errorf("failed to update write settings: %w", err)
+		writeThreads := threads - int(readThreads)
+		if writeThreads <= 1 {
+			d.WriteSettings["threads"] = "1"
+		} else {
+			d.WriteSettings["threads"] = strconv.Itoa(writeThreads)
+		}
 	}
 	return nil
 }
@@ -1269,12 +1231,6 @@ func newVersion() string {
 
 func dbName(table, version string) string {
 	return fmt.Sprintf("%s__%s__db", table, version)
-}
-
-type settings struct {
-	MaxMemory string `mapstructure:"max_memory"`
-	Threads   string `mapstructure:"threads"`
-	// Can be more settings
 }
 
 // Regex to parse human-readable size returned by DuckDB

--- a/runtime/pkg/rduckdb/db.go
+++ b/runtime/pkg/rduckdb/db.go
@@ -81,6 +81,9 @@ type DBOptions struct {
 }
 
 func (d *DBOptions) ValidateSettings() error {
+	if d.ReadWriteRatio < 0 || d.ReadWriteRatio > 1 {
+		return fmt.Errorf("read_write_ratio should be between 0 and 1")
+	}
 	if d.ReadSettings == nil {
 		d.ReadSettings = make(map[string]string)
 	}

--- a/runtime/pkg/rduckdb/db_test.go
+++ b/runtime/pkg/rduckdb/db_test.go
@@ -216,12 +216,13 @@ func TestResetLocal(t *testing.T) {
 	bucket, err := fileblob.OpenBucket(remoteDir, nil)
 	require.NoError(t, err)
 	db, err = NewDB(ctx, &DBOptions{
-		LocalPath:     localDir,
-		Remote:        bucket,
-		ReadSettings:  map[string]string{"memory_limit": "2GB", "threads": "1"},
-		WriteSettings: map[string]string{"memory_limit": "2GB", "threads": "1"},
-		InitQueries:   []string{"SET autoinstall_known_extensions=true", "SET autoload_known_extensions=true"},
-		Logger:        logger,
+		LocalPath:      localDir,
+		Remote:         bucket,
+		MemoryLimitGB:  2,
+		CPU:            1,
+		ReadWriteRatio: 0.5,
+		InitQueries:    []string{"SET autoinstall_known_extensions=true", "SET autoload_known_extensions=true"},
+		Logger:         logger,
 	})
 	require.NoError(t, err)
 
@@ -278,12 +279,13 @@ func TestResetSelectiveLocal(t *testing.T) {
 	bucket, err := fileblob.OpenBucket(remoteDir, nil)
 	require.NoError(t, err)
 	db, err = NewDB(ctx, &DBOptions{
-		LocalPath:     localDir,
-		Remote:        bucket,
-		ReadSettings:  map[string]string{"memory_limit": "2GB", "threads": "1"},
-		WriteSettings: map[string]string{"memory_limit": "2GB", "threads": "1"},
-		InitQueries:   []string{"SET autoinstall_known_extensions=true", "SET autoload_known_extensions=true"},
-		Logger:        logger,
+		LocalPath:      localDir,
+		Remote:         bucket,
+		MemoryLimitGB:  2,
+		CPU:            1,
+		ReadWriteRatio: 0.5,
+		InitQueries:    []string{"SET autoinstall_known_extensions=true", "SET autoload_known_extensions=true"},
+		Logger:         logger,
 	})
 	require.NoError(t, err)
 	verifyTable(t, db, "SELECT id, country FROM test2_view", []testData{{ID: 2, Country: "USA"}})
@@ -310,12 +312,13 @@ func TestResetTablesRemote(t *testing.T) {
 	bucket, err := fileblob.OpenBucket(remoteDir, &fileblob.Options{CreateDir: true})
 	require.NoError(t, err)
 	db, err = NewDB(ctx, &DBOptions{
-		LocalPath:     localDir,
-		Remote:        bucket,
-		ReadSettings:  map[string]string{"memory_limit": "2GB", "threads": "1"},
-		WriteSettings: map[string]string{"memory_limit": "2GB", "threads": "1"},
-		InitQueries:   []string{"SET autoinstall_known_extensions=true", "SET autoload_known_extensions=true"},
-		Logger:        logger,
+		LocalPath:      localDir,
+		Remote:         bucket,
+		MemoryLimitGB:  2,
+		CPU:            1,
+		ReadWriteRatio: 0.5,
+		InitQueries:    []string{"SET autoinstall_known_extensions=true", "SET autoload_known_extensions=true"},
+		Logger:         logger,
 	})
 	require.NoError(t, err)
 	require.ErrorContains(t, db.DropTable(ctx, "test"), "not found")
@@ -356,12 +359,13 @@ func TestResetSelectiveTablesRemote(t *testing.T) {
 	bucket, err := fileblob.OpenBucket(remoteDir, nil)
 	require.NoError(t, err)
 	db, err = NewDB(ctx, &DBOptions{
-		LocalPath:     localDir,
-		Remote:        bucket,
-		ReadSettings:  map[string]string{"memory_limit": "2GB", "threads": "1"},
-		WriteSettings: map[string]string{"memory_limit": "2GB", "threads": "1"},
-		InitQueries:   []string{"SET autoinstall_known_extensions=true", "SET autoload_known_extensions=true"},
-		Logger:        logger,
+		LocalPath:      localDir,
+		Remote:         bucket,
+		MemoryLimitGB:  2,
+		CPU:            1,
+		ReadWriteRatio: 0.5,
+		InitQueries:    []string{"SET autoinstall_known_extensions=true", "SET autoload_known_extensions=true"},
+		Logger:         logger,
 	})
 	require.NoError(t, err)
 	verifyTable(t, db, "SELECT id, country FROM test", []testData{{ID: 1, Country: "India"}})
@@ -494,12 +498,13 @@ func prepareDB(t *testing.T) (db DB, localDir, remoteDir string) {
 	bucket, err := fileblob.OpenBucket(remoteDir, nil)
 	require.NoError(t, err)
 	db, err = NewDB(ctx, &DBOptions{
-		LocalPath:     localDir,
-		Remote:        bucket,
-		ReadSettings:  map[string]string{"memory_limit": "2GB", "threads": "1"},
-		WriteSettings: map[string]string{"memory_limit": "2GB", "threads": "1"},
-		InitQueries:   []string{"SET autoinstall_known_extensions=true", "SET autoload_known_extensions=true"},
-		Logger:        logger,
+		LocalPath:      localDir,
+		Remote:         bucket,
+		MemoryLimitGB:  2,
+		CPU:            1,
+		ReadWriteRatio: 0.5,
+		InitQueries:    []string{"SET autoinstall_known_extensions=true", "SET autoload_known_extensions=true"},
+		Logger:         logger,
 	})
 	require.NoError(t, err)
 	return


### PR DESCRIPTION
The default split of resources is 50/50 for reads and writes. The ratio can be used to change the split.