### PR TITLE
feat (Explore): Show the "last refreshed" date to everyone

### DIFF
--- a/web-admin/src/features/dashboards/listing/DashboardsTableCompositeCell.svelte
+++ b/web-admin/src/features/dashboards/listing/DashboardsTableCompositeCell.svelte
@@ -18,8 +18,7 @@
   $: organization = $page.params.organization;
   $: project = $page.params.project;
 
-  $: lastRefreshedDate = new Date(lastRefreshed);
-  $: isValidLastRefreshedDate = !isNaN(lastRefreshedDate.getTime());
+  $: lastRefreshedDate = lastRefreshed ? new Date(lastRefreshed) : null;
 
   $: href = isEmbedded
     ? undefined
@@ -51,7 +50,7 @@
   </div>
   <div class="pl-[22px] flex gap-x-1 text-gray-500 text-xs font-normal">
     <span class="truncate">{name}</span>
-    {#if isValidLastRefreshedDate}
+    {#if lastRefreshedDate}
       <span>•</span>
       <Tooltip distance={8}>
         <span class="shrink-0">Last refreshed {timeAgo(lastRefreshedDate)}</span

--- a/web-admin/src/features/dashboards/listing/LastRefreshedDate.svelte
+++ b/web-admin/src/features/dashboards/listing/LastRefreshedDate.svelte
@@ -1,27 +1,37 @@
 <script lang="ts">
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
+  import { createRuntimeServiceGetExplore } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
-  import { useDashboardV2 } from "./selectors";
   import { timeAgo } from "./utils";
 
   export let dashboard: string;
 
   $: ({ instanceId } = $runtime);
 
-  $: dashboardQuery = useDashboardV2(instanceId, dashboard);
-  $: lastRefreshedDate =
-    $dashboardQuery?.data?.refreshedOn &&
-    new Date($dashboardQuery.data.refreshedOn);
+  $: lastRefreshedQuery = createRuntimeServiceGetExplore(
+    instanceId,
+    { name: dashboard },
+    {
+      query: {
+        select: (data) => {
+          const refreshDate =
+            data?.metricsView?.metricsView?.state?.modelRefreshedOn;
+          return refreshDate ? new Date(refreshDate) : null;
+        },
+      },
+    },
+  );
+  $: ({ data } = $lastRefreshedQuery);
 </script>
 
-{#if lastRefreshedDate}
+{#if data}
   <Tooltip distance={8}>
     <div class="text-[11px] text-gray-600">
-      Last refreshed {timeAgo(lastRefreshedDate)}
+      Last refreshed {timeAgo(data)}
     </div>
     <TooltipContent slot="tooltip-content">
-      {lastRefreshedDate.toLocaleString()}
+      {data.toLocaleString()}
     </TooltipContent>
   </Tooltip>
 {/if}

--- a/web-admin/src/features/dashboards/listing/selectors.ts
+++ b/web-admin/src/features/dashboards/listing/selectors.ts
@@ -83,16 +83,20 @@ export function useDashboardsV2(
   });
 }
 
+// Super naive heuristic for now.
 function getCanvasRefreshedOn(
   dashboard: V1Resource,
   allResources: Map<string, V1Resource>,
 ): string | undefined {
   if (!dashboard) return undefined;
 
+  // First, get the first referenced resource for the canvas
   const refResourceName = dashboard.meta.refs[0];
   const refResource = allResources.get(
     `${refResourceName?.kind}_${refResourceName?.name}`,
   );
+
+  // Second, get the refreshedOn from the referenced resource
   return (
     refResource?.model?.state.refreshedOn ||
     refResource?.source?.state.refreshedOn
@@ -105,12 +109,13 @@ function getExploreRefreshedOn(
 ): string | undefined {
   if (!explore) return undefined;
 
-  // 1st get the metrics view for the explore
+  // First, get the metrics view for the explore
   const exploreRefName = explore.meta.refs[0];
   const metricsView = allResources.get(
     `${exploreRefName?.kind}_${exploreRefName?.name}`,
   );
   if (!metricsView) return undefined;
 
+  // Second, get the refreshedOn from the metrics view
   return metricsView?.metricsView?.state?.modelRefreshedOn;
 }

--- a/web-admin/src/features/dashboards/listing/selectors.ts
+++ b/web-admin/src/features/dashboards/listing/selectors.ts
@@ -83,38 +83,6 @@ export function useDashboardsV2(
   });
 }
 
-// This iteration of `useDashboard` returns the above `DashboardResource` type, which includes `refreshedOn`
-export function useDashboardV2(
-  instanceId: string,
-  name: string,
-): CreateQueryResult<DashboardResource> {
-  return createRuntimeServiceListResources(instanceId, undefined, {
-    query: {
-      enabled: !!instanceId && !!name,
-      select: (data) => {
-        if (!name) return;
-
-        const resource = data.resources.find(
-          (res) => res.meta.name.name.toLowerCase() === name.toLowerCase(),
-        );
-        // create a map since we are potentially looking up twice per explore
-        const allResources = getMapFromArray(
-          data.resources,
-          (r) => `${r.meta.name.kind}_${r.meta.name.name}`,
-        );
-
-        if (resource.canvas) {
-          const refreshedOn = getCanvasRefreshedOn(resource, allResources);
-          return { resource, refreshedOn };
-        }
-
-        const refreshedOn = getExploreRefreshedOn(resource, allResources);
-        return { resource, refreshedOn };
-      },
-    },
-  });
-}
-
 function getCanvasRefreshedOn(
   dashboard: V1Resource,
   allResources: Map<string, V1Resource>,


### PR DESCRIPTION
Previously, the "last refreshed" date was only visible to project admins because it was stored on the `model` (admin-only access). Since PR #6735 replicated this date onto the `metricsView` (accessible to all users), this PR updates the UI to integrate with this new property and display the date to everyone.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
