### PR TITLE
Fix: handle special characters in charts

### DIFF
--- a/web-common/src/features/canvas/components/charts/area/spec.ts
+++ b/web-common/src/features/canvas/components/charts/area/spec.ts
@@ -41,6 +41,8 @@ export function generateVLAreaChartSpec(
       type: config.x?.type,
       ...(config.x.type === "temporal" && { format: "%b %d, %Y %H:%M" }),
     });
+
+    multiValueTooltipChannel = multiValueTooltipChannel.slice(0, 50);
   }
 
   spec.layer = [

--- a/web-common/src/features/canvas/components/charts/line-chart/spec.ts
+++ b/web-common/src/features/canvas/components/charts/line-chart/spec.ts
@@ -41,6 +41,8 @@ export function generateVLLineChartSpec(
       type: config.x?.type,
       ...(config.x.type === "temporal" && { format: "%b %d, %Y %H:%M" }),
     });
+
+    multiValueTooltipChannel = multiValueTooltipChannel.slice(0, 50);
   }
 
   spec.encoding = { x: createXEncoding(config, data) };

--- a/web-common/src/features/templates/charts/utils.ts
+++ b/web-common/src/features/templates/charts/utils.ts
@@ -25,7 +25,11 @@ export function multiLayerBaseSpec() {
 
 export function sanitizeValueForVega(value: unknown) {
   if (typeof value === "string") {
-    return value.replace(/[\.\-\{\}\[\]]/g, (match) => `\\${match}`); //eslint-disable-line
+    // Escape all special characters including quotes, brackets, operators, etc.
+    return value.replace(
+      /[!@#$%^&*()+=\-[\]\\';,./{}|":<>?~_]/g,
+      (match) => `\\${match}`,
+    );
   } else {
     return String(value);
   }

--- a/web-common/src/features/templates/charts/utils.ts
+++ b/web-common/src/features/templates/charts/utils.ts
@@ -27,7 +27,7 @@ export function sanitizeValueForVega(value: unknown) {
   if (typeof value === "string") {
     // Escape all special characters including quotes, brackets, operators, etc.
     return value.replace(
-      /[!@#$%^&*()+=\-[\]\\';,./{}|":<>?~_]/g,
+      /[!@#$%^&*()+=\-[\]\\';,./{}|:<>?~]/g,
       (match) => `\\${match}`,
     );
   } else {


### PR DESCRIPTION
The line and area charts would break when there were other special characters like `'`. This PR addresses it by escaping them.


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
