### PR TITLE
Refac: Move to canvas from svg for vega charts

### DIFF
--- a/web-common/src/components/vega/VegaLiteRenderer.svelte
+++ b/web-common/src/components/vega/VegaLiteRenderer.svelte
@@ -39,7 +39,7 @@
 
   $: options = <EmbedOptions>{
     config: config || getRillTheme(canvasDashboard),
-    renderer: "svg",
+    renderer: "canvas",
     actions: false,
     logLevel: 0, // only show errors
     width: canvasDashboard ? width : undefined,


### PR DESCRIPTION
With an increased number of elements and custom tooltip objects in our charts, using SVG is causing subtle lag. In this PR, I’m switching Vega’s renderer from SVG to Canvas. I did some preliminary QA, and the performance appears to be improved.


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
