### PR TITLE
refac: create range spec for measure axis formatting

### DIFF
--- a/web-common/src/components/data-graphic/guides/Axis.svelte
+++ b/web-common/src/components/data-graphic/guides/Axis.svelte
@@ -2,9 +2,6 @@
 This component will draw an axis on the specified side.
 -->
 <script lang="ts">
-  import { NumberKind } from "@rilldata/web-common/lib/number-formatting/humanizer-types";
-  import { SingleDigitTimesPowerOfTenFormatter } from "@rilldata/web-common/lib/number-formatting/strategies/SingleDigitTimesPowerOfTen";
-  import { formatMsInterval } from "@rilldata/web-common/lib/number-formatting/strategies/intervals";
   import { getContext } from "svelte";
   import { contexts } from "../constants";
   import type { ScaleStore, SimpleConfigurationStore } from "../state/types";
@@ -21,7 +18,9 @@ This component will draw an axis on the specified side.
   export let placement = "middle";
 
   export let labelColor = "fill-gray-600";
-  export let numberKind: NumberKind = NumberKind.ANY;
+  export let measureFormatter: (
+    v: number | string | null | undefined,
+  ) => string | undefined | null = (v) => v?.toString();
 
   // superlabel properties
   export let superlabel = false;
@@ -161,20 +160,7 @@ This component will draw an axis on the specified side.
     );
   } else {
     superlabel = false;
-    // Note that SingleDigitTimesPowerOfTenFormatter expects a single
-    // digit time a power of ten. The d3 axis function used upstream
-    // in this context _normally_ satisfies this requirement, but
-    // there are edge cases where it does not. In these edge cases,
-    // this formatter often does the right thing, but may not in some
-    // circumstances. See https://github.com/rilldata/rill/issues/3631
-    const formatter = new SingleDigitTimesPowerOfTenFormatter(ticks, {
-      numberKind,
-      padWithInsignificantZeros: false,
-    });
-    formatterFunction = (x) =>
-      numberKind === "INTERVAL"
-        ? formatMsInterval(x)
-        : formatter.stringFormat(x);
+    formatterFunction = measureFormatter;
   }
 </script>
 

--- a/web-common/src/features/dashboards/time-series/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureChart.svelte
@@ -10,6 +10,7 @@
     Grid,
   } from "@rilldata/web-common/components/data-graphic/guides";
   import { ScaleType } from "@rilldata/web-common/components/data-graphic/state";
+  import type { ScaleStore } from "@rilldata/web-common/components/data-graphic/state/types";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
   import { tableInteractionStore } from "@rilldata/web-common/features/dashboards/time-dimension-details/time-dimension-data-store";
@@ -41,7 +42,6 @@
     localToTimeZoneOffset,
     niceMeasureExtents,
   } from "./utils";
-  import type { ScaleStore } from "@rilldata/web-common/components/data-graphic/state/types";
 
   export let measure: MetricsViewSpecMeasureV2;
   export let exploreName: string;
@@ -76,6 +76,11 @@
     v.toString();
 
   $: mouseoverFormat = createMeasureValueFormatter<null | undefined>(measure);
+  $: axisFormat = createMeasureValueFormatter<null | undefined>(
+    measure,
+    "axis",
+  );
+
   $: numberKind = numberKindForMeasure(measure);
 
   const tweenProps = { duration: 400, easing: cubicOut };
@@ -265,7 +270,7 @@
     yMin={internalYMin}
     yMinTweenProps={tweenProps}
   >
-    <Axis {numberKind} side="right" />
+    <Axis measureFormatter={axisFormat} side="right" />
     <Grid />
     <MeasurePan
       on:pan={(e) => updateRange(e.detail.start, e.detail.end)}

--- a/web-common/src/lib/number-formatting/format-measure-value.ts
+++ b/web-common/src/lib/number-formatting/format-measure-value.ts
@@ -23,6 +23,11 @@ import {
 } from "./strategies/intervals";
 import { PerRangeFormatter } from "./strategies/per-range";
 import {
+  axisCurrencyOptions,
+  axisDefaultFormattingOptions,
+  axisPercentOptions,
+} from "./strategies/per-range-axis-options";
+import {
   bigNumCurrencyOptions,
   bigNumDefaultFormattingOptions,
   bigNumPercentOptions,
@@ -71,6 +76,13 @@ function humanizeDataType(
       currencyEur: bigNumCurrencyOptions(NumberKind.EURO),
       percent: bigNumPercentOptions,
       humanize: bigNumDefaultFormattingOptions,
+    },
+    axis: {
+      none: axisDefaultFormattingOptions,
+      currencyUsd: axisCurrencyOptions(NumberKind.DOLLAR),
+      currencyEur: axisCurrencyOptions(NumberKind.EURO),
+      percent: axisPercentOptions,
+      humanize: axisDefaultFormattingOptions,
     },
     table: {
       none: defaultNoFormattingOptions,
@@ -156,6 +168,7 @@ export function createMeasureValueFormatter<T extends null | undefined = never>(
 ): (value: number | string | T) => string | T {
   const useUnabridged = type === "unabridged";
   const isBigNumber = type === "big-number";
+  const isAxis = type === "axis";
   const isTooltip = type === "tooltip";
 
   let humanizer: (value: number, type: FormatPreset) => string;
@@ -196,7 +209,7 @@ export function createMeasureValueFormatter<T extends null | undefined = never>(
         if (typeof value !== "number") return value;
 
         // For the Big Number and Tooltips, override the d3formatter
-        if (isBigNumber || isTooltip) {
+        if (isBigNumber || isTooltip || isAxis) {
           if (hasCurrencySymbol) {
             if (isValidLocale && measureSpec?.formatD3Locale?.currency) {
               const currency = measureSpec.formatD3Locale.currency as [
@@ -232,7 +245,7 @@ export function createMeasureValueFormatter<T extends null | undefined = never>(
       ? (measureSpec.formatPreset as FormatPreset)
       : FormatPreset.NONE;
 
-  if (isBigNumber && formatPreset === FormatPreset.NONE) {
+  if ((isAxis || isBigNumber) && formatPreset === FormatPreset.NONE) {
     formatPreset = FormatPreset.HUMANIZE;
   }
 

--- a/web-common/src/lib/number-formatting/format-measure-value.ts
+++ b/web-common/src/lib/number-formatting/format-measure-value.ts
@@ -208,7 +208,7 @@ export function createMeasureValueFormatter<T extends null | undefined = never>(
       return (value: number | string | T) => {
         if (typeof value !== "number") return value;
 
-        // For the Big Number and Tooltips, override the d3formatter
+        // For the Big Number, Axis and Tooltips, override the d3formatter
         if (isBigNumber || isTooltip || isAxis) {
           if (hasCurrencySymbol) {
             if (isValidLocale && measureSpec?.formatD3Locale?.currency) {

--- a/web-common/src/lib/number-formatting/humanizer-types.ts
+++ b/web-common/src/lib/number-formatting/humanizer-types.ts
@@ -307,6 +307,7 @@ export type FormatterContext =
   | "table"
   | "unabridged"
   | "big-number"
+  | "axis"
   | "tooltip";
 
 export type FormatterContextSurface = Exclude<FormatterContext, "unabridged">;

--- a/web-common/src/lib/number-formatting/strategies/per-range-axis-options.ts
+++ b/web-common/src/lib/number-formatting/strategies/per-range-axis-options.ts
@@ -36,7 +36,6 @@ export const axisDefaultFormattingOptions: FormatterOptionsCommon &
   numberKind: NumberKind.ANY,
   rangeSpecs: axisRangeSpec,
   defaultMaxDigitsRight: 0,
-  padWithInsignificantZeros: false,
 };
 
 export const axisPercentOptions: FormatterOptionsCommon &

--- a/web-common/src/lib/number-formatting/strategies/per-range-axis-options.ts
+++ b/web-common/src/lib/number-formatting/strategies/per-range-axis-options.ts
@@ -1,0 +1,55 @@
+import {
+  type FormatterOptionsCommon,
+  type FormatterRangeSpecsStrategy,
+  NumberKind,
+  type RangeFormatSpec,
+} from "../humanizer-types";
+
+const axisRangeSpec: RangeFormatSpec[] = [
+  {
+    minMag: -4,
+    supMag: -2,
+    maxDigitsRight: 3,
+    baseMagnitude: 0,
+    padWithInsignificantZeros: false,
+  },
+  {
+    minMag: -2,
+    supMag: 3,
+    maxDigitsRight: 2,
+    baseMagnitude: 0,
+    useTrailingDot: false,
+    padWithInsignificantZeros: false,
+  },
+  {
+    minMag: 3,
+    supMag: 11,
+    maxDigitsRight: 2,
+    baseMagnitude: 0,
+    useTrailingDot: false,
+    padWithInsignificantZeros: false,
+  },
+];
+
+export const axisDefaultFormattingOptions: FormatterOptionsCommon &
+  FormatterRangeSpecsStrategy = {
+  numberKind: NumberKind.ANY,
+  rangeSpecs: axisRangeSpec,
+  defaultMaxDigitsRight: 0,
+  padWithInsignificantZeros: false,
+};
+
+export const axisPercentOptions: FormatterOptionsCommon &
+  FormatterRangeSpecsStrategy = {
+  rangeSpecs: axisRangeSpec,
+  defaultMaxDigitsRight: 0,
+  numberKind: NumberKind.PERCENT,
+};
+
+export const axisCurrencyOptions = (
+  numberKind: NumberKind,
+): FormatterOptionsCommon & FormatterRangeSpecsStrategy => ({
+  rangeSpecs: axisRangeSpec,
+  defaultMaxDigitsRight: 0,
+  numberKind,
+});


### PR DESCRIPTION
https://github.com/rilldata/rill-private-issues/issues/1346


For axis formatting, replace `NumberKind` with measure formatter.
Create a new formatter context for `axis`

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!


