### PR TITLE
handle divide by zero causing null value to appear on top

### DIFF
--- a/web-admin/tests/setup/projects/openrtb/metrics/bids_metrics.yaml
+++ b/web-admin/tests/setup/projects/openrtb/metrics/bids_metrics.yaml
@@ -36,7 +36,7 @@ measures:
     format_preset: humanize
   - display_name: "CTR"
     name: ctr
-    expression: "sum(click_reg_cnt)*1.0/sum(imp_cnt)"
+    expression: "sum(click_reg_cnt)*1.0/nullif(sum(imp_cnt),0)"
     description: "Click Through Rate"
     format_preset: percentage
   - display_name: "Video Starts"
@@ -61,7 +61,7 @@ measures:
     format_preset: currency_usd
   - display_name: "eCPM"
     name: ecpm
-    expression: "sum(media_spend_usd)*1.0/1000/sum(imp_cnt)"
+    expression: "sum(media_spend_usd)*1.0/1000/nullif(sum(imp_cnt),0)"
     description: "eCPM"
     format_preset: currency_usd
   - display_name: "Avg Bid Floor"


### PR DESCRIPTION
Close [#1553](https://github.com/rilldata/rill-private-issues/issues/1553)

Actually, the null-like value appears at the top because it's not a real `NULL` — it's a `NaN`. We later convert it to `NULL` in the Go code. According to the DuckDB documentation:

`NaN compares equal to NaN and is greater than any other floating-point number.`

This means NaN will sort higher than any valid numeric value, which explains why it shows up first in sorted results.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
