### PR TITLE
fix: dimension uri coming in as int instead of bool breaking UI

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -8,7 +8,7 @@
   import { clamp } from "@rilldata/web-common/lib/clamp";
   import { formatMeasurePercentageDifference } from "@rilldata/web-common/lib/number-formatting/percentage-formatter";
   import { slide } from "svelte/transition";
-  import type { LeaderboardItemData } from "./leaderboard-utils";
+  import { type LeaderboardItemData, makeHref } from "./leaderboard-utils";
   import LeaderboardItemFilterIcon from "./LeaderboardItemFilterIcon.svelte";
   import LeaderboardTooltipContent from "./LeaderboardTooltipContent.svelte";
   import LongBarZigZag from "./LongBarZigZag.svelte";
@@ -86,7 +86,7 @@
 
   $: negativeChange = deltaAbs !== null && deltaAbs < 0;
 
-  $: href = makeHref(uri);
+  $: href = makeHref(uri, dimensionValue);
 
   $: percentOfTotal = isSummableMeasure && pctOfTotal ? pctOfTotal : 0;
 
@@ -131,31 +131,6 @@
     ? `linear-gradient(to right, ${barColor}
     ${fourthCellBarLength}px, transparent ${fourthCellBarLength}px)`
     : undefined;
-
-  // uri template or "true" string literal or undefined
-  function makeHref(uriTemplateOrBoolean: string | boolean | null) {
-    if (!uriTemplateOrBoolean) {
-      return undefined;
-    }
-
-    // temporary fix where uriTemplateOrBoolean is coming in as 0/1 instead of false/true
-    if (typeof uriTemplateOrBoolean === "number") {
-      uriTemplateOrBoolean = Boolean(uriTemplateOrBoolean);
-    }
-
-    const uri =
-      uriTemplateOrBoolean === true
-        ? dimensionValue
-        : uriTemplateOrBoolean.replace(/\s/g, "");
-
-    const hasProtocol = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(uri);
-
-    if (!hasProtocol) {
-      return "https://" + uri;
-    } else {
-      return uri;
-    }
-  }
 
   function shiftClickHandler(label: string) {
     let truncatedLabel = label?.toString();

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -138,6 +138,11 @@
       return undefined;
     }
 
+    // temporary fix where uriTemplateOrBoolean is coming in as 0/1 instead of false/true
+    if (typeof uriTemplateOrBoolean === "number") {
+      uriTemplateOrBoolean = Boolean(uriTemplateOrBoolean);
+    }
+
     const uri =
       uriTemplateOrBoolean === true
         ? dimensionValue

--- a/web-common/src/features/dashboards/leaderboard/leaderboard-utils.spec.ts
+++ b/web-common/src/features/dashboards/leaderboard/leaderboard-utils.spec.ts
@@ -1,0 +1,22 @@
+import { makeHref } from "@rilldata/web-common/features/dashboards/leaderboard/leaderboard-utils";
+import { describe, it, expect } from "vitest";
+
+describe("makeHref", () => {
+  const TestCases: [
+    string | number | boolean | null,
+    string,
+    string | undefined,
+  ][] = [
+    [null, "http://localhost/dim", undefined],
+    ["http://localhost", "http://localhost/dim", "http://localhost"],
+    [true, "http://localhost/dim", "http://localhost/dim"],
+    [1, "http://localhost/dim", "http://localhost/dim"],
+  ];
+  for (const [uri, dimValue, expected] of TestCases) {
+    it(`makeHref(${uri}, ${dimValue})=${expected}`, () => {
+      expect(makeHref(uri as string | boolean | null, dimValue)).toEqual(
+        expected,
+      );
+    });
+  }
+});

--- a/web-common/src/features/dashboards/leaderboard/leaderboard-utils.spec.ts
+++ b/web-common/src/features/dashboards/leaderboard/leaderboard-utils.spec.ts
@@ -2,17 +2,33 @@ import { makeHref } from "@rilldata/web-common/features/dashboards/leaderboard/l
 import { describe, it, expect } from "vitest";
 
 describe("makeHref", () => {
-  const TestCases: [
-    string | number | boolean | null,
-    string,
-    string | undefined,
-  ][] = [
-    [null, "http://localhost/dim", undefined],
-    ["http://localhost", "http://localhost/dim", "http://localhost"],
-    [true, "http://localhost/dim", "http://localhost/dim"],
-    [1, "http://localhost/dim", "http://localhost/dim"],
+  const TestCases: {
+    uri: string | number | boolean | null;
+    dimValue: string;
+    expected: string | undefined;
+  }[] = [
+    {
+      uri: null,
+      dimValue: "http://localhost/dim",
+      expected: undefined,
+    },
+    {
+      uri: "http://localhost",
+      dimValue: "http://localhost/dim",
+      expected: "http://localhost",
+    },
+    {
+      uri: true,
+      dimValue: "http://localhost/dim",
+      expected: "http://localhost/dim",
+    },
+    {
+      uri: 1,
+      dimValue: "http://localhost/dim",
+      expected: "http://localhost/dim",
+    },
   ];
-  for (const [uri, dimValue, expected] of TestCases) {
+  for (const { uri, dimValue, expected } of TestCases) {
     it(`makeHref(${uri}, ${dimValue})=${expected}`, () => {
       expect(makeHref(uri as string | boolean | null, dimValue)).toEqual(
         expected,

--- a/web-common/src/features/dashboards/leaderboard/leaderboard-utils.ts
+++ b/web-common/src/features/dashboards/leaderboard/leaderboard-utils.ts
@@ -284,3 +284,32 @@ export function compareLeaderboardValues(selected: string, value: any) {
       return selected === value;
   }
 }
+
+// uri template or "true" string literal or undefined
+export function makeHref(
+  uriTemplateOrBoolean: string | boolean | null,
+  dimensionValue: string,
+) {
+  if (!uriTemplateOrBoolean) {
+    return undefined;
+  }
+
+  // temporary fix where uriTemplateOrBoolean is coming in as 0/1 instead of false/true
+  if (typeof uriTemplateOrBoolean === "number") {
+    uriTemplateOrBoolean = Boolean(uriTemplateOrBoolean);
+  }
+
+  // TODO: what should the value be if uriTemplateOrBoolean=false?
+  let uri = dimensionValue;
+  if (typeof uriTemplateOrBoolean === "string") {
+    uri = uriTemplateOrBoolean.replace(/\s/g, "");
+  }
+
+  const hasProtocol = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(uri);
+
+  if (!hasProtocol) {
+    return "https://" + uri;
+  } else {
+    return uri;
+  }
+}


### PR DESCRIPTION
For certain cases dimension uri comes in as `0/1` instead of `false/true`. Until we figure out the query/data issue this fixes the UI crashing.