### PR TITLE
fix (Models): Always show the output table preview, even if a partition has errors

### DIFF
--- a/web-common/src/features/workspaces/ModelWorkspace.svelte
+++ b/web-common/src/features/workspaces/ModelWorkspace.svelte
@@ -136,10 +136,10 @@
 
     {#if $tableVisible}
       <WorkspaceTableContainer {filePath}>
-        {#if !allErrors.length}
+        {#if connector && tableName}
           <ConnectedPreviewTable
             {connector}
-            table={tableName ?? ""}
+            table={tableName}
             loading={resourceIsReconciling}
           />
         {/if}


### PR DESCRIPTION
Previously:
<img width="818" alt="image" src="https://github.com/user-attachments/assets/5e1b06f8-505e-4c0b-9f93-ba8891b1c856" />

Now:

<img width="625" alt="image" src="https://github.com/user-attachments/assets/38ea5dd4-2a33-4b58-b9cd-51ca1488cba7" />

[Reported in Slack](https://rilldata.slack.com/archives/C02T907FEUB/p1744214629290899)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
