### PR TITLE
chore: upgrade vega packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9031,7 +9031,8 @@
     "node_modules/@types/geojson": {
       "version": "7946.0.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -13296,9 +13297,10 @@
       }
     },
     "node_modules/d3-geo": {
-      "version": "3.1.0",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "d3-array": "2.5.0 - 3"
       },
@@ -13443,9 +13445,10 @@
       }
     },
     "node_modules/d3-scale-chromatic": {
-      "version": "3.0.0",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-interpolate": "1 - 3"
@@ -16276,6 +16279,30 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fetch-retry": {
       "version": "5.0.6",
       "dev": true,
@@ -16791,6 +16818,19 @@
       "version": "1.0.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/formidable": {
       "version": "2.1.2",
@@ -23804,6 +23844,26 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
     "node_modules/node-emoji": {
@@ -32902,13 +32962,15 @@
     "node_modules/vega-event-selector": {
       "version": "3.0.1",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/vega-expression": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.2.tgz",
       "integrity": "sha512-fFeDTh4UtOxlZWL54jf1ZqJHinyerWq/ROiqrQxqLkNJRJ86RmxYTgXwt65UoZ/l4VUv9eAd2qoJeDEf610Umw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
         "vega-util": "^1.17.3"
@@ -33007,6 +33069,7 @@
       "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.23.0.tgz",
       "integrity": "sha512-l4J6+AWE3DIjvovEoHl2LdtCUkfm4zs8Xxx7INwZEAv+XVb6kR6vIN1gt3t2gN2gs/y4DYTs/RPoTeYAuEg6mA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "json-stringify-pretty-compact": "~4.0.0",
         "tslib": "~2.8.1",
@@ -33032,6 +33095,7 @@
       "version": "8.0.1",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -33044,18 +33108,21 @@
     "node_modules/vega-lite/node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/vega-lite/node_modules/json-stringify-pretty-compact": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
       "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/vega-lite/node_modules/string-width": {
       "version": "4.2.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -33069,6 +33136,7 @@
       "version": "7.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -33085,6 +33153,7 @@
       "version": "17.7.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -33102,6 +33171,7 @@
       "version": "21.1.1",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -33277,7 +33347,8 @@
       "version": "1.17.3",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.3.tgz",
       "integrity": "sha512-nSNpZLUrRvFo46M5OK4O6x6f08WD1yOcEzHNlqivF+sDLSsVpstaF6fdJYwrbf/debFi2L9Tkp4gZQtssup9iQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/vega-view": {
       "version": "5.12.0",
@@ -33879,6 +33950,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/web-vitals": {
@@ -35557,8 +35638,8 @@
         "ua-parser-js": "^1.0.2",
         "uuid": "^9.0.0",
         "vega-interpreter": "^2.0.0",
-        "vega-lite": "^5.23.0",
-        "vega-typings": "^1.3.1",
+        "vega-lite": "^6.1.0",
+        "vega-typings": "^2.0.1",
         "vitest": "^2.1.3",
         "yaml": "^2.4.5",
         "yup": "^1.4.0"
@@ -35596,6 +35677,12 @@
       "dependencies": {
         "@orval/core": "6.12.0"
       }
+    },
+    "web-common/node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true
     },
     "web-common/node_modules/@vitest/expect": {
       "version": "2.1.3",
@@ -35722,6 +35809,30 @@
         "node": ">= 16"
       }
     },
+    "web-common/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "web-common/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "web-common/node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -35736,6 +35847,12 @@
       "version": "3.1.0",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)"
+    },
+    "web-common/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "web-common/node_modules/fflate": {
       "version": "0.8.2",
@@ -35760,6 +35877,12 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "web-common/node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "dev": true
     },
     "web-common/node_modules/loupe": {
       "version": "3.1.2",
@@ -35787,6 +35910,25 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "web-common/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "web-common/node_modules/orval": {
@@ -35826,6 +35968,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
+      }
+    },
+    "web-common/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "web-common/node_modules/svelte-preprocess": {
@@ -35904,6 +36060,181 @@
         "node": ">=14.0.0"
       }
     },
+    "web-common/node_modules/vega": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-6.1.2.tgz",
+      "integrity": "sha512-d5GT7wRoRnK+bsQWgauOHyPFY4td52PTuX5IzMXr9PXHkz2OKXpVti7LeK5evAoyhNxVenkT1ptpRQKU2MRJdw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "vega-crossfilter": "~5.0.0",
+        "vega-dataflow": "~6.0.0",
+        "vega-encode": "~5.0.0",
+        "vega-event-selector": "~4.0.0",
+        "vega-expression": "~6.0.0",
+        "vega-force": "~5.0.0",
+        "vega-format": "~2.0.0",
+        "vega-functions": "~6.0.0",
+        "vega-geo": "~5.0.0",
+        "vega-hierarchy": "~5.0.0",
+        "vega-label": "~2.0.0",
+        "vega-loader": "~5.0.0",
+        "vega-parser": "~7.0.0",
+        "vega-projection": "~2.0.0",
+        "vega-regression": "~2.0.0",
+        "vega-runtime": "~7.0.0",
+        "vega-scale": "~8.0.0",
+        "vega-scenegraph": "~5.0.0",
+        "vega-statistics": "~2.0.0",
+        "vega-time": "~3.0.0",
+        "vega-transforms": "~5.0.0",
+        "vega-typings": "~2.0.0",
+        "vega-util": "~2.0.0",
+        "vega-view": "~6.0.0",
+        "vega-view-transforms": "~5.0.0",
+        "vega-voronoi": "~5.0.0",
+        "vega-wordcloud": "~5.0.0"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      }
+    },
+    "web-common/node_modules/vega-canvas": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-2.0.0.tgz",
+      "integrity": "sha512-9x+4TTw/USYST5nx4yN272sy9WcqSRjAR0tkQYZJ4cQIeon7uVsnohvoPQK1JZu7K1QXGUqzj08z0u/UegBVMA==",
+      "dev": true,
+      "peer": true
+    },
+    "web-common/node_modules/vega-crossfilter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-5.0.0.tgz",
+      "integrity": "sha512-9PnDXpoLY4rWBubTjtAxEmEdSLq4pg1OyyucugnGNX6HsaAuF5fXYmXdpe4UB4SMMHMnWM3ZBA2wkkycct11sQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "vega-dataflow": "^6.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-dataflow": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-6.0.0.tgz",
+      "integrity": "sha512-/6Cl06lqTPDiGwwRgRJ6osAy/qwgeelwK4+tZ4QS/aNJhoEAJU5xPXuWl6U0trabUT2Pe0+Qpo1+/u0oAOmmCg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "vega-format": "^2.0.0",
+        "vega-loader": "^5.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-encode": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-5.0.0.tgz",
+      "integrity": "sha512-3YdnCGDMNppicdzyaawP1fYYyJhMUMREwgQmQvF//NFRMY3bzI59Rjhq4v+tIMXXSvnTztJ1Chm9eSvZGiNs+g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-interpolate": "^3.0.1",
+        "vega-dataflow": "^6.0.0",
+        "vega-scale": "^8.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-event-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-4.0.0.tgz",
+      "integrity": "sha512-CcWF4m4KL/al1Oa5qSzZ5R776q8lRxCj3IafCHs5xipoEHrkgu1BWa7F/IH5HrDNXeIDnqOpSV1pFsAWRak4gQ==",
+      "dev": true
+    },
+    "web-common/node_modules/vega-expression": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-6.0.0.tgz",
+      "integrity": "sha512-aw6hGpTSiakAe5KqCsnpXNsBgN823IMq84x2Gg1pJj+H6zxlEfN4FCibPAC0PYWOmSvCRUoXMr7b/wWiwsiPIg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.6",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-force": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-5.0.0.tgz",
+      "integrity": "sha512-j3HNCrngjuFvOmBl2gg2NNgDys5q6i+v6pliIt9grSAcgzStNNuxcVp+OjNeWP4NSa0Hc7efEGmYvmBqTP/HpQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "d3-force": "^3.0.0",
+        "vega-dataflow": "^6.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-2.0.0.tgz",
+      "integrity": "sha512-RrMI/HedVEb4PDFyiNjzbJtOLt/H7aan1Fs3sQQamOdSAj5gcq6r9IavzKy7dC4XaovEjdStJL6JSAfTW53CiQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-format": "^3.1.0",
+        "d3-time-format": "^4.1.0",
+        "vega-time": "^3.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-functions": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-6.0.0.tgz",
+      "integrity": "sha512-1Qy7VOUIa3GzbfLXYYpTDPQMyJVV27a7U8xCqXtMPozXQo4cKQRb/OKAqMk7A/0eCTs3E08pc41kFa/tYSOIag==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.1",
+        "vega-dataflow": "^6.0.0",
+        "vega-expression": "^6.0.0",
+        "vega-scale": "^8.0.0",
+        "vega-scenegraph": "^5.0.0",
+        "vega-selections": "^6.0.0",
+        "vega-statistics": "^2.0.0",
+        "vega-time": "^3.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-geo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-5.0.0.tgz",
+      "integrity": "sha512-cr7Tjktgq0cuYwqhz5Mak6tv7BeaRBz1HaojNLJxJzQtNw1oBdT8gXxSYN1PA61OExHP2mG8GZRF+XdjbnN3LQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.1",
+        "vega-canvas": "^2.0.0",
+        "vega-dataflow": "^6.0.0",
+        "vega-projection": "^2.0.0",
+        "vega-statistics": "^2.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-hierarchy": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-5.0.0.tgz",
+      "integrity": "sha512-W2nVICp5946eG5zf5jenHo4Q+LBcYmDQjFt7/7HyRzvZT8IIdhBEuotb2MwmgJ9GeOsmt/DRb53DNZbXMSB9ww==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "d3-hierarchy": "^3.1.2",
+        "vega-dataflow": "^6.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
     "web-common/node_modules/vega-interpreter": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/vega-interpreter/-/vega-interpreter-2.0.0.tgz",
@@ -35913,23 +36244,261 @@
         "vega-util": "^2.0.0"
       }
     },
-    "web-common/node_modules/vega-interpreter/node_modules/vega-util": {
+    "web-common/node_modules/vega-label": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-2.0.0.tgz",
+      "integrity": "sha512-e+JIojHNiEcI/4jFoOLhtocbqoQzJqurZwyP3lFgV7nJOQPOZSZYiEUOUhbhYuMgnhz0HDBe3GDqSAeo1yUhfw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "vega-canvas": "^2.0.0",
+        "vega-dataflow": "^6.0.0",
+        "vega-scenegraph": "^5.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-lite": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-6.1.0.tgz",
+      "integrity": "sha512-SgL/s0Ddoq2Do0GFd9pOMtJmWW1YOjht98v/fixnpnWi+7hijWRha1tAziDeQLOBwsv5NmjzrJXpYhedRAbv2A==",
+      "dev": true,
+      "dependencies": {
+        "json-stringify-pretty-compact": "~4.0.0",
+        "tslib": "~2.8.1",
+        "vega-event-selector": "~4.0.0",
+        "vega-expression": "~6.0.0",
+        "vega-util": "~2.0.0",
+        "yargs": "~17.7.2"
+      },
+      "bin": {
+        "vl2pdf": "bin/vl2pdf",
+        "vl2png": "bin/vl2png",
+        "vl2svg": "bin/vl2svg",
+        "vl2vg": "bin/vl2vg"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      },
+      "peerDependencies": {
+        "vega": "^6.0.0"
+      }
+    },
+    "web-common/node_modules/vega-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-5.0.0.tgz",
+      "integrity": "sha512-THLOtcbL0gQjv3GunKWutUiELdLc74nQOfIWNL/kx2qXtM2kYhE5FcCKQNTA9aZzklY3oN8Bt4siJ22ugO0WyA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "d3-dsv": "^3.0.1",
+        "node-fetch": "^3.3.2",
+        "topojson-client": "^3.1.0",
+        "vega-format": "^2.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-7.0.0.tgz",
+      "integrity": "sha512-820pladvhez0SQBZ8Yohou0fpWd4Vl+AbekGG0eu+mh2BhjJmIDaNC/5j/5sZ/A+ufHO2GPCAt4DSiM/X2jWqg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "vega-dataflow": "^6.0.0",
+        "vega-event-selector": "^4.0.0",
+        "vega-functions": "^6.0.0",
+        "vega-scale": "^8.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-projection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-2.0.0.tgz",
+      "integrity": "sha512-oeNTNKD5iwDImiSTjNqxGrDGACxVmF+1XWxKgplgHsnoB0k4wtcGm0Lc6cZ0rwC6zyJ/4WRVxjUeOVGKpNCpxA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "d3-geo": "^3.1.1",
+        "d3-geo-projection": "^4.0.0",
+        "vega-scale": "^8.0.0"
+      }
+    },
+    "web-common/node_modules/vega-regression": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-2.0.0.tgz",
+      "integrity": "sha512-0OW2+Pp0VQJXkNxpI+a3b3kUdqJacbmHoOKl0frGYtrJzB4GsebBsdd7N2WSztrzPh5cP3oHaYJeQSHgj9P9xw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "vega-dataflow": "^6.0.0",
+        "vega-statistics": "^2.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-runtime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-7.0.0.tgz",
+      "integrity": "sha512-bFMqxaYwOYVoXIjI3GCZstgjoXI3lvjtRSKMN3n8ASVGbakiGjtUPRcpueYQqrpGFXR8UoQcGeXtIyyHRC68mw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "vega-dataflow": "^6.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-scale": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-8.0.0.tgz",
+      "integrity": "sha512-9jEVbxi7NXVYYF2l+2PB2UcvAX/RxBMzOam7afP+68w2DeGJz43AF/8NGc9tjZZAE5SYTERotxKki31PkAPOFg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.1.0",
+        "vega-time": "^3.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-scenegraph": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-5.0.0.tgz",
+      "integrity": "sha512-BkE4n+mgMpEcHF2EKo+27Sjso0x/zPqgZjoP5dngjSkeyJqKfyxi93lDEJNylWBJqcyjNEmOrAkQQi3B4RNtKA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "d3-path": "^3.1.0",
+        "d3-shape": "^3.2.0",
+        "vega-canvas": "^2.0.0",
+        "vega-loader": "^5.0.0",
+        "vega-scale": "^8.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-selections": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-6.0.0.tgz",
+      "integrity": "sha512-ig2NHIV+ZWeQJAD3T+cIJ13qM583an7NvHaDkmuOPPIRvtnrO9CbXCqQ84yHhLrJSzxLwO2h8ExSGkoOmzPUaw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "d3-array": "3.2.4",
+        "vega-expression": "^6.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-statistics": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-2.0.0.tgz",
+      "integrity": "sha512-dGPfDXnBlgXbZF3oxtkb8JfeRXd5TYHx25Z/tIoaa9jWua4Vf/AoW2wwh8J1qmMy8J03/29aowkp1yk4DOPazQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.4"
+      }
+    },
+    "web-common/node_modules/vega-time": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-3.0.0.tgz",
+      "integrity": "sha512-Ifs95YXaQ6/3NCJ7l9jdda74uovwLodUHFYQqqXPanjUtF9e5juw4/VurbgIPYnB76w4ye6/q19OdlUeUdVQuw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-time": "^3.1.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-transforms": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-5.0.0.tgz",
+      "integrity": "sha512-a4fo0tlfZFE1C/aV+IpEEl/SAyz9JnVqYCxcEeuQm6byglCz+PnjZmnqFyKFBnmVHDjQ/GP82DkqGBx52Cr0Kg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "vega-dataflow": "^6.0.0",
+        "vega-statistics": "^2.0.0",
+        "vega-time": "^3.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-typings": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-2.0.1.tgz",
+      "integrity": "sha512-Jfw2zeAv4rQ8YqfgBae3QauK0T9FUpQ+0q3NNLW24Z6nyjf8H2ucnyLhw6pIqfVytne6VB4WkvazTOgJPuv5vw==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "7946.0.16",
+        "vega-event-selector": "^4.0.0",
+        "vega-expression": "^6.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-util": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
       "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
       "dev": true
     },
-    "web-common/node_modules/vega-typings": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-1.3.1.tgz",
-      "integrity": "sha512-j9Sdgmvowz09jkMgTFGVfiv7ycuRP/TQkdHRPXIYwt3RDgPQn7inyFcJ8C8ABFt4MiMWdjOwbneF6KWW8TRXIw==",
+    "web-common/node_modules/vega-view": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-6.0.0.tgz",
+      "integrity": "sha512-Q4bS6eEt+d8N1ZKGg/jueEFboR1CGO8olye7vz3gS/iyg4fPDwMx0sh4pDiX077OPD3UW/0NbplIiHwzQyabEg==",
       "dev": true,
-      "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
-        "@types/geojson": "7946.0.4",
-        "vega-event-selector": "^3.0.1",
-        "vega-expression": "^5.1.1",
-        "vega-util": "^1.17.2"
+        "d3-array": "^3.2.4",
+        "d3-timer": "^3.0.1",
+        "vega-dataflow": "^6.0.0",
+        "vega-format": "^2.0.0",
+        "vega-functions": "^6.0.0",
+        "vega-runtime": "^7.0.0",
+        "vega-scenegraph": "^5.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-view-transforms": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-5.0.0.tgz",
+      "integrity": "sha512-AqQStHIYZtjsm84rx43z6P18DdR4/l20q/mfWXJ2Ifts1T2gPshC24/0xUfGrnwpqM5m3X1HwkJUiyEJxzVQrQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "vega-dataflow": "^6.0.0",
+        "vega-scenegraph": "^5.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-voronoi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-5.0.0.tgz",
+      "integrity": "sha512-mmsQFo7Aj8WM/QS8Ta79QWxADU3WpvEQ0OIR20WFgY/QLJ+42FEcJkBlaSQQ+DFl2Ci5PdbpZtRFMPJoRokFMw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "d3-delaunay": "^6.0.4",
+        "vega-dataflow": "^6.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "web-common/node_modules/vega-wordcloud": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-5.0.0.tgz",
+      "integrity": "sha512-Rm46D1ginGdunWLtsiymllU5RvJTEtpKRaWcc/pABpFiz7QHGGrZ9FhOczxW1o3n89h07gzc9n8xlWYco06Fdw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "vega-canvas": "^2.0.0",
+        "vega-dataflow": "^6.0.0",
+        "vega-scale": "^8.0.0",
+        "vega-statistics": "^2.0.0",
+        "vega-util": "^2.0.0"
       }
     },
     "web-common/node_modules/vite-node": {
@@ -36019,6 +36588,23 @@
         }
       }
     },
+    "web-common/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "web-common/node_modules/yaml": {
       "version": "2.4.5",
       "dev": true,
@@ -36028,6 +36614,33 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "web-common/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "web-common/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "web-local": {

--- a/web-common/package.json
+++ b/web-common/package.json
@@ -97,8 +97,8 @@
     "ua-parser-js": "^1.0.2",
     "uuid": "^9.0.0",
     "vega-interpreter": "^2.0.0",
-    "vega-lite": "^5.23.0",
-    "vega-typings": "^1.3.1",
+    "vega-lite": "^6.1.0",
+    "vega-typings": "^2.0.1",
     "vitest": "^2.1.3",
     "yaml": "^2.4.5",
     "yup": "^1.4.0"


### PR DESCRIPTION
Upgrade vega packages.

Couldn't upgrade `svelte-vega` as that requires us to be on Svelte 5.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
