### PR TITLE
make max open conns configurable

### DIFF
--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -150,7 +150,7 @@ func (d driver) Open(instanceID string, config map[string]any, st *storage.Clien
 	// build clickhouse options
 	var opts *clickhouse.Options
 	var embed *embedClickHouse
-	maxOpenConnections := 10 // based on observations
+	maxOpenConnections := 20 // based on observations
 	if conf.DSN != "" {
 		opts, err = clickhouse.ParseDSN(conf.DSN)
 		if err != nil {

--- a/runtime/drivers/druid/druid.go
+++ b/runtime/drivers/druid/druid.go
@@ -98,6 +98,8 @@ type configProperties struct {
 	SSL bool `mapstructure:"ssl"`
 	// LogQueries controls whether to log the raw SQL passed to OLAP.Execute.
 	LogQueries bool `mapstructure:"log_queries"`
+	// MaxOpenConns is the maximum number of open connections to the database. Set to 0 to use the default value or -1 for unlimited.
+	MaxOpenConns int `mapstructure:"max_open_conns"`
 }
 
 // Opens a connection to Apache Druid using HTTP API.
@@ -122,7 +124,11 @@ func (d driver) Open(instanceID string, config map[string]any, st *storage.Clien
 	if err != nil {
 		return nil, err
 	}
-	db.SetMaxOpenConns(10) // based on observations
+
+	if conf.MaxOpenConns == 0 {
+		conf.MaxOpenConns = 20 // default value
+	}
+	db.SetMaxOpenConns(conf.MaxOpenConns)
 
 	err = otelsql.RegisterDBStatsMetrics(db, otelsql.WithAttributes(attribute.String("instance_id", instanceID)))
 	if err != nil {

--- a/runtime/drivers/druid/druid.go
+++ b/runtime/drivers/druid/druid.go
@@ -125,10 +125,11 @@ func (d driver) Open(instanceID string, config map[string]any, st *storage.Clien
 		return nil, err
 	}
 
-	if conf.MaxOpenConns == 0 {
-		conf.MaxOpenConns = 20 // default value
+	maxOpenConns := conf.MaxOpenConns
+	if maxOpenConns == 0 {
+		maxOpenConns = 20 // default value
 	}
-	db.SetMaxOpenConns(conf.MaxOpenConns)
+	db.SetMaxOpenConns(maxOpenConns)
 
 	err = otelsql.RegisterDBStatsMetrics(db, otelsql.WithAttributes(attribute.String("instance_id", instanceID)))
 	if err != nil {

--- a/runtime/drivers/pinot/pinot.go
+++ b/runtime/drivers/pinot/pinot.go
@@ -174,10 +174,11 @@ func (d driver) Open(instanceID string, config map[string]any, st *storage.Clien
 		return nil, err
 	}
 
-	if conf.MaxOpenConns == 0 {
-		conf.MaxOpenConns = 20 // default value
+	maxOpenConns := conf.MaxOpenConns
+	if maxOpenConns == 0 {
+		maxOpenConns = 20 // default value
 	}
-	db.SetMaxOpenConns(conf.MaxOpenConns)
+	db.SetMaxOpenConns(maxOpenConns)
 
 	err = otelsql.RegisterDBStatsMetrics(db, otelsql.WithAttributes(attribute.String("instance_id", instanceID)))
 	if err != nil {


### PR DESCRIPTION
Instead of hardcoding here - https://github.com/rilldata/rill/pull/6935 lets make it configurable. Would have liked to use `*int` for this config as `0` means unlimited but we already have this as `int` in clickhouse configs since sometime. (Not sure if anybody is setting it otherwise can convert all to pointers)