### PR TITLE
Remove cleanup in error cases in CreateProject

### DIFF
--- a/admin/projects.go
+++ b/admin/projects.go
@@ -105,13 +105,9 @@ func (s *Service) CreateProject(ctx context.Context, org *database.Organization,
 		return nil, err
 	}
 
-	var createdByID, createdByEmail string
-	if opts.CreatedByUserID != nil {
-		user, err := s.DB.FindUser(ctx, *proj.CreatedByUserID)
-		if err == nil {
-			createdByID = user.ID
-			createdByEmail = user.Email
-		}
+	plan, err := s.Biller.GetDefaultPlan(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	s.Logger.Info("created project", zap.String("id", proj.ID), zap.String("name", proj.Name), zap.String("org", org.Name), zap.String("user_id", createdByID), zap.String("user_email", createdByEmail))

--- a/admin/projects.go
+++ b/admin/projects.go
@@ -110,7 +110,7 @@ func (s *Service) CreateProject(ctx context.Context, org *database.Organization,
 		return nil, err
 	}
 
-	s.Logger.Info("created project", zap.String("id", proj.ID), zap.String("name", proj.Name), zap.String("org", org.Name), zap.String("user_id", createdByID), zap.String("user_email", createdByEmail))
+	s.Logger.Info("created project", zap.String("id", proj.ID), zap.String("name", proj.Name), zap.String("org", org.Name), zap.Any("user_id", opts.CreatedByUserID), zap.String("user_email", user.Email), zap.String("billing_plan", plan.Name))
 
 	return res, nil
 }

--- a/admin/projects.go
+++ b/admin/projects.go
@@ -81,8 +81,7 @@ func (s *Service) CreateProject(ctx context.Context, org *database.Organization,
 		OLAPDSN:     proj.ProdOLAPDSN,
 	})
 	if err != nil {
-		err2 := s.DB.DeleteProject(ctx, proj.ID)
-		return nil, multierr.Combine(err, err2)
+		return nil, err
 	}
 
 	// Update prod deployment on project
@@ -103,22 +102,19 @@ func (s *Service) CreateProject(ctx context.Context, org *database.Organization,
 		Annotations:          proj.Annotations,
 	})
 	if err != nil {
-		err2 := s.TeardownDeployment(ctx, depl)
-		err3 := s.DB.DeleteProject(ctx, proj.ID)
-		return nil, multierr.Combine(err, err2, err3)
-	}
-
-	user, err := s.DB.FindUser(ctx, *proj.CreatedByUserID)
-	if err != nil {
 		return nil, err
 	}
 
-	plan, err := s.Biller.GetDefaultPlan(ctx)
-	if err != nil {
-		return nil, err
+	var createdByID, createdByEmail string
+	if opts.CreatedByUserID != nil {
+		user, err := s.DB.FindUser(ctx, *proj.CreatedByUserID)
+		if err == nil {
+			createdByID = user.ID
+			createdByEmail = user.Email
+		}
 	}
 
-	s.Logger.Info("created project", zap.String("id", proj.ID), zap.String("name", proj.Name), zap.String("org", org.Name), zap.Any("user_id", opts.CreatedByUserID), zap.String("user_email", user.Email), zap.String("billing_plan", plan.Name))
+	s.Logger.Info("created project", zap.String("id", proj.ID), zap.String("name", proj.Name), zap.String("org", org.Name), zap.String("user_id", createdByID), zap.String("user_email", createdByEmail))
 
 	return res, nil
 }


### PR DESCRIPTION
This fixes an issue where project deletion after deployment creation leads to a foreign key error:
```
GET https://node-<id>.us-east1.gcp.runtime.rilldata.com/v1/ping giving up after 6 attempt(s);

ERROR: update or delete on table "projects" violates foreign key constraint "deployments_project_id_fkey" on table "deployments" (SQLSTATE 23503)
```

Since we now have relatively graceful handling and ability to retry deployment errors after the project is created, I think we can just remove the cleanup logic in the error cases.