### PR TITLE
Canvas: Chart improvements

### DIFF
--- a/web-common/src/components/vega/vega-config.ts
+++ b/web-common/src/components/vega/vega-config.ts
@@ -61,7 +61,7 @@ export const getRillTheme: (isCustomDashboard: boolean) => Config = (
     titleFontSize: 12,
   },
   axisY: {
-    orient: "right",
+    orient: "left",
     gridColor: gridColor,
     gridDash: [2],
     tickColor: gridColor,

--- a/web-common/src/features/canvas/AddComponentDropdown.svelte
+++ b/web-common/src/features/canvas/AddComponentDropdown.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
+  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
+  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { chartMetadata } from "@rilldata/web-common/features/canvas/components/charts/util";
   import { PlusCircle } from "lucide-svelte";
   import type { ComponentType, SvelteComponent } from "svelte";
@@ -9,8 +11,6 @@
   import ChartIcon from "./icons/ChartIcon.svelte";
   import TableIcon from "./icons/TableIcon.svelte";
   import TextIcon from "./icons/TextIcon.svelte";
-  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
-  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
 
   type MenuItem = {
     id: CanvasComponentType;
@@ -20,7 +20,9 @@
 
   // Function to get a random chart type
   function getRandomChartType(): ChartType {
-    const chartTypes = chartMetadata.map((chart) => chart.type);
+    const chartTypes = chartMetadata
+      .map((chart) => chart.type)
+      .filter((t) => t !== "stacked_bar_normalized");
     const randomIndex = Math.floor(Math.random() * chartTypes.length);
     return chartTypes[randomIndex];
   }

--- a/web-common/src/features/canvas/components/charts/area/spec.ts
+++ b/web-common/src/features/canvas/components/charts/area/spec.ts
@@ -56,6 +56,9 @@ export function generateVLAreaChartSpec(
       layer: [
         { mark: "area" },
         {
+          mark: { type: "line", opacity: 0.5 },
+        },
+        {
           transform: [{ filter: { param: "hover", empty: false } }],
           mark: {
             type: "point",
@@ -66,9 +69,6 @@ export function generateVLAreaChartSpec(
             stroke: "white",
             strokeWidth: 1,
           },
-        },
-        {
-          mark: { type: "line", opacity: 0.5 },
         },
       ],
     },

--- a/web-common/src/features/canvas/components/charts/index.ts
+++ b/web-common/src/features/canvas/components/charts/index.ts
@@ -6,6 +6,7 @@ import {
 } from "@rilldata/web-common/features/canvas/components/util";
 import type { InputParams } from "@rilldata/web-common/features/canvas/inspector/types";
 import type { FileArtifact } from "@rilldata/web-common/features/entity-management/file-artifact";
+import { defaultPrimaryColors } from "@rilldata/web-common/features/themes/color-config";
 import type { V1MetricsViewSpec } from "@rilldata/web-common/runtime-client";
 import type {
   ComponentCommonProperties,
@@ -61,31 +62,25 @@ export class ChartComponent extends BaseCanvasComponent<ChartSpec> {
   ): ChartSpec {
     // Randomly select a measure and dimension if available
     const measures = metricsViewSpec?.measures || [];
+
+    const timeDimension = metricsViewSpec?.timeDimension;
     const dimensions = metricsViewSpec?.dimensions || [];
 
     const randomMeasure = measures[Math.floor(Math.random() * measures.length)]
       ?.name as string;
 
-    const randomDimension = dimensions[
-      Math.floor(Math.random() * dimensions.length)
-    ]?.name as string;
-
-    let randomColorDimension: string | undefined = undefined;
-    if (dimensions.length > 1) {
-      const availableDimensions = dimensions.filter(
-        (d) => d.name !== randomDimension,
-      );
-      randomColorDimension =
-        availableDimensions[
-          Math.floor(Math.random() * availableDimensions.length)
-        ]?.name;
+    let randomDimension = "";
+    if (!timeDimension) {
+      randomDimension = dimensions[
+        Math.floor(Math.random() * dimensions.length)
+      ]?.name as string;
     }
 
     const spec: ChartSpec = {
       metrics_view: metricsViewName,
       x: {
-        type: "nominal",
-        field: randomDimension,
+        type: timeDimension ? "temporal" : "nominal",
+        field: timeDimension || randomDimension,
         sort: "-y",
         limit: 20,
       },
@@ -94,15 +89,8 @@ export class ChartComponent extends BaseCanvasComponent<ChartSpec> {
         field: randomMeasure,
         zeroBasedOrigin: true,
       },
+      color: `hsl(${defaultPrimaryColors[500].split(" ").join(",")})`,
     };
-
-    // Only add color if we have more than one dimension
-    if (randomColorDimension) {
-      spec.color = {
-        type: "nominal",
-        field: randomColorDimension,
-      };
-    }
 
     return spec;
   }


### PR DESCRIPTION

- Do not use normalized 100% stacked bar chart when a new chart is added
- Use time as the default dimension for charts
- Orient Y axis to the left of the chart


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
