### PR TITLE
fix: all time in yaml crashing the app

### DIFF
--- a/web-common/src/features/dashboards/time-controls/new-time-controls.ts
+++ b/web-common/src/features/dashboards/time-controls/new-time-controls.ts
@@ -84,8 +84,8 @@ export type RillPreviousPeriod = RillPreviousPeriodTuple[number];
 type RillLatestTuple = typeof RILL_LATEST;
 export type RillLatest = RillLatestTuple[number];
 
-export const CUSTOM_TIME_RANGE_ALIAS = "CUSTOM" as const;
-export const ALL_TIME_RANGE_ALIAS = "inf" as const;
+export const CUSTOM_TIME_RANGE_ALIAS = "CUSTOM";
+export const ALL_TIME_RANGE_ALIAS = "inf";
 export type AllTime = typeof ALL_TIME_RANGE_ALIAS;
 export type CustomRange = typeof CUSTOM_TIME_RANGE_ALIAS;
 export type ISODurationString = string;
@@ -418,7 +418,7 @@ export function bucketYamlRanges(
         record.periodToDate.push({ range, label: RILL_TO_LABEL[range] });
       } else if (isRillPreviousPeriod(range)) {
         record.previous.push({ range, label: RILL_TO_LABEL[range] });
-      } else {
+      } else if (isValidISODuration(range)) {
         record.latest.push({ range, label: getDurationLabel(range) });
       }
 


### PR DESCRIPTION
While bucketing the time ranges from yaml we do not validate iso and throw an error if it fails. This is an issue for `inf` or `All time` defined in the yaml.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
