### PR TITLE
fix: incorrect url path for canvas hrefs

### DIFF
--- a/web-common/src/features/dashboards/dashboard-utils.ts
+++ b/web-common/src/features/dashboards/dashboard-utils.ts
@@ -181,7 +181,7 @@ export function getBreadcrumbOptions(
     const label = canvasResource?.canvas?.spec?.displayName || name;
 
     if (label && name)
-      map.set(name.toLowerCase(), { label, section: "custom", depth: 0 });
+      map.set(name.toLowerCase(), { label, section: "canvas", depth: 0 });
 
     return map;
   }, new Map<string, PathOption>());


### PR DESCRIPTION
The keyword "custom" was still being used for canvas paths.