### PR TITLE
Hotfix: measures formatter

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -71,15 +71,16 @@
   export let suppressTooltip = false;
   export let leaderboardMeasureCountFeatureFlag: boolean;
   export let measureLabel: (measureName: string) => string;
+  export let formatters: Record<
+    string,
+    (value: number | string | null | undefined) => string | null | undefined
+  >;
   export let toggleDimensionValueSelection: (
     dimensionName: string,
     dimensionValue: string,
     keepPillVisible?: boolean | undefined,
     isExclusiveFilter?: boolean | undefined,
   ) => void;
-  export let formatter:
-    | ((_value: number | undefined) => undefined)
-    | ((value: string | number) => string);
   export let setPrimaryDimension: (dimensionName: string) => void;
   export let toggleSort: (sortType: DashboardState_LeaderboardSortType) => void;
   export let toggleComparisonDimension: (
@@ -364,7 +365,7 @@
             {isTimeComparisonActive}
             {activeMeasureNames}
             {toggleDimensionValueSelection}
-            {formatter}
+            {formatters}
           />
         {/each}
       {/if}
@@ -386,7 +387,7 @@
           borderTop={i === 0}
           borderBottom={i === belowTheFoldRows.length - 1}
           {toggleDimensionValueSelection}
-          {formatter}
+          {formatters}
         />
       {/each}
     </tbody>

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -25,7 +25,7 @@
   const {
     selectors: {
       activeMeasure: { isValidPercentOfTotal, isSummableMeasure },
-      numberFormat: { measureFormatters },
+      numberFormat: { measureFormatters, activeMeasureFormatter },
       dimensionFilters: { isFilterExcludeMode },
       dimensions: { visibleDimensions },
       comparison: { isBeingCompared: isBeingComparedReadable },
@@ -117,7 +117,9 @@
                 timeRange.end,
               )}
               isBeingCompared={$isBeingComparedReadable(dimension.name)}
-              formatters={$measureFormatters}
+              formatters={$leaderboardMeasureCountFeatureFlag
+                ? $measureFormatters
+                : { [activeMeasureName]: $activeMeasureFormatter }}
               {setPrimaryDimension}
               {toggleSort}
               {toggleDimensionValueSelection}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -25,7 +25,7 @@
   const {
     selectors: {
       activeMeasure: { isValidPercentOfTotal, isSummableMeasure },
-      numberFormat: { activeMeasureFormatter },
+      numberFormat: { measureFormatters },
       dimensionFilters: { isFilterExcludeMode },
       dimensions: { visibleDimensions },
       comparison: { isBeingCompared: isBeingComparedReadable },
@@ -117,7 +117,7 @@
                 timeRange.end,
               )}
               isBeingCompared={$isBeingComparedReadable(dimension.name)}
-              formatter={$activeMeasureFormatter}
+              formatters={$measureFormatters}
               {setPrimaryDimension}
               {toggleSort}
               {toggleDimensionValueSelection}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -38,9 +38,10 @@
     keepPillVisible?: boolean | undefined,
     isExclusiveFilter?: boolean | undefined,
   ) => void;
-  export let formatter:
-    | ((_value: number | undefined) => undefined)
-    | ((value: string | number) => string);
+  export let formatters: Record<
+    string,
+    (value: number | string | null | undefined) => string | null | undefined
+  >;
   export let dimensionColumnWidth: number;
   export let suppressTooltip: boolean;
 
@@ -73,7 +74,9 @@
     activeMeasureNames.length === 1 &&
     prevValues[activeMeasureNames[0]] !== undefined &&
     prevValues[activeMeasureNames[0]] !== null
-      ? formatter(prevValues[activeMeasureNames[0]] as number)
+      ? formatters[activeMeasureNames[0]]?.(
+          prevValues[activeMeasureNames[0]] as number,
+        )
       : undefined;
 
   $: href = makeHref(uri, dimensionValue);
@@ -291,7 +294,9 @@
       <div class="w-fit ml-auto bg-transparent" bind:contentRect={valueRect}>
         <FormattedDataType
           type="INTEGER"
-          value={values[measureName] ? formatter(values[measureName]) : null}
+          value={values[measureName]
+            ? formatters[measureName]?.(values[measureName])
+            : null}
         />
       </div>
 
@@ -334,7 +339,7 @@
           color="text-gray-500"
           type="INTEGER"
           value={deltaAbsMap[measureName]
-            ? formatter(deltaAbsMap[measureName])
+            ? formatters[measureName]?.(deltaAbsMap[measureName])
             : null}
           customStyle={deltaAbsMap[measureName] !== null &&
           deltaAbsMap[measureName] < 0

--- a/web-common/src/features/dashboards/state-managers/selectors/data-formatting.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/data-formatting.ts
@@ -2,6 +2,7 @@ import { createMeasureValueFormatter } from "@rilldata/web-common/lib/number-for
 import { FormatPreset } from "@rilldata/web-common/lib/number-formatting/humanizer-types";
 import { activeMeasure } from "./active-measure";
 import type { DashboardDataSources } from "./types";
+import { visibleMeasures } from "./measures";
 
 export const formattingSelectors = {
   /**
@@ -12,16 +13,15 @@ export const formattingSelectors = {
     FormatPreset.HUMANIZE,
 
   /**
-   * A readable containing a function that formats values
-   * according to the active measure's format specification,
-   * whether it's a d3 format string or a format preset.
+   * A map of measure names to their formatters
    */
-  activeMeasureFormatter: (args: DashboardDataSources) => {
-    const measure = activeMeasure(args);
-    if (measure === undefined) {
-      return (_value: number | undefined) => undefined;
-    }
-
-    return createMeasureValueFormatter(measure);
+  measureFormatters: (args: DashboardDataSources) => {
+    const measures = visibleMeasures(args);
+    return Object.fromEntries(
+      measures.map((measure) => [
+        measure.name,
+        createMeasureValueFormatter(measure),
+      ]),
+    );
   },
 };

--- a/web-common/src/features/dashboards/state-managers/selectors/data-formatting.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/data-formatting.ts
@@ -13,6 +13,20 @@ export const formattingSelectors = {
     FormatPreset.HUMANIZE,
 
   /**
+   * A readable containing a function that formats values
+   * according to the active measure's format specification,
+   * whether it's a d3 format string or a format preset.
+   */
+  activeMeasureFormatter: (args: DashboardDataSources) => {
+    const measure = activeMeasure(args);
+    if (measure === undefined) {
+      return (_value: number | undefined) => undefined;
+    }
+
+    return createMeasureValueFormatter(measure);
+  },
+
+  /**
    * A map of measure names to their formatters
    */
   measureFormatters: (args: DashboardDataSources) => {


### PR DESCRIPTION
Reported by https://rilldata.slack.com/archives/C02T907FEUB/p1743004498455459

Closes https://github.com/rilldata/rill-private-issues/issues/1459

After [the recent changes in multiple metrics](https://github.com/rilldata/rill/pull/6816), it has come to our attention that the measure formatting still relies on the active measure. When the `leaderboardMeasureCount` flag is enabled, we want to use each measure's own formatter rather than relying on the active measure's format.

See the recording:

https://github.com/user-attachments/assets/fb6ae8a1-237d-49ba-b7cc-f5e160bf7ed3

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
