### PR TITLE
Clone instance before mutating it in `UpdateInstanceConnector`

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -182,6 +182,10 @@ func (r *Runtime) UpdateInstanceConnector(ctx context.Context, instanceID, name 
 		return err
 	}
 
+	// Shallow clone for editing
+	tmp := *inst
+	inst = &tmp
+
 	// remove the connector if it exists
 	for i, c := range inst.ProjectConnectors {
 		if c.Name == name {


### PR DESCRIPTION
The problem is that `r.Instance(ctx, instanceID)` returns the same cached value/pointer to all callers. So to avoid race conditions, it must not be mutated directly.