### PR TITLE
Fix dimension and measure gradients in single measure selection

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -369,6 +369,7 @@
             {toggleDimensionValueSelection}
             {leaderboardSortByMeasureName}
             {formatters}
+            {dimensionColumnWidth}
           />
         {/each}
       </DelayedLoadingRows>
@@ -391,6 +392,7 @@
           {toggleDimensionValueSelection}
           {leaderboardSortByMeasureName}
           {formatters}
+          {dimensionColumnWidth}
         />
       {/each}
     </tbody>

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -34,6 +34,7 @@
   export let leaderboardShowContextForAllMeasures: boolean;
   export let leaderboardSortByMeasureName: string | null;
   export let isValidPercentOfTotal: (measureName: string) => boolean;
+  export let dimensionColumnWidth: number;
   export let toggleDimensionValueSelection: (
     dimensionName: string,
     dimensionValue: string,
@@ -94,12 +95,6 @@
   $: valueColumn.update(valueElementWith);
   $: deltaColumn.update(deltaElementWidth);
 
-  $: barColor = excluded
-    ? "rgb(243 244 246)"
-    : selected || hovered
-      ? "var(--color-primary-200)"
-      : "var(--color-primary-100)";
-
   $: barLengths = Object.fromEntries(
     Object.entries(pctOfTotals).map(([name, pct]) => [
       name,
@@ -126,91 +121,28 @@
     ]),
   );
 
-  // $: percentOfTotalCellBarLengths = Object.fromEntries(
-  //   Object.entries(barLengths).map(([name, length]) => [
-  //     name,
-  //     isValidPercentOfTotal(name) ? clamp(0, length, DEFAULT_COLUMN_WIDTH) : 0,
-  //   ]),
-  // );
-
-  // $: deltaAbsoluteCellBarLengths = Object.fromEntries(
-  //   Object.entries(barLengths).map(([name, length]) => [
-  //     name,
-  //     isTimeComparisonActive
-  //       ? clamp(
-  //           0,
-  //           length - $valueColumn - (percentOfTotalCellBarLengths[name] || 0),
-  //           COMPARISON_COLUMN_WIDTH,
-  //         )
-  //       : 0,
-  //   ]),
-  // );
-
-  // $: deltaPercentCellBarLengths = Object.fromEntries(
-  //   Object.entries(barLengths).map(([name, length]) => [
-  //     name,
-  //     isTimeComparisonActive
-  //       ? clamp(
-  //           0,
-  //           length -
-  //             $valueColumn -
-  //             (percentOfTotalCellBarLengths[name] || 0) -
-  //             (deltaAbsoluteCellBarLengths[name] || 0),
-  //           COMPARISON_COLUMN_WIDTH,
-  //         )
-  //       : 0,
-  //   ]),
-  // );
+  $: barColor = excluded
+    ? "rgb(243 244 246)"
+    : selected || hovered
+      ? "var(--color-primary-200)"
+      : "var(--color-primary-100)";
 
   $: dimensionGradients =
     leaderboardMeasureNames.length === 1
-      ? `linear-gradient(to right, ${barColor}
-      ${totalBarLength}px, transparent ${totalBarLength}px)`
+      ? `linear-gradient(to right, ${barColor} ${Math.min(dimensionColumnWidth, totalBarLength)}px, transparent ${Math.min(dimensionColumnWidth, totalBarLength)}px)`
       : undefined;
 
   $: measureGradients =
-    leaderboardMeasureNames.length > 1
-      ? Object.fromEntries(
+    leaderboardMeasureNames.length === 1
+      ? `linear-gradient(to right, ${barColor} ${Math.max(0, totalBarLength - dimensionColumnWidth)}px, transparent ${Math.max(0, totalBarLength - dimensionColumnWidth)}px)`
+      : Object.fromEntries(
           Object.entries(measureCellBarLengths).map(([name, length]) => [
             name,
             length
               ? `linear-gradient(to right, transparent 16px, ${barColor} 16px, ${barColor} ${length + 16}px, transparent ${length + 16}px)`
               : undefined,
           ]),
-        )
-      : undefined;
-
-  // $: percentOfTotalGradients =
-  //   leaderboardMeasureNames.length > 1
-  //     ? Object.fromEntries(
-  //         Object.entries(percentOfTotalCellBarLengths).map(([name, length]) => [
-  //           name,
-  //           length
-  //             ? `linear-gradient(to right, ${barColor}
-  //   ${length}px, transparent ${length}px)`
-  //             : undefined,
-  //         ]),
-  //       )
-  //     : undefined;
-
-  // $: deltaAbsoluteGradients = Object.fromEntries(
-  //   Object.entries(deltaAbsoluteCellBarLengths).map(([name, length]) => [
-  //     name,
-  //     length
-  //       ? `linear-gradient(to right, ${barColor}
-  //   ${length}px, transparent ${length}px)`
-  //       : undefined,
-  //   ]),
-  // );
-
-  // $: deltaPercentGradients = Object.fromEntries(
-  //   Object.entries(deltaPercentCellBarLengths).map(([name, length]) => [
-  //     name,
-  //     length
-  //       ? `linear-gradient(to right, ${barColor}
-  //   ${length}px, transparent ${length}px)`  //       : undefined,
-  //   ]),
-  // );
+        );
 
   $: showTooltip = hovered && !suppressTooltip;
 
@@ -231,6 +163,9 @@
   class:border-b={borderBottom}
   class:border-t={borderTop}
   class="relative"
+  style:background={leaderboardMeasureNames.length === 1
+    ? dimensionGradients
+    : undefined}
   on:mouseenter={() => (hovered = true)}
   on:mouseleave={() => (hovered = false)}
   on:click={(e) => {
@@ -291,7 +226,7 @@
       on:click={modified({
         shift: () => shiftClickHandler(values[measureName]?.toString() || ""),
       })}
-      style:background={measureGradients?.[measureName]}
+      style:background={measureGradients}
     >
       <div class="w-fit ml-auto bg-transparent" bind:contentRect={valueRect}>
         <FormattedDataType

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -135,13 +135,21 @@
   $: measureGradients =
     leaderboardMeasureNames.length === 1
       ? `linear-gradient(to right, ${barColor} ${Math.max(0, totalBarLength - dimensionColumnWidth)}px, transparent ${Math.max(0, totalBarLength - dimensionColumnWidth)}px)`
+      : undefined;
+
+  $: measureGradientMap =
+    leaderboardMeasureNames.length === 1
+      ? undefined
       : Object.fromEntries(
-          Object.entries(measureCellBarLengths).map(([name, length]) => [
-            name,
-            length
-              ? `linear-gradient(to right, transparent 16px, ${barColor} 16px, ${barColor} ${length + 16}px, transparent ${length + 16}px)`
-              : undefined,
-          ]),
+          leaderboardMeasureNames.map((name) => {
+            const length = measureCellBarLengths[name];
+            return [
+              name,
+              length
+                ? `linear-gradient(to right, transparent 16px, ${barColor} 16px, ${barColor} ${length + 16}px, transparent ${length + 16}px)`
+                : undefined,
+            ];
+          }),
         );
 
   $: showTooltip = hovered && !suppressTooltip;
@@ -226,7 +234,9 @@
       on:click={modified({
         shift: () => shiftClickHandler(values[measureName]?.toString() || ""),
       })}
-      style:background={measureGradients}
+      style:background={leaderboardMeasureNames.length === 1
+        ? measureGradients
+        : measureGradientMap?.[measureName]}
     >
       <div class="w-fit ml-auto bg-transparent" bind:contentRect={valueRect}>
         <FormattedDataType


### PR DESCRIPTION
Fixes https://github.com/rilldata/rill-private-issues/issues/1592

This pull request restores the gradients behavior prior to the implementation of the multiple measures first pass. See screenshots below for reference. In single selection, the gradients extend across both the dimension and measure cells. For multiple selections, the gradients are limited to their respective measure cells.

**Gradients behavior in 0.56:**
![image](https://github.com/user-attachments/assets/8bcc86cc-f02a-4eed-ab82-a9cc4181a097)

**Gradients behavior in the latest main (after multiple metrics first + second pass):**
![CleanShot 2025-04-18 at 14 47 33@2x](https://github.com/user-attachments/assets/a856b97d-0b9b-457f-80ef-9829bbf6ebb5)

**Gradients behavior in this branch:**
![CleanShot 2025-04-18 at 14 45 49@2x](https://github.com/user-attachments/assets/38215eb3-9894-4d16-bb38-323b99c51346)


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request fixes gradient issues in leaderboard components by restoring proper behavior for single measure selection. The changes ensure gradients extend correctly across dimension and measure cells, improving visual consistency while removing obsolete code.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>