### PR TITLE
fix: edge cases with dimension search

### DIFF
--- a/web-common/src/components/search/Search.svelte
+++ b/web-common/src/components/search/Search.svelte
@@ -38,13 +38,10 @@
    */
   function handleInput(event) {
     value = event.target?.value;
-    if (multiline) {
-      updateTextAreaHeight();
-    }
+    if (multiline) updateTextAreaHeight();
   }
 
   function updateTextAreaHeight() {
-    ref.style.height = "auto"; // Reset height
     ref.style.height = ref.scrollHeight + "px"; // Set to scroll height
   }
 
@@ -52,6 +49,7 @@
     if (!retainValueOnMount) value = "";
     // Keep ref optional here. If component is unmounted before this animation frame runs, ref will be null and throw a TypeError
     if (autofocus) window.requestAnimationFrame(() => ref?.focus());
+    if (multiline) updateTextAreaHeight();
   });
 </script>
 
@@ -87,6 +85,7 @@
     aria-label={label}
     role="textbox"
     tabindex="-1"
+    {value}
   />
 </form>
 
@@ -96,7 +95,7 @@
   }
 
   textarea {
-    height: auto;
+    height: 28px;
     /* min height for 1 row */
     min-height: 28px;
     /* Max of 5 rows. 28 + 16 * 5 = 92 */

--- a/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
+++ b/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
@@ -15,7 +15,10 @@
     DimensionFilterMode,
     DimensionFilterModeOptions,
   } from "@rilldata/web-common/features/dashboards/filters/dimension-filters/dimension-filter-mode";
-  import { splitDimensionSearchText } from "@rilldata/web-common/features/dashboards/filters/dimension-filters/split-dimension-search-text";
+  import {
+    mergeDimensionSearchValues,
+    splitDimensionSearchText,
+  } from "@rilldata/web-common/features/dashboards/filters/dimension-filters/dimension-search-text-utils";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { fly } from "svelte/transition";
   import {
@@ -152,7 +155,7 @@
 
       case DimensionFilterMode.InList:
         curMode = DimensionFilterMode.InList;
-        curSearchText = selectedValues.join(",");
+        curSearchText = mergeDimensionSearchValues(selectedValues);
         break;
 
       case DimensionFilterMode.Contains:
@@ -194,7 +197,7 @@
     if (open) {
       curSearchText =
         mode === DimensionFilterMode.InList
-          ? selectedValues.join(",")
+          ? mergeDimensionSearchValues(selectedValues)
           : (sanitisedSearchText ?? "");
     } else {
       if (selectedValues.length === 0 && !inputText) {

--- a/web-common/src/features/dashboards/filters/dimension-filters/dimension-search-text-utils.ts
+++ b/web-common/src/features/dashboards/filters/dimension-filters/dimension-search-text-utils.ts
@@ -22,3 +22,8 @@ export function splitDimensionSearchText(searchText: string) {
   }
   return values;
 }
+
+export function mergeDimensionSearchValues(values: string[]) {
+  const someValueHasComma = values.some((value) => value.includes(","));
+  return someValueHasComma ? values.join("\n") : values.join(",");
+}

--- a/web-common/src/features/dashboards/filters/dimension-filters/split-dimension-search-text.spec.ts
+++ b/web-common/src/features/dashboards/filters/dimension-filters/split-dimension-search-text.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { splitDimensionSearchText } from "./split-dimension-search-text";
+import { splitDimensionSearchText } from "web-common/src/features/dashboards/filters/dimension-filters/dimension-search-text-utils";
 
 describe("splitDimensionSearchText", () => {
   it("should split by comma and return trimmed parts", () => {


### PR DESCRIPTION
Fixes a few issues with dimension search,
1. Auto height of search text has incorrect initial height. Tweaking the logic to start from the correct initial height.
2. Refreshing the page doesnt populate the search.
3. If we refresh on the page after using "in-list" search with values with comma, the selection becomes invalid. This is because after getting the value from filter we always join using a comma. Updating this to join using newline if any value has a comma.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
