### PR TITLE
fix: orgs with migrated plans with existing payment issues

### DIFF
--- a/web-admin/src/features/billing/issues/useBillingIssueMessage.ts
+++ b/web-admin/src/features/billing/issues/useBillingIssueMessage.ts
@@ -81,15 +81,18 @@ export function useBillingIssueMessage(
         categorisedIssuesResp.data?.payment.length &&
         subscriptionResp.data?.subscription
       ) {
-        return {
-          isFetching: false,
-          error: undefined,
-          data: getMessageForPaymentIssues(
-            !!subscriptionResp.data.subscription.plan &&
-              !isTeamPlan(subscriptionResp.data.subscription.plan),
-            categorisedIssuesResp.data.payment,
-          ),
-        };
+        const paymentIssue = getMessageForPaymentIssues(
+          !!subscriptionResp.data.subscription.plan &&
+            !isTeamPlan(subscriptionResp.data.subscription.plan),
+          categorisedIssuesResp.data.payment,
+        );
+        // if we do not have any payment related message to show, skip it
+        if (paymentIssue)
+          return {
+            isFetching: false,
+            error: undefined,
+            data: paymentIssue,
+          };
       }
 
       if (allProjectsHibernatingResp.data) {


### PR DESCRIPTION
closes #6617

When orgs are migrated to a managed/enterprise plan we do not clear all payment issues. Only the PaymentFailed is relevant to blocking the projects. So ignore others while showing the banner.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
