### PR TITLE
refac(canvas): column and row resizing

### DIFF
--- a/web-common/src/features/canvas/CanvasDashboardEmbed.svelte
+++ b/web-common/src/features/canvas/CanvasDashboardEmbed.svelte
@@ -43,7 +43,8 @@
         {maxWidth}
         {rowIndex}
         zIndex={50 - rowIndex * 2}
-        height="{height}{heightUnit}"
+        {height}
+        {heightUnit}
         gridTemplate={widths.map((w) => `${w}fr`).join(" ")}
       >
         {#each items as item, columnIndex (columnIndex)}

--- a/web-common/src/features/canvas/EditableCanvasRow.svelte
+++ b/web-common/src/features/canvas/EditableCanvasRow.svelte
@@ -1,0 +1,211 @@
+<script lang="ts">
+  import type {
+    V1CanvasRow as APIV1CanvasRow,
+    V1CanvasItem,
+  } from "@rilldata/web-common/runtime-client";
+  import type { CanvasComponentType } from "./components/types";
+  import RowDropZone from "./RowDropZone.svelte";
+  import RowWrapper from "./RowWrapper.svelte";
+  import {
+    COLUMN_COUNT,
+    getInitialHeight,
+    MIN_HEIGHT,
+    MIN_WIDTH,
+    normalizeSizeArray,
+  } from "./layout-util";
+  import { mousePosition } from "./layout-util";
+  import type { Unsubscriber } from "svelte/store";
+  import { clamp } from "@rilldata/web-common/lib/clamp";
+  import type { CanvasResponse } from "./selector";
+
+  type V1CanvasRow = Omit<APIV1CanvasRow, "items"> & {
+    items: (V1CanvasItem | null)[];
+  };
+
+  export let row: V1CanvasRow;
+  export let zIndex = 50;
+  export let maxWidth: number;
+  export let heightUnit: string = "px";
+  export let rowIndex: number;
+  export let movingWidget: boolean;
+
+  export let onDrop: (row: number, column: number | null) => void;
+  export let initializeRow: (row: number, type: CanvasComponentType) => void;
+  export let updateRowHeight: (newHeight: number, index: number) => void;
+  export let updateComponentWidths: (
+    index: number,
+    newWidths: number[],
+  ) => void;
+  export let canvasData: CanvasResponse | undefined;
+  export let columnWidth: number;
+
+  let rowHeight = row.height ?? MIN_HEIGHT;
+  let componentWidths: number[] = normalizeSizeArray(
+    row.items?.map((item) => item?.width ?? 0),
+  );
+  let hasLocalChange = false;
+  let initialMousePosition: { x: number; y: number };
+  let initialHeight: number;
+  let unsubscriber: Unsubscriber | undefined = undefined;
+
+  $: items = row.items ?? [];
+
+  $: isSpreadEvenly = componentWidths.every((w) => w === componentWidths[0]);
+
+  $: heightUnit = row.heightUnit ?? "px";
+
+  $: types = types = items?.map(
+    (item) =>
+      canvasData?.components?.[item?.component ?? ""]?.component?.spec
+        ?.renderer,
+  );
+
+  $: resizeRowMinimum =
+    types.reduce((acc, type) => {
+      return Math.max(acc, getInitialHeight(type) ?? MIN_HEIGHT);
+    }, 0) ?? MIN_HEIGHT;
+
+  $: updateHeightFromSpec(row.height);
+  $: updateWidthsFromSpec(row.items?.map((item) => item?.width ?? 0));
+
+  function onRowResizeStart() {
+    initialMousePosition = $mousePosition;
+    hasLocalChange = true;
+
+    initialHeight =
+      document.querySelector(`#canvas-row-${rowIndex}`)?.getBoundingClientRect()
+        .height ??
+      rowHeight ??
+      MIN_HEIGHT;
+
+    unsubscriber = mousePosition.subscribe((position) => {
+      const diff = position.y - initialMousePosition.y;
+
+      rowHeight = Math.max(resizeRowMinimum, Math.floor(diff + initialHeight));
+    });
+
+    window.addEventListener(
+      "mouseup",
+      () => {
+        unsubscriber?.();
+        unsubscriber = undefined;
+        updateRowHeight(rowHeight, rowIndex);
+      },
+      { once: true },
+    );
+  }
+
+  function updateHeightFromSpec(newSpecHeight: number | undefined) {
+    if (newSpecHeight === undefined) return;
+
+    const matchesLocal = newSpecHeight === rowHeight;
+
+    if (hasLocalChange && matchesLocal) {
+      hasLocalChange = false;
+    } else if (!hasLocalChange && !matchesLocal) {
+      rowHeight = newSpecHeight;
+      hasLocalChange = false;
+    }
+  }
+
+  function updateWidthsFromSpec(newWidths: number[]) {
+    if (newWidths === undefined) return;
+    const normalized = normalizeSizeArray(newWidths);
+    const matchesLocal = normalized.every((w, i) => w === componentWidths[i]);
+
+    if (hasLocalChange && matchesLocal) {
+      hasLocalChange = false;
+    } else if (!hasLocalChange && !matchesLocal) {
+      componentWidths = normalized;
+      hasLocalChange = false;
+    }
+  }
+
+  function onColumnResizeStart(columnIndex: number) {
+    initialMousePosition = $mousePosition;
+    hasLocalChange = true;
+
+    const nextElementWidth = componentWidths[columnIndex + 1];
+    if (nextElementWidth === undefined) return;
+
+    const maxWidth = componentWidths.reduce((acc, el, i) => {
+      if (i === columnIndex) {
+        return acc;
+      } else if (i === columnIndex + 1) {
+        return acc - MIN_WIDTH;
+      } else {
+        return acc - el;
+      }
+    }, COLUMN_COUNT);
+
+    const width = componentWidths[columnIndex];
+
+    initialHeight =
+      document.querySelector(`#canvas-row-${rowIndex}`)?.getBoundingClientRect()
+        .height ??
+      rowHeight ??
+      MIN_HEIGHT;
+
+    unsubscriber = mousePosition.subscribe((position) => {
+      const delta = position.x - (initialMousePosition?.x ?? 0);
+      const columnDelta = Math.round(delta / columnWidth);
+
+      const newValue = clamp(MIN_WIDTH, width + columnDelta, maxWidth);
+
+      const clampedDelta = newValue - width;
+
+      componentWidths[columnIndex] = newValue;
+
+      componentWidths[columnIndex + 1] = nextElementWidth - clampedDelta;
+    });
+
+    window.addEventListener(
+      "mouseup",
+      () => {
+        unsubscriber?.();
+        unsubscriber = undefined;
+        updateComponentWidths(rowIndex, componentWidths);
+      },
+      { once: true },
+    );
+  }
+</script>
+
+<RowWrapper
+  {zIndex}
+  {maxWidth}
+  height={rowHeight}
+  {heightUnit}
+  {rowIndex}
+  gridTemplate={componentWidths.map((w) => `${w}fr`).join(" ")}
+>
+  <slot
+    widths={componentWidths}
+    {isSpreadEvenly}
+    {types}
+    {items}
+    {onColumnResizeStart}
+  />
+
+  <RowDropZone
+    allowDrop={movingWidget}
+    resizeIndex={rowIndex}
+    dropIndex={rowIndex + 1}
+    {onRowResizeStart}
+    {onDrop}
+    addItem={(type) => {
+      initializeRow(rowIndex + 1, type);
+    }}
+  />
+
+  {#if rowIndex === 0}
+    <RowDropZone
+      allowDrop={movingWidget}
+      dropIndex={0}
+      {onDrop}
+      addItem={(type) => {
+        initializeRow(rowIndex, type);
+      }}
+    />
+  {/if}
+</RowWrapper>

--- a/web-common/src/features/canvas/ElementDivider.svelte
+++ b/web-common/src/features/canvas/ElementDivider.svelte
@@ -11,7 +11,6 @@
   export let addIndex: number;
   export let rowLength: number;
   export let rowIndex: number;
-  export let resizingColumn = false;
   export let columnWidth: number | undefined = undefined;
   export let isSpreadEvenly: boolean;
   export let dragging: boolean;
@@ -19,7 +18,8 @@
     position: { row: number; column: number },
     item: CanvasComponentType[],
   ) => void;
-  export let onMouseDown: ((e: MouseEvent) => void) | undefined = undefined;
+  export let onColumnResizeStart: ((columnIndex: number) => void) | undefined =
+    undefined;
   export let spreadEvenly: (rowIndex: number) => void;
 
   let menuOpen = false;
@@ -36,7 +36,7 @@
 
   $: notActiveDivider = !isActiveDivider && !!$activeDivider;
 
-  $: forceShowDivider = menuOpen || resizingColumn || isDropZone;
+  $: forceShowDivider = menuOpen || isActiveDivider || isDropZone;
 
   $: if (isActiveDivider) {
     document.body.style.cursor = "col-resize";
@@ -74,8 +74,8 @@
         : "auto"}
       class:!opacity-100={isDropZone}
       class="peer h-full flex items-center justify-center w-4 disabled:opacity-60 disabled:cursor-default cursor-col-resize"
-      on:mousedown={(e) => {
-        if (onMouseDown) onMouseDown(e);
+      on:mousedown={() => {
+        if (onColumnResizeStart) onColumnResizeStart(resizeIndex);
         activeDivider.set(dividerId);
         window.addEventListener(
           "mouseup",

--- a/web-common/src/features/canvas/RowDropZone.svelte
+++ b/web-common/src/features/canvas/RowDropZone.svelte
@@ -7,7 +7,6 @@
   export let allowDrop: boolean;
   export let resizeIndex = -1;
   export let dropIndex: number;
-  export let resizingRow = false;
   export let onDrop: (row: number, column: number | null) => void;
   export let onRowResizeStart: (e: MouseEvent) => void = () => {};
   export let addItem: (type: CanvasComponentType) => void;
@@ -24,7 +23,7 @@
 
   $: notResizable = resizeIndex === -1;
 
-  $: forceShowDivider = menuOpen || resizingRow || isDropZone;
+  $: forceShowDivider = menuOpen || isActiveDivider || isDropZone;
 </script>
 
 <div

--- a/web-common/src/features/canvas/RowWrapper.svelte
+++ b/web-common/src/features/canvas/RowWrapper.svelte
@@ -2,7 +2,8 @@
   export let zIndex = 50;
   export let maxWidth: number;
   export let gridTemplate: string;
-  export let height: string = "80px";
+  export let height: number = 80;
+  export let heightUnit: string = "px";
   export let rowIndex: number;
 </script>
 
@@ -12,7 +13,7 @@
   class="w-full grid canvas-row relative h-fit min-h-fit pointer-events-none"
   style:z-index={zIndex}
   style:max-width="{maxWidth}px"
-  style:--row-height={height}
+  style:--row-height="{height}{heightUnit}"
   style:grid-template-columns={gridTemplate}
 >
   <slot />

--- a/web-common/src/features/canvas/layout-util.ts
+++ b/web-common/src/features/canvas/layout-util.ts
@@ -6,6 +6,7 @@ import type {
 import { YAMLMap, YAMLSeq } from "yaml";
 import type { CanvasComponentType } from "./components/types";
 import { getComponentRegistry } from "./components/util";
+import { writable } from "svelte/store";
 
 export const initialHeights: Record<CanvasComponentType, number> = {
   line_chart: 320,
@@ -27,6 +28,18 @@ export const MIN_HEIGHT = 40;
 export const MIN_WIDTH = 3;
 export const COLUMN_COUNT = 12;
 export const DEFAULT_DASHBOARD_WIDTH = 1200;
+
+export const mousePosition = (() => {
+  const store = writable({ x: 0, y: 0 });
+
+  function update(event: MouseEvent) {
+    store.set({ x: event.clientX, y: event.clientY });
+  }
+
+  window.addEventListener("mousemove", update);
+
+  return store;
+})();
 
 type YAMLItem = Record<string, unknown> & {
   width?: number;

--- a/web-common/src/features/workspaces/CanvasWorkspace.svelte
+++ b/web-common/src/features/workspaces/CanvasWorkspace.svelte
@@ -21,7 +21,7 @@
   import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import PreviewButton from "../explores/PreviewButton.svelte";
-  import RowBasedCanvas from "../canvas/RowBasedCanvas.svelte";
+  import CanvasBuilder from "../canvas/CanvasBuilder.svelte";
   import DelayedSpinner from "../entity-management/DelayedSpinner.svelte";
   import { useCanvas } from "../canvas/selector";
 
@@ -126,7 +126,7 @@
           {:else if canvasResolverQueryResult.isLoading}
             <DelayedSpinner isLoading={true} size="48px" />
           {:else if canvasData}
-            <RowBasedCanvas
+            <CanvasBuilder
               {canvasData}
               {canvasName}
               openSidebar={workspace.inspector.open}


### PR DESCRIPTION
- Creates a new `EditableCanvasRow` component that houses the resizing and rendering logic
- Renames `RowBasedCanvas` to `CanvasBuilder`
- Creates a shared store to track the current mouse position
- New `EditableCanvasRow` component manages its own column/row resizing state rather than co-opting the spec object
- Fixes an issue where multiple resizing events in quick succession would cause unnecessary updates
- Uses the existing `activeDivider` store to capture whether or not a row or column is being resized
- Variable renaming for clarity

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
