### PR TITLE
fix: empty Vega chart for TDD

### DIFF
--- a/web-common/src/components/vega/VegaRenderer.svelte
+++ b/web-common/src/components/vega/VegaRenderer.svelte
@@ -64,6 +64,7 @@
     height,
     renderer,
     expressionFunctions,
+    useExpressionInterpreter: false,
   });
 
   const onError = (e: CustomEvent<{ error: Error }>) => {

--- a/web-common/src/components/vega/vega-embed-options.ts
+++ b/web-common/src/components/vega/vega-embed-options.ts
@@ -13,6 +13,7 @@ export interface CreateEmbedOptionsParams {
   config?: Config;
   renderer?: "canvas" | "svg";
   expressionFunctions?: ExpressionFunction;
+  useExpressionInterpreter?: boolean;
 }
 
 export function createEmbedOptions({
@@ -22,6 +23,7 @@ export function createEmbedOptions({
   config,
   renderer = "canvas",
   expressionFunctions = {},
+  useExpressionInterpreter = true,
 }: CreateEmbedOptionsParams): EmbedOptions {
   const jwt = get(runtime).jwt;
 
@@ -32,9 +34,11 @@ export function createEmbedOptions({
     logLevel: 0, // only show errors
     width: canvasDashboard ? width : undefined,
     height: canvasDashboard ? height : undefined,
-    // Add interpreter so that vega expressions are CSP compliant
-    ast: true,
-    expr: expressionInterpreter,
+    ...(useExpressionInterpreter && {
+      // Add interpreter so that vega expressions are CSP compliant
+      ast: true,
+      expr: expressionInterpreter,
+    }),
     expressionFunctions,
     loader: {
       baseURL: `${get(runtime).host}/v1/instances/${get(runtime).instanceId}/assets/`,


### PR DESCRIPTION
Post https://github.com/rilldata/rill/pull/6988 TDD Vega charts are not rendering any marks. This is a hotfix to disable expression interpreter for Vega charts until we can debug what is going wrong.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
