### PR TITLE
fix: do not select if shift key is used

### DIFF
--- a/web-common/src/components/virtualized-table/core/Cell.svelte
+++ b/web-common/src/components/virtualized-table/core/Cell.svelte
@@ -47,6 +47,7 @@
   }
 
   function onSelectItem(e: MouseEvent) {
+    if (e.shiftKey) return;
     dispatch("select-item", { index: row.index, meta: e.ctrlKey || e.metaKey });
   }
 


### PR DESCRIPTION
https://github.com/rilldata/rill-private-issues/issues/1279

Do not dispatch `select-item` is shift key was pressed.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
