### PR TITLE
Process remaining valid flags

### DIFF
--- a/web-common/src/features/feature-flags.ts
+++ b/web-common/src/features/feature-flags.ts
@@ -52,7 +52,7 @@ class FeatureFlags {
     const updateFlags = (userFlags: V1InstanceFeatureFlags) => {
       for (const key in userFlags) {
         const flag = this[key] as FeatureFlag | undefined;
-        if (!flag || flag.internalOnly) return;
+        if (!flag || flag.internalOnly) continue;
         flag.set(userFlags[key]);
       }
     };


### PR DESCRIPTION
Address https://www.notion.so/rilldata/Allow-this-feature-flag-to-be-used-simultaneously-with-leaderboardMeasureCount-feature-flag-1bdba33c8f5780488d2bca320dc69215

When an invalid flag is encountered, the function returns immediately instead of continuing to process the remaining valid flags. We will skip that flag and continue processing the remaining flags to fix this.

To repro:
1. Check out `bgh/drag-poc`
2. Apply this in the `rill.yaml`
```
features:
  # - leaderboardMeasureCount
  - reorderMeasuresDimensions
```
3. With this PR, it will now process the `reorderMeasuresDimensions` instead of early returning from the function.

**BTW**
- `leaderboardMeasureCount` is only available in https://github.com/rilldata/rill/pull/6816
- `reorderMeasuresDimensions` is only available in https://github.com/rilldata/rill/pull/6949


**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
