### PR TITLE
fix: Save trace on failed tests for web-local E2E

### DIFF
--- a/web-local/playwright.config.ts
+++ b/web-local/playwright.config.ts
@@ -17,8 +17,8 @@ export default defineConfig({
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: "http://localhost:8083",
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: "on-first-retry",
+    /* Collect trace when tests fail. See https://playwright.dev/docs/trace-viewer */
+    trace: "retain-on-failure",
     video: "retain-on-failure",
     launchOptions: {
       slowMo: parseInt(process.env.PLAYWRIGHT_SLOW_MO || "0"),


### PR DESCRIPTION
We only save trace of the tests on retry for web-local E2E. This never happens on CI so it is hard to debug failures there. Mimic web-admin's setting of `retain-on-failure` to better debug in the future.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
