### PR TITLE
fix: public urls with computed measures and dependant measures are hidden

### DIFF
--- a/web-admin/src/features/public-urls/form-utils.ts
+++ b/web-admin/src/features/public-urls/form-utils.ts
@@ -33,13 +33,6 @@ export function getExploreFields(
   if (everythingIsVisible) return undefined; // Not specifying any fields means all fields are visible
 
   const filteredDimensions = getAllIdentifiers(dashboardStore.whereFilter);
-  const allMeasureNames = new Set<string>();
-  visibleMeasures.forEach((measure) => {
-    allMeasureNames.add(measure.name);
-    measure.referencedMeasures?.forEach((refMes) =>
-      allMeasureNames.add(refMes),
-    );
-  });
 
   return [
     ...visibleDimensions
@@ -49,7 +42,7 @@ export function getExploreFields(
         // Including `!!dimension` fixes a hidden TS error
         (dimension) => !!dimension && !filteredDimensions.includes(dimension),
       ),
-    ...allMeasureNames,
+    ...visibleMeasures.map((measure) => measure.name),
   ] as string[];
 }
 

--- a/web-admin/src/features/public-urls/form-utils.ts
+++ b/web-admin/src/features/public-urls/form-utils.ts
@@ -33,6 +33,13 @@ export function getExploreFields(
   if (everythingIsVisible) return undefined; // Not specifying any fields means all fields are visible
 
   const filteredDimensions = getAllIdentifiers(dashboardStore.whereFilter);
+  const allMeasureNames = new Set<string>();
+  visibleMeasures.forEach((measure) => {
+    allMeasureNames.add(measure.name);
+    measure.referencedMeasures?.forEach((refMes) =>
+      allMeasureNames.add(refMes),
+    );
+  });
 
   return [
     ...visibleDimensions
@@ -42,7 +49,7 @@ export function getExploreFields(
         // Including `!!dimension` fixes a hidden TS error
         (dimension) => !!dimension && !filteredDimensions.includes(dimension),
       ),
-    ...visibleMeasures.map((measure) => measure.name),
+    ...allMeasureNames,
   ] as string[];
 }
 

--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -102,7 +102,6 @@
   $: measures = getMeasuresForDimensionTable(
     activeMeasureName,
     dimensionThresholdFilters,
-    metricsView,
     visibleMeasureNames,
   )
     .map(

--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -12,7 +12,6 @@
     type MetricsViewSpecDimensionV2,
     type V1Expression,
     type V1MetricsViewAggregationMeasure,
-    type V1MetricsViewSpec,
     type V1TimeRange,
   } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
@@ -36,7 +35,6 @@
   export let whereFilter: V1Expression;
   export let metricsViewName: string;
   export let dimensionThresholdFilters: DimensionThresholdFilter[];
-  export let metricsView: V1MetricsViewSpec;
   export let visibleMeasureNames: string[];
   export let timeControlsReady: boolean;
   export let dimension: MetricsViewSpecDimensionV2;

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -6,7 +6,6 @@
     MetricsViewSpecDimensionV2,
     V1Expression,
     V1MetricsViewAggregationMeasure,
-    V1MetricsViewSpec,
     V1TimeRange,
   } from "@rilldata/web-common/runtime-client";
   import {
@@ -59,7 +58,6 @@
   export let dimensionThresholdFilters: DimensionThresholdFilter[];
   export let activeMeasureName: string;
   export let metricsViewName: string;
-  export let metricsView: V1MetricsViewSpec;
   export let sortType: SortType;
   export let tableWidth: number;
   export let sortedAscending: boolean;

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -24,7 +24,6 @@
     additionalMeasures,
     getFiltersForOtherDimensions,
   } from "../selectors";
-  import { getIndependentMeasures } from "../state-managers/selectors/measures";
   import {
     createAndExpression,
     createOrExpression,
@@ -125,10 +124,7 @@
         undefined,
       );
 
-  $: measures = getIndependentMeasures(
-    metricsView,
-    additionalMeasures(activeMeasureName, dimensionThresholdFilters),
-  )
+  $: measures = additionalMeasures(activeMeasureName, dimensionThresholdFilters)
     .map(
       (n) =>
         ({

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -2,7 +2,6 @@
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import type {
     V1Expression,
-    V1MetricsViewSpec,
     V1TimeRange,
   } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
@@ -22,7 +21,6 @@
   export let comparisonTimeRange: V1TimeRange | undefined;
   export let timeControlsReady: boolean;
   export let activeMeasureName: string;
-  export let metricsView: V1MetricsViewSpec;
 
   const StateManagers = getStateManagers();
   const {
@@ -108,7 +106,6 @@
               isSummableMeasure={$isSummableMeasure}
               {parentElement}
               {suppressTooltip}
-              {metricsView}
               {timeControlsReady}
               selectedValues={$selectedDimensionValues(dimension.name)}
               isBeingCompared={$isBeingComparedReadable(dimension.name)}

--- a/web-common/src/features/dashboards/state-managers/selectors/dashboard-queries.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/dashboard-queries.ts
@@ -1,17 +1,14 @@
-import { getIndependentMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
-import type { V1MetricsViewSpec } from "@rilldata/web-common/runtime-client";
 import { additionalMeasures } from "../../selectors";
 import type { DimensionThresholdFilter } from "../../stores/metrics-explorer-entity";
 
 export function getMeasuresForDimensionTable(
   activeMeasureName: string,
   dimensionThresholdFilters: DimensionThresholdFilter[],
-  metricsView: V1MetricsViewSpec | undefined,
   visibleMeasureNames: string[],
 ) {
   const allMeasures = new Set([
     ...visibleMeasureNames,
     ...additionalMeasures(activeMeasureName, dimensionThresholdFilters),
   ]);
-  return getIndependentMeasures(metricsView ?? {}, [...allMeasures]);
+  return [...allMeasures];
 }

--- a/web-common/src/features/dashboards/state-managers/selectors/measures.spec.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/measures.spec.ts
@@ -15,6 +15,7 @@ describe("measures selectors", () => {
         timeGrain: V1TimeGrain.TIME_GRAIN_DAY,
         expected: {
           measures: ["mes", "mes_time_no_grain"],
+          nonWindowMeasures: ["mes", "mes_time_no_grain"],
           dimensions: [
             {
               name: "time",
@@ -34,6 +35,7 @@ describe("measures selectors", () => {
         timeGrain: V1TimeGrain.TIME_GRAIN_DAY,
         expected: {
           measures: ["mes", "mes_time_no_grain", "mes_time_day_grain"],
+          nonWindowMeasures: ["mes", "mes_time_no_grain", "mes_time_day_grain"],
           dimensions: [
             {
               name: "time",
@@ -53,6 +55,11 @@ describe("measures selectors", () => {
         timeGrain: V1TimeGrain.TIME_GRAIN_WEEK,
         expected: {
           measures: ["mes", "mes_time_no_grain", "mes_time_week_grain"],
+          nonWindowMeasures: [
+            "mes",
+            "mes_time_no_grain",
+            "mes_time_week_grain",
+          ],
           dimensions: [
             {
               name: "time",
@@ -72,6 +79,7 @@ describe("measures selectors", () => {
         timeGrain: V1TimeGrain.TIME_GRAIN_MONTH,
         expected: {
           measures: ["mes", "mes_time_no_grain"],
+          nonWindowMeasures: ["mes", "mes_time_no_grain"],
           dimensions: [
             {
               name: "time",

--- a/web-common/src/features/dashboards/state-managers/selectors/measures.spec.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/measures.spec.ts
@@ -1,4 +1,4 @@
-import { getFilteredMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
+import { removeSomeAdvancedMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
 import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import {
   type V1MetricsViewSpec,
@@ -99,7 +99,7 @@ describe("measures selectors", () => {
     for (const { title, measures, timeGrain, expectedMeasures } of TestCases) {
       it(title, () => {
         expect(
-          getFilteredMeasures(
+          removeSomeAdvancedMeasures(
             {
               selectedTimeRange: {
                 interval: timeGrain,
@@ -115,7 +115,7 @@ describe("measures selectors", () => {
 
     it("with window measure and do not select it", () => {
       expect(
-        getFilteredMeasures(
+        removeSomeAdvancedMeasures(
           {
             selectedTimeRange: {
               interval: V1TimeGrain.TIME_GRAIN_UNSPECIFIED,

--- a/web-common/src/features/dashboards/state-managers/selectors/measures.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/measures.ts
@@ -82,10 +82,12 @@ export const filteredSimpleMeasures = ({
 };
 
 /**
- * Selects measure valid for current dashboard selections.
- * Also includes additional dimensions needed for any advanced measures.
+ * Selects measure valid for current dashboard selections. We filter out advanced measures that are,
+ * 1. Of type MEASURE_TYPE_TIME_COMPARISON.
+ * 2. Dependent on a time dimension with a defined grain and not equal to the current selected grain.
+ * 3. Window measures if includeWindowMeasures=false. Right now totals query does not support these.
  */
-export const getFilteredMeasures = (
+export const removeSomeAdvancedMeasures = (
   exploreState: MetricsExplorerEntity,
   metricsViewSpec: V1MetricsViewSpec,
   measureNames: string[],

--- a/web-common/src/features/dashboards/state-managers/selectors/measures.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/measures.ts
@@ -93,10 +93,12 @@ export const getFilteredMeasuresAndDimensions = ({
     measureNames: string[],
   ): {
     measures: string[];
+    nonWindowMeasures: string[];
     dimensions: MetricsViewSpecDimensionSelector[];
   } => {
     const dimensions = new Map<string, V1TimeGrain>();
     const measures = new Set<string>();
+    const nonWindowMeasures = new Set<string>();
     measureNames.forEach((measureName) => {
       const measure = metricsViewSpec.measures?.find(
         (m) => m.name === measureName,
@@ -145,36 +147,17 @@ export const getFilteredMeasuresAndDimensions = ({
       });
       if (skipMeasure) return;
       measures.add(measureName);
-      if (!measure.window) return;
-      measure.referencedMeasures?.filter((refMes) => measures.add(refMes));
+      if (!measure.window) nonWindowMeasures.add(measureName);
     });
     return {
       measures: [...measures],
+      nonWindowMeasures: [...nonWindowMeasures],
       dimensions: [...dimensions.entries()].map(([name, timeGrain]) => ({
         name,
         timeGrain,
       })),
     };
   };
-};
-
-export const getIndependentMeasures = (
-  metricsViewSpec: V1MetricsViewSpec,
-  measureNames: string[],
-) => {
-  const measures = new Set<string>();
-  measureNames.forEach((measureName) => {
-    const measure = metricsViewSpec.measures?.find(
-      (m) => m.name === measureName,
-    );
-    // temporary check for window measures until the PR to move to AggregationApi is merged
-    if (!measure || measure.requiredDimensions?.length || !!measure.window)
-      return;
-    measures.add(measureName);
-    if (!measure.window) return;
-    measure.referencedMeasures?.filter((refMes) => measures.add(refMes));
-  });
-  return [...measures];
 };
 
 export const getSimpleMeasures = (measures: MetricsViewSpecMeasureV2[]) => {

--- a/web-common/src/features/dashboards/state-managers/selectors/measures.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/measures.ts
@@ -145,6 +145,7 @@ export const getFilteredMeasuresAndDimensions = ({
       });
       if (skipMeasure) return;
       measures.add(measureName);
+      if (!measure.window) return;
       measure.referencedMeasures?.filter((refMes) => measures.add(refMes));
     });
     return {
@@ -170,6 +171,7 @@ export const getIndependentMeasures = (
     if (!measure || measure.requiredDimensions?.length || !!measure.window)
       return;
     measures.add(measureName);
+    if (!measure.window) return;
     measure.referencedMeasures?.filter((refMes) => measures.add(refMes));
   });
   return [...measures];

--- a/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
+++ b/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
@@ -1,5 +1,5 @@
 import { mergeMeasureFilters } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
-import { getFilteredMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
+import { removeSomeAdvancedMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
 import type { StateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
 import { sanitiseExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
 import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
@@ -130,13 +130,13 @@ export function createTimeSeriesDataStore(
           : [];
       }
 
-      const measuresForTimeSeries = getFilteredMeasures(
+      const measuresForTimeSeries = removeSomeAdvancedMeasures(
         dashboardStore,
         metricsView ?? {},
         measures,
         true,
       );
-      const measuresForTotals = getFilteredMeasures(
+      const measuresForTotals = removeSomeAdvancedMeasures(
         dashboardStore,
         metricsView ?? {},
         measures,

--- a/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
+++ b/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
@@ -151,7 +151,7 @@ export function createTimeSeriesDataStore(
           : writable({
               isFetching: false,
               isError: false,
-              data: {},
+              data: { data: [] },
               error: undefined,
             });
 

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -90,8 +90,6 @@
       }
     : undefined;
 
-  $: metricsView = $explore.data?.metricsView ?? {};
-
   let metricsWidth = DEFAULT_TIMESERIES_WIDTH;
   let resizing = false;
 </script>
@@ -187,7 +185,6 @@
               {comparisonTimeRange}
               activeMeasureName={$activeMeasureName}
               {timeControlsReady}
-              {metricsView}
               visibleMeasureNames={$visibleMeasures.map(
                 ({ name }) => name ?? "",
               )}
@@ -201,7 +198,6 @@
               {dimensionThresholdFilters}
               {timeRange}
               {comparisonTimeRange}
-              {metricsView}
               {timeControlsReady}
             />
           {/if}


### PR DESCRIPTION
If a public url is created by selecting a computed measure but not the measure it is computed on, the dashboard fails to load since all required measures are not added to the token.

~~So we need to add all `referencedMeasures` to fields as well. This has a side effect of showing measures that were not selected.~~

We do not need to send the `referencedMeasures` for non-window computed measures.