### PR TITLE
tweak: display measure error

### DIFF
--- a/web-common/src/components/forms/Input.svelte
+++ b/web-common/src/components/forms/Input.svelte
@@ -140,6 +140,7 @@
       class="input-wrapper {textClass}"
       style:padding-left="{leftPadding}px"
       style:width
+      class:error-input-wrapper={!!errors?.length}
       style:font-family={fontFamily}
     >
       {#if $$slots.icon}

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
@@ -152,6 +152,7 @@
       errors={$errors["value1"]}
       id="value1"
       onEnter={submit}
+      alwaysShowError
       placeholder={isBetweenExpression ? "Lower Value" : "Enter a Number"}
     />
 
@@ -161,6 +162,7 @@
         errors={$errors["value2"]}
         id="value2"
         placeholder="Higher Value"
+        alwaysShowError
         onEnter={submit}
       />
     {/if}


### PR DESCRIPTION
Force measure filter form errors to always display.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
