### PR TITLE
Fix incremental inserts being skipped when a `pre_exec` is configured for the `merge` strategy on DuckDB

### DIFF
--- a/runtime/drivers/duckdb/olap.go
+++ b/runtime/drivers/duckdb/olap.go
@@ -298,7 +298,9 @@ func (c *connection) InsertTableAsSelect(ctx context.Context, name, sql string, 
 			// Execute the pre-init SQL first
 			if opts.BeforeInsert != "" {
 				_, err := conn.ExecContext(ctx, opts.BeforeInsert)
-				return err
+				if err != nil {
+					return err
+				}
 			}
 			defer func() {
 				if opts.AfterInsert != "" {

--- a/runtime/resolvers/testdata/models_incremental_duckdb.yaml
+++ b/runtime/resolvers/testdata/models_incremental_duckdb.yaml
@@ -1,0 +1,37 @@
+project_files:
+  range_partitions_append.yaml:
+    type: model
+    partitions:
+      sql: SELECT range AS num FROM range(0, 10)
+    pre_exec: SELECT 1
+    sql: SELECT {{ .partition.num }} AS num
+    post_exec: SELECT 1
+    output:
+      incremental_strategy: append
+  range_partitions_merge.yaml:
+    type: model
+    partitions:
+      sql: SELECT range AS num FROM range(0, 10)
+    pre_exec: SELECT 1
+    sql: SELECT {{ .partition.num }} AS num
+    post_exec: SELECT 1
+    output:
+      incremental_strategy: merge
+      unique_key: [num]
+tests:
+  - name: range_partitions_append_stats
+    resolver: sql
+    properties:
+      sql: SELECT COUNT(*) AS count, MIN(num) AS min, MAX(num) AS max FROM range_partitions_append
+    result:
+      - count: 10
+        min: 0
+        max: 9
+  - name: range_partitions_merge_stats
+    resolver: sql
+    properties:
+      sql: SELECT COUNT(*) AS count, MIN(num) AS min, MAX(num) AS max FROM range_partitions_merge
+    result:
+      - count: 10
+        min: 0
+        max: 9

--- a/runtime/resolvers/testdata/s3_connector.yaml
+++ b/runtime/resolvers/testdata/s3_connector.yaml
@@ -29,6 +29,18 @@ project_files:
     materialize: true
     pre_exec: "CREATE SECRET secret1 (TYPE s3, KEY_ID '{{.env.connector.s3.aws_access_key_id}}', SECRET '{{.env.connector.s3.aws_secret_access_key}}', REGION 'us-east-1')"
     sql: "select * from read_csv('s3://integration-test.rilldata.com/glob_test/y=202*/a*.csv', auto_detect=true, ignore_errors=1, header=true)"
+  all_datatypes_duckdb_model_partitions.yaml:
+    type: model
+    connector: duckdb
+    materialize: true
+    pre_exec: "CREATE SECRET secret1 (TYPE s3, KEY_ID '{{.env.connector.s3.aws_access_key_id}}', SECRET '{{.env.connector.s3.aws_secret_access_key}}', REGION 'us-east-1')"
+    partitions:
+      glob:
+        path: s3://integration-test.rilldata.com/glob_test/y=202*/a*.csv
+    sql: "select * from read_csv('{{ .partition.uri }}', auto_detect=true, ignore_errors=0, header=true)"
+    output:
+      incremental_strategy: merge
+      unique_key: id
   all_datatypes_duckdb_model_parquet.yaml:
     type: model
     connector: duckdb
@@ -297,6 +309,13 @@ tests:
       4,true,123,45678901234,1.23,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,0001-01-01T00:02:03.456Z,0001-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,[1 2 3],['apple' 'banana' 'cherry'],"[('key1', 10), ('key2', 20)]","{'field_int_col': 42, 'field_float_col': 3.140000104904175, 'field_string_col': 'example'}",2023
       5,false,0,0,0,0,,0000000000000000,,0,1970-01-01,0001-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0000000000000000,[],[],[],"{'field_int_col': 0, 'field_float_col': 0.0, 'field_string_col': ''}",2023
       6,,,,,,,,,,,,,,,,,,,,2023
+  - name: query_count_duckdb_model_partitions
+    resolver: sql
+    properties:
+      sql: "select count(*) as count from all_datatypes_duckdb_model_partitions"
+    result_csv: |
+      count
+      6
   - name: query_all_result_clickhouse_glob
     resolver: sql
     properties:


### PR DESCRIPTION
This bug surfaced after we started setting `pre_exec` automatically for models that contain `s3://`.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
