### PR TITLE
fix: incorrect as of reference

### DIFF
--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -146,14 +146,16 @@
 
   $: availableTimeZones = getPinnedTimeZones(exploreSpec);
 
+  $: allTimeRangeInterval = allTimeRange
+    ? Interval.fromDateTimes(allTimeRange.start, allTimeRange.end)
+    : Interval.invalid("Invalid interval");
+
   $: interval = selectedTimeRange
     ? Interval.fromDateTimes(
         DateTime.fromJSDate(selectedTimeRange.start).setZone(activeTimeZone),
         DateTime.fromJSDate(selectedTimeRange.end).setZone(activeTimeZone),
       )
-    : allTimeRange
-      ? Interval.fromDateTimes(allTimeRange.start, allTimeRange.end)
-      : Interval.invalid("Invalid interval");
+    : allTimeRangeInterval;
 
   $: baseTimeRange = selectedTimeRange?.start &&
     selectedTimeRange?.end && {
@@ -345,7 +347,7 @@
         />
       {/if}
 
-      {#if interval.end?.isValid}
+      {#if allTimeRangeInterval?.end?.isValid}
         <Tooltip.Root openDelay={0}>
           <Tooltip.Trigger>
             <span class="text-gray-600 italic">
@@ -353,7 +355,7 @@
                 italic
                 suppress
                 showDate={false}
-                date={interval.end}
+                date={allTimeRangeInterval.end}
                 zone={activeTimeZone}
               />
             </span>


### PR DESCRIPTION
The `as of` element was using the end of the currently selected time range as its reference rather than the overall bounds of the dataset. This was a holdover from a previous version of this element was not the intended behavior for release.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
