### PR TITLE
increase default maximum number of concurrent model executions to 5

### DIFF
--- a/runtime/drivers/registry.go
+++ b/runtime/drivers/registry.go
@@ -141,7 +141,7 @@ func (i *Instance) Config() (InstanceConfig, error) {
 		StageChanges:                         true,
 		ModelDefaultMaterialize:              false,
 		ModelMaterializeDelaySeconds:         0,
-		ModelConcurrentExecutionLimit:        1,
+		ModelConcurrentExecutionLimit:        5,
 		MetricsApproximateComparisons:        true,
 		MetricsApproximateComparisonsCTE:     false,
 		MetricsApproxComparisonTwoPhaseLimit: 250,


### PR DESCRIPTION
When we saw OOMes on projects ingesting from Snowflake, there was no limit on concurrent execution and the parquet row buffer group size to be kept in memory was 512MB which has now been reduced to [64MB](https://github.com/rilldata/rill/blob/88dc93d0058026090c3cd4eea2f778de4c380ee5/runtime/drivers/snowflake/warehouse.go#L30-L31)
Lets experiment with 5 and reduce for projects where we see OOMes.