### PR TITLE
hotfix: truncate long draggable list item names

### DIFF
--- a/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
+++ b/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
@@ -466,7 +466,7 @@
 
                     <button
                       class="hover:bg-slate-200 p-1 rounded-sm active:bg-slate-300"
-                      on:click={() => {
+                      on:click|stopPropagation={() => {
                         selectedItems = [...selectedItems, id];
                         onSelectedChange(selectedItems);
                       }}

--- a/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
+++ b/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
@@ -437,55 +437,100 @@
             {#each filteredHiddenItems as [id = "", item], i (i)}
               {@const elementId = `hidden-${type === "measure" ? "measures" : "dimensions"}-${id}`}
               {@const isDragItem = dragId === elementId}
-              <Tooltip.Root openDelay={200} portal="body">
-                <Tooltip.Trigger>
-                  <div
-                    data-index={i + selectedItems.length - 1}
-                    id={elementId}
-                    data-item-name={id}
-                    class:z-50={isDragItem}
-                    class:opacity-0={isDragItem}
-                    style:height="{ITEM_HEIGHT}px"
-                    class="w-full flex gap-x-1 px-2 py-1 justify-between pointer-events-auto items-center p-1 rounded-sm hover:bg-slate-50 cursor-pointer"
-                    on:click={() => {
-                      selectedItems = [...selectedItems, id];
-                      onSelectedChange(selectedItems);
-                    }}
-                    on:keydown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        selectedItems = [...selectedItems, id];
-                        onSelectedChange(selectedItems);
-                      }
-                    }}
-                    role="presentation"
-                  >
-                    <span class="truncate flex-1 text-left pointer-events-none"
-                      >{item.displayName}</span
-                    >
-
-                    <button
-                      class="hover:bg-slate-200 p-1 rounded-sm active:bg-slate-300"
-                      on:click|stopPropagation={() => {
+              {#if item.description}
+                <Tooltip.Root openDelay={200} portal="body">
+                  <Tooltip.Trigger>
+                    <div
+                      data-index={i + selectedItems.length - 1}
+                      id={elementId}
+                      data-item-name={id}
+                      class:z-50={isDragItem}
+                      class:opacity-0={isDragItem}
+                      style:height="{ITEM_HEIGHT}px"
+                      class="w-full flex gap-x-1 px-2 py-1 justify-between pointer-events-auto items-center p-1 rounded-sm hover:bg-slate-50 cursor-pointer"
+                      on:click={() => {
                         selectedItems = [...selectedItems, id];
                         onSelectedChange(selectedItems);
                       }}
-                      aria-label="Toggle visibility"
-                      data-testid="toggle-visibility-button"
+                      on:keydown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          selectedItems = [...selectedItems, id];
+                          onSelectedChange(selectedItems);
+                        }
+                      }}
+                      role="presentation"
                     >
-                      <EyeOffIcon size="14px" color="#9ca3af" />
-                    </button>
-                  </div>
-                </Tooltip.Trigger>
+                      <span
+                        class="truncate flex-1 text-left pointer-events-none"
+                        >{item.displayName}</span
+                      >
 
-                <Tooltip.Content side="right" sideOffset={12} class="z-popover">
-                  <div
-                    class="bg-gray-800 text-gray-50 rounded p-2 pt-1 pb-1 shadow-md pointer-events-none z-50"
+                      <button
+                        class="hover:bg-slate-200 p-1 rounded-sm active:bg-slate-300"
+                        on:click|stopPropagation={() => {
+                          selectedItems = [...selectedItems, id];
+                          onSelectedChange(selectedItems);
+                        }}
+                        aria-label="Toggle visibility"
+                        data-testid="toggle-visibility-button"
+                      >
+                        <EyeOffIcon size="14px" color="#9ca3af" />
+                      </button>
+                    </div>
+                  </Tooltip.Trigger>
+
+                  <Tooltip.Content
+                    side="right"
+                    sideOffset={12}
+                    class="z-popover"
                   >
-                    {item.description}
-                  </div>
-                </Tooltip.Content>
-              </Tooltip.Root>
+                    <div
+                      class="bg-gray-800 text-gray-50 rounded p-2 pt-1 pb-1 shadow-md pointer-events-none z-50"
+                    >
+                      {item.description}
+                    </div>
+                  </Tooltip.Content>
+                </Tooltip.Root>
+              {:else}
+                <div
+                  data-index={i + selectedItems.length - 1}
+                  id={elementId}
+                  data-item-name={id}
+                  class:z-50={isDragItem}
+                  class:opacity-0={isDragItem}
+                  style:height="{ITEM_HEIGHT}px"
+                  class="w-full flex gap-x-1 px-2 py-1 justify-between pointer-events-auto items-center p-1 rounded-sm hover:bg-slate-50 cursor-pointer"
+                  on:click={() => {
+                    selectedItems = [...selectedItems, id];
+                    onSelectedChange(selectedItems);
+                  }}
+                  on:keydown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      selectedItems = [...selectedItems, id];
+                      onSelectedChange(selectedItems);
+                    }
+                  }}
+                  role="presentation"
+                >
+                  <span class="truncate flex-1 text-left pointer-events-none"
+                    >{item.displayName}</span
+                  >
+
+                  <button
+                    class="hover:bg-slate-200 p-1 rounded-sm active:bg-slate-300"
+                    on:click|stopPropagation={() => {
+                      selectedItems = [...selectedItems, id];
+                      onSelectedChange(selectedItems);
+                    }}
+                    aria-label="Toggle visibility"
+                    data-testid="toggle-visibility-button"
+                  >
+                    <EyeOffIcon size="14px" color="#9ca3af" />
+                  </button>
+                </div>
+              {/if}
             {/each}
           {/if}
         </div>

--- a/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
+++ b/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
@@ -437,43 +437,55 @@
             {#each filteredHiddenItems as [id = "", item], i (i)}
               {@const elementId = `hidden-${type === "measure" ? "measures" : "dimensions"}-${id}`}
               {@const isDragItem = dragId === elementId}
-              <div
-                data-index={i + selectedItems.length - 1}
-                id={elementId}
-                data-item-name={id}
-                class:z-50={isDragItem}
-                class:opacity-0={isDragItem}
-                style:height="{ITEM_HEIGHT}px"
-                class="w-full flex gap-x-1 px-2 py-1 justify-between pointer-events-auto items-center p-1 rounded-sm hover:bg-slate-50 cursor-pointer"
-                on:click={() => {
-                  selectedItems = [...selectedItems, id];
-                  onSelectedChange(selectedItems);
-                }}
-                on:keydown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    selectedItems = [...selectedItems, id];
-                    onSelectedChange(selectedItems);
-                  }
-                }}
-                role="presentation"
-              >
-                <span class="truncate flex-1 text-left pointer-events-none"
-                  >{item.displayName}</span
-                >
+              <Tooltip.Root openDelay={200} portal="body">
+                <Tooltip.Trigger>
+                  <div
+                    data-index={i + selectedItems.length - 1}
+                    id={elementId}
+                    data-item-name={id}
+                    class:z-50={isDragItem}
+                    class:opacity-0={isDragItem}
+                    style:height="{ITEM_HEIGHT}px"
+                    class="w-full flex gap-x-1 px-2 py-1 justify-between pointer-events-auto items-center p-1 rounded-sm hover:bg-slate-50 cursor-pointer"
+                    on:click={() => {
+                      selectedItems = [...selectedItems, id];
+                      onSelectedChange(selectedItems);
+                    }}
+                    on:keydown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        selectedItems = [...selectedItems, id];
+                        onSelectedChange(selectedItems);
+                      }
+                    }}
+                    role="presentation"
+                  >
+                    <span class="truncate flex-1 text-left pointer-events-none"
+                      >{item.displayName}</span
+                    >
 
-                <button
-                  class="hover:bg-slate-200 p-1 rounded-sm active:bg-slate-300"
-                  on:click={() => {
-                    selectedItems = [...selectedItems, id];
-                    onSelectedChange(selectedItems);
-                  }}
-                  aria-label="Toggle visibility"
-                  data-testid="toggle-visibility-button"
-                >
-                  <EyeOffIcon size="14px" color="#9ca3af" />
-                </button>
-              </div>
+                    <button
+                      class="hover:bg-slate-200 p-1 rounded-sm active:bg-slate-300"
+                      on:click={() => {
+                        selectedItems = [...selectedItems, id];
+                        onSelectedChange(selectedItems);
+                      }}
+                      aria-label="Toggle visibility"
+                      data-testid="toggle-visibility-button"
+                    >
+                      <EyeOffIcon size="14px" color="#9ca3af" />
+                    </button>
+                  </div>
+                </Tooltip.Trigger>
+
+                <Tooltip.Content side="right" sideOffset={12} class="z-popover">
+                  <div
+                    class="bg-gray-800 text-gray-50 rounded p-2 pt-1 pb-1 shadow-md pointer-events-none z-50"
+                  >
+                    {item.description}
+                  </div>
+                </Tooltip.Content>
+              </Tooltip.Root>
             {/each}
           {/if}
         </div>

--- a/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
+++ b/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
@@ -309,8 +309,10 @@
                   >
                     <DragHandle size="16px" className="text-gray-400" />
 
-                    {allItemsMap.get(id)?.displayName ??
-                      `Unknown ${type === "measure" ? "measure" : "dimension"}`}
+                    <span class="truncate flex-1 text-left pointer-events-none"
+                      >{allItemsMap.get(id)?.displayName ??
+                        `Unknown ${type === "measure" ? "measure" : "dimension"}`}</span
+                    >
 
                     <button
                       class="ml-auto hover:bg-slate-200 p-1 rounded-sm active:bg-slate-300"
@@ -347,7 +349,6 @@
                 </Tooltip.Content>
               </Tooltip.Root>
             {:else}
-              <!-- FIXME: hoist to DraggableListItem -->
               <div
                 role="presentation"
                 data-index={i}
@@ -380,8 +381,10 @@
               >
                 <DragHandle size="16px" className="text-gray-400" />
 
-                {allItemsMap.get(id)?.displayName ??
-                  `Unknown ${type === "measure" ? "measure" : "dimension"}`}
+                <span class="truncate flex-1 text-left pointer-events-none"
+                  >{allItemsMap.get(id)?.displayName ??
+                    `Unknown ${type === "measure" ? "measure" : "dimension"}`}</span
+                >
 
                 <button
                   class="ml-auto hover:bg-slate-200 p-1 rounded-sm active:bg-slate-300"
@@ -455,7 +458,9 @@
                 }}
                 role="presentation"
               >
-                {item.displayName}
+                <span class="truncate flex-1 text-left pointer-events-none"
+                  >{item.displayName}</span
+                >
 
                 <button
                   class="hover:bg-slate-200 p-1 rounded-sm active:bg-slate-300"


### PR DESCRIPTION
Reported in https://rilldata.slack.com/archives/C02T907FEUB/p1744295510607029

This pull request fixes the styling tweak of long draggable list item names by truncation.

https://github.com/user-attachments/assets/2f4d42d3-54bf-437c-88d0-9b140b6a90ff

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
