### PR TITLE
fix (e2e): Prevent CLI from opening URLs in the OS default browser

### DIFF
--- a/cli/cmd/auth/login.go
+++ b/cli/cmd/auth/login.go
@@ -75,7 +75,9 @@ func Login(ctx context.Context, ch *cmdutil.Helper, redirectURL string) error {
 
 	ch.PrintfBold("\nOpen this URL in your browser to confirm the login: %s\n\n", deviceVerification.VerificationCompleteURL)
 
-	_ = browser.Open(deviceVerification.VerificationCompleteURL)
+	if ch.Interactive {
+		_ = browser.Open(deviceVerification.VerificationCompleteURL)
+	}
 
 	res1, err := authenticator.GetAccessTokenForDevice(ctx, deviceVerification)
 	if err != nil {

--- a/cli/cmd/project/connect_github.go
+++ b/cli/cmd/project/connect_github.go
@@ -325,7 +325,9 @@ func createGithubRepoFlow(ctx context.Context, ch *cmdutil.Helper, localGitPath 
 			ch.Print("\t" + res.GrantAccessUrl + "\n\n")
 
 			// Open browser if possible
-			_ = browser.Open(res.GrantAccessUrl)
+			if ch.Interactive {
+				_ = browser.Open(res.GrantAccessUrl)
+			}
 		}
 	}
 
@@ -535,7 +537,9 @@ func githubFlow(ctx context.Context, ch *cmdutil.Helper, githubURL string) (*adm
 		ch.Print("\t" + res.GrantAccessUrl + "\n\n")
 
 		// Open browser if possible
-		_ = browser.Open(res.GrantAccessUrl)
+		if ch.Interactive {
+			_ = browser.Open(res.GrantAccessUrl)
+		}
 
 		// Poll for permission granted
 		pollCtx, cancel := context.WithTimeout(ctx, pollTimeout)

--- a/web-admin/tests/setup/fixtures/cli.ts
+++ b/web-admin/tests/setup/fixtures/cli.ts
@@ -9,7 +9,7 @@ export async function cliLogin(page: Page) {
   // Run the login command and capture the verification URL
   const { process, match }: SpawnAndMatchResult = await spawnAndMatch(
     "rill",
-    ["login"],
+    ["login", "--interactive=false"],
     /Open this URL in your browser to confirm the login: (.*)\n/,
   );
 

--- a/web-admin/tests/setup/setup.ts
+++ b/web-admin/tests/setup/setup.ts
@@ -144,6 +144,7 @@ setup(
         "--project",
         "openrtb",
         "--github",
+        "--interactive=false",
       ],
       /https?:\/\/[^\s]+/,
     );


### PR DESCRIPTION
Prevents the Rill CLI from automatically opening certain URLs in the OS default browser when running e2e tests with Playwright’s Chromium.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
