### PR TITLE
e2e (Cloud): Add dedicated test project

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -17,6 +17,7 @@ temp/
 dev-project/
 proto/
 playwright-report/
+web-admin/tests/setup/projects
 web-local/tests/data/projects
 
 .env

--- a/web-admin/.gitignore
+++ b/web-admin/.gitignore
@@ -1,3 +1,5 @@
 /.svelte-kit
 build
+tests/setup/projects/**/.rillcloud
+tests/setup/projects/**/tmp
 tests/embed.html

--- a/web-admin/tests/embeds.spec.ts
+++ b/web-admin/tests/embeds.spec.ts
@@ -1,7 +1,5 @@
-import { expect } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import { test } from "./setup/base";
-
-import { type Page } from "@playwright/test";
 
 async function waitForReadyMessage(embedPage: Page, logMessages: string[]) {
   return new Promise<void>((resolve) => {
@@ -28,7 +26,7 @@ test.describe("Embeds", () => {
     await frame.getByRole("menuitem", { name: "UTC GMT +00:00 UTC" }).click();
 
     await expect(
-      frame.getByRole("button", { name: "Advertising Spend Overall $1.30M" }),
+      frame.getByRole("button", { name: "Advertising Spend Overall $20,603" }),
     ).toBeVisible();
   });
 
@@ -40,7 +38,7 @@ test.describe("Embeds", () => {
     await frame.getByLabel("Timezone selector").click();
     await frame.getByRole("menuitem", { name: "UTC GMT +00:00 UTC" }).click();
 
-    await frame.getByRole("row", { name: "Instacart $107.3k" }).click();
+    await frame.getByRole("row", { name: "Instacart $2.1k" }).click();
     await embedPage.waitForTimeout(500);
 
     expect(
@@ -58,7 +56,7 @@ test.describe("Embeds", () => {
     await frame.getByLabel("Timezone selector").click();
     await frame.getByRole("menuitem", { name: "UTC GMT +00:00 UTC" }).click();
 
-    await frame.getByRole("row", { name: "Instacart $107.3k" }).click();
+    await frame.getByRole("row", { name: "Instacart $2.1k" }).click();
     await embedPage.waitForTimeout(500);
 
     await embedPage.evaluate(() => {
@@ -95,7 +93,7 @@ test.describe("Embeds", () => {
 
     await expect(frame.getByLabel("Timezone selector")).toHaveText("UTC");
     await expect(
-      frame.getByRole("row", { name: "Instacart $107.3k" }),
+      frame.getByRole("row", { name: "Instacart $2.1k" }),
     ).toBeVisible();
     expect(
       logMessages.some((msg) => msg.includes(`{"id":1337,"result":true}`)),

--- a/web-admin/tests/embeds.spec.ts
+++ b/web-admin/tests/embeds.spec.ts
@@ -22,9 +22,6 @@ test.describe("Embeds", () => {
   test("embeds should load", async ({ embedPage }) => {
     const frame = embedPage.frameLocator("iframe");
 
-    await frame.getByLabel("Timezone selector").click();
-    await frame.getByRole("menuitem", { name: "UTC GMT +00:00 UTC" }).click();
-
     await expect(
       frame.getByRole("button", { name: "Advertising Spend Overall $20,603" }),
     ).toBeVisible();
@@ -35,15 +32,12 @@ test.describe("Embeds", () => {
     await waitForReadyMessage(embedPage, logMessages);
     const frame = embedPage.frameLocator("iframe");
 
-    await frame.getByLabel("Timezone selector").click();
-    await frame.getByRole("menuitem", { name: "UTC GMT +00:00 UTC" }).click();
-
     await frame.getByRole("row", { name: "Instacart $2.1k" }).click();
     await embedPage.waitForTimeout(500);
 
     expect(
       logMessages.some((msg) =>
-        msg.includes("tz=UTC&f=advertiser_name+IN+('Instacart')"),
+        msg.includes("f=advertiser_name+IN+('Instacart')"),
       ),
     ).toBeTruthy();
   });
@@ -52,9 +46,6 @@ test.describe("Embeds", () => {
     const logMessages: string[] = [];
     await waitForReadyMessage(embedPage, logMessages);
     const frame = embedPage.frameLocator("iframe");
-
-    await frame.getByLabel("Timezone selector").click();
-    await frame.getByRole("menuitem", { name: "UTC GMT +00:00 UTC" }).click();
 
     await frame.getByRole("row", { name: "Instacart $2.1k" }).click();
     await embedPage.waitForTimeout(500);
@@ -68,7 +59,7 @@ test.describe("Embeds", () => {
     expect(
       logMessages.some((msg) =>
         msg.includes(
-          `{"id":1337,"result":{"state":"tz=UTC&f=advertiser_name+IN+('Instacart')"}}`,
+          `{"id":1337,"result":{"state":"f=advertiser_name+IN+('Instacart')"}}`,
         ),
       ),
     ).toBeTruthy();
@@ -85,13 +76,12 @@ test.describe("Embeds", () => {
         {
           id: 1337,
           method: "setState",
-          params: "tz=UTC&f=advertiser_name+IN+('Instacart')",
+          params: "f=advertiser_name+IN+('Instacart')",
         },
         "*",
       );
     });
 
-    await expect(frame.getByLabel("Timezone selector")).toHaveText("UTC");
     await expect(
       frame.getByRole("row", { name: "Instacart $2.1k" }),
     ).toBeVisible();

--- a/web-admin/tests/explores.spec.ts
+++ b/web-admin/tests/explores.spec.ts
@@ -11,10 +11,6 @@ test.describe("Explores", () => {
       .first()
       .click();
 
-    // Set the time zone to UTC
-    await page.getByLabel("Timezone selector").click();
-    await page.getByRole("menuitem", { name: "UTC GMT +00:00 UTC" }).click();
-
     // Check the Big Number
     await expect(
       page.getByRole("button", { name: "Requests 6.60M" }),

--- a/web-admin/tests/explores.spec.ts
+++ b/web-admin/tests/explores.spec.ts
@@ -17,7 +17,7 @@ test.describe("Explores", () => {
 
     // Check the Big Number
     await expect(
-      page.getByRole("button", { name: "Requests 547M" }),
+      page.getByRole("button", { name: "Requests 6.60M" }),
     ).toBeVisible();
   });
 });

--- a/web-admin/tests/setup/projects/openrtb/README.md
+++ b/web-admin/tests/setup/projects/openrtb/README.md
@@ -1,0 +1,47 @@
+# OpenRTB Programmatic Advertising
+
+This is a demo project designed to illustrate using Rill to analyze programmatic bid logs using the canonical open RTB framework. 
+
+If you have added the full Rill Example project, run `rill start` from this directory to get started.
+
+To run this example specifically:
+
+```
+git clone https://github.com/rilldata/rill-examples.git
+cd rill-examples/rill-openrtb-prog-ads
+rill start
+```
+
+Rill will build your project from data sources to dashboard and then launch in a new browser window.
+
+## Overview
+This dataset contains a week of sampled programmatic bid stream data in two data sources - Auctions and Bids. 
+
+Advertisers, DSPs, SSPs, and Publishers will all recognize the familiar metrics (auctions, bids, wins, bid price, bid floor) and dimensions (domain, device details, app/site, etc). Rill’s was born out of a long history with programmatic data via Metamarkets and is well-suited for this type of analysis. More details on OpenRTB via the IAB: https://iabtechlab.com/standards/openrtb/.
+
+## Data Model
+In these datasets, you’ll see:
+
+Auction Data:
+  - Illustrative Bid Requests sent to advertisers for programmatic bidding 
+
+Bid Data: 
+  - Illustrative Bid Responses to those requests including bid prices, winning bids, and advertiser information
+
+## Dashboard Details
+
+For Buyers:
+  - Manage all campaigns across multiple supply sources
+  - View inventory and audience availability to avoid missing key opportunities and to optimize spend
+
+For Sellers:
+  - See both direct and indirect channels across your digital assets
+  - Quickly slice and dice inventory to find trends and discover revenue opportunities
+
+For Marketplaces/Technology Providers:
+  - Troubleshoot campaigns and quickly identify ad server issues
+  - Instantly view top-line revenue, volume, eCPM, and other key metrics without pulling complex reports
+
+## Extra Dashboard
+
+An additional dashboard is created with row policies enabled for specific emails. This is used in our embed examples found, [here](https://rill-embedding-example.netlify.app/).

--- a/web-admin/tests/setup/projects/openrtb/dashboards/auction_explore.yaml
+++ b/web-admin/tests/setup/projects/openrtb/dashboards/auction_explore.yaml
@@ -1,0 +1,45 @@
+# Explore YAML
+# Reference documentation: https://docs.rilldata.com/reference/project-files/explores
+
+type: explore
+
+title: "Programmatic Ads Auction"
+metrics_view: auction_metrics
+
+dimensions: '*'
+measures: '*'
+
+time_zones:
+  - America/Los_Angeles
+  - America/Chicago
+  - America/New_York
+  - Europe/London
+  - Europe/Paris
+
+embeds:
+  hide_pivot: true
+defaults:
+  measures:
+    - requests
+    - avg_bid_floor
+    - 1d_qps
+  dimensions:
+    - app_site_name
+    - app_site_domain
+    - pub_name
+    - app_site_cat
+    - ad_size
+    - device_state
+    - device_osv
+    - bid_floor_bucket
+    - platform_browser
+    - device_os
+    - device_type
+    - ad_position
+    - video_max_duration_bucket
+    - video_min_duration_bucket
+    - placement_type
+    - auction_type
+    - app_or_site
+    - device_country
+  time_range: P7D

--- a/web-admin/tests/setup/projects/openrtb/dashboards/auction_explore.yaml
+++ b/web-admin/tests/setup/projects/openrtb/dashboards/auction_explore.yaml
@@ -10,6 +10,7 @@ dimensions: '*'
 measures: '*'
 
 time_zones:
+  - UTC
   - America/Los_Angeles
   - America/Chicago
   - America/New_York

--- a/web-admin/tests/setup/projects/openrtb/dashboards/bids_explore.yaml
+++ b/web-admin/tests/setup/projects/openrtb/dashboards/bids_explore.yaml
@@ -1,0 +1,64 @@
+# Explore YAML
+# Reference documentation: https://docs.rilldata.com/reference/project-files/explores
+
+type: explore
+
+title: "Programmatic Ads Bids"
+metrics_view: bids_metrics
+
+dimensions: '*'
+measures: '*'
+
+#default:
+#  time_range: "PT24H"
+
+time_zones:
+  - America/Los_Angeles
+  - America/Chicago
+  - America/New_York
+  - Europe/London
+  - Europe/Paris
+  - Asia/Jerusalem
+  - Europe/Moscow
+  - Asia/Kolkata
+  - Asia/Shanghai
+  - Asia/Tokyo
+  - Australia/Sydney
+defaults:
+  measures:
+    - overall_spend
+    - total_bids
+    - impressions
+    - win_rate
+    - clicks
+    - ctr
+    - video_starts
+    - video_completes
+    - video_completion_rate
+    - avg_bid_price
+    - ecpm
+    - avg_bid_floor
+  dimensions:
+    - adomain
+    - advertiser_name
+    - app_or_site
+    - sites_domain
+    - app_site_name
+    - auction_type
+    - bid_floor_bucket
+    - campaign_name
+    - creative_type
+    - device_os
+    - device_osv
+    - device_region
+    - device_type
+    - interstitial
+    - line_item_name
+    - placement_type
+    - platform_browser
+    - player_size
+    - privacy
+    - pub_name
+    - sdk
+    - video_activity
+  time_range: P7D

--- a/web-admin/tests/setup/projects/openrtb/dashboards/bids_explore.yaml
+++ b/web-admin/tests/setup/projects/openrtb/dashboards/bids_explore.yaml
@@ -13,6 +13,7 @@ measures: '*'
 #  time_range: "PT24H"
 
 time_zones:
+  - UTC
   - America/Los_Angeles
   - America/Chicago
   - America/New_York

--- a/web-admin/tests/setup/projects/openrtb/metrics/auction_metrics.yaml
+++ b/web-admin/tests/setup/projects/openrtb/metrics/auction_metrics.yaml
@@ -1,0 +1,101 @@
+# Metrics view YAML
+# Reference documentation: https://docs.rilldata.com/reference/project-files/dashboards
+
+version: 1
+model: "auction_data_model"
+type: metrics_view
+
+timeseries: "__time"
+smallest_time_grain: "hour"
+
+measures:
+  - display_name: Requests
+    name: requests
+    expression: sum(bid_request_cnt)
+    description: Total Requests
+    format_preset: humanize
+  - display_name: "Avg Bid Floor"
+    name: avg_bid_floor
+    expression: "sum(bid_floor) / sum(has_bid_floor_cnt) "
+    description: "Average Bid Floor"
+    format_preset: currency_usd
+  - display_name: "1D QPS"
+    name: 1d_qps
+    expression: "sum(bid_request_cnt) / 86400 "
+    description: "1D QPS"
+    format_preset: humanize
+
+
+dimensions:
+  - name: app_site_name
+    display_name: App Site Name
+    column: app_site_name
+    description: ""
+  - display_name: App Site Domain
+    column: app_site_domain
+    description: ""
+    name: app_site_domain
+  - name: pub_name
+    display_name: Pub Name
+    column: pub_name
+    description: ""
+  - name: app_site_cat
+    display_name: App Site Cat
+    column: app_site_cat
+    description: ""
+  - name: ad_size
+    display_name: Ad Size
+    column: ad_size
+    description: ""
+  - name: device_state
+    display_name: Device State
+    column: device_state
+    description: ""
+  - name: device_osv
+    display_name: Device OS Version
+    column: device_osv
+    description: ""
+  - name: bid_floor_bucket
+    display_name: Bid Floor Bucket
+    column: bid_floor_bucket
+    description: ""
+  - name: platform_browser
+    display_name: Platform Browser
+    column: platform_browser
+    description: ""
+  - name: device_os
+    display_name: Device OS
+    column: device_os
+    description: ""
+  - name: device_type
+    display_name: Device Type
+    column: device_type
+    description: ""
+  - name: ad_position
+    display_name: Ad Position
+    column: ad_position
+    description: ""
+  - name: video_max_duration_bucket
+    display_name: Video Max Duration Bucket
+    column: video_max_duration_bucket
+    description: ""
+  - name: video_min_duration_bucket
+    display_name: Video Min Duration Bucket
+    column: video_min_duration_bucket
+    description: ""
+  - display_name: Placement Type
+    column: placement_type
+    description: ""
+    name: placement_type
+  - name: auction_type
+    display_name: Auction Type
+    column: auction_type
+    description: ""
+  - name: app_or_site
+    display_name: App or Site
+    column: app_or_site
+    description: ""
+  - name: device_country
+    display_name: "Device Country"
+    column: "device_country"
+    description: ""

--- a/web-admin/tests/setup/projects/openrtb/metrics/bids_metrics.yaml
+++ b/web-admin/tests/setup/projects/openrtb/metrics/bids_metrics.yaml
@@ -1,0 +1,158 @@
+# Metrics view YAML
+# Reference documentation: https://docs.rilldata.com/reference/project-files/dashboards
+
+version: 1
+model: "bids_data_model"
+type: metrics_view
+
+timeseries: "__time"
+smallest_time_grain: "hour"
+
+measures:
+  - display_name: Advertising Spend Overall
+    name: overall_spend
+    expression: sum(media_spend_usd)/1000
+    description: Total Spend
+    format_preset: currency_usd
+  - display_name: "Bids"
+    name: total_bids
+    expression: "sum(bid_cnt)"
+    description: "Total Bids"
+    format_preset: humanize
+  - display_name: "Impressions"
+    name: impressions
+    expression: "sum(imp_cnt)"
+    description: "Total Impressions"
+    format_preset: humanize
+  - display_name: "Win Rate"
+    name: win_rate
+    expression: "sum(imp_cnt)*1.0/sum(bid_cnt)"
+    description: "Impressions / Bids"
+    format_preset: percentage
+  - display_name: "Clicks"
+    name: clicks
+    expression: "sum(click_reg_cnt)"
+    description: "Total Clicks"
+    format_preset: humanize
+  - display_name: "CTR"
+    name: ctr
+    expression: "sum(click_reg_cnt)*1.0/sum(imp_cnt)"
+    description: "Click Through Rate"
+    format_preset: percentage
+  - display_name: "Video Starts"
+    name: video_starts
+    expression: "sum(video_start_cnt)"
+    description: "Total Video Starts"
+    format_preset: humanize
+  - display_name: "Video Completes"
+    name: video_completes
+    expression: "sum(video_complete_cnt)"
+    description: "Total Video Completes"
+    format_preset: humanize
+  - display_name: "Video Completion Rate"
+    name: video_completion_rate
+    expression: "sum(video_complete_cnt)*1.0/sum(video_start_cnt)"
+    description: "Video Completion Rate"
+    format_preset: percentage
+  - display_name: "Avg Bid Price"
+    name: avg_bid_price
+    expression: "sum(bid_price_usd)*1.0/sum(bid_cnt)/1000"
+    description: "Average Bid Price"
+    format_preset: currency_usd
+  - display_name: "eCPM"
+    name: ecpm
+    expression: "sum(media_spend_usd)*1.0/1000/sum(imp_cnt)"
+    description: "eCPM"
+    format_preset: currency_usd
+  - display_name: "Avg Bid Floor"
+    name: avg_bid_floor
+    expression: "sum(bid_floor)*1.0/sum(has_bid_floor_cnt)"
+    description: "Average Bid Floor"
+    format_preset: currency_usd
+
+dimensions:
+  - column: adomain
+    name: adomain
+    display_name: Adomain
+  - column: advertiser_name
+    name: advertiser_name
+    display_name: Advertiser Name
+  - display_name: App or Site
+    name: app_or_site
+    column: app_or_site
+    description: ""
+  - display_name: Site Domain
+    name: sites_domain
+    column: app_site_domain
+    description: ""
+  - column: app_site_name
+    name: app_site_name
+    display_name: App Name
+  - name: auction_type
+    display_name: Auction Type
+    column: auction_type
+    description: ""
+  - display_name: Bid Floor Bucket
+    column: bid_floor_bucket
+    description: ""
+    name: bid_floor_bucket
+  - name: campaign_name
+    display_name: Campaign Name
+    column: campaign_name
+    description: ""
+  - name: creative_type
+    display_name: Creative type
+    column: creative_type
+    description: ""
+  - name: device_os
+    display_name: Device OS
+    column: device_os
+    description:
+  - name: device_osv
+    display_name: Device OSV
+    column: device_osv
+    description: ""
+  - name: device_region
+    display_name: Device Region
+    column: device_region
+    description: ""
+  - display_name: Device Type
+    column: device_type
+    description: ""
+    name: device_type
+  - name: interstitial
+    display_name: Interstitial
+    column: interstitial
+    description: ""
+  - name: line_item_name
+    display_name: Line Item Name
+    column: line_item_name
+    description: ""
+  - display_name: Placement Type
+    column: placement_type
+    description: ""
+    name: placement_type
+  - name: platform_browser
+    display_name: Platform Browser
+    column: platform_browser
+    description: ""
+  - name: player_size
+    display_name: Player Size
+    column: player_size
+    description: ""
+  - name: privacy
+    display_name: Privacy
+    column: privacy
+    description: ""
+  - name: pub_name
+    display_name: Pub Name
+    column: pub_name
+    description: ""
+  - name: sdk
+    display_name: SDK
+    column: sdk
+    description: ""
+  - name: video_activity
+    display_name: Video Activity
+    column: video_activity
+    description: ""

--- a/web-admin/tests/setup/projects/openrtb/models/auction_data_model.sql
+++ b/web-admin/tests/setup/projects/openrtb/models/auction_data_model.sql
@@ -1,0 +1,8 @@
+-- Model SQL
+-- Reference documentation: https://docs.rilldata.com/reference/project-files/models
+-- @materialize: true
+
+select * EXCLUDE (device_region), 
+CASE WHEN device_region ILIKE '%/%' THEN SPLIT(device_region, '/')[2] ELSE 'Unknown' END AS device_state, 
+CASE WHEN device_region ILIKE '%/%' THEN SPLIT(device_region, '/')[1] ELSE 'Unknown' END AS device_country
+from auction_data_raw

--- a/web-admin/tests/setup/projects/openrtb/models/bids_data_model.sql
+++ b/web-admin/tests/setup/projects/openrtb/models/bids_data_model.sql
@@ -1,0 +1,5 @@
+-- Model SQL
+-- Reference documentation: https://docs.rilldata.com/reference/project-files/models
+-- @materialize: true
+
+select * from bids_data_raw

--- a/web-admin/tests/setup/projects/openrtb/rill.yaml
+++ b/web-admin/tests/setup/projects/openrtb/rill.yaml
@@ -1,0 +1,14 @@
+
+compiler: rillv1
+
+title: Open RTB Ads
+description: Open RTB Ads
+
+mock_users:
+- email: someone@rilldata.com
+  name: John Doe
+  admin: true
+- email: jane@partnercompany.com
+  groups:
+    - partners
+- email: test@domain.com

--- a/web-admin/tests/setup/projects/openrtb/sources/auction_data_raw.yaml
+++ b/web-admin/tests/setup/projects/openrtb/sources/auction_data_raw.yaml
@@ -1,0 +1,4 @@
+# Visit https://docs.rilldata.com/ to learn more about Rill code artifacts.
+type: source
+connector: "https"
+uri: "https://storage.googleapis.com/rilldata-public/e2e/auction_data_sampled.parquet"

--- a/web-admin/tests/setup/projects/openrtb/sources/bids_data_raw.yaml
+++ b/web-admin/tests/setup/projects/openrtb/sources/bids_data_raw.yaml
@@ -1,0 +1,4 @@
+# Visit https://docs.rilldata.com/ to learn more about Rill code artifacts.
+type: source
+connector: "https"
+uri: "https://storage.googleapis.com/rilldata-public/e2e/bids_data_sampled.parquet"

--- a/web-admin/tests/setup/setup.ts
+++ b/web-admin/tests/setup/setup.ts
@@ -25,7 +25,7 @@ import { cliLogin } from "./fixtures/cli";
 setup.describe("global setup", () => {
   setup.describe.configure({
     mode: "serial",
-    timeout: 240_000,
+    timeout: 180_000,
   });
 
   setup("should start services", async () => {
@@ -162,21 +162,13 @@ setup.describe("global setup", () => {
   });
 
   setup("should deploy the OpenRTB project", async ({ adminPage }) => {
-    // Pull the repositories to be used for testing
-    const examplesRepoPath = "tests/setup/git/repos/rill-examples";
-    await execAsync(
-      `rm -rf ${examplesRepoPath} && git clone https://github.com/rilldata/rill-examples.git ${examplesRepoPath}`,
-    );
-
     // Deploy the OpenRTB project
     const { match } = await spawnAndMatch(
       "rill",
       [
         "deploy",
         "--path",
-        "tests/setup/git/repos/rill-examples",
-        "--subpath",
-        "rill-openrtb-prog-ads",
+        "tests/setup/projects/openrtb",
         "--project",
         RILL_PROJECT_NAME,
         "--upload",
@@ -190,6 +182,7 @@ setup.describe("global setup", () => {
     await adminPage.goto(url);
     await expect(adminPage.getByText(RILL_ORG_NAME)).toBeVisible(); // Organization breadcrumb
     await expect(adminPage.getByText(RILL_PROJECT_NAME)).toBeVisible(); // Project breadcrumb
+
     // Trial is started in an async job after the 1st deploy. It is not worth the effort to re-fetch the issues list right now.
     // So disabling this for now, we could add a re-fetch to the issues list if users start facing issues.
     // await expect(
@@ -215,7 +208,7 @@ setup.describe("global setup", () => {
           });
           return listing.textContent();
         },
-        { intervals: Array(24).fill(5_000), timeout: 180_000 },
+        { intervals: Array(12).fill(5_000), timeout: 60_000 },
       )
       .toContain("Last refreshed");
 
@@ -228,7 +221,7 @@ setup.describe("global setup", () => {
           });
           return listing.textContent();
         },
-        { intervals: Array(24).fill(5_000), timeout: 180_000 },
+        { intervals: Array(12).fill(5_000), timeout: 60_000 },
       )
       .toContain("Last refreshed");
   });

--- a/web-admin/tests/setup/setup.ts
+++ b/web-admin/tests/setup/setup.ts
@@ -208,7 +208,7 @@ setup.describe("global setup", () => {
           });
           return listing.textContent();
         },
-        { intervals: Array(12).fill(5_000), timeout: 60_000 },
+        { intervals: Array(36).fill(5_000), timeout: 180_000 },
       )
       .toContain("Last refreshed");
 

--- a/web-admin/tests/setup/teardown.ts
+++ b/web-admin/tests/setup/teardown.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
-import fs from "fs";
 import { execAsync } from "@rilldata/web-common/tests/utils/spawn";
+import fs from "fs";
 import { test as teardown } from "./base";
 import { RILL_DEVTOOL_BACKGROUND_PROCESS_PID_FILE } from "./constants";
 
@@ -38,9 +38,6 @@ teardown.describe("global teardown", () => {
     await execAsync(
       "docker compose -f ../cli/cmd/devtool/data/cloud-deps.docker-compose.yml down --volumes",
     );
-
-    // Remove the test repositories
-    await execAsync("rm -rf tests/setup/git/repos");
   });
 });
 


### PR DESCRIPTION
This PR embeds a dedicated OpenRTB project into `web-admin/tests` rather than re-use the OpenRTB project in the `rill-examples` repo.

Benefits:
- Downsamples the data source for faster ingestion.
- Provides a flexible space to expand test cases (see https://github.com/rilldata/rill/issues/6707) without impacting the example project.
- Simplifies global setup by eliminating the need to pull an external repo.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
