### PR TITLE
fest: add banner to canvas

### DIFF
--- a/docs/docs/reference/project-files/canvas-dashboards.md
+++ b/docs/docs/reference/project-files/canvas-dashboards.md
@@ -15,6 +15,8 @@ In your Rill project directory, create a explore dashboard, `<dashboard_name>.ya
 
 **`display_name`** - Refers to the display name for the metrics view _(required)_.
 
+**`banner`** - Refers to the custom banner displayed at the header of an Canvas dashboard  _(optional)_.
+
 **`rows`** - Refers to all of the rows displayed on the Canvas dashboard _(required)_.
 
     - **`items`** - Refers to each row of components, mulitple items can be listed in a single `items` . _(required)_.

--- a/runtime/compilers/rillv1/parse_canvas.go
+++ b/runtime/compilers/rillv1/parse_canvas.go
@@ -19,6 +19,7 @@ type CanvasYAML struct {
 	commonYAML  `yaml:",inline"`       // Not accessed here, only setting it so we can use KnownFields for YAML parsing
 	DisplayName string                 `yaml:"display_name"`
 	Title       string                 `yaml:"title"` // Deprecated: use display_name
+	Banner      string                 `yaml:"banner"`
 	MaxWidth    uint32                 `yaml:"max_width"`
 	GapX        uint32                 `yaml:"gap_x"`
 	GapY        uint32                 `yaml:"gap_y"`
@@ -248,6 +249,7 @@ func (p *Parser) parseCanvas(node *Node) error {
 	if r.CanvasSpec.DisplayName == "" {
 		r.CanvasSpec.DisplayName = ToDisplayName(node.Name)
 	}
+	r.CanvasSpec.Banner = tmp.Banner
 	r.CanvasSpec.MaxWidth = tmp.MaxWidth
 	r.CanvasSpec.GapX = tmp.GapX
 	r.CanvasSpec.GapY = tmp.GapY

--- a/web-local/src/routes/(viz)/canvas/[name]/+page.svelte
+++ b/web-local/src/routes/(viz)/canvas/[name]/+page.svelte
@@ -1,12 +1,37 @@
 <script lang="ts">
+  import { onNavigate } from "$app/navigation";
   import CanvasDashboardEmbed from "@rilldata/web-common/features/canvas/CanvasDashboardEmbed.svelte";
   import CanvasThemeProvider from "@rilldata/web-common/features/canvas/CanvasThemeProvider.svelte";
   import StateManagersProvider from "@rilldata/web-common/features/canvas/state-managers/StateManagersProvider.svelte";
   import type { PageData } from "./$types";
+  import {
+    DashboardBannerID,
+    DashboardBannerPriority,
+  } from "@rilldata/web-common/components/banner/constants";
+  import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
 
   export let data: PageData;
 
   $: canvasName = data.dashboardName;
+  $: hasBanner = !!data.dashboard.canvas?.state?.validSpec?.banner;
+
+  $: if (hasBanner) {
+    eventBus.emit("add-banner", {
+      id: DashboardBannerID,
+      priority: DashboardBannerPriority,
+      message: {
+        type: "default",
+        message: data.dashboard.canvas?.state?.validSpec?.banner ?? "",
+        iconType: "alert",
+      },
+    });
+  }
+
+  onNavigate(() => {
+    if (hasBanner) {
+      eventBus.emit("remove-banner", DashboardBannerID);
+    }
+  });
 </script>
 
 {#key canvasName}


### PR DESCRIPTION
Adds `banner` to canvas. Was already present in proto.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
