### PR TITLE
Perf fix: leaderboard measures requests

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -88,8 +88,6 @@
     dimensionName: string | undefined,
   ) => void;
 
-  $: console.log("sortBy: ", sortBy);
-  $: console.log("activeMeasureName: ", activeMeasureName);
   const observer = new IntersectionObserver(
     ([entry]) => {
       visible = entry.isIntersecting;

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -47,6 +47,7 @@
   const queryLimit = 8;
   const maxValuesToShow = 15;
 
+  // FIXME: clean up `sortBy` and `activeMeasureName`
   export let dimension: MetricsViewSpecDimensionV2;
   export let timeRange: V1TimeRange;
   export let comparisonTimeRange: V1TimeRange | undefined;
@@ -87,6 +88,8 @@
     dimensionName: string | undefined,
   ) => void;
 
+  $: console.log("sortBy: ", sortBy);
+  $: console.log("activeMeasureName: ", activeMeasureName);
   const observer = new IntersectionObserver(
     ([entry]) => {
       visible = entry.isIntersecting;

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -128,7 +128,7 @@
 
   $: measures = [
     ...(leaderboardMeasureCountFeatureFlag
-      ? visibleMeasures.map(
+      ? leaderboardMeasureNames.map(
           (name) =>
             ({
               name,
@@ -144,7 +144,7 @@
     // Add comparison measures if there's a comparison time range
     ...(comparisonTimeRange
       ? (leaderboardMeasureCountFeatureFlag
-          ? visibleMeasures
+          ? leaderboardMeasureNames
           : [activeMeasureName]
         ).flatMap((name) => getComparisonRequestMeasures(name))
       : []),

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -94,6 +94,7 @@
             <Leaderboard
               isValidPercentOfTotal={$isMeasureValidPercentOfTotal}
               {metricsViewName}
+              sortBy={$sortByMeasure}
               {activeMeasureName}
               {leaderboardMeasureNames}
               visibleMeasures={validVisibleMeasures}
@@ -127,7 +128,6 @@
               {toggleSort}
               {toggleDimensionValueSelection}
               {toggleComparisonDimension}
-              sortBy={$sortByMeasure}
               measureLabel={$measureLabel}
               leaderboardMeasureCountFeatureFlag={$leaderboardMeasureCountFeatureFlag}
             />

--- a/web-common/src/features/dashboards/state-managers/actions/core-actions.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/core-actions.ts
@@ -1,11 +1,21 @@
 import { resetAllContextColumnWidths } from "./context-columns";
 import type { DashboardMutables } from "./types";
 
+// NOTE: this is a temporary action to set the leaderboard measure count.
+// It will be removed in the multiple measures second pass anyway.
 export const setLeaderboardMeasureCount = (
   { dashboard }: DashboardMutables,
   count: number,
 ) => {
   dashboard.leaderboardMeasureCount = count;
+
+  // If the current leaderboard measure is not in the first N visible measures,
+  // set it to the first visible measure
+  const visibleMeasures = dashboard.visibleMeasures.slice(0, count);
+  if (!visibleMeasures.includes(dashboard.leaderboardMeasureName)) {
+    dashboard.leaderboardMeasureName =
+      visibleMeasures[0] || dashboard.leaderboardMeasureName;
+  }
 };
 
 export const setLeaderboardMeasureName = (

--- a/web-common/src/features/dashboards/state-managers/actions/core-actions.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/core-actions.ts
@@ -13,8 +13,7 @@ export const setLeaderboardMeasureCount = (
   // set it to the first visible measure
   const visibleMeasures = dashboard.visibleMeasures.slice(0, count);
   if (!visibleMeasures.includes(dashboard.leaderboardMeasureName)) {
-    dashboard.leaderboardMeasureName =
-      visibleMeasures[0] || dashboard.leaderboardMeasureName;
+    dashboard.leaderboardMeasureName = visibleMeasures[0];
   }
 };
 


### PR DESCRIPTION
https://rilldata.slack.com/archives/C02T907FEUB/p1743691556738219?thread_ts=1743689026.881769&cid=C02T907FEUB

**Before**

1 measure count, all visible measures are being ran

![CleanShot 2025-04-03 at 09 49 46@2x](https://github.com/user-attachments/assets/b31f45c2-6c08-4f54-bbbb-9825566081ec)

**After**

the network calls are now based on the leaderboard measures (selected measure count)

https://github.com/user-attachments/assets/857ef1df-cca5-4811-b63c-1ca1db998295

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
