### PR TITLE
Add support for untyped `layout:` in the canvas YAML

### DIFF
--- a/proto/gen/rill/runtime/v1/resources.pb.go
+++ b/proto/gen/rill/runtime/v1/resources.pb.go
@@ -5399,6 +5399,8 @@ type CanvasSpec struct {
 	Variables []*ComponentVariable `protobuf:"bytes,5,rep,name=variables,proto3" json:"variables,omitempty"`
 	// Items to render on the canvas
 	Items []*CanvasItem `protobuf:"bytes,4,rep,name=items,proto3" json:"items,omitempty"`
+	// Layout is an untyped object pending a formal definition.
+	Layout *structpb.Value `protobuf:"bytes,16,opt,name=layout,proto3" json:"layout,omitempty"`
 	// Security rules to apply for access to the canvas.
 	SecurityRules []*SecurityRule `protobuf:"bytes,6,rep,name=security_rules,json=securityRules,proto3" json:"security_rules,omitempty"`
 }
@@ -5515,6 +5517,13 @@ func (x *CanvasSpec) GetVariables() []*ComponentVariable {
 func (x *CanvasSpec) GetItems() []*CanvasItem {
 	if x != nil {
 		return x.Items
+	}
+	return nil
+}
+
+func (x *CanvasSpec) GetLayout() *structpb.Value {
+	if x != nil {
+		return x.Layout
 	}
 	return nil
 }
@@ -8081,7 +8090,7 @@ var file_rill_runtime_v1_resources_proto_rawDesc = []byte{
 	0x70, 0x65, 0x63, 0x52, 0x04, 0x73, 0x70, 0x65, 0x63, 0x12, 0x32, 0x0a, 0x05, 0x73, 0x74, 0x61,
 	0x74, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x72, 0x69, 0x6c, 0x6c, 0x2e,
 	0x72, 0x75, 0x6e, 0x74, 0x69, 0x6d, 0x65, 0x2e, 0x76, 0x31, 0x2e, 0x43, 0x61, 0x6e, 0x76, 0x61,
-	0x73, 0x53, 0x74, 0x61, 0x74, 0x65, 0x52, 0x05, 0x73, 0x74, 0x61, 0x74, 0x65, 0x22, 0xdc, 0x04,
+	0x73, 0x53, 0x74, 0x61, 0x74, 0x65, 0x52, 0x05, 0x73, 0x74, 0x61, 0x74, 0x65, 0x22, 0x8c, 0x05,
 	0x0a, 0x0a, 0x43, 0x61, 0x6e, 0x76, 0x61, 0x73, 0x53, 0x70, 0x65, 0x63, 0x12, 0x21, 0x0a, 0x0c,
 	0x64, 0x69, 0x73, 0x70, 0x6c, 0x61, 0x79, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01,
 	0x28, 0x09, 0x52, 0x0b, 0x64, 0x69, 0x73, 0x70, 0x6c, 0x61, 0x79, 0x4e, 0x61, 0x6d, 0x65, 0x12,
@@ -8115,7 +8124,10 @@ var file_rill_runtime_v1_resources_proto_rawDesc = []byte{
 	0x6c, 0x65, 0x73, 0x12, 0x31, 0x0a, 0x05, 0x69, 0x74, 0x65, 0x6d, 0x73, 0x18, 0x04, 0x20, 0x03,
 	0x28, 0x0b, 0x32, 0x1b, 0x2e, 0x72, 0x69, 0x6c, 0x6c, 0x2e, 0x72, 0x75, 0x6e, 0x74, 0x69, 0x6d,
 	0x65, 0x2e, 0x76, 0x31, 0x2e, 0x43, 0x61, 0x6e, 0x76, 0x61, 0x73, 0x49, 0x74, 0x65, 0x6d, 0x52,
-	0x05, 0x69, 0x74, 0x65, 0x6d, 0x73, 0x12, 0x44, 0x0a, 0x0e, 0x73, 0x65, 0x63, 0x75, 0x72, 0x69,
+	0x05, 0x69, 0x74, 0x65, 0x6d, 0x73, 0x12, 0x2e, 0x0a, 0x06, 0x6c, 0x61, 0x79, 0x6f, 0x75, 0x74,
+	0x18, 0x10, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x16, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e,
+	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x06,
+	0x6c, 0x61, 0x79, 0x6f, 0x75, 0x74, 0x12, 0x44, 0x0a, 0x0e, 0x73, 0x65, 0x63, 0x75, 0x72, 0x69,
 	0x74, 0x79, 0x5f, 0x72, 0x75, 0x6c, 0x65, 0x73, 0x18, 0x06, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x1d,
 	0x2e, 0x72, 0x69, 0x6c, 0x6c, 0x2e, 0x72, 0x75, 0x6e, 0x74, 0x69, 0x6d, 0x65, 0x2e, 0x76, 0x31,
 	0x2e, 0x53, 0x65, 0x63, 0x75, 0x72, 0x69, 0x74, 0x79, 0x52, 0x75, 0x6c, 0x65, 0x52, 0x0d, 0x73,
@@ -8589,34 +8601,35 @@ var file_rill_runtime_v1_resources_proto_depIdxs = []int32{
 	70,  // 135: rill.runtime.v1.CanvasSpec.default_preset:type_name -> rill.runtime.v1.CanvasPreset
 	65,  // 136: rill.runtime.v1.CanvasSpec.variables:type_name -> rill.runtime.v1.ComponentVariable
 	69,  // 137: rill.runtime.v1.CanvasSpec.items:type_name -> rill.runtime.v1.CanvasItem
-	22,  // 138: rill.runtime.v1.CanvasSpec.security_rules:type_name -> rill.runtime.v1.SecurityRule
-	67,  // 139: rill.runtime.v1.CanvasState.valid_spec:type_name -> rill.runtime.v1.CanvasSpec
-	1,   // 140: rill.runtime.v1.CanvasPreset.comparison_mode:type_name -> rill.runtime.v1.ExploreComparisonMode
-	72,  // 141: rill.runtime.v1.API.spec:type_name -> rill.runtime.v1.APISpec
-	73,  // 142: rill.runtime.v1.API.state:type_name -> rill.runtime.v1.APIState
-	94,  // 143: rill.runtime.v1.APISpec.resolver_properties:type_name -> google.protobuf.Struct
-	94,  // 144: rill.runtime.v1.APISpec.openapi_parameters:type_name -> google.protobuf.Struct
-	94,  // 145: rill.runtime.v1.APISpec.openapi_response_schema:type_name -> google.protobuf.Struct
-	22,  // 146: rill.runtime.v1.APISpec.security_rules:type_name -> rill.runtime.v1.SecurityRule
-	79,  // 147: rill.runtime.v1.ParseError.start_location:type_name -> rill.runtime.v1.CharLocation
-	81,  // 148: rill.runtime.v1.ConnectorV2.spec:type_name -> rill.runtime.v1.ConnectorSpec
-	82,  // 149: rill.runtime.v1.ConnectorV2.state:type_name -> rill.runtime.v1.ConnectorState
-	91,  // 150: rill.runtime.v1.ConnectorSpec.properties:type_name -> rill.runtime.v1.ConnectorSpec.PropertiesEntry
-	94,  // 151: rill.runtime.v1.ConnectorSpec.provision_args:type_name -> google.protobuf.Struct
-	92,  // 152: rill.runtime.v1.ConnectorSpec.properties_from_variables:type_name -> rill.runtime.v1.ConnectorSpec.PropertiesFromVariablesEntry
-	96,  // 153: rill.runtime.v1.MetricsViewSpec.DimensionSelector.time_grain:type_name -> rill.runtime.v1.TimeGrain
-	84,  // 154: rill.runtime.v1.MetricsViewSpec.MeasureWindow.order_by:type_name -> rill.runtime.v1.MetricsViewSpec.DimensionSelector
-	5,   // 155: rill.runtime.v1.MetricsViewSpec.MeasureV2.type:type_name -> rill.runtime.v1.MetricsViewSpec.MeasureType
-	85,  // 156: rill.runtime.v1.MetricsViewSpec.MeasureV2.window:type_name -> rill.runtime.v1.MetricsViewSpec.MeasureWindow
-	84,  // 157: rill.runtime.v1.MetricsViewSpec.MeasureV2.per_dimensions:type_name -> rill.runtime.v1.MetricsViewSpec.DimensionSelector
-	84,  // 158: rill.runtime.v1.MetricsViewSpec.MeasureV2.required_dimensions:type_name -> rill.runtime.v1.MetricsViewSpec.DimensionSelector
-	94,  // 159: rill.runtime.v1.MetricsViewSpec.MeasureV2.format_d3_locale:type_name -> google.protobuf.Struct
-	87,  // 160: rill.runtime.v1.MetricsViewSpec.AvailableTimeRange.comparison_offsets:type_name -> rill.runtime.v1.MetricsViewSpec.AvailableComparisonOffset
-	161, // [161:161] is the sub-list for method output_type
-	161, // [161:161] is the sub-list for method input_type
-	161, // [161:161] is the sub-list for extension type_name
-	161, // [161:161] is the sub-list for extension extendee
-	0,   // [0:161] is the sub-list for field type_name
+	100, // 138: rill.runtime.v1.CanvasSpec.layout:type_name -> google.protobuf.Value
+	22,  // 139: rill.runtime.v1.CanvasSpec.security_rules:type_name -> rill.runtime.v1.SecurityRule
+	67,  // 140: rill.runtime.v1.CanvasState.valid_spec:type_name -> rill.runtime.v1.CanvasSpec
+	1,   // 141: rill.runtime.v1.CanvasPreset.comparison_mode:type_name -> rill.runtime.v1.ExploreComparisonMode
+	72,  // 142: rill.runtime.v1.API.spec:type_name -> rill.runtime.v1.APISpec
+	73,  // 143: rill.runtime.v1.API.state:type_name -> rill.runtime.v1.APIState
+	94,  // 144: rill.runtime.v1.APISpec.resolver_properties:type_name -> google.protobuf.Struct
+	94,  // 145: rill.runtime.v1.APISpec.openapi_parameters:type_name -> google.protobuf.Struct
+	94,  // 146: rill.runtime.v1.APISpec.openapi_response_schema:type_name -> google.protobuf.Struct
+	22,  // 147: rill.runtime.v1.APISpec.security_rules:type_name -> rill.runtime.v1.SecurityRule
+	79,  // 148: rill.runtime.v1.ParseError.start_location:type_name -> rill.runtime.v1.CharLocation
+	81,  // 149: rill.runtime.v1.ConnectorV2.spec:type_name -> rill.runtime.v1.ConnectorSpec
+	82,  // 150: rill.runtime.v1.ConnectorV2.state:type_name -> rill.runtime.v1.ConnectorState
+	91,  // 151: rill.runtime.v1.ConnectorSpec.properties:type_name -> rill.runtime.v1.ConnectorSpec.PropertiesEntry
+	94,  // 152: rill.runtime.v1.ConnectorSpec.provision_args:type_name -> google.protobuf.Struct
+	92,  // 153: rill.runtime.v1.ConnectorSpec.properties_from_variables:type_name -> rill.runtime.v1.ConnectorSpec.PropertiesFromVariablesEntry
+	96,  // 154: rill.runtime.v1.MetricsViewSpec.DimensionSelector.time_grain:type_name -> rill.runtime.v1.TimeGrain
+	84,  // 155: rill.runtime.v1.MetricsViewSpec.MeasureWindow.order_by:type_name -> rill.runtime.v1.MetricsViewSpec.DimensionSelector
+	5,   // 156: rill.runtime.v1.MetricsViewSpec.MeasureV2.type:type_name -> rill.runtime.v1.MetricsViewSpec.MeasureType
+	85,  // 157: rill.runtime.v1.MetricsViewSpec.MeasureV2.window:type_name -> rill.runtime.v1.MetricsViewSpec.MeasureWindow
+	84,  // 158: rill.runtime.v1.MetricsViewSpec.MeasureV2.per_dimensions:type_name -> rill.runtime.v1.MetricsViewSpec.DimensionSelector
+	84,  // 159: rill.runtime.v1.MetricsViewSpec.MeasureV2.required_dimensions:type_name -> rill.runtime.v1.MetricsViewSpec.DimensionSelector
+	94,  // 160: rill.runtime.v1.MetricsViewSpec.MeasureV2.format_d3_locale:type_name -> google.protobuf.Struct
+	87,  // 161: rill.runtime.v1.MetricsViewSpec.AvailableTimeRange.comparison_offsets:type_name -> rill.runtime.v1.MetricsViewSpec.AvailableComparisonOffset
+	162, // [162:162] is the sub-list for method output_type
+	162, // [162:162] is the sub-list for method input_type
+	162, // [162:162] is the sub-list for extension type_name
+	162, // [162:162] is the sub-list for extension extendee
+	0,   // [0:162] is the sub-list for field type_name
 }
 
 func init() { file_rill_runtime_v1_resources_proto_init() }

--- a/proto/gen/rill/runtime/v1/resources.pb.validate.go
+++ b/proto/gen/rill/runtime/v1/resources.pb.validate.go
@@ -10399,6 +10399,35 @@ func (m *CanvasSpec) validate(all bool) error {
 
 	}
 
+	if all {
+		switch v := interface{}(m.GetLayout()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, CanvasSpecValidationError{
+					field:  "Layout",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, CanvasSpecValidationError{
+					field:  "Layout",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetLayout()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return CanvasSpecValidationError{
+				field:  "Layout",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
 	for idx, item := range m.GetSecurityRules() {
 		_, _ = idx, item
 

--- a/proto/gen/rill/runtime/v1/runtime.swagger.yaml
+++ b/proto/gen/rill/runtime/v1/runtime.swagger.yaml
@@ -3635,6 +3635,8 @@ definitions:
           type: object
           $ref: '#/definitions/v1CanvasItem'
         title: Items to render on the canvas
+      layout:
+        description: Layout is an untyped object pending a formal definition.
       securityRules:
         type: array
         items:

--- a/proto/rill/runtime/v1/resources.proto
+++ b/proto/rill/runtime/v1/resources.proto
@@ -726,6 +726,8 @@ message CanvasSpec {
   repeated ComponentVariable variables = 5;
   // Items to render on the canvas
   repeated CanvasItem items = 4;
+  // Layout is an untyped object pending a formal definition.
+  google.protobuf.Value layout = 16;
   // Security rules to apply for access to the canvas.
   repeated SecurityRule security_rules = 6;
 }

--- a/runtime/compilers/rillv1/parse_canvas.go
+++ b/runtime/compilers/rillv1/parse_canvas.go
@@ -10,6 +10,7 @@ import (
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime/pkg/rilltime"
 	"golang.org/x/exp/maps"
+	"google.golang.org/protobuf/types/known/structpb"
 	"gopkg.in/yaml.v3"
 )
 
@@ -39,6 +40,7 @@ type CanvasYAML struct {
 		Width     *uint32   `yaml:"width"`
 		Height    *uint32   `yaml:"height"`
 	} `yaml:"items"`
+	Layout   any                 `yaml:"layout"` // Untyped pending a formal definition
 	Security *SecurityPolicyYAML `yaml:"security"`
 }
 
@@ -144,6 +146,15 @@ func (p *Parser) parseCanvas(node *Node) error {
 		node.Refs = append(node.Refs, ResourceName{Kind: ResourceKindComponent, Name: component})
 	}
 
+	// Parse layout (currently untyped pending a formal definition)
+	var layout *structpb.Value
+	if tmp.Layout != nil {
+		layout, err = structpb.NewValue(tmp.Layout)
+		if err != nil {
+			return fmt.Errorf("invalid layout: %w", err)
+		}
+	}
+
 	// Build and validate presets
 	var defaultPreset *runtimev1.CanvasPreset
 	if tmp.Defaults != nil {
@@ -208,6 +219,7 @@ func (p *Parser) parseCanvas(node *Node) error {
 	r.CanvasSpec.EmbeddedTheme = themeSpec
 	r.CanvasSpec.Variables = variables
 	r.CanvasSpec.Items = items
+	r.CanvasSpec.Layout = layout
 	r.CanvasSpec.SecurityRules = rules
 
 	// Track inline components

--- a/runtime/compilers/rillv1/parser_test.go
+++ b/runtime/compilers/rillv1/parser_test.go
@@ -1715,6 +1715,10 @@ items:
 - component:
     markdown:
       content: "Hello world!"
+
+layout:
+- 1, 2, 3
+- 4, 5, 6
 `,
 	})
 
@@ -1790,6 +1794,7 @@ items:
 					{Component: "c2", Width: asPtr(uint32(1)), Height: asPtr(uint32(2))},
 					{Component: "d1--component-2", DefinedInCanvas: true},
 				},
+				Layout: must(structpb.NewValue([]any{"1, 2, 3", "4, 5, 6"})),
 			},
 		},
 	}

--- a/web-common/src/proto/gen/rill/runtime/v1/resources_pb.ts
+++ b/web-common/src/proto/gen/rill/runtime/v1/resources_pb.ts
@@ -4564,6 +4564,13 @@ export class CanvasSpec extends Message<CanvasSpec> {
   items: CanvasItem[] = [];
 
   /**
+   * Layout is an untyped object pending a formal definition.
+   *
+   * @generated from field: google.protobuf.Value layout = 16;
+   */
+  layout?: Value;
+
+  /**
    * Security rules to apply for access to the canvas.
    *
    * @generated from field: repeated rill.runtime.v1.SecurityRule security_rules = 6;
@@ -4590,6 +4597,7 @@ export class CanvasSpec extends Message<CanvasSpec> {
     { no: 15, name: "default_preset", kind: "message", T: CanvasPreset },
     { no: 5, name: "variables", kind: "message", T: ComponentVariable, repeated: true },
     { no: 4, name: "items", kind: "message", T: CanvasItem, repeated: true },
+    { no: 16, name: "layout", kind: "message", T: Value },
     { no: 6, name: "security_rules", kind: "message", T: SecurityRule, repeated: true },
   ]);
 

--- a/web-common/src/runtime-client/gen/index.schemas.ts
+++ b/web-common/src/runtime-client/gen/index.schemas.ts
@@ -2380,6 +2380,8 @@ The values should be valid IANA location identifiers. */
   /** Variables that can be used in the canvas. */
   variables?: V1ComponentVariable[];
   items?: V1CanvasItem[];
+  /** Layout is an untyped object pending a formal definition. */
+  layout?: unknown;
   /** Security rules to apply for access to the canvas. */
   securityRules?: V1SecurityRule[];
 }


### PR DESCRIPTION
Example:

```yaml
type: canvas
...
layout:
- 1, 2, 3
- 4, 5, 6
```