### PR TITLE
Connect project invites to org invites

### DIFF
--- a/admin/database/database.go
+++ b/admin/database/database.go
@@ -908,9 +908,11 @@ type OrganizationInvite struct {
 }
 
 // ProjectInvite represents an outstanding invitation to join a project.
+// A ProjectInvite must have a corresponding OrganizationInvite.
 type ProjectInvite struct {
 	ID              string
 	Email           string
+	OrgInviteID     string    `db:"org_invite_id"`
 	ProjectID       string    `db:"project_id"`
 	ProjectRoleID   string    `db:"project_role_id"`
 	InvitedByUserID string    `db:"invited_by_user_id"`
@@ -979,10 +981,11 @@ type InsertOrganizationInviteOptions struct {
 }
 
 type InsertProjectInviteOptions struct {
-	Email     string `validate:"email"`
-	InviterID string
-	ProjectID string `validate:"required"`
-	RoleID    string `validate:"required"`
+	Email       string `validate:"email"`
+	OrgInviteID string `validate:"required"`
+	ProjectID   string `validate:"required"`
+	RoleID      string `validate:"required"`
+	InviterID   string
 }
 
 type ProjectAccessRequest struct {

--- a/admin/database/postgres/migrations/0065.sql
+++ b/admin/database/postgres/migrations/0065.sql
@@ -17,14 +17,14 @@ INSERT INTO org_invites (email, org_id, org_role_id, invited_by_user_id, created
 SELECT pi.email, p.org_id, (SELECT id FROM org_roles WHERE name = 'guest'), pi.invited_by_user_id, pi.created_on
 FROM project_invites pi
 JOIN projects p ON pi.project_id = p.id
-WHERE NOT EXISTS (SELECT 1 FROM org_invites oi WHERE oi.email = pi.email AND oi.org_id = p.org_id);
+WHERE NOT EXISTS (SELECT 1 FROM org_invites oi WHERE lower(oi.email) = lower(pi.email) AND oi.org_id = p.org_id);
 
 -- Update the project invites with the org invite ids
 UPDATE project_invites pi
 SET org_invite_id = oi.id
 FROM org_invites oi
 JOIN projects p ON oi.org_id = p.org_id
-WHERE pi.email = oi.email AND p.id = pi.project_id;
+WHERE lower(pi.email) = lower(oi.email) AND p.id = pi.project_id;
 
 -- Add the not null constraint
 ALTER TABLE project_invites ALTER COLUMN org_invite_id SET NOT NULL;

--- a/admin/database/postgres/migrations/0065.sql
+++ b/admin/database/postgres/migrations/0065.sql
@@ -1,0 +1,30 @@
+-- This migration ensures there's an org_invite for every project_invite.
+-- This ensures that listing org-level invites covers all invites within the org,
+-- and removing an org-level invite will remove all project-level invites for that email.
+
+-- Add the org_invite_id column
+ALTER TABLE project_invites ADD COLUMN org_invite_id UUID;
+
+-- Add the foreign key
+ALTER TABLE project_invites
+ADD CONSTRAINT project_invites_org_invite_id_fkey
+FOREIGN KEY (org_invite_id)
+REFERENCES org_invites (id)
+ON DELETE CASCADE;
+
+-- Create org invites for project invites that don't have one
+INSERT INTO org_invites (email, org_id, org_role_id, invited_by_user_id, created_on)
+SELECT pi.email, p.org_id, (SELECT id FROM org_roles WHERE name = 'guest'), pi.invited_by_user_id, pi.created_on
+FROM project_invites pi
+JOIN projects p ON pi.project_id = p.id
+WHERE NOT EXISTS (SELECT 1 FROM org_invites oi WHERE oi.email = pi.email AND oi.org_id = p.org_id);
+
+-- Update the project invites with the org invite ids
+UPDATE project_invites pi
+SET org_invite_id = oi.id
+FROM org_invites oi
+JOIN projects p ON oi.org_id = p.org_id
+WHERE pi.email = oi.email AND p.id = pi.project_id;
+
+-- Add the not null constraint
+ALTER TABLE project_invites ALTER COLUMN org_invite_id SET NOT NULL;

--- a/admin/database/postgres/postgres.go
+++ b/admin/database/postgres/postgres.go
@@ -1936,7 +1936,9 @@ func (c *connection) InsertProjectInvite(ctx context.Context, opts *database.Ins
 		return err
 	}
 
-	_, err := c.getDB(ctx).ExecContext(ctx, "INSERT INTO project_invites (email, invited_by_user_id, project_id, project_role_id) VALUES ($1, $2, $3, $4)", opts.Email, opts.InviterID, opts.ProjectID, opts.RoleID)
+	_, err := c.getDB(ctx).ExecContext(ctx,
+		`INSERT INTO project_invites (email, org_invite_id, project_id, project_role_id, invited_by_user_id) VALUES ($1, $2, $3, $4)`,
+		opts.Email, opts.OrgInviteID, opts.ProjectID, opts.RoleID, opts.InviterID)
 	if err != nil {
 		return parseErr("project invite", err)
 	}

--- a/admin/database/postgres/postgres.go
+++ b/admin/database/postgres/postgres.go
@@ -1937,7 +1937,7 @@ func (c *connection) InsertProjectInvite(ctx context.Context, opts *database.Ins
 	}
 
 	_, err := c.getDB(ctx).ExecContext(ctx,
-		`INSERT INTO project_invites (email, org_invite_id, project_id, project_role_id, invited_by_user_id) VALUES ($1, $2, $3, $4)`,
+		`INSERT INTO project_invites (email, org_invite_id, project_id, project_role_id, invited_by_user_id) VALUES ($1, $2, $3, $4, $5)`,
 		opts.Email, opts.OrgInviteID, opts.ProjectID, opts.RoleID, opts.InviterID)
 	if err != nil {
 		return parseErr("project invite", err)

--- a/admin/user.go
+++ b/admin/user.go
@@ -272,7 +272,7 @@ func (s *Service) CreateOrUpdateUser(ctx context.Context, email, name, photoURL 
 		// NOTE: Not deleting the project invite because its already been deleted by the CASCADE from the org invite delete.
 		// As a sanity check, let's ensure an org invite was processed for this project invite.
 		if !addedToOrgIDs[project.OrganizationID] {
-			return nil, fmt.Errorf("project invite processed without a matching org invite for project_id=%s", project.ID)
+			s.Logger.Error("project invite processed without a matching org invite", zap.String("project_id", project.ID))
 		}
 	}
 

--- a/admin/user.go
+++ b/admin/user.go
@@ -220,6 +220,8 @@ func (s *Service) CreateOrUpdateUser(ctx context.Context, email, name, photoURL 
 			}
 		}
 
+		// NOTE: This cascades to deleting all project invites in the org.
+		// That's alright because we already loaded the project invites to apply, but we must not reference them in the database after this.
 		err = s.DB.DeleteOrganizationInvite(ctx, invite.ID)
 		if err != nil {
 			return nil, err
@@ -264,12 +266,14 @@ func (s *Service) CreateOrUpdateUser(ctx context.Context, email, name, photoURL 
 		if err != nil {
 			return nil, err
 		}
-		err = s.DB.DeleteProjectInvite(ctx, invite.ID)
-		if err != nil {
-			return nil, err
-		}
 		addedToProjectIDs[project.ID] = true
 		addedToProjectNames = append(addedToProjectNames, project.Name)
+
+		// NOTE: Not deleting the project invite because its already been deleted by the CASCADE from the org invite delete.
+		// As a sanity check, let's ensure an org invite was processed for this project invite.
+		if !addedToOrgIDs[project.OrganizationID] {
+			return nil, fmt.Errorf("project invite processed without a matching org invite for project_id=%s", project.ID)
+		}
 	}
 
 	// check if users email domain is whitelisted for some projects


### PR DESCRIPTION
**Changes:**

- When a project-level invite is created, it automatically creates an org-level guest invite as well (unless another org-level invite already exists)
- When removing an org-level invite, it automatically removes all project-level invites as well

Contributes to https://github.com/rilldata/rill/issues/6578

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
