### PR TITLE
fix: merging expressions with (i)like and subquery filters removing them instead of retaining them

### DIFF
--- a/web-common/src/features/canvas/AddComponentDropdown.svelte
+++ b/web-common/src/features/canvas/AddComponentDropdown.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
-  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
-  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { chartMetadata } from "@rilldata/web-common/features/canvas/components/charts/util";
   import { Plus, PlusCircle } from "lucide-svelte";
   import type { ComponentType, SvelteComponent } from "svelte";

--- a/web-common/src/features/canvas/components/charts/query.ts
+++ b/web-common/src/features/canvas/components/charts/query.ts
@@ -64,7 +64,6 @@ export function createChartDataQuery(
       } else if (config.x?.type === "temporal" && timeGrain) {
         dimensions = [{ name: config.x?.field, timeGrain }];
       }
-      console.log(outerWhere, where);
 
       if (typeof config.color === "object" && config.color?.field) {
         dimensions = [...dimensions, { name: config.color.field }];

--- a/web-common/src/features/canvas/components/charts/query.ts
+++ b/web-common/src/features/canvas/components/charts/query.ts
@@ -64,6 +64,7 @@ export function createChartDataQuery(
       } else if (config.x?.type === "temporal" && timeGrain) {
         dimensions = [{ name: config.x?.field, timeGrain }];
       }
+      console.log(outerWhere, where);
 
       if (typeof config.color === "object" && config.color?.field) {
         dimensions = [...dimensions, { name: config.color.field }];


### PR DESCRIPTION
Ref issue: https://www.notion.so/rilldata/Chart-filters-don-t-seem-to-be-working-1b4ba33c8f5780efbd4aebd740b852b1

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
