### PR TITLE
fix: respect leaderboard measure names based on visible measures

### DIFF
--- a/web-common/src/features/dashboards/state-managers/actions/measures.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/measures.ts
@@ -8,11 +8,23 @@ export const toggleMeasureVisibility = (
   const index = dashboard.visibleMeasures.indexOf(measureName);
   if (index > -1) {
     dashboard.visibleMeasures.splice(index, 1);
+    // If we're hiding the current sort measure or it's the only visible measure, select a new one
     if (
-      dashboard.leaderboardSortByMeasureName === measureName &&
-      dashboard.visibleMeasures.length > 1
+      (dashboard.leaderboardSortByMeasureName === measureName ||
+        dashboard.visibleMeasures.length === 0) &&
+      dashboard.visibleMeasures.length > 0
     ) {
-      dashboard.leaderboardSortByMeasureName = dashboard.visibleMeasures[0];
+      // Find the next visible measure in leaderboardMeasureNames order
+      const nextMeasure = dashboard.leaderboardMeasureNames?.find(
+        (name) =>
+          name !== measureName && dashboard.visibleMeasures.includes(name),
+      );
+      if (nextMeasure) {
+        dashboard.leaderboardSortByMeasureName = nextMeasure;
+      } else {
+        // Fallback to first visible measure if no leaderboard measure is available
+        dashboard.leaderboardSortByMeasureName = dashboard.visibleMeasures[0];
+      }
     }
   } else {
     dashboard.visibleMeasures.push(measureName);
@@ -46,7 +58,16 @@ export const setMeasureVisibility = (
     !measures.includes(dashboard.leaderboardSortByMeasureName) &&
     measures.length > 0
   ) {
-    dashboard.leaderboardSortByMeasureName = measures[0];
+    // Find the next visible measure in leaderboardMeasureNames order
+    const nextMeasure = dashboard.leaderboardMeasureNames?.find((name) =>
+      measures.includes(name),
+    );
+    if (nextMeasure) {
+      dashboard.leaderboardSortByMeasureName = nextMeasure;
+    } else {
+      // Fallback to first visible measure if no leaderboard measure is available
+      dashboard.leaderboardSortByMeasureName = measures[0];
+    }
   }
 
   // Update leaderboard measure names to only include visible measures, maintaining their order

--- a/web-common/src/features/dashboards/state-managers/actions/measures.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/measures.ts
@@ -49,6 +49,13 @@ export const setMeasureVisibility = (
     dashboard.leaderboardSortByMeasureName = measures[0];
   }
 
+  // Update leaderboard measure names to only include visible measures, maintaining their order
+  if (dashboard.leaderboardMeasureNames) {
+    dashboard.leaderboardMeasureNames = dashboard.leaderboardMeasureNames
+      .filter((name) => measures.includes(name))
+      .sort((a, b) => measures.indexOf(a) - measures.indexOf(b));
+  }
+
   dashboard.allMeasuresVisible =
     dashboard.visibleMeasures.length === allMeasures.length;
 };

--- a/web-common/src/features/dashboards/state-managers/selectors/leaderboard.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/leaderboard.ts
@@ -16,9 +16,14 @@ export const leaderboardMeasureNames = ({
     visibleMeasuresList.map((measure) => measure.name),
   );
 
-  const filteredNames = dashboard.leaderboardMeasureNames?.filter((name) =>
-    visibleMeasureNames.has(name),
-  );
+  // Filter and sort the leaderboard measure names based on the order in visibleMeasures
+  const filteredNames = dashboard.leaderboardMeasureNames
+    ?.filter((name) => visibleMeasureNames.has(name))
+    .sort((a, b) => {
+      const aIndex = visibleMeasuresList.findIndex((m) => m.name === a);
+      const bIndex = visibleMeasuresList.findIndex((m) => m.name === b);
+      return aIndex - bIndex;
+    });
 
   return filteredNames?.length
     ? filteredNames
@@ -33,8 +38,6 @@ export const leaderboardShowContextForAllMeasures = ({
 
 export const leaderboardSelectors = {
   leaderboardSortByMeasureName,
-
   leaderboardMeasureNames,
-
   leaderboardShowContextForAllMeasures,
 };

--- a/web-common/src/features/dashboards/url-state/url-state-variations.spec.ts
+++ b/web-common/src/features/dashboards/url-state/url-state-variations.spec.ts
@@ -266,7 +266,8 @@ const TestCases: {
       AD_BIDS_TOGGLE_BID_PUBLISHER_DIMENSION_VISIBILITY,
       AD_BIDS_TOGGLE_BID_PUBLISHER_DIMENSION_VISIBILITY,
     ],
-    expectedSearch: "measures=bid_price%2Cimpressions&dims=domain%2Cpublisher",
+    expectedSearch:
+      "measures=bid_price%2Cimpressions&dims=domain%2Cpublisher&sort_by=bid_price",
   },
 
   {


### PR DESCRIPTION
This pull request ensures that leaderboard measures now respect the order of visible measures.﻿

Closes https://www.notion.so/rilldata/Order-of-Measures-in-Leaderboard-grid-don-t-match-the-order-of-measures-in-the-measure-dropdown-1d2ba33c8f578028a0a6fc0016758cb2

This will not be cherry-picked if we haven't branched out for the new release.

https://github.com/user-attachments/assets/581fd935-7557-4d99-b4e3-ef4a49c711b2



**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
