### PR TITLE
fix: dont show warning when not switching model

### DIFF
--- a/web-common/src/features/workspaces/VisualMetrics.svelte
+++ b/web-common/src/features/workspaces/VisualMetrics.svelte
@@ -581,6 +581,7 @@
             placeholder="Select a model"
             label="Model"
             onChange={async (newModelOrSourceName) => {
+              if (modelOrSourceOrTableName === newModelOrSourceName) return;
               if (!modelOrSourceOrTableName) {
                 updateProperties({ model: newModelOrSourceName }, [
                   "table",


### PR DESCRIPTION
When selecting a already selected model in the model dropdown we show a warning dialog.
This checks early if the new value was actually changed.