### PR TITLE
fix: billing banner clearing explore banner

### DIFF
--- a/web-admin/src/features/billing/banner/BillingBannerManager.svelte
+++ b/web-admin/src/features/billing/banner/BillingBannerManager.svelte
@@ -1,10 +1,19 @@
 <script lang="ts">
+  import { onNavigate } from "$app/navigation";
   import type { V1OrganizationPermissions } from "@rilldata/web-admin/client";
   import BillingBannerManagerForAdmins from "@rilldata/web-admin/features/billing/banner/BillingBannerManagerForAdmins.svelte";
   import BillingBannerManagerForViewers from "@rilldata/web-admin/features/billing/banner/BillingBannerManagerForViewers.svelte";
+  import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
 
   export let organization: string;
   export let organizationPermissions: V1OrganizationPermissions;
+
+  onNavigate(({ from, to }) => {
+    // Clear out any dashboard banners
+    if (!from || !to || from.params.organization !== to.params.organization) {
+      eventBus.emit("banner", null);
+    }
+  });
 </script>
 
 {#if organizationPermissions.manageOrg}

--- a/web-admin/src/features/billing/banner/BillingBannerManager.svelte
+++ b/web-admin/src/features/billing/banner/BillingBannerManager.svelte
@@ -9,8 +9,9 @@
   export let organizationPermissions: V1OrganizationPermissions;
 
   onNavigate(({ from, to }) => {
-    // Clear out any dashboard banners
-    if (!from || !to || from.params.organization !== to.params.organization) {
+    const changedOrganization =
+      !from || !to || from.params.organization !== to.params.organization;
+    if (changedOrganization) {
       eventBus.emit("banner", null);
     }
   });

--- a/web-admin/src/features/billing/banner/BillingBannerManagerForAdmins.svelte
+++ b/web-admin/src/features/billing/banner/BillingBannerManagerForAdmins.svelte
@@ -1,13 +1,10 @@
 <script lang="ts">
-  import { onNavigate } from "$app/navigation";
-  import { errorStore } from "@rilldata/web-admin/components/errors/error-store";
   import { BillingCTAHandler } from "@rilldata/web-admin/features/billing/BillingCTAHandler";
   import {
     type BillingIssueMessage,
     useBillingIssueMessage,
   } from "@rilldata/web-admin/features/billing/issues/useBillingIssueMessage";
   import StartTeamPlanDialog from "@rilldata/web-admin/features/billing/plans/StartTeamPlanDialog.svelte";
-  import { viewAsUserStore } from "@rilldata/web-admin/features/view-as-user/viewAsUserStore";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
 
   export let organization: string;

--- a/web-admin/src/features/billing/banner/BillingBannerManagerForAdmins.svelte
+++ b/web-admin/src/features/billing/banner/BillingBannerManagerForAdmins.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+  import { onNavigate } from "$app/navigation";
+  import { errorStore } from "@rilldata/web-admin/components/errors/error-store";
   import { BillingCTAHandler } from "@rilldata/web-admin/features/billing/BillingCTAHandler";
   import {
     type BillingIssueMessage,
     useBillingIssueMessage,
   } from "@rilldata/web-admin/features/billing/issues/useBillingIssueMessage";
   import StartTeamPlanDialog from "@rilldata/web-admin/features/billing/plans/StartTeamPlanDialog.svelte";
+  import { viewAsUserStore } from "@rilldata/web-admin/features/view-as-user/viewAsUserStore";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
 
   export let organization: string;
@@ -33,14 +36,8 @@
     });
   }
 
-  $: if (!$billingIssueMessage.isFetching) {
-    // is fetching guard is to avoid flicker while the issues are re-fetched
-    if ($billingIssueMessage.data) {
-      showBillingIssueBanner($billingIssueMessage.data);
-    } else {
-      // when switching orgs we need to make sure we clear previous org's banner.
-      eventBus.emit("banner", null);
-    }
+  $: if ($billingIssueMessage.data) {
+    showBillingIssueBanner($billingIssueMessage.data);
   }
 </script>
 

--- a/web-admin/src/features/billing/banner/BillingBannerManagerForViewers.svelte
+++ b/web-admin/src/features/billing/banner/BillingBannerManagerForViewers.svelte
@@ -6,19 +6,13 @@
 
   $: allProjectsHibernating = areAllProjectsHibernating(organization);
 
-  $: if (!$allProjectsHibernating.isFetching) {
-    if ($allProjectsHibernating.data) {
-      // we have a generic banner for viewers when org is defunct for some reason and projects are hibernating
-      eventBus.emit("banner", {
-        type: "default",
-        message:
-          "This org’s projects are hibernating. Please reach out to your administrator to regain access.",
-        iconType: "sleep",
-      });
-    } else {
-      // when switching orgs we need to make sure we clear previous org's banner.
-      // TODO: could this interfere with other banners?
-      eventBus.emit("banner", null);
-    }
+  $: if ($allProjectsHibernating.data) {
+    // we have a generic banner for viewers when org is defunct for some reason and projects are hibernating
+    eventBus.emit("banner", {
+      type: "default",
+      message:
+        "This org’s projects are hibernating. Please reach out to your administrator to regain access.",
+      iconType: "sleep",
+    });
   }
 </script>

--- a/web-admin/src/routes/[organization]/[project]/explore/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/explore/[dashboard]/+page.svelte
@@ -80,12 +80,15 @@
     });
   }
 
-  onNavigate(() => {
+  onNavigate(({ from, to }) => {
     viewAsUserStore.set(null);
     errorStore.reset();
 
     // Clear out any dashboard banners
-    if (hasBanner) {
+    if (
+      hasBanner &&
+      (!from || !to || from.params.dashboard !== to.params.dashboard)
+    ) {
       eventBus.emit("banner", null);
     }
   });

--- a/web-admin/src/routes/[organization]/[project]/explore/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/explore/[dashboard]/+page.svelte
@@ -84,11 +84,10 @@
     viewAsUserStore.set(null);
     errorStore.reset();
 
+    const changedDashboard =
+      !from || !to || from.params.dashboard !== to.params.dashboard;
     // Clear out any dashboard banners
-    if (
-      hasBanner &&
-      (!from || !to || from.params.dashboard !== to.params.dashboard)
-    ) {
+    if (hasBanner && changedDashboard) {
       eventBus.emit("banner", null);
     }
   });


### PR DESCRIPTION
closes https://github.com/rilldata/rill-private-issues/issues/1241

This PR fixes issues where billing banner component clears the banner from explore even if nothing is to be shown. This is not the full fix. We need a priority based stack system where new banners are temporarily shown and restored to previous banner.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
