### PR TITLE
fix: weak type check for kpi hover in canvas

### DIFF
--- a/web-common/src/features/canvas/components/kpi/KPI.svelte
+++ b/web-common/src/features/canvas/components/kpi/KPI.svelte
@@ -224,7 +224,7 @@
         <span
           class="text-3xl font-medium text-gray-600 flex gap-x-0.5 items-end"
         >
-          {#if hoveredPoints?.[0]?.value !== undefined}
+          {#if hoveredPoints?.[0]?.value != null}
             <span class="text-primary-500">
               {measureValueFormatter(currentValue)}
             </span>


### PR DESCRIPTION
Weak type check to catch both undefined and nulls on hover to prevent null / total on hover