### PR TITLE
Use visibleMeasures for querying and sorting in `leaderboardMeasureCount`

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -65,7 +65,6 @@
   export let isValidPercentOfTotal: boolean;
   export let timeControlsReady: boolean;
   export let dimensionColumnWidth: number;
-  export let isSummableMeasure: boolean;
   export let filterExcludeMode: boolean;
   export let isBeingCompared: boolean;
   export let parentElement: HTMLElement;
@@ -359,7 +358,6 @@
             {suppressTooltip}
             {tableWidth}
             {dimensionColumnWidth}
-            {isSummableMeasure}
             {isBeingCompared}
             {filterExcludeMode}
             {atLeastOneActive}
@@ -379,7 +377,6 @@
           {suppressTooltip}
           {itemData}
           {dimensionColumnWidth}
-          {isSummableMeasure}
           {tableWidth}
           {dimensionName}
           {isBeingCompared}

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -55,8 +55,7 @@
   export let whereFilter: V1Expression;
   export let dimensionThresholdFilters: DimensionThresholdFilter[];
   export let activeMeasureName: string;
-  // FIXME: rename
-  export let activeMeasureNames: string[]; // For display (limited by leaderboardMeasureCount)
+  export let leaderboardMeasureNames: string[]; // For display (limited by leaderboardMeasureCount)
   export let visibleMeasures: string[]; // For querying/sorting (all visible measures)
   export let metricsViewName: string;
   export let sortType: SortType;
@@ -189,7 +188,7 @@
     {
       ...(leaderboardMeasureCountFeatureFlag
         ? {
-            measures: activeMeasureNames.map((name) => ({ name })),
+            measures: leaderboardMeasureNames.map((name) => ({ name })),
           }
         : {
             measures: [{ name: activeMeasureName }],
@@ -210,7 +209,7 @@
 
   $: leaderboardTotals = totalsData?.data?.[0]
     ? Object.fromEntries(
-        activeMeasureNames.map((name) => [
+        leaderboardMeasureNames.map((name) => [
           name,
           (totalsData?.data?.[0]?.[name] as number) ?? null,
         ]),
@@ -221,7 +220,7 @@
     prepareLeaderboardItemData(
       sortedData?.data,
       dimensionName,
-      activeMeasureNames,
+      leaderboardMeasureNames,
       slice,
       $selectedValues?.data ?? [],
       leaderboardTotals,
@@ -278,7 +277,7 @@
     cleanUpComparisonValue(
       item,
       dimensionName,
-      activeMeasureNames,
+      leaderboardMeasureNames,
       leaderboardTotals,
       $selectedValues?.data?.findIndex((value) =>
         compareLeaderboardValues(value, item[dimensionName]),
@@ -290,10 +289,10 @@
 
   $: columnCount =
     1 + // Base column (dimension)
-    activeMeasureNames.length + // Value column for each measure
+    leaderboardMeasureNames.length + // Value column for each measure
     (isTimeComparisonActive
-      ? activeMeasureNames.length * // For each measure
-        ((isValidPercentOfTotal ? 1 : 0) + // Percent of total column
+      ? leaderboardMeasureNames.length * // For each measure
+        ((isValidPercentOfTotal(activeMeasureName) ? 1 : 0) + // Percent of total column
           (isTimeComparisonActive ? 2 : 0)) // Delta absolute and delta percent columns
       : 0);
 </script>
@@ -310,9 +309,9 @@
     <colgroup>
       <col data-gutter-column style:width="{gutterWidth}px" />
       <col data-dimension-column style:width="{dimensionColumnWidth}px" />
-      {#each activeMeasureNames as _, index (index)}
+      {#each leaderboardMeasureNames as _, index (index)}
         <col data-measure-column style:width="{$valueColumn}px" />
-        {#if isValidPercentOfTotal}
+        {#if isValidPercentOfTotal(leaderboardMeasureNames[index])}
           <col
             data-percent-of-total-column
             style:width="{COMPARISON_COLUMN_WIDTH}px"
@@ -342,7 +341,7 @@
       {isValidPercentOfTotal}
       {isTimeComparisonActive}
       {sortedAscending}
-      {activeMeasureNames}
+      activeMeasureNames={leaderboardMeasureNames}
       {toggleSort}
       {setPrimaryDimension}
       {toggleComparisonDimension}
@@ -368,7 +367,7 @@
             {itemData}
             {isValidPercentOfTotal}
             {isTimeComparisonActive}
-            {activeMeasureNames}
+            activeMeasureNames={leaderboardMeasureNames}
             {toggleDimensionValueSelection}
             {formatters}
           />
@@ -388,7 +387,7 @@
           {atLeastOneActive}
           {isValidPercentOfTotal}
           {isTimeComparisonActive}
-          {activeMeasureNames}
+          activeMeasureNames={leaderboardMeasureNames}
           borderTop={i === 0}
           borderBottom={i === belowTheFoldRows.length - 1}
           {toggleDimensionValueSelection}

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -62,7 +62,7 @@
   export let sortBy: string | null;
   export let tableWidth: number;
   export let sortedAscending: boolean;
-  export let isValidPercentOfTotal: boolean;
+  export let isValidPercentOfTotal: (measureName: string) => boolean;
   export let timeControlsReady: boolean;
   export let dimensionColumnWidth: number;
   export let filterExcludeMode: boolean;

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -55,7 +55,9 @@
   export let whereFilter: V1Expression;
   export let dimensionThresholdFilters: DimensionThresholdFilter[];
   export let activeMeasureName: string;
-  export let activeMeasureNames: string[];
+  // FIXME: rename
+  export let activeMeasureNames: string[]; // For display (limited by leaderboardMeasureCount)
+  export let visibleMeasures: string[]; // For querying/sorting (all visible measures)
   export let metricsViewName: string;
   export let sortType: SortType;
   export let sortBy: string | null;
@@ -128,7 +130,7 @@
 
   $: measures = [
     ...(leaderboardMeasureCountFeatureFlag
-      ? activeMeasureNames.map(
+      ? visibleMeasures.map(
           (name) =>
             ({
               name,
@@ -143,7 +145,10 @@
 
     // Add comparison measures if there's a comparison time range
     ...(comparisonTimeRange
-      ? activeMeasureNames.flatMap((name) => getComparisonRequestMeasures(name))
+      ? (leaderboardMeasureCountFeatureFlag
+          ? visibleMeasures
+          : [activeMeasureName]
+        ).flatMap((name) => getComparisonRequestMeasures(name))
       : []),
 
     // Add URI measure if URI is present

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -187,7 +187,7 @@
     {
       ...(leaderboardMeasureCountFeatureFlag
         ? {
-            measures: leaderboardMeasureNames.map((name) => ({ name })),
+            measures: visibleMeasures.map((name) => ({ name })),
           }
         : {
             measures: [{ name: activeMeasureName }],
@@ -208,7 +208,10 @@
 
   $: leaderboardTotals = totalsData?.data?.[0]
     ? Object.fromEntries(
-        leaderboardMeasureNames.map((name) => [
+        (leaderboardMeasureCountFeatureFlag
+          ? visibleMeasures
+          : leaderboardMeasureNames
+        ).map((name) => [
           name,
           (totalsData?.data?.[0]?.[name] as number) ?? null,
         ]),

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -55,8 +55,8 @@
   export let whereFilter: V1Expression;
   export let dimensionThresholdFilters: DimensionThresholdFilter[];
   export let activeMeasureName: string;
-  export let leaderboardMeasureNames: string[]; // For display (limited by leaderboardMeasureCount)
-  export let visibleMeasures: string[]; // For querying/sorting (all visible measures)
+  export let leaderboardMeasureNames: string[];
+  export let visibleMeasures: string[];
   export let metricsViewName: string;
   export let sortType: SortType;
   export let sortBy: string | null;

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -19,7 +19,7 @@
   export let comparisonTimeRange: V1TimeRange | undefined;
   export let timeControlsReady: boolean;
   export let activeMeasureName: string;
-  export let activeMeasureNames: string[];
+  export let leaderboardMeasureNames: string[];
 
   const StateManagers = getStateManagers();
   const {
@@ -72,6 +72,10 @@
       : showPercentOfTotal
         ? COMPARISON_COLUMN_WIDTH
         : 0);
+
+  $: validVisibleMeasures = $visibleMeasures
+    .map((m) => m.name)
+    .filter((name) => name !== undefined);
 </script>
 
 <div class="flex flex-col overflow-hidden size-full" aria-label="Leaderboards">
@@ -96,10 +100,8 @@
               isValidPercentOfTotal={$isValidPercentOfTotal}
               {metricsViewName}
               {activeMeasureName}
-              {activeMeasureNames}
-              visibleMeasures={$visibleMeasures
-                .map((m) => m.name)
-                .filter((name) => name !== undefined)}
+              {leaderboardMeasureNames}
+              visibleMeasures={validVisibleMeasures}
               {whereFilter}
               {dimensionThresholdFilters}
               {instanceId}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -24,17 +24,12 @@
   const StateManagers = getStateManagers();
   const {
     selectors: {
-      activeMeasure: { isValidPercentOfTotal, isSummableMeasure },
       numberFormat: { measureFormatters, activeMeasureFormatter },
       dimensionFilters: { isFilterExcludeMode },
       dimensions: { visibleDimensions },
       comparison: { isBeingCompared: isBeingComparedReadable },
       sorting: { sortedAscending, sortType, sortByMeasure },
-<<<<<<< HEAD
-      measures: { measureLabel },
-=======
       measures: { measureLabel, isMeasureValidPercentOfTotal, visibleMeasures },
->>>>>>> 7f9e72c51 (use visible measures for querying/sorting)
     },
     actions: {
       dimensions: { setPrimaryDimension },
@@ -61,7 +56,7 @@
 
   $: dimensionColumnWidth = 164;
 
-  $: showPercentOfTotal = isValidPercentOfTotal;
+  $: showPercentOfTotal = $isMeasureValidPercentOfTotal(activeMeasureName);
   $: showDeltaPercent = !!comparisonTimeRange;
 
   $: tableWidth =
@@ -113,7 +108,6 @@
               filterExcludeMode={$isFilterExcludeMode(dimension.name)}
               {comparisonTimeRange}
               {dimension}
-              isSummableMeasure={$isSummableMeasure}
               {parentElement}
               {suppressTooltip}
               {timeControlsReady}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -92,7 +92,7 @@
         {#each $visibleDimensions as dimension (dimension.name)}
           {#if dimension.name}
             <Leaderboard
-              isValidPercentOfTotal={$isValidPercentOfTotal}
+              isValidPercentOfTotal={$isMeasureValidPercentOfTotal}
               {metricsViewName}
               {activeMeasureName}
               {leaderboardMeasureNames}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -97,6 +97,9 @@
               {metricsViewName}
               {activeMeasureName}
               {activeMeasureNames}
+              visibleMeasures={$visibleMeasures
+                .map((m) => m.name)
+                .filter((name) => name !== undefined)}
               {whereFilter}
               {dimensionThresholdFilters}
               {instanceId}
@@ -131,9 +134,6 @@
               sortBy={$sortByMeasure}
               measureLabel={$measureLabel}
               leaderboardMeasureCountFeatureFlag={$leaderboardMeasureCountFeatureFlag}
-              visibleMeasures={$visibleMeasures
-                .map((m) => m.name)
-                .filter((name) => name !== undefined)}
             />
           {/if}
         {/each}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -30,7 +30,11 @@
       dimensions: { visibleDimensions },
       comparison: { isBeingCompared: isBeingComparedReadable },
       sorting: { sortedAscending, sortType, sortByMeasure },
+<<<<<<< HEAD
       measures: { measureLabel },
+=======
+      measures: { measureLabel, isMeasureValidPercentOfTotal, visibleMeasures },
+>>>>>>> 7f9e72c51 (use visible measures for querying/sorting)
     },
     actions: {
       dimensions: { setPrimaryDimension },
@@ -127,6 +131,9 @@
               sortBy={$sortByMeasure}
               measureLabel={$measureLabel}
               leaderboardMeasureCountFeatureFlag={$leaderboardMeasureCountFeatureFlag}
+              visibleMeasures={$visibleMeasures
+                .map((m) => m.name)
+                .filter((name) => name !== undefined)}
             />
           {/if}
         {/each}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
@@ -15,7 +15,7 @@
 
   export let dimensionName: string;
   export let isFetching: boolean;
-  export let isValidPercentOfTotal: boolean;
+  export let isValidPercentOfTotal: (measureName: string) => boolean;
   export let isTimeComparisonActive: boolean;
   export let dimensionDescription: string;
   export let isBeingCompared: boolean;
@@ -115,7 +115,7 @@
         </button>
       </th>
 
-      {#if isValidPercentOfTotal}
+      {#if isValidPercentOfTotal(measureName)}
         <th data-percent-of-total-header>
           <button
             aria-label="Toggle sort leaderboards by percent of total"

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -25,7 +25,6 @@
   export let tableWidth: number;
   export let borderTop = false;
   export let borderBottom = false;
-  export let isSummableMeasure: boolean;
   export let isBeingCompared: boolean;
   export let filterExcludeMode: boolean;
   export let atLeastOneActive: boolean;
@@ -96,7 +95,7 @@
   $: barLengths = Object.fromEntries(
     Object.entries(pctOfTotals).map(([name, pct]) => [
       name,
-      isSummableMeasure && pct ? tableWidth * pct : 0,
+      pct ? tableWidth * pct : 0,
     ]),
   );
 

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -28,7 +28,7 @@
   export let isBeingCompared: boolean;
   export let filterExcludeMode: boolean;
   export let atLeastOneActive: boolean;
-  export let isValidPercentOfTotal: boolean;
+  export let isValidPercentOfTotal: (measureName: string) => boolean;
   export let isTimeComparisonActive: boolean;
   export let activeMeasureNames: string[] = [];
   export let toggleDimensionValueSelection: (
@@ -122,7 +122,7 @@
             length - dimensionColumnWidth - $valueColumn,
             COMPARISON_COLUMN_WIDTH,
           )
-        : isValidPercentOfTotal
+        : isValidPercentOfTotal(name)
           ? clamp(
               0,
               length - dimensionColumnWidth - $valueColumn,
@@ -299,12 +299,12 @@
         />
       </div>
 
-      {#if showZigZags[measureName] && !isTimeComparisonActive && !isValidPercentOfTotal}
+      {#if showZigZags[measureName] && !isTimeComparisonActive && !isValidPercentOfTotal(measureName)}
         <LongBarZigZag />
       {/if}
     </td>
 
-    {#if isValidPercentOfTotal}
+    {#if isValidPercentOfTotal(measureName)}
       <td
         data-comparison-cell
         style:background={percentOfTotalGradients[measureName]}

--- a/web-common/src/features/dashboards/state-managers/selectors/active-measure.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/active-measure.ts
@@ -15,6 +15,7 @@ export const activeMeasure = (
   return activeMeasure;
 };
 
+// FIXME: to consolidate web-common/src/features/dashboards/state-managers/selectors/measures.ts
 export const activeMeasureName = (dashData: DashboardDataSources): string => {
   return dashData.dashboard.leaderboardMeasureName;
 };

--- a/web-common/src/features/dashboards/state-managers/selectors/measures.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/measures.ts
@@ -28,6 +28,7 @@ export const allMeasures = ({
   );
 };
 
+// FIXME: to consolidate web-common/src/features/dashboards/state-managers/selectors/active-measure.ts
 export const leaderboardMeasureName = ({ dashboard }: DashboardDataSources) => {
   return dashboard.leaderboardMeasureName;
 };

--- a/web-common/src/features/dashboards/state-managers/selectors/measures.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/measures.ts
@@ -39,6 +39,26 @@ export const leaderboardMeasureCount = ({
   return dashboard.leaderboardMeasureCount ?? 1;
 };
 
+export const activeMeasureNamesFromMeasureCount = ({
+  validMetricsView,
+  validExplore,
+  dashboard,
+}: DashboardDataSources): string[] => {
+  if (!validMetricsView?.measures || !validExplore?.measures) return [];
+
+  const visibleMeasures = Array.from(dashboard.visibleMeasureKeys).map(
+    (key) =>
+      validMetricsView.measures?.find(
+        (m) => m.name === key,
+      ) as MetricsViewSpecMeasureV2,
+  );
+
+  return visibleMeasures
+    .slice(0, dashboard.leaderboardMeasureCount ?? 1)
+    .map(({ name }) => name)
+    .filter((name): name is string => name !== undefined);
+};
+
 export const visibleMeasures = ({
   validMetricsView,
   validExplore,
@@ -197,4 +217,6 @@ export const measureSelectors = {
   leaderboardMeasureName,
 
   leaderboardMeasureCount,
+
+  activeMeasureNamesFromMeasureCount,
 };

--- a/web-common/src/features/dashboards/state-managers/selectors/measures.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/measures.ts
@@ -39,7 +39,7 @@ export const leaderboardMeasureCount = ({
   return dashboard.leaderboardMeasureCount ?? 1;
 };
 
-export const activeMeasureNamesFromMeasureCount = ({
+export const activeMeasuresFromMeasureCount = ({
   validMetricsView,
   validExplore,
   dashboard,
@@ -218,5 +218,5 @@ export const measureSelectors = {
 
   leaderboardMeasureCount,
 
-  activeMeasureNamesFromMeasureCount,
+  activeMeasuresFromMeasureCount,
 };

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -33,7 +33,7 @@
       measures: {
         visibleMeasures,
         leaderboardMeasureName,
-        activeMeasureNamesFromMeasureCount,
+        activeMeasuresFromMeasureCount,
       },
       dimensions: { getDimensionByName },
       pivot: { showPivot },
@@ -52,7 +52,7 @@
   let exploreContainerWidth: number;
 
   $: leaderboardMeasureNames = $leaderboardMeasureCountFeatureFlag
-    ? $activeMeasureNamesFromMeasureCount
+    ? $activeMeasuresFromMeasureCount
     : [$leaderboardMeasureName];
 
   $: ({ instanceId } = $runtime);
@@ -234,7 +234,7 @@
             <LeaderboardDisplay
               {metricsViewName}
               activeMeasureName={$leaderboardMeasureName}
-              activeMeasureNames={leaderboardMeasureNames}
+              {leaderboardMeasureNames}
               {whereFilter}
               {dimensionThresholdFilters}
               {timeRange}

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -32,8 +32,8 @@
     selectors: {
       measures: {
         visibleMeasures,
-        leaderboardMeasureCount,
         leaderboardMeasureName,
+        activeMeasureNamesFromMeasureCount,
       },
       dimensions: { getDimensionByName },
       pivot: { showPivot },
@@ -51,14 +51,8 @@
 
   let exploreContainerWidth: number;
 
-  // FIXME: move to activeMeasure selectors
-  $: activeMeasureNamesFromMeasureCount = $visibleMeasures
-    .slice(0, $leaderboardMeasureCount)
-    .map(({ name }) => name)
-    .filter(isDefined);
-
   $: leaderboardMeasureNames = $leaderboardMeasureCountFeatureFlag
-    ? activeMeasureNamesFromMeasureCount
+    ? $activeMeasureNamesFromMeasureCount
     : [$leaderboardMeasureName];
 
   $: ({ instanceId } = $runtime);

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -30,8 +30,11 @@
   const StateManagers = getStateManagers();
   const {
     selectors: {
-      measures: { visibleMeasures, leaderboardMeasureCount },
-      activeMeasure: { activeMeasureName },
+      measures: {
+        visibleMeasures,
+        leaderboardMeasureCount,
+        leaderboardMeasureName,
+      },
       dimensions: { getDimensionByName },
       pivot: { showPivot },
     },
@@ -56,7 +59,7 @@
 
   $: leaderboardMeasureNames = $leaderboardMeasureCountFeatureFlag
     ? activeMeasureNamesFromMeasureCount
-    : [$activeMeasureName];
+    : [$leaderboardMeasureName];
 
   $: ({ instanceId } = $runtime);
 
@@ -228,7 +231,7 @@
               {dimensionThresholdFilters}
               {timeRange}
               {comparisonTimeRange}
-              activeMeasureName={$activeMeasureName}
+              activeMeasureName={$leaderboardMeasureName}
               {timeControlsReady}
               {visibleMeasureNames}
               hideStartPivotButton={hidePivot}
@@ -236,7 +239,7 @@
           {:else}
             <LeaderboardDisplay
               {metricsViewName}
-              activeMeasureName={$activeMeasureName}
+              activeMeasureName={$leaderboardMeasureName}
               activeMeasureNames={leaderboardMeasureNames}
               {whereFilter}
               {dimensionThresholdFilters}

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -130,10 +130,6 @@
       console.error("Error running initEmbedPublicAPI:", error);
     }
   }
-
-  function isDefined(value: string | undefined): value is string {
-    return value !== undefined;
-  }
 </script>
 
 <article


### PR DESCRIPTION
Closes #7008

When using the leaderboard measure count feature flag, NaN values were appearing in the percent of total column. This was happening because we were querying totals for `leaderboardMeasureNames` but displaying data for `visibleMeasures`, causing a mismatch where some measures didn't have corresponding totals.

- Updated the totals query in `Leaderboard.svelte` to use `visibleMeasures` instead of `leaderboardMeasureNames` when `leaderboardMeasureCountFeatureFlag` is true
- Modified the `leaderboardTotals` calculation to use the same set of measures as the totals query
- Ensured consistent measure selection between data and totals queries

**Reviewers**
You must enable `leaderboardMeasureCount` and `reorderMeasuresDimensions` to test this branch properly.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
