### PR TITLE
Fix: Handle duplicates in arrayUnorderedEquals

### DIFF
--- a/web-common/src/lib/arrayUtils.spec.ts
+++ b/web-common/src/lib/arrayUtils.spec.ts
@@ -1,4 +1,7 @@
-import { createBatches } from "@rilldata/web-common/lib/arrayUtils";
+import {
+  arrayUnorderedEquals,
+  createBatches,
+} from "@rilldata/web-common/lib/arrayUtils";
 import { describe, expect, it } from "vitest";
 
 describe("createBatches", () => {
@@ -28,6 +31,31 @@ describe("createBatches", () => {
   for (const { batchSize, expected } of TestCases) {
     it(`input=${Input.join(",")} batchSize=${batchSize}`, () => {
       expect(createBatches(Input, batchSize)).toEqual(expected);
+    });
+  }
+});
+
+describe("arrayUnorderedEquals", () => {
+  const TestCases = [
+    {
+      src: [1, 2, 3],
+      tar: [3, 2, 1],
+      equals: true,
+    },
+    {
+      src: [1, 2, 3],
+      tar: [1, 2],
+      equals: false,
+    },
+    {
+      src: [1, 2, 3],
+      tar: [1, 2, 1],
+      equals: false,
+    },
+  ];
+  for (const { src, tar, equals } of TestCases) {
+    it(`arrayUnorderedEquals(${src.join(",")}, ${tar.join(",")})`, () => {
+      expect(arrayUnorderedEquals(src, tar)).toEqual(equals);
     });
   }
 });

--- a/web-common/src/lib/arrayUtils.ts
+++ b/web-common/src/lib/arrayUtils.ts
@@ -28,9 +28,10 @@ export function createBatches<T>(array: T[], batchSize: number): T[][] {
 }
 
 export function arrayUnorderedEquals<T>(src: T[], tar: T[]) {
-  if (src.length !== tar.length) return false;
-  const set = new Set<T>(src);
-  return tar.every((t) => set.has(t));
+  const srcSet = new Set<T>(src);
+  const tarSet = new Set<T>(tar);
+  if (srcSet.size !== tarSet.size) return false;
+  return tar.every((t) => srcSet.has(t));
 }
 
 export function arrayOrderedEquals<T>(src: T[], tar: T[]) {


### PR DESCRIPTION
closes https://github.com/rilldata/rill-private-issues/issues/1359

This lead to weird interactions when list of dimensions/measures has duplicates.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
