### PR TITLE
refactor (e2e): break the `setup` suite into granular tests

### DIFF
--- a/admin/server/organizations.go
+++ b/admin/server/organizations.go
@@ -76,7 +76,7 @@ func (s *Server) GetOrganization(ctx context.Context, req *adminv1.GetOrganizati
 
 	// TODO: This is used to update plan name cache and can be removed a few months after Feb 2025 when plans have been cached for most orgs.
 	// after that we can return empty plan name for uncached orgs, discussion - https://github.com/rilldata/rill/pull/6338#discussion_r1952713404
-	if org.BillingPlanName == nil {
+	if org.BillingPlanName == nil && org.BillingCustomerID != "" {
 		_, org, err = s.getSubscriptionAndUpdateOrg(ctx, org)
 		if err != nil {
 			return nil, err

--- a/web-admin/tests/setup/setup.ts
+++ b/web-admin/tests/setup/setup.ts
@@ -43,6 +43,7 @@ setup.describe("global setup", () => {
 
     // Check that the required environment variables are set
     // The above `rill devtool` command pulls the `.env` file with these values.
+    // Fail quickly if any of these are missing.
     if (
       !process.env.RILL_DEVTOOL_E2E_ADMIN_ACCOUNT_EMAIL ||
       !process.env.RILL_DEVTOOL_E2E_ADMIN_ACCOUNT_PASSWORD ||
@@ -93,6 +94,7 @@ setup.describe("global setup", () => {
   });
 
   setup("should log in with the admin account", async () => {
+    // Again, check that the required environment variables are set. This is for type-safety.
     if (
       !process.env.RILL_DEVTOOL_E2E_ADMIN_ACCOUNT_EMAIL ||
       !process.env.RILL_DEVTOOL_E2E_ADMIN_ACCOUNT_PASSWORD ||
@@ -126,8 +128,8 @@ setup.describe("global setup", () => {
     await page.getByRole("button", { name: "Continue with Email" }).click();
     await page.waitForURL("/");
 
-    // Save auth cookies to file
-    // Subsequent tests can seed their browser with these cookies, instead of going through the log-in flow again.
+    // Save the admin's Rill auth cookies to file. The resultant file will include both the GitHub and Rill auth cookies.
+    // Subsequent tests can seed their browser with this state, instead of needing to go through the log-in flow again.
     await page.context().storageState({ path: ADMIN_STORAGE_STATE });
   });
 
@@ -166,8 +168,8 @@ setup.describe("global setup", () => {
     );
 
     // Navigate to the GitHub auth URL
-    // (In a fresh browser, this would typically trigger a log-in to GitHub, but we've bootstrapped the Playwright browser with GitHub auth cookies.
-    // See the `save-github-cookies` project in `playwright.config.ts` for details.)
+    // (In a fresh browser, this would typically trigger a log-in to GitHub, but we've bootstrapped the Playwright browser with an authenticated GitHub session.
+    // See the `setup-github-session` project in `playwright.config.ts` for details.)
     const url = match[0];
     await adminPage.goto(url);
     await adminPage.waitForURL("/-/github/connect/success");


### PR DESCRIPTION
This will make it easier to quickly see what's going wrong when the `setup` project fails.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
