### PR TITLE
fix (Cloud UI): Always redirect to login when auth token expires

### DIFF
--- a/web-admin/src/client/redirect-utils.ts
+++ b/web-admin/src/client/redirect-utils.ts
@@ -2,9 +2,10 @@ import {
   ADMIN_URL,
   CANONICAL_ADMIN_URL,
 } from "@rilldata/web-admin/client/http-client";
+import { redirect } from "@sveltejs/kit";
 
 export function redirectToLogin() {
-  window.location.href = buildLoginUrl();
+  throw redirect(307, buildLoginUrl());
 }
 
 export function redirectToLogout() {

--- a/web-admin/src/routes/+layout.ts
+++ b/web-admin/src/routes/+layout.ts
@@ -15,6 +15,7 @@ import {
   type V1ProjectPermissions,
   type V1User,
 } from "@rilldata/web-admin/client";
+import { redirectToLogin } from "@rilldata/web-admin/client/redirect-utils";
 import { redirectToLoginOrRequestAccess } from "@rilldata/web-admin/features/authentication/checkUserAccess";
 import { getFetchOrganizationQueryOptions } from "@rilldata/web-admin/features/organizations/selectors";
 import { fetchProjectDeploymentDetails } from "@rilldata/web-admin/features/projects/selectors";
@@ -63,8 +64,11 @@ export const load = async ({ params, url, route, depends }) => {
       queryFn: () => adminServiceGetCurrentUser(),
     });
     user = userQuery.user;
-  } catch {
-    // no-op
+  } catch (e) {
+    // If the user's auth token has expired, we automatically redirect to the login page
+    if (isAxiosError<RpcStatus>(e) && e.response?.status === 401) {
+      redirectToLogin();
+    }
   }
 
   // If no organization or project, return empty permissions


### PR DESCRIPTION
Ensures users are always redirected to the login page when their auth token expires. Follows [#6733](https://github.com/rilldata/rill/pull/6733).


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
