### PR TITLE
Support limiting the concurrency of source and model execution

### DIFF
--- a/runtime/drivers/registry.go
+++ b/runtime/drivers/registry.go
@@ -83,6 +83,8 @@ type InstanceConfig struct {
 	ModelDefaultMaterialize bool `mapstructure:"rill.models.default_materialize"`
 	// ModelMaterializeDelaySeconds adds a delay before materializing models.
 	ModelMaterializeDelaySeconds uint32 `mapstructure:"rill.models.materialize_delay_seconds"`
+	// ModelConcurrentExecutionLimit sets the maximum number of concurrent model executions.
+	ModelConcurrentExecutionLimit uint32 `mapstructure:"rill.models.concurrent_execution_limit"`
 	// MetricsComparisonsExact indicates whether to rewrite metrics comparison queries to approximately correct queries.
 	// Approximated comparison queries are faster but may not return comparison data points for all values.
 	MetricsApproximateComparisons bool `mapstructure:"rill.metrics.approximate_comparisons"`
@@ -139,6 +141,7 @@ func (i *Instance) Config() (InstanceConfig, error) {
 		StageChanges:                         true,
 		ModelDefaultMaterialize:              false,
 		ModelMaterializeDelaySeconds:         0,
+		ModelConcurrentExecutionLimit:        10,
 		MetricsApproximateComparisons:        true,
 		MetricsApproximateComparisonsCTE:     false,
 		MetricsApproxComparisonTwoPhaseLimit: 250,

--- a/runtime/drivers/registry.go
+++ b/runtime/drivers/registry.go
@@ -141,7 +141,7 @@ func (i *Instance) Config() (InstanceConfig, error) {
 		StageChanges:                         true,
 		ModelDefaultMaterialize:              false,
 		ModelMaterializeDelaySeconds:         0,
-		ModelConcurrentExecutionLimit:        10,
+		ModelConcurrentExecutionLimit:        1,
 		MetricsApproximateComparisons:        true,
 		MetricsApproximateComparisonsCTE:     false,
 		MetricsApproxComparisonTwoPhaseLimit: 250,

--- a/runtime/reconcilers/alert.go
+++ b/runtime/reconcilers/alert.go
@@ -40,8 +40,8 @@ type AlertReconciler struct {
 	C *runtime.Controller
 }
 
-func newAlertReconciler(c *runtime.Controller) runtime.Reconciler {
-	return &AlertReconciler{C: c}
+func newAlertReconciler(ctx context.Context, c *runtime.Controller) (runtime.Reconciler, error) {
+	return &AlertReconciler{C: c}, nil
 }
 
 func (r *AlertReconciler) Close(ctx context.Context) error {

--- a/runtime/reconcilers/api.go
+++ b/runtime/reconcilers/api.go
@@ -17,8 +17,8 @@ type APIReconciler struct {
 	C *runtime.Controller
 }
 
-func newAPIReconciler(c *runtime.Controller) runtime.Reconciler {
-	return &APIReconciler{C: c}
+func newAPIReconciler(ctx context.Context, c *runtime.Controller) (runtime.Reconciler, error) {
+	return &APIReconciler{C: c}, nil
 }
 
 func (r *APIReconciler) Close(ctx context.Context) error {

--- a/runtime/reconcilers/canvas.go
+++ b/runtime/reconcilers/canvas.go
@@ -17,8 +17,8 @@ type CanvasReconciler struct {
 	C *runtime.Controller
 }
 
-func newCanvasReconciler(c *runtime.Controller) runtime.Reconciler {
-	return &CanvasReconciler{C: c}
+func newCanvasReconciler(ctx context.Context, c *runtime.Controller) (runtime.Reconciler, error) {
+	return &CanvasReconciler{C: c}, nil
 }
 
 func (r *CanvasReconciler) Close(ctx context.Context) error {

--- a/runtime/reconcilers/component.go
+++ b/runtime/reconcilers/component.go
@@ -17,8 +17,8 @@ type ComponentReconciler struct {
 	C *runtime.Controller
 }
 
-func newComponentReconciler(c *runtime.Controller) runtime.Reconciler {
-	return &ComponentReconciler{C: c}
+func newComponentReconciler(ctx context.Context, c *runtime.Controller) (runtime.Reconciler, error) {
+	return &ComponentReconciler{C: c}, nil
 }
 
 func (r *ComponentReconciler) Close(ctx context.Context) error {

--- a/runtime/reconcilers/connector.go
+++ b/runtime/reconcilers/connector.go
@@ -24,8 +24,8 @@ type ConnectorReconciler struct {
 	C *runtime.Controller
 }
 
-func newConnectorReconciler(c *runtime.Controller) runtime.Reconciler {
-	return &ConnectorReconciler{C: c}
+func newConnectorReconciler(ctx context.Context, c *runtime.Controller) (runtime.Reconciler, error) {
+	return &ConnectorReconciler{C: c}, nil
 }
 
 func (r *ConnectorReconciler) Close(ctx context.Context) error {

--- a/runtime/reconcilers/explore.go
+++ b/runtime/reconcilers/explore.go
@@ -18,8 +18,8 @@ type ExploreReconciler struct {
 	C *runtime.Controller
 }
 
-func newExploreReconciler(c *runtime.Controller) runtime.Reconciler {
-	return &ExploreReconciler{C: c}
+func newExploreReconciler(ctx context.Context, c *runtime.Controller) (runtime.Reconciler, error) {
+	return &ExploreReconciler{C: c}, nil
 }
 
 func (r *ExploreReconciler) Close(ctx context.Context) error {

--- a/runtime/reconcilers/metrics_view.go
+++ b/runtime/reconcilers/metrics_view.go
@@ -18,8 +18,8 @@ type MetricsViewReconciler struct {
 	C *runtime.Controller
 }
 
-func newMetricsViewReconciler(c *runtime.Controller) runtime.Reconciler {
-	return &MetricsViewReconciler{C: c}
+func newMetricsViewReconciler(ctx context.Context, c *runtime.Controller) (runtime.Reconciler, error) {
+	return &MetricsViewReconciler{C: c}, nil
 }
 
 func (r *MetricsViewReconciler) Close(ctx context.Context) error {

--- a/runtime/reconcilers/migration.go
+++ b/runtime/reconcilers/migration.go
@@ -19,8 +19,8 @@ type MigrationReconciler struct {
 	C *runtime.Controller
 }
 
-func newMigrationReconciler(c *runtime.Controller) runtime.Reconciler {
-	return &MigrationReconciler{C: c}
+func newMigrationReconciler(ctx context.Context, c *runtime.Controller) (runtime.Reconciler, error) {
+	return &MigrationReconciler{C: c}, nil
 }
 
 func (r *MigrationReconciler) Close(ctx context.Context) error {

--- a/runtime/reconcilers/model.go
+++ b/runtime/reconcilers/model.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rilldata/rill/runtime/pkg/pbutil"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -40,11 +41,20 @@ func init() {
 }
 
 type ModelReconciler struct {
-	C *runtime.Controller
+	C       *runtime.Controller
+	execSem *semaphore.Weighted
 }
 
-func newModelReconciler(c *runtime.Controller) runtime.Reconciler {
-	return &ModelReconciler{C: c}
+func newModelReconciler(ctx context.Context, c *runtime.Controller) (runtime.Reconciler, error) {
+	cfg, err := c.Runtime.InstanceConfig(ctx, c.InstanceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get model execution concurrency limit: %w", err)
+	}
+
+	return &ModelReconciler{
+		C:       c,
+		execSem: semaphore.NewWeighted(int64(cfg.ModelConcurrentExecutionLimit)),
+	}, nil
 }
 
 func (r *ModelReconciler) Close(ctx context.Context) error {
@@ -118,6 +128,12 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceNa
 	// Handle deletion
 	if self.Meta.DeletedOn != nil {
 		if prevManager != nil {
+			err := r.execSem.Acquire(ctx, 1)
+			if err != nil {
+				return runtime.ReconcileResult{Err: err}
+			}
+			defer r.execSem.Release(1)
+
 			err = prevManager.Delete(ctx, prevResult)
 			return runtime.ReconcileResult{Err: err}
 		}
@@ -133,12 +149,24 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceNa
 	// Handle renames
 	if self.Meta.RenamedFrom != nil {
 		if prevManager != nil {
-			renameRes, err := prevManager.Rename(ctx, prevResult, self.Meta.Name.Name, modelEnv)
-			if err == nil {
-				err = r.updateStateWithResult(ctx, self, renameRes)
-			}
-			if err != nil {
-				r.C.Logger.Warn("failed to rename model", zap.String("model", n.Name), zap.String("renamed_from", self.Meta.RenamedFrom.Name), zap.Error(err))
+			// Using a nested scope to ensure the execSem is safely acquired and released.
+			func() {
+				err := r.execSem.Acquire(ctx, 1)
+				if err != nil {
+					return // Safe to ignore because the err can only be ctx.Err()
+				}
+				defer r.execSem.Release(1)
+
+				renameRes, err := prevManager.Rename(ctx, prevResult, self.Meta.Name.Name, modelEnv)
+				if err == nil {
+					err = r.updateStateWithResult(ctx, self, renameRes)
+				}
+				if err != nil {
+					r.C.Logger.Warn("failed to rename model", zap.String("model", n.Name), zap.String("renamed_from", self.Meta.RenamedFrom.Name), zap.Error(err))
+				}
+			}()
+			if ctx.Err() != nil {
+				return runtime.ReconcileResult{Err: ctx.Err()}
 			}
 
 			// Note: Not exiting early. We may need to retrigger the model in some cases. We also need to set the correct retrigger time.
@@ -155,12 +183,18 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceNa
 	if err != nil {
 		// If not staging changes, we need to drop the previous output (if any) before returning
 		if !modelEnv.StageChanges && prevManager != nil {
+			err := r.execSem.Acquire(ctx, 1)
+			if err != nil {
+				return runtime.ReconcileResult{Err: err}
+			}
+			defer r.execSem.Release(1)
+
 			err2 := prevManager.Delete(ctx, prevResult)
 			if err2 != nil {
 				r.C.Logger.Warn("failed to delete model output", zap.String("model", n.Name), zap.Error(err2))
 			}
 
-			err := r.clearPartitions(ctx, model)
+			err = r.clearPartitions(ctx, model)
 			if err != nil {
 				return runtime.ReconcileResult{Err: err}
 			}
@@ -225,6 +259,13 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceNa
 		}
 		return runtime.ReconcileResult{Retrigger: refreshOn}
 	}
+
+	// Acquire the execution semaphore for the remainder of the function.
+	err = r.execSem.Acquire(ctx, 1)
+	if err != nil {
+		return runtime.ReconcileResult{Err: err}
+	}
+	defer r.execSem.Release(1)
 
 	// If the output connector has changed, drop data in the old output connector (if any).
 	// If only the output properties have changed, the executor will handle dropping existing data (to comply with StageChanges).

--- a/runtime/reconcilers/project_parser.go
+++ b/runtime/reconcilers/project_parser.go
@@ -26,8 +26,8 @@ type ProjectParserReconciler struct {
 	C *runtime.Controller
 }
 
-func newProjectParser(c *runtime.Controller) runtime.Reconciler {
-	return &ProjectParserReconciler{C: c}
+func newProjectParser(ctx context.Context, c *runtime.Controller) (runtime.Reconciler, error) {
+	return &ProjectParserReconciler{C: c}, nil
 }
 
 func (r *ProjectParserReconciler) Close(ctx context.Context) error {

--- a/runtime/reconcilers/pull_trigger.go
+++ b/runtime/reconcilers/pull_trigger.go
@@ -19,8 +19,8 @@ type PullTriggerReconciler struct {
 	C *runtime.Controller
 }
 
-func newPullTriggerReconciler(c *runtime.Controller) runtime.Reconciler {
-	return &PullTriggerReconciler{C: c}
+func newPullTriggerReconciler(ctx context.Context, c *runtime.Controller) (runtime.Reconciler, error) {
+	return &PullTriggerReconciler{C: c}, nil
 }
 
 func (r *PullTriggerReconciler) Close(ctx context.Context) error {

--- a/runtime/reconcilers/refresh_trigger.go
+++ b/runtime/reconcilers/refresh_trigger.go
@@ -23,8 +23,8 @@ type RefreshTriggerReconciler struct {
 	C *runtime.Controller
 }
 
-func newRefreshTriggerReconciler(c *runtime.Controller) runtime.Reconciler {
-	return &RefreshTriggerReconciler{C: c}
+func newRefreshTriggerReconciler(ctx context.Context, c *runtime.Controller) (runtime.Reconciler, error) {
+	return &RefreshTriggerReconciler{C: c}, nil
 }
 
 func (r *RefreshTriggerReconciler) Close(ctx context.Context) error {

--- a/runtime/reconcilers/report.go
+++ b/runtime/reconcilers/report.go
@@ -36,8 +36,8 @@ type ReportReconciler struct {
 	C *runtime.Controller
 }
 
-func newReportReconciler(c *runtime.Controller) runtime.Reconciler {
-	return &ReportReconciler{C: c}
+func newReportReconciler(ctx context.Context, c *runtime.Controller) (runtime.Reconciler, error) {
+	return &ReportReconciler{C: c}, nil
 }
 
 func (r *ReportReconciler) Close(ctx context.Context) error {

--- a/runtime/reconcilers/source.go
+++ b/runtime/reconcilers/source.go
@@ -37,6 +37,7 @@ func newSourceReconciler(ctx context.Context, c *runtime.Controller) (runtime.Re
 	if err != nil {
 		return nil, fmt.Errorf("failed to get model execution concurrency limit: %w", err)
 	}
+	// Re-using the model limit since we are deprecating sources soon (so everything will be a model).
 	if cfg.ModelConcurrentExecutionLimit <= 0 {
 		return nil, errors.New("model_concurrent_execution_limit must be greater than zero")
 	}

--- a/runtime/reconcilers/source.go
+++ b/runtime/reconcilers/source.go
@@ -119,7 +119,7 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceN
 
 				// Rename and update state
 				err = olapForceRenameTable(ctx, r.C, src.State.Connector, src.State.Table, false, tableName)
-				if err != nil {
+				if err == nil {
 					src.State.Table = tableName
 					err = r.C.UpdateState(ctx, self.Meta.Name, self)
 				}

--- a/runtime/reconcilers/source.go
+++ b/runtime/reconcilers/source.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rilldata/rill/runtime/pkg/pbutil"
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
+	"golang.org/x/sync/semaphore"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -27,11 +28,20 @@ func init() {
 }
 
 type SourceReconciler struct {
-	C *runtime.Controller
+	C       *runtime.Controller
+	execSem *semaphore.Weighted
 }
 
-func newSourceReconciler(c *runtime.Controller) runtime.Reconciler {
-	return &SourceReconciler{C: c}
+func newSourceReconciler(ctx context.Context, c *runtime.Controller) (runtime.Reconciler, error) {
+	cfg, err := c.Runtime.InstanceConfig(ctx, c.InstanceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get model execution concurrency limit: %w", err)
+	}
+
+	return &SourceReconciler{
+		C:       c,
+		execSem: semaphore.NewWeighted(int64(cfg.ModelConcurrentExecutionLimit)),
+	}, nil
 }
 
 func (r *SourceReconciler) Close(ctx context.Context) error {
@@ -80,6 +90,12 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceN
 
 	// Handle deletion
 	if self.Meta.DeletedOn != nil {
+		err = r.execSem.Acquire(ctx, 1)
+		if err != nil {
+			return runtime.ReconcileResult{Err: err}
+		}
+		defer r.execSem.Release(1)
+
 		olapDropTableIfExists(ctx, r.C, src.State.Connector, src.State.Table)
 		olapDropTableIfExists(ctx, r.C, src.State.Connector, r.stagingTableName(tableName))
 		return runtime.ReconcileResult{}
@@ -91,15 +107,26 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceN
 		_, ok := olapTableInfo(ctx, r.C, src.State.Connector, src.State.Table)
 		// NOTE: Not checking if it's a view because some backends will represent sources as views (like DuckDB with external table storage enabled).
 		if ok {
-			// Rename and update state
-			err = olapForceRenameTable(ctx, r.C, src.State.Connector, src.State.Table, false, tableName)
-			if err != nil {
-				return runtime.ReconcileResult{Err: fmt.Errorf("failed to rename table: %w", err)}
-			}
-			src.State.Table = tableName
-			err = r.C.UpdateState(ctx, self.Meta.Name, self)
-			if err != nil {
-				return runtime.ReconcileResult{Err: err}
+			// Using a nested scope to ensure the execSem is released (even if there's a panic).
+			func() {
+				err = r.execSem.Acquire(ctx, 1)
+				if err != nil {
+					return // Safe to ignore because the err can only be ctx.Err()
+				}
+				defer r.execSem.Release(1)
+
+				// Rename and update state
+				err = olapForceRenameTable(ctx, r.C, src.State.Connector, src.State.Table, false, tableName)
+				if err != nil {
+					src.State.Table = tableName
+					err = r.C.UpdateState(ctx, self.Meta.Name, self)
+				}
+				if err != nil {
+					r.C.Logger.Warn("failed to rename source", zap.String("source", n.Name), zap.String("renamed_from", self.Meta.RenamedFrom.Name), zap.Error(err))
+				}
+			}()
+			if ctx.Err() != nil {
+				return runtime.ReconcileResult{Err: ctx.Err()}
 			}
 		}
 		// Note: Not exiting early. It might need to be (re-)ingested, and we need to set the correct retrigger time based on the refresh schedule.
@@ -114,6 +141,12 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceN
 	err = checkRefs(ctx, r.C, self.Meta.Refs)
 	if err != nil {
 		if !src.Spec.StageChanges && src.State.Table != "" {
+			err = r.execSem.Acquire(ctx, 1)
+			if err != nil {
+				return runtime.ReconcileResult{Err: err}
+			}
+			defer r.execSem.Release(1)
+
 			// Remove previously ingested table
 			olapDropTableIfExists(ctx, r.C, src.State.Connector, src.State.Table)
 			src.State.Connector = ""
@@ -167,6 +200,13 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceN
 	if !trigger {
 		return runtime.ReconcileResult{Retrigger: refreshOn}
 	}
+
+	// Acquire the execution semaphore for the remainder of the function.
+	err = r.execSem.Acquire(ctx, 1)
+	if err != nil {
+		return runtime.ReconcileResult{Err: err}
+	}
+	defer r.execSem.Release(1)
 
 	// If the SinkConnector was changed, drop data in the old connector
 	if src.State.Table != "" && src.State.Connector != src.Spec.SinkConnector {

--- a/runtime/reconcilers/theme.go
+++ b/runtime/reconcilers/theme.go
@@ -17,8 +17,8 @@ type ThemeReconciler struct {
 	C *runtime.Controller
 }
 
-func newThemeReconciler(c *runtime.Controller) runtime.Reconciler {
-	return &ThemeReconciler{C: c}
+func newThemeReconciler(ctx context.Context, c *runtime.Controller) (runtime.Reconciler, error) {
+	return &ThemeReconciler{C: c}, nil
 }
 
 func (r *ThemeReconciler) Close(ctx context.Context) error {


### PR DESCRIPTION
Changes:
- Adds `rill.models.concurrent_execution_limit` as a config key with a default limit of 1.
- The limit applies to source and model resources, but is enforced separately for each type (since we'll soon unify the two it's not worth centralizing it)
- The limit only applies if there are expensive operations like ingestion or deletion, not for simple reconciles that just do integrity or refresh time checks.

Example for changing the limit to 3:
```
rill env set rill.models.concurrent_execution_limit 3
```