### PR TITLE
fix (Sources): Handle Sources-as-Models in UI

### DIFF
--- a/web-common/src/features/models/workspace/ModelEditor.svelte
+++ b/web-common/src/features/models/workspace/ModelEditor.svelte
@@ -10,10 +10,10 @@
   import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
   import { DuckDBSQL } from "../../../components/editor/presets/duckDBDialect";
   import { runtime } from "../../../runtime-client/runtime-store";
-  import { useAllSourceColumns } from "../../sources/selectors";
-  import { useAllModelColumns } from "../selectors";
   import Editor from "../../editor/Editor.svelte";
   import { FileArtifact } from "../../entity-management/file-artifact";
+  import { useAllSourceColumns } from "../../sources/selectors";
+  import { useAllModelColumns } from "../selectors";
 
   const schema: { [table: string]: string[] } = {};
 
@@ -40,7 +40,7 @@
     }
   }
 
-  //Auto complete: model tables
+  // Autocomplete: model tables
   $: allModelColumns = useAllModelColumns(queryClient, instanceId);
   $: if ($allModelColumns?.length) {
     for (const modelTable of $allModelColumns) {

--- a/web-common/src/features/sources/selectors.ts
+++ b/web-common/src/features/sources/selectors.ts
@@ -20,8 +20,10 @@ export type SourceFromYaml = {
 export function useSources(instanceId: string) {
   return useClientFilteredResources(
     instanceId,
-    ResourceKind.Source,
-    (res) => !!res.source?.state?.table,
+    ResourceKind.Model,
+    (res) =>
+      res.meta?.name?.name === res.model?.state?.resultTable &&
+      !!res.model?.spec?.definedAsSource,
   );
 }
 


### PR DESCRIPTION
Two tweaks to account for the fact that the runtime now treats Sources as Models:
- Adds an "Create new model" menu item to the model context menu
- Fixes the editor's autocomplete of Source table names (by looking for Models not Sources)

[Addresses this Slack report](https://rilldata.slack.com/archives/C02T907FEUB/p1744044299628589)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
