### PR TITLE
fix: remove explore state managers from canvas leaderboards

### DIFF
--- a/web-common/src/features/canvas/components/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/canvas/components/leaderboard/LeaderboardDisplay.svelte
@@ -19,20 +19,8 @@
     LEADERBOARD_WRAPPER_PADDING,
     MIN_DIMENSION_COLUMN_WIDTH,
   } from "./util";
-  import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
 
   export let component: LeaderboardComponent;
-
-  const StateManagers = getStateManagers();
-  const {
-    selectors: {
-      // FIXME: move to leaderboardProperties?
-      leaderboard: {
-        leaderboardShowContextForAllMeasures,
-        leaderboardSortByMeasureName,
-      },
-    },
-  } = StateManagers;
 
   let metricsViewName: string;
   let leaderboardMeasureNames: string[] = [];
@@ -176,9 +164,10 @@
                 {instanceId}
                 {isValidPercentOfTotal}
                 {metricsViewName}
-                leaderboardSortByMeasureName={$leaderboardSortByMeasureName}
+                leaderboardSortByMeasureName={$leaderboardState.leaderboardSortByMeasureName ??
+                  leaderboardMeasureNames?.[0]}
                 {leaderboardMeasureNames}
-                leaderboardShowContextForAllMeasures={$leaderboardShowContextForAllMeasures}
+                leaderboardShowContextForAllMeasures={true}
                 {whereFilter}
                 {dimensionThresholdFilters}
                 tableWidth={dimensionColumnWidth + totalContextWidth}

--- a/web-common/src/features/canvas/components/leaderboard/index.ts
+++ b/web-common/src/features/canvas/components/leaderboard/index.ts
@@ -17,7 +17,7 @@ import type {
   V1MetricsViewSpec,
   V1Resource,
 } from "@rilldata/web-common/runtime-client";
-import { derived, get, writable, type Writable } from "svelte/store";
+import { get, writable, type Writable } from "svelte/store";
 import type { CanvasEntity, ComponentPath } from "../../stores/canvas-entity";
 import type {
   CanvasComponentType,
@@ -115,15 +115,6 @@ export class LeaderboardComponent extends BaseCanvasComponent<LeaderboardSpec> {
       dimensions,
       num_rows: 7,
     };
-  }
-
-  get sortByMeasure() {
-    return derived(this.leaderboardState, (state) => {
-      return state.sortType !== SortType.DIMENSION &&
-        state.sortType !== SortType.UNSPECIFIED
-        ? state.leaderboardSortByMeasureName
-        : null;
-    });
   }
 
   validateAndResetSortMeasure = (spec: LeaderboardSpec) => {


### PR DESCRIPTION
- Fix E2E error for canvas leaderboards
- Removes the reference of explore state managers in canvas leaderboards.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
