### PR TITLE
throw error on missing template keys for connectors

### DIFF
--- a/runtime/compilers/rillv1/parse_metrics_view.go
+++ b/runtime/compilers/rillv1/parse_metrics_view.go
@@ -222,7 +222,7 @@ func (p *SecurityPolicyYAML) Proto() ([]*runtimev1.SecurityRule, error) {
 	}
 
 	if p.Access != "" {
-		tmp, err := ResolveTemplate(p.Access, validationTemplateData)
+		tmp, err := ResolveTemplate(p.Access, validationTemplateData, false)
 		if err != nil {
 			return nil, fmt.Errorf(`invalid 'security': 'access' templating is not valid: %w`, err)
 		}
@@ -251,7 +251,7 @@ func (p *SecurityPolicyYAML) Proto() ([]*runtimev1.SecurityRule, error) {
 	}
 
 	if p.RowFilter != "" {
-		_, err := ResolveTemplate(p.RowFilter, validationTemplateData)
+		_, err := ResolveTemplate(p.RowFilter, validationTemplateData, false)
 		if err != nil {
 			return nil, fmt.Errorf(`invalid 'security': 'row_filter' templating is not valid: %w`, err)
 		}
@@ -270,7 +270,7 @@ func (p *SecurityPolicyYAML) Proto() ([]*runtimev1.SecurityRule, error) {
 			continue
 		}
 
-		tmp, err := ResolveTemplate(inc.Condition, validationTemplateData)
+		tmp, err := ResolveTemplate(inc.Condition, validationTemplateData, false)
 		if err != nil {
 			return nil, fmt.Errorf(`invalid 'security': 'if' condition templating is not valid: %w`, err)
 		}
@@ -318,7 +318,7 @@ func (p *SecurityPolicyYAML) Proto() ([]*runtimev1.SecurityRule, error) {
 			continue
 		}
 
-		tmp, err := ResolveTemplate(exc.Condition, validationTemplateData)
+		tmp, err := ResolveTemplate(exc.Condition, validationTemplateData, false)
 		if err != nil {
 			return nil, fmt.Errorf(`invalid 'security': 'if' condition templating is not valid: %w`, err)
 		}
@@ -377,7 +377,7 @@ type SecurityRuleYAML struct {
 func (r *SecurityRuleYAML) Proto() (*runtimev1.SecurityRule, error) {
 	condition := r.If
 	if condition != "" {
-		tmp, err := ResolveTemplate(condition, validationTemplateData)
+		tmp, err := ResolveTemplate(condition, validationTemplateData, false)
 		if err != nil {
 			return nil, fmt.Errorf(`invalid 'if': templating is not valid: %w`, err)
 		}

--- a/runtime/compilers/rillv1/template_test.go
+++ b/runtime/compilers/rillv1/template_test.go
@@ -95,7 +95,7 @@ func TestResolve(t *testing.T) {
 			"domain": "rilldata.com",
 			"groups": []string{"admin", "user"},
 		},
-	})
+	}, false)
 	require.NoError(t, err)
 	require.Equal(t, "SELECT partner_id FROM domain_partner_mapping WHERE domain = 'rilldata.com' AND groups IN ('admin', 'user') OR true", resolved)
 }
@@ -107,7 +107,7 @@ func TestVariables(t *testing.T) {
 			"a":   "1",
 			"b.a": "2",
 		},
-	})
+	}, false)
 	require.NoError(t, err)
 	require.Equal(t, "a=1 b.a=2 b.a=2", resolved)
 }

--- a/runtime/connections.go
+++ b/runtime/connections.go
@@ -329,7 +329,7 @@ func ResolveConnectorProperties(environment string, vars map[string]string, c *r
 		v, err := rillv1.ResolveTemplate(v, rillv1.TemplateData{
 			Environment: environment,
 			Variables:   vars,
-		})
+		}, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve templated property %q: %w", k, err)
 		}

--- a/runtime/reconcilers/migration.go
+++ b/runtime/reconcilers/migration.go
@@ -143,7 +143,7 @@ func (r *MigrationReconciler) executeMigration(ctx context.Context, self *runtim
 				State: res.Resource.(*runtimev1.Resource_Model).Model.State,
 			}, nil
 		},
-	})
+	}, false)
 	if err != nil {
 		return fmt.Errorf("failed to resolve template: %w", err)
 	}

--- a/runtime/reconcilers/model.go
+++ b/runtime/reconcilers/model.go
@@ -1445,7 +1445,7 @@ func (r *ModelReconciler) resolveTemplatedProps(ctx context.Context, self *runti
 		},
 	}
 
-	val, err := compilerv1.ResolveTemplateRecursively(props, td)
+	val, err := compilerv1.ResolveTemplateRecursively(props, td, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve template: %w", err)
 	}

--- a/runtime/resolvers/glob.go
+++ b/runtime/resolvers/glob.go
@@ -107,7 +107,7 @@ func newGlob(ctx context.Context, opts *runtime.ResolverOptions) (runtime.Resolv
 		ExtraProps: map[string]any{
 			"table": tmpTableName,
 		},
-	})
+	}, false)
 	if err != nil {
 		return nil, fmt.Errorf("glob resolver: failed to resolve templating: %w", err)
 	}

--- a/runtime/resolvers/sql.go
+++ b/runtime/resolvers/sql.go
@@ -264,7 +264,7 @@ func resolveTemplate(sqlTemplate string, args map[string]any, inst *drivers.Inst
 			// TODO: As of now it is using `DialectDuckDB` in all cases since in certain cases like metrics_sql it is not possible to identify OLAP connector before template resolution.
 			return drivers.DialectDuckDB.EscapeIdentifier(ref.Name), nil
 		},
-	})
+	}, false)
 	if err != nil {
 		return "", nil, err
 	}

--- a/runtime/security.go
+++ b/runtime/security.go
@@ -472,7 +472,7 @@ func (p *securityEngine) applySecurityRuleAccess(res *ResolvedSecurity, _ *runti
 	}
 
 	if rule.Condition != "" {
-		expr, err := rillv1.ResolveTemplate(rule.Condition, td)
+		expr, err := rillv1.ResolveTemplate(rule.Condition, td, false)
 		if err != nil {
 			return err
 		}
@@ -528,7 +528,7 @@ func (p *securityEngine) applySecurityRuleFieldAccess(res *ResolvedSecurity, r *
 
 	// Determine if the rule should be applied
 	if rule.Condition != "" {
-		expr, err := rillv1.ResolveTemplate(rule.Condition, td)
+		expr, err := rillv1.ResolveTemplate(rule.Condition, td, false)
 		if err != nil {
 			return err
 		}
@@ -566,7 +566,7 @@ func (p *securityEngine) applySecurityRuleFieldAccess(res *ResolvedSecurity, r *
 func (p *securityEngine) applySecurityRuleRowFilter(res *ResolvedSecurity, _ *runtimev1.Resource, rule *runtimev1.SecurityRuleRowFilter, td rillv1.TemplateData) error {
 	// Determine if the rule should be applied
 	if rule.Condition != "" {
-		expr, err := rillv1.ResolveTemplate(rule.Condition, td)
+		expr, err := rillv1.ResolveTemplate(rule.Condition, td, false)
 		if err != nil {
 			return err
 		}
@@ -582,7 +582,7 @@ func (p *securityEngine) applySecurityRuleRowFilter(res *ResolvedSecurity, _ *ru
 
 	// Handle raw SQL row filters
 	if rule.Sql != "" {
-		sql, err := rillv1.ResolveTemplate(rule.Sql, td)
+		sql, err := rillv1.ResolveTemplate(rule.Sql, td, false)
 		if err != nil {
 			return err
 		}

--- a/runtime/server/canvases.go
+++ b/runtime/server/canvases.go
@@ -84,7 +84,7 @@ func (s *Server) ResolveCanvas(ctx context.Context, req *runtimev1.ResolveCanvas
 			// Resolve the renderer properties in the valid_spec.
 			validSpec := cmp.GetComponent().State.ValidSpec
 			if validSpec != nil && validSpec.RendererProperties != nil {
-				v, err := rillv1.ResolveTemplateRecursively(validSpec.RendererProperties.AsMap(), td)
+				v, err := rillv1.ResolveTemplateRecursively(validSpec.RendererProperties.AsMap(), td, false)
 				if err != nil {
 					return nil, status.Errorf(codes.InvalidArgument, "component %q: failed to resolve templating: %s", item.Component, err.Error())
 				}
@@ -203,7 +203,7 @@ func (s *Server) ResolveComponent(ctx context.Context, req *runtimev1.ResolveCom
 	// Resolve templating in the renderer properties
 	var rendererProps *structpb.Struct
 	if spec.RendererProperties != nil {
-		v, err := rillv1.ResolveTemplateRecursively(spec.RendererProperties.AsMap(), td)
+		v, err := rillv1.ResolveTemplateRecursively(spec.RendererProperties.AsMap(), td, false)
 		if err != nil {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}


### PR DESCRIPTION
https://github.com/rilldata/rill-private-issues/issues/1372

Currently we don't throw error if variables are missing. I see following [TODO](https://github.com/rilldata/rill/blob/48e0d184db14844251677f5bff287b7b5e55e8a5/runtime/compilers/rillv1/template.go#L257) for the same. 

This is definitely problematic for connectors and leads to bad user experience as highlighted in the issue.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
