### PR TITLE
Change zap timestamps to RFC3339Nano strings

### DIFF
--- a/cli/cmd/admin/start.go
+++ b/cli/cmd/admin/start.go
@@ -122,6 +122,7 @@ func StartCmd(ch *cmdutil.Helper) *cobra.Command {
 			// Init logger
 			cfg := zap.NewProductionConfig()
 			cfg.Level.SetLevel(conf.LogLevel)
+			cfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 			logger, err := cfg.Build()
 			if err != nil {
 				fmt.Printf("error: failed to create logger: %s\n", err.Error())

--- a/cli/cmd/runtime/start.go
+++ b/cli/cmd/runtime/start.go
@@ -118,6 +118,7 @@ func StartCmd(ch *cmdutil.Helper) *cobra.Command {
 			cfg := zap.NewProductionConfig()
 			cfg.Level.SetLevel(conf.LogLevel)
 			cfg.EncoderConfig.NameKey = zapcore.OmitKey
+			cfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 			logger, err := cfg.Build()
 			if err != nil {
 				fmt.Printf("error: failed to create logger: %s\n", err.Error())

--- a/cli/pkg/local/app.go
+++ b/cli/pkg/local/app.go
@@ -525,6 +525,7 @@ func initLogger(isVerbose bool, logFormat LogFormat) (logger *zap.Logger, cleanu
 	cfg := zap.NewProductionEncoderConfig()
 	// hide logger name like `console`
 	cfg.NameKey = zapcore.OmitKey
+	cfg.EncodeTime = zapcore.ISO8601TimeEncoder
 	fileCore := zapcore.NewCore(zapcore.NewJSONEncoder(cfg), zapcore.AddSync(luLogger), logLevel)
 
 	var consoleEncoder zapcore.Encoder
@@ -533,6 +534,7 @@ func initLogger(isVerbose bool, logFormat LogFormat) (logger *zap.Logger, cleanu
 	case LogFormatJSON:
 		cfg := zap.NewProductionEncoderConfig()
 		cfg.NameKey = zapcore.OmitKey
+		cfg.EncodeTime = zapcore.ISO8601TimeEncoder
 		// never
 		opts = append(opts, zap.AddStacktrace(zapcore.InvalidLevel))
 		consoleEncoder = zapcore.NewJSONEncoder(cfg)


### PR DESCRIPTION
Changes the Zap production loggers to use `zapcore.ISO8601TimeEncoder`, which has this format:
```
2006-01-02T15:04:05.000Z0700
```
