### PR TITLE
fix (Connector Explorer): Don't hide OLAP tables when there's no explicit `database`

### DIFF
--- a/web-common/src/features/connectors/olap/DatabaseExplorer.svelte
+++ b/web-common/src/features/connectors/olap/DatabaseExplorer.svelte
@@ -28,9 +28,7 @@
     {:else}
       <ol transition:slide={{ duration }}>
         {#each data as database (database)}
-          {#if database}
-            <DatabaseEntry {instanceId} {connector} {database} {store} />
-          {/if}
+          <DatabaseEntry {instanceId} {connector} {database} {store} />
         {/each}
       </ol>
     {/if}

--- a/web-common/src/features/connectors/olap/selectors.ts
+++ b/web-common/src/features/connectors/olap/selectors.ts
@@ -73,7 +73,7 @@ export function useDatabases(instanceId: string, connector: string) {
           // Get the unique databases
           return (
             data.tables
-              ?.map((table) => table.database)
+              ?.map((tableInfo) => tableInfo.database ?? "")
               .filter((value, index, self) => self.indexOf(value) === index) ??
             []
           );


### PR DESCRIPTION
Reverts a small regression introduced in https://github.com/rilldata/rill/pull/6774

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
