### PR TITLE
fix: monthly parsing of report cron

### DIFF
--- a/web-common/src/features/scheduled-reports/time-utils.ts
+++ b/web-common/src/features/scheduled-reports/time-utils.ts
@@ -119,7 +119,9 @@ export function getTimeOfDayFromCronExpression(cronExpr: string): string {
 
 export function getDayOfMonthFromCronExpression(cronExpr: string): number {
   const [, , dayOfMonth] = cronExpr.split(" ");
-  return Number(dayOfMonth);
+  const dayOfMonthAsNum = Number(dayOfMonth);
+  if (Number.isNaN(dayOfMonthAsNum)) return 1;
+  return dayOfMonthAsNum;
 }
 
 export function makeTimeZoneOptions(availableTimeZones: string[] | undefined) {

--- a/web-common/src/features/scheduled-reports/utils.ts
+++ b/web-common/src/features/scheduled-reports/utils.ts
@@ -6,7 +6,6 @@ import {
   getNextQuarterHour,
   getTimeIn24FormatFromDateTime,
   getTimeOfDayFromCronExpression,
-  getTodaysDayOfMonth,
   getTodaysDayOfWeek,
   ReportFrequency,
 } from "@rilldata/web-common/features/scheduled-reports/time-utils";
@@ -60,7 +59,7 @@ export function getInitialValues(
       ? getDayOfMonthFromCronExpression(
           reportSpec.refreshSchedule?.cron as string,
         )
-      : getTodaysDayOfMonth(),
+      : 1, // We only support first of day right now
     timeOfDay: reportSpec
       ? getTimeOfDayFromCronExpression(
           reportSpec.refreshSchedule?.cron as string,


### PR DESCRIPTION
If monthly part of a cron is `*` we are incorrectly parsing it as NaN. So switching to monthly in a report edit will make it NaN from then on.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
