### PR TITLE
fix: default time comparison range being incorrect

### DIFF
--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -260,7 +260,7 @@
     const validComparison =
       allTimeRange &&
       getValidComparisonOption(
-        exploreSpec,
+        exploreSpec.timeRanges,
         range,
         $exploreState.selectedComparisonTimeRange?.name as
           | TimeComparisonOption

--- a/web-common/src/features/dashboards/time-controls/time-control-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.ts
@@ -1,11 +1,11 @@
 import type { StateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
 import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import { getValidComparisonOption } from "@rilldata/web-common/features/dashboards/time-controls/time-range-store";
 import { getOrderedStartEnd } from "@rilldata/web-common/features/dashboards/time-series/utils";
 import {
   getComparionRangeForScrub,
   getComparisonRange,
   getTimeComparisonParametersForComponent,
-  inferCompareTimeRange,
 } from "@rilldata/web-common/lib/time/comparisons";
 import { DEFAULT_TIME_RANGES } from "@rilldata/web-common/lib/time/config";
 import {
@@ -422,7 +422,12 @@ export function getComparisonTimeRange(
   if (!timeRange || !timeRange.name || !allTimeRange) return undefined;
 
   if (!comparisonTimeRange?.name) {
-    const comparisonOption = inferCompareTimeRange(timeRanges, timeRange.name);
+    const comparisonOption = getValidComparisonOption(
+      timeRanges,
+      timeRange,
+      undefined,
+      allTimeRange,
+    );
     const range = getTimeComparisonParametersForComponent(
       comparisonOption,
       allTimeRange.start,
@@ -431,7 +436,7 @@ export function getComparisonTimeRange(
       timeRange.end,
     );
 
-    if (range.isComparisonRangeAvailable && range.start && range.end) {
+    if (range.start && range.end) {
       return {
         start: range.start,
         end: range.end,

--- a/web-common/src/features/dashboards/time-controls/time-range-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-range-store.ts
@@ -24,6 +24,7 @@ import {
 } from "@rilldata/web-common/lib/time/types";
 import {
   type V1ExploreSpec,
+  type V1ExploreTimeRange,
   type V1MetricsViewSpec,
   type V1MetricsViewTimeRangeResponse,
   V1TimeGrain,
@@ -217,17 +218,17 @@ export function timeComparisonOptionsSelector([
 }
 
 export function getValidComparisonOption(
-  explore: V1ExploreSpec,
+  timeRanges: V1ExploreTimeRange[] | undefined,
   selectedTimeRange: TimeRange,
   prevComparisonOption: TimeComparisonOption | undefined,
   allTimeRange: TimeRange,
 ) {
-  if (!explore.timeRanges?.length) {
+  if (!timeRanges?.length) {
     return DEFAULT_TIME_RANGES[selectedTimeRange.name as TimeRangePreset]
       ?.defaultComparison as TimeComparisonOption;
   }
 
-  const timeRange = explore.timeRanges.find(
+  const timeRange = timeRanges.find(
     (tr) => tr.range === selectedTimeRange.name,
   );
   if (!timeRange) return undefined;

--- a/web-common/src/features/dashboards/url-state/getDefaultExplorePreset.ts
+++ b/web-common/src/features/dashboards/url-state/getDefaultExplorePreset.ts
@@ -1,4 +1,5 @@
 import { createAndExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
+import { getValidComparisonOption } from "@rilldata/web-common/features/dashboards/time-controls/time-range-store";
 import { getDefaultTimeGrain } from "@rilldata/web-common/features/dashboards/time-controls/time-range-utils";
 import { TDDChart } from "@rilldata/web-common/features/dashboards/time-dimension-details/types";
 import { ExploreStateDefaultTimezone } from "@rilldata/web-common/features/dashboards/url-state/defaults";
@@ -6,10 +7,10 @@ import {
   ToURLParamTDDChartMap,
   ToURLParamTimeGrainMapMap,
 } from "@rilldata/web-common/features/dashboards/url-state/mappers";
-import { inferCompareTimeRange } from "@rilldata/web-common/lib/time/comparisons";
 import { ISODurationToTimePreset } from "@rilldata/web-common/lib/time/ranges";
 import { isoDurationToFullTimeRange } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
 import { getLocalIANA } from "@rilldata/web-common/lib/time/timezone";
+import { TimeRangePreset } from "@rilldata/web-common/lib/time/types";
 import {
   V1ExploreComparisonMode,
   V1ExploreSortType,
@@ -17,6 +18,7 @@ import {
   type V1ExploreSpec,
   V1ExploreWebView,
   type V1MetricsViewTimeRangeResponse,
+  type V1TimeRangeSummary,
 } from "@rilldata/web-common/runtime-client";
 
 export function getDefaultExplorePreset(
@@ -77,7 +79,11 @@ export function getDefaultExplorePreset(
   if (defaultExplorePreset.comparisonMode) {
     Object.assign(
       defaultExplorePreset,
-      getDefaultComparisonFields(defaultExplorePreset, explore),
+      getDefaultComparisonFields(
+        defaultExplorePreset,
+        explore,
+        fullTimeRange?.timeRangeSummary,
+      ),
     );
   }
 
@@ -114,6 +120,7 @@ function getDefaultPresetTimeGrain(
 function getDefaultComparisonFields(
   defaultExplorePreset: V1ExplorePreset,
   explore: V1ExploreSpec,
+  timeRangeSummary: V1TimeRangeSummary | undefined,
 ): V1ExplorePreset {
   if (
     defaultExplorePreset.comparisonMode ===
@@ -136,7 +143,9 @@ function getDefaultComparisonFields(
 
   if (
     !defaultExplorePreset.timeRange ||
-    defaultExplorePreset.timeRange === "inf"
+    defaultExplorePreset.timeRange === "inf" ||
+    !timeRangeSummary?.min ||
+    !timeRangeSummary?.max
   ) {
     return {};
   }
@@ -149,7 +158,26 @@ function getDefaultComparisonFields(
       true,
     );
     if (!preset) return {};
-    comparisonOption = inferCompareTimeRange(explore.timeRanges, preset);
+
+    const allTimeRange = {
+      name: TimeRangePreset.ALL_TIME,
+      start: new Date(timeRangeSummary.min),
+      end: new Date(timeRangeSummary.max),
+    };
+
+    const timeRange = isoDurationToFullTimeRange(
+      preset,
+      allTimeRange.start,
+      allTimeRange.end,
+      defaultExplorePreset.timezone,
+    );
+
+    comparisonOption = getValidComparisonOption(
+      explore.timeRanges,
+      timeRange,
+      undefined,
+      allTimeRange,
+    );
   }
 
   return {

--- a/web-common/src/lib/time/comparisons/index.ts
+++ b/web-common/src/lib/time/comparisons/index.ts
@@ -1,13 +1,7 @@
-import {
-  DEFAULT_TIME_RANGES,
-  TIME_COMPARISON,
-} from "@rilldata/web-common/lib/time/config";
+import { TIME_COMPARISON } from "@rilldata/web-common/lib/time/config";
 import { prettyFormatTimeRange } from "@rilldata/web-common/lib/time/ranges";
 import { humaniseISODuration } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
-import type {
-  V1ExploreTimeRange,
-  V1TimeRange,
-} from "@rilldata/web-common/runtime-client";
+import type { V1TimeRange } from "@rilldata/web-common/runtime-client";
 import { Duration, Interval } from "luxon";
 import { getTimeWidth, transformDate } from "../transforms";
 import {
@@ -272,19 +266,4 @@ export function getComparisonLabel(comparisonTimeRange: V1TimeRange) {
     default:
       return `Last ${humaniseISODuration(comparisonTimeRange.isoOffset)}`;
   }
-}
-
-export function inferCompareTimeRange(
-  timeRanges: V1ExploreTimeRange[] | undefined,
-  selectedTimeRangeName: string,
-) {
-  const defaultForTimeRange = DEFAULT_TIME_RANGES[
-    selectedTimeRangeName as TimeComparisonOption
-  ]?.defaultComparison as TimeComparisonOption;
-  return (
-    defaultForTimeRange ??
-    timeRanges?.find((tr) => tr.range === selectedTimeRangeName)
-      ?.comparisonTimeRanges?.[0]?.offset ??
-    TimeComparisonOption.CONTIGUOUS
-  );
 }


### PR DESCRIPTION
closes #1212

Our compare time range pill uses a different method than time-control-store. This leads to incorrect compare time range shown vs actually selected. Moving to using a single method to make sure things are consistant.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
