### PR TITLE
e2e: Capture logs from Go services

### DIFF
--- a/.github/workflows/web-test-e2e.yml
+++ b/.github/workflows/web-test-e2e.yml
@@ -129,3 +129,10 @@ jobs:
           name: ${{ matrix.name }}-playwright-report
           path: ${{ matrix.name }}/playwright-report/
           retention-days: 30
+
+      - uses: actions/upload-artifact@v4
+        if: always() && matrix.name == 'web-admin'
+        with:
+          name: web-admin-services-log
+          path: web-admin/playwright/logs/admin-runtime.log
+          retention-days: 30


### PR DESCRIPTION
Captures and uploads logs from the `admin` and `runtime` services. These'll help debug any failing tests. Like the Playwright reports, this log file can be found in the GitHub Action's summary "artifacts" section:

<img width="1557" alt="image" src="https://github.com/user-attachments/assets/5effa722-8e32-4f44-b6bd-f8ba7b07251a" />


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
