### PR TITLE
fix : minor tweaks to temporary view cleanups during clickhouse modeling

### DIFF
--- a/runtime/drivers/clickhouse/olap.go
+++ b/runtime/drivers/clickhouse/olap.go
@@ -278,7 +278,7 @@ func (c *connection) InsertTableAsSelect(ctx context.Context, name, sql string, 
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 			err = c.Exec(ctx, &drivers.Statement{
-				Query:    fmt.Sprintf("DROP TABLE %s %s", safeSQLName(tempName), onClusterClause),
+				Query:    fmt.Sprintf("DROP TABLE IF EXISTS %s %s", safeSQLName(tempName), onClusterClause),
 				Priority: 1,
 			})
 			if err != nil {


### PR DESCRIPTION
closes https://github.com/rilldata/rill-private-issues/issues/1112

**Note** : This is a best effort cleanup and there are chances that views can still linger.