### PR TITLE
Prevent overlapping success/error notifications in users invite

### DIFF
--- a/web-admin/src/features/organizations/users/AddUsersDialog.svelte
+++ b/web-admin/src/features/organizations/users/AddUsersDialog.svelte
@@ -61,7 +61,6 @@
       isSuperUser = false;
     } catch (error) {
       console.error("Error adding user to organization", error);
-      throw error; // Propagate error to be handled by the form submission
     }
   }
 

--- a/web-admin/src/features/organizations/users/AddUsersDialog.svelte
+++ b/web-admin/src/features/organizations/users/AddUsersDialog.svelte
@@ -125,7 +125,9 @@
         if (failed.length > 0) {
           eventBus.emit("notification", {
             type: "error",
-            message: `Failed to invite ${failed.join(", ")}`,
+            message: `Failed to invite ${failed.length} ${
+              failed.length === 1 ? "person" : "people"
+            }`,
             options: {
               persisted: true,
             },

--- a/web-admin/src/features/organizations/users/AddUsersDialog.svelte
+++ b/web-admin/src/features/organizations/users/AddUsersDialog.svelte
@@ -33,7 +33,6 @@
   const addOrganizationMemberUser =
     createAdminServiceAddOrganizationMemberUser();
 
-  // Add state for failed invites
   let failedInvites: string[] = [];
 
   async function handleCreate(
@@ -211,7 +210,7 @@
       </MultiInput>
       {#if failedInvites.length > 0}
         <div class="text-sm text-red-500 py-2">
-          {failedInvites.join(", ")}
+          Failed to invite {failedInvites.join(", ")}
         </div>
       {/if}
     </form>

--- a/web-admin/src/features/organizations/users/AddUsersDialog.svelte
+++ b/web-admin/src/features/organizations/users/AddUsersDialog.svelte
@@ -61,6 +61,7 @@
       isSuperUser = false;
     } catch (error) {
       console.error("Error adding user to organization", error);
+      throw error;
     }
   }
 
@@ -125,13 +126,14 @@
           eventBus.emit("notification", {
             type: "error",
             message: `Failed to invite ${failed.join(", ")}`,
+            options: {
+              persisted: true,
+            },
           });
         }
 
-        // Only close dialog if all invites succeeded
-        if (failed.length === 0) {
-          open = false;
-        }
+        // Close dialog after showing notifications
+        open = false;
       },
       validationMethod: "oninput",
     },

--- a/web-common/src/components/notifications/NotificationCenter.svelte
+++ b/web-common/src/components/notifications/NotificationCenter.svelte
@@ -12,7 +12,8 @@
     const unsubscribeNotification = eventBus.on(
       "notification",
       (notification) => {
-        notifications = [...notifications, notification];
+        // Clear existing notifications before showing new one
+        notifications = [notification];
 
         // Clear any existing timeout
         if (currentTimeoutId) {


### PR DESCRIPTION
Closes #6655

- Fixed duplicate notifications by removing individual success/error messages from handleCreate and only showing consolidated notifications after all invites are processed
- Fixed failed invites being marked as successful by properly tracking failed/succeeded invites separately and only adding to succeeded array when the invite actually succeeds
- Prevent notification stacking by showing only one at a time

To test this PR by setting the org invite limit, `rill sudo quota set --org <org_name> --outstanding-invites 0`

https://github.com/user-attachments/assets/99cede5d-411c-4a97-8835-a5ada2b1667a



**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
