### PR TITLE
change_install_and_load_order

### DIFF
--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -452,15 +452,15 @@ func (c *connection) reopenDB(ctx context.Context) error {
 	}
 	dbInitQueries = append(dbInitQueries,
 		"INSTALL 'json'",
-		"LOAD 'json'",
-		"INSTALL 'icu'",
-		"LOAD 'icu'",
-		"INSTALL 'parquet'",
-		"LOAD 'parquet'",
-		"INSTALL 'httpfs'",
-		"LOAD 'httpfs'",
 		"INSTALL 'sqlite'",
+		"INSTALL 'icu'",
+		"INSTALL 'parquet'",
+		"INSTALL 'httpfs'",
+		"LOAD 'json'",
 		"LOAD 'sqlite'",
+		"LOAD 'icu'",
+		"LOAD 'parquet'",
+		"LOAD 'httpfs'",
 		"SET GLOBAL timezone='UTC'",
 		"SET GLOBAL old_implicit_casting = true", // Implicit Cast to VARCHAR
 		"SET GLOBAL allow_community_extensions = false", // This locks the configuration, so it can't later be enabled.


### PR DESCRIPTION
Not sure but feel like some not install sqlite is not full finished and load sqlite run. Trying changing the order of install and load so give some time between install and load
Closes [#1505](https://github.com/rilldata/rill-private-issues/issues/1505)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
