### PR TITLE
Fix: Jobs to clean Dangling Resources

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Go report card
         uses: creekorful/goreportcard-action@v1.0
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v6.5.0
         with:
           version: v1.61

--- a/admin/database/database.go
+++ b/admin/database/database.go
@@ -72,6 +72,7 @@ type DB interface {
 	FindOrganizationWhitelistedDomainsForDomain(ctx context.Context, domain string) ([]*OrganizationWhitelistedDomain, error)
 	InsertOrganizationWhitelistedDomain(ctx context.Context, opts *InsertOrganizationWhitelistedDomainOptions) (*OrganizationWhitelistedDomain, error)
 	DeleteOrganizationWhitelistedDomain(ctx context.Context, id string) error
+	FindInactiveOrganizations(ctx context.Context) ([]*Organization, error)
 
 	FindProjects(ctx context.Context, afterName string, limit int) ([]*Project, error)
 	FindProjectsByVersion(ctx context.Context, version, afterName string, limit int) ([]*Project, error)

--- a/admin/database/postgres/postgres.go
+++ b/admin/database/postgres/postgres.go
@@ -234,7 +234,9 @@ func (c *connection) FindInactiveOrganizations(ctx context.Context) ([]*database
 	// TODO: This definition may change, but for now, we are considering an organization as inactive if it has no users
 	res := []*database.Organization{}
 	err := c.getDB(ctx).SelectContext(ctx, &res, `
-		SELECT o.* FROM orgs o WHERE NOT EXISTS ( SELECT 1 FROM users_orgs_roles uor WHERE uor.org_id = o.id )
+		SELECT o.* FROM orgs o
+		WHERE now() - o.updated_on > INTERVAL '1 DAY'
+		AND NOT EXISTS ( SELECT 1 FROM users_orgs_roles uor WHERE uor.org_id = o.id )
 	`)
 	if err != nil {
 		return nil, parseErr("orgs", err)

--- a/admin/database/postgres/postgres.go
+++ b/admin/database/postgres/postgres.go
@@ -234,10 +234,7 @@ func (c *connection) FindInactiveOrganizations(ctx context.Context) ([]*database
 	// TODO: This definition may change, but for now, we are considering an organization as inactive if it has no users
 	res := []*database.Organization{}
 	err := c.getDB(ctx).SelectContext(ctx, &res, `
-		SELECT o.* FROM orgs o
-		WHERE o.updated_on < now() - interval '30 days' AND NOT EXISTS (
-			SELECT 1 FROM users_orgs_roles uor WHERE uor.org_id = o.id
-		)
+		SELECT o.* FROM orgs o WHERE NOT EXISTS ( SELECT 1 FROM users_orgs_roles uor WHERE uor.org_id = o.id )
 	`)
 	if err != nil {
 		return nil, parseErr("orgs", err)

--- a/admin/jobs/jobs.go
+++ b/admin/jobs/jobs.go
@@ -28,7 +28,6 @@ type Client interface {
 	StartOrgTrial(ctx context.Context, orgID string) (*InsertResult, error)
 	DeleteOrg(ctx context.Context, orgID string) (*InsertResult, error)
 	LogInactiveOrgs(ctx context.Context) (*InsertResult, error)
-	DeleteInactiveOrgs(ctx context.Context) (*InsertResult, error)
 
 	PlanChanged(ctx context.Context, billingCustomerID string) (*InsertResult, error)
 }

--- a/admin/jobs/jobs.go
+++ b/admin/jobs/jobs.go
@@ -27,6 +27,8 @@ type Client interface {
 	RepairOrgBilling(ctx context.Context, orgID string) (*InsertResult, error) // biller is just used for deduplication
 	StartOrgTrial(ctx context.Context, orgID string) (*InsertResult, error)
 	DeleteOrg(ctx context.Context, orgID string) (*InsertResult, error)
+	LogInactiveOrgs(ctx context.Context) (*InsertResult, error)
+	DeleteInactiveOrgs(ctx context.Context) (*InsertResult, error)
 
 	PlanChanged(ctx context.Context, billingCustomerID string) (*InsertResult, error)
 }

--- a/admin/jobs/jobs.go
+++ b/admin/jobs/jobs.go
@@ -27,7 +27,7 @@ type Client interface {
 	RepairOrgBilling(ctx context.Context, orgID string) (*InsertResult, error) // biller is just used for deduplication
 	StartOrgTrial(ctx context.Context, orgID string) (*InsertResult, error)
 	DeleteOrg(ctx context.Context, orgID string) (*InsertResult, error)
-	LogInactiveOrgs(ctx context.Context) (*InsertResult, error)
+	HibernateInactiveOrgs(ctx context.Context) (*InsertResult, error)
 
 	PlanChanged(ctx context.Context, billingCustomerID string) (*InsertResult, error)
 }

--- a/admin/jobs/noop.go
+++ b/admin/jobs/noop.go
@@ -71,3 +71,11 @@ func (n *noop) DeleteOrg(ctx context.Context, orgID string) (*InsertResult, erro
 func (n *noop) PlanChanged(ctx context.Context, billingCustomerID string) (*InsertResult, error) {
 	return nil, nil
 }
+
+func (n *noop) LogInactiveOrgs(ctx context.Context) (*InsertResult, error) {
+	return nil, nil
+}
+
+func (n *noop) DeleteInactiveOrgs(ctx context.Context) (*InsertResult, error) {
+	return nil, nil
+}

--- a/admin/jobs/noop.go
+++ b/admin/jobs/noop.go
@@ -75,7 +75,3 @@ func (n *noop) PlanChanged(ctx context.Context, billingCustomerID string) (*Inse
 func (n *noop) LogInactiveOrgs(ctx context.Context) (*InsertResult, error) {
 	return nil, nil
 }
-
-func (n *noop) DeleteInactiveOrgs(ctx context.Context) (*InsertResult, error) {
-	return nil, nil
-}

--- a/admin/jobs/noop.go
+++ b/admin/jobs/noop.go
@@ -72,6 +72,6 @@ func (n *noop) PlanChanged(ctx context.Context, billingCustomerID string) (*Inse
 	return nil, nil
 }
 
-func (n *noop) LogInactiveOrgs(ctx context.Context) (*InsertResult, error) {
+func (n *noop) HibernateInactiveOrgs(ctx context.Context) (*InsertResult, error) {
 	return nil, nil
 }

--- a/admin/jobs/river/river.go
+++ b/admin/jobs/river/river.go
@@ -96,8 +96,7 @@ func New(ctx context.Context, dsn string, adm *admin.Service) (jobs.Client, erro
 	river.AddWorker(workers, &RepairOrgBillingWorker{admin: adm, logger: billingLogger})
 	river.AddWorker(workers, &StartTrialWorker{admin: adm, logger: billingLogger})
 	river.AddWorker(workers, &DeleteOrgWorker{admin: adm, logger: billingLogger})
-	river.AddWorker(workers, &LogInactiveOrgsWorker{admin: adm, logger: billingLogger})
-	river.AddWorker(workers, &DeleteInactiveOrgsWorker{admin: adm, logger: billingLogger}) // Manual trigger
+	river.AddWorker(workers, &HibernateInactiveOrgsWorker{admin: adm, logger: billingLogger})
 
 	periodicJobs := []*river.PeriodicJob{
 		// NOTE: Add new periodic jobs here
@@ -107,7 +106,7 @@ func New(ctx context.Context, dsn string, adm *admin.Service) (jobs.Client, erro
 		newPeriodicJob(&TrialEndCheckArgs{}, "10 1 * * *", true),                 // daily at 1:10am UTC
 		newPeriodicJob(&TrialGracePeriodCheckArgs{}, "15 1 * * *", true),         // daily at 1:15am UTC
 		newPeriodicJob(&SubscriptionCancellationCheckArgs{}, "20 1 * * *", true), // daily at 1:20am UTC
-		newPeriodicJob(&LogInactiveOrgsArgs{}, "0 1 * * 0", true),                // weekly at 1am UTC on Sunday
+		newPeriodicJob(&HibernateInactiveOrgsArgs{}, "0 1 * * 0", true),          // weekly at 1am UTC on Sunday
 	}
 
 	// Wire our zap logger to a slog logger for the river client
@@ -392,18 +391,7 @@ func (c *Client) PlanChanged(ctx context.Context, billingCustomerID string) (*jo
 }
 
 func (c *Client) LogInactiveOrgs(ctx context.Context) (*jobs.InsertResult, error) {
-	res, err := c.riverClient.Insert(ctx, LogInactiveOrgsArgs{}, nil)
-	if err != nil {
-		return nil, err
-	}
-	return &jobs.InsertResult{
-		ID:        res.Job.ID,
-		Duplicate: res.UniqueSkippedAsDuplicate,
-	}, nil
-}
-
-func (c *Client) DeleteInactiveOrgs(ctx context.Context) (*jobs.InsertResult, error) {
-	res, err := c.riverClient.Insert(ctx, DeleteInactiveOrgsArgs{}, nil)
+	res, err := c.riverClient.Insert(ctx, HibernateInactiveOrgsArgs{}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/admin/jobs/river/river.go
+++ b/admin/jobs/river/river.go
@@ -97,6 +97,7 @@ func New(ctx context.Context, dsn string, adm *admin.Service) (jobs.Client, erro
 	river.AddWorker(workers, &StartTrialWorker{admin: adm, logger: billingLogger})
 	river.AddWorker(workers, &DeleteOrgWorker{admin: adm, logger: billingLogger})
 	river.AddWorker(workers, &LogInactiveOrgsWorker{admin: adm, logger: billingLogger})
+	river.AddWorker(workers, &DeleteInactiveOrgsWorker{admin: adm, logger: billingLogger}) // Manual trigger
 
 	periodicJobs := []*river.PeriodicJob{
 		// NOTE: Add new periodic jobs here

--- a/admin/jobs/river/river.go
+++ b/admin/jobs/river/river.go
@@ -106,7 +106,7 @@ func New(ctx context.Context, dsn string, adm *admin.Service) (jobs.Client, erro
 		newPeriodicJob(&TrialEndCheckArgs{}, "10 1 * * *", true),                 // daily at 1:10am UTC
 		newPeriodicJob(&TrialGracePeriodCheckArgs{}, "15 1 * * *", true),         // daily at 1:15am UTC
 		newPeriodicJob(&SubscriptionCancellationCheckArgs{}, "20 1 * * *", true), // daily at 1:20am UTC
-		newPeriodicJob(&HibernateInactiveOrgsArgs{}, "0 1 * * 0", true),          // weekly at 1am UTC on Sunday
+		newPeriodicJob(&HibernateInactiveOrgsArgs{}, "0 7 * * 1", true),          // Monday at 7:00am UTC
 	}
 
 	// Wire our zap logger to a slog logger for the river client

--- a/admin/jobs/river/river.go
+++ b/admin/jobs/river/river.go
@@ -390,7 +390,7 @@ func (c *Client) PlanChanged(ctx context.Context, billingCustomerID string) (*jo
 	}, nil
 }
 
-func (c *Client) LogInactiveOrgs(ctx context.Context) (*jobs.InsertResult, error) {
+func (c *Client) HibernateInactiveOrgs(ctx context.Context) (*jobs.InsertResult, error) {
 	res, err := c.riverClient.Insert(ctx, HibernateInactiveOrgsArgs{}, nil)
 	if err != nil {
 		return nil, err

--- a/cli/cmd/devtool/data/cloud-deps.docker-compose.yml
+++ b/cli/cmd/devtool/data/cloud-deps.docker-compose.yml
@@ -73,3 +73,12 @@ services:
     ports:
       - '9000:9000' # Native port
       - '8123:8123' # HTTP port
+  pgweb:
+    image: sosedoff/pgweb
+    restart: always
+    ports:
+      - "8081:8081"
+    environment:
+      - DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres?sslmode=disable
+    depends_on:
+      - postgres

--- a/cli/cmd/devtool/data/cloud-deps.docker-compose.yml
+++ b/cli/cmd/devtool/data/cloud-deps.docker-compose.yml
@@ -77,7 +77,7 @@ services:
     image: sosedoff/pgweb
     restart: always
     ports:
-      - "8081:8081"
+      - "8082:8081"
     environment:
       - DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres?sslmode=disable
     depends_on:


### PR DESCRIPTION
This PR creates two jobs to assist with dangling resources. https://github.com/rilldata/rill/issues/6607

- **Job 1** Logs inactive organizations and hibernates projects. The criteria for the current logic is that an organization must  have no users.

- **Job 2** Enables inactive organizations to be deleted. This is only manual triggered at this time.

> Additionally adds pgweb to devtool containers

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
