### PR TITLE
fix: use display name instead of title

### DIFF
--- a/web-common/src/features/file-explorer/new-files.ts
+++ b/web-common/src/features/file-explorer/new-files.ts
@@ -170,7 +170,7 @@ measures:
 
 type: explore
 
-title: "${metricsViewTitle ? metricsViewTitle : metricsViewName} dashboard"
+display_name: "${metricsViewTitle ? metricsViewTitle : metricsViewName} dashboard"
 metrics_view: ${metricsViewName}
 
 dimensions: '*'
@@ -182,7 +182,7 @@ measures: '*'
 
 type: explore
 
-title: "My metrics dashboard"
+display_name: "My metrics dashboard"
 metrics_view: example_metrics_view # Choose a metrics view to underpin the dashboard
 
 dimensions: '*'
@@ -198,58 +198,12 @@ type: api
 metrics_sql: |
   select measure, dimension from metrics_view
 `;
-    case ResourceKind.Component:
-      return `# Component YAML
-# Reference documentation: https://docs.rilldata.com/reference/project-files/components
-    
-type: component
-
-data:
-  sql: |
-    SELECT * FROM (VALUES 
-      ('Monday', 300),
-      ('Tuesday', 150),
-      ('Wednesday', 200),
-      ('Thursday', 400),
-      ('Friday', 650),
-      ('Saturday', 575),
-      ('Sunday', 500)
-    ) AS t(day_of_week, revenue)
-
-vega_lite: |
-  {
-    "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
-    "data": { "name": "table" },
-    "mark": "line",
-    "width": "container",
-    "encoding": {
-      "x": {
-        "field": "day_of_week",
-        "type": "ordinal",
-        "axis": { "title": "Day of the Week" },
-        "sort": [
-          "Monday",
-          "Tuesday",
-          "Wednesday",
-          "Thursday",
-          "Friday",
-          "Saturday",
-          "Sunday"
-        ]
-      },
-      "y": {
-        "field": "revenue",
-        "type": "quantitative",
-        "axis": { "title": "Revenue" }
-      }
-    }
-  }`;
     case ResourceKind.Canvas:
       return `# Explore YAML
 # Reference documentation: https://docs.rilldata.com/reference/project-files/canvas-dashboards
 
 type: canvas
-title: "Canvas Dashboard"
+display_name: "Canvas Dashboard"
 defaults:
   time_range: PT24H
   comparison_mode: time


### PR DESCRIPTION
`title`is deprecated, use `display_name` instead

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
