### PR TITLE
Fix: River Trial Check error log

### DIFF
--- a/admin/database/postgres/postgres.go
+++ b/admin/database/postgres/postgres.go
@@ -105,7 +105,7 @@ func (c *connection) FindOrganizationByName(ctx context.Context, name string) (*
 
 func (c *connection) CountProjectsForOrganization(ctx context.Context, orgID string) (int, error) {
 	var count int
-	err := c.getDB(ctx).SelectContext(ctx, &count, "SELECT COUNT(*) FROM projects WHERE org_id=$1", orgID)
+	err := c.getDB(ctx).QueryRowxContext(ctx, "SELECT COUNT(*) FROM projects WHERE org_id=$1", orgID).Scan(&count)
 	if err != nil {
 		return 0, parseErr("projects", err)
 	}


### PR DESCRIPTION
Fixes error in River Queue Logs. Logger expects a number. 

I swapped to `.QueryRowxContext()` as we only expect a single row to be returned from the count query.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
