### PR TITLE
fix: clicking on eye icon to show measure/dimension triggering twice

### DIFF
--- a/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
+++ b/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
@@ -459,7 +459,7 @@
 
                 <button
                   class="hover:bg-slate-200 p-1 rounded-sm active:bg-slate-300"
-                  on:click={() => {
+                  on:click|stopPropagation={() => {
                     selectedItems = [...selectedItems, id];
                     onSelectedChange(selectedItems);
                   }}


### PR DESCRIPTION
Clicking on the eye icon in measure/dimension drop down in the hidden list triggers twice.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
