### PR TITLE
remove invalid element

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -104,7 +104,6 @@ linters-settings:
       - lostcancel
       - nilfunc
       - nilness
-      - nlreturn
       - printf
       - reflectvaluecompare
       - shift


### PR DESCRIPTION
its invalid as per schema https://golangci-lint.run/jsonschema/golangci.jsonschema.json, lint jobs are failing now. Adding it to `linters` level will require a lot of changes as its need a blank line before each return/break/continue.