### PR TITLE
fix (Reports): safer typing to prevent malformed reports

### DIFF
--- a/web-admin/src/features/scheduled-reports/metadata/ReportMetadata.svelte
+++ b/web-admin/src/features/scheduled-reports/metadata/ReportMetadata.svelte
@@ -200,7 +200,9 @@
 {#if reportSpec}
   <ScheduledReportDialog
     bind:open={showEditReportDialog}
-    {reportSpec}
-    exploreName={$dashboardName.data}
+    props={{
+      mode: "edit",
+      reportSpec,
+    }}
   />
 {/if}

--- a/web-common/src/features/exports/ExportMenu.svelte
+++ b/web-common/src/features/exports/ExportMenu.svelte
@@ -31,6 +31,7 @@
   let scheduledReportQuery: V1Query | undefined;
 
   // Get the query when the dialog is opened.
+  // (Note: it might be better to pass pre-computed queries into the `ExportMenu` component.)
   $: if (open) {
     exportQuery = getQuery(false);
     scheduledReportQuery = getQuery(true);
@@ -90,17 +91,20 @@
   <DropdownMenu.Content align="start">
     <DropdownMenu.Item
       on:click={() => handleExport(V1ExportFormat.EXPORT_FORMAT_CSV)}
+      disabled={!exportQuery}
     >
       Export as CSV
     </DropdownMenu.Item>
     <DropdownMenu.Item
       on:click={() => handleExport(V1ExportFormat.EXPORT_FORMAT_PARQUET)}
+      disabled={!exportQuery}
     >
       Export as Parquet
     </DropdownMenu.Item>
 
     <DropdownMenu.Item
       on:click={() => handleExport(V1ExportFormat.EXPORT_FORMAT_XLSX)}
+      disabled={!exportQuery}
     >
       Export as XLSX
     </DropdownMenu.Item>

--- a/web-common/src/features/exports/ExportMenu.svelte
+++ b/web-common/src/features/exports/ExportMenu.svelte
@@ -27,8 +27,14 @@
   let showScheduledReportDialog = false;
   let open = false;
 
-  $: exportQuery = getQuery(false);
-  $: scheduledReportQuery = getQuery(true);
+  let exportQuery: V1Query | undefined;
+  let scheduledReportQuery: V1Query | undefined;
+
+  // Get the query when the dialog is opened.
+  $: if (open) {
+    exportQuery = getQuery(false);
+    scheduledReportQuery = getQuery(true);
+  }
 
   const exportDash = createQueryServiceExport();
   const { reports } = featureFlags;

--- a/web-common/src/features/exports/ExportMenu.svelte
+++ b/web-common/src/features/exports/ExportMenu.svelte
@@ -5,6 +5,7 @@
   import Export from "@rilldata/web-common/components/icons/Export.svelte";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
+  import { featureFlags } from "@rilldata/web-common/features/feature-flags";
   import {
     createQueryServiceExport,
     V1ExportFormat,
@@ -14,7 +15,6 @@
   import { onMount } from "svelte";
   import { get } from "svelte/store";
   import { runtime } from "../../runtime-client/runtime-store";
-  import { featureFlags } from "@rilldata/web-common/features/feature-flags";
   import type TScheduledReportDialog from "../scheduled-reports/ScheduledReportDialog.svelte";
 
   export let disabled: boolean = false;
@@ -27,6 +27,9 @@
   let showScheduledReportDialog = false;
   let open = false;
 
+  $: exportQuery = getQuery(false);
+  $: scheduledReportQuery = getQuery(true);
+
   const exportDash = createQueryServiceExport();
   const { reports } = featureFlags;
 
@@ -34,7 +37,7 @@
     const result = await $exportDash.mutateAsync({
       instanceId: get(runtime).instanceId,
       data: {
-        query: getQuery(false),
+        query: exportQuery,
         format,
       },
     });
@@ -96,20 +99,26 @@
       Export as XLSX
     </DropdownMenu.Item>
 
-    {#if includeScheduledReport && $reports}
-      <DropdownMenu.Item on:click={() => (showScheduledReportDialog = true)}>
+    {#if includeScheduledReport && $reports && exploreName}
+      <DropdownMenu.Item
+        on:click={() => (showScheduledReportDialog = true)}
+        disabled={!scheduledReportQuery}
+      >
         Create scheduled report...
       </DropdownMenu.Item>
     {/if}
   </DropdownMenu.Content>
 </DropdownMenu.Root>
 
-{#if includeScheduledReport && ScheduledReportDialog && showScheduledReportDialog}
+{#if includeScheduledReport && ScheduledReportDialog && showScheduledReportDialog && scheduledReportQuery && exploreName}
   <svelte:component
     this={ScheduledReportDialog}
-    query={getQuery(true)}
-    {exploreName}
     bind:open={showScheduledReportDialog}
+    props={{
+      mode: "create",
+      query: scheduledReportQuery,
+      exploreName,
+    }}
   />
 {/if}
 

--- a/web-common/src/features/scheduled-reports/ScheduledReportDialog.svelte
+++ b/web-common/src/features/scheduled-reports/ScheduledReportDialog.svelte
@@ -151,7 +151,7 @@
                   ],
             webOpenMode:
               props.mode === "create"
-                ? "recipient"
+                ? "recipient" // To be changed to "filtered" once support is added
                 : ((props.reportSpec.annotations as V1ReportSpecAnnotations)[
                     "web_open_mode"
                   ] ?? "recipient"), // Backwards compatibility

--- a/web-common/src/features/scheduled-reports/ScheduledReportDialog.svelte
+++ b/web-common/src/features/scheduled-reports/ScheduledReportDialog.svelte
@@ -1,3 +1,16 @@
+<script lang="ts" context="module">
+  export type CreateReportProps = {
+    mode: "create";
+    query: V1Query;
+    exploreName: string;
+  };
+
+  export type EditReportProps = {
+    mode: "edit";
+    reportSpec: V1ReportSpec;
+  };
+</script>
+
 <script lang="ts">
   import { page } from "$app/stores";
   import {
@@ -8,8 +21,9 @@
   import * as Dialog from "@rilldata/web-common/components/dialog-v2";
   import {
     getDashboardNameFromReport,
-    getInitialValues,
-    getQueryArgsFromQuery,
+    getExistingReportInitialFormValues,
+    getNewReportInitialFormValues,
+    getQueryArgsJsonFromQuery,
     getQueryNameFromQuery,
     type ReportValues,
   } from "@rilldata/web-common/features/scheduled-reports/utils";
@@ -17,7 +31,7 @@
   import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
   import { get } from "svelte/store";
   import { defaults, superForm } from "sveltekit-superforms";
-  import { type ValidationAdapter, yup } from "sveltekit-superforms/adapters";
+  import { yup, type ValidationAdapter } from "sveltekit-superforms/adapters";
   import { array, object, string } from "yup";
   import { Button } from "../../components/button";
   import {
@@ -34,30 +48,34 @@
   import { convertFormValuesToCronExpression } from "./time-utils";
 
   export let open: boolean;
-  export let query: V1Query | undefined = undefined;
-  export let exploreName: string | undefined = undefined;
-  export let reportSpec: V1ReportSpec | undefined = undefined;
+  export let props: CreateReportProps | EditReportProps;
 
   const user = createAdminServiceGetCurrentUser();
 
   $: ({ organization, project, report: reportName } = $page.params);
   $: ({ instanceId } = $runtime);
 
-  $: isEdit = !!reportSpec;
+  $: mutation =
+    props.mode === "create"
+      ? createAdminServiceCreateReport()
+      : createAdminServiceEditReport();
 
-  $: mutation = isEdit
-    ? createAdminServiceEditReport()
-    : createAdminServiceCreateReport();
+  $: queryName =
+    props.mode === "create"
+      ? getQueryNameFromQuery(props.query)
+      : props.reportSpec.queryName;
+  $: queryArgsJson =
+    props.mode === "create"
+      ? getQueryArgsJsonFromQuery(props.query)
+      : props.reportSpec.queryArgsJson;
 
-  $: if (!exploreName) {
-    exploreName = getDashboardNameFromReport(reportSpec) ?? "";
-  }
-
-  $: queryName = query ? getQueryNameFromQuery(query) : undefined;
-  $: queryArgs = query ? getQueryArgsFromQuery(query) : undefined;
+  $: exploreName =
+    props.mode === "create"
+      ? props.exploreName
+      : getDashboardNameFromReport(props.reportSpec);
 
   let currentProtobufState: string | undefined = undefined;
-  if (open && !isEdit) {
+  if (open && props.mode === "create") {
     const stateManagers = getStateManagers();
     const { dashboardStore } = stateManagers;
     currentProtobufState = get(dashboardStore).proto;
@@ -72,7 +90,14 @@
     }),
   ) as ValidationAdapter<ReportValues>;
 
-  $: initialValues = getInitialValues(reportSpec, $user.data?.user?.email);
+  $: initialValues =
+    props.mode === "create"
+      ? getNewReportInitialFormValues($user.data?.user?.email)
+      : getExistingReportInitialFormValues(
+          props.reportSpec,
+          $user.data?.user?.email,
+        );
+
   $: ({ form, errors, enhance, submit, submitting } = superForm(
     defaults(initialValues, schema),
     {
@@ -107,12 +132,8 @@
             refreshCron: refreshCron, // for testing: "* * * * *"
             refreshTimeZone: values.timeZone,
             explore: exploreName,
-            queryName: reportSpec?.queryName ?? queryName,
-            queryArgsJson: JSON.stringify(
-              reportSpec?.queryArgsJson
-                ? JSON.parse(reportSpec.queryArgsJson)
-                : queryArgs,
-            ),
+            queryName: queryName,
+            queryArgsJson: queryArgsJson,
             exportLimit: values.exportLimit || undefined,
             exportFormat: values.exportFormat,
             emailRecipients: values.emailRecipients.filter(Boolean),
@@ -122,21 +143,23 @@
             slackUsers: values.enableSlackNotification
               ? values.slackUsers.filter(Boolean)
               : undefined,
-            webOpenState: reportSpec
-              ? (reportSpec.annotations as V1ReportSpecAnnotations)[
-                  "web_open_state"
-                ]
-              : currentProtobufState,
-            webOpenMode: isEdit
-              ? ((reportSpec?.annotations as V1ReportSpecAnnotations)[
-                  "web_open_mode"
-                ] ?? "recipient") // Backwards compatibility
-              : "recipient", // To be changed to "filtered" once support is added
+            webOpenState:
+              props.mode === "create"
+                ? currentProtobufState
+                : (props.reportSpec.annotations as V1ReportSpecAnnotations)[
+                    "web_open_state"
+                  ],
+            webOpenMode:
+              props.mode === "create"
+                ? "recipient"
+                : ((props.reportSpec.annotations as V1ReportSpecAnnotations)[
+                    "web_open_mode"
+                  ] ?? "recipient"), // Backwards compatibility
           },
         },
       });
 
-      if (isEdit) {
+      if (props.mode === "edit") {
         await queryClient.invalidateQueries(
           getRuntimeServiceGetResourceQueryKey(instanceId, {
             "name.name": reportName,
@@ -152,13 +175,14 @@
       open = false;
 
       eventBus.emit("notification", {
-        message: `Report ${isEdit ? "edited" : "created"}`,
-        link: reportSpec
-          ? undefined
-          : {
-              href: `/${organization}/${project}/-/reports`,
-              text: "Go to scheduled reports",
-            },
+        message: `Report ${props.mode === "create" ? "created" : "edited"}`,
+        link:
+          props.mode === "create"
+            ? {
+                href: `/${organization}/${project}/-/reports`,
+                text: "Go to scheduled reports",
+              }
+            : undefined,
         type: "success",
       });
     } catch {
@@ -192,7 +216,7 @@
         submitForm
         type="primary"
       >
-        {isEdit ? "Save" : "Create"}
+        {props.mode === "create" ? "Create" : "Save"}
       </Button>
     </div>
   </Dialog.Content>

--- a/web-common/src/features/scheduled-reports/utils.ts
+++ b/web-common/src/features/scheduled-reports/utils.ts
@@ -17,7 +17,7 @@ import {
   type V1ReportSpec,
 } from "@rilldata/web-common/runtime-client";
 
-export type ReportValues = ReturnType<typeof getInitialValues>;
+export type ReportValues = ReturnType<typeof getNewReportInitialFormValues>;
 
 export function getQueryNameFromQuery(query: V1Query) {
   if (query.metricsViewAggregationRequest) {
@@ -29,9 +29,9 @@ export function getQueryNameFromQuery(query: V1Query) {
   }
 }
 
-export function getQueryArgsFromQuery(query: V1Query) {
+export function getQueryArgsJsonFromQuery(query: V1Query): string {
   if (query.metricsViewAggregationRequest) {
-    return query.metricsViewAggregationRequest;
+    return JSON.stringify(query.metricsViewAggregationRequest);
   } else {
     throw new Error(
       "Currently, only `MetricsViewAggregation` queries can be scheduled through the UI",
@@ -39,68 +39,64 @@ export function getQueryArgsFromQuery(query: V1Query) {
   }
 }
 
-export function getInitialValues(
-  reportSpec: V1ReportSpec | undefined,
-  userEmail: string | undefined,
-) {
+export function getNewReportInitialFormValues(userEmail: string | undefined) {
   return {
-    title: reportSpec?.displayName ?? "",
-    frequency: reportSpec
-      ? getFrequencyFromCronExpression(
-          reportSpec.refreshSchedule?.cron as string,
-        )
-      : ReportFrequency.Weekly,
-    dayOfWeek: reportSpec
-      ? getDayOfWeekFromCronExpression(
-          reportSpec.refreshSchedule?.cron as string,
-        )
-      : getTodaysDayOfWeek(),
-    dayOfMonth: reportSpec
-      ? getDayOfMonthFromCronExpression(
-          reportSpec.refreshSchedule?.cron as string,
-        )
-      : 1, // We only support first of day right now
-    timeOfDay: reportSpec
-      ? getTimeOfDayFromCronExpression(
-          reportSpec.refreshSchedule?.cron as string,
-        )
-      : getTimeIn24FormatFromDateTime(getNextQuarterHour()),
-    timeZone: reportSpec?.refreshSchedule?.timeZone ?? getLocalIANA(),
-    exportFormat: reportSpec
-      ? (reportSpec?.exportFormat ?? V1ExportFormat.EXPORT_FORMAT_UNSPECIFIED)
-      : V1ExportFormat.EXPORT_FORMAT_CSV,
-    exportLimit: reportSpec
-      ? reportSpec.exportLimit === "0"
-        ? ""
-        : reportSpec.exportLimit
-      : "",
-    ...extractNotificationV2(reportSpec?.notifiers, userEmail, !!reportSpec),
+    title: "",
+    frequency: ReportFrequency.Weekly,
+    dayOfWeek: getTodaysDayOfWeek(),
+    dayOfMonth: 1,
+    timeOfDay: getTimeIn24FormatFromDateTime(getNextQuarterHour()),
+    timeZone: getLocalIANA(),
+    exportFormat: V1ExportFormat.EXPORT_FORMAT_CSV as V1ExportFormat,
+    exportLimit: "",
+    ...extractNotification(undefined, userEmail, false),
   };
 }
 
-export function getDashboardNameFromReport(
-  reportSpec: V1ReportSpec | undefined,
-): string | null {
-  if (!reportSpec) return null;
+export function getExistingReportInitialFormValues(
+  reportSpec: V1ReportSpec,
+  userEmail: string | undefined,
+) {
+  return {
+    title: reportSpec.displayName ?? "",
+    frequency: getFrequencyFromCronExpression(
+      reportSpec.refreshSchedule?.cron as string,
+    ),
+    dayOfWeek: getDayOfWeekFromCronExpression(
+      reportSpec.refreshSchedule?.cron as string,
+    ),
+    dayOfMonth: getDayOfMonthFromCronExpression(
+      reportSpec.refreshSchedule?.cron as string,
+    ),
+    timeOfDay: getTimeOfDayFromCronExpression(
+      reportSpec.refreshSchedule?.cron as string,
+    ),
+    timeZone: reportSpec.refreshSchedule?.timeZone ?? getLocalIANA(),
+    exportFormat:
+      reportSpec?.exportFormat ?? V1ExportFormat.EXPORT_FORMAT_UNSPECIFIED,
+    exportLimit: reportSpec.exportLimit === "0" ? "" : reportSpec.exportLimit,
+    ...extractNotification(reportSpec.notifiers, userEmail, true),
+  };
+}
 
+export function getDashboardNameFromReport(reportSpec: V1ReportSpec): string {
   if (reportSpec.annotations?.explore) return reportSpec.annotations.explore;
 
   if (reportSpec.annotations?.web_open_path)
     return getExploreName(reportSpec.annotations.web_open_path);
 
-  if (!reportSpec?.queryArgsJson) return null;
+  const queryArgsJson = JSON.parse(reportSpec.queryArgsJson!);
 
-  const queryArgsJson = JSON.parse(reportSpec.queryArgsJson);
   return (
     queryArgsJson?.metrics_view_name ??
     queryArgsJson?.metricsViewName ??
     queryArgsJson?.metrics_view ??
     queryArgsJson?.metricsView ??
-    null
+    ""
   );
 }
 
-export function extractNotificationV2(
+function extractNotification(
   notifiers: V1Notifier[] | undefined,
   userEmail: string | undefined,
   isEdit: boolean,


### PR DESCRIPTION
Now, if for some reason the Scheduled Report query cannot be constructed, we disable the Scheduled Report menu item.

This is a fairly minimal, incremental fix to avoid malformed reports. A further improvement could be to ensure that the various calls to `getQuery` passed into the `<ExportMenu />` cannot return `undefined` in the first place.

[Addresses this Slack thread](https://rilldata.slack.com/archives/C02T907FEUB/p1743003794456339)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
