### PR TITLE
fix: follow local filters comparison toggle

### DIFF
--- a/web-common/src/features/canvas/ComponentHeader.svelte
+++ b/web-common/src/features/canvas/ComponentHeader.svelte
@@ -30,7 +30,7 @@
     {/if}
   </div>
 {:else if atleastOneFilter}
-  <div class="absolute top-0 left-0 z-50 pl-1 pt-1">
+  <div class="absolute top-0 left-0 z-[60] pl-1 pt-1">
     <LocalFiltersHeader {atleastOneFilter} {filters} />
   </div>
 {/if}

--- a/web-common/src/features/canvas/stores/canvas-entity.ts
+++ b/web-common/src/features/canvas/stores/canvas-entity.ts
@@ -186,9 +186,8 @@ export class CanvasEntity {
               timeZone,
             };
 
-            if (!localShowTimeComparison) {
-              showTimeComparison = false;
-            }
+            showTimeComparison = localShowTimeComparison;
+
             timeGrain = localTimeRangeState?.selectedTimeRange?.interval;
 
             timeRangeState = localTimeRangeState;


### PR DESCRIPTION
https://www.notion.so/rilldata/Comparisons-do-not-work-when-local-comparison-is-on-but-global-comparison-is-off-1b4ba33c8f5780589f9dd73de15afea9?pvs=23

- Follow local filter's comparison toggle 
- Increase `z-index` for local filters icon so that it's visible over KPI grid

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
