### PR TITLE
fix: report run now button throwing type error

### DIFF
--- a/web-admin/src/features/scheduled-reports/metadata/RunNowButton.svelte
+++ b/web-admin/src/features/scheduled-reports/metadata/RunNowButton.svelte
@@ -37,8 +37,9 @@
 
     // Refetch the resource query until the new report run shows up in the recent history table
     while (
+      !$reportQuery.data ||
       $reportQuery.data.resource.report.state.executionHistory[0] ===
-      lastExecution
+        lastExecution
     ) {
       await queryClient.invalidateQueries(
         getRuntimeServiceGetResourceQueryKey(instanceId, {


### PR DESCRIPTION
Report's run now button throws a type error while waiting for a new execution to show up. Adding a null check to make sure we do not break while the refetch is happening.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
