### PR TITLE
fix: `mergeFilter` not working as expected for `in` and `not in` expressions for same dimension

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-merge-filters.spec.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-merge-filters.spec.ts
@@ -1,0 +1,59 @@
+import { mergeFilters } from "@rilldata/web-common/features/dashboards/pivot/pivot-merge-filters";
+import {
+  createInExpression,
+  createAndExpression,
+} from "@rilldata/web-common/features/dashboards/stores/filter-utils";
+import { convertExpressionToFilterParam } from "@rilldata/web-common/features/dashboards/url-state/filters/converters";
+import { describe, it, expect } from "vitest";
+
+describe("mergeFilters", () => {
+  it("merge in filters", () => {
+    expect(
+      convertExpressionToFilterParam(
+        mergeFilters(
+          createAndExpression([
+            createInExpression("publisher", ["Facebook", "Yahoo"]),
+            createInExpression("publisher", ["Google"], true),
+          ]),
+          createAndExpression([
+            createInExpression("publisher", ["Facebook", "Microsoft"]),
+            createInExpression("publisher", [null], true),
+          ]),
+        )!,
+      ),
+    ).toEqual(`publisher IN ('Facebook') AND publisher NIN ('Google',null)`);
+  });
+
+  it("merge filters without wrappers", () => {
+    expect(
+      convertExpressionToFilterParam(
+        mergeFilters(
+          createAndExpression([
+            createInExpression("publisher", ["Facebook", "Microsoft"]),
+          ]),
+          createInExpression("publisher", ["Facebook", "Yahoo"]),
+        )!,
+      ),
+    ).toEqual(`publisher IN ('Facebook')`);
+
+    expect(
+      convertExpressionToFilterParam(
+        mergeFilters(
+          createInExpression("publisher", ["Facebook", "Microsoft"]),
+          createAndExpression([
+            createInExpression("publisher", ["Facebook", "Yahoo"]),
+          ]),
+        )!,
+      ),
+    ).toEqual(`publisher IN ('Facebook')`);
+
+    expect(
+      convertExpressionToFilterParam(
+        mergeFilters(
+          createInExpression("publisher", ["Facebook", "Microsoft"]),
+          createInExpression("publisher", ["Facebook", "Yahoo"]),
+        )!,
+      ),
+    ).toEqual(`publisher IN ('Facebook')`);
+  });
+});

--- a/web-common/src/features/dashboards/pivot/pivot-merge-filters.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-merge-filters.ts
@@ -2,20 +2,12 @@ import {
   copyFilterExpression,
   createAndExpression,
   forEachIdentifier,
+  wrapNonJoinerExpression,
 } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
 import {
   V1Operation,
   type V1Expression,
 } from "@rilldata/web-common/runtime-client";
-
-function valueIntersection(
-  valueArray1: V1Expression[],
-  valueArray2: V1Expression[],
-) {
-  return valueArray1.filter((obj1) =>
-    valueArray2.some((obj2) => obj1.val === obj2.val),
-  );
-}
 
 export function mergeFilters(
   filter1: V1Expression | undefined,
@@ -24,8 +16,12 @@ export function mergeFilters(
   if (!filter1 && !filter2) return undefined;
   if (!filter1) return filter2;
   if (!filter2) return filter1;
+  filter1 = wrapNonJoinerExpression(filter1);
+  filter2 = wrapNonJoinerExpression(filter2);
 
+  // IN and NIN are merged separately. So maintain separate references
   const inExprMap = new Map<string, V1Expression>();
+  const notInExprMap = new Map<string, V1Expression>();
   const likeExprMap = new Map<string, V1Expression>();
 
   // build a map of identifier to IN and LIKE expressions separately
@@ -36,9 +32,12 @@ export function mergeFilters(
     ) {
       if (likeExprMap.has(ident)) return;
       likeExprMap.set(ident, e);
-    } else {
+    } else if (e.cond?.op === V1Operation.OPERATION_IN) {
       if (inExprMap.has(ident) || !!e.cond?.exprs?.[1]?.subquery) return;
       inExprMap.set(ident, e);
+    } else if (e.cond?.op === V1Operation.OPERATION_NIN) {
+      if (notInExprMap.has(ident) || !!e.cond?.exprs?.[1]?.subquery) return;
+      notInExprMap.set(ident, e);
     }
   });
 
@@ -51,31 +50,41 @@ export function mergeFilters(
       e.cond?.op === V1Operation.OPERATION_NLIKE
     )
       return;
-    if (!inExprMap.has(ident) || !!e.cond?.exprs?.[1]?.subquery) return;
+    if (e.cond?.exprs?.[1]?.subquery) return;
 
-    /**
-     * We take an intersection of the values in the IN expressions.
-     * This is to make sure sorting, row expansion filter all work as
-     * expected along with global filters. Otherwise, we would get data
-     * for a larger subset than intended
-     */
-    const inExpr = inExprMap.get(ident);
-    const inExprVals = inExpr?.cond?.exprs?.slice(1) ?? [];
-    const exprVals = e.cond?.exprs?.slice(1) ?? [];
-    const intersection = valueIntersection(inExprVals, exprVals);
-    if (intersection.length === 0) {
-      // no intersection, remove the identifier from the map
+    if (inExprMap.has(ident) && e.cond?.op === V1Operation.OPERATION_IN) {
+      /**
+       * We take an intersection of the values in the IN expressions.
+       * This is to make sure sorting, row expansion filter all work as
+       * expected along with global filters. Otherwise, we would get data
+       * for a larger subset than intended
+       */
+      const inExpr = inExprMap.get(ident)!;
+      // replace the expression with the intersection
+      e.cond.exprs = [{ ident }, ...valueIntersection(inExpr, e)];
+      // remove the identifier from the map
       inExprMap.delete(ident);
-      return;
+    } else if (
+      notInExprMap.has(ident) &&
+      e.cond?.op === V1Operation.OPERATION_NIN
+    ) {
+      const notInExpr = notInExprMap.get(ident)!;
+      // replace the expression with the union
+      e.cond.exprs = [{ ident }, ...valueUnion(notInExpr, e)];
+      // remove the identifier from the map
+      notInExprMap.delete(ident);
     }
-    // replace the expression with the intersection
-    e.cond!.exprs = [{ ident }, ...intersection]; // asserting that e.cond is not undefined
-    // remove the identifier from the map
-    inExprMap.delete(ident);
   });
 
   // add the remaining in expressions
   inExprMap.forEach((ie) => {
+    if (!filter2.cond?.exprs) {
+      filter2.cond!.exprs = [copyFilterExpression(ie)];
+    }
+    filter2.cond?.exprs?.push(copyFilterExpression(ie));
+  });
+  // add the remaining in expressions
+  notInExprMap.forEach((ie) => {
     if (!filter2.cond?.exprs) {
       filter2.cond!.exprs = [copyFilterExpression(ie)];
     }
@@ -90,4 +99,32 @@ export function mergeFilters(
   });
 
   return filter2;
+}
+
+function valueIntersection(inExpr1: V1Expression, inExpr2: V1Expression) {
+  const inExpr1Vals = inExpr1?.cond?.exprs?.slice(1) ?? [];
+  const inExpr2Vals = inExpr2.cond?.exprs?.slice(1) ?? [];
+
+  const intersection = inExpr1Vals.filter((obj1) =>
+    inExpr2Vals.some((obj2) => obj1.val === obj2.val),
+  );
+  // backwards compatibility. if there are no intersections, retain from expr1
+  if (intersection.length === 0) return inExpr1Vals;
+  return intersection;
+}
+
+function valueUnion(notInExpr1: V1Expression, notInExpr2: V1Expression) {
+  const notInExpr1Vals = notInExpr1?.cond?.exprs?.slice(1) ?? [];
+  const notInExpr2Vals = notInExpr2.cond?.exprs?.slice(1) ?? [];
+
+  const seen = new Set(notInExpr1Vals.map((o1) => o1.val));
+  const unionValues = [...notInExpr1Vals];
+
+  notInExpr2Vals.forEach((o2) => {
+    if (seen.has(o2.val)) return;
+    unionValues.push(o2);
+    seen.add(o2.val);
+  });
+
+  return unionValues;
 }

--- a/web-common/src/features/dashboards/stores/filter-utils.ts
+++ b/web-common/src/features/dashboards/stores/filter-utils.ts
@@ -421,3 +421,8 @@ export function buildValidMetricsViewFilter(
     undefined,
   );
 }
+
+export function wrapNonJoinerExpression(expr: V1Expression): V1Expression {
+  if (isJoinerExpression(expr)) return expr;
+  return createAndExpression([expr]);
+}


### PR DESCRIPTION
`mergeFilter` method is used in some places to easily apply additional filters on top of the global filter set. It was not handling both `in` and `not in` expressions for the same dimension.

Handling `in` and `not in` separately. Also supporting merging non-joiner expressions.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
