### PR TITLE
fix (Explore): Show error component when there's no valid `Explore` resource

### DIFF
--- a/web-admin/src/routes/[organization]/[project]/explore/[dashboard]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/explore/[dashboard]/+page.svelte
@@ -46,9 +46,9 @@
   $: explore = useExplore(instanceId, exploreName, {
     refetchInterval: (data) => {
       if (!data) return false;
-      if (isDashboardReconcilingForFirstTime(data))
+      if (isExploreReconcilingForFirstTime(data))
         return PollIntervalWhenDashboardFirstReconciling;
-      if (isDashboardErrored(data)) return PollIntervalWhenDashboardErrored;
+      if (isExploreErrored(data)) return PollIntervalWhenDashboardErrored;
       return false;
     },
   });
@@ -92,38 +92,30 @@
     }
   });
 
-  function isDashboardReconcilingForFirstTime(
+  function isExploreReconcilingForFirstTime(
     exploreResponse: V1GetExploreResponse,
   ) {
     if (!exploreResponse) return undefined;
-    const isMetricsViewReconcilingForFirstTime =
-      !exploreResponse.metricsView?.metricsView?.state?.validSpec &&
-      !exploreResponse.metricsView?.meta?.reconcileError;
     const isExploreReconcilingForFirstTime =
       !exploreResponse.explore?.explore?.state?.validSpec &&
       !exploreResponse.explore?.meta?.reconcileError;
-    return (
-      isMetricsViewReconcilingForFirstTime || isExploreReconcilingForFirstTime
-    );
+    return isExploreReconcilingForFirstTime;
   }
 
-  function isDashboardErrored(exploreResponse: V1GetExploreResponse) {
+  function isExploreErrored(exploreResponse: V1GetExploreResponse) {
     if (!exploreResponse) return undefined;
     // We only consider a dashboard errored (from the end-user perspective) when BOTH a reconcile error exists AND a validSpec does not exist.
     // If there's any validSpec (which can persist from a previous, non-current spec), then we serve that version of the dashboard to the user,
     // so the user does not see an error state.
-    const isMetricsViewErrored =
-      !exploreResponse.metricsView?.metricsView?.state?.validSpec &&
-      !!exploreResponse.metricsView?.meta?.reconcileError;
     const isExploreErrored =
       !exploreResponse.explore?.explore?.state?.validSpec &&
       !!exploreResponse.explore?.meta?.reconcileError;
-    return isMetricsViewErrored || isExploreErrored;
+    return isExploreErrored;
   }
 
   let reconcilingForFirstTime: boolean | undefined;
   $: if ($explore.isSuccess) {
-    const newReconcilingForFirstTime = isDashboardReconcilingForFirstTime(
+    const newReconcilingForFirstTime = isExploreReconcilingForFirstTime(
       $explore.data,
     );
     // reconcilingForFirstTime means the dashboard is reconciling for the 1st time in the current deployment.
@@ -144,9 +136,9 @@
 </svelte:head>
 
 {#if $explore.isSuccess}
-  {#if isDashboardReconcilingForFirstTime($explore.data)}
+  {#if isExploreReconcilingForFirstTime($explore.data)}
     <DashboardBuilding />
-  {:else if isDashboardErrored($explore.data)}
+  {:else if isExploreErrored($explore.data)}
     <DashboardErrored organization={orgName} project={projectName} />
   {:else if metricsViewName}
     {#key exploreName}


### PR DESCRIPTION
[Discussed in Slack](https://rilldata.slack.com/archives/C02T907FEUB/p1740402458606639?thread_ts=1738937017.202969&cid=C02T907FEUB)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
