### PR TITLE
e2e (Bookmarks): Add tests to delete bookmarks

### DIFF
--- a/web-admin/src/features/bookmarks/BookmarksDropdownMenuItem.svelte
+++ b/web-admin/src/features/bookmarks/BookmarksDropdownMenuItem.svelte
@@ -79,6 +79,7 @@
             class="bg-gray-100 hover:bg-primary-100 px-2 h-7 text-gray-400 hover:text-gray-500"
             disabled={disableDelete}
             aria-disabled={disableDelete}
+            aria-label="Delete bookmark"
           >
             <Trash size="16px" />
           </button>

--- a/web-admin/tests/bookmarks.spec.ts
+++ b/web-admin/tests/bookmarks.spec.ts
@@ -1,7 +1,7 @@
 import { expect, type Page } from "@playwright/test";
 import { assertUrlParams } from "@rilldata/web-common/tests/utils/assert-url-params";
-import { test } from "./setup/base";
 import { interactWithTimeRangeMenu } from "@rilldata/web-common/tests/utils/explore-interactions";
+import { test } from "./setup/base";
 
 test.describe("Bookmarks", () => {
   // TODO: use a separate explore to isolate bookmarks to avoid conflicts.
@@ -89,6 +89,17 @@ test.describe("Bookmarks", () => {
         adminPage,
         `view=tdd&tr=PT6H&grain=hour&f=app_site_name IN ('FuboTV','Philo')&measure=requests`,
       );
+    });
+
+    test("Should delete filter-only bookmark", async ({ adminPage }) => {
+      await adminPage.goto("/e2e/openrtb/explore/auction_explore_bookmarks");
+      await adminPage.getByLabel("Bookmark dropdown").click();
+      const menuItem = adminPage.getByLabel("Filter-Only Bookmark Entry");
+      await menuItem.hover();
+      await menuItem.getByRole("button", { name: "Delete bookmark" }).click();
+      await expect(
+        adminPage.getByText("Bookmark Filter-Only deleted"),
+      ).toBeVisible();
     });
   });
 
@@ -178,6 +189,17 @@ test.describe("Bookmarks", () => {
         `tr=PT6H&compare_tr=rill-PP&grain=hour&f=app_site_name IN ('FuboTV','Philo')&expand_dim=app_site_domain`,
       );
     });
+
+    test("Should delete complete bookmark", async ({ adminPage }) => {
+      await adminPage.goto("/e2e/openrtb/explore/auction_explore_bookmarks");
+      await adminPage.getByLabel("Bookmark dropdown").click();
+      const menuItem = adminPage.getByLabel("Complete Bookmark Entry");
+      await menuItem.hover();
+      await menuItem.getByRole("button", { name: "Delete bookmark" }).click();
+      await expect(
+        adminPage.getByText("Bookmark Complete deleted"),
+      ).toBeVisible();
+    });
   });
 
   // Home bookmark interferes with other bookmark creation since we are adding some filters.
@@ -265,6 +287,15 @@ test.describe("Bookmarks", () => {
       // In "App Site Name" dimension table
       await expect(adminPage.getByLabel("Dimension Display")).toBeVisible();
       await expect(adminPage.getByText("App Site Name")).toBeVisible();
+    });
+
+    test("Should delete home bookmark", async ({ adminPage }) => {
+      await adminPage.goto("/e2e/openrtb/explore/auction_explore_bookmarks");
+      await adminPage.getByLabel("Bookmark dropdown").click();
+      const menuItem = adminPage.getByLabel("Home Bookmark Entry");
+      await menuItem.hover();
+      await menuItem.getByRole("button", { name: "Delete bookmark" }).click();
+      await expect(adminPage.getByText("Bookmark Home deleted")).toBeVisible();
     });
 
     // TODO: verify editing home bookmark. since these are changing in a future feature, these tests should be part of that PR


### PR DESCRIPTION
Currently, the bookmark tests cannot be run twice because there's no teardown. This PR adds tests to delete the bookmarks, so that the test suite can be run twice-in-a-row.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
