### PR TITLE
fix (Column Profiling): zero records triggered a histogram bug

### DIFF
--- a/web-common/src/components/data-graphic/utils.ts
+++ b/web-common/src/components/data-graphic/utils.ts
@@ -7,11 +7,7 @@ import { derived, writable } from "svelte/store";
 import { contexts } from "./constants";
 import { curveStepExtended } from "./marks/curveStepExtended";
 import { ScaleType } from "./state";
-import type {
-  GraphicScale,
-  ScaleStore,
-  SimpleConfigurationStore,
-} from "./state/types";
+import type { GraphicScale } from "./state/types";
 
 /**
  * Creates a string to be fed into the d attribute of a path,
@@ -202,10 +198,12 @@ export function barplotPolyline(
 
     return pointsPathString + `${p1} ${p2} ${p3} ${p4} ${closedBottom} `;
   }, " ");
+  const lastElement = data.findLast((d) => d[yAccessor]);
+  if (!lastElement) return "";
   return (
     `M${X(data[0][xLow]) + separator},${Y(0)} ` +
     path +
-    ` ${X(data.findLast((d) => d[yAccessor])[xHigh]) - separator},${Y(0)} `
+    ` ${X(lastElement[xHigh]) - separator},${Y(0)} `
   );
 }
 
@@ -217,9 +215,9 @@ export function createAdaptiveLineThicknessStore(yAccessor) {
   let data;
 
   // get xScale, yScale, and config from contexts
-  const xScale = getContext(contexts.scale("x")) as ScaleStore;
-  const yScale = getContext(contexts.scale("y")) as ScaleStore;
-  const config = getContext(contexts.config) as SimpleConfigurationStore;
+  const xScale = getContext(contexts.scale("x"));
+  const yScale = getContext(contexts.scale("y"));
+  const config = getContext(contexts.config);
 
   // capture data state.
   const dataStore = writable(data);

--- a/web-common/src/components/data-graphic/utils.ts
+++ b/web-common/src/components/data-graphic/utils.ts
@@ -7,7 +7,11 @@ import { derived, writable } from "svelte/store";
 import { contexts } from "./constants";
 import { curveStepExtended } from "./marks/curveStepExtended";
 import { ScaleType } from "./state";
-import type { GraphicScale } from "./state/types";
+import type {
+  GraphicScale,
+  ScaleStore,
+  SimpleConfigurationStore,
+} from "./state/types";
 
 /**
  * Creates a string to be fed into the d attribute of a path,
@@ -215,9 +219,9 @@ export function createAdaptiveLineThicknessStore(yAccessor) {
   let data;
 
   // get xScale, yScale, and config from contexts
-  const xScale = getContext(contexts.scale("x"));
-  const yScale = getContext(contexts.scale("y"));
-  const config = getContext(contexts.config);
+  const xScale = getContext<ScaleStore>(contexts.scale("x"));
+  const yScale = getContext<ScaleStore>(contexts.scale("y"));
+  const config = getContext<SimpleConfigurationStore>(contexts.config);
 
   // capture data state.
   const dataStore = writable(data);


### PR DESCRIPTION
The Rill Cloud Metrics project was occasionally crashing due to a histogram bug. It was reproducible when limiting a model's output to 0 records.

![image](https://github.com/user-attachments/assets/1b004f0e-2250-48e4-a2ca-5726dc18834a)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
