### PR TITLE
chore (deps): Update `browerslist` db

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11558,9 +11558,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001664",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001664.tgz",
-      "integrity": "sha512-AmE7k4dXiNKQipgn7a2xg558IRqPN3jMQY/rOsbxDhrd0tyChwbITBfiwtnqz8bi2M5mIWbxAYBvk7W7QBUS2g==",
+      "version": "1.0.30001706",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001706.tgz",
+      "integrity": "sha512-3ZczoTApMAZwPKYWmwVbQMFpXBDds3/0VciVoUwPUbldlYyVLmRVuRs/PcUZtHpbLRpzzDvrvnFuREsGt6lUug==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Updates the `browserlist` database (and removes this warning from our build process)

<img width="716" alt="image" src="https://github.com/user-attachments/assets/c66d012d-f20f-40ad-8f8f-4ad9a9d704ed" />