### PR TITLE
fix: pivot sort on delta column

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
@@ -187,7 +187,7 @@ export function mergeRowTotalsInOrder(
       const unsortedRowIndex = unsortedRowValuesMap.get(rowValue);
       if (unsortedRowIndex === undefined) {
         /**
-         * Exclude null values when sorting by deltas to ensure only dimension values
+         * Exclude missing values when sorting by deltas to ensure only dimension values
          * present in both time ranges are returned.
          *
          * This prevents discrepancies between the unsorted and sorted table row sets.

--- a/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
@@ -179,16 +179,24 @@ export function mergeRowTotalsInOrder(
     return sortedRowTotals;
   }
 
+  const NOT_AVAILABLE = Symbol("NOT_AVAILABLE");
   const unsortedRowValuesMap = createIndexMap(unsortedRowValues);
 
-  const orderedRowTotals = rowValues.map((rowValue) => {
-    const unsortedRowIndex = unsortedRowValuesMap.get(rowValue);
-    if (unsortedRowIndex === undefined) {
-      console.error("Row value not found in unsorted row values", rowValue);
-    }
-    const rowTotal = unsortedRowTotals[unsortedRowIndex as number];
-    return rowTotal;
-  });
+  const orderedRowTotals = rowValues
+    .map((rowValue) => {
+      const unsortedRowIndex = unsortedRowValuesMap.get(rowValue);
+      if (unsortedRowIndex === undefined) {
+        /**
+         * Exclude null values when sorting by deltas to ensure only dimension values
+         * present in both time ranges are returned.
+         *
+         * This prevents discrepancies between the unsorted and sorted table row sets.
+         */
+        return NOT_AVAILABLE;
+      }
+      return unsortedRowTotals[unsortedRowIndex];
+    })
+    .filter((rowTotal) => rowTotal !== NOT_AVAILABLE);
 
   return orderedRowTotals;
 }


### PR DESCRIPTION
Pivot table in some cases crashed when sorted on a delta column for a measure within a column dimension.
Context : https://rilldata.slack.com/archives/CTCJ58H3M/p1740566509343249


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
