### PR TITLE
fix: 0<grain> and timezones in the new rill time syntax

### DIFF
--- a/runtime/pkg/rilltime/rilltime_test.go
+++ b/runtime/pkg/rilltime/rilltime_test.go
@@ -24,8 +24,9 @@ func Test_Eval(t *testing.T) {
 
 		{"m", "2025-03-10T06:31:00Z", "2025-03-10T06:32:00Z", timeutil.TimeGrainSecond},
 		{"m by s", "2025-03-10T06:31:00Z", "2025-03-10T06:32:00Z", timeutil.TimeGrainSecond},
-		{"0m", "2025-03-10T06:31:00Z", "2025-03-10T06:32:00Z", timeutil.TimeGrainSecond},
 		{"m~", "2025-03-10T06:32:00Z", "2025-03-10T06:33:00Z", timeutil.TimeGrainSecond},
+		// 0m is equivalent to m~. This is to keep things like -1m, 0m and +1m consistent
+		{"0m", "2025-03-10T06:32:00Z", "2025-03-10T06:33:00Z", timeutil.TimeGrainSecond},
 		// We always ceil by 1st term. So this is the same as `m~`
 		{"m~ by s", "2025-03-10T06:32:00Z", "2025-03-10T06:33:00Z", timeutil.TimeGrainSecond},
 		{"-1m", "2025-03-10T06:31:00Z", "2025-03-10T06:32:00Z", timeutil.TimeGrainSecond},
@@ -41,6 +42,7 @@ func Test_Eval(t *testing.T) {
 		{"h~ by s", "2025-03-10T06:00:00Z", "2025-03-10T07:00:00Z", timeutil.TimeGrainSecond},
 
 		{"-2d", "2025-03-08T00:00:00Z", "2025-03-09T00:00:00Z", timeutil.TimeGrainDay},
+		{"-2d tz Asia/Kathmandu", "2025-03-07T18:15:00Z", "2025-03-08T18:15:00Z", timeutil.TimeGrainDay},
 		{"+2d", "2025-03-12T00:00:00Z", "2025-03-13T00:00:00Z", timeutil.TimeGrainDay},
 		{"<2d", "2025-03-10T00:00:00Z", "2025-03-12T00:00:00Z", timeutil.TimeGrainDay},
 		{">2d", "2025-03-15T00:00:00Z", "2025-03-17T00:00:00Z", timeutil.TimeGrainDay},
@@ -64,10 +66,11 @@ func Test_Eval(t *testing.T) {
 		{"W1 by H", "2025-03-03T00:00:00Z", "2025-03-10T00:00:00Z", timeutil.TimeGrainHour},
 		// `of M` means previous month, so this will be of Feb. Since 1st of feb is on a friday we take the next monday as start.
 		{"W1 of M", "2025-02-03T00:00:00Z", "2025-02-10T00:00:00Z", timeutil.TimeGrainDay},
+		{"W1 of M tz Asia/Kathmandu", "2025-02-02T18:15:00Z", "2025-02-09T18:15:00Z", timeutil.TimeGrainDay},
 		// `of M~` means to use current month unlike `of M`
 		{"W1 of M~", "2025-03-03T00:00:00Z", "2025-03-10T00:00:00Z", timeutil.TimeGrainDay},
-		// `of 0M` means previous month.
-		{"W1 of 0M", "2025-02-03T00:00:00Z", "2025-02-10T00:00:00Z", timeutil.TimeGrainDay},
+		// `of 0M` means current month.
+		{"W1 of 0M", "2025-03-03T00:00:00Z", "2025-03-10T00:00:00Z", timeutil.TimeGrainDay},
 		// 1st of Jan is on a Wednesday, so include the 2 days from Dec 2024.
 		{"W1 of -2M", "2024-12-30T00:00:00Z", "2025-01-06T00:00:00Z", timeutil.TimeGrainDay},
 		// 1st of May is on a Thursday, so include the 2 days from Dec 2024.
@@ -80,9 +83,11 @@ func Test_Eval(t *testing.T) {
 		{"2025-03-09T09:30", "2025-03-09T09:30:00Z", "2025-03-09T09:31:00Z", timeutil.TimeGrainSecond},
 		{"2025-03-09T09", "2025-03-09T09:00:00Z", "2025-03-09T10:00:00Z", timeutil.TimeGrainMinute},
 		{"2025-03-09", "2025-03-09T00:00:00Z", "2025-03-10T00:00:00Z", timeutil.TimeGrainHour},
-		{"2025-03", "2025-03-01T00:00:00Z", "2025-04-01T00:00:00Z", timeutil.TimeGrainWeek},
+		{"2025-03", "2025-03-01T00:00:00Z", "2025-04-01T00:00:00Z", timeutil.TimeGrainDay},
+		{"2025-03 tz Asia/Kathmandu", "2025-02-28T18:15:00Z", "2025-03-31T18:15:00Z", timeutil.TimeGrainDay},
 		{"2025", "2025-01-01T00:00:00Z", "2026-01-01T00:00:00Z", timeutil.TimeGrainMonth},
 		{"D3 of W1 of 2022", "2022-01-05T00:00:00Z", "2022-01-06T00:00:00Z", timeutil.TimeGrainHour},
+		{"D3 of W1 of 2022 tz Asia/Kathmandu", "2022-01-04T18:15:00Z", "2022-01-05T18:15:00Z", timeutil.TimeGrainHour},
 		{"<3m of H2 of 2025-02-04", "2025-02-04T01:00:00Z", "2025-02-04T01:03:00Z", timeutil.TimeGrainMinute},
 
 		{"W1 to W3", "2025-03-03T00:00:00Z", "2025-03-17T00:00:00Z", timeutil.TimeGrainDay},

--- a/runtime/pkg/timeutil/timeutil.go
+++ b/runtime/pkg/timeutil/timeutil.go
@@ -185,31 +185,31 @@ func AddTimeProto(to time.Time, tg runtimev1.TimeGrain, count int) time.Time {
 	return to
 }
 
-func OffsetTime(tm time.Time, tg TimeGrain, n int) time.Time {
+func OffsetTime(tm time.Time, tg TimeGrain, tz *time.Location, n int) time.Time {
+	tm = tm.In(tz)
 	switch tg {
 	case TimeGrainUnspecified:
-		return tm
 	case TimeGrainMillisecond:
-		return tm.Add(time.Duration(n) * time.Millisecond)
+		tm = tm.Add(time.Duration(n) * time.Millisecond)
 	case TimeGrainSecond:
-		return tm.Add(time.Duration(n) * time.Second)
+		tm = tm.Add(time.Duration(n) * time.Second)
 	case TimeGrainMinute:
-		return tm.Add(time.Duration(n) * time.Minute)
+		tm = tm.Add(time.Duration(n) * time.Minute)
 	case TimeGrainHour:
-		return tm.Add(time.Duration(n) * time.Hour)
+		tm = tm.Add(time.Duration(n) * time.Hour)
 	case TimeGrainDay:
-		return tm.AddDate(0, 0, n)
+		tm = tm.AddDate(0, 0, n)
 	case TimeGrainWeek:
-		return tm.AddDate(0, 0, n*7)
+		tm = tm.AddDate(0, 0, n*7)
 	case TimeGrainMonth:
-		return tm.AddDate(0, n, 0)
+		tm = tm.AddDate(0, n, 0)
 	case TimeGrainQuarter:
-		return tm.AddDate(0, n*3, 0)
+		tm = tm.AddDate(0, n*3, 0)
 	case TimeGrainYear:
-		return tm.AddDate(n, 0, 0)
+		tm = tm.AddDate(n, 0, 0)
 	}
 
-	return tm
+	return tm.In(time.UTC)
 }
 
 // CopyTimeComponentsUntil Copies components of `src` into `tar` starting from year and going down all the way to `until` (inclusive).


### PR DESCRIPTION
1. `0D` should be equal to `D~` instead of `-1D`. This makes `-1D`, `0D` and `+1D` consistent.
2. Also update the timezone for the new syntax. With some fixes to certain scenarios.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
