### PR TITLE
tweak: remove bounding client binding

### DIFF
--- a/web-common/src/components/data-types/Base.svelte
+++ b/web-common/src/components/data-types/Base.svelte
@@ -1,28 +1,14 @@
 <script lang="ts">
-  import { onMount, onDestroy } from "svelte";
-
   export let classes = "";
   export let isNull = false;
   export let dark = false;
   export let truncate = false;
   export let color = "text-gray-900";
-  export let contentRect: DOMRect | undefined = undefined;
 
   $: color = dark ? "" : color;
-
-  let element: HTMLSpanElement;
-  onMount(() => {
-    if (element) {
-      contentRect = element.getBoundingClientRect();
-    }
-  });
-
-  onDestroy(() => {
-    contentRect = undefined;
-  });
 </script>
 
-<span bind:this={element} class:truncate class="{classes} {color}">
+<span class:truncate class="{classes} {color}">
   {#if isNull}
     <span class="text-gray-400">-</span>
   {:else}

--- a/web-common/src/components/data-types/FormattedDataType.svelte
+++ b/web-common/src/components/data-types/FormattedDataType.svelte
@@ -29,7 +29,6 @@
   export let customStyle = "";
   export let truncate = false;
   export let color = "";
-  export let contentRect: DOMRect | undefined = undefined;
 
   let dataType;
   $: {
@@ -67,6 +66,5 @@ about unknown props.
     {value}
     {truncate}
     {color}
-    bind:contentRect
   />
 {/if}

--- a/web-common/src/components/data-types/Number.svelte
+++ b/web-common/src/components/data-types/Number.svelte
@@ -10,7 +10,6 @@
   export let value;
   export let truncate = false;
   export let color = "";
-  export let contentRect: DOMRect | undefined = undefined;
 </script>
 
 <Base
@@ -21,7 +20,6 @@
     : ''} {customStyle}"
   {dark}
   {color}
-  bind:contentRect
 >
   <slot name="value">
     {formatDataType(value, type)}


### PR DESCRIPTION
The `Base` component is currently used in contexts where it's possible to render hundreds or thousands of elements. There is an effort to remove the need for this formatter component and/or virtualize in places where it is used, but, in the meantime, we should not be querying the DOM for this info. If the bounding info is still needed in places where fewer elements are being rendered, a wrapper element can be used.