### PR TITLE
Fix leaderboard bg gradients

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -363,7 +363,6 @@
           <LeaderboardRow
             {suppressTooltip}
             {tableWidth}
-            {dimensionColumnWidth}
             {isBeingCompared}
             {filterExcludeMode}
             {atLeastOneActive}
@@ -382,7 +381,6 @@
         <LeaderboardRow
           {suppressTooltip}
           {itemData}
-          {dimensionColumnWidth}
           {tableWidth}
           {dimensionName}
           {isBeingCompared}

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -343,7 +343,7 @@
       {isValidPercentOfTotal}
       {isTimeComparisonActive}
       {sortedAscending}
-      activeMeasureNames={leaderboardMeasureNames}
+      {leaderboardMeasureNames}
       {toggleSort}
       {setPrimaryDimension}
       {toggleComparisonDimension}
@@ -371,7 +371,7 @@
             {itemData}
             {isValidPercentOfTotal}
             {isTimeComparisonActive}
-            activeMeasureNames={leaderboardMeasureNames}
+            {leaderboardMeasureNames}
             {toggleDimensionValueSelection}
             {formatters}
           />
@@ -390,7 +390,7 @@
           {atLeastOneActive}
           {isValidPercentOfTotal}
           {isTimeComparisonActive}
-          activeMeasureNames={leaderboardMeasureNames}
+          {leaderboardMeasureNames}
           borderTop={i === 0}
           borderBottom={i === belowTheFoldRows.length - 1}
           {toggleDimensionValueSelection}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
@@ -23,7 +23,7 @@
   export let displayName: string;
   export let hovered: boolean;
   export let sortType: SortType;
-  export let activeMeasureNames: string[] = [];
+  export let leaderboardMeasureNames: string[] = [];
   export let sortBy: string | null;
   export let leaderboardMeasureCountFeatureFlag: boolean;
   export let toggleSort: (sortType: SortType, measureName?: string) => void;
@@ -80,7 +80,7 @@
       </Tooltip>
     </th>
 
-    {#each activeMeasureNames as measureName, index (index)}
+    {#each leaderboardMeasureNames as measureName, index (index)}
       <th data-measure-header>
         <button
           aria-label="Toggle sort leaderboards by value"

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -30,7 +30,6 @@
   export let atLeastOneActive: boolean;
   export let isTimeComparisonActive: boolean;
   export let leaderboardMeasureNames: string[] = [];
-  export let dimensionColumnWidth: number;
   export let suppressTooltip: boolean;
   export let isValidPercentOfTotal: (measureName: string) => boolean;
   export let toggleDimensionValueSelection: (

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -99,6 +99,11 @@
     ]),
   );
 
+  $: totalBarLength = Object.values(barLengths).reduce(
+    (sum, length) => sum + length,
+    0,
+  );
+
   $: showZigZags = Object.fromEntries(
     Object.entries(barLengths).map(([name, length]) => [
       name,
@@ -161,17 +166,11 @@
     ]),
   );
 
-  // $: dimensionGradients = `linear-gradient(to right, ${barColor}
-  //   ${Math.max(...Object.values(barLengths))}px, transparent ${Math.max(...Object.values(barLengths))}px)`;
-
-  // $: measureGradients = Object.fromEntries(
-  //   Object.entries(secondCellBarLengths).map(([name, length]) => [
-  //     name,
-  //     length
-  //       ? `linear-gradient(to right, transparent 16px, ${barColor} 16px, ${barColor} ${length + 16}px, transparent ${length + 16}px)`
-  //       : undefined,
-  //   ]),
-  // );
+  $: dimensionGradients =
+    leaderboardMeasureNames.length === 1
+      ? `linear-gradient(to right, ${barColor}
+      ${totalBarLength}px, transparent ${totalBarLength}px)`
+      : undefined;
 
   $: deltaAbsoluteGradients = Object.fromEntries(
     Object.entries(thirdCellBarLengths).map(([name, length]) => [
@@ -250,6 +249,7 @@
       shift: () => shiftClickHandler(dimensionValue),
     })}
     class="relative size-full flex flex-none justify-between items-center leaderboard-label"
+    style:background={dimensionGradients}
   >
     <FormattedDataType value={dimensionValue} truncate />
 
@@ -304,7 +304,6 @@
           shift: () =>
             shiftClickHandler(pctOfTotals[measureName]?.toString() || ""),
         })}
-        title={pctOfTotals[measureName]?.toString() || ""}
       >
         <PercentageChange
           value={pctOfTotals[measureName]}
@@ -324,7 +323,6 @@
           shift: () =>
             shiftClickHandler(deltaAbsMap[measureName]?.toString() || ""),
         })}
-        title={deltaAbsMap[measureName]?.toString() || ""}
       >
         <FormattedDataType
           color="text-gray-500"
@@ -349,7 +347,6 @@
           shift: () =>
             shiftClickHandler(deltaRels[measureName]?.toString() || ""),
         })}
-        title={deltaRels[measureName]?.toString() || ""}
       >
         <PercentageChange
           value={deltaRels[measureName]

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -28,9 +28,11 @@
   export let isBeingCompared: boolean;
   export let filterExcludeMode: boolean;
   export let atLeastOneActive: boolean;
-  export let isValidPercentOfTotal: (measureName: string) => boolean;
   export let isTimeComparisonActive: boolean;
-  export let activeMeasureNames: string[] = [];
+  export let leaderboardMeasureNames: string[] = [];
+  export let dimensionColumnWidth: number;
+  export let suppressTooltip: boolean;
+  export let isValidPercentOfTotal: (measureName: string) => boolean;
   export let toggleDimensionValueSelection: (
     dimensionName: string,
     dimensionValue: string,
@@ -41,8 +43,6 @@
     string,
     (value: number | string | null | undefined) => string | null | undefined
   >;
-  export let dimensionColumnWidth: number;
-  export let suppressTooltip: boolean;
 
   let hovered = false;
   let valueRect = new DOMRect(0, 0, DEFAULT_COLUMN_WIDTH);
@@ -70,11 +70,11 @@
     : false;
 
   $: previousValueString =
-    activeMeasureNames.length === 1 &&
-    prevValues[activeMeasureNames[0]] !== undefined &&
-    prevValues[activeMeasureNames[0]] !== null
-      ? formatters[activeMeasureNames[0]]?.(
-          prevValues[activeMeasureNames[0]] as number,
+    leaderboardMeasureNames.length === 1 &&
+    prevValues[leaderboardMeasureNames[0]] !== undefined &&
+    prevValues[leaderboardMeasureNames[0]] !== null
+      ? formatters[leaderboardMeasureNames[0]]?.(
+          prevValues[leaderboardMeasureNames[0]] as number,
         )
       : undefined;
 
@@ -161,23 +161,17 @@
     ]),
   );
 
-  $: dimensionGradients =
-    activeMeasureNames.length >= 2
-      ? "bg-white"
-      : `linear-gradient(to right, ${barColor}
-    ${Math.max(...Object.values(barLengths))}px, transparent ${Math.max(...Object.values(barLengths))}px)`;
+  // $: dimensionGradients = `linear-gradient(to right, ${barColor}
+  //   ${Math.max(...Object.values(barLengths))}px, transparent ${Math.max(...Object.values(barLengths))}px)`;
 
-  $: measureGradients =
-    activeMeasureNames.length === 1
-      ? "bg-white"
-      : Object.fromEntries(
-          Object.entries(secondCellBarLengths).map(([name, length]) => [
-            name,
-            length
-              ? `linear-gradient(to right, transparent 16px, ${barColor} 16px, ${barColor} ${length + 16}px, transparent ${length + 16}px)`
-              : undefined,
-          ]),
-        );
+  // $: measureGradients = Object.fromEntries(
+  //   Object.entries(secondCellBarLengths).map(([name, length]) => [
+  //     name,
+  //     length
+  //       ? `linear-gradient(to right, transparent 16px, ${barColor} 16px, ${barColor} ${length + 16}px, transparent ${length + 16}px)`
+  //       : undefined,
+  //   ]),
+  // );
 
   $: deltaAbsoluteGradients = Object.fromEntries(
     Object.entries(thirdCellBarLengths).map(([name, length]) => [
@@ -249,7 +243,6 @@
   </td>
   <td
     data-dimension-cell
-    style:background={dimensionGradients}
     class:ui-copy={!atLeastOneActive}
     class:ui-copy-disabled={excluded}
     class:ui-copy-strong={!excluded && selected}
@@ -285,7 +278,6 @@
   {#each Object.keys(values) as measureName}
     <td
       data-measure-cell
-      style:background={measureGradients[measureName]}
       on:click={modified({
         shift: () => shiftClickHandler(values[measureName]?.toString() || ""),
       })}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -124,34 +124,34 @@
     ]),
   );
 
-  $: deltaAbsoluteCellBarLengths = Object.fromEntries(
-    Object.entries(barLengths).map(([name, length]) => [
-      name,
-      isTimeComparisonActive
-        ? clamp(
-            0,
-            length - $valueColumn - (percentOfTotalCellBarLengths[name] || 0),
-            COMPARISON_COLUMN_WIDTH,
-          )
-        : 0,
-    ]),
-  );
+  // $: deltaAbsoluteCellBarLengths = Object.fromEntries(
+  //   Object.entries(barLengths).map(([name, length]) => [
+  //     name,
+  //     isTimeComparisonActive
+  //       ? clamp(
+  //           0,
+  //           length - $valueColumn - (percentOfTotalCellBarLengths[name] || 0),
+  //           COMPARISON_COLUMN_WIDTH,
+  //         )
+  //       : 0,
+  //   ]),
+  // );
 
-  $: deltaPercentCellBarLengths = Object.fromEntries(
-    Object.entries(barLengths).map(([name, length]) => [
-      name,
-      isTimeComparisonActive
-        ? clamp(
-            0,
-            length -
-              $valueColumn -
-              (percentOfTotalCellBarLengths[name] || 0) -
-              (deltaAbsoluteCellBarLengths[name] || 0),
-            COMPARISON_COLUMN_WIDTH,
-          )
-        : 0,
-    ]),
-  );
+  // $: deltaPercentCellBarLengths = Object.fromEntries(
+  //   Object.entries(barLengths).map(([name, length]) => [
+  //     name,
+  //     isTimeComparisonActive
+  //       ? clamp(
+  //           0,
+  //           length -
+  //             $valueColumn -
+  //             (percentOfTotalCellBarLengths[name] || 0) -
+  //             (deltaAbsoluteCellBarLengths[name] || 0),
+  //           COMPARISON_COLUMN_WIDTH,
+  //         )
+  //       : 0,
+  //   ]),
+  // );
 
   $: dimensionGradients =
     leaderboardMeasureNames.length === 1
@@ -171,38 +171,38 @@
         )
       : undefined;
 
-  $: percentOfTotalGradients =
-    leaderboardMeasureNames.length > 1
-      ? Object.fromEntries(
-          Object.entries(percentOfTotalCellBarLengths).map(([name, length]) => [
-            name,
-            length
-              ? `linear-gradient(to right, ${barColor}
-    ${length}px, transparent ${length}px)`
-              : undefined,
-          ]),
-        )
-      : undefined;
+  // $: percentOfTotalGradients =
+  //   leaderboardMeasureNames.length > 1
+  //     ? Object.fromEntries(
+  //         Object.entries(percentOfTotalCellBarLengths).map(([name, length]) => [
+  //           name,
+  //           length
+  //             ? `linear-gradient(to right, ${barColor}
+  //   ${length}px, transparent ${length}px)`
+  //             : undefined,
+  //         ]),
+  //       )
+  //     : undefined;
 
-  $: deltaAbsoluteGradients = Object.fromEntries(
-    Object.entries(deltaAbsoluteCellBarLengths).map(([name, length]) => [
-      name,
-      length
-        ? `linear-gradient(to right, ${barColor}
-    ${length}px, transparent ${length}px)`
-        : undefined,
-    ]),
-  );
+  // $: deltaAbsoluteGradients = Object.fromEntries(
+  //   Object.entries(deltaAbsoluteCellBarLengths).map(([name, length]) => [
+  //     name,
+  //     length
+  //       ? `linear-gradient(to right, ${barColor}
+  //   ${length}px, transparent ${length}px)`
+  //       : undefined,
+  //   ]),
+  // );
 
-  $: deltaPercentGradients = Object.fromEntries(
-    Object.entries(deltaPercentCellBarLengths).map(([name, length]) => [
-      name,
-      length
-        ? `linear-gradient(to right, ${barColor}
-    ${length}px, transparent ${length}px)`
-        : undefined,
-    ]),
-  );
+  // $: deltaPercentGradients = Object.fromEntries(
+  //   Object.entries(deltaPercentCellBarLengths).map(([name, length]) => [
+  //     name,
+  //     length
+  //       ? `linear-gradient(to right, ${barColor}
+  //   ${length}px, transparent ${length}px)`
+  //       : undefined,
+  //   ]),
+  // );
 
   $: showTooltip = hovered && !suppressTooltip;
 
@@ -302,7 +302,7 @@
     {#if isValidPercentOfTotal(measureName)}
       <td
         data-comparison-cell
-        style:background={percentOfTotalGradients?.[measureName]}
+        title={pctOfTotals[measureName]?.toString() || ""}
         on:click={modified({
           shift: () =>
             shiftClickHandler(pctOfTotals[measureName]?.toString() || ""),
@@ -321,7 +321,7 @@
     {#if isTimeComparisonActive}
       <td
         data-comparison-cell
-        style:background={deltaAbsoluteGradients[measureName]}
+        title={deltaAbsMap[measureName]?.toString() || ""}
         on:click={modified({
           shift: () =>
             shiftClickHandler(deltaAbsMap[measureName]?.toString() || ""),
@@ -345,7 +345,7 @@
     {#if isTimeComparisonActive}
       <td
         data-comparison-cell
-        style:background={deltaPercentGradients[measureName]}
+        title={deltaRels[measureName]?.toString() || ""}
         on:click={modified({
           shift: () =>
             shiftClickHandler(deltaRels[measureName]?.toString() || ""),

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -117,12 +117,12 @@
     ]),
   );
 
-  $: percentOfTotalCellBarLengths = Object.fromEntries(
-    Object.entries(barLengths).map(([name, length]) => [
-      name,
-      isValidPercentOfTotal(name) ? clamp(0, length, DEFAULT_COLUMN_WIDTH) : 0,
-    ]),
-  );
+  // $: percentOfTotalCellBarLengths = Object.fromEntries(
+  //   Object.entries(barLengths).map(([name, length]) => [
+  //     name,
+  //     isValidPercentOfTotal(name) ? clamp(0, length, DEFAULT_COLUMN_WIDTH) : 0,
+  //   ]),
+  // );
 
   // $: deltaAbsoluteCellBarLengths = Object.fromEntries(
   //   Object.entries(barLengths).map(([name, length]) => [


### PR DESCRIPTION
Fixes https://www.notion.so/rilldata/Background-bar-charts-seem-broken-1c8ba33c8f5780f69e8bf5c93447a315 and https://www.notion.so/rilldata/Blue-bars-showing-inaccurately-1c8ba33c8f57817e9411f82cc8d696fc

Also reported in https://rilldata.slack.com/archives/C087E4NS7FH/p1743541702913749

1 measure
![CleanShot 2025-04-01 at 16 51 58@2x](https://github.com/user-attachments/assets/d53c8619-825e-4031-9a0f-301ea232292c)

1+ measures
![CleanShot 2025-04-01 at 16 52 28@2x](https://github.com/user-attachments/assets/e56f024e-4204-4751-99f8-4bfd18b5b2a8)


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
