### PR TITLE
fix: select all measures/dimensions in version 0.58

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
@@ -24,7 +24,11 @@
     },
     actions: {
       contextColumn: { setContextColumn },
-      dimensions: { setDimensionVisibility, toggleDimensionVisibility },
+      dimensions: {
+        setDimensionVisibility,
+        toggleAllDimensionsVisibility,
+        toggleDimensionVisibility,
+      },
       setLeaderboardMeasureCount,
       setLeaderboardMeasureName,
     },
@@ -41,7 +45,7 @@
 
   $: activeLeaderboardMeasure = $getMeasureByName($leaderboardMeasureName);
 
-  $: validPercentOfTotal = leaderboardMeasureCountFeatureFlag
+  $: validPercentOfTotal = $leaderboardMeasureCountFeatureFlag
     ? $visibleMeasures.some((measure) => measure.validPercentOfTotal)
     : activeLeaderboardMeasure?.validPercentOfTotal || false;
 
@@ -93,7 +97,7 @@
           }))}
           selectedItems={visibleDimensionsNames}
           onToggleSelectAll={() => {
-            toggleDimensionVisibility(allDimensionNames);
+            toggleAllDimensionsVisibility(allDimensionNames);
           }}
         />
       {/if}

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -66,7 +66,11 @@
       dimensionFilters: { includedDimensionValues },
     },
     actions: {
-      measures: { setMeasureVisibility, toggleMeasureVisibility },
+      measures: {
+        setMeasureVisibility,
+        toggleAllMeasuresVisibility,
+        toggleMeasureVisibility,
+      },
     },
     validSpecStore,
   } = getStateManagers();
@@ -324,7 +328,7 @@
           }))}
           selectedItems={visibleMeasureNames}
           onToggleSelectAll={() => {
-            toggleMeasureVisibility(allMeasureNames);
+            toggleAllMeasuresVisibility(allMeasureNames);
           }}
         />
       {/if}


### PR DESCRIPTION
Due to a bad merge select all measures/dimensions is broken on `release-0.58` branch

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
