### PR TITLE
fix: Support CSV and Table output for `rill query` --format

### DIFF
--- a/cli/pkg/printer/resources.go
+++ b/cli/pkg/printer/resources.go
@@ -544,6 +544,7 @@ type billingIssue struct {
 	EventTime    string `header:"event_time,timestamp(ms|utc|human)" json:"event_time"`
 }
 
+// PrintQueryResponse prints the query response in the desired format (human, json, csv)
 func (p *Printer) PrintQueryResponse(res *runtimev1.QueryResolverResponse) {
 	if len(res.Data) == 0 {
 		p.PrintfWarn("No data found\n")
@@ -551,6 +552,7 @@ func (p *Printer) PrintQueryResponse(res *runtimev1.QueryResolverResponse) {
 	}
 
 	switch p.Format {
+	// Interceptor for human format
 	case FormatHuman:
 		headers := extractQueryHeaders(res.Schema)
 		rows := make([][]string, len(res.Data))
@@ -569,6 +571,7 @@ func (p *Printer) PrintQueryResponse(res *runtimev1.QueryResolverResponse) {
 		tableprinter.New(p.dataOut()).Render(headers, rows, nil, false)
 		return
 
+	// Interceptor for CSV format
 	case FormatCSV:
 		headers := extractQueryHeaders(res.Schema)
 		w := csv.NewWriter(p.dataOut())

--- a/cli/pkg/printer/resources.go
+++ b/cli/pkg/printer/resources.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -550,25 +551,61 @@ func (p *Printer) PrintQueryResponse(res *runtimev1.QueryResolverResponse) {
 	}
 
 	switch p.Format {
-	// Human readable table
 	case FormatHuman:
-		columns := make([]string, len(res.Schema.Fields))
-		for i, field := range res.Schema.Fields {
-			columns[i] = field.Name
+		headers := extractQueryHeaders(res.Schema)
+		rows := make([][]string, len(res.Data))
+
+		for i, row := range res.Data {
+			rows[i] = make([]string, len(headers))
+			for j, field := range headers {
+				if val, ok := row.GetFields()[field]; ok {
+					rows[i][j] = fmt.Sprintf("%v", val.AsInterface())
+				} else {
+					rows[i][j] = "null"
+				}
+			}
 		}
 
-		printer := tableprinter.New(p.dataOut())
-		printer.Render(columns, nil, nil, false)
+		tableprinter.New(p.dataOut()).Render(headers, rows, nil, false)
+		return
+
+	case FormatCSV:
+		headers := extractQueryHeaders(res.Schema)
+		w := csv.NewWriter(p.dataOut())
+
+		if err := w.Write(headers); err != nil {
+			panic(fmt.Errorf("failed to write CSV headers: %w", err))
+		}
 
 		for _, row := range res.Data {
-			values := make([]string, len(columns))
-			for i, col := range columns {
-				values[i] = fmt.Sprintf("%v", row.Fields[col].AsInterface())
+			record := make([]string, len(headers))
+			for i, field := range headers {
+				if val, ok := row.GetFields()[field]; ok {
+					record[i] = fmt.Sprintf("%v", val.AsInterface())
+				} else {
+					record[i] = ""
+				}
 			}
-			printer.RenderRow(values, nil)
+			if err := w.Write(record); err != nil {
+				panic(fmt.Errorf("failed to write CSV row: %w", err))
+			}
 		}
+
+		w.Flush()
+		if err := w.Error(); err != nil {
+			panic(fmt.Errorf("failed to flush CSV writer: %w", err))
+		}
+
 		return
 	default:
 		p.PrintData(res.Data)
 	}
+}
+
+func extractQueryHeaders(schema *runtimev1.StructType) []string {
+	headers := make([]string, len(schema.Fields))
+	for i, field := range schema.Fields {
+		headers[i] = field.Name
+	}
+	return headers
 }


### PR DESCRIPTION
relates to: https://github.com/rilldata/rill/pull/6734

Sample Format outputs
```
rill query --sql "select ad_position, bid_floor, pub_name, app_or_site from auction_data_raw" --limit 3
```

`--format human`

```
  AD POSITION     BID FLOOR   PUB NAME        APP OR SITE
 --------------- ----------- --------------- -------------
  Not Available   0.1218      GG Software     App
  Not Available   0.425       Singular One    App
  Not Available   0.89        Not Available   Site
```


`--format json`

```
[
  {
    "ad_position": "Not Available",
    "app_or_site": "App",
    "bid_floor": 0.1218,
    "pub_name": "GG Software"
  },
  {
    "ad_position": "Not Available",
    "app_or_site": "App",
    "bid_floor": 0.425,
    "pub_name": "Singular One"
  },
  {
    "ad_position": "Not Available",
    "app_or_site": "Site",
    "bid_floor": 0.89,
    "pub_name": "Not Available"
  }
]
```

`--format csv`

```
ad_position,bid_floor,pub_name,app_or_site
Not Available,0.1218,GG Software,App
Not Available,0.425,Singular One,App
Not Available,0.89,Not Available,Site
```


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
