### PR TITLE
Check host before opening runtime client

### DIFF
--- a/admin/deployments.go
+++ b/admin/deployments.go
@@ -405,6 +405,13 @@ func (s *Service) CheckProvisionerResource(ctx context.Context, pr *database.Pro
 }
 
 func (s *Service) OpenRuntimeClient(depl *database.Deployment) (*client.Client, error) {
+	if depl.RuntimeHost == "" {
+		if depl.Status == database.DeploymentStatusError {
+			return nil, fmt.Errorf("deployment %q has no runtime host: %s", depl.ID, depl.StatusMessage)
+		}
+		return nil, fmt.Errorf("deployment %q has no runtime host", depl.ID)
+	}
+
 	jwt, err := s.IssueRuntimeManagementToken(depl.RuntimeAudience)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
While a deployment is `pending`, it may not yet have a runtime host. If we try to open a runtime client during that time, it will accidentally attempt to connect to localhost. See this alert for an example: https://rilldata.slack.com/archives/C05TXA7QSTY/p1741392301834499

This PR fixes the issue by not allowing connection to an empty runtime host.