### PR TITLE
Ignore NoErrAlreadyUpToDate error

### DIFF
--- a/admin/server/github.go
+++ b/admin/server/github.go
@@ -1061,7 +1061,9 @@ func (s *Server) pushToGit(ctx context.Context, copyData func(projPath string) e
 	}
 
 	if err := ghRepo.PushContext(ctx, &git.PushOptions{Auth: gitAuth}); err != nil {
-		return fmt.Errorf("failed to push to remote %q : %w", repo, err)
+		if !errors.Is(err, git.NoErrAlreadyUpToDate) {
+			return fmt.Errorf("failed to push to remote %q : %w", repo, err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Closed [#1590](https://github.com/rilldata/rill-private-issues/issues/1590)

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances the GitHub integration component by modifying error handling to properly ignore NoErrAlreadyUpToDate errors. The change prevents unnecessary error propagation when remote repositories are already up-to-date during push operations, improving the overall robustness of Git operations.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>