### PR TITLE
check project perms for report open link

### DIFF
--- a/admin/server/reports.go
+++ b/admin/server/reports.go
@@ -89,9 +89,8 @@ func (s *Server) GetReportMeta(ctx context.Context, req *adminv1.GetReportMetaRe
 				if errors.Is(err, database.ErrNotFound) {
 					canOpenReport[email] = false
 					continue
-				} else {
-					return nil, fmt.Errorf("failed to find user by email: %w", err)
 				}
+				return nil, fmt.Errorf("failed to find user by email: %w", err)
 			}
 			// check user's project permissions
 			orgPerms, err := s.admin.OrganizationPermissionsForUser(ctx, proj.OrganizationID, usr.ID)

--- a/admin/server/reports.go
+++ b/admin/server/reports.go
@@ -81,17 +81,29 @@ func (s *Server) GetReportMeta(ctx context.Context, req *adminv1.GetReportMetaRe
 		return nil, fmt.Errorf("failed to issue magic auth tokens: %w", err)
 	}
 
-	externalEmailSet := make(map[string]bool)
+	canOpenReport := make(map[string]bool)
 	if webOpenMode == WebOpenModeRecipient {
 		for _, email := range req.EmailRecipients {
-			_, err := s.admin.DB.FindUserByEmail(ctx, email)
+			usr, err := s.admin.DB.FindUserByEmail(ctx, email)
 			if err != nil {
 				if errors.Is(err, database.ErrNotFound) {
-					externalEmailSet[email] = true
+					canOpenReport[email] = false
+					continue
 				} else {
 					return nil, fmt.Errorf("failed to find user by email: %w", err)
 				}
 			}
+			// check user's project permissions
+			orgPerms, err := s.admin.OrganizationPermissionsForUser(ctx, proj.OrganizationID, usr.ID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get organization permissions for user: %w", err)
+			}
+			projectPermissions, err := s.admin.ProjectPermissionsForUser(ctx, proj.ID, usr.ID, orgPerms)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get project permissions for user: %w", err)
+			}
+			canOpenReport[email] = projectPermissions.ReadProject && projectPermissions.ReadProd
+			// there's still an edge case where user has access to project but not to the metrics view because of security policy but report creator needs to take care of this consistency
 		}
 	}
 
@@ -111,7 +123,7 @@ func (s *Server) GetReportMeta(ctx context.Context, req *adminv1.GetReportMetaRe
 		}
 		if webOpenMode == WebOpenModeCreator {
 			urls[recipient].OpenUrl = s.admin.URLs.WithCustomDomain(org.CustomDomain).ReportOpen(org.Name, proj.Name, req.Report, tokens[recipient], req.ExecutionTime.AsTime())
-		} else if webOpenMode == WebOpenModeRecipient && !externalEmailSet[recipient] {
+		} else if webOpenMode == WebOpenModeRecipient && canOpenReport[recipient] {
 			urls[recipient].OpenUrl = s.admin.URLs.WithCustomDomain(org.CustomDomain).ReportOpen(org.Name, proj.Name, req.Report, "", req.ExecutionTime.AsTime())
 		}
 	}

--- a/cli/cmd/devtool/data/cloud-deps.docker-compose.yml
+++ b/cli/cmd/devtool/data/cloud-deps.docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
     ports:
-      - '5432:5432'
+      - '5433:5432'
     volumes:
       - ../../../../${RILL_DEVTOOL_STATE_DIRECTORY}/postgres:/var/lib/postgresql/data
   e2e-postgres:
@@ -90,6 +90,6 @@ services:
     ports:
       - "8082:8081"
     environment:
-      - DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres?sslmode=disable
+      - DATABASE_URL=postgres://postgres:postgres@postgres:5433/postgres?sslmode=disable
     depends_on:
       - postgres

--- a/cli/cmd/devtool/data/cloud-deps.docker-compose.yml
+++ b/cli/cmd/devtool/data/cloud-deps.docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
     ports:
-      - '5433:5432'
+      - '5432:5432'
     volumes:
       - ../../../../${RILL_DEVTOOL_STATE_DIRECTORY}/postgres:/var/lib/postgresql/data
   e2e-postgres:
@@ -90,6 +90,6 @@ services:
     ports:
       - "8082:8081"
     environment:
-      - DATABASE_URL=postgres://postgres:postgres@postgres:5433/postgres?sslmode=disable
+      - DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres?sslmode=disable
     depends_on:
       - postgres


### PR DESCRIPTION
Resolves one more edge case where user who accidentally sign up to Rill get open link and they can request access when they open the report link. Main issue happens if admins accidentally accepts the request assuming they are giving access just to the report.
