### PR TITLE
fix: default params strippings for non-explore views

### DIFF
--- a/web-common/src/features/dashboards/url-state/convert-partial-explore-state-to-url-params.ts
+++ b/web-common/src/features/dashboards/url-state/convert-partial-explore-state-to-url-params.ts
@@ -25,6 +25,7 @@ import {
   ExploreStateKeyToURLParamMap,
   ExploreStateURLParams,
 } from "@rilldata/web-common/features/dashboards/url-state/url-params";
+import { stripDefaultUrlParams } from "@rilldata/web-common/features/dashboards/url-state/url-params-strip-utils";
 import { arrayOrderedEquals } from "@rilldata/web-common/lib/arrayUtils";
 import {
   TimeComparisonOption,
@@ -53,30 +54,23 @@ export function getCleanedUrlParamsForGoto(
     timeControlsState,
   );
 
-  // Remove params with default values
-  [...stateParams.entries()].forEach(([key, value]) => {
-    const defaultValue = defaultExploreUrlParams.get(key);
-    if (
-      (defaultValue === null && value !== "") ||
-      (defaultValue !== null && value !== defaultValue)
-    ) {
-      return;
-    }
-    stateParams.delete(key);
-  });
+  const strippedUrlParams = stripDefaultUrlParams(
+    stateParams,
+    defaultExploreUrlParams,
+  );
 
-  if (!urlForCompressionCheck) return stateParams;
+  if (!urlForCompressionCheck) return strippedUrlParams;
 
   // compression
   const urlCopy = new URL(urlForCompressionCheck);
-  urlCopy.search = stateParams.toString();
+  urlCopy.search = strippedUrlParams.toString();
   const shouldCompress = shouldCompressParams(urlCopy);
-  if (!shouldCompress) return stateParams;
+  if (!shouldCompress) return strippedUrlParams;
 
   const compressedUrlParams = new URLSearchParams();
   compressedUrlParams.set(
     ExploreStateURLParams.GzippedParams,
-    compressUrlParams(stateParams.toString()),
+    compressUrlParams(strippedUrlParams.toString()),
   );
   return compressedUrlParams;
 }

--- a/web-common/src/features/dashboards/url-state/convert-partial-explore-state-to-url-params.ts
+++ b/web-common/src/features/dashboards/url-state/convert-partial-explore-state-to-url-params.ts
@@ -25,7 +25,7 @@ import {
   ExploreStateKeyToURLParamMap,
   ExploreStateURLParams,
 } from "@rilldata/web-common/features/dashboards/url-state/url-params";
-import { stripDefaultUrlParams } from "@rilldata/web-common/features/dashboards/url-state/url-params-strip-utils";
+import { stripDefaultOrEmptyUrlParams } from "@rilldata/web-common/features/dashboards/url-state/url-params-strip-utils";
 import { arrayOrderedEquals } from "@rilldata/web-common/lib/arrayUtils";
 import {
   TimeComparisonOption,
@@ -54,23 +54,24 @@ export function getCleanedUrlParamsForGoto(
     timeControlsState,
   );
 
-  const strippedUrlParams = stripDefaultUrlParams(
+  // Clean the url params of any default or empty values.
+  const cleanedUrlParams = stripDefaultOrEmptyUrlParams(
     stateParams,
     defaultExploreUrlParams,
   );
 
-  if (!urlForCompressionCheck) return strippedUrlParams;
+  if (!urlForCompressionCheck) return cleanedUrlParams;
 
   // compression
   const urlCopy = new URL(urlForCompressionCheck);
-  urlCopy.search = strippedUrlParams.toString();
+  urlCopy.search = cleanedUrlParams.toString();
   const shouldCompress = shouldCompressParams(urlCopy);
-  if (!shouldCompress) return strippedUrlParams;
+  if (!shouldCompress) return cleanedUrlParams;
 
   const compressedUrlParams = new URLSearchParams();
   compressedUrlParams.set(
     ExploreStateURLParams.GzippedParams,
-    compressUrlParams(strippedUrlParams.toString()),
+    compressUrlParams(cleanedUrlParams.toString()),
   );
   return compressedUrlParams;
 }

--- a/web-common/src/features/dashboards/url-state/explore-web-view-specific-url-params.ts
+++ b/web-common/src/features/dashboards/url-state/explore-web-view-specific-url-params.ts
@@ -93,3 +93,18 @@ export function copyUrlSearchParamsForView(
     },
   );
 }
+
+export function paramValidInBothViews(
+  view1: ExploreUrlWebView,
+  view2: ExploreUrlWebView,
+  param: ExploreStateURLParams,
+) {
+  return (
+    view1 === view2 ||
+    // If the param is not specific to a web view then it is valid for both views
+    !ExploreURLParamsSpecificToSomeWebView.has(param) ||
+    // Else we have a map that defines whether a param is actually shared.
+    // There are cases where param name is same but they mean different things. EG: sort_by is different in explore and pivot views
+    ExploreWebViewCommonURLParams[view1]?.[view2]?.includes(param)
+  );
+}

--- a/web-common/src/features/dashboards/url-state/explore-web-view-specific-url-params.ts
+++ b/web-common/src/features/dashboards/url-state/explore-web-view-specific-url-params.ts
@@ -56,6 +56,30 @@ export const ExploreWebViewCommonURLParams: Partial<
   },
 };
 
+// Sparse map of keys that are common by name between some but mean different things.
+// TODO: build this automatically given ExploreWebViewSpecificURLParams and ExploreWebViewCommonURLParams
+export const ExploreWebViewCommonNameDifferentMeaningURLParams: Partial<
+  Record<
+    ExploreUrlWebView,
+    Partial<Record<ExploreUrlWebView, ExploreStateURLParams[]>>
+  >
+> = {
+  explore: {
+    pivot: [
+      ExploreStateURLParams.SortBy,
+      ExploreStateURLParams.SortType,
+      ExploreStateURLParams.SortDirection,
+    ],
+  },
+  pivot: {
+    explore: [
+      ExploreStateURLParams.SortBy,
+      ExploreStateURLParams.SortType,
+      ExploreStateURLParams.SortDirection,
+    ],
+  },
+};
+
 const ExploreURLParamsSpecificToSomeWebView = new Set(
   Object.values(ExploreWebViewSpecificURLParams).flat(),
 );
@@ -94,17 +118,12 @@ export function copyUrlSearchParamsForView(
   );
 }
 
-export function paramValidInBothViews(
+export function isParamCommonButDifferentMeaning(
   view1: ExploreUrlWebView,
   view2: ExploreUrlWebView,
   param: ExploreStateURLParams,
 ) {
-  return (
-    view1 === view2 ||
-    // If the param is not specific to a web view then it is valid for both views
-    !ExploreURLParamsSpecificToSomeWebView.has(param) ||
-    // Else we have a map that defines whether a param is actually shared.
-    // There are cases where param name is same but they mean different things. EG: sort_by is different in explore and pivot views
-    ExploreWebViewCommonURLParams[view1]?.[view2]?.includes(param)
-  );
+  return ExploreWebViewCommonNameDifferentMeaningURLParams[view1]?.[
+    view2
+  ]?.includes(param);
 }

--- a/web-common/src/features/dashboards/url-state/url-params-strip-utils.spec.ts
+++ b/web-common/src/features/dashboards/url-state/url-params-strip-utils.spec.ts
@@ -1,4 +1,4 @@
-import { stripDefaultUrlParams } from "@rilldata/web-common/features/dashboards/url-state/url-params-strip-utils";
+import { stripDefaultOrEmptyUrlParams } from "@rilldata/web-common/features/dashboards/url-state/url-params-strip-utils";
 import { describe, it, expect } from "vitest";
 
 const TestCases: {
@@ -63,7 +63,7 @@ describe("url-params-strip-utils", () => {
       const defaultParams = new URLSearchParams(defaultSearch);
       const params = new URLSearchParams(search);
 
-      const stripedParams = stripDefaultUrlParams(params, defaultParams);
+      const stripedParams = stripDefaultOrEmptyUrlParams(params, defaultParams);
       expect(stripedParams.toString()).toEqual(expectedStrippedSearch);
     });
   }

--- a/web-common/src/features/dashboards/url-state/url-params-strip-utils.spec.ts
+++ b/web-common/src/features/dashboards/url-state/url-params-strip-utils.spec.ts
@@ -1,0 +1,60 @@
+import { stripDefaultUrlParams } from "@rilldata/web-common/features/dashboards/url-state/url-params-strip-utils";
+import { describe, it, expect } from "vitest";
+
+const TestCases: {
+  title: string;
+  defaultSearch: string;
+  search: string;
+  expectedStrippedSearch: string;
+}[] = [
+  {
+    title: "should remove default params for explore views",
+    defaultSearch:
+      "view=explore&tr=PT6H&tz=UTC&compare_tr=&grain=hour&compare_dim=",
+    search: "view=explore&tr=P7D&tz=UTC&compare_tr=&grain=day&compare_dim=",
+    expectedStrippedSearch: "tr=P7D&grain=day",
+  },
+  {
+    title: "should keep unknown params for explore views",
+    defaultSearch:
+      "view=explore&tr=PT6H&tz=UTC&compare_tr=&grain=hour&compare_dim=",
+    search:
+      "view=explore&tr=P7D&tz=UTC&compare_tr=&grain=day&compare_dim=&unknown=abc",
+    expectedStrippedSearch: "tr=P7D&grain=day&unknown=abc",
+  },
+
+  {
+    title: "should remove default params for explore and tdd",
+    defaultSearch:
+      "view=explore&tr=PT6H&tz=UTC&compare_tr=&grain=hour&compare_dim=",
+    search:
+      "view=tdd&tr=P7D&tz=UTC&compare_tr=&grain=hour&compare_dim=&measure=impressions",
+    expectedStrippedSearch: "view=tdd&tr=P7D&measure=impressions",
+  },
+  {
+    title: "should remove default params for explore and pivot",
+    defaultSearch:
+      "view=explore&tr=PT6H&tz=UTC&compare_tr=&grain=hour&compare_dim=&sort_by=impressions&sort_dir=DESC",
+    search:
+      "view=pivot&tr=P7D&tz=UTC&compare_tr=&rows=publisher&cols=impressions&sort_by=impressions&sort_dir=DESC",
+    expectedStrippedSearch:
+      "view=pivot&tr=P7D&rows=publisher&cols=impressions&sort_by=impressions&sort_dir=DESC",
+  },
+];
+
+describe("url-params-strip-utils", () => {
+  for (const {
+    title,
+    defaultSearch,
+    search,
+    expectedStrippedSearch,
+  } of TestCases) {
+    it(title, () => {
+      const defaultParams = new URLSearchParams(defaultSearch);
+      const params = new URLSearchParams(search);
+
+      const stripedParams = stripDefaultUrlParams(params, defaultParams);
+      expect(stripedParams.toString()).toEqual(expectedStrippedSearch);
+    });
+  }
+});

--- a/web-common/src/features/dashboards/url-state/url-params-strip-utils.spec.ts
+++ b/web-common/src/features/dashboards/url-state/url-params-strip-utils.spec.ts
@@ -40,6 +40,16 @@ const TestCases: {
     expectedStrippedSearch:
       "view=pivot&tr=P7D&rows=publisher&cols=impressions&sort_by=impressions&sort_dir=DESC",
   },
+
+  {
+    title: "should remove default params for explore and pivot in flat mode",
+    defaultSearch:
+      "view=explore&tr=PT6H&tz=UTC&compare_tr=&grain=hour&compare_dim=&sort_by=impressions&sort_dir=DESC",
+    search:
+      "view=pivot&tr=P7D&tz=UTC&compare_tr=&rows=&cols=publisher%2Cimpressions&sort_by=impressions&sort_dir=DESC&table_mode=flat",
+    expectedStrippedSearch:
+      "view=pivot&tr=P7D&cols=publisher%2Cimpressions&sort_by=impressions&sort_dir=DESC&table_mode=flat",
+  },
 ];
 
 describe("url-params-strip-utils", () => {

--- a/web-common/src/features/dashboards/url-state/url-params-strip-utils.ts
+++ b/web-common/src/features/dashboards/url-state/url-params-strip-utils.ts
@@ -1,0 +1,40 @@
+import { paramValidInBothViews } from "@rilldata/web-common/features/dashboards/url-state/explore-web-view-specific-url-params";
+import { ExploreUrlWebView } from "@rilldata/web-common/features/dashboards/url-state/mappers";
+import { ExploreStateURLParams } from "@rilldata/web-common/features/dashboards/url-state/url-params";
+
+export function stripDefaultUrlParams(
+  searchParams: URLSearchParams,
+  defaultUrlParams: URLSearchParams,
+) {
+  const currentView =
+    (searchParams.get(
+      ExploreStateURLParams.WebView,
+    ) as ExploreUrlWebView | null) ?? ExploreUrlWebView.Explore;
+  const defaultView =
+    (defaultUrlParams.get(
+      ExploreStateURLParams.WebView,
+    ) as ExploreUrlWebView | null) ?? ExploreUrlWebView.Explore;
+
+  const strippedUrlParams = new URLSearchParams();
+  searchParams.forEach((value, key) => {
+    if (
+      !paramValidInBothViews(
+        currentView,
+        defaultView,
+        key as ExploreStateURLParams,
+      )
+    ) {
+      // If the param is not valid in both views then checking equality doesn't make sense.
+      // So set it and return early.
+      strippedUrlParams.set(key, value);
+      return;
+    }
+
+    const defaultValue = defaultUrlParams.get(key);
+    if (defaultValue !== null && value === defaultValue) {
+      return;
+    }
+    strippedUrlParams.set(key, value);
+  });
+  return strippedUrlParams;
+}

--- a/web-common/src/features/dashboards/url-state/url-params-strip-utils.ts
+++ b/web-common/src/features/dashboards/url-state/url-params-strip-utils.ts
@@ -2,7 +2,13 @@ import { isParamCommonButDifferentMeaning } from "@rilldata/web-common/features/
 import { ExploreUrlWebView } from "@rilldata/web-common/features/dashboards/url-state/mappers";
 import { ExploreStateURLParams } from "@rilldata/web-common/features/dashboards/url-state/url-params";
 
-export function stripDefaultUrlParams(
+/**
+ * Removes any params that are equal to default param value.
+ * If there is no default param then we remove params with empty value.
+ *
+ * Right now the defaults are either the rill opinionated defaults or from yaml config.
+ */
+export function stripDefaultOrEmptyUrlParams(
   searchParams: URLSearchParams,
   defaultUrlParams: URLSearchParams,
 ) {
@@ -19,16 +25,14 @@ export function stripDefaultUrlParams(
   searchParams.forEach((value, key: ExploreStateURLParams) => {
     const defaultValue = defaultUrlParams.get(key);
 
-    if (
-      // if there is no default value then skip setting if the value is empty then skip adding it.
-      (defaultValue === null && value === "") ||
-      // else if there is a default value,
-      (defaultValue !== null &&
-        // make sure it is not one of the common param name but different meaning
-        !isParamCommonButDifferentMeaning(currentView, defaultView, key) &&
-        // and values match then skip adding it
-        value === defaultValue)
-    ) {
+    const hasNoDefaultAndValueIsEmpty = defaultValue === null && value === "";
+    const hasDefaultAndIsUnmodified =
+      defaultValue !== null &&
+      // make sure it is not one of the params that have the same name but different meaning
+      !isParamCommonButDifferentMeaning(currentView, defaultView, key) &&
+      value === defaultValue;
+
+    if (hasNoDefaultAndValueIsEmpty || hasDefaultAndIsUnmodified) {
       return;
     }
 


### PR DESCRIPTION
We have a default set of params that we strip from the url. But we do not take into account the difference in view. This is an issue only for pivot since there is an overlap in param name but they mean different things.

We should revisit the stripping and look at doing it using explore state directly.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
