### PR TITLE
feat: improved leaderboard loading state

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/DelayedLoadingRows.svelte
+++ b/web-common/src/features/dashboards/leaderboard/DelayedLoadingRows.svelte
@@ -1,27 +1,31 @@
-<!-- @component 
-  This component is used to only show loading rows if the loading state is true after a delay.
-  This is handy for preventing the loading rows from flickering.
--->
 <script lang="ts">
   import { onDestroy } from "svelte";
   import { writable } from "svelte/store";
   import LoadingRows from "./LoadingRows.svelte";
 
   export let isLoading: boolean;
+  export let isFetching: boolean;
   export let delay: number = 300;
-  export let rows: number = 7;
-  export let columns: number = 4;
+  export let rowCount: number;
+  export let columnCount: number = 4;
 
-  const showLoading = writable(false);
+  const showPlaceholder = writable(false);
 
-  let timeoutId;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined = undefined;
+  let previousRowCount = rowCount ?? 7;
 
   $: {
-    clearTimeout(timeoutId);
+    if (timeoutId) clearTimeout(timeoutId);
+
     if (isLoading) {
-      timeoutId = setTimeout(() => showLoading.set(true), delay);
+      showPlaceholder.set(true);
+    } else if (isFetching) {
+      timeoutId = setTimeout(() => {
+        showPlaceholder.set(true);
+      }, delay);
     } else {
-      showLoading.set(false);
+      showPlaceholder.set(false);
+      previousRowCount = rowCount;
     }
   }
 
@@ -30,6 +34,8 @@
   });
 </script>
 
-{#if $showLoading}
-  <LoadingRows {rows} {columns} />
+{#if $showPlaceholder}
+  <LoadingRows rows={previousRowCount || 7} columns={columnCount} />
+{:else}
+  <slot />
 {/if}

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -200,7 +200,7 @@
     },
   );
 
-  $: ({ data: sortedData, isFetching } = $sortedQuery);
+  $: ({ data: sortedData, isFetching, isLoading } = $sortedQuery);
   $: ({ data: totalsData } = $totalsQuery);
 
   $: leaderboardTotals = totalsData?.data?.[0]
@@ -347,9 +347,12 @@
     />
 
     <tbody>
-      {#if isFetching}
-        <DelayedLoadingRows isLoading={isFetching} columns={columnCount + 1} />
-      {:else}
+      <DelayedLoadingRows
+        {isLoading}
+        {isFetching}
+        rowCount={aboveTheFold.length}
+        columnCount={columnCount + 1}
+      >
         {#each aboveTheFold as itemData (itemData.dimensionValue)}
           <LeaderboardRow
             {suppressTooltip}
@@ -368,7 +371,7 @@
             {formatters}
           />
         {/each}
-      {/if}
+      </DelayedLoadingRows>
 
       {#each belowTheFoldRows as itemData, i (itemData.dimensionValue)}
         <LeaderboardRow

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
@@ -36,7 +36,7 @@
 
 <thead>
   <tr>
-    <th aria-label="Comparison column">
+    <th aria-label="Comparison column" class="grid place-content-center">
       {#if isFetching}
         <DelayedSpinner isLoading={isFetching} size="16px" />
       {:else if hovered || isBeingCompared}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -403,6 +403,7 @@
 
   tr {
     @apply cursor-pointer;
+    max-height: 22px;
   }
 
   tr:hover {
@@ -429,5 +430,9 @@
 
   a:hover {
     @apply bg-primary-100;
+  }
+
+  td {
+    height: 22px !important;
   }
 </style>


### PR DESCRIPTION
This implementation will change slightly after https://github.com/rilldata/rill/pull/6986 merges and we start to use TanStack Query v5's new features, but this is a stopgap solution to fix a few issues.

The primary issue is that `keepPreviousData` or, in v5, `placeholderData` does not work with reactive query assignment https://github.com/TanStack/query/issues/5913. We can address this once we upgrade to v5 and can pass the query options as a store, but, in the meantime, it means we should display some kind of skeleton loading state whenever the aggregation queries are running.

The DelayedLoadingRows implementation has changed to take both `isLoading` and `isFetching`. Loading rows should always be displayed if `isLoading` is true, but if only `isFetching` is true, then we should wait a certain amount of time before displaying the loading state. In v4 (or at least our pinned version), it appears that `isFetching` and `isLoading` do not have the same separation as they do in v5. They are usually the same.

Additionally, it supports rendering a variable number of rows based on the previous row count rather than always showing 7 rows.

Fixes a styling issue with the `LeaderboardHeader` loading indicator.

In general, the idea going forward will be this:

1. Interact with Leaderboard to trigger a new query
2. After ~150ms, display the refetching indicator in the LeaderboardHeader, but continue to display the previous data
3. If still loading after ~500ms (values tbd), display the `LoadingRows` component, which may be consolidated with `LeaderboardRow` itself

<img width="547" alt="Screenshot 2025-03-31 at 3 23 21 PM" src="https://github.com/user-attachments/assets/575a197c-9dff-4b84-95e0-9a3303598c1a" />

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
