### PR TITLE
Fix: disable time summary query for metrics without time dimension

### DIFF
--- a/web-common/src/features/canvas/stores/time-control.ts
+++ b/web-common/src/features/canvas/stores/time-control.ts
@@ -338,6 +338,8 @@ export class TimeControls {
           {},
           {
             query: {
+              enabled:
+                !!metricsViews[metricView]?.state?.validSpec?.timeDimension,
               queryClient: queryClient,
               staleTime: Infinity,
               cacheTime: Infinity,


### PR DESCRIPTION
https://www.notion.so/rilldata/Canvas-breaks-for-metrics_views-without-time-column-1b4ba33c8f5780ceb114f19172ada1d3

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
