### PR TITLE
fix: various time ranges issues in alerts

### DIFF
--- a/runtime/queries/metricsview_aggregation.go
+++ b/runtime/queries/metricsview_aggregation.go
@@ -314,6 +314,9 @@ func (q *MetricsViewAggregation) rewriteToMetricsViewQuery(export bool) (*metric
 		res.IsoDuration = q.TimeRange.IsoDuration
 		res.IsoOffset = q.TimeRange.IsoOffset
 		res.RoundToGrain = metricsview.TimeGrainFromProto(q.TimeRange.RoundToGrain)
+		if q.TimeRange.TimeZone != "" {
+			qry.TimeZone = q.TimeRange.TimeZone
+		}
 		qry.TimeRange = res
 	}
 
@@ -329,6 +332,9 @@ func (q *MetricsViewAggregation) rewriteToMetricsViewQuery(export bool) (*metric
 		res.IsoDuration = q.ComparisonTimeRange.IsoDuration
 		res.IsoOffset = q.ComparisonTimeRange.IsoOffset
 		res.RoundToGrain = metricsview.TimeGrainFromProto(q.ComparisonTimeRange.RoundToGrain)
+		if q.ComparisonTimeRange.TimeZone != "" && qry.TimeZone == "qry.TimeZone" {
+			qry.TimeZone = q.ComparisonTimeRange.TimeZone
+		}
 		qry.ComparisonTimeRange = res
 	}
 

--- a/runtime/queries/metricsview_aggregation.go
+++ b/runtime/queries/metricsview_aggregation.go
@@ -332,7 +332,10 @@ func (q *MetricsViewAggregation) rewriteToMetricsViewQuery(export bool) (*metric
 		res.IsoDuration = q.ComparisonTimeRange.IsoDuration
 		res.IsoOffset = q.ComparisonTimeRange.IsoOffset
 		res.RoundToGrain = metricsview.TimeGrainFromProto(q.ComparisonTimeRange.RoundToGrain)
-		if q.ComparisonTimeRange.TimeZone != "" && qry.TimeZone == "qry.TimeZone" {
+		if q.ComparisonTimeRange.TimeZone != "" {
+			if qry.TimeZone != "" && qry.TimeZone != q.ComparisonTimeRange.TimeZone {
+				return nil, fmt.Errorf("comparison_time_range has a different time zone")
+			}
 			qry.TimeZone = q.ComparisonTimeRange.TimeZone
 		}
 		qry.ComparisonTimeRange = res

--- a/web-common/src/features/alerts/CreateAlertForm.svelte
+++ b/web-common/src/features/alerts/CreateAlertForm.svelte
@@ -59,11 +59,16 @@
   }
 
   // TODO: get metrics view spec
-  const timeRange = mapTimeRange(timeControls, {});
+  const timeRange = mapTimeRange(
+    timeControls,
+    $dashboardStore.selectedTimezone,
+    {},
+  );
   const comparisonTimeRange = mapComparisonTimeRange(
     $dashboardStore,
     timeControls,
     timeRange,
+    true,
   );
 
   const formState = createForm<AlertFormValues>({

--- a/web-common/src/features/alerts/CreateAlertForm.svelte
+++ b/web-common/src/features/alerts/CreateAlertForm.svelte
@@ -64,12 +64,7 @@
     $dashboardStore.selectedTimezone,
     {},
   );
-  const comparisonTimeRange = mapComparisonTimeRange(
-    $dashboardStore,
-    timeControls,
-    timeRange,
-    true,
-  );
+  const comparisonTimeRange = mapComparisonTimeRange(timeControls, timeRange);
 
   const formState = createForm<AlertFormValues>({
     initialValues: {

--- a/web-common/src/features/alerts/form-utils.ts
+++ b/web-common/src/features/alerts/form-utils.ts
@@ -87,7 +87,7 @@ export function getAlertQueryArgsFromFormValues(
         op: formValues.criteriaOperation,
         exprs: formValues.criteria
           .map(mapMeasureFilterToExpr)
-          .filter((e) => !!e) as V1Expression[],
+          .filter((e) => !!e),
       },
     }),
     timeRange: {
@@ -98,7 +98,7 @@ export function getAlertQueryArgsFromFormValues(
     sort: [
       {
         name: formValues.measure,
-        desc: false,
+        desc: true,
       },
     ],
     ...(formValues.comparisonTimeRange

--- a/web-common/src/features/dashboards/dimension-table/dimension-table-export-utils.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-export-utils.ts
@@ -45,10 +45,8 @@ export function getDimensionTableExportArgs(
       if (!timeRange) return undefined;
 
       const comparisonTimeRange = mapComparisonTimeRange(
-        dashboardState,
         timeControlState,
         timeRange,
-        false,
       );
 
       return getDimensionTableAggregationRequestForTime(

--- a/web-common/src/features/dashboards/dimension-table/dimension-table-export-utils.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-export-utils.ts
@@ -39,6 +39,7 @@ export function getDimensionTableExportArgs(
 
       const timeRange = mapTimeRange(
         timeControlState,
+        dashboardState.selectedTimezone,
         validSpecStore.data.explore,
       );
       if (!timeRange) return undefined;
@@ -47,6 +48,7 @@ export function getDimensionTableExportArgs(
         dashboardState,
         timeControlState,
         timeRange,
+        false,
       );
 
       return getDimensionTableAggregationRequestForTime(

--- a/web-common/src/features/dashboards/pivot/pivot-export.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-export.ts
@@ -111,7 +111,11 @@ export function getPivotExportArgs(ctx: StateManagers) {
 
       const metricsViewSpec = validSpecStore.data?.metricsView ?? {};
       const exploreSpec = validSpecStore.data?.explore ?? {};
-      const timeRange = mapTimeRange(timeControlState, exploreSpec);
+      const timeRange = mapTimeRange(
+        timeControlState,
+        dashboardState.selectedTimezone,
+        exploreSpec,
+      );
       if (!timeRange) return undefined;
 
       return getPivotAggregationRequest(

--- a/web-common/src/features/dashboards/time-controls/time-range-mappers.ts
+++ b/web-common/src/features/dashboards/time-controls/time-range-mappers.ts
@@ -1,4 +1,3 @@
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import type { TimeControlState } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import {
   TimeComparisonOption,

--- a/web-common/src/features/dashboards/time-controls/time-range-mappers.ts
+++ b/web-common/src/features/dashboards/time-controls/time-range-mappers.ts
@@ -42,6 +42,7 @@ export const PreviousCompleteRangeMap: Partial<
  */
 export function mapTimeRange(
   timeControlState: TimeControlState,
+  timeZone: string,
   explore: V1ExploreSpec,
 ) {
   if (!timeControlState.selectedTimeRange?.name) return undefined;
@@ -72,6 +73,8 @@ export function mapTimeRange(
       break;
   }
 
+  timeRange.timeZone = timeZone;
+
   return timeRange;
 }
 
@@ -82,10 +85,11 @@ export function mapComparisonTimeRange(
   dashboardState: MetricsExplorerEntity,
   timeControlState: TimeControlState,
   timeRange: V1TimeRange | undefined,
+  forceTimeComparison: boolean,
 ) {
   if (
     !timeRange ||
-    dashboardState.selectedComparisonDimension ||
+    (!forceTimeComparison && dashboardState.selectedComparisonDimension) ||
     !timeControlState.showTimeComparison ||
     !timeControlState.selectedComparisonTimeRange?.name
   ) {

--- a/web-common/src/features/dashboards/time-controls/time-range-mappers.ts
+++ b/web-common/src/features/dashboards/time-controls/time-range-mappers.ts
@@ -82,14 +82,11 @@ export function mapTimeRange(
  * Maps selectedComparisonTimeRange to V1TimeRange if time comparison is enabled.
  */
 export function mapComparisonTimeRange(
-  dashboardState: MetricsExplorerEntity,
   timeControlState: TimeControlState,
   timeRange: V1TimeRange | undefined,
-  forceTimeComparison: boolean,
 ) {
   if (
     !timeRange ||
-    (!forceTimeComparison && dashboardState.selectedComparisonDimension) ||
     !timeControlState.showTimeComparison ||
     !timeControlState.selectedComparisonTimeRange?.name
   ) {

--- a/web-common/src/features/dashboards/time-dimension-details/getTDDExportArgs.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/getTDDExportArgs.ts
@@ -65,10 +65,8 @@ export function getTDDAggregationRequest(
   if (!timeRange) return undefined;
 
   const comparisonTimeRange = mapComparisonTimeRange(
-    dashboardState,
     timeControlState,
     timeRange,
-    false,
   );
 
   const measures: V1MetricsViewAggregationMeasure[] = [

--- a/web-common/src/features/dashboards/time-dimension-details/getTDDExportArgs.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/getTDDExportArgs.ts
@@ -57,13 +57,18 @@ export function getTDDAggregationRequest(
   )
     return undefined;
 
-  const timeRange = mapTimeRange(timeControlState, explore);
+  const timeRange = mapTimeRange(
+    timeControlState,
+    dashboardState.selectedTimezone,
+    explore,
+  );
   if (!timeRange) return undefined;
 
   const comparisonTimeRange = mapComparisonTimeRange(
     dashboardState,
     timeControlState,
     timeRange,
+    false,
   );
 
   const measures: V1MetricsViewAggregationMeasure[] = [


### PR DESCRIPTION
closes #6447

- [x] Fix time zone not getting passed through for metrics aggregation query.
- [x] Sort preview by descending.
- [x] Fix time comparison not enabled in alert even when enabled while in pivot view.