### PR TITLE
fix : Do not watch ignored paths in repo watcher

### DIFF
--- a/runtime/drivers/file/watcher.go
+++ b/runtime/drivers/file/watcher.go
@@ -245,7 +245,7 @@ func (w *watcher) addDir(p string, replay, errIfNotExist bool) error {
 		// should never happen unless some bug in the code
 		return fmt.Errorf("failed to add path %q to watcher: failed to get relative path", zap.String("p", p))
 	}
-	relPath = path.Join("/", relPath)
+	relPath = filepath.Join(string(filepath.Separator), relPath)
 	if drivers.IsIgnored(relPath, w.ignorePaths) {
 		w.logger.Debug("ignoring path", zap.String("path", relPath))
 		return nil

--- a/runtime/drivers/file/watcher.go
+++ b/runtime/drivers/file/watcher.go
@@ -238,7 +238,20 @@ func (w *watcher) runInner() error {
 }
 
 func (w *watcher) addDir(p string, replay, errIfNotExist bool) error {
-	err := w.watcher.Add(p)
+	// Check if it is an ignored path
+	// We do not watch files for ignored paths
+	relPath, err := filepath.Rel(w.root, p)
+	if err != nil {
+		// should never happen unless some bug in the code
+		return fmt.Errorf("failed to add path %q to watcher: failed to get relative path", zap.String("p", p))
+	}
+	relPath = path.Join("/", relPath)
+	if drivers.IsIgnored(relPath, w.ignorePaths) {
+		w.logger.Debug("ignoring path", zap.String("path", relPath))
+		return nil
+	}
+
+	err = w.watcher.Add(p)
 	if err != nil {
 		// Need to check unix.ENOENT (and probably others) since fsnotify doesn't always use cross-platform syscalls.
 		if !errIfNotExist && isNotExists(err) {

--- a/runtime/drivers/file/watcher.go
+++ b/runtime/drivers/file/watcher.go
@@ -243,11 +243,11 @@ func (w *watcher) addDir(p string, replay, errIfNotExist bool) error {
 	relPath, err := filepath.Rel(w.root, p)
 	if err != nil {
 		// should never happen unless some bug in the code
-		return fmt.Errorf("failed to add path %q to watcher: failed to get relative path", zap.String("p", p))
+		return fmt.Errorf("failed to add path %q to watcher: failed to get relative path", p)
 	}
 	relPath = filepath.Join(string(filepath.Separator), relPath)
 	if drivers.IsIgnored(relPath, w.ignorePaths) {
-		w.logger.Debug("ignoring path", zap.String("path", relPath))
+		w.logger.Debug("watcher: ignoring path", zap.String("path", p))
 		return nil
 	}
 


### PR DESCRIPTION
We are ignoring events for `ignorePaths` but ideally we should not watch them at all.
I still kept the check when processing events.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
