### PR TITLE
Canvas: use selector for canvas components on editing

### DIFF
--- a/web-common/src/features/canvas/components/util.ts
+++ b/web-common/src/features/canvas/components/util.ts
@@ -120,10 +120,12 @@ const displayMap: Record<CanvasComponentType, string> = {
   area_chart: "Chart",
 };
 
-export function getHeaderForComponent(componentType: string | undefined) {
+export function getHeaderForComponent(
+  componentType: CanvasComponentType | null,
+) {
   if (!componentType) return "Component";
-  if (!displayMap[componentType as CanvasComponentType]) {
+  if (!displayMap[componentType]) {
     return "Component";
   }
-  return displayMap[componentType as CanvasComponentType];
+  return displayMap[componentType];
 }

--- a/web-common/src/features/canvas/inspector/VisualCanvasEditing.svelte
+++ b/web-common/src/features/canvas/inspector/VisualCanvasEditing.svelte
@@ -11,7 +11,6 @@
   export let autoSave: boolean;
 
   const { canvasEntity } = getCanvasStateManagers();
-  const { canvasSpec } = canvasEntity.spec;
 
   $: ({ editorContent, updateEditorContent, saveLocalContent, path } =
     fileArtifact);

--- a/web-common/src/features/canvas/inspector/VisualCanvasEditing.svelte
+++ b/web-common/src/features/canvas/inspector/VisualCanvasEditing.svelte
@@ -19,11 +19,6 @@
   $: parsedDocument = parseDocument($editorContent ?? "");
   $: selectedComponentIndex = canvasEntity.selectedComponentIndex;
 
-  $: selectedComponentName =
-    $selectedComponentIndex !== null
-      ? $canvasSpec?.items?.[$selectedComponentIndex]?.component
-      : null;
-
   async function updateProperties(
     newRecord: Record<string, unknown>,
     removeProperties?: Array<string | string[]>,
@@ -61,8 +56,11 @@
 </script>
 
 <Inspector minWidth={320} filePath={path}>
-  {#if selectedComponentName}
-    <ComponentsEditor {fileArtifact} {selectedComponentName} />
+  {#if $selectedComponentIndex !== null}
+    <ComponentsEditor
+      {fileArtifact}
+      selectedComponentIndex={$selectedComponentIndex}
+    />
   {:else}
     <PageEditor {fileArtifact} {updateProperties} />
   {/if}

--- a/web-common/src/features/canvas/stores/canvas-component.ts
+++ b/web-common/src/features/canvas/stores/canvas-component.ts
@@ -12,7 +12,7 @@ export class CanvasComponentState {
     this.filters = new CanvasFilters(spec);
     this.spec = spec;
 
-    const componentResourceStore = spec.getComponentResource(name);
+    const componentResourceStore = spec.getComponentResourceFromName(name);
     const componentResource = get(componentResourceStore);
 
     if (

--- a/web-common/src/features/canvas/stores/canvas-spec.ts
+++ b/web-common/src/features/canvas/stores/canvas-spec.ts
@@ -236,7 +236,9 @@ export class CanvasResolvedSpec {
     );
   };
 
-  getDimensionsFromMeasure(measureName: string): MetricsViewSpecDimensionV2[] {
+  getDimensionsFromMeasure = (
+    measureName: string,
+  ): MetricsViewSpecDimensionV2[] => {
     const metricsMeasureMap = get(this.metricsViewMeasureMap);
     let metricViewName: string | undefined;
     for (const [key, value] of Object.entries(metricsMeasureMap)) {
@@ -246,16 +248,16 @@ export class CanvasResolvedSpec {
     if (metricViewName)
       return get(this.getDimensionsForMetricView(metricViewName));
     return [];
-  }
+  };
 
-  getMetricsViewNamesForDimension(dimensionName: string): string[] {
+  getMetricsViewNamesForDimension = (dimensionName: string): string[] => {
     const metricsDimensionMap = get(this.metricsViewDimensionsMap);
     const metricViewNames: string[] = [];
     for (const [key, value] of Object.entries(metricsDimensionMap)) {
       if (value.has(dimensionName)) metricViewNames.push(key);
     }
     return metricViewNames;
-  }
+  };
 
   private filterSimpleMeasures = (
     measures: MetricsViewSpecMeasureV2[] | undefined,


### PR DESCRIPTION
Removes resource query from `ComponentsEditor` and subscribes to the canvas spec using store selectors