### PR TITLE
fix: backward compatibility for s3 compatibile servers with duckdb

### DIFF
--- a/runtime/drivers/duckdb/model_executor_objectstore_self.go
+++ b/runtime/drivers/duckdb/model_executor_objectstore_self.go
@@ -159,11 +159,11 @@ func objectStoreSecretSQL(ctx context.Context, path, model, inputConnector strin
 			if !ok {
 				return "", fmt.Errorf("internal error: invalid input handle type")
 			}
-			url, err := globutil.ParseBucketURL(path)
+			uri, err := globutil.ParseBucketURL(path)
 			if err != nil {
 				return "", fmt.Errorf("failed to parse path %q, %w", path, err)
 			}
-			reg, err := conn.GetBucketRegion(ctx, url.Host)
+			reg, err := conn.GetBucketRegion(ctx, uri.Host)
 			if err != nil {
 				return "", fmt.Errorf("failed to get bucket region: %w. Set `region` in model yaml", err)
 			}


### PR DESCRIPTION
Previously we expected the endpoint of type `https://<>`
Duckdb expects the endpoint of type `<>` i.e. without scheme.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
