### PR TITLE
fix: Derived explore security policies

### DIFF
--- a/runtime/reconcilers/explore.go
+++ b/runtime/reconcilers/explore.go
@@ -135,8 +135,8 @@ func (r *ExploreReconciler) validateAndRewrite(ctx context.Context, self *runtim
 			}
 		}
 	} else {
-		securityRules := append(mv.SecurityRules, spec.SecurityRules...)
-		access := mergeConditionRules(securityRules)
+		mv.SecurityRules = append(mv.SecurityRules, spec.SecurityRules...)
+		access := mergeConditionRules(mv.SecurityRules)
 		if access != nil {
 			spec.SecurityRules = []*runtimev1.SecurityRule{access}
 		}


### PR DESCRIPTION
Issue: https://github.com/rilldata/rill/issues/6559


https://github.com/user-attachments/assets/cf52f293-f3ed-4604-9b78-5cef1a114cd8
> Expected flow works the same in local and cloud

```yaml
# Explore YAML
# Reference documentation: https://docs.rilldata.com/reference/project-files/explores

type: explore

title: "Programmatic Ads Auction"
metrics_view: auction_metrics

dimensions: '*'
measures: '*'

security:
  access: "{{ .user.admin }} OR '{{ .user.domain }}' == 'rilldata.com'"

time_zones:
  - America/Los_Angeles
  - America/Chicago
  - America/New_York
  - Europe/London
  - Europe/Paris

embeds:
  hide_pivot: true
defaults:
  measures:
    - requests
    - avg_bid_floor
    - 1d_qps
  dimensions:
    - app_site_name
    - app_site_cat
    - ad_size
    - device_state
  time_range: P7D

---

# Metrics view YAML
# Reference documentation: https://docs.rilldata.com/reference/project-files/dashboards

version: 1
model: "auction_data_model"
type: metrics_view

timeseries: "__time"
smallest_time_grain: "hour"

security:
  access: true
  row_filter: >
    device_state = 'NY'
  exclude:
    - if: "'{{.user.domain}}' != 'rilldata.com'"
      names:
        - app_site_name

measures:
  - display_name: Requests
    name: requests
    expression: sum(bid_request_cnt)
    description: Total Requests
    format_preset: humanize
  - display_name: "Avg Bid Floor"
    name: avg_bid_floor
    expression: "sum(bid_floor) / sum(has_bid_floor_cnt) "
    description: "Average Bid Floor"
    format_preset: currency_usd
  - display_name: "1D QPS"
    name: 1d_qps
    expression: "sum(bid_request_cnt) / 86400 "
    description: "1D QPS"
    format_preset: humanize


dimensions:
  - name: app_site_name
    display_name: App Site Name
    column: app_site_name
    description: ""
  - name: app_site_cat
    display_name: App Site Cat
    column: app_site_cat
    description: ""
  - name: ad_size
    display_name: Ad Size
    column: ad_size
    description: ""
  - name: device_state
    display_name: Device State
    column: device_state
    description: ""

```

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

c.c. @royendo 