### PR TITLE
fix (Cloud UI): Retry initial runtime requests that fail to establish a connection

### DIFF
--- a/web-admin/src/features/dashboards/listing/selectors.ts
+++ b/web-admin/src/features/dashboards/listing/selectors.ts
@@ -3,6 +3,7 @@ import { useValidExplores } from "@rilldata/web-common/features/dashboards/selec
 import { getMapFromArray } from "@rilldata/web-common/lib/arrayUtils";
 import type { V1Resource } from "@rilldata/web-common/runtime-client";
 import { createRuntimeServiceListResources } from "@rilldata/web-common/runtime-client";
+import { shouldRetryConnectionError } from "@rilldata/web-common/runtime-client/retries";
 import type { CreateQueryResult } from "@tanstack/svelte-query";
 import { derived } from "svelte/store";
 
@@ -79,6 +80,7 @@ export function useDashboardsV2(
         );
         return allDashboards;
       },
+      retry: shouldRetryConnectionError,
     },
   });
 }

--- a/web-admin/src/features/projects/status/ProjectGlobalStatusIndicator.svelte
+++ b/web-admin/src/features/projects/status/ProjectGlobalStatusIndicator.svelte
@@ -5,6 +5,7 @@
   import LoadingSpinner from "@rilldata/web-common/components/icons/LoadingSpinner.svelte";
   import { useProjectParser } from "@rilldata/web-common/features/entity-management/resource-selectors";
   import { createRuntimeServiceListResources } from "@rilldata/web-common/runtime-client";
+  import { shouldRetryConnectionError } from "@rilldata/web-common/runtime-client/retries";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { useQueryClient } from "@tanstack/svelte-query";
   import { useProjectDeployment } from "./selectors";
@@ -34,6 +35,7 @@
         },
         refetchOnMount: true,
         refetchOnWindowFocus: true,
+        retry: shouldRetryConnectionError,
       },
     },
   );
@@ -46,6 +48,7 @@
   $: projectParserQuery = useProjectParser(queryClient, instanceId, {
     refetchOnMount: true,
     refetchOnWindowFocus: true,
+    retry: shouldRetryConnectionError,
   });
   $: ({
     data: projectParserData,

--- a/web-common/src/features/feature-flags.ts
+++ b/web-common/src/features/feature-flags.ts
@@ -5,6 +5,7 @@ import {
   createRuntimeServiceGetInstance,
   type V1InstanceFeatureFlags,
 } from "../runtime-client";
+import { shouldRetryConnectionError } from "../runtime-client/retries";
 import { runtime } from "../runtime-client/runtime-store";
 
 class FeatureFlag {
@@ -65,6 +66,7 @@ class FeatureFlags {
         query: {
           select: (data) => data?.instance?.featureFlags,
           queryClient,
+          retry: shouldRetryConnectionError,
         },
       }).subscribe((features) => {
         if (features.data) updateFlags(features.data);

--- a/web-common/src/runtime-client/retries.ts
+++ b/web-common/src/runtime-client/retries.ts
@@ -1,0 +1,11 @@
+import type { HTTPError } from "./fetchWrapper";
+
+export function shouldRetryConnectionError(
+  failureCount: number,
+  error: HTTPError,
+) {
+  if (error.message.includes("Failed to fetch")) {
+    return failureCount < 3;
+  }
+  return false;
+}


### PR DESCRIPTION
Currently, the project deployment e2e test is flaky. It fails when a project is deployed, and initial requests to the runtime cannot establish a connection (see attached screenshot). This occurs due to transient connection failures (e.g., `ERR_CONNECTION_REFUSED`), likely because the runtime is not yet ready.

This PR introduces retries for these requests as a speculative fix, aiming to ensure they succeed once the runtime becomes available.

![image](https://github.com/user-attachments/assets/a3f09023-daf1-4499-873a-f31d85b04eec)


**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
