### PR TITLE
fix: Update favicon upload copy to specify a square icon upload

### DIFF
--- a/web-admin/src/features/organizations/settings/FaviconSettings.svelte
+++ b/web-admin/src/features/organizations/settings/FaviconSettings.svelte
@@ -47,6 +47,7 @@
   <div slot="body" class="flex flex-col gap-y-2">
     <div>
       Click to upload your favicon and customize Rill for your organization.
+      Upload a square icon to get the best results.
     </div>
     <UploadImagePopover
       imageUrl={organizationFaviconUrl}


### PR DESCRIPTION
**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
