### PR TITLE
Canvas: clear all table cache on unmount

### DIFF
--- a/web-common/src/features/canvas/components/table/TableTemplate.svelte
+++ b/web-common/src/features/canvas/components/table/TableTemplate.svelte
@@ -13,6 +13,7 @@
     type PivotState,
   } from "@rilldata/web-common/features/dashboards/pivot/types";
   import type { V1ComponentSpecRendererProperties } from "@rilldata/web-common/runtime-client";
+  import { onDestroy } from "svelte";
   import { writable, type Readable } from "svelte/store";
   import { validateTableSchema } from "./selector";
   import { clearTableCache, getTableConfig, usePivotForCanvas } from "./util";
@@ -98,6 +99,10 @@
 
   $: hasColumnAndNoMeasure =
     pivotColumns.dimension.length > 0 && pivotColumns.measure.length === 0;
+
+  onDestroy(() => {
+    clearTableCache();
+  });
 </script>
 
 <div class="size-full overflow-hidden" style:max-height="inherit">

--- a/web-common/src/features/canvas/components/table/util.ts
+++ b/web-common/src/features/canvas/components/table/util.ts
@@ -26,7 +26,6 @@ export function clearTableCache(componentName?: string) {
       if (!componentName) {
         // Clear all cache entries if componentName is undefined
         for (const entry of cache.values()) {
-          console.log("unsubscribing", entry);
           entry.unsubscribe();
         }
         cache.clear();

--- a/web-common/src/features/canvas/components/table/util.ts
+++ b/web-common/src/features/canvas/components/table/util.ts
@@ -20,14 +20,23 @@ type CacheEntry = {
 };
 
 const tableStoreCache = writable<Map<string, CacheEntry>>(new Map());
-
-export function clearTableCache(componentName: string) {
+export function clearTableCache(componentName?: string) {
   tableStoreCache.update(
     (cache: Map<string, CacheEntry>): Map<string, CacheEntry> => {
-      for (const [key, entry] of cache.entries()) {
-        if (key.startsWith(componentName)) {
+      if (!componentName) {
+        // Clear all cache entries if componentName is undefined
+        for (const entry of cache.values()) {
+          console.log("unsubscribing", entry);
           entry.unsubscribe();
-          cache.delete(key);
+        }
+        cache.clear();
+      } else {
+        // Clear only entries matching componentName
+        for (const [key, entry] of cache.entries()) {
+          if (key.startsWith(componentName)) {
+            entry.unsubscribe();
+            cache.delete(key);
+          }
         }
       }
       return cache;


### PR DESCRIPTION
Clears all table cache on destroy

**Checklist:**
- [] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
