### PR TITLE
Nit: remove last reference to `MetricsViewTotals` API

### DIFF
--- a/web-common/src/features/dashboards/state-managers/selectors/dimension-table.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/dimension-table.ts
@@ -3,7 +3,6 @@ import type {
   MetricsViewSpecDimensionV2,
   RpcStatus,
   V1MetricsViewAggregationResponse,
-  V1MetricsViewTotalsResponse,
 } from "@rilldata/web-common/runtime-client";
 import type { QueryObserverResult } from "@tanstack/svelte-query";
 import { isSummableMeasure } from "../../dashboard-utils";
@@ -39,7 +38,10 @@ export const virtualizedTableColumns =
   (
     dashData: DashboardDataSources,
   ): ((
-    totalsQuery: QueryObserverResult<V1MetricsViewTotalsResponse, RpcStatus>,
+    totalsQuery: QueryObserverResult<
+      V1MetricsViewAggregationResponse,
+      RpcStatus
+    >,
   ) => VirtualizedTableColumns[]) =>
   (totalsQuery) => {
     const dimension = primaryDimension(dashData);


### PR DESCRIPTION
Updates the type from `V1MetricsViewTotalsResponse` to `V1MetricsViewAggregationResponse` to make it more clear that the frontend is no longer using the `MetricsViewTotals` API.