### PR TITLE
fix: default comparison when a non-standard time range is selected as default

### DIFF
--- a/web-common/src/features/dashboards/time-controls/time-range-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-range-store.ts
@@ -13,13 +13,11 @@ import {
 } from "@rilldata/web-common/lib/time/config";
 import { getChildTimeRanges } from "@rilldata/web-common/lib/time/ranges";
 import { isoDurationToTimeRangeMeta } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
-import type {
-  DashboardTimeControls,
-  TimeRangeOption,
-} from "@rilldata/web-common/lib/time/types";
 import {
+  type DashboardTimeControls,
   TimeComparisonOption,
   type TimeRange,
+  type TimeRangeOption,
   TimeRangePreset,
 } from "@rilldata/web-common/lib/time/types";
 import {
@@ -224,8 +222,11 @@ export function getValidComparisonOption(
   allTimeRange: TimeRange,
 ) {
   if (!timeRanges?.length) {
-    return DEFAULT_TIME_RANGES[selectedTimeRange.name as TimeRangePreset]
-      ?.defaultComparison as TimeComparisonOption;
+    return (
+      (DEFAULT_TIME_RANGES[selectedTimeRange.name as TimeRangePreset]
+        ?.defaultComparison as TimeComparisonOption) ??
+      TimeComparisonOption.CONTIGUOUS
+    );
   }
 
   const timeRange = timeRanges.find(

--- a/web-common/src/features/dashboards/url-state/convertExploreStateToURLSearchParams.ts
+++ b/web-common/src/features/dashboards/url-state/convertExploreStateToURLSearchParams.ts
@@ -34,6 +34,7 @@ import {
 import { mergeSearchParams } from "@rilldata/web-common/lib/url-utils";
 import { DashboardState_ActivePage } from "@rilldata/web-common/proto/gen/rill/ui/v1/dashboard_pb";
 import {
+  V1ExploreComparisonMode,
   type V1ExplorePreset,
   type V1ExploreSpec,
 } from "@rilldata/web-common/runtime-client";
@@ -191,6 +192,12 @@ function toTimeRangesUrl(
       ExploreStateURLParams.ComparisonTimeRange,
       toTimeRangeParam(timeControlsState.selectedComparisonTimeRange),
     );
+  } else if (
+    !exploreState.showTimeComparison &&
+    preset.comparisonMode ===
+      V1ExploreComparisonMode.EXPLORE_COMPARISON_MODE_TIME
+  ) {
+    searchParams.set(ExploreStateURLParams.ComparisonTimeRange, "");
   }
 
   const mappedTimeGrain =

--- a/web-common/src/features/dashboards/url-state/convertURLToExplorePreset.ts
+++ b/web-common/src/features/dashboards/url-state/convertURLToExplorePreset.ts
@@ -285,6 +285,8 @@ export function fromTimeRangesParams(
         V1ExploreComparisonMode.EXPLORE_COMPARISON_MODE_TIME;
     } else if (ctr == "") {
       preset.compareTimeRange = "";
+      preset.comparisonMode =
+        V1ExploreComparisonMode.EXPLORE_COMPARISON_MODE_NONE;
     } else {
       errors.push(getSingleFieldError("compare time range", ctr));
     }

--- a/web-common/src/features/dashboards/url-state/url-state-variations.spec.ts
+++ b/web-common/src/features/dashboards/url-state/url-state-variations.spec.ts
@@ -446,7 +446,6 @@ describe("Human readable URL state variations", () => {
         applyMutationsToDashboard(AD_BIDS_EXPLORE_NAME, mutations);
         const curState =
           getCleanMetricsExploreForAssertion() as MetricsExplorerEntity;
-        console.log(curState);
 
         const url = new URL("http://localhost");
         // load url with legacy protobuf state
@@ -459,7 +458,6 @@ describe("Human readable URL state variations", () => {
             explore,
             defaultExplorePreset,
           );
-        console.log(entityFromUrl);
         expect(entityFromUrl).toEqual(curState);
 
         // go back to default url

--- a/web-common/src/features/dashboards/url-state/url-state-variations.spec.ts
+++ b/web-common/src/features/dashboards/url-state/url-state-variations.spec.ts
@@ -59,6 +59,7 @@ import {
   TimeRangePreset,
 } from "@rilldata/web-common/lib/time/types";
 import {
+  V1ExploreComparisonMode,
   type V1ExplorePreset,
   type V1ExploreSpec,
 } from "@rilldata/web-common/runtime-client";
@@ -142,6 +143,16 @@ const TestCases: {
     ],
     preset: AD_BIDS_PRESET,
     expectedUrl: "http://localhost/?tr=P4W&grain=week",
+    legacyNotSupported: true,
+  },
+  {
+    title: "Time range comparison with non-standard time range in preset",
+    mutations: [AD_BIDS_DISABLE_COMPARE_TIME_RANGE_FILTER],
+    preset: {
+      timeRange: "P9D",
+      comparisonMode: V1ExploreComparisonMode.EXPLORE_COMPARISON_MODE_TIME,
+    },
+    expectedUrl: "http://localhost/?compare_tr=",
     legacyNotSupported: true,
   },
 
@@ -435,6 +446,7 @@ describe("Human readable URL state variations", () => {
         applyMutationsToDashboard(AD_BIDS_EXPLORE_NAME, mutations);
         const curState =
           getCleanMetricsExploreForAssertion() as MetricsExplorerEntity;
+        console.log(curState);
 
         const url = new URL("http://localhost");
         // load url with legacy protobuf state
@@ -447,6 +459,7 @@ describe("Human readable URL state variations", () => {
             explore,
             defaultExplorePreset,
           );
+        console.log(entityFromUrl);
         expect(entityFromUrl).toEqual(curState);
 
         // go back to default url


### PR DESCRIPTION
More details: https://www.notion.so/rilldata/Custom-default-time-range-returns-undefined-comparison-range-1b0ba33c8f5780c1aba1dedba800ecaf

When the selected default time range is non-standard then the comparison time range is not defined. It is ok to set it to previous period in this case.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
