### PR TITLE
Fix: pivot sort when toggling comparison

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-utils.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-utils.ts
@@ -432,7 +432,7 @@ export function getSortForAccessor(
     sortPivotBy = [
       {
         desc: config.pivot.sorting[0].desc,
-        name: measureNames[parseInt(measureIndex)],
+        name: measureName,
       },
     ];
   }

--- a/web-common/src/features/dashboards/pivot/pivot-utils.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-utils.ts
@@ -426,12 +426,16 @@ export function getSortForAccessor(
     columnDimensionAxes,
   );
 
-  sortPivotBy = [
-    {
-      desc: config.pivot.sorting[0].desc,
-      name: measureNames[parseInt(measureIndex)],
-    },
-  ];
+  const measureName = measureNames[parseInt(measureIndex)];
+
+  if (measureName) {
+    sortPivotBy = [
+      {
+        desc: config.pivot.sorting[0].desc,
+        name: measureNames[parseInt(measureIndex)],
+      },
+    ];
+  }
 
   return {
     where: filters,


### PR DESCRIPTION
https://rilldata.slack.com/archives/C02T907FEUB/p1742294486176259

On toggling comparison, the previous sorted measure was not available leading to 400 error.


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
