### PR TITLE
fix: first time deployment dialog not showing

### DIFF
--- a/web-common/src/features/dashboards/workspace/DeployProjectCTA.svelte
+++ b/web-common/src/features/dashboards/workspace/DeployProjectCTA.svelte
@@ -36,10 +36,14 @@
       refetchOnWindowFocus: true,
     },
   });
+
   $: isDeployed = !!$currentProject.data?.project;
+  $: userNotLoggedIn = !$user.data?.user;
+  $: everyOrgHasNeverSubscribed = $orgsMetadata.data?.orgs?.every(
+    (o) => !!getNeverSubscribedIssue(o.issues),
+  );
   $: isFirstTimeDeploy =
-    !isDeployed &&
-    $orgsMetadata.data?.orgs?.every((o) => !!getNeverSubscribedIssue(o.issues));
+    !isDeployed && (userNotLoggedIn || everyOrgHasNeverSubscribed);
 
   $: allowPrimary.set(isDeployed || !hasValidDashboard);
 
@@ -48,7 +52,7 @@
 
   $: deployPageUrl = `${$page.url.protocol}//${$page.url.host}/deploy`;
 
-  $: if (!$user.data?.user && $metadata.data) {
+  $: if (userNotLoggedIn && $metadata.data) {
     deployCTAUrl = `${$metadata.data.loginUrl}?redirect=${deployPageUrl}`;
   } else {
     deployCTAUrl = deployPageUrl;


### PR DESCRIPTION
closes https://github.com/rilldata/rill-private-issues/issues/1322

We need to show the first time deployment to new users. But new users are most likely to not be logged in or registered even. So as a hack we also show the message to users not logged in.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
