### PR TITLE
fix: unstable e2e cloud setup

### DIFF
--- a/.github/workflows/web-test-e2e.yml
+++ b/.github/workflows/web-test-e2e.yml
@@ -104,6 +104,9 @@ jobs:
         if: matrix.name == 'web-admin'
         run: PLAYWRIGHT_TEST=true make cli-only
 
+      - name: Install duckdb extensions
+        run: ./rill runtime install-duckdb-extensions
+
       - name: Add CLI binary to PATH
         run: echo "$GITHUB_WORKSPACE" >> $GITHUB_PATH
 

--- a/web-admin/src/components/layout/ContentContainer.svelte
+++ b/web-admin/src/components/layout/ContentContainer.svelte
@@ -9,7 +9,7 @@
 >
   <section class="w-full flex flex-col gap-y-3" style:max-width="{maxWidth}px">
     {#if title && showTitle}
-      <h1 class="text-2xl font-semibold">
+      <h1 class="text-2xl font-semibold" aria-label="Container title">
         {title}
       </h1>
     {/if}

--- a/web-admin/tests/setup/setup.ts
+++ b/web-admin/tests/setup/setup.ts
@@ -190,6 +190,21 @@ setup.describe("global setup", () => {
     // ).toBeVisible(); // Billing banner
     // await expect(adminPage.getByText("Free trial")).toBeVisible(); // Billing status
 
+    // There is a scenario where page loads before runtime can identify what files are present.
+    // This leads to a case where we never refresh the resources list.
+    // TODO: find a solution to refetch in the app itself
+    await expect
+      .poll(
+        async () => {
+          await adminPage.reload();
+          console.log("RELOADING...");
+          const title = adminPage.getByLabel("Container title");
+          return title.textContent();
+        },
+        { intervals: Array(5).fill(1_000), timeout: 5_000 },
+      )
+      .toEqual("Project dashboards");
+
     // Check that the dashboards are listed
     await expect(
       adminPage.getByRole("link", { name: "Programmatic Ads Auction" }).first(),
@@ -208,7 +223,10 @@ setup.describe("global setup", () => {
           });
           return listing.textContent();
         },
-        { intervals: Array(6).fill(5_000), timeout: 30_000 },
+        {
+          intervals: [10_000, 10_000, 20_000, 20_000, 30_000, 30_000],
+          timeout: 120_000,
+        },
       )
       .toContain("Last refreshed");
 

--- a/web-admin/tests/setup/setup.ts
+++ b/web-admin/tests/setup/setup.ts
@@ -197,7 +197,6 @@ setup.describe("global setup", () => {
       .poll(
         async () => {
           await adminPage.reload();
-          console.log("RELOADING...");
           const title = adminPage.getByLabel("Container title");
           return title.textContent();
         },
@@ -224,6 +223,7 @@ setup.describe("global setup", () => {
           return listing.textContent();
         },
         {
+          // Increased timeout for the 1st dashboard to make sure sources are reconciled.
           intervals: [10_000, 10_000, 20_000, 20_000, 30_000, 30_000],
           timeout: 120_000,
         },


### PR DESCRIPTION
This is an attempt to fix unstable e2e OpenRTB project deploy. Earlier it was stuck at getting dashboard listing. Now after adding a refresh there it gets stuck at getting the last refreshed which is available after reconcile is finished.

1. Locally the resources do reconcile after a long time. This PR stabilised the setup locally.
2. On CI there is still an issue with `sqlite_scanner` which seems to be blocking this. Pre-loading duckdb extensions as a temp fix.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
