### PR TITLE
fix (Pinot): Update client-side `yup` schema

### DIFF
--- a/runtime/drivers/athena/athena.go
+++ b/runtime/drivers/athena/athena.go
@@ -32,6 +32,7 @@ var spec = drivers.Spec{
 			Secret: true,
 		},
 	},
+	// Important: Any edits to the below properties must be accompanied by changes to the client-side form validation schemas.
 	SourceProperties: []*drivers.PropertySpec{
 		{
 			Key:         "sql",

--- a/runtime/drivers/azure/azure.go
+++ b/runtime/drivers/azure/azure.go
@@ -43,6 +43,7 @@ var spec = drivers.Spec{
 			Secret: true,
 		},
 	},
+	// Important: Any edits to the below properties must be accompanied by changes to the client-side form validation schemas.
 	SourceProperties: []*drivers.PropertySpec{
 		{
 			Key:         "path",

--- a/runtime/drivers/bigquery/bigquery.go
+++ b/runtime/drivers/bigquery/bigquery.go
@@ -32,6 +32,7 @@ var spec = drivers.Spec{
 			Hint: "Enter path of file to load from.",
 		},
 	},
+	// Important: Any edits to the below properties must be accompanied by changes to the client-side form validation schemas.
 	SourceProperties: []*drivers.PropertySpec{
 		{
 			Key:         "sql",

--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -32,6 +32,7 @@ var spec = drivers.Spec{
 	DisplayName: "ClickHouse",
 	Description: "Connect to ClickHouse.",
 	DocsURL:     "https://docs.rilldata.com/reference/olap-engines/clickhouse",
+	// Important: Any edits to the below properties must be accompanied by changes to the client-side form validation schemas.
 	ConfigProperties: []*drivers.PropertySpec{
 		{
 			Key:         "dsn",

--- a/runtime/drivers/druid/druid.go
+++ b/runtime/drivers/druid/druid.go
@@ -33,6 +33,7 @@ var spec = drivers.Spec{
 	DisplayName: "Druid",
 	Description: "Connect to Apache Druid.",
 	DocsURL:     "https://docs.rilldata.com/reference/olap-engines/druid",
+	// Important: Any edits to the below properties must be accompanied by changes to the client-side form validation schemas.
 	ConfigProperties: []*drivers.PropertySpec{
 		{
 			Key:         "dsn",

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -49,6 +49,7 @@ var spec = drivers.Spec{
 			Placeholder: "/path/to/main.db",
 		},
 	},
+	// Important: Any edits to the below properties must be accompanied by changes to the client-side form validation schemas.
 	SourceProperties: []*drivers.PropertySpec{
 		{
 			Key:         "db",

--- a/runtime/drivers/gcs/gcs.go
+++ b/runtime/drivers/gcs/gcs.go
@@ -38,6 +38,7 @@ var spec = drivers.Spec{
 			Hint: "Enter path of file to load from.",
 		},
 	},
+	// Important: Any edits to the below properties must be accompanied by changes to the client-side form validation schemas.
 	SourceProperties: []*drivers.PropertySpec{
 		{
 			Key:         "path",

--- a/runtime/drivers/https/https.go
+++ b/runtime/drivers/https/https.go
@@ -24,6 +24,7 @@ func init() {
 var spec = drivers.Spec{
 	DisplayName: "https",
 	Description: "Connect to a remote file.",
+	// Important: Any edits to the below properties must be accompanied by changes to the client-side form validation schemas.
 	SourceProperties: []*drivers.PropertySpec{
 		{
 			Key:         "path",

--- a/runtime/drivers/mysql/mysql.go
+++ b/runtime/drivers/mysql/mysql.go
@@ -27,6 +27,7 @@ var spec = drivers.Spec{
 			Secret:      true,
 		},
 	},
+	// Important: Any edits to the below properties must be accompanied by changes to the client-side form validation schemas.
 	SourceProperties: []*drivers.PropertySpec{
 		{
 			Key:         "sql",

--- a/runtime/drivers/pinot/pinot.go
+++ b/runtime/drivers/pinot/pinot.go
@@ -26,6 +26,7 @@ var spec = drivers.Spec{
 	DisplayName: "Pinot",
 	Description: "Connect to Apache Pinot.",
 	DocsURL:     "https://docs.rilldata.com/reference/olap-engines/pinot",
+	// Important: Any edits to the below properties must be accompanied by changes to the client-side form validation schemas.
 	ConfigProperties: []*drivers.PropertySpec{
 		{
 			Key:         "dsn",

--- a/runtime/drivers/postgres/postgres.go
+++ b/runtime/drivers/postgres/postgres.go
@@ -25,6 +25,7 @@ var spec = drivers.Spec{
 			Secret: true,
 		},
 	},
+	// Important: Any edits to the below properties must be accompanied by changes to the client-side form validation schemas.
 	SourceProperties: []*drivers.PropertySpec{
 		{
 			Key:         "sql",

--- a/runtime/drivers/redshift/redshift.go
+++ b/runtime/drivers/redshift/redshift.go
@@ -32,6 +32,7 @@ var spec = drivers.Spec{
 			Secret: true,
 		},
 	},
+	// Important: Any edits to the below properties must be accompanied by changes to the client-side form validation schemas.
 	SourceProperties: []*drivers.PropertySpec{
 		{
 			Key:         "sql",

--- a/runtime/drivers/s3/s3.go
+++ b/runtime/drivers/s3/s3.go
@@ -29,6 +29,7 @@ var spec = drivers.Spec{
 			Secret: true,
 		},
 	},
+	// Important: Any edits to the below properties must be accompanied by changes to the client-side form validation schemas.
 	SourceProperties: []*drivers.PropertySpec{
 		{
 			Key:         "path",

--- a/runtime/drivers/salesforce/salesforce.go
+++ b/runtime/drivers/salesforce/salesforce.go
@@ -53,6 +53,7 @@ var spec = drivers.Spec{
 			Secret: false,
 		},
 	},
+	// Important: Any edits to the below properties must be accompanied by changes to the client-side form validation schemas.
 	SourceProperties: []*drivers.PropertySpec{
 		{
 			Key:         "soql",

--- a/runtime/drivers/snowflake/snowflake.go
+++ b/runtime/drivers/snowflake/snowflake.go
@@ -29,6 +29,7 @@ var spec = drivers.Spec{
 			Secret: true,
 		},
 	},
+	// Important: Any edits to the below properties must be accompanied by changes to the client-side form validation schemas.
 	SourceProperties: []*drivers.PropertySpec{
 		{
 			Key:         "sql",

--- a/runtime/drivers/sqlite/sqlite.go
+++ b/runtime/drivers/sqlite/sqlite.go
@@ -56,6 +56,7 @@ func (d driver) Spec() drivers.Spec {
 	return drivers.Spec{
 		DisplayName: "SQLite",
 		Description: "Import data from SQLite into DuckDB.",
+		// Important: Any edits to the below properties must be accompanied by changes to the client-side form validation schemas.
 		SourceProperties: []*drivers.PropertySpec{
 			{
 				Key:         "db",

--- a/web-common/src/features/sources/modal/yupSchemas.ts
+++ b/web-common/src/features/sources/modal/yupSchemas.ts
@@ -201,14 +201,24 @@ export const getYupSchema = {
   }),
 
   pinot: yup.object().shape({
-    host: yup
+    broker_host: yup
       .string()
-      .required("Host is required")
+      .required("Broker host is required")
       .matches(
         /^(?!https?:\/\/)[a-zA-Z0-9.-]+$/,
         "Do not prefix the host with `http(s)://`", // It will be added by the runtime
       ),
-    port: yup
+    broker_port: yup
+      .string() // Purposefully using a string input, not a numeric input
+      .matches(/^\d+$/, "Port must be a number"),
+    controller_host: yup
+      .string()
+      .required("Controller host is required")
+      .matches(
+        /^(?!https?:\/\/)[a-zA-Z0-9.-]+$/,
+        "Do not prefix the host with `http(s)://`", // It will be added by the runtime
+      ),
+    controller_port: yup
       .string() // Purposefully using a string input, not a numeric input
       .matches(/^\d+$/, "Port must be a number"),
     username: yup.string(),


### PR DESCRIPTION
Our backend schema for Pinot connectors changed, yet we hadn't updated our frontend schema that we use for form validation. This PR updates the frontend `yup` schema, so that the two match.

Going forward, we should consider moving toward a common JSON Schema that can be used by both the backend & frontend.

Addresses [this Slack report](https://rilldata.slack.com/archives/CTZ8XBQ85/p1745423185035169)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
