### PR TITLE
Fix: preserve local filters for canvas on refresh

### DIFF
--- a/web-common/src/features/canvas/stores/canvas-component.ts
+++ b/web-common/src/features/canvas/stores/canvas-component.ts
@@ -32,22 +32,12 @@ export class CanvasComponentState {
     this.localFilters = new Filters(spec);
     this.localTimeControls = new TimeControls(specStore, name);
 
-    if (
-      componentResource &&
-      componentResource.rendererProperties?.dimension_filters
-    ) {
-      this.localFilters.setFiltersFromText(
-        componentResource.rendererProperties?.dimension_filters as string,
-      );
+    if (componentResource && this.filterText) {
+      this.localFilters.setFiltersFromText(this.filterText);
     }
 
-    if (
-      componentResource &&
-      componentResource.rendererProperties?.time_filters
-    ) {
-      this.localTimeControls.setTimeFiltersFromText(
-        componentResource.rendererProperties?.time_filters as string,
-      );
+    if (componentResource && this.timeFilterText) {
+      this.localTimeControls.setTimeFiltersFromText(this.timeFilterText);
     }
   }
 }

--- a/web-common/src/features/canvas/stores/time-control.ts
+++ b/web-common/src/features/canvas/stores/time-control.ts
@@ -475,5 +475,7 @@ export class TimeControls {
     this.selectedTimeRange.set(selectedTimeRange);
     this.selectedComparisonTimeRange.set(selectedComparisonTimeRange);
     this.showTimeComparison.set(showTimeComparison);
+
+    this.isInitialStateSet = true;
   };
 }


### PR DESCRIPTION

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
