### PR TITLE
fix: support space in measure dimension names for charts

### DIFF
--- a/web-common/src/features/canvas/components/charts/Chart.svelte
+++ b/web-common/src/features/canvas/components/charts/Chart.svelte
@@ -17,7 +17,12 @@
   import type { Readable } from "svelte/store";
   import { getChartData, validateChartSchema } from "./selector";
   import type { ChartType } from "./types";
-  import { generateSpec, getChartTitle, mergedVlConfig } from "./util";
+  import {
+    generateSpec,
+    getChartTitle,
+    mergedVlConfig,
+    sanitizeFieldName,
+  } from "./util";
 
   export let rendererProperties: V1ComponentSpecRendererProperties;
   export let renderer: string;
@@ -49,7 +54,7 @@
     chartConfig.metrics_view,
   );
 
-  $: measureName = $measure?.name || "measure";
+  $: measureName = sanitizeFieldName($measure?.name || "measure");
 
   $: measureFormatter = createMeasureValueFormatter<null | undefined>(
     $measure as MetricsViewSpecMeasureV2,

--- a/web-common/src/features/canvas/components/charts/builder.ts
+++ b/web-common/src/features/canvas/components/charts/builder.ts
@@ -3,6 +3,7 @@ import type {
   ChartConfig,
   TooltipValue,
 } from "@rilldata/web-common/features/canvas/components/charts/types";
+import { sanitizeFieldName } from "@rilldata/web-common/features/canvas/components/charts/util";
 import { sanitizeValueForVega } from "@rilldata/web-common/features/templates/charts/utils";
 import type { VisualizationSpec } from "svelte-vega";
 import type {
@@ -52,7 +53,7 @@ export function createXEncoding(
     ...(config.x.sort && { sort: config.x.sort }),
     axis: {
       ...(config.x.type === "quantitative" && {
-        formatType: config.x.field,
+        formatType: sanitizeFieldName(config.x.field),
       }),
       ...(metaData && "format" in metaData && { format: metaData.format }),
       ...(!config.x.showAxisTitle && { title: null }),
@@ -77,7 +78,7 @@ export function createYEncoding(
     }),
     axis: {
       ...(config.y.type === "quantitative" && {
-        formatType: config.y.field,
+        formatType: sanitizeFieldName(config.y.field),
       }),
       ...(!config.y.showAxisTitle && { title: null }),
       ...(metaData && "format" in metaData && { format: metaData.format }),
@@ -147,7 +148,7 @@ export function createDefaultTooltipEncoding(
       title: data.fields[config.x.field]?.displayName || config.x.field,
       type: config.x.type,
       ...(config.x.type === "quantitative" && {
-        formatType: config.x.field,
+        formatType: sanitizeFieldName(config.x.field),
       }),
       ...(config.x.type === "temporal" && { format: "%b %d, %Y %H:%M" }),
     });
@@ -158,7 +159,7 @@ export function createDefaultTooltipEncoding(
       title: data.fields[config.y.field]?.displayName || config.y.field,
       type: config.y.type,
       ...(config.y.type === "quantitative" && {
-        formatType: config.y.field,
+        formatType: sanitizeFieldName(config.y.field),
       }),
       ...(config.y.type === "temporal" && { format: "%b %d, %Y %H:%M" }),
     });

--- a/web-common/src/features/canvas/components/charts/util.ts
+++ b/web-common/src/features/canvas/components/charts/util.ts
@@ -4,6 +4,7 @@ import StackedArea from "@rilldata/web-common/components/icons/StackedArea.svelt
 import StackedBar from "@rilldata/web-common/components/icons/StackedBar.svelte";
 import StackedBarFull from "@rilldata/web-common/components/icons/StackedBarFull.svelte";
 import { getRillTheme } from "@rilldata/web-common/components/vega/vega-config";
+import { sanitizeValueForVega } from "@rilldata/web-common/features/templates/charts/utils";
 import { V1TimeGrain } from "@rilldata/web-common/runtime-client";
 import merge from "deepmerge";
 import type { Config } from "vega-lite";
@@ -97,3 +98,8 @@ export const timeGrainToVegaTimeUnitMap: Record<V1TimeGrain, string> = {
   [V1TimeGrain.TIME_GRAIN_YEAR]: "year",
   [V1TimeGrain.TIME_GRAIN_UNSPECIFIED]: "yearmonthdate",
 };
+
+export function sanitizeFieldName(fieldName: string) {
+  const specialCharactersRemoved = sanitizeValueForVega(fieldName);
+  return specialCharactersRemoved.replace(" ", "__");
+}


### PR DESCRIPTION
https://www.notion.so/rilldata/Expression-parse-error-Roy-1a7ba33c8f57806e98a4fd434e77083a

Sanitize measure name used for identifying formatter. Likely a bug in Vega Lite where it does not support space in `formatType`