### PR TITLE
Improve compound query for different query results

### DIFF
--- a/web-common/src/features/compound-query-result.ts
+++ b/web-common/src/features/compound-query-result.ts
@@ -1,4 +1,3 @@
-import type { HTTPError } from "@rilldata/web-common/runtime-client/fetchWrapper";
 import type {
   CreateQueryResult,
   QueryObserverResult,


### PR DESCRIPTION
Splitting https://github.com/rilldata/rill/pull/6964 into smaller PRs.

This deals with improvements to `getCompoundQuery` to support different query results.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
