### PR TITLE
Fixes for project creation log

### DIFF
--- a/admin/projects.go
+++ b/admin/projects.go
@@ -108,17 +108,16 @@ func (s *Service) CreateProject(ctx context.Context, org *database.Organization,
 		return nil, multierr.Combine(err, err2, err3)
 	}
 
-	user, err := s.DB.FindUser(ctx, *proj.CreatedByUserID)
-	if err != nil {
-		return nil, err
+	var createdByID, createdByEmail string
+	if opts.CreatedByUserID != nil {
+		user, err := s.DB.FindUser(ctx, *proj.CreatedByUserID)
+		if err == nil {
+			createdByID = user.ID
+			createdByEmail = user.Email
+		}
 	}
 
-	plan, err := s.Biller.GetDefaultPlan(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	s.Logger.Info("created project", zap.String("id", proj.ID), zap.String("name", proj.Name), zap.String("org", org.Name), zap.Any("user_id", opts.CreatedByUserID), zap.String("user_email", user.Email), zap.String("billing_plan", plan.Name))
+	s.Logger.Info("created project", zap.String("id", proj.ID), zap.String("name", proj.Name), zap.String("org", org.Name), zap.String("user_id", createdByID), zap.String("user_email", createdByEmail))
 
 	return res, nil
 }


### PR DESCRIPTION
- The user ID pointer may be `nil`.
- The default plan is not necessarily the plan that the project's org is on. Also, the plan names are not currently cached, and it's best to avoid an Orb dependency in project deployment. This PR may provide a resolution: https://github.com/rilldata/rill/pull/6338.