### PR TITLE
Add dashbaord long loading component

### DIFF
--- a/web-common/src/features/dashboards/state-managers/loaders/DashboardLoading.svelte
+++ b/web-common/src/features/dashboards/state-managers/loaders/DashboardLoading.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import { EntityStatus } from "@rilldata/web-common/features/entity-management/types.js";
+  import Spinner from "@rilldata/web-common/features/entity-management/Spinner.svelte";
+  import CtaContentContainer from "@rilldata/web-common/components/calls-to-action/CTAContentContainer.svelte";
+  import CtaLayoutContainer from "@rilldata/web-common/components/calls-to-action/CTALayoutContainer.svelte";
+  import { LoadingTracker } from "@rilldata/web-common/lib/LoadingTracker";
+  import { fade } from "svelte/transition";
+
+  export let isLoading: boolean;
+  export let shortLoadDelay: number = 1000;
+  export let longLoadDelay: number = 5000;
+  const loadingTracker = new LoadingTracker(shortLoadDelay, longLoadDelay);
+
+  $: loadingTracker.updateLoading(isLoading);
+  $: ({ loadingForShortTime, loadingForLongTime } = loadingTracker);
+</script>
+
+{#if $loadingForShortTime}
+  <CtaLayoutContainer>
+    <CtaContentContainer>
+      <div class="h-36">
+        <Spinner status={EntityStatus.Running} size="7rem" duration={725} />
+      </div>
+      {#if $loadingForLongTime}
+        <h1
+          class="text-lg font-semibold text-gray-800 text-center"
+          transition:fade|local={{ duration: 50 }}
+        >
+          Loading your dashboard...If this is taking a while, your database may
+          be waking up.
+        </h1>
+      {/if}
+    </CtaContentContainer>
+  </CtaLayoutContainer>
+{/if}

--- a/web-common/src/lib/LoadingTracker.ts
+++ b/web-common/src/lib/LoadingTracker.ts
@@ -1,0 +1,52 @@
+import { writable } from "svelte/store";
+
+/**
+ * Tracks loading state with support for loading for short and long status.
+ * Pass in shortLoadDelay and longLoadDelay to control the behavior.
+ */
+export class LoadingTracker {
+  public readonly loadingForShortTime = writable(false);
+  public readonly loadingForLongTime = writable(false);
+
+  private loadingForShortTimeout: ReturnType<typeof setTimeout> | undefined;
+  private loadingForLongTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  public constructor(
+    private readonly shortLoadDelay: number,
+    private readonly longLoadDelay: number,
+  ) {}
+
+  public updateLoading(loading: boolean) {
+    if (loading) {
+      this.startedLoading();
+    } else {
+      this.endedLoading();
+    }
+  }
+
+  private startedLoading() {
+    if (!this.loadingForShortTimeout) {
+      this.loadingForShortTimeout = setTimeout(() => {
+        this.loadingForShortTime.set(true);
+        this.loadingForShortTimeout = undefined;
+      }, this.shortLoadDelay);
+    }
+
+    if (!this.loadingForLongTimeout) {
+      this.loadingForLongTimeout = setTimeout(() => {
+        this.loadingForLongTime.set(true);
+        this.loadingForLongTimeout = undefined;
+      }, this.longLoadDelay);
+    }
+  }
+
+  private endedLoading() {
+    this.loadingForShortTime.set(false);
+    this.loadingForLongTime.set(false);
+
+    if (this.loadingForShortTimeout) clearTimeout(this.loadingForShortTimeout);
+    this.loadingForShortTimeout = undefined;
+    if (this.loadingForLongTimeout) clearTimeout(this.loadingForLongTimeout);
+    this.loadingForLongTimeout = undefined;
+  }
+}


### PR DESCRIPTION
Splitting https://github.com/rilldata/rill/pull/6964 into smaller PRs.

Adds a component `DashboardLoading.svelte` that will be used to show a loading spinner with additional message if it is loading for too long. Also adds a class `LoadingTracker` that encapsulates the loading for short/long.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
