### PR TITLE
fix: Add loading state for MetricsViewTimerange query

### DIFF
--- a/web-admin/src/routes/+layout.ts
+++ b/web-admin/src/routes/+layout.ts
@@ -121,13 +121,13 @@ export const load = async ({ params, url, route, depends }) => {
       runtime: runtimeData,
     } = await fetchProjectDeploymentDetails(organization, project, token);
 
-    await runtime.setRuntime(
-      queryClient,
-      fixLocalhostRuntimePort(runtimeData.host ?? ""),
-      runtimeData.instanceId,
-      runtimeData.jwt?.token,
-      runtimeData.jwt?.authContext,
-    );
+    // await runtime.setRuntime(
+    //   queryClient,
+    //   fixLocalhostRuntimePort(runtimeData.host ?? ""),
+    //   runtimeData.instanceId,
+    //   runtimeData.jwt?.token,
+    //   runtimeData.jwt?.authContext,
+    // );
 
     return {
       user,

--- a/web-admin/src/routes/[organization]/[project]/explore/[dashboard]/+layout.ts
+++ b/web-admin/src/routes/[organization]/[project]/explore/[dashboard]/+layout.ts
@@ -1,18 +1,10 @@
-import type { V1Bookmark } from "@rilldata/web-admin/client";
 import {
   fetchBookmarks,
   isHomeBookmark,
 } from "@rilldata/web-admin/features/bookmarks/selectors";
 import { getDashboardStateFromUrl } from "@rilldata/web-common/features/dashboards/proto-state/fromProto";
 import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
-import {
-  fetchExploreSpec,
-  fetchMetricsViewSchema,
-} from "@rilldata/web-common/features/explores/selectors";
-import {
-  type V1ExplorePreset,
-  type V1Resource,
-} from "@rilldata/web-common/runtime-client";
+import { fetchExploreSpec } from "@rilldata/web-common/features/explores/selectors";
 
 export const load = async ({ params, depends, parent }) => {
   const { user, project, runtime } = await parent();
@@ -21,66 +13,26 @@ export const load = async ({ params, depends, parent }) => {
 
   depends(`explore:${exploreName}`);
 
-  let explore: V1Resource | undefined;
-  let metricsView: V1Resource | undefined;
-  let defaultExplorePreset: V1ExplorePreset | undefined;
-  let exploreStateFromYAMLConfig: Partial<MetricsExplorerEntity> = {};
-  let bookmarks: V1Bookmark[] | undefined;
+  const exploreSpecPromise = fetchExploreSpec(runtime?.instanceId, exploreName);
+  const homeBookmarkExploreStatePromise = user
+    ? exploreSpecPromise.then(async ({ explore, metricsView, schema }) => {
+        const metricsViewSpec = metricsView.metricsView?.state?.validSpec ?? {};
+        const exploreSpec = explore.explore?.state?.validSpec ?? {};
 
-  try {
-    [
-      {
-        explore,
-        metricsView,
-        defaultExplorePreset,
-        exploreStateFromYAMLConfig,
-      },
-      bookmarks,
-    ] = await Promise.all([
-      fetchExploreSpec(runtime?.instanceId, exploreName),
-      // public projects might not have a logged-in user. bookmarks are not available in this case
-      user ? fetchBookmarks(project.id, exploreName) : Promise.resolve([]),
-    ]);
-  } catch {
-    // error handled in +page.svelte for now
-    // TODO: move it here
-    return {
-      explore: <V1Resource>{},
-      metricsView: <V1Resource>{},
-      defaultExplorePreset: <V1ExplorePreset>{},
-      exploreStateFromYAMLConfig,
-    };
-  }
-
-  const metricsViewSpec = metricsView.metricsView?.state?.validSpec ?? {};
-  const exploreSpec = explore.explore?.state?.validSpec ?? {};
-
-  let homeBookmarkExploreState: Partial<MetricsExplorerEntity> | undefined =
-    undefined;
-  try {
-    const homeBookmark = bookmarks.find(isHomeBookmark);
-    const schema = await fetchMetricsViewSchema(
-      runtime?.instanceId,
-      exploreSpec.metricsView ?? "",
-    );
-
-    if (homeBookmark) {
-      homeBookmarkExploreState = getDashboardStateFromUrl(
-        homeBookmark.data ?? "",
-        metricsViewSpec,
-        exploreSpec,
-        schema,
-      );
-    }
-  } catch {
-    // TODO
-  }
+        const bookmarks = await fetchBookmarks(project.id, exploreName);
+        const homeBookmark = bookmarks.find(isHomeBookmark);
+        if (!homeBookmark) return <Partial<MetricsExplorerEntity>>{};
+        return getDashboardStateFromUrl(
+          homeBookmark.data ?? "",
+          metricsViewSpec,
+          exploreSpec,
+          schema,
+        );
+      })
+    : Promise.resolve(<Partial<MetricsExplorerEntity>>{});
 
   return {
-    explore,
-    metricsView,
-    defaultExplorePreset,
-    exploreStateFromYAMLConfig,
-    homeBookmarkExploreState,
+    exploreSpecPromise,
+    homeBookmarkExploreStatePromise,
   };
 };

--- a/web-admin/src/routes/[organization]/[project]/explore/[dashboard]/+page.ts
+++ b/web-admin/src/routes/[organization]/[project]/explore/[dashboard]/+page.ts
@@ -1,20 +1,27 @@
 import { getExploreStates } from "@rilldata/web-common/features/explores/selectors";
 
 export const load = async ({ url, parent, params }) => {
-  const { explore, metricsView, defaultExplorePreset } = await parent();
+  const { exploreSpecPromise } = await parent();
   const { organization, project, dashboard: exploreName } = params;
-  const metricsViewSpec = metricsView.metricsView?.state?.validSpec;
-  const exploreSpec = explore.explore?.state?.validSpec;
+
+  const exploreStatePromise = exploreSpecPromise.then(
+    ({ explore, metricsView, defaultExplorePreset }) => {
+      const metricsViewSpec = metricsView.metricsView?.state?.validSpec ?? {};
+      const exploreSpec = explore.explore?.state?.validSpec ?? {};
+
+      return getExploreStates(
+        exploreName,
+        `${organization}__${project}__`,
+        url.searchParams,
+        metricsViewSpec,
+        exploreSpec,
+        defaultExplorePreset,
+      );
+    },
+  );
 
   return {
     exploreName,
-    ...getExploreStates(
-      exploreName,
-      `${organization}__${project}__`,
-      url.searchParams,
-      metricsViewSpec,
-      exploreSpec,
-      defaultExplorePreset,
-    ),
+    exploreStatePromise,
   };
 };

--- a/web-admin/src/routes/[organization]/[project]/explore/[dashboard]/+page.ts
+++ b/web-admin/src/routes/[organization]/[project]/explore/[dashboard]/+page.ts
@@ -1,9 +1,11 @@
 import { getExploreStates } from "@rilldata/web-common/features/explores/selectors";
+import { asyncWait } from "@rilldata/web-common/lib/waitUtils";
 
 export const load = async ({ url, parent, params }) => {
   const { exploreSpecPromise } = await parent();
   const { organization, project, dashboard: exploreName } = params;
 
+  const searchParams = url.searchParams;
   const exploreStatePromise = exploreSpecPromise.then(
     ({ explore, metricsView, defaultExplorePreset }) => {
       const metricsViewSpec = metricsView.metricsView?.state?.validSpec ?? {};
@@ -12,7 +14,7 @@ export const load = async ({ url, parent, params }) => {
       return getExploreStates(
         exploreName,
         `${organization}__${project}__`,
-        url.searchParams,
+        searchParams,
         metricsViewSpec,
         exploreSpec,
         defaultExplorePreset,

--- a/web-common/src/features/dashboards/url-state/DashboardURLStateSync.svelte
+++ b/web-common/src/features/dashboards/url-state/DashboardURLStateSync.svelte
@@ -263,6 +263,7 @@
       defaultExplorePreset,
     );
     const newUrl = u.toString();
+    console.log("gotoNewState", prevUrl, newUrl);
     if (!prevUrl || prevUrl === newUrl) return;
 
     prevUrl = newUrl;

--- a/web-common/src/features/explores/selectors.ts
+++ b/web-common/src/features/explores/selectors.ts
@@ -88,6 +88,7 @@ export async function fetchExploreSpec(
   instanceId: string,
   exploreName: string,
 ) {
+  console.log("fetchExploreSpec");
   await waitUntil(() => get(runtime).instanceId === instanceId, 5_000, 50);
 
   const queryParams = {
@@ -171,7 +172,7 @@ export async function fetchMetricsViewSchema(
       metricsViewName,
     ),
     queryFn: async () => {
-      await asyncWait(10_000);
+      await asyncWait(1_000);
       return queryServiceMetricsViewSchema(instanceId, metricsViewName);
     },
   });


### PR DESCRIPTION
closes #6646

We make a call to `MetricsViewTimerange` API in loader functions. The problem with this is we cannot add a loader state without moving the fetching out of it. While we can handle navigation from non-dashboard to dashboard page a direct visit of a dashboard doesnt start rendering until all layout and page loader functions are run.

Converting the data to promises and awaiting in page component. This also means we dont have to set runtime in layout page.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
