### PR TITLE
Increase timeout for graceful controller shutdown to 30s

### DIFF
--- a/runtime/controller.go
+++ b/runtime/controller.go
@@ -276,7 +276,7 @@ func (c *Controller) Run(ctx context.Context) error {
 	c.mu.RUnlock()
 
 	// Allow 10 seconds for closing invocations and reconcilers
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	// Need to consume all the cancelled invocation completions (otherwise, they will hang on sending to c.completed)


### PR DESCRIPTION
We're seeing the current timeout of 10s being reached when complex models are being materialized. One hypothesis is that DuckDB needs more time than 10s to clean up temporary disk state in these cases. This PR increases the limit to 30s.

Note that 30s is quite high and we should beware if we observe signs of more force shutdowns. Even in Rill Developer, a slow graceful shutdown may cause the user to force shutdown instead.