### PR TITLE
fix: comparison fallbacks

### DIFF
--- a/web-common/src/features/dashboards/time-controls/super-pill/components/Comparison.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/Comparison.svelte
@@ -44,7 +44,7 @@
       )
     : undefined;
 
-  $: firstVisibleMonth = interval?.start ?? DateTime.now();
+  $: firstVisibleMonth = interval?.start ?? currentInterval.end;
 
   $: comparisonOption =
     (selectedComparison?.name as TimeComparisonOption | undefined) || null;

--- a/web-common/src/features/dashboards/time-controls/time-range-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-range-store.ts
@@ -220,7 +220,7 @@ export function getValidComparisonOption(
   selectedTimeRange: TimeRange,
   prevComparisonOption: TimeComparisonOption | undefined,
   allTimeRange: TimeRange,
-) {
+): TimeComparisonOption {
   if (!timeRanges?.length) {
     return (
       (DEFAULT_TIME_RANGES[selectedTimeRange.name as TimeRangePreset]
@@ -238,7 +238,8 @@ export function getValidComparisonOption(
   if (!timeRange?.comparisonTimeRanges?.length) {
     return (
       DEFAULT_TIME_RANGES[selectedTimeRange.name as TimeRangePreset]
-        ?.defaultComparison ?? TimeComparisonOption.CONTIGUOUS
+        ?.defaultComparison ??
+      (TimeComparisonOption.CONTIGUOUS as TimeComparisonOption)
     );
   }
 
@@ -255,7 +256,7 @@ export function getValidComparisonOption(
   );
   // if currently selected comparison option is in allowed list and is valid select it
   if (existing && existingComparison.isComparisonRangeAvailable) {
-    return prevComparisonOption;
+    return prevComparisonOption ?? TimeComparisonOption.CONTIGUOUS;
   }
 
   return timeRange.comparisonTimeRanges[0].offset as TimeComparisonOption;

--- a/web-common/src/features/dashboards/time-controls/time-range-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-range-store.ts
@@ -232,12 +232,14 @@ export function getValidComparisonOption(
   const timeRange = timeRanges.find(
     (tr) => tr.range === selectedTimeRange.name,
   );
-  if (!timeRange) return undefined;
 
   // If comparisonOffsets are not defined get default from presets.
-  if (!timeRange.comparisonTimeRanges?.length) {
-    return DEFAULT_TIME_RANGES[selectedTimeRange.name as TimeRangePreset]
-      ?.defaultComparison as TimeComparisonOption;
+  // This does not handle time ranges like P7M that are not in our defaults
+  if (!timeRange?.comparisonTimeRanges?.length) {
+    return (
+      DEFAULT_TIME_RANGES[selectedTimeRange.name as TimeRangePreset]
+        ?.defaultComparison ?? TimeComparisonOption.CONTIGUOUS
+    );
   }
 
   const existing = timeRange.comparisonTimeRanges?.find(

--- a/web-common/src/lib/time/types.ts
+++ b/web-common/src/lib/time/types.ts
@@ -107,7 +107,7 @@ export interface TimeRangeMeta {
   label: string;
   defaultGrain?: V1TimeGrain; // Affordance for future use
   rangePreset?: RangePresetType | string;
-  defaultComparison?: TimeComparisonOption | string;
+  defaultComparison?: TimeComparisonOption;
   start?: string | RelativePointInTime;
   end?: string | RelativePointInTime;
 }


### PR DESCRIPTION
The process by which default comparison periods were being derived was returning `undefined` when the primary time range was one not listed in the Explore YAML `time_ranges` list. So, `CUSTOM` or a `default_time_range`, implicit time range or URL time range that was not in the list.

Because of that, the `Calendar` component (via the `Comparison` component) was falling back to DateTime.now() instead of the end of the primary interval. As such, when selecting dates, the local time zone was being used instead of the selected time zone.

This is a patch fix. The code requires significant refactoring, some of which will be addressed by rillTime.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
