### PR TITLE
Allow requests to proceed on cache server connection errors

### DIFF
--- a/admin/server/server.go
+++ b/admin/server/server.go
@@ -344,12 +344,6 @@ func (s *Server) checkRateLimit(ctx context.Context) (context.Context, error) {
 		return ctx, fmt.Errorf("server context does not have a method")
 	}
 
-	// If the connection to the cache server is lost, skip rate limiting.
-	if err := s.limiter.Ping(ctx); err != nil {
-		s.logger.Warn("skipping rate limiting due to cache connection error", zap.Error(err))
-		return ctx, nil
-	}
-
 	// Don't rate limit superusers. This is useful for scripting.
 	if auth.GetClaims(ctx).Superuser(ctx) {
 		return ctx, nil

--- a/runtime/server/server.go
+++ b/runtime/server/server.go
@@ -343,12 +343,6 @@ func mapGRPCError(err error) error {
 }
 
 func (s *Server) checkRateLimit(ctx context.Context) (context.Context, error) {
-	// If the connection to the cache server is lost, skip rate limiting.
-	if err := s.limiter.Ping(ctx); err != nil {
-		s.logger.Warn("skipping rate limiting due to cache connection error", zap.Error(err))
-		return ctx, nil
-	}
-
 	// Any request type might be limited separately as it is part of Metadata
 	// Any request type might be excluded from this limit check and limited later,
 	// e.g. in the corresponding request handler by calling s.limiter.Limit(ctx, "limitKey", redis_rate.PerMinute(100))


### PR DESCRIPTION
Checks the error returned from the calls to `s.limiter.Limit` and allow requests to proceed on cache server connection errors.

Resolves: https://github.com/rilldata/rill-private-issues/issues/1392

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
