### PR TITLE
add structs to mv query cache key

### DIFF
--- a/runtime/metricsview/query.go
+++ b/runtime/metricsview/query.go
@@ -67,7 +67,7 @@ func (q *Query) AsMap() (map[string]any, error) {
 					return nil, fmt.Errorf("expected time.Time, got %T", data)
 				}
 				return map[string]any{
-					"t": t.Format(time.RFC3339),
+					"t": t.Format(time.RFC3339Nano),
 				}, nil
 			}
 			return data, nil

--- a/runtime/metricsview/query.go
+++ b/runtime/metricsview/query.go
@@ -64,7 +64,7 @@ func (q *Query) AsMap() (map[string]any, error) {
 			if from == reflect.TypeOf(&time.Time{}) {
 				t, ok := data.(*time.Time)
 				if !ok {
-					return nil, fmt.Errorf("expected time.Time, got %T", data)
+					return nil, fmt.Errorf("expected *time.Time, got %T", data)
 				}
 				return map[string]any{
 					"t": t.Format(time.RFC3339Nano),

--- a/runtime/metricsview/query.go
+++ b/runtime/metricsview/query.go
@@ -2,8 +2,10 @@ package metricsview
 
 import (
 	"fmt"
+	"reflect"
 	"time"
 
+	"github.com/mitchellh/mapstructure"
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime/pkg/timeutil"
 )
@@ -52,6 +54,33 @@ type MeasureCompute struct {
 	ComparisonRatio *MeasureComputeComparisonRatio `mapstructure:"comparison_ratio"`
 	PercentOfTotal  *MeasureComputePercentOfTotal  `mapstructure:"percent_of_total"`
 	URI             *MeasureComputeURI             `mapstructure:"uri"`
+}
+
+func (q *Query) AsMap() (map[string]any, error) {
+	queryMap := make(map[string]any)
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result: &queryMap,
+		DecodeHook: func(from reflect.Type, to reflect.Type, data any) (any, error) {
+			if from == reflect.TypeOf(&time.Time{}) {
+				t, ok := data.(*time.Time)
+				if !ok {
+					return nil, fmt.Errorf("expected time.Time, got %T", data)
+				}
+				return map[string]any{
+					"t": t.Format(time.RFC3339),
+				}, nil
+			}
+			return data, nil
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	err = decoder.Decode(q)
+	if err != nil {
+		return nil, err
+	}
+	return queryMap, nil
 }
 
 func (m *MeasureCompute) Validate() error {

--- a/runtime/pkg/mapstructureutil/mapstructureutil.go
+++ b/runtime/pkg/mapstructureutil/mapstructureutil.go
@@ -1,7 +1,6 @@
 package mapstructureutil
 
 import (
-	"reflect"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
@@ -10,7 +9,7 @@ import (
 // WeakDecode is similar to mapstructure.WeakDecode, but it also supports decoding RFC3339Nano-formatted timestamp strings to time.Time.
 func WeakDecode(input, output any) error {
 	config := &mapstructure.DecoderConfig{
-		DecodeHook:       stringToTimeHook,
+		DecodeHook:       mapstructure.StringToTimeHookFunc(time.RFC3339Nano),
 		Metadata:         nil,
 		Result:           output,
 		WeaklyTypedInput: true,
@@ -22,12 +21,4 @@ func WeakDecode(input, output any) error {
 	}
 
 	return decoder.Decode(input)
-}
-
-func stringToTimeHook(from, to reflect.Type, data any) (any, error) {
-	if to == reflect.TypeOf(time.Time{}) && from == reflect.TypeOf("") {
-		return time.Parse(time.RFC3339Nano, data.(string))
-	}
-
-	return data, nil
 }

--- a/runtime/resolvers/metrics.go
+++ b/runtime/resolvers/metrics.go
@@ -127,24 +127,6 @@ func (r *metricsResolver) CacheKey(ctx context.Context) ([]byte, bool, error) {
 		}
 		queryMap["comparison_time_range"] = buf.Bytes()
 	}
-	if r.query.Where != nil {
-		var buf bytes.Buffer
-		enc := gob.NewEncoder(&buf)
-		err = enc.Encode(r.query.Where)
-		if err != nil {
-			return nil, false, err
-		}
-		queryMap["where"] = buf.Bytes()
-	}
-	if r.query.Having != nil {
-		var buf bytes.Buffer
-		enc := gob.NewEncoder(&buf)
-		err = enc.Encode(r.query.Having)
-		if err != nil {
-			return nil, false, err
-		}
-		queryMap["having"] = buf.Bytes()
-	}
 	b, err := json.Marshal(queryMap)
 	return b, true, err
 }

--- a/runtime/resolvers/metrics.go
+++ b/runtime/resolvers/metrics.go
@@ -1,7 +1,9 @@
 package resolvers
 
 import (
+	"bytes"
 	"context"
+	"encoding/gob"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -107,8 +109,44 @@ func (r *metricsResolver) CacheKey(ctx context.Context) ([]byte, bool, error) {
 	}
 
 	queryMap["mv_cache_key"] = key
-	bytes, err := json.Marshal(queryMap)
-	return bytes, true, err
+	if r.query.TimeRange != nil {
+		var buf bytes.Buffer
+		enc := gob.NewEncoder(&buf)
+		err = enc.Encode(r.query.TimeRange)
+		if err != nil {
+			return nil, false, err
+		}
+		queryMap["time_range"] = buf.Bytes()
+	}
+	if r.query.ComparisonTimeRange != nil {
+		var buf bytes.Buffer
+		enc := gob.NewEncoder(&buf)
+		err = enc.Encode(r.query.ComparisonTimeRange)
+		if err != nil {
+			return nil, false, err
+		}
+		queryMap["comparison_time_range"] = buf.Bytes()
+	}
+	if r.query.Where != nil {
+		var buf bytes.Buffer
+		enc := gob.NewEncoder(&buf)
+		err = enc.Encode(r.query.Where)
+		if err != nil {
+			return nil, false, err
+		}
+		queryMap["where"] = buf.Bytes()
+	}
+	if r.query.Having != nil {
+		var buf bytes.Buffer
+		enc := gob.NewEncoder(&buf)
+		err = enc.Encode(r.query.Having)
+		if err != nil {
+			return nil, false, err
+		}
+		queryMap["having"] = buf.Bytes()
+	}
+	b, err := json.Marshal(queryMap)
+	return b, true, err
 }
 
 func (r *metricsResolver) Refs() []*runtimev1.ResourceName {

--- a/runtime/resolvers/metrics.go
+++ b/runtime/resolvers/metrics.go
@@ -109,6 +109,8 @@ func (r *metricsResolver) CacheKey(ctx context.Context) ([]byte, bool, error) {
 	}
 
 	queryMap["mv_cache_key"] = key
+
+	// add time ranges explicitly as decoding does not work out of box - https://github.com/mitchellh/mapstructure/issues/270
 	if r.query.TimeRange != nil {
 		var buf bytes.Buffer
 		enc := gob.NewEncoder(&buf)

--- a/runtime/resolvers/testdata/metrics_comparisons.yaml
+++ b/runtime/resolvers/testdata/metrics_comparisons.yaml
@@ -164,11 +164,11 @@ tests:
             comparison_value:
               measure: sum
       time_range:
-        end: 2022-01-05T00:00:00Z
-        start: 2022-01-03T00:00:00Z
+        end: 2024-01-05T00:00:00Z
+        start: 2024-01-03T00:00:00Z
       comparison_time_range:
-        end: 2022-01-03T00:00:00Z
-        start: 2022-01-01T00:00:00Z
+        end: 2024-01-03T00:00:00Z
+        start: 2024-01-01T00:00:00Z
       sort:
         - name: time__day
       where:
@@ -176,7 +176,7 @@ tests:
           op: in
           exprs:
             - val: country
-            - val: US
+            - val: IN
   - name: iso_ranges_duckdb
     resolver: metrics
     properties:

--- a/runtime/resolvers/testdata/metrics_comparisons.yaml
+++ b/runtime/resolvers/testdata/metrics_comparisons.yaml
@@ -147,6 +147,36 @@ tests:
       - sum: 4
         sum_prev: 2
         time__day: "2024-01-04T00:00:00Z"
+  - name: time_as_dimension_check_cache_duckdb
+    resolver: metrics
+    properties:
+      metrics_view: duckdb_metrics
+      dimensions:
+        - name: time__day
+          compute:
+            time_floor:
+              dimension: time
+              grain: day
+      measures:
+        - name: sum
+        - name: sum_prev
+          compute:
+            comparison_value:
+              measure: sum
+      time_range:
+        end: 2022-01-05T00:00:00Z
+        start: 2022-01-03T00:00:00Z
+      comparison_time_range:
+        end: 2022-01-03T00:00:00Z
+        start: 2022-01-01T00:00:00Z
+      sort:
+        - name: time__day
+      where:
+        cond:
+          op: in
+          exprs:
+            - val: country
+            - val: US
   - name: iso_ranges_duckdb
     resolver: metrics
     properties:

--- a/runtime/resolvers/testdata/metrics_comparisons.yaml
+++ b/runtime/resolvers/testdata/metrics_comparisons.yaml
@@ -164,19 +164,17 @@ tests:
             comparison_value:
               measure: sum
       time_range:
-        end: 2024-01-05T00:00:00Z
+        end: 2024-01-04T00:00:00Z
         start: 2024-01-03T00:00:00Z
       comparison_time_range:
-        end: 2024-01-03T00:00:00Z
+        end: 2024-01-02T00:00:00Z
         start: 2024-01-01T00:00:00Z
       sort:
         - name: time__day
-      where:
-        cond:
-          op: in
-          exprs:
-            - val: country
-            - val: IN
+    result:
+      - sum: 3
+        sum_prev: 1
+        time__day: "2024-01-03T00:00:00Z"
   - name: iso_ranges_duckdb
     resolver: metrics
     properties:
@@ -197,9 +195,9 @@ tests:
       sort:
         - name: sum
     result:
-      - sum: 7
+      - country: US
+        sum: 7
         sum_prev: 2
-        country: "US"
   - name: iso_ranges_clickhouse
     resolver: metrics
     properties:
@@ -220,9 +218,9 @@ tests:
       sort:
         - name: sum
     result:
-      - sum: 7
+      - country: US
+        sum: 7
         sum_prev: 2
-        country: "US"
   - name: rill_time_ranges_duckdb
     resolver: metrics
     properties:
@@ -242,12 +240,12 @@ tests:
       sort:
         - name: sum
     result:
-      - sum: 5
+      - country: DK
+        sum: 5
         sum_prev: 1
-        country: "DK"
-      - sum: 7
+      - country: US
+        sum: 7
         sum_prev: 2
-        country: "US"
   - name: rill_time_ranges_clickhouse
     resolver: metrics
     properties:
@@ -267,9 +265,9 @@ tests:
       sort:
         - name: sum
     result:
-      - sum: 5
+      - country: DK
+        sum: 5
         sum_prev: 1
-        country: "DK"
-      - sum: 7
+      - country: US
+        sum: 7
         sum_prev: 2
-        country: "US"


### PR DESCRIPTION
Without the fix, test will use cached results from previous query and thus fail. Cause of this failure as well -https://github.com/rilldata/rill/actions/runs/13655204432/job/38178639449