### PR TITLE
refactor (state management): use explicit `activePage` state to route to Explore views

### DIFF
--- a/web-common/src/features/dashboards/state-managers/selectors/pivot.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/pivot.ts
@@ -1,11 +1,13 @@
 import { splitPivotChips } from "@rilldata/web-common/features/dashboards/pivot/pivot-utils";
 import { filteredSimpleMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
+import { DashboardState_ActivePage } from "../../../../proto/gen/rill/ui/v1/dashboard_pb";
 import { PivotChipType } from "../../pivot/types";
 import { allDimensions } from "./dimensions";
 import type { DashboardDataSources } from "./types";
 
 export const pivotSelectors = {
-  showPivot: ({ dashboard }: DashboardDataSources) => dashboard.pivot.active,
+  showPivot: ({ dashboard }: DashboardDataSources) =>
+    dashboard.activePage === DashboardState_ActivePage.PIVOT,
   rows: ({ dashboard }: DashboardDataSources) => dashboard.pivot.rows,
   originalColumns: ({ dashboard }: DashboardDataSources) =>
     dashboard.pivot.columns,

--- a/web-common/src/features/dashboards/time-series/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureChart.svelte
@@ -56,7 +56,7 @@
   export let zone: string;
 
   export let showComparison = false;
-  export let isInTimeDimensionView: boolean;
+  export let showTimeDimensionDetail: boolean;
   export let data;
   export let dimensionData: DimensionDataItem[] = [];
   export let xAccessor = "ts";
@@ -257,7 +257,7 @@
     on:scrub-move={(e) => scrub?.moveScrub(e)}
     on:scrub-start={(e) => scrub?.startScrub(e)}
     overflowHidden={false}
-    right={isInTimeDimensionView ? 20 : 40}
+    right={showTimeDimensionDetail ? 20 : 40}
     shareYScale={false}
     top={4}
     {width}

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -3,6 +3,7 @@
   import SimpleDataGraphic from "@rilldata/web-common/components/data-graphic/elements/SimpleDataGraphic.svelte";
   import { Axis } from "@rilldata/web-common/components/data-graphic/guides";
   import { bisectData } from "@rilldata/web-common/components/data-graphic/utils";
+  import DashboardMetricsDraggableList from "@rilldata/web-common/components/menu/DashboardMetricsDraggableList.svelte";
   import { LeaderboardContextColumn } from "@rilldata/web-common/features/dashboards/leaderboard-context-column";
   import ReplacePivotDialog from "@rilldata/web-common/features/dashboards/pivot/ReplacePivotDialog.svelte";
   import { splitPivotChips } from "@rilldata/web-common/features/dashboards/pivot/pivot-utils";
@@ -35,6 +36,7 @@
   } from "@rilldata/web-common/lib/time/types";
   import type { MetricsViewSpecMeasure } from "@rilldata/web-common/runtime-client";
   import { TIME_GRAIN } from "../../../lib/time/config";
+  import { DashboardState_ActivePage } from "../../../proto/gen/rill/ui/v1/dashboard_pb";
   import Spinner from "../../entity-management/Spinner.svelte";
   import MeasureBigNumber from "../big-number/MeasureBigNumber.svelte";
   import ChartInteractions from "./ChartInteractions.svelte";
@@ -46,7 +48,6 @@
     getOrderedStartEnd,
     updateChartInteractionStore,
   } from "./utils";
-  import DashboardMetricsDraggableList from "@rilldata/web-common/components/menu/DashboardMetricsDraggableList.svelte";
 
   export let exploreName: string;
   export let workspaceWidth: number;
@@ -84,8 +85,11 @@
 
   $: exploreState = useExploreState(exploreName);
 
+  $: activePage = $exploreState?.activePage;
+  $: showTimeDimensionDetail = Boolean(
+    activePage === DashboardState_ActivePage.TIME_DIMENSIONAL_DETAIL,
+  );
   $: expandedMeasureName = $exploreState?.tdd?.expandedMeasureName;
-  $: isInTimeDimensionView = Boolean(expandedMeasureName);
 
   $: comparisonDimension = $exploreState?.selectedComparisonDimension;
   $: showComparison = Boolean($timeControlsStore.showTimeComparison);
@@ -108,7 +112,10 @@
   $: expandedMeasure = $getMeasureByName(expandedMeasureName);
   let renderedMeasures: MetricsViewSpecMeasure[];
   $: {
-    renderedMeasures = expandedMeasure ? [expandedMeasure] : $visibleMeasures;
+    renderedMeasures =
+      showTimeDimensionDetail && expandedMeasure
+        ? [expandedMeasure]
+        : $visibleMeasures;
   }
 
   $: totals = $timeSeriesDataStore.total as { [key: string]: number };
@@ -211,7 +218,7 @@
   }
 
   $: if (
-    isInTimeDimensionView &&
+    showTimeDimensionDetail &&
     formattedData &&
     $timeControlsStore.selectedTimeRange &&
     !isScrubbing
@@ -286,14 +293,14 @@
 </script>
 
 <TimeSeriesChartContainer
-  enableFullWidth={isInTimeDimensionView}
+  enableFullWidth={showTimeDimensionDetail}
   end={endValue}
   start={startValue}
   {workspaceWidth}
   {timeSeriesWidth}
 >
   <div class:mb-6={isAlternateChart} class="flex items-center gap-x-1 px-2.5">
-    {#if isInTimeDimensionView}
+    {#if showTimeDimensionDetail}
       <BackToExplore />
       <ChartTypeSelector
         hasComparison={Boolean(
@@ -335,7 +342,7 @@
               overflowHidden={false}
               top={29}
               bottom={0}
-              right={isInTimeDimensionView ? 10 : 25}
+              right={showTimeDimensionDetail ? 10 : 25}
               xMin={startValue}
               xMax={endValue}
             >
@@ -349,7 +356,7 @@
 
   {#if renderedMeasures}
     <div
-      class:pb-4={!isInTimeDimensionView}
+      class:pb-4={!showTimeDimensionDetail}
       class="flex flex-col gap-y-2 overflow-y-scroll h-full max-h-fit"
     >
       <!-- FIXME: this is pending the remaining state work for show/hide measures and dimensions -->
@@ -368,7 +375,7 @@
           <MeasureBigNumber
             {measure}
             value={bigNum}
-            isMeasureExpanded={isInTimeDimensionView}
+            isMeasureExpanded={showTimeDimensionDetail}
             {showComparison}
             {comparisonValue}
             errorMessage={$timeSeriesDataStore?.error?.totals}
@@ -391,7 +398,7 @@
                 <span>Unable to fetch data from the API</span>
               {/if}
             </div>
-          {:else if expandedMeasureName && tddChartType != TDDChart.DEFAULT}
+          {:else if showTimeDimensionDetail && expandedMeasureName && tddChartType != TDDChart.DEFAULT}
             <TDDAlternateChart
               timeGrain={interval}
               chartType={tddChartType}
@@ -452,7 +459,7 @@
             <MeasureChart
               bind:mouseoverValue
               {measure}
-              {isInTimeDimensionView}
+              {showTimeDimensionDetail}
               {isScrubbing}
               {scrubStart}
               {scrubEnd}

--- a/web-common/src/features/dashboards/time-series/multiple-dimension-queries.ts
+++ b/web-common/src/features/dashboards/time-series/multiple-dimension-queries.ts
@@ -31,9 +31,10 @@ import {
 } from "@rilldata/web-common/runtime-client";
 import type { HTTPError } from "@rilldata/web-common/runtime-client/fetchWrapper";
 import {
-  keepPreviousData,
   type CreateQueryResult,
+  keepPreviousData,
 } from "@tanstack/svelte-query";
+import { DashboardState_ActivePage } from "../../../proto/gen/rill/ui/v1/dashboard_pb";
 import { dimensionSearchText } from "../stores/dashboard-stores";
 import {
   getFilterForComparedDimension,
@@ -88,7 +89,10 @@ export function getDimensionValuesForComparison(
         measures?.length > 0 && measures?.every((m) => m !== undefined);
 
       const dimensionName = dashboardStore?.selectedComparisonDimension;
-      const isInTimeDimensionView = dashboardStore?.tdd.expandedMeasureName;
+      const showTimeDimensionDetail = Boolean(
+        dashboardStore?.activePage ===
+          DashboardState_ActivePage.TIME_DIMENSIONAL_DETAIL,
+      );
 
       if (!isValidMeasureList || !dimensionName) return;
 
@@ -103,7 +107,7 @@ export function getDimensionValuesForComparison(
           // For TDD view max 11 allowed, for Explore max 7 allowed
           comparisonValues = dimensionValues.slice(
             0,
-            isInTimeDimensionView ? 11 : 7,
+            showTimeDimensionDetail ? 11 : 7,
           ) as (string | null)[];
         }
         return set({
@@ -111,7 +115,7 @@ export function getDimensionValuesForComparison(
           filter: dashboardStore?.whereFilter,
         });
       } else if (surface === "table") {
-        let sortBy = isInTimeDimensionView
+        let sortBy = showTimeDimensionDetail
           ? dashboardStore.tdd.expandedMeasureName
           : dashboardStore.leaderboardSortByMeasureName;
         if (dashboardStore?.dashboardSortType === SortType.DIMENSION) {

--- a/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
+++ b/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
@@ -22,6 +22,7 @@ import {
   type CreateQueryResult,
 } from "@tanstack/svelte-query";
 import { type Readable, type Writable, derived, writable } from "svelte/store";
+import { DashboardState_ActivePage } from "../../../proto/gen/rill/ui/v1/dashboard_pb";
 import { memoizeMetricsStore } from "../state-managers/memoize-metrics-store";
 import {
   type DimensionDataItem,
@@ -128,8 +129,12 @@ export function createTimeSeriesDataStore(
 
       const allMeasures = explore?.measures ?? [];
       let measures = allMeasures;
+      const showTimeDimensionDetail = Boolean(
+        dashboardStore?.activePage ===
+          DashboardState_ActivePage.TIME_DIMENSIONAL_DETAIL,
+      );
       const expandedMeasuerName = dashboardStore?.tdd?.expandedMeasureName;
-      if (expandedMeasuerName) {
+      if (showTimeDimensionDetail && expandedMeasuerName) {
         measures = allMeasures.filter(
           (measure) => measure === expandedMeasuerName,
         );

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -8,6 +8,7 @@
   import Resizer from "@rilldata/web-common/layout/Resizer.svelte";
   import { onMount, tick } from "svelte";
   import { useExploreState } from "web-common/src/features/dashboards/stores/dashboard-stores";
+  import { DashboardState_ActivePage } from "../../../proto/gen/rill/ui/v1/dashboard_pb";
   import { runtime } from "../../../runtime-client/runtime-store";
   import MeasuresContainer from "../big-number/MeasuresContainer.svelte";
   import DimensionDisplay from "../dimension-table/DimensionDisplay.svelte";
@@ -61,6 +62,14 @@
   $: extraLeftPadding = !$navigationOpen;
 
   $: exploreState = useExploreState(exploreName);
+
+  $: activePage = $exploreState?.activePage;
+  $: showTimeDimensionDetail = Boolean(
+    activePage === DashboardState_ActivePage.TIME_DIMENSIONAL_DETAIL,
+  );
+  $: showDimensionTable = Boolean(
+    activePage === DashboardState_ActivePage.DIMENSION_TABLE,
+  );
 
   $: selectedDimensionName = $exploreState?.selectedDimensionName;
   $: selectedDimension =
@@ -166,13 +175,13 @@
   {:else}
     <div
       class="flex gap-x-1 gap-y-2 size-full overflow-hidden pl-4 slide bg-surface"
-      class:flex-col={expandedMeasureName}
-      class:flex-row={!expandedMeasureName}
+      class:flex-col={showTimeDimensionDetail}
+      class:flex-row={!showTimeDimensionDetail}
       class:left-shift={extraLeftPadding}
     >
       <div
         class="pt-2 flex-none"
-        style:width={expandedMeasureName ? "auto" : `${metricsWidth}px`}
+        style:width={showTimeDimensionDetail ? "auto" : `${metricsWidth}px`}
       >
         {#key exploreName}
           {#if hasTimeSeries}
@@ -188,7 +197,7 @@
         {/key}
       </div>
 
-      {#if expandedMeasureName}
+      {#if showTimeDimensionDetail && expandedMeasureName}
         <hr class="border-t border-gray-200 -ml-4" />
         <TimeDimensionDisplay
           {exploreName}
@@ -210,7 +219,7 @@
           />
         </div>
         <div class="pt-2 pl-1 overflow-auto w-full">
-          {#if selectedDimension}
+          {#if showDimensionTable && selectedDimension}
             <DimensionDisplay
               dimension={selectedDimension}
               {metricsViewName}
@@ -241,7 +250,7 @@
   {/if}
 </article>
 
-{#if (isRillDeveloper || $cloudDataViewer) && !expandedMeasureName && !mockUserHasNoAccess}
+{#if (isRillDeveloper || $cloudDataViewer) && !showTimeDimensionDetail && !mockUserHasNoAccess}
   <RowsViewerAccordion {metricsViewName} {exploreName} />
 {/if}
 


### PR DESCRIPTION
There are various "views" within an Explore dashboard: the expanded dimension table, time dimension detail (TDD), and the pivot table. Our monolithic Explore state store (aka `MetricsExplorerEntity`) keeps state for each of these views _and_ keeps track of the active view via the `activePage` property.

While we've long had the `activePage` property, up until now we've chosen to route to the various views via this logic:
- If `exploreState.selectedDimensionName`, route to the expanded dimension table
- If `exploreState.tdd.expandedMeasureName`, route to TDD
- If `exploreState.pivot.active`, route to the pivot table


This PR updates our view routing logic so that we merely look at `activePage` to determine the view.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
