### PR TITLE
refactor (Big Number): Clean up data fetching

### DIFF
--- a/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
+++ b/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
@@ -4,8 +4,8 @@ import type { StateManagers } from "@rilldata/web-common/features/dashboards/sta
 import { sanitiseExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
 import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import {
-  createTotalsForMeasure,
-  createUnfilteredTotalsForMeasure,
+  createTotalsForMeasures,
+  createUnfilteredTotalsForMeasures,
 } from "@rilldata/web-common/features/dashboards/time-series/totals-data-store";
 import { prepareTimeSeries } from "@rilldata/web-common/features/dashboards/time-series/utils";
 import { TIME_GRAIN } from "@rilldata/web-common/lib/time/config";
@@ -169,7 +169,7 @@ export function createTimeSeriesDataStore(
 
       const primaryTotals =
         measuresForTotals.length > 0
-          ? createTotalsForMeasure(ctx, measuresForTotals, false)
+          ? createTotalsForMeasures(ctx, measuresForTotals, false)
           : writable({
               isFetching: false,
               isError: false,
@@ -182,7 +182,7 @@ export function createTimeSeriesDataStore(
         | Writable<null> = writable(null);
 
       if (dashboardStore?.selectedComparisonDimension) {
-        unfilteredTotals = createUnfilteredTotalsForMeasure(
+        unfilteredTotals = createUnfilteredTotalsForMeasures(
           ctx,
           measures,
           dashboardStore?.selectedComparisonDimension,
@@ -200,7 +200,7 @@ export function createTimeSeriesDataStore(
           measuresForTimeSeries,
           true,
         );
-        comparisonTotals = createTotalsForMeasure(ctx, measures, true);
+        comparisonTotals = createTotalsForMeasures(ctx, measures, true);
       }
 
       let dimensionTimeSeriesCharts:


### PR DESCRIPTION
This PR:
- Pulls the big number API requests out of the `timeseries-data-store` and into a dedicated `big-number-queries.ts` file
- Uses stable Query Observers (made possible via TanStack Query v5)

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
