### PR TITLE
fix (Org Projects): Handle overflow

### DIFF
--- a/web-admin/src/components/layout/ContentContainer.svelte
+++ b/web-admin/src/components/layout/ContentContainer.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <main
-  class="size-full p-8 lg:pt-12 flex flex-col items-center px-8 sm:px-16 lg:px-32 2xl:px-40 overflow-y-auto"
+  class="size-full pt-8 pb-16 lg:pt-12 flex flex-col items-center px-8 sm:px-16 lg:px-32 2xl:px-40 overflow-y-auto"
 >
   <section class="w-full flex flex-col gap-y-3" style:max-width="{maxWidth}px">
     {#if title && showTitle}

--- a/web-admin/src/features/organizations/OrganizationHero.svelte
+++ b/web-admin/src/features/organizations/OrganizationHero.svelte
@@ -2,6 +2,6 @@
   export let title: string;
 </script>
 
-<h1 class="text-sky-950 text-4xl font-light leading-10">
+<h1 class="text-sky-950 text-4xl font-light leading-10 pt-12">
   {title}
 </h1>

--- a/web-admin/src/routes/[organization]/+page.svelte
+++ b/web-admin/src/routes/[organization]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from "$app/stores";
+  import ContentContainer from "@rilldata/web-admin/components/layout/ContentContainer.svelte";
   import OrganizationHibernating from "@rilldata/web-admin/features/organizations/hibernating/OrganizationHibernating.svelte";
   import { areAllProjectsHibernating } from "@rilldata/web-admin/features/organizations/selectors";
   import {
@@ -28,10 +29,8 @@
   <title>{title} overview - Rill</title>
 </svelte:head>
 
-{#if $org.data && $org.data.organization && $projs.data}
-  <section
-    class="mx-8 my-8 sm:my-16 sm:mx-16 lg:mx-32 lg:my-24 2xl:mx-64 mx-auto flex flex-col gap-y-4"
-  >
+<ContentContainer showTitle={false} maxWidth={1300}>
+  {#if $org.data && $org.data.organization && $projs.data}
     {#if $projs.data.projects?.length === 0}
       <OrganizationHero {title} />
       <span>
@@ -52,5 +51,5 @@
         <ProjectCards organization={orgName} />
       </div>
     {/if}
-  </section>
-{/if}
+  {/if}
+</ContentContainer>


### PR DESCRIPTION
Currently, the organization page does not correctly handle many projects. See the background color change in the "demo" organization:
<img width="1916" alt="image" src="https://github.com/user-attachments/assets/32fe472a-ccfc-427c-9eb4-33e9aec271ca" />

Fixed by this PR.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
