### PR TITLE
fix : change duckdb connection held check to log after 3 hours

### DIFF
--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -729,7 +729,7 @@ func (c *connection) periodicallyEmitStats(d time.Duration) {
 }
 
 // maxAcquiredConnDuration is the maximum duration a connection can be held for before we consider it potentially hanging/deadlocked.
-const maxAcquiredConnDuration = 1 * time.Hour
+const maxAcquiredConnDuration = 3 * time.Hour
 
 // periodicallyCheckConnDurations periodically checks the durations of all acquired connections and logs a warning if any have been held for longer than maxAcquiredConnDuration.
 func (c *connection) periodicallyCheckConnDurations(d time.Duration) {

--- a/runtime/reconcilers/model.go
+++ b/runtime/reconcilers/model.go
@@ -28,6 +28,7 @@ import (
 )
 
 const (
+	// If changing this value also update maxAcquiredConnDuration in runtime/drivers/duckdb/duckdb.go
 	_modelDefaultTimeout = 3 * time.Hour
 
 	_modelSyncPartitionsBatchSize    = 1000

--- a/runtime/reconcilers/source.go
+++ b/runtime/reconcilers/source.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// If changing this value also update maxAcquiredConnDuration in runtime/drivers/duckdb/duckdb.go
 const _defaultIngestTimeout = 3 * time.Hour
 
 func init() {


### PR DESCRIPTION
The default model and source timeout is now 3 hours so a connection can be held for 3 hours.
**Note** : A user can override with a longer timeout as well but that seems unlikely. 

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
