### PR TITLE
Fix panic when re-opening an errored connection

### DIFF
--- a/runtime/pkg/conncache/conncache.go
+++ b/runtime/pkg/conncache/conncache.go
@@ -267,6 +267,7 @@ func (c *cacheImpl) HangingErr() error {
 
 // beginOpen must be called while c.mu is held.
 func (c *cacheImpl) beginOpen(k string, e *entry) {
+	// Check the cases where it's safe to call beginOpen.
 	switch {
 	case e.status == entryStatusUnspecified:
 	case e.status == entryStatusOpen && e.err != nil:

--- a/runtime/pkg/conncache/conncache.go
+++ b/runtime/pkg/conncache/conncache.go
@@ -267,7 +267,11 @@ func (c *cacheImpl) HangingErr() error {
 
 // beginOpen must be called while c.mu is held.
 func (c *cacheImpl) beginOpen(k string, e *entry) {
-	if e.status != entryStatusUnspecified && e.status != entryStatusClosed {
+	switch {
+	case e.status == entryStatusUnspecified:
+	case e.status == entryStatusOpen && e.err != nil:
+	case e.status == entryStatusClosed:
+	default:
 		panic(fmt.Errorf("conncache: beginOpen called on entry with status %v", e.status))
 	}
 

--- a/runtime/pkg/conncache/conncache_test.go
+++ b/runtime/pkg/conncache/conncache_test.go
@@ -2,6 +2,7 @@ package conncache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -302,4 +303,39 @@ func TestAcquireCloseAfterOpening(t *testing.T) {
 
 	// Close cache
 	require.NoError(t, c.Close(context.Background()))
+}
+
+func TestErrorTTL(t *testing.T) {
+	opens := atomic.Int64{}
+	shouldError := true
+	c := New(Options{
+		MaxIdleConnections: 2,
+		ErrTTL:             250 * time.Millisecond,
+		OpenFunc: func(ctx context.Context, cfg any) (Connection, error) {
+			opens.Add(1)
+			if shouldError {
+				return nil, errors.New("errored!")
+			}
+			return &mockConn{cfg: cfg.(string)}, nil
+		},
+		KeyFunc: func(cfg any) string {
+			return cfg.(string)
+		},
+	})
+
+	_, _, err := c.Acquire(context.Background(), "foo")
+	require.NotNil(t, err)
+	require.Equal(t, int64(1), opens.Load())
+
+	_, _, err = c.Acquire(context.Background(), "foo")
+	require.NotNil(t, err)
+	require.Equal(t, int64(1), opens.Load())
+
+	time.Sleep(500 * time.Millisecond)
+	shouldError = false
+
+	_, r1, err := c.Acquire(context.Background(), "foo")
+	require.Nil(t, err)
+	require.Equal(t, int64(2), opens.Load())
+	r1()
 }


### PR DESCRIPTION
Fixes an issue introduced here: https://github.com/rilldata/rill/pull/6587

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
