### PR TITLE
Refactor `OLAPStore.Execute` to `Query`

### DIFF
--- a/runtime/drivers/clickhouse/olap.go
+++ b/runtime/drivers/clickhouse/olap.go
@@ -103,7 +103,7 @@ func (c *connection) Exec(ctx context.Context, stmt *drivers.Statement) error {
 	return err
 }
 
-func (c *connection) Execute(ctx context.Context, stmt *drivers.Statement) (res *drivers.Result, outErr error) {
+func (c *connection) Query(ctx context.Context, stmt *drivers.Statement) (res *drivers.Result, outErr error) {
 	ctx = contextWithQueryID(ctx)
 	// Log query if enabled (usually disabled)
 	if c.config.LogQueries {
@@ -470,7 +470,7 @@ func (c *connection) RenameTable(ctx context.Context, oldName, newName string) e
 			args = []any{nil, oldName}
 		}
 		var engineFull string
-		res, err := c.Execute(ctx, &drivers.Statement{
+		res, err := c.Query(ctx, &drivers.Statement{
 			Query:    "SELECT engine_full FROM system.tables WHERE database = coalesce(?, currentDatabase()) AND name = ?",
 			Args:     args,
 			Priority: 100,
@@ -529,7 +529,7 @@ func (c *connection) renameView(ctx context.Context, oldName, newName, onCluster
 	if c.config.Database == "" {
 		args = []any{nil, oldName}
 	}
-	res, err := c.Execute(ctx, &drivers.Statement{
+	res, err := c.Query(ctx, &drivers.Statement{
 		Query:    "SELECT as_select FROM system.tables WHERE database = coalesce(?, currentDatabase()) AND name = ?",
 		Args:     args,
 		Priority: 100,
@@ -726,7 +726,7 @@ func (c *connection) columnClause(ctx context.Context, table string) (string, er
 	if c.config.Database == "" {
 		args = []any{nil, table}
 	}
-	res, err := c.Execute(ctx, &drivers.Statement{
+	res, err := c.Query(ctx, &drivers.Statement{
 		Query:    "SELECT name, type FROM system.columns WHERE database = coalesce(?, currentDatabase()) AND table = ?",
 		Args:     args,
 		Priority: 100,
@@ -842,7 +842,7 @@ func (c *connection) getTableEngine(ctx context.Context, name string) (string, e
 	if c.config.Database == "" {
 		args = []any{nil, name}
 	}
-	res, err := c.Execute(ctx, &drivers.Statement{
+	res, err := c.Query(ctx, &drivers.Statement{
 		Query:    "SELECT engine FROM system.tables WHERE database = coalesce(?, currentDatabase()) AND name = ?",
 		Args:     args,
 		Priority: 1,
@@ -864,7 +864,7 @@ func (c *connection) getTableEngine(ctx context.Context, name string) (string, e
 }
 
 func (c *connection) getTablePartitions(ctx context.Context, name string) ([]string, error) {
-	res, err := c.Execute(ctx, &drivers.Statement{
+	res, err := c.Query(ctx, &drivers.Statement{
 		Query:    "SELECT DISTINCT partition FROM system.parts WHERE table = ?",
 		Args:     []any{name},
 		Priority: 1,

--- a/runtime/drivers/clickhouse/olap_test.go
+++ b/runtime/drivers/clickhouse/olap_test.go
@@ -72,7 +72,7 @@ func testWithConnection(t *testing.T, olap drivers.OLAPStore) {
 		})
 		require.NoError(t, err)
 
-		res, err := olap.Execute(ctx, &drivers.Statement{
+		res, err := olap.Query(ctx, &drivers.Statement{
 			Query: "SELECT id, planet FROM tbl",
 		})
 		require.NoError(t, err)
@@ -116,7 +116,7 @@ func testRenameView(t *testing.T, olap drivers.OLAPStore) {
 	notExists(t, olap, "foo_view")
 	notExists(t, olap, "foo_view1")
 
-	res, err := olap.Execute(ctx, &drivers.Statement{Query: "SELECT id FROM bar_view"})
+	res, err := olap.Query(ctx, &drivers.Statement{Query: "SELECT id FROM bar_view"})
 	require.NoError(t, err)
 	require.True(t, res.Next())
 	var id int
@@ -138,7 +138,7 @@ func testRenameTable(t *testing.T, olap drivers.OLAPStore) {
 }
 
 func notExists(t *testing.T, olap drivers.OLAPStore, tbl string) {
-	result, err := olap.Execute(context.Background(), &drivers.Statement{
+	result, err := olap.Query(context.Background(), &drivers.Statement{
 		Query: "EXISTS " + tbl,
 	})
 	require.NoError(t, err)
@@ -180,7 +180,7 @@ func testInsertTableAsSelect_WithAppend(t *testing.T, olap drivers.OLAPStore) {
 	_, err = olap.InsertTableAsSelect(context.Background(), "append_tbl", "SELECT 2 AS id, 'Mars' AS planet", insertOpts)
 	require.NoError(t, err)
 
-	res, err := olap.Execute(context.Background(), &drivers.Statement{Query: "SELECT id, planet FROM append_tbl ORDER BY id"})
+	res, err := olap.Query(context.Background(), &drivers.Statement{Query: "SELECT id, planet FROM append_tbl ORDER BY id"})
 	require.NoError(t, err)
 
 	var result []struct {
@@ -251,7 +251,7 @@ func testInsertTableAsSelect_WithMerge(t *testing.T, olap drivers.OLAPStore) {
 		Value string
 	}
 
-	res, err := olap.Execute(context.Background(), &drivers.Statement{Query: "SELECT id, value FROM merge_tbl ORDER BY id"})
+	res, err := olap.Query(context.Background(), &drivers.Statement{Query: "SELECT id, value FROM merge_tbl ORDER BY id"})
 	require.NoError(t, err)
 
 	for res.Next() {
@@ -318,7 +318,7 @@ func testInsertTableAsSelect_WithPartitionOverwrite(t *testing.T, olap drivers.O
 	_, err = olap.InsertTableAsSelect(context.Background(), "replace_tbl", "SELECT generate_series AS id, 'replace' AS value FROM generate_series(2, 5)", insertOpts)
 	require.NoError(t, err)
 
-	res, err := olap.Execute(context.Background(), &drivers.Statement{Query: "SELECT id, value FROM replace_tbl ORDER BY id"})
+	res, err := olap.Query(context.Background(), &drivers.Statement{Query: "SELECT id, value FROM replace_tbl ORDER BY id"})
 	require.NoError(t, err)
 
 	var result []struct {
@@ -386,7 +386,7 @@ func testInsertTableAsSelect_WithPartitionOverwrite_DatePartition(t *testing.T, 
 	_, err = olap.InsertTableAsSelect(context.Background(), "replace_tbl", "SELECT date_add(hour, generate_series, toDate('2024-12-01')) AS dt, 'replace' AS value FROM generate_series(2, 5)", insertOpts)
 	require.NoError(t, err)
 
-	res, err := olap.Execute(context.Background(), &drivers.Statement{Query: "SELECT dt, value FROM replace_tbl ORDER BY dt"})
+	res, err := olap.Query(context.Background(), &drivers.Statement{Query: "SELECT dt, value FROM replace_tbl ORDER BY dt"})
 	require.NoError(t, err)
 
 	var result []struct {
@@ -441,7 +441,7 @@ func testDictionary(t *testing.T, olap drivers.OLAPStore) {
 	err = olap.RenameTable(context.Background(), "dict", "dict1")
 	require.NoError(t, err)
 
-	res, err := olap.Execute(context.Background(), &drivers.Statement{Query: "SELECT id, planet FROM dict1"})
+	res, err := olap.Query(context.Background(), &drivers.Statement{Query: "SELECT id, planet FROM dict1"})
 	require.NoError(t, err)
 
 	require.True(t, res.Next())
@@ -468,7 +468,7 @@ func testIntervalType(t *testing.T, olap drivers.OLAPStore) {
 		{query: "SELECT INTERVAL '6' YEAR", ms: 6 * 365 * 24 * 60 * 60 * 1000},
 	}
 	for _, c := range cases {
-		rows, err := olap.Execute(context.Background(), &drivers.Statement{Query: c.query})
+		rows, err := olap.Query(context.Background(), &drivers.Statement{Query: c.query})
 		require.NoError(t, err)
 		require.Equal(t, runtimev1.Type_CODE_INTERVAL, rows.Schema.Fields[0].Type.Code)
 

--- a/runtime/drivers/druid/druid_container_test.go
+++ b/runtime/drivers/druid/druid_container_test.go
@@ -137,7 +137,7 @@ func testIngest(t *testing.T, coordinatorURL string) {
 
 func testCount(t *testing.T, olap drivers.OLAPStore) {
 	qry := fmt.Sprintf("SELECT count(*) FROM %s", testTable)
-	rows, err := olap.Execute(context.Background(), &drivers.Statement{Query: qry})
+	rows, err := olap.Query(context.Background(), &drivers.Statement{Query: qry})
 	require.NoError(t, err)
 
 	var count int
@@ -151,7 +151,7 @@ func testCount(t *testing.T, olap drivers.OLAPStore) {
 func testMax(t *testing.T, olap drivers.OLAPStore) {
 	qry := fmt.Sprintf("SELECT max(id) FROM %s", testTable)
 	expectedValue := 16000
-	rows, err := olap.Execute(context.Background(), &drivers.Statement{Query: qry})
+	rows, err := olap.Query(context.Background(), &drivers.Statement{Query: qry})
 	require.NoError(t, err)
 
 	var count int
@@ -163,7 +163,7 @@ func testMax(t *testing.T, olap drivers.OLAPStore) {
 
 func testTimeFloor(t *testing.T, olap drivers.OLAPStore) {
 	qry := fmt.Sprintf("SELECT time_floor(__time, 'P1D', null, CAST(? AS VARCHAR)) FROM %s", testTable)
-	rows, err := olap.Execute(context.Background(), &drivers.Statement{
+	rows, err := olap.Query(context.Background(), &drivers.Statement{
 		Query: qry,
 		Args:  []any{"Asia/Kathmandu"},
 	})

--- a/runtime/drivers/druid/druid_test.go
+++ b/runtime/drivers/druid/druid_test.go
@@ -16,7 +16,7 @@ import (
 func TestScan(t *testing.T) {
 	_, olap := acquireTestDruid(t)
 
-	rows, err := olap.Execute(context.Background(), &drivers.Statement{Query: "SELECT 1, 'hello world', true, null, CAST('2024-01-01T00:00:00Z' AS TIMESTAMP)"})
+	rows, err := olap.Query(context.Background(), &drivers.Statement{Query: "SELECT 1, 'hello world', true, null, CAST('2024-01-01T00:00:00Z' AS TIMESTAMP)"})
 	require.NoError(t, err)
 
 	var i int

--- a/runtime/drivers/druid/olap.go
+++ b/runtime/drivers/druid/olap.go
@@ -61,7 +61,7 @@ func (c *connection) WithConnection(ctx context.Context, priority int, longRunni
 }
 
 func (c *connection) Exec(ctx context.Context, stmt *drivers.Statement) error {
-	res, err := c.Execute(ctx, stmt)
+	res, err := c.Query(ctx, stmt)
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func (c *connection) Exec(ctx context.Context, stmt *drivers.Statement) error {
 	return res.Close()
 }
 
-func (c *connection) Execute(ctx context.Context, stmt *drivers.Statement) (*drivers.Result, error) {
+func (c *connection) Query(ctx context.Context, stmt *drivers.Statement) (*drivers.Result, error) {
 	// Log query if enabled (usually disabled)
 	if c.config.LogQueries {
 		c.logger.Info("druid query", zap.String("sql", stmt.Query), zap.Any("args", stmt.Args), observability.ZapCtx(ctx))

--- a/runtime/drivers/druid/sql_driver_test.go
+++ b/runtime/drivers/druid/sql_driver_test.go
@@ -25,7 +25,7 @@ func Ignore_TestDriver_types(t *testing.T) {
 	olap, ok := handle.AsOLAP("")
 	require.True(t, ok)
 
-	res, err := olap.Execute(context.Background(), &drivers.Statement{
+	res, err := olap.Query(context.Background(), &drivers.Statement{
 		Query: `select 
 		cast(1 as boolean) as bool1, 
 		cast(1 as bigint) as bigint1, 
@@ -62,7 +62,7 @@ func Ignore_TestDriver_array_type(t *testing.T) {
 	olap, ok := handle.AsOLAP("")
 	require.True(t, ok)
 
-	res, err := olap.Execute(context.Background(), &drivers.Statement{
+	res, err := olap.Query(context.Background(), &drivers.Statement{
 		Query: `select 
 		array [1,2] as array1
 		`,
@@ -88,7 +88,7 @@ func Ignore_TestDriver_json_type(t *testing.T) {
 	olap, ok := handle.AsOLAP("")
 	require.True(t, ok)
 
-	res, err := olap.Execute(context.Background(), &drivers.Statement{
+	res, err := olap.Query(context.Background(), &drivers.Statement{
 		Query: `select 
 			json_object('a':'b') as json1 
 		`,
@@ -113,7 +113,7 @@ func Ignore_TestDriver_multiple_rows(t *testing.T) {
 	olap, ok := handle.AsOLAP("")
 	require.True(t, ok)
 
-	res, err := olap.Execute(context.Background(), &drivers.Statement{
+	res, err := olap.Query(context.Background(), &drivers.Statement{
 		Query: `
 		select 
 			cast(1 as boolean) as bool1,
@@ -149,7 +149,7 @@ func Ignore_TestDriver_error(t *testing.T) {
 	olap, ok := handle.AsOLAP("")
 	require.True(t, ok)
 
-	_, err = olap.Execute(context.Background(), &drivers.Statement{
+	_, err = olap.Query(context.Background(), &drivers.Statement{
 		Query: `select select`,
 	})
 	require.Error(t, err)

--- a/runtime/drivers/duckdb/config_test.go
+++ b/runtime/drivers/duckdb/config_test.go
@@ -46,7 +46,7 @@ func Test_specialCharInPath(t *testing.T) {
 	olap, ok := conn.AsOLAP("")
 	require.True(t, ok)
 
-	res, err := olap.Execute(context.Background(), &drivers.Statement{Query: "SELECT 1"})
+	res, err := olap.Query(context.Background(), &drivers.Statement{Query: "SELECT 1"})
 	require.NoError(t, err)
 	require.NoError(t, res.Close())
 	require.NoError(t, conn.Close())

--- a/runtime/drivers/duckdb/duckDB_to_duckDB_test.go
+++ b/runtime/drivers/duckdb/duckDB_to_duckDB_test.go
@@ -60,7 +60,7 @@ func TestDuckDBToDuckDBTransfer(t *testing.T) {
 	_, err = me.Execute(context.Background(), execOpts)
 	require.NoError(t, err)
 
-	rows, err := duckDB.(*connection).Execute(context.Background(), &drivers.Statement{Query: "SELECT COUNT(*) FROM sink"})
+	rows, err := duckDB.(*connection).Query(context.Background(), &drivers.Statement{Query: "SELECT COUNT(*) FROM sink"})
 	require.NoError(t, err)
 
 	var count int
@@ -73,7 +73,7 @@ func TestDuckDBToDuckDBTransfer(t *testing.T) {
 	_, err = me.Execute(context.Background(), execOpts)
 	require.NoError(t, err)
 
-	rows, err = duckDB.(*connection).Execute(context.Background(), &drivers.Statement{Query: "SELECT COUNT(*) FROM sink"})
+	rows, err = duckDB.(*connection).Query(context.Background(), &drivers.Statement{Query: "SELECT COUNT(*) FROM sink"})
 	require.NoError(t, err)
 
 	rows.Next()

--- a/runtime/drivers/duckdb/model_executor_https_self_test.go
+++ b/runtime/drivers/duckdb/model_executor_https_self_test.go
@@ -92,7 +92,7 @@ func TestHTTPToDuckDBTransfer(t *testing.T) {
 	olap, ok := to.AsOLAP("default")
 	require.True(t, ok)
 
-	res, err := olap.Execute(context.Background(), &drivers.Statement{Query: "select count(*) from sink"})
+	res, err := olap.Query(context.Background(), &drivers.Statement{Query: "select count(*) from sink"})
 	require.NoError(t, err)
 	for res.Next() {
 		var count int

--- a/runtime/drivers/duckdb/model_executor_self_file_test.go
+++ b/runtime/drivers/duckdb/model_executor_self_file_test.go
@@ -25,7 +25,7 @@ func TestExecute(t *testing.T) {
 	require.True(t, ok)
 
 	// Create test table with all types
-	result, err := olap.Execute(context.Background(), &drivers.Statement{
+	result, err := olap.Query(context.Background(), &drivers.Statement{
 		Query: `CREATE TABLE all_types (
 			id INTEGER PRIMARY KEY,
 			small_int SMALLINT,
@@ -113,7 +113,7 @@ func TestExecute(t *testing.T) {
 		require.True(t, stat.Size() > 0)
 
 		// Read back and verify contents
-		compareResult, err := olap.Execute(context.Background(), &drivers.Statement{
+		compareResult, err := olap.Query(context.Background(), &drivers.Statement{
 			Query: fmt.Sprintf(`
 				WITH 
 				actual AS (SELECT * FROM read_csv_auto('%s')),

--- a/runtime/drivers/duckdb/mysql_to_duckDB_test.go
+++ b/runtime/drivers/duckdb/mysql_to_duckDB_test.go
@@ -143,7 +143,7 @@ func mysqlToDuckDB(t *testing.T, dsn string) {
 	olap, ok := duckDB.AsOLAP("default")
 	require.True(t, ok)
 
-	res, err := olap.Execute(context.Background(), &drivers.Statement{Query: "select count(*) from sink"})
+	res, err := olap.Query(context.Background(), &drivers.Statement{Query: "select count(*) from sink"})
 	require.NoError(t, err)
 	for res.Next() {
 		var count int

--- a/runtime/drivers/duckdb/olap.go
+++ b/runtime/drivers/duckdb/olap.go
@@ -52,7 +52,7 @@ func (c *connection) WithConnection(ctx context.Context, priority int, longRunni
 }
 
 func (c *connection) Exec(ctx context.Context, stmt *drivers.Statement) error {
-	res, err := c.Execute(ctx, stmt)
+	res, err := c.Query(ctx, stmt)
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func (c *connection) Exec(ctx context.Context, stmt *drivers.Statement) error {
 	return c.checkErr(err)
 }
 
-func (c *connection) Execute(ctx context.Context, stmt *drivers.Statement) (res *drivers.Result, outErr error) {
+func (c *connection) Query(ctx context.Context, stmt *drivers.Statement) (res *drivers.Result, outErr error) {
 	// Log query if enabled (usually disabled)
 	if c.config.LogQueries {
 		c.logger.Info("duckdb query", zap.String("sql", stmt.Query), zap.Any("args", stmt.Args), observability.ZapCtx(ctx))

--- a/runtime/drivers/duckdb/olap_test.go
+++ b/runtime/drivers/duckdb/olap_test.go
@@ -22,7 +22,7 @@ func TestQuery(t *testing.T) {
 	conn := prepareConn(t)
 	olap, _ := conn.AsOLAP("")
 
-	rows, err := olap.Execute(context.Background(), &drivers.Statement{Query: "SELECT COUNT(*) FROM foo"})
+	rows, err := olap.Query(context.Background(), &drivers.Statement{Query: "SELECT COUNT(*) FROM foo"})
 	require.NoError(t, err)
 
 	var count int
@@ -51,7 +51,7 @@ func TestPriorityQueue(t *testing.T) {
 	for i := n; i > 0; i-- {
 		priority := i
 		g.Go(func() error {
-			rows, err := olap.Execute(context.Background(), &drivers.Statement{
+			rows, err := olap.Query(context.Background(), &drivers.Statement{
 				Query:    "SELECT ?",
 				Args:     []any{priority},
 				Priority: priority,
@@ -121,7 +121,7 @@ func TestCancel(t *testing.T) {
 				<-cancelCh
 			}
 
-			rows, err := olap.Execute(ctx, &drivers.Statement{
+			rows, err := olap.Query(ctx, &drivers.Statement{
 				Query:    "SELECT ?",
 				Args:     []any{priority},
 				Priority: priority,
@@ -176,7 +176,7 @@ func TestClose(t *testing.T) {
 	for i := n; i > 0; i-- {
 		priority := i
 		g.Go(func() error {
-			rows, err := olap.Execute(context.Background(), &drivers.Statement{
+			rows, err := olap.Query(context.Background(), &drivers.Statement{
 				Query:    "SELECT ?",
 				Args:     []any{priority},
 				Priority: priority,

--- a/runtime/drivers/duckdb/postgres_to_duckDB_test.go
+++ b/runtime/drivers/duckdb/postgres_to_duckDB_test.go
@@ -106,7 +106,7 @@ func pgxToDuckDB(t *testing.T, pgdb *sql.DB, dbURL string) {
 	olap, ok := duckDB.AsOLAP("default")
 	require.True(t, ok)
 
-	res, err := olap.Execute(context.Background(), &drivers.Statement{Query: "select count(*) from sink"})
+	res, err := olap.Query(context.Background(), &drivers.Statement{Query: "select count(*) from sink"})
 	require.NoError(t, err)
 	for res.Next() {
 		var count int
@@ -131,7 +131,7 @@ func pgxToDuckDB(t *testing.T, pgdb *sql.DB, dbURL string) {
 	_, err = me.Execute(context.Background(), execOpts)
 	require.NoError(t, err)
 
-	res, err = olap.Execute(context.Background(), &drivers.Statement{Query: "select count(*) from sink"})
+	res, err = olap.Query(context.Background(), &drivers.Statement{Query: "select count(*) from sink"})
 	require.NoError(t, err)
 	for res.Next() {
 		var count int

--- a/runtime/drivers/duckdb/sqlite_to_duckDB_test.go
+++ b/runtime/drivers/duckdb/sqlite_to_duckDB_test.go
@@ -62,7 +62,7 @@ func Test_sqliteToDuckDB_Transfer(t *testing.T) {
 	_, err = me.Execute(context.Background(), execOpts)
 	require.NoError(t, err)
 
-	res, err := olap.Execute(context.Background(), &drivers.Statement{Query: "SELECT count(*) from sink"})
+	res, err := olap.Query(context.Background(), &drivers.Statement{Query: "SELECT count(*) from sink"})
 	require.NoError(t, err)
 	res.Next()
 	var count int

--- a/runtime/drivers/file/model_executor_olap_self.go
+++ b/runtime/drivers/file/model_executor_olap_self.go
@@ -61,7 +61,7 @@ func (e *olapToSelfExecutor) Execute(ctx context.Context, opts *drivers.ModelExe
 	}
 
 	// Execute the SQL
-	res, err := e.olap.Execute(ctx, &drivers.Statement{
+	res, err := e.olap.Query(ctx, &drivers.Statement{
 		Query:    inputProps.SQL,
 		Args:     inputProps.Args,
 		Priority: opts.Priority,

--- a/runtime/drivers/file/model_executor_olap_self_test.go
+++ b/runtime/drivers/file/model_executor_olap_self_test.go
@@ -26,7 +26,7 @@ func TestExecute(t *testing.T) {
 
 	// Create test table with all types
 	// need to remove INSTALL spatial when we upgrade to duckdb1.2 also change st_read to read_xlsx in csv export
-	result, err := olap.Execute(context.Background(), &drivers.Statement{
+	result, err := olap.Query(context.Background(), &drivers.Statement{
 		Query: `CREATE TABLE all_types (
 			id INTEGER PRIMARY KEY,
 			small_int SMALLINT,
@@ -115,7 +115,7 @@ func TestExecute(t *testing.T) {
 		require.True(t, stat.Size() > 0)
 
 		// Read back the exported file and verify contents
-		compareResult, err := olap.Execute(context.Background(), &drivers.Statement{
+		compareResult, err := olap.Query(context.Background(), &drivers.Statement{
 			Query: fmt.Sprintf(`
 				WITH 
 				actual AS (SELECT * FROM read_parquet('%s')),
@@ -166,7 +166,7 @@ func TestExecute(t *testing.T) {
 		require.True(t, stat.Size() > 0)
 
 		// Read back and verify contents
-		compareResult, err := olap.Execute(context.Background(), &drivers.Statement{
+		compareResult, err := olap.Query(context.Background(), &drivers.Statement{
 			Query: fmt.Sprintf(`
 				WITH 
 				actual AS (SELECT * FROM read_csv('%s')),
@@ -217,7 +217,7 @@ func TestExecute(t *testing.T) {
 		require.True(t, stat.Size() > 0)
 
 		// Read back and verify contents
-		compareResult, err := olap.Execute(context.Background(), &drivers.Statement{
+		compareResult, err := olap.Query(context.Background(), &drivers.Statement{
 			Query: fmt.Sprintf(`
 				WITH 
 				actual AS (SELECT * FROM st_read('%s')),

--- a/runtime/drivers/olap.go
+++ b/runtime/drivers/olap.go
@@ -61,7 +61,7 @@ type OLAPStore interface {
 	Dialect() Dialect
 	WithConnection(ctx context.Context, priority int, longRunning bool, fn WithConnectionFunc) error
 	Exec(ctx context.Context, stmt *Statement) error
-	Execute(ctx context.Context, stmt *Statement) (*Result, error)
+	Query(ctx context.Context, stmt *Statement) (*Result, error)
 	InformationSchema() InformationSchema
 
 	CreateTableAsSelect(ctx context.Context, name, sql string, opts *CreateTableOptions) (*TableWriteMetrics, error)

--- a/runtime/drivers/pinot/olap.go
+++ b/runtime/drivers/pinot/olap.go
@@ -59,7 +59,7 @@ func (c *connection) WithConnection(ctx context.Context, priority int, longRunni
 }
 
 func (c *connection) Exec(ctx context.Context, stmt *drivers.Statement) error {
-	res, err := c.Execute(ctx, stmt)
+	res, err := c.Query(ctx, stmt)
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func (c *connection) Exec(ctx context.Context, stmt *drivers.Statement) error {
 	return res.Close()
 }
 
-func (c *connection) Execute(ctx context.Context, stmt *drivers.Statement) (*drivers.Result, error) {
+func (c *connection) Query(ctx context.Context, stmt *drivers.Statement) (*drivers.Result, error) {
 	if c.logQueries {
 		c.logger.Info("pinot query", zap.String("sql", stmt.Query), zap.Any("args", stmt.Args), observability.ZapCtx(ctx))
 	}

--- a/runtime/metricsview/executor.go
+++ b/runtime/metricsview/executor.go
@@ -98,7 +98,7 @@ func (e *Executor) CacheKey(ctx context.Context) ([]byte, bool, error) {
 		return []byte(ts.Watermark.Format(time.RFC3339)), true, nil
 	}
 
-	res, err := e.olap.Execute(ctx, &drivers.Statement{
+	res, err := e.olap.Query(ctx, &drivers.Statement{
 		Query:    spec.CacheKeySql,
 		Priority: e.priority,
 	})
@@ -224,7 +224,7 @@ func (e *Executor) Schema(ctx context.Context) (*runtimev1.StructType, error) {
 		return nil, err
 	}
 
-	res, err := e.olap.Execute(ctx, &drivers.Statement{
+	res, err := e.olap.Query(ctx, &drivers.Statement{
 		Query:            sql,
 		Args:             args,
 		Priority:         e.priority,
@@ -296,7 +296,7 @@ func (e *Executor) Query(ctx context.Context, qry *Query, executionTime *time.Ti
 			return nil, err
 		}
 
-		res, err = e.olap.Execute(ctx, &drivers.Statement{
+		res, err = e.olap.Query(ctx, &drivers.Statement{
 			Query:            sql,
 			Args:             args,
 			Priority:         e.priority,
@@ -336,7 +336,7 @@ func (e *Executor) Query(ctx context.Context, qry *Query, executionTime *time.Ti
 		}
 
 		// Use DuckDB to read the Parquet file into a *drivers.Result
-		res, err = duck.Execute(ctx, &drivers.Statement{
+		res, err = duck.Query(ctx, &drivers.Statement{
 			Query:            fmt.Sprintf("SELECT * FROM '%s'", path),
 			Priority:         e.priority,
 			ExecutionTimeout: defaultInteractiveTimeout,
@@ -502,7 +502,7 @@ func (e *Executor) Search(ctx context.Context, qry *SearchQuery, executionTime *
 		finalArgs = append(finalArgs, args...)
 	}
 
-	res, err := e.olap.Execute(ctx, &drivers.Statement{
+	res, err := e.olap.Query(ctx, &drivers.Statement{
 		Query:            finalSQL.String(),
 		Args:             finalArgs,
 		Priority:         e.priority,
@@ -577,7 +577,7 @@ func (e *Executor) executeSearchInDruid(ctx context.Context, qry *SearchQuery, e
 	if a.Root.Where != nil {
 		// NOTE :: this does not work for measure filters.
 		// The query planner resolves them to joins instead of filters.
-		rows, err := e.olap.Execute(ctx, &drivers.Statement{
+		rows, err := e.olap.Query(ctx, &drivers.Statement{
 			Query:            fmt.Sprintf("EXPLAIN PLAN FOR SELECT 1 FROM %s WHERE %s", *a.Root.FromTable, a.Root.Where.Expr),
 			Args:             a.Root.Where.Args,
 			Priority:         e.priority,

--- a/runtime/metricsview/executor_rewrite_druid_exactify.go
+++ b/runtime/metricsview/executor_rewrite_druid_exactify.go
@@ -71,7 +71,7 @@ func (e *Executor) rewriteQueryDruidExactify(ctx context.Context, qry *Query) er
 	if err != nil {
 		return err
 	}
-	res, err := e.olap.Execute(ctx, &drivers.Statement{
+	res, err := e.olap.Query(ctx, &drivers.Statement{
 		Query:            sql,
 		Args:             args,
 		Priority:         e.priority,

--- a/runtime/metricsview/executor_rewrite_percent_of_totals.go
+++ b/runtime/metricsview/executor_rewrite_percent_of_totals.go
@@ -59,7 +59,7 @@ func (e *Executor) rewritePercentOfTotals(ctx context.Context, qry *Query) error
 	if err != nil {
 		return err
 	}
-	res, err := e.olap.Execute(ctx, &drivers.Statement{
+	res, err := e.olap.Query(ctx, &drivers.Statement{
 		Query:            sql,
 		Args:             args,
 		Priority:         e.priority,

--- a/runtime/metricsview/executor_timestamps.go
+++ b/runtime/metricsview/executor_timestamps.go
@@ -37,7 +37,7 @@ func (e *Executor) resolveDuckDBClickHouseAndPinot(ctx context.Context) (Timesta
 		filter,
 	)
 
-	rows, err := e.olap.Execute(ctx, &drivers.Statement{
+	rows, err := e.olap.Query(ctx, &drivers.Statement{
 		Query:            rangeSQL,
 		Priority:         e.priority,
 		ExecutionTimeout: defaultExecutionTimeout,
@@ -91,7 +91,7 @@ func (e *Executor) resolveDruid(ctx context.Context) (TimestampsResult, error) {
 			filter,
 		)
 
-		rows, err := e.olap.Execute(ctx, &drivers.Statement{
+		rows, err := e.olap.Query(ctx, &drivers.Statement{
 			Query:            minSQL,
 			Priority:         e.priority,
 			ExecutionTimeout: defaultExecutionTimeout,
@@ -127,7 +127,7 @@ func (e *Executor) resolveDruid(ctx context.Context) (TimestampsResult, error) {
 			filter,
 		)
 
-		rows, err := e.olap.Execute(ctx, &drivers.Statement{
+		rows, err := e.olap.Query(ctx, &drivers.Statement{
 			Query:            maxSQL,
 			Priority:         e.priority,
 			ExecutionTimeout: defaultExecutionTimeout,
@@ -163,7 +163,7 @@ func (e *Executor) resolveDruid(ctx context.Context) (TimestampsResult, error) {
 				filter,
 			)
 
-			rows, err := e.olap.Execute(ctx, &drivers.Statement{
+			rows, err := e.olap.Query(ctx, &drivers.Statement{
 				Query:            maxSQL,
 				Priority:         e.priority,
 				ExecutionTimeout: defaultExecutionTimeout,

--- a/runtime/pkg/metricssql/parser_test.go
+++ b/runtime/pkg/metricssql/parser_test.go
@@ -169,7 +169,7 @@ func TestCompile(t *testing.T) {
 		require.Equal(t, test.outSQL, sql)
 		require.ElementsMatch(t, test.args, args)
 
-		res, err := olap.Execute(context.Background(), &drivers.Statement{Query: sql, Args: args})
+		res, err := olap.Query(context.Background(), &drivers.Statement{Query: sql, Args: args})
 		require.NoError(t, err)
 		require.NoError(t, res.Close())
 	}

--- a/runtime/queries/column_cardinality.go
+++ b/runtime/queries/column_cardinality.go
@@ -67,7 +67,7 @@ func (q *ColumnCardinality) Resolve(ctx context.Context, rt *runtime.Runtime, in
 		return fmt.Errorf("not available for dialect '%s'", olap.Dialect())
 	}
 
-	rows, err := olap.Execute(ctx, &drivers.Statement{
+	rows, err := olap.Query(ctx, &drivers.Statement{
 		Query:            requestSQL,
 		Priority:         priority,
 		ExecutionTimeout: defaultExecutionTimeout,

--- a/runtime/queries/column_desc_stats.go
+++ b/runtime/queries/column_desc_stats.go
@@ -86,7 +86,7 @@ func (q *ColumnDescriptiveStatistics) Resolve(ctx context.Context, rt *runtime.R
 		return fmt.Errorf("not available for dialect '%s'", olap.Dialect())
 	}
 
-	rows, err := olap.Execute(ctx, &drivers.Statement{
+	rows, err := olap.Query(ctx, &drivers.Statement{
 		Query:            descriptiveStatisticsSQL,
 		Priority:         priority,
 		ExecutionTimeout: defaultExecutionTimeout,

--- a/runtime/queries/column_null_count.go
+++ b/runtime/queries/column_null_count.go
@@ -65,7 +65,7 @@ func (q *ColumnNullCount) Resolve(ctx context.Context, rt *runtime.Runtime, inst
 		safeName(q.ColumnName),
 	)
 
-	rows, err := olap.Execute(ctx, &drivers.Statement{
+	rows, err := olap.Query(ctx, &drivers.Statement{
 		Query:            nullCountSQL,
 		Priority:         priority,
 		ExecutionTimeout: defaultExecutionTimeout,

--- a/runtime/queries/column_numeric_histogram.go
+++ b/runtime/queries/column_numeric_histogram.go
@@ -97,7 +97,7 @@ func (q *ColumnNumericHistogram) calculateBucketSize(ctx context.Context, olap d
 		olap.Dialect().EscapeTable(q.Database, q.DatabaseSchema, q.TableName),
 	)
 
-	rows, err := olap.Execute(ctx, &drivers.Statement{
+	rows, err := olap.Query(ctx, &drivers.Statement{
 		Query:            querySQL,
 		Priority:         priority,
 		ExecutionTimeout: defaultExecutionTimeout,
@@ -230,7 +230,7 @@ func (q *ColumnNumericHistogram) calculateFDMethod(ctx context.Context, rt *runt
 		*rng,
 	)
 
-	histogramRows, err := olap.Execute(ctx, &drivers.Statement{
+	histogramRows, err := olap.Query(ctx, &drivers.Statement{
 		Query:            histogramSQL,
 		Priority:         priority,
 		ExecutionTimeout: defaultExecutionTimeout,
@@ -365,7 +365,7 @@ func (q *ColumnNumericHistogram) calculateDiagnosticMethod(ctx context.Context, 
 		endTick-startTick,
 	)
 
-	histogramRows, err := olap.Execute(ctx, &drivers.Statement{
+	histogramRows, err := olap.Query(ctx, &drivers.Statement{
 		Query:            histogramSQL,
 		Priority:         priority,
 		ExecutionTimeout: defaultExecutionTimeout,
@@ -414,7 +414,7 @@ func getMinMaxRange(ctx context.Context, olap drivers.OLAPStore, columnName, dat
 		selectColumn,
 	)
 
-	minMaxRow, err := olap.Execute(ctx, &drivers.Statement{
+	minMaxRow, err := olap.Query(ctx, &drivers.Statement{
 		Query:            minMaxSQL,
 		Priority:         priority,
 		ExecutionTimeout: defaultExecutionTimeout,

--- a/runtime/queries/column_rug_histogram.go
+++ b/runtime/queries/column_rug_histogram.go
@@ -147,7 +147,7 @@ func (q *ColumnRugHistogram) Resolve(ctx context.Context, rt *runtime.Runtime, i
 		*rng,                     // 7
 	)
 
-	outlierResults, err := olap.Execute(ctx, &drivers.Statement{
+	outlierResults, err := olap.Query(ctx, &drivers.Statement{
 		Query:            rugSQL,
 		Priority:         priority,
 		ExecutionTimeout: defaultExecutionTimeout,

--- a/runtime/queries/column_time_grain.go
+++ b/runtime/queries/column_time_grain.go
@@ -166,7 +166,7 @@ func (q *ColumnTimeGrain) Resolve(ctx context.Context, rt *runtime.Runtime, inst
 		return fmt.Errorf("not available for dialect '%s'", olap.Dialect())
 	}
 
-	rows, err := olap.Execute(ctx, &drivers.Statement{
+	rows, err := olap.Query(ctx, &drivers.Statement{
 		Query:            estimateSQL,
 		Priority:         priority,
 		ExecutionTimeout: defaultExecutionTimeout,

--- a/runtime/queries/column_time_range.go
+++ b/runtime/queries/column_time_range.go
@@ -81,7 +81,7 @@ func (q *ColumnTimeRange) resolveDuckDBAndClickhouse(ctx context.Context, olap d
 		drivers.DialectDuckDB.EscapeTable(q.Database, q.DatabaseSchema, q.TableName),
 	)
 
-	rows, err := olap.Execute(ctx, &drivers.Statement{
+	rows, err := olap.Query(ctx, &drivers.Statement{
 		Query:            rangeSQL,
 		Priority:         priority,
 		ExecutionTimeout: defaultExecutionTimeout,
@@ -129,7 +129,7 @@ func (q *ColumnTimeRange) resolveDruid(ctx context.Context, olap drivers.OLAPSto
 			drivers.DialectDruid.EscapeTable(q.Database, q.DatabaseSchema, q.TableName),
 		)
 
-		rows, err := olap.Execute(ctx, &drivers.Statement{
+		rows, err := olap.Query(ctx, &drivers.Statement{
 			Query:            minSQL,
 			Priority:         priority,
 			ExecutionTimeout: defaultExecutionTimeout,
@@ -162,7 +162,7 @@ func (q *ColumnTimeRange) resolveDruid(ctx context.Context, olap drivers.OLAPSto
 			drivers.DialectDruid.EscapeTable(q.Database, q.DatabaseSchema, q.TableName),
 		)
 
-		rows, err := olap.Execute(ctx, &drivers.Statement{
+		rows, err := olap.Query(ctx, &drivers.Statement{
 			Query:            maxSQL,
 			Priority:         priority,
 			ExecutionTimeout: defaultExecutionTimeout,

--- a/runtime/queries/column_timeseries.go
+++ b/runtime/queries/column_timeseries.go
@@ -154,7 +154,7 @@ func (q *ColumnTimeseries) Resolve(ctx context.Context, rt *runtime.Runtime, ins
 			})
 		}()
 
-		rows, err := olap.Execute(ctx, &drivers.Statement{
+		rows, err := olap.Query(ctx, &drivers.Statement{
 			Query:            fmt.Sprintf(`SELECT * FROM %q`, temporaryTableName),
 			Priority:         priority,
 			ExecutionTimeout: defaultExecutionTimeout,
@@ -465,7 +465,7 @@ func (q *ColumnTimeseries) CreateTimestampRollupReduction(
 	}
 
 	if rowCount < int64(q.Pixels*4) {
-		rows, err := olap.Execute(ctx, &drivers.Statement{
+		rows, err := olap.Query(ctx, &drivers.Statement{
 			Query:            `SELECT ` + safeTimestampColumnName + ` as ts, "` + valueColumn + `"::DOUBLE as count FROM "` + tableName + `"`,
 			Priority:         priority,
 			ExecutionTimeout: defaultExecutionTimeout,
@@ -540,7 +540,7 @@ func (q *ColumnTimeseries) CreateTimestampRollupReduction(
       ORDER BY bin
     `
 
-	rows, err := olap.Execute(ctx, &drivers.Statement{
+	rows, err := olap.Query(ctx, &drivers.Statement{
 		Query:            querySQL,
 		Priority:         priority,
 		ExecutionTimeout: defaultExecutionTimeout,
@@ -605,7 +605,7 @@ func (q *ColumnTimeseries) CreateTimestampRollupReduction(
 }
 
 func (q *ColumnTimeseries) resolveRowCount(ctx context.Context, olap drivers.OLAPStore, priority int) (int64, error) {
-	rows, err := olap.Execute(ctx, &drivers.Statement{
+	rows, err := olap.Query(ctx, &drivers.Statement{
 		Query:    fmt.Sprintf("SELECT count(*) AS count FROM %s", olap.Dialect().EscapeTable(q.Database, q.DatabaseSchema, q.TableName)),
 		Priority: priority,
 	})

--- a/runtime/queries/column_topk.go
+++ b/runtime/queries/column_topk.go
@@ -74,7 +74,7 @@ func (q *ColumnTopK) Resolve(ctx context.Context, rt *runtime.Runtime, instanceI
 	)
 
 	// Run query
-	rows, err := olap.Execute(ctx, &drivers.Statement{
+	rows, err := olap.Query(ctx, &drivers.Statement{
 		Query:            qry,
 		Priority:         priority,
 		ExecutionTimeout: defaultExecutionTimeout,

--- a/runtime/queries/metricsview.go
+++ b/runtime/queries/metricsview.go
@@ -69,7 +69,7 @@ func lookupMetricsView(ctx context.Context, rt *runtime.Runtime, instanceID, nam
 }
 
 func metricsQuery(ctx context.Context, olap drivers.OLAPStore, priority int, sql string, args []any) ([]*runtimev1.MetricsViewColumn, []*structpb.Struct, error) {
-	rows, err := olap.Execute(ctx, &drivers.Statement{
+	rows, err := olap.Query(ctx, &drivers.Statement{
 		Query:            sql,
 		Args:             args,
 		Priority:         priority,
@@ -751,7 +751,7 @@ func DuckDBCopyExport(ctx context.Context, w io.Writer, opts *runtime.ExportOpti
 		sql += " (FORMAT CSV, HEADER)"
 	}
 
-	rows, err := olap.Execute(ctx, &drivers.Statement{
+	rows, err := olap.Query(ctx, &drivers.Statement{
 		Query:            sql,
 		Args:             args,
 		Priority:         opts.Priority,

--- a/runtime/queries/resource_watermark.go
+++ b/runtime/queries/resource_watermark.go
@@ -96,7 +96,7 @@ func (q *ResourceWatermark) resolveMetricsView(ctx context.Context, rt *runtime.
 	}
 	defer release()
 
-	res, err := olap.Execute(ctx, &drivers.Statement{
+	res, err := olap.Query(ctx, &drivers.Statement{
 		Query:            sql,
 		Priority:         priority,
 		ExecutionTimeout: defaultExecutionTimeout,

--- a/runtime/queries/table_cardinality.go
+++ b/runtime/queries/table_cardinality.go
@@ -60,7 +60,7 @@ func (q *TableCardinality) Resolve(ctx context.Context, rt *runtime.Runtime, ins
 	}
 
 	countSQL := fmt.Sprintf("SELECT count(*) AS count FROM %s", olap.Dialect().EscapeTable(q.Database, q.DatabaseSchema, q.TableName))
-	rows, err := olap.Execute(ctx, &drivers.Statement{
+	rows, err := olap.Query(ctx, &drivers.Statement{
 		Query:            countSQL,
 		Priority:         priority,
 		ExecutionTimeout: defaultExecutionTimeout,

--- a/runtime/queries/table_columns.go
+++ b/runtime/queries/table_columns.go
@@ -90,7 +90,7 @@ func (q *TableColumns) Resolve(ctx context.Context, rt *runtime.Runtime, instanc
 				})
 			}()
 
-			rows, err := olap.Execute(ctx, &drivers.Statement{
+			rows, err := olap.Query(ctx, &drivers.Statement{
 				Query: fmt.Sprintf(`
 					SELECT column_name AS name, data_type AS type
 					FROM information_schema.columns

--- a/runtime/queries/table_head.go
+++ b/runtime/queries/table_head.go
@@ -73,7 +73,7 @@ func (q *TableHead) Resolve(ctx context.Context, rt *runtime.Runtime, instanceID
 		return err
 	}
 
-	rows, err := olap.Execute(ctx, &drivers.Statement{
+	rows, err := olap.Query(ctx, &drivers.Statement{
 		Query:            query,
 		Priority:         priority,
 		ExecutionTimeout: defaultExecutionTimeout,

--- a/runtime/resolvers/glob.go
+++ b/runtime/resolvers/glob.go
@@ -335,7 +335,7 @@ func (r *globResolver) transformResult(ctx context.Context, rows []map[string]an
 		}()
 
 		// Execute the transform SQL
-		rows, err := olap.Execute(wrappedCtx, &drivers.Statement{
+		rows, err := olap.Query(wrappedCtx, &drivers.Statement{
 			Query: sql,
 		})
 		if err != nil {

--- a/runtime/resolvers/sql.go
+++ b/runtime/resolvers/sql.go
@@ -108,7 +108,7 @@ func (r *sqlResolver) Refs() []*runtimev1.ResourceName {
 }
 
 func (r *sqlResolver) Validate(ctx context.Context) error {
-	_, err := r.olap.Execute(ctx, &drivers.Statement{
+	_, err := r.olap.Query(ctx, &drivers.Statement{
 		Query:  r.sql,
 		DryRun: true,
 	})
@@ -120,7 +120,7 @@ func (r *sqlResolver) ResolveInteractive(ctx context.Context) (runtime.ResolverR
 	// Adding +1 to the limit so we can return a nice error message if the limit is exceeded.
 	sql := fmt.Sprintf("SELECT * FROM (%s\n) LIMIT %d", r.sql, r.interactiveRowLimit+1)
 
-	res, err := r.olap.Execute(ctx, &drivers.Statement{
+	res, err := r.olap.Query(ctx, &drivers.Statement{
 		Query:    sql,
 		Priority: r.priority,
 	})
@@ -158,7 +158,7 @@ func (r *sqlResolver) ResolveExport(ctx context.Context, w io.Writer, opts *runt
 }
 
 func (r *sqlResolver) generalExport(ctx context.Context, w io.Writer, filename string, opts *runtime.ExportOptions) error {
-	res, err := r.olap.Execute(ctx, &drivers.Statement{
+	res, err := r.olap.Query(ctx, &drivers.Statement{
 		Query:    r.sql,
 		Priority: opts.Priority,
 	})

--- a/runtime/server/queries.go
+++ b/runtime/server/queries.go
@@ -50,7 +50,7 @@ func (s *Server) Query(ctx context.Context, req *runtimev1.QueryRequest) (*runti
 		}
 	}
 
-	res, err := olap.Execute(ctx, &drivers.Statement{
+	res, err := olap.Query(ctx, &drivers.Statement{
 		Query:            transformedSQL,
 		Args:             args,
 		DryRun:           req.DryRun,
@@ -109,7 +109,7 @@ func rowsToData(rows *drivers.Result) ([]*structpb.Struct, error) {
 }
 
 func ensureLimits(ctx context.Context, olap drivers.OLAPStore, inputSQL string, limit int) (string, error) {
-	r, err := olap.Execute(ctx, &drivers.Statement{
+	r, err := olap.Query(ctx, &drivers.Statement{
 		Query: "select json_serialize_sql(?::VARCHAR)",
 		Args:  []any{inputSQL},
 	})
@@ -139,7 +139,7 @@ func ensureLimits(ctx context.Context, olap drivers.OLAPStore, inputSQL string, 
 	}
 
 	transformedJSON := v.MustMarshalString()
-	r, err = olap.Execute(ctx, &drivers.Statement{
+	r, err = olap.Query(ctx, &drivers.Statement{
 		Query: "select json_deserialize_sql(json(?))",
 		Args:  []any{transformedJSON},
 	})

--- a/runtime/server/queries_columns_test.go
+++ b/runtime/server/queries_columns_test.go
@@ -606,7 +606,7 @@ func getColumnTestServerWithModel(t *testing.T, sql string, expectation int) (*s
 	olap, release, err := rt.OLAP(testCtx(), instanceID, "")
 	require.NoError(t, err)
 	defer release()
-	res, err := olap.Execute(testCtx(), &drivers.Statement{Query: "SELECT count(*) FROM test"})
+	res, err := olap.Query(testCtx(), &drivers.Statement{Query: "SELECT count(*) FROM test"})
 	require.NoError(t, err)
 	defer res.Close()
 

--- a/runtime/testruntime/olap.go
+++ b/runtime/testruntime/olap.go
@@ -36,7 +36,7 @@ func RequireOLAPTableCount(t testing.TB, rt *runtime.Runtime, id, name string, c
 	_, err = olap.InformationSchema().Lookup(context.Background(), "", "", name)
 	require.NoError(t, err)
 
-	rows, err := olap.Execute(context.Background(), &drivers.Statement{Query: fmt.Sprintf(`SELECT count(*) FROM %s`, drivers.DialectDuckDB.EscapeIdentifier(name))})
+	rows, err := olap.Query(context.Background(), &drivers.Statement{Query: fmt.Sprintf(`SELECT count(*) FROM %s`, drivers.DialectDuckDB.EscapeIdentifier(name))})
 	require.NoError(t, err)
 	defer rows.Close()
 


### PR DESCRIPTION
Using `Query` better aligns with the terminology used by `database/sql`, and more clearly distinguishes it from `OLAPStore.Exec` and `ModelExecutor.Execute`

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
