### PR TITLE
fix: check for homedir on rill start

### DIFF
--- a/cli/cmd/start/start.go
+++ b/cli/cmd/start/start.go
@@ -65,6 +65,20 @@ func StartCmd(ch *cmdutil.Helper) *cobra.Command {
 					return err
 				}
 
+				if currentDir == homeDir {
+					confirm, err := cmdutil.ConfirmPrompt(
+						"You are trying to start Rill in your home directory, which is not recommended. Are you sure you want to continue?",
+						"", false,
+					)
+					if err != nil {
+						return err
+					}
+					if !confirm {
+						ch.PrintfWarn("Aborted\n")
+						return nil
+					}
+				}
+
 				displayPath := currentDir
 				defval := true
 				if currentDir == homeDir {

--- a/runtime/server/queries_timeseries_test.go
+++ b/runtime/server/queries_timeseries_test.go
@@ -434,7 +434,7 @@ func TestServer_Timeseries_timezone_dst_forward(t *testing.T) {
 		Sql:        "select current_setting('TimeZone') as value",
 	})
 	require.NoError(t, err)
-	require.Equal(t, "UTC", resp.Data[0].Fields["value"].GetStringValue())
+	require.Equal(t, "Etc/UTC", resp.Data[0].Fields["value"].GetStringValue())
 
 	response, err := server.ColumnTimeSeries(testCtx(), &runtimev1.ColumnTimeSeriesRequest{
 		InstanceId:          instanceID,

--- a/runtime/server/queries_timeseries_test.go
+++ b/runtime/server/queries_timeseries_test.go
@@ -434,7 +434,7 @@ func TestServer_Timeseries_timezone_dst_forward(t *testing.T) {
 		Sql:        "select current_setting('TimeZone') as value",
 	})
 	require.NoError(t, err)
-	require.Equal(t, "Etc/UTC", resp.Data[0].Fields["value"].GetStringValue())
+	require.Equal(t, "UTC", resp.Data[0].Fields["value"].GetStringValue())
 
 	response, err := server.ColumnTimeSeries(testCtx(), &runtimev1.ColumnTimeSeriesRequest{
 		InstanceId:          instanceID,


### PR DESCRIPTION
Prompts the user if they are trying to run `rill start` in the homedir.
Still allowing `rill start .` as that seems intentional

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
