### PR TITLE
fix: org invalidation after logo/favicon upload

### DIFF
--- a/web-admin/src/features/organizations/settings/FaviconSettings.svelte
+++ b/web-admin/src/features/organizations/settings/FaviconSettings.svelte
@@ -26,7 +26,7 @@
     void queryClient.invalidateQueries(
       getAdminServiceGetOrganizationQueryKey(organization),
     );
-    void invalidate("root");
+    void invalidate("app:root");
   }
 
   async function onRemove() {
@@ -39,7 +39,7 @@
     void queryClient.invalidateQueries(
       getAdminServiceGetOrganizationQueryKey(organization),
     );
-    void invalidate("root");
+    void invalidate("app:root");
   }
 </script>
 

--- a/web-admin/src/features/organizations/settings/LogoSettings.svelte
+++ b/web-admin/src/features/organizations/settings/LogoSettings.svelte
@@ -27,7 +27,7 @@
     void queryClient.invalidateQueries(
       getAdminServiceGetOrganizationQueryKey(organization),
     );
-    void invalidate("root");
+    void invalidate("app:root");
   }
 
   async function onRemove() {
@@ -40,7 +40,7 @@
     void queryClient.invalidateQueries(
       getAdminServiceGetOrganizationQueryKey(organization),
     );
-    void invalidate("root");
+    void invalidate("app:root");
   }
 </script>
 

--- a/web-admin/src/routes/+layout.ts
+++ b/web-admin/src/routes/+layout.ts
@@ -26,7 +26,7 @@ import { error, redirect, type Page } from "@sveltejs/kit";
 import { isAxiosError } from "axios";
 
 export const load = async ({ params, url, route, depends }) => {
-  depends("root");
+  depends("app:root");
   // Route params
   const { organization, project, token: routeToken } = params;
   const pageState = {


### PR DESCRIPTION
After uploading/removing a logo/favicon org request is not invalidated in all cases. The usage of `depends` and `invalidate` is exactly how it is like the docs. Updating to have `[a-z]+:` prefix https://svelte.dev/docs/kit/$app-navigation#invalidate

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
