### PR TITLE
fix: embedded dashboards without time series

### DIFF
--- a/web-common/src/features/dashboards/url-state/DashboardURLStateSyncWrapper.svelte
+++ b/web-common/src/features/dashboards/url-state/DashboardURLStateSyncWrapper.svelte
@@ -59,9 +59,11 @@
 
   // only reactive to url and defaultExplorePreset
   $: parseUrl($page.url, defaultExplorePreset);
+
+  $: validSpec = $validSpecStore.data;
 </script>
 
-{#if !$validSpecStore.isLoading}
+{#if !$validSpecStore.isLoading && (!validSpec?.metricsView?.timeDimension || !$metricsViewTimeRange.isLoading)}
   <DashboardURLStateSync
     metricsViewName={$metricsViewName}
     exploreName={$exploreName}

--- a/web-common/src/features/dashboards/url-state/DashboardURLStateSyncWrapper.svelte
+++ b/web-common/src/features/dashboards/url-state/DashboardURLStateSyncWrapper.svelte
@@ -61,15 +61,13 @@
   $: parseUrl($page.url, defaultExplorePreset);
 </script>
 
-{#if !$validSpecStore.isLoading && !$metricsViewTimeRange.isLoading}
-  <DashboardURLStateSync
-    metricsViewName={$metricsViewName}
-    exploreName={$exploreName}
-    {defaultExplorePreset}
-    {exploreStateFromYAMLConfig}
-    {partialExploreStateFromUrl}
-    {exploreStateFromSessionStorage}
-  >
-    <slot />
-  </DashboardURLStateSync>
-{/if}
+<DashboardURLStateSync
+  metricsViewName={$metricsViewName}
+  exploreName={$exploreName}
+  {defaultExplorePreset}
+  {exploreStateFromYAMLConfig}
+  {partialExploreStateFromUrl}
+  {exploreStateFromSessionStorage}
+>
+  <slot />
+</DashboardURLStateSync>

--- a/web-common/src/features/dashboards/url-state/DashboardURLStateSyncWrapper.svelte
+++ b/web-common/src/features/dashboards/url-state/DashboardURLStateSyncWrapper.svelte
@@ -61,13 +61,15 @@
   $: parseUrl($page.url, defaultExplorePreset);
 </script>
 
-<DashboardURLStateSync
-  metricsViewName={$metricsViewName}
-  exploreName={$exploreName}
-  {defaultExplorePreset}
-  {exploreStateFromYAMLConfig}
-  {partialExploreStateFromUrl}
-  {exploreStateFromSessionStorage}
->
-  <slot />
-</DashboardURLStateSync>
+{#if !$validSpecStore.isLoading}
+  <DashboardURLStateSync
+    metricsViewName={$metricsViewName}
+    exploreName={$exploreName}
+    {defaultExplorePreset}
+    {exploreStateFromYAMLConfig}
+    {partialExploreStateFromUrl}
+    {exploreStateFromSessionStorage}
+  >
+    <slot />
+  </DashboardURLStateSync>
+{/if}


### PR DESCRIPTION
Dashboards that lacked time series data were prevented from loading due to a conditional in `DashboardUrlStateSyncWrapper`