### PR TITLE
CLI: Extra validation in `rill query` and reorder `rill -h`

### DIFF
--- a/cli/cmd/completion.go
+++ b/cli/cmd/completion.go
@@ -3,14 +3,16 @@ package cmd
 import (
 	"os"
 
+	"github.com/rilldata/rill/cli/pkg/cmdutil"
 	"github.com/spf13/cobra"
 )
 
 // See: https://github.com/spf13/cobra/blob/main/shell_completions.md
-var completionCmd = &cobra.Command{
-	Use:   "completion [bash|zsh|fish|powershell]",
-	Short: "Generate completion script for your shell",
-	Long: `To load completions:
+func completionCmd(ch *cmdutil.Helper) *cobra.Command {
+	return &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate completion script for your shell",
+		Long: `To load completions:
 Bash:
   $ source <(rill completion bash)
   # To load completions for each session, execute once:
@@ -35,24 +37,25 @@ PowerShell:
   PS> rill completion powershell > rill.ps1
   # and source this file from your PowerShell profile.
 `,
-	DisableFlagsInUseLine: true,
-	Hidden:                true,
-	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
-	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		var err error
+		DisableFlagsInUseLine: true,
+		Hidden:                !ch.IsDev(),
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
 
-		switch args[0] {
-		case "bash":
-			err = cmd.Root().GenBashCompletion(os.Stdout)
-		case "zsh":
-			err = cmd.Root().GenZshCompletion(os.Stdout)
-		case "fish":
-			err = cmd.Root().GenFishCompletion(os.Stdout, true)
-		case "powershell":
-			err = cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
-		}
+			switch args[0] {
+			case "bash":
+				err = cmd.Root().GenBashCompletion(os.Stdout)
+			case "zsh":
+				err = cmd.Root().GenZshCompletion(os.Stdout)
+			case "fish":
+				err = cmd.Root().GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				err = cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			}
 
-		return err
-	},
+			return err
+		},
+	}
 }

--- a/cli/cmd/devtool/devtool.go
+++ b/cli/cmd/devtool/devtool.go
@@ -19,7 +19,7 @@ func DevtoolCmd(ch *cmdutil.Helper) *cobra.Command {
   rill devtool start local --reset
   rill devtool switch-env stage
   rill devtool dotenv upload cloud`,
-		Hidden:  true,
+		Hidden:  !ch.IsDev(),
 		GroupID: internalGroupID,
 	}
 

--- a/cli/cmd/query/query.go
+++ b/cli/cmd/query/query.go
@@ -39,14 +39,17 @@ func QueryCmd(ch *cmdutil.Helper) *cobra.Command {
 			if resolver != "" && (sql != "" || connector != "") {
 				return fmt.Errorf("cannot combine --resolver with --sql or --connector")
 			}
-			if resolver == "" && (len(args) > 0 || len(properties) > 0) {
-				return fmt.Errorf("must provide --resolver when using --args or --properties")
+			if sql != "" && len(properties) > 0 {
+				return fmt.Errorf("cannot combine --sql with --properties")
 			}
 
 			// Rewrite --sql to resolver
 			if sql != "" {
 				resolver = "sql"
 				properties = map[string]string{"sql": sql}
+				if connector != "" {
+					properties["connector"] = connector
+				}
 			}
 
 			// Determine project name
@@ -111,7 +114,7 @@ func buildStruct(m map[string]string) *structpb.Struct {
 	}
 	pb, err := structpb.NewStruct(anyMap)
 	if err != nil {
-		// Acceptable to panic because there are no unknown types
+		// Acceptable to panic because there are no unknown types, so this should never happen.
 		panic(fmt.Errorf("failed to build struct: %w", err))
 	}
 	return pb

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -159,20 +159,20 @@ func runCmd(ctx context.Context, ver cmdutil.Version) error {
 	// Internal commands
 	cmdutil.AddGroup(rootCmd, "Internal", !ch.IsDev(),
 		// These commands are hidden from the help menu
+		sudo.SudoCmd(ch),
+		devtool.DevtoolCmd(ch),
+		verifyInstallCmd(ch),
 		admin.AdminCmd(ch),
 		runtime.RuntimeCmd(ch),
-		devtool.DevtoolCmd(ch),
-		sudo.SudoCmd(ch),
-		verifyInstallCmd(ch),
 	)
 
 	// Additional sub-commands
 	rootCmd.AddCommand(
-		completionCmd,
-		docs.DocsCmd(ch, rootCmd),
 		versioncmd.VersionCmd(),
 		upgrade.UpgradeCmd(ch),
 		uninstall.UninstallCmd(ch),
+		docs.DocsCmd(ch, rootCmd),
+		completionCmd(ch),
 	)
 
 	return rootCmd.ExecuteContext(ctx)

--- a/cli/cmd/sudo/sudo.go
+++ b/cli/cmd/sudo/sudo.go
@@ -19,7 +19,7 @@ func SudoCmd(ch *cmdutil.Helper) *cobra.Command {
 	sudoCmd := &cobra.Command{
 		Use:     "sudo",
 		Short:   "sudo commands for superusers",
-		Hidden:  true,
+		Hidden:  !ch.IsDev(),
 		GroupID: internalGroupID,
 	}
 	sudoCmd.AddCommand(lookupCmd(ch))


### PR DESCRIPTION
**Changes:**
- Added validation so running `rill query` without any args doesn't fire off an empty SQL query
- Moved a few things around I noticed at the same time

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
