### PR TITLE
Increase health check concurrency to 32

### DIFF
--- a/admin/worker/deployments_health_check.go
+++ b/admin/worker/deployments_health_check.go
@@ -34,7 +34,7 @@ func (w *Worker) deploymentsHealthCheck(ctx context.Context) error {
 		}
 
 		group, cctx := errgroup.WithContext(ctx)
-		group.SetLimit(8)
+		group.SetLimit(32)
 		for _, d := range deployments {
 			d := d
 			if d.Status != database.DeploymentStatusOK {


### PR DESCRIPTION
Hopefully prevents job timeouts, as seen here: https://rilldata.slack.com/archives/C05TXA7QSTY/p1737643082675709