### PR TITLE
fix: Add email from user assume to logs

### DIFF
--- a/admin/server/users.go
+++ b/admin/server/users.go
@@ -167,7 +167,6 @@ func (s *Server) UpdateUserPreferences(ctx context.Context, req *adminv1.UpdateU
 func (s *Server) IssueRepresentativeAuthToken(ctx context.Context, req *adminv1.IssueRepresentativeAuthTokenRequest) (*adminv1.IssueRepresentativeAuthTokenResponse, error) {
 	observability.AddRequestAttributes(ctx,
 		attribute.Int64("args.ttl_minutes", req.TtlMinutes),
-		attribute.String("args.email", req.Email),
 	)
 
 	claims := auth.GetClaims(ctx)
@@ -185,6 +184,10 @@ func (s *Server) IssueRepresentativeAuthToken(ctx context.Context, req *adminv1.
 	if err != nil {
 		return nil, err
 	}
+
+	observability.AddRequestAttributes(ctx,
+		attribute.String("args.user_id", u.ID),
+	)
 
 	ttl := time.Duration(req.TtlMinutes) * time.Minute
 	displayName := fmt.Sprintf("Support for %s", u.Email)

--- a/admin/server/users.go
+++ b/admin/server/users.go
@@ -167,6 +167,7 @@ func (s *Server) UpdateUserPreferences(ctx context.Context, req *adminv1.UpdateU
 func (s *Server) IssueRepresentativeAuthToken(ctx context.Context, req *adminv1.IssueRepresentativeAuthTokenRequest) (*adminv1.IssueRepresentativeAuthTokenResponse, error) {
 	observability.AddRequestAttributes(ctx,
 		attribute.Int64("args.ttl_minutes", req.TtlMinutes),
+		attribute.String("args.email", req.Email),
 	)
 
 	claims := auth.GetClaims(ctx)


### PR DESCRIPTION
To better audit usages of `rill sudo user assume` this logs the target email id.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
