### PR TITLE
fix: rule placement in canvas area chart

### DIFF
--- a/web-common/src/components/vega/VegaLiteRenderer.svelte
+++ b/web-common/src/components/vega/VegaLiteRenderer.svelte
@@ -21,6 +21,7 @@
   export let error: string | null = null;
   export let canvasDashboard = false;
   export let chartView = false;
+  export let renderer: "canvas" | "svg" = "canvas";
   export let config: Config | undefined = undefined;
   export let tooltipFormatter: VLTooltipFormatter | undefined = undefined;
   export let viewVL: View;
@@ -39,7 +40,7 @@
 
   $: options = <EmbedOptions>{
     config: config || getRillTheme(canvasDashboard),
-    renderer: "canvas",
+    renderer,
     actions: false,
     logLevel: 0, // only show errors
     width: canvasDashboard ? width : undefined,

--- a/web-common/src/features/canvas/components/charts/Chart.svelte
+++ b/web-common/src/features/canvas/components/charts/Chart.svelte
@@ -20,6 +20,7 @@
   import {
     generateSpec,
     getChartTitle,
+    isChartLineLike,
     mergedVlConfig,
     sanitizeFieldName,
   } from "./util";
@@ -95,6 +96,7 @@
           canvasDashboard
           data={{ "metrics-view": $data.data }}
           {spec}
+          renderer={isChartLineLike(chartType) ? "svg" : "canvas"}
           expressionFunctions={{
             [measureName]: { fn: (val) => measureFormatter(val) },
           }}

--- a/web-common/src/features/canvas/components/charts/area/spec.ts
+++ b/web-common/src/features/canvas/components/charts/area/spec.ts
@@ -45,10 +45,11 @@ export function generateVLAreaChartSpec(
     multiValueTooltipChannel = multiValueTooltipChannel.slice(0, 50);
   }
 
+  spec.encoding = { x: createXEncoding(config, data) };
+
   spec.layer = [
     {
       encoding: {
-        x: createXEncoding(config, data),
         y: { ...createYEncoding(config, data), stack: "zero" },
         color: createColorEncoding(config, data),
       },
@@ -60,7 +61,7 @@ export function generateVLAreaChartSpec(
             type: "point",
             filled: true,
             opacity: 1,
-            size: 40,
+            size: 50,
             clip: true,
             stroke: "white",
             strokeWidth: 1,

--- a/web-common/src/features/canvas/components/charts/line-chart/spec.ts
+++ b/web-common/src/features/canvas/components/charts/line-chart/spec.ts
@@ -61,7 +61,7 @@ export function generateVLLineChartSpec(
             type: "point",
             filled: true,
             opacity: 1,
-            size: 40,
+            size: 50,
             clip: true,
             stroke: "white",
             strokeWidth: 1,

--- a/web-common/src/features/canvas/components/charts/util.ts
+++ b/web-common/src/features/canvas/components/charts/util.ts
@@ -48,6 +48,10 @@ export const chartMetadata: ChartMetadata[] = [
   { type: "area_chart", title: "Stacked Area", icon: StackedArea },
 ];
 
+export function isChartLineLike(chartType: ChartType) {
+  return chartType === "line_chart" || chartType === "area_chart";
+}
+
 export function mergedVlConfig(config: string): Config {
   const defaultConfig = getRillTheme(true);
   let parsedConfig: Config;


### PR DESCRIPTION
The `canvas` renderer mode in Vega was hiding the `rule` mark in line and area charts on Canvas dashboards. However, it appeared to work fine for Explore dashboards.

As a stopgap fix for `release-0.57` this PR reverts area and line charts back to `svg`. Further debugging is needed to determine the exact issue. My guess is that on Canvas dashboards, we might not be setting the chart container's size or bounds correctly.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
