### PR TITLE
Feat: Support .env files in nested project directories

### DIFF
--- a/runtime/compilers/rillv1/parse_dotenv.go
+++ b/runtime/compilers/rillv1/parse_dotenv.go
@@ -2,18 +2,14 @@ package rillv1
 
 import (
 	"context"
-	"os"
 
 	"github.com/joho/godotenv"
 )
 
-// parseDotEnv parses the env file present at repo root
+// parseDotEnv parses the .env file at the given path and merges it with the existing env vars
 func (p *Parser) parseDotEnv(ctx context.Context, path string) error {
 	data, err := p.Repo.Get(ctx, path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
 		return err
 	}
 	envMap, err := godotenv.Unmarshal(data)
@@ -21,6 +17,35 @@ func (p *Parser) parseDotEnv(ctx context.Context, path string) error {
 		return err
 	}
 
-	p.DotEnv = envMap
+	if p.DotEnv == nil {
+		p.DotEnv = envMap
+		return nil
+	}
+
+	p.DotEnv = mergeDotEnvMaps(p.DotEnv, envMap)
+
 	return nil
+}
+
+// parseDotEnvs parses and merges .env files at the given paths
+func (p *Parser) parseDotEnvs(ctx context.Context, paths []string) error {
+	for _, path := range paths {
+		err := p.parseDotEnv(ctx, path)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// mergeDotEnvMaps merges two env maps
+func mergeDotEnvMaps(a, b map[string]string) map[string]string {
+	merged := make(map[string]string, len(a)+len(b))
+	for k, v := range a {
+		merged[k] = v
+	}
+	for k, v := range b {
+		merged[k] = v
+	}
+	return merged
 }

--- a/runtime/compilers/rillv1/parse_dotenv_test.go
+++ b/runtime/compilers/rillv1/parse_dotenv_test.go
@@ -1,0 +1,114 @@
+package rillv1_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/rilldata/rill/runtime/compilers/rillv1"
+	"github.com/rilldata/rill/runtime/drivers"
+	"github.com/rilldata/rill/runtime/pkg/activity"
+	"github.com/rilldata/rill/runtime/storage"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestEnvParsing tests repo without a .env file
+func TestEnvParsing(t *testing.T) {
+	t.Run("without env file", func(t *testing.T) {
+		ctx := context.Background()
+		repo := makeRepo(t, map[string]string{
+			`rill.yaml`: ``,
+		})
+
+		parser, err := rillv1.Parse(ctx, repo, "", "", "duckdb")
+		require.NoError(t, err)
+		require.Equal(t, len(parser.DotEnv), 0)
+	})
+
+	t.Run("with single env file", func(t *testing.T) {
+		ctx := context.Background()
+		repo := makeRepo(t, map[string]string{
+			"rill.yaml": ``,
+			".env": `
+TEST=test
+FOO=bar
+`,
+		})
+
+		parser, err := rillv1.Parse(ctx, repo, "", "", "duckdb")
+		require.NoError(t, err)
+
+		require.Equal(t, "test", parser.DotEnv["TEST"])
+		require.Equal(t, "bar", parser.DotEnv["FOO"])
+	})
+
+	t.Run("with multiple env files", func(t *testing.T) {
+		ctx := context.Background()
+		repo := makeRepo(t, map[string]string{
+			`rill.yaml`: ``,
+			".env": `
+ROOT_TEST_VAR=root
+`,
+			"models/.env": `
+MODELS_FOLDER_TEST_VAR=models
+`,
+		})
+
+		parser, err := rillv1.Parse(ctx, repo, "", "", "duckdb")
+		require.NoError(t, err)
+
+		require.Empty(t, parser.Errors)
+		require.Equal(t, "root", parser.DotEnv["ROOT_TEST_VAR"], "root-only variable should be preserved")
+		require.Equal(t, "models", parser.DotEnv["MODELS_FOLDER_TEST_VAR"], "models-only variable should be preserved")
+	})
+
+	t.Run("env value merge behavior", func(t *testing.T) {
+		ctx := context.Background()
+		repo := makeRepo(t, map[string]string{
+			`rill.yaml`: ``,
+			".env": `
+SHARED_VAR=root_value
+ROOT_ONLY=root_value
+`,
+			"models/.env": `
+SHARED_VAR=models_value
+MODELS_ONLY=models_value
+`,
+			"models/nested/.env": `
+SHARED_VAR=nested_value
+NESTED_ONLY=nested_value
+`,
+		})
+
+		parser, err := rillv1.Parse(ctx, repo, "", "", "duckdb")
+		require.NoError(t, err)
+		require.Empty(t, parser.Errors)
+
+		// Check that variables from all levels exist
+		require.Equal(t, "root_value", parser.DotEnv["ROOT_ONLY"], "root-only variable should be preserved")
+		require.Equal(t, "models_value", parser.DotEnv["MODELS_ONLY"], "models-only variable should be preserved")
+		require.Equal(t, "nested_value", parser.DotEnv["NESTED_ONLY"], "nested-only variable should be preserved")
+
+		// Check that shared variable takes the value from the deepest .env file
+		require.Equal(t, "nested_value", parser.DotEnv["SHARED_VAR"], "shared variable should take value from deepest .env file")
+	})
+}
+
+// Helper functions
+
+// makeRepo is a helper function that creates a new repo with the given files
+func makeRepo(t testing.TB, files map[string]string) drivers.RepoStore {
+	root := t.TempDir()
+	handle, err := drivers.Open("file", "default", map[string]any{"dsn": root}, storage.MustNew(root, nil), activity.NewNoopClient(), zap.NewNop())
+	require.NoError(t, err)
+
+	repo, ok := handle.AsRepoStore("")
+	require.True(t, ok)
+
+	for path, data := range files {
+		err := repo.Put(context.Background(), path, strings.NewReader(data))
+		require.NoError(t, err)
+	}
+	return repo
+}

--- a/runtime/compilers/rillv1/parser.go
+++ b/runtime/compilers/rillv1/parser.go
@@ -563,6 +563,24 @@ func (p *Parser) parsePaths(ctx context.Context, paths []string) error {
 		if pathIsRillYAML(b) {
 			return 1
 		}
+
+		// Sort .env files by path depth with always root first. This ensures that .env files are parsed in order from root to deepest nested
+		aIsDotEnv := pathIsDotEnv(a)
+		bIsDotEnv := pathIsDotEnv(b)
+		if aIsDotEnv && !bIsDotEnv {
+			return -1
+		}
+		if !aIsDotEnv && bIsDotEnv {
+			return 1
+		}
+		if aIsDotEnv && bIsDotEnv {
+			aDepth := strings.Count(a, "/")
+			bDepth := strings.Count(b, "/")
+			if aDepth != bDepth {
+				return aDepth - bDepth
+			}
+		}
+
 		return strings.Compare(a, b)
 	})
 
@@ -1045,9 +1063,9 @@ func pathIsRillYAML(path string) bool {
 	return path == "/rill.yaml" || path == "/rill.yml"
 }
 
-// pathIsDotEnv returns true if the path is .env
+// pathIsDotEnv returns true if the path is a .env file (in any directory)
 func pathIsDotEnv(path string) bool {
-	return path == "/.env"
+	return strings.HasSuffix(path, "/.env")
 }
 
 // pathIsIgnored returns true if the path should be ignored by the parser.


### PR DESCRIPTION
This PR updates the Project parser to handle multiple `.env` files. Nested `.env` files will be parsed and merged with variables loaded from other `.env` files.

Issue: https://github.com/rilldata/rill/issues/6490

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
