### PR TITLE
fix: toggle on comparisons

### DIFF
--- a/web-common/src/features/dashboards/state-managers/actions/leaderboard.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/leaderboard.ts
@@ -23,6 +23,9 @@ export const setLeaderboardShowContextForAllMeasures = (
   showAllMeasures: boolean,
 ) => {
   dashboard.leaderboardShowContextForAllMeasures = showAllMeasures;
+  if (showAllMeasures && !dashboard.showTimeComparison) {
+    dashboard.showTimeComparison = true;
+  }
 };
 
 export const leaderboardActions = {


### PR DESCRIPTION
If Show context for all measures is set to true and time comparison is off. Toggle it on to save the user one click.


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
