### PR TITLE
Fix unwarranted panic in DeleteMagicAuthTokens

### DIFF
--- a/admin/database/postgres/postgres.go
+++ b/admin/database/postgres/postgres.go
@@ -1203,8 +1203,8 @@ func (c *connection) DeleteMagicAuthToken(ctx context.Context, id string) error 
 }
 
 func (c *connection) DeleteMagicAuthTokens(ctx context.Context, ids []string) error {
-	res, err := c.getDB(ctx).ExecContext(ctx, "DELETE FROM magic_auth_tokens WHERE id=ANY($1)", ids)
-	return checkDeleteRow("magic auth token", res, err)
+	_, err := c.getDB(ctx).ExecContext(ctx, "DELETE FROM magic_auth_tokens WHERE id=ANY($1)", ids)
+	return parseErr("magic auth token", err)
 }
 
 func (c *connection) DeleteExpiredMagicAuthTokens(ctx context.Context, retention time.Duration) error {


### PR DESCRIPTION
Fixes this error when calling `DeleteMagicAuthTokens` with multiple tokens:
```
panic caught: expected to delete 1 row, but deleted 2
```
DataDog [link here](https://rill.datadoghq.com/logs?query=service%3Arill-cloud%20%40level%3Aerror%20-%22otel%20error%22%20container_name%3Acloud-admin-server%20-%40error%3A%22not%20authenticated%20as%20a%20user%22&agg_m=count&agg_m_source=base&agg_q=environment&agg_q_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZStGD-0po6FlQAAABhBWlN0R0VOU0FBRHVoS1pqTEh0X2ZRQUQAAAAkMDE5NGFkMWMtNmRiYS00MDQyLWIyNmEtZWQzNDNkNDVhZGExAAAdTg&fromUser=true&index=main&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1738070582000&to_ts=1738070882000&live=false).