### PR TITLE
fix (Breadcrumbs): Missing label for projects outside the first page

### DIFF
--- a/web-admin/src/features/navigation/TopNavigationBar.svelte
+++ b/web-admin/src/features/navigation/TopNavigationBar.svelte
@@ -74,11 +74,17 @@
     },
   );
 
-  $: projectsQuery = listProjects(organization, undefined, {
-    query: {
-      enabled: !!organization,
+  $: projectsQuery = listProjects(
+    organization,
+    {
+      pageSize: 100,
     },
-  });
+    {
+      query: {
+        enabled: !!organization,
+      },
+    },
+  );
 
   $: visualizationsQuery = useDashboardsV2(instanceId);
 


### PR DESCRIPTION
The problem:
<img width="504" alt="image" src="https://github.com/user-attachments/assets/c4f66711-ca3e-4066-9dcb-7c23f0c5e75c" />


Quick fix. Bumps the page size from 20 -> 100 on the `ListProjects` request.