### PR TITLE
Canvas: activate comparison by default, use global time

### DIFF
--- a/web-common/src/features/canvas/components/charts/index.ts
+++ b/web-common/src/features/canvas/components/charts/index.ts
@@ -69,7 +69,6 @@ export class ChartComponent extends BaseCanvasComponent<ChartSpec> {
         type: "quantitative",
         field: measure,
       },
-      time_range: "PT24H",
     };
   }
 }

--- a/web-common/src/features/canvas/components/kpi/index.ts
+++ b/web-common/src/features/canvas/components/kpi/index.ts
@@ -60,7 +60,6 @@ export class KPIComponent extends BaseCanvasComponent<KPISpec> {
     return {
       metrics_view,
       measure,
-      time_range: "PT24H",
       sparkline: true,
     };
   }

--- a/web-common/src/features/canvas/components/table/index.ts
+++ b/web-common/src/features/canvas/components/table/index.ts
@@ -76,7 +76,6 @@ export class TableCanvasComponent extends BaseCanvasComponent<TableSpec> {
       metrics_view,
       measures: [measure],
       row_dimensions: [dimension],
-      time_range: "PT24H",
     };
   }
 }

--- a/web-common/src/features/canvas/inspector/ComponentsEditor.svelte
+++ b/web-common/src/features/canvas/inspector/ComponentsEditor.svelte
@@ -7,6 +7,8 @@
   import VegaConfigInput from "@rilldata/web-common/features/canvas/inspector/VegaConfigInput.svelte";
   import { getCanvasStateManagers } from "@rilldata/web-common/features/canvas/state-managers/state-managers";
   import type { FileArtifact } from "@rilldata/web-common/features/entity-management/file-artifact";
+  import Spinner from "@rilldata/web-common/features/entity-management/Spinner.svelte";
+  import { EntityStatus } from "@rilldata/web-common/features/entity-management/types";
   import SidebarWrapper from "@rilldata/web-common/features/visual-editing/SidebarWrapper.svelte";
   import ComponentTabs from "./ComponentTabs.svelte";
   import FiltersMapper from "./filters/FiltersMapper.svelte";
@@ -67,9 +69,19 @@
         <VegaConfigInput {component} paramValues={rendererProperties} />
       {/if}
     {/key}
+  {:else if !renderer}
+    <div class="inspector-center">
+      <Spinner status={EntityStatus.Running} size="16px" />
+    </div>
   {:else}
-    <div>
+    <div class="inspector-center">
       Unknown Component {renderer}
     </div>
   {/if}
 </SidebarWrapper>
+
+<style lang="postcss">
+  .inspector-center {
+    @apply flex items-center justify-center h-full w-full;
+  }
+</style>

--- a/web-common/src/features/canvas/stores/canvas-time-control.ts
+++ b/web-common/src/features/canvas/stores/canvas-time-control.ts
@@ -1,6 +1,9 @@
 import type { CanvasResponse } from "@rilldata/web-common/features/canvas/selector";
 import type { CanvasSpecResponseStore } from "@rilldata/web-common/features/canvas/types";
-import { getTimeGrain } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
+import {
+  getComparisonTimeRange,
+  getTimeGrain,
+} from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
 import { isoDurationToFullTimeRange } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
 import {
@@ -10,6 +13,7 @@ import {
 } from "@rilldata/web-common/lib/time/types";
 import {
   createQueryServiceMetricsViewTimeRange,
+  V1ExploreComparisonMode,
   V1TimeGrain,
   type RpcStatus,
 } from "@rilldata/web-common/runtime-client";
@@ -61,6 +65,10 @@ export class CanvasTimeControls {
 
   setInitialState(validSpecStore: CanvasSpecResponseStore) {
     this.timeRangeSummaryStore(runtime, validSpecStore);
+
+    const selectedTimezone = get(this.selectedTimezone);
+    const comparisonTimeRange = get(this.selectedComparisonTimeRange);
+
     const store = derived(
       [this.allTimeRange, validSpecStore],
       ([allTimeRange, validSpec]) => {
@@ -68,9 +76,11 @@ export class CanvasTimeControls {
           this.isReady.set(false);
         }
 
-        const selectedTimezone = get(this.selectedTimezone);
+        const { defaultPreset } = validSpec.data?.canvas || {};
+        const timeRanges = validSpec?.data?.canvas?.timeRanges;
+
         const defaultTimeRange = isoDurationToFullTimeRange(
-          validSpec.data?.canvas?.defaultPreset?.timeRange,
+          defaultPreset?.timeRange,
           allTimeRange.start,
           allTimeRange.end,
           selectedTimezone,
@@ -87,6 +97,20 @@ export class CanvasTimeControls {
           newTimeRange,
           V1TimeGrain.TIME_GRAIN_UNSPECIFIED,
         );
+
+        if (
+          defaultPreset?.comparisonMode ===
+          V1ExploreComparisonMode.EXPLORE_COMPARISON_MODE_TIME
+        ) {
+          const newComparisonRange = getComparisonTimeRange(
+            timeRanges,
+            allTimeRange,
+            newTimeRange,
+            comparisonTimeRange,
+          );
+          this.selectedComparisonTimeRange.set(newComparisonRange);
+          this.showTimeComparison.set(true);
+        }
 
         this.selectedTimeRange.set(newTimeRange);
         this.isReady.set(true);

--- a/web-common/src/features/dashboards/time-controls/time-control-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.ts
@@ -27,6 +27,7 @@ import {
 } from "@rilldata/web-common/lib/time/types";
 import {
   type V1ExploreSpec,
+  type V1ExploreTimeRange,
   type V1MetricsViewSpec,
   type V1MetricsViewTimeRangeResponse,
   V1TimeGrain,
@@ -264,7 +265,7 @@ function calculateComparisonTimeRangePartial(
   timeRangeState: TimeRangeState,
 ): ComparisonTimeRangeState {
   const selectedComparisonTimeRange = getComparisonTimeRange(
-    explore,
+    explore.timeRanges,
     allTimeRange,
     timeRangeState.selectedTimeRange,
     metricsExplorer.selectedComparisonTimeRange,
@@ -393,19 +394,16 @@ export function getTimeGrain(
   return timeGrain;
 }
 
-function getComparisonTimeRange(
-  explore: V1ExploreSpec,
-  allTimeRange: DashboardTimeControls | undefined,
+export function getComparisonTimeRange(
+  timeRanges: V1ExploreTimeRange[] | undefined,
+  allTimeRange: TimeRange | undefined,
   timeRange: DashboardTimeControls | undefined,
   comparisonTimeRange: DashboardTimeControls | undefined,
 ) {
   if (!timeRange || !timeRange.name || !allTimeRange) return undefined;
 
   if (!comparisonTimeRange?.name) {
-    const comparisonOption = inferCompareTimeRange(
-      explore.timeRanges,
-      timeRange.name,
-    );
+    const comparisonOption = inferCompareTimeRange(timeRanges, timeRange.name);
     const range = getTimeComparisonParametersForComponent(
       comparisonOption,
       allTimeRange.start,

--- a/web-common/src/features/file-explorer/new-files.ts
+++ b/web-common/src/features/file-explorer/new-files.ts
@@ -245,8 +245,14 @@ vega_lite: |
     }
   }`;
     case ResourceKind.Canvas:
-      return `type: canvas
+      return `# Explore YAML
+# Reference documentation: https://docs.rilldata.com/reference/project-files/canvas-dashboards
+
+type: canvas
 title: "Canvas Dashboard"
+defaults:
+  time_range: PT24H
+  comparison_mode: time
 `;
     case ResourceKind.Theme:
       return `# Theme YAML


### PR DESCRIPTION
This PR 
- Removes the override time range so that new components inherit the global time ranges by default
- Support setting comparison mode as time in preset and use that as default for new canvas
- Respect comparison toggle for KPIs inhering comparison range from global filters