### PR TITLE
feat: skip rate limiting on cache connection error

### DIFF
--- a/runtime/server/server.go
+++ b/runtime/server/server.go
@@ -332,6 +332,12 @@ func mapGRPCError(err error) error {
 }
 
 func (s *Server) checkRateLimit(ctx context.Context) (context.Context, error) {
+	// If the connection to the cache server is lost, skip rate limiting.
+	if err := s.limiter.Ping(ctx); err != nil {
+		s.logger.Warn("skipping rate limiting due to cache connection error", zap.Error(err))
+		return ctx, nil
+	}
+
 	// Any request type might be limited separately as it is part of Metadata
 	// Any request type might be excluded from this limit check and limited later,
 	// e.g. in the corresponding request handler by calling s.limiter.Limit(ctx, "limitKey", redis_rate.PerMinute(100))


### PR DESCRIPTION
[Cache unavailability should be a no-op for runtimes/admin](https://github.com/rilldata/rill-private-issues/issues/1274)

If the cache is unavailable, we can bypass the rate limiting middleware. This will avoid unnecessary errors from the middleware and only errors from the cache connection.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
