### PR TITLE
test: add global timeout

### DIFF
--- a/web-local/tests/setup/base.ts
+++ b/web-local/tests/setup/base.ts
@@ -57,6 +57,9 @@ export const test = base.extend<MyFixtures>({
 
     await page.goto(`http://localhost:${TEST_PORT}`);
 
+    // Seems to help with issues related to DOM elements not being ready
+    await page.waitForTimeout(1000);
+
     await use(page);
 
     rmSync(TEST_PROJECT_DIRECTORY, {


### PR DESCRIPTION
This appears to have solved some of the issues with test flakiness in web-local, especially when running them on my local machine.
