### PR TITLE
fix: allows show custom of legacy dashboards

### DIFF
--- a/runtime/parser/parse_metrics_view.go
+++ b/runtime/parser/parse_metrics_view.go
@@ -902,6 +902,7 @@ func (p *Parser) parseMetricsView(node *Node) error {
 		ComparisonMode:      comparisonModesMap[tmp.DefaultComparison.Mode],
 		ComparisonDimension: compareDim,
 	}
+	// Backwards compatibility: explore parser will default to true so also emit true on the emitted explore spec
 	e.ExploreSpec.AllowCustomTimeRange = true
 
 	return nil

--- a/runtime/parser/parse_metrics_view.go
+++ b/runtime/parser/parse_metrics_view.go
@@ -902,6 +902,7 @@ func (p *Parser) parseMetricsView(node *Node) error {
 		ComparisonMode:      comparisonModesMap[tmp.DefaultComparison.Mode],
 		ComparisonDimension: compareDim,
 	}
+	e.ExploreSpec.AllowCustomTimeRange = true
 
 	return nil
 }


### PR DESCRIPTION
`allow_custom_timerange` was introduced for explore and canvas dashboards which defaults to true.
It was missing for legacy dashboards, this PR adds a always true custom timerange for legacy dashboards.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
