### PR TITLE
Improve url compression function signature

### DIFF
--- a/web-admin/src/features/embeds/init-embed-public-api.ts
+++ b/web-admin/src/features/embeds/init-embed-public-api.ts
@@ -68,8 +68,6 @@ export default function initEmbedPublicAPI(instanceId: string): () => void {
           exploreSpec,
           timeControlsState,
           defaultExplorePreset,
-          get(page).url,
-          true,
         ).toString(),
       );
     },
@@ -109,8 +107,6 @@ export default function initEmbedPublicAPI(instanceId: string): () => void {
         exploreSpec,
         timeControlsState,
         defaultExplorePreset,
-        get(page).url,
-        true,
       ).toString(),
     );
     return { state: stateString };

--- a/web-common/src/features/dashboards/url-state/convertExploreStateToURLSearchParams.ts
+++ b/web-common/src/features/dashboards/url-state/convertExploreStateToURLSearchParams.ts
@@ -82,8 +82,7 @@ export function convertExploreStateToURLSearchParams(
   timeControlsState: TimeControlState | undefined,
   preset: V1ExplorePreset,
   // Used to decide whether to compress or not based on the full url length
-  url: URL,
-  disableCompression = false,
+  urlForCompressionCheck?: URL,
 ): URLSearchParams {
   const searchParams = new URLSearchParams();
 
@@ -141,9 +140,9 @@ export function convertExploreStateToURLSearchParams(
       break;
   }
 
-  if (disableCompression) return searchParams;
+  if (!urlForCompressionCheck) return searchParams;
 
-  const urlCopy = new URL(url);
+  const urlCopy = new URL(urlForCompressionCheck);
   urlCopy.search = searchParams.toString();
   const shouldCompress = shouldCompressParams(urlCopy);
   if (!shouldCompress) return searchParams;


### PR DESCRIPTION
Splitting https://github.com/rilldata/rill/pull/6964 into smaller PRs.

This deals with improvements to `convertExploreStateToURLSearchParams` to avoid sending extra params when compression is not needed.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
