### PR TITLE
Revert concurrent writes in duckdb

### DIFF
--- a/runtime/drivers/duckdb/config.go
+++ b/runtime/drivers/duckdb/config.go
@@ -13,10 +13,8 @@ const (
 
 // config represents the DuckDB driver config
 type config struct {
-	// ReadPoolSize is the number of concurrent connections and read queries allowed
-	ReadPoolSize int `mapstructure:"pool_size"`
-	// WritePoolSize is the maximum number of concurrent write connections allowed.
-	WritePoolSize int `mapstructure:"write_pool_size"`
+	// PoolSize is the number of concurrent connections and queries allowed
+	PoolSize int `mapstructure:"pool_size"`
 	// AllowHostAccess denotes whether to limit access to the local environment and file system
 	AllowHostAccess bool `mapstructure:"allow_host_access"`
 	// CPU cores available for the DB. If no ratio is set then this is split evenly between read and write.
@@ -43,12 +41,12 @@ func newConfig(cfgMap map[string]any) (*config, error) {
 	}
 
 	// Set pool size
-	poolSize := cfg.ReadPoolSize
+	poolSize := cfg.PoolSize
 	if poolSize == 0 && cfg.CPU != 0 {
 		poolSize = min(poolSizeMax, cfg.CPU) // Only enforce max pool size when inferred from CPU
 	}
 	poolSize = max(poolSizeMin, poolSize) // Always enforce min pool size
-	cfg.ReadPoolSize = poolSize
+	cfg.PoolSize = poolSize
 	return cfg, nil
 }
 

--- a/runtime/drivers/duckdb/config_test.go
+++ b/runtime/drivers/duckdb/config_test.go
@@ -18,19 +18,19 @@ import (
 func TestConfig(t *testing.T) {
 	cfg, err := newConfig(map[string]any{})
 	require.NoError(t, err)
-	require.Equal(t, 2, cfg.ReadPoolSize)
+	require.Equal(t, 2, cfg.PoolSize)
 
 	cfg, err = newConfig(map[string]any{"dsn": "", "cpu": 2})
 	require.NoError(t, err)
-	require.Equal(t, 2, cfg.ReadPoolSize)
+	require.Equal(t, 2, cfg.PoolSize)
 
 	cfg, err = newConfig(map[string]any{"pool_size": 10})
 	require.NoError(t, err)
-	require.Equal(t, 10, cfg.ReadPoolSize)
+	require.Equal(t, 10, cfg.PoolSize)
 
 	cfg, err = newConfig(map[string]any{"dsn": "duck.db", "memory_limit_gb": "8", "cpu": "2"})
 	require.NoError(t, err)
-	require.Equal(t, 2, cfg.ReadPoolSize)
+	require.Equal(t, 2, cfg.PoolSize)
 }
 
 func Test_specialCharInPath(t *testing.T) {

--- a/runtime/drivers/duckdb/crud.go
+++ b/runtime/drivers/duckdb/crud.go
@@ -19,6 +19,7 @@ type tableWriteMetrics struct {
 
 type createTableOptions struct {
 	view         bool
+	initQueries  []string
 	beforeCreate string
 	afterCreate  string
 }
@@ -46,6 +47,7 @@ func (c *connection) createTableAsSelect(ctx context.Context, name, sql string, 
 	}
 	res, err := db.CreateTableAsSelect(ctx, name, sql, &rduckdb.CreateTableOptions{
 		View:           opts.view,
+		InitQueries:    opts.initQueries,
 		BeforeCreateFn: beforeCreateFn,
 		AfterCreateFn:  afterCreateFn,
 	})

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -146,7 +146,7 @@ func (d Driver) Open(instanceID string, cfgMap map[string]any, st *storage.Clien
 	}
 
 	// See note in connection struct
-	olapSemSize := cfg.ReadPoolSize - 1
+	olapSemSize := cfg.PoolSize - 1
 	if olapSemSize < 1 {
 		olapSemSize = 1
 	}
@@ -456,13 +456,11 @@ func (c *connection) reopenDB(ctx context.Context) error {
 		"INSTALL 'icu'",
 		"INSTALL 'parquet'",
 		"INSTALL 'httpfs'",
-		"INSTALL 'aws'",
 		"LOAD 'json'",
 		"LOAD 'sqlite'",
 		"LOAD 'icu'",
 		"LOAD 'parquet'",
 		"LOAD 'httpfs'",
-		"LOAD 'aws'",
 		"SET GLOBAL timezone='UTC'",
 		"SET GLOBAL old_implicit_casting = true", // Implicit Cast to VARCHAR
 		"SET GLOBAL allow_community_extensions = false", // This locks the configuration, so it can't later be enabled.
@@ -496,7 +494,6 @@ func (c *connection) reopenDB(ctx context.Context) error {
 		ReadWriteRatio:  c.config.ReadWriteRatio,
 		ReadSettings:    c.config.readSettings(),
 		WriteSettings:   c.config.writeSettings(),
-		WritePoolSize:   c.config.WritePoolSize,
 		DBInitQueries:   dbInitQueries,
 		ConnInitQueries: connInitQueries,
 		LogQueries:      c.config.LogQueries,

--- a/runtime/drivers/duckdb/model_executor_motherduck_self.go
+++ b/runtime/drivers/duckdb/model_executor_motherduck_self.go
@@ -81,8 +81,8 @@ func (e *mdToSelfExecutor) Execute(ctx context.Context, opts *drivers.ModelExecu
 
 	clone := *opts
 	m := &ModelInputProperties{
-		SQL:     inputProps.SQL,
-		PreExec: fmt.Sprintf("INSTALL 'motherduck'; LOAD 'motherduck'; SET motherduck_token=%s; ATTACH IF NOT EXISTS %s;", safeSQLString(token), safeSQLString(inputProps.resolveDSN())),
+		SQL:         inputProps.SQL,
+		InitQueries: fmt.Sprintf("INSTALL 'motherduck'; LOAD 'motherduck'; SET motherduck_token=%s; ATTACH %s;", safeSQLString(token), safeSQLString(inputProps.resolveDSN())),
 	}
 	var props map[string]any
 	err = mapstructure.Decode(m, &props)

--- a/runtime/drivers/duckdb/model_executor_objectstore_self.go
+++ b/runtime/drivers/duckdb/model_executor_objectstore_self.go
@@ -125,7 +125,7 @@ func objectStoreSecretSQL(ctx context.Context, path, model, inputConnector strin
 			return "", fmt.Errorf("failed to parse s3 config properties: %w", err)
 		}
 		var sb strings.Builder
-		sb.WriteString("CREATE TEMPORARY SECRET IF NOT EXISTS ")
+		sb.WriteString("CREATE OR REPLACE TEMPORARY SECRET ")
 		sb.WriteString(safeSecretName)
 		sb.WriteString(" (TYPE S3")
 		if s3Config.AllowHostAccess {
@@ -183,7 +183,7 @@ func objectStoreSecretSQL(ctx context.Context, path, model, inputConnector strin
 			return "", errGCSUsesNativeCreds
 		}
 		var sb strings.Builder
-		sb.WriteString("CREATE TEMPORARY SECRET IF NOT EXISTS ")
+		sb.WriteString("CREATE OR REPLACE TEMPORARY SECRET ")
 		sb.WriteString(safeSecretName)
 		sb.WriteString(" (TYPE GCS")
 		if gcsConfig.AllowHostAccess {
@@ -201,7 +201,7 @@ func objectStoreSecretSQL(ctx context.Context, path, model, inputConnector strin
 			return "", fmt.Errorf("failed to parse s3 config properties: %w", err)
 		}
 		var sb strings.Builder
-		sb.WriteString("CREATE TEMPORARY SECRET IF NOT EXISTS ")
+		sb.WriteString("CREATE OR REPLACE TEMPORARY SECRET ")
 		sb.WriteString(safeSecretName)
 		sb.WriteString(" (TYPE AZURE")
 		// if connection string is set then use that and fall back to env credentials only if host access is allowed and connection string is not set

--- a/runtime/drivers/duckdb/model_executor_self.go
+++ b/runtime/drivers/duckdb/model_executor_self.go
@@ -130,6 +130,9 @@ func (e *selfToSelfExecutor) Execute(ctx context.Context, opts *drivers.ModelExe
 				beforeCreate: inputProps.PreExec,
 				afterCreate:  inputProps.PostExec,
 			}
+			if inputProps.InitQueries != "" {
+				createTableOpts.initQueries = []string{inputProps.InitQueries}
+			}
 			res, err := e.c.createTableAsSelect(ctx, stagingTableName, inputProps.SQL, createTableOpts)
 			if err != nil {
 				_ = e.c.dropTable(ctx, stagingTableName)
@@ -153,6 +156,9 @@ func (e *selfToSelfExecutor) Execute(ctx context.Context, opts *drivers.ModelExe
 			ByName:       false,
 			Strategy:     outputProps.IncrementalStrategy,
 			UniqueKey:    outputProps.UniqueKey,
+		}
+		if inputProps.InitQueries != "" {
+			insertTableOpts.InitQueries = []string{inputProps.InitQueries}
 		}
 		res, err := e.c.insertTableAsSelect(ctx, tableName, inputProps.SQL, insertTableOpts)
 		if err != nil {
@@ -192,12 +198,9 @@ func (e *selfToSelfExecutor) createFromExternalDuckDB(ctx context.Context, input
 			}
 		}
 
-		if _, err := conn.ExecContext(ctx, fmt.Sprintf("ATTACH IF NOT EXISTS %s AS %s (READ_ONLY)", safeSQLString(inputProps.Database), safeDBName)); err != nil {
+		if _, err := conn.ExecContext(ctx, fmt.Sprintf("ATTACH %s AS %s (READ_ONLY)", safeSQLString(inputProps.Database), safeDBName)); err != nil {
 			return err
 		}
-		defer func() {
-			_, _ = conn.ExecContext(ctx, fmt.Sprintf("DETACH %s;", safeDBName))
-		}()
 
 		var localDB, localSchema string
 		if err := conn.QueryRowxContext(ctx, "SELECT current_database(),current_schema();").Scan(&localDB, &localSchema); err != nil {
@@ -213,7 +216,7 @@ func (e *selfToSelfExecutor) createFromExternalDuckDB(ctx context.Context, input
 		query := fmt.Sprintf("CREATE OR REPLACE TABLE %s.%s.%s AS (%s\n);", safeName(localDB), safeName(localSchema), safeTempTable, userQuery)
 		_, execErr := conn.ExecContext(ctx, query)
 		// revert to localdb and schema before returning
-		_, err := conn.ExecContext(context.Background(), fmt.Sprintf("USE %s.%s;", safeName(localDB), safeName(localSchema)))
+		_, err := conn.ExecContext(ctx, fmt.Sprintf("USE %s.%s;", safeName(localDB), safeName(localSchema)))
 		return errors.Join(execErr, err)
 	}
 	afterCreateFn := func(ctx context.Context, conn *sqlx.Conn) error {

--- a/runtime/drivers/duckdb/model_manager.go
+++ b/runtime/drivers/duckdb/model_manager.go
@@ -10,10 +10,12 @@ import (
 )
 
 type ModelInputProperties struct {
-	SQL      string `mapstructure:"sql"`
-	Args     []any  `mapstructure:"args"`
-	PreExec  string `mapstructure:"pre_exec"`
-	PostExec string `mapstructure:"post_exec"`
+	SQL  string `mapstructure:"sql"`
+	Args []any  `mapstructure:"args"`
+	// InitQueries are queries that are run during initialisation of write handle before model is created of any pre_exec queries are run.
+	InitQueries string `mapstructure:"init_queries"`
+	PreExec     string `mapstructure:"pre_exec"`
+	PostExec    string `mapstructure:"post_exec"`
 	// Database is set if sql is to be run against an external database
 	Database string `mapstructure:"db"`
 }

--- a/runtime/pkg/rduckdb/db.go
+++ b/runtime/pkg/rduckdb/db.go
@@ -906,10 +906,8 @@ func (d *db) acquireWriteConn(ctx context.Context, dbPath, table string, attachE
 		ctx, cancel := graceful.WithMinimumDuration(ctx, 15*time.Second)
 		defer cancel()
 
-		// run an explicit checkpoint in the attached DB to make sure that the wal file is flushed
-		_, cpErr := conn.ExecContext(ctx, "CHECKPOINT "+attachName)
-		_, deErr := conn.ExecContext(ctx, "DETACH "+attachName)
-		return errors.Join(cpErr, deErr, conn.Close())
+		_, err := conn.ExecContext(ctx, "DETACH "+attachName)
+		return errors.Join(err, conn.Close())
 	}
 	return conn, releaseFn, nil
 }

--- a/runtime/pkg/rduckdb/db.go
+++ b/runtime/pkg/rduckdb/db.go
@@ -16,13 +16,11 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/XSAM/otelsql"
 	"github.com/jmoiron/sqlx"
 	"github.com/marcboeker/go-duckdb"
-	"github.com/rilldata/rill/runtime/pkg/graceful"
 	"github.com/rilldata/rill/runtime/pkg/observability"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -87,9 +85,6 @@ type DBOptions struct {
 	ReadSettings map[string]string
 	// WriteSettings are settings applied the write duckDB handle.
 	WriteSettings map[string]string
-	// WritePoolSize is the maximum number of concurrent connections to the write duckDB handle.
-	// If val is zero then a default value is used.
-	WritePoolSize int `mapstructure:"write_conn_limit"`
 	// DBInitQueries are run when the database is first created. These are typically global duckdb configurations.
 	DBInitQueries []string
 	// ConnInitQueries are run when a new connection is created. These are typically local duckdb configurations.
@@ -169,6 +164,9 @@ func (d *DBOptions) ValidateSettings() error {
 type CreateTableOptions struct {
 	// View specifies whether the created table is a view.
 	View bool
+	// InitQueries are queries that are run during initialisation of write handle. Applies only to the current table.
+	// For queries that should apply to all tables refer to DBOptions.ConnInitQueries
+	InitQueries []string
 	// If BeforeCreateFn is set, it will be executed before the create query is executed.
 	BeforeCreateFn func(ctx context.Context, conn *sqlx.Conn) error
 	// If AfterCreateFn is set, it will be executed after the create query is executed.
@@ -192,17 +190,15 @@ func NewDB(ctx context.Context, opts *DBOptions) (DB, error) {
 
 	bgctx, cancel := context.WithCancel(context.Background())
 	db := &db{
-		opts:               opts,
-		localPath:          opts.LocalPath,
-		remote:             opts.Remote,
-		writeMetaSem:       semaphore.NewWeighted(1),
-		readMetaSem:        semaphore.NewWeighted(1),
-		localDirty:         true,
-		writesInProgress:   make(map[string]any),
-		writesInProgressMu: sync.Mutex{},
-		logger:             opts.Logger,
-		ctx:                bgctx,
-		cancel:             cancel,
+		opts:       opts,
+		localPath:  opts.LocalPath,
+		remote:     opts.Remote,
+		writeSem:   semaphore.NewWeighted(1),
+		metaSem:    semaphore.NewWeighted(1),
+		localDirty: true,
+		logger:     opts.Logger,
+		ctx:        bgctx,
+		cancel:     cancel,
 	}
 	// create local path
 	err = os.MkdirAll(db.localPath, fs.ModePerm)
@@ -280,7 +276,7 @@ func NewDB(ctx context.Context, opts *DBOptions) (DB, error) {
 		opts.Logger,
 	)
 
-	db.read, err = db.openDBAndAttach(ctx, filepath.Join(db.localPath, "main.db"), "", nil, true)
+	db.dbHandle, err = db.openDBAndAttach(ctx, filepath.Join(db.localPath, "main.db"), "", nil, true)
 	if err != nil {
 		if strings.Contains(err.Error(), "Symbol not found") {
 			fmt.Printf("Your version of macOS is not supported. Please upgrade to the latest major release of macOS. See this link for details: https://support.apple.com/en-in/macos/upgrade")
@@ -288,19 +284,6 @@ func NewDB(ctx context.Context, opts *DBOptions) (DB, error) {
 		}
 		return nil, err
 	}
-	db.write, err = db.openDBAndAttach(ctx, "", "", nil, false)
-	if err != nil {
-		return nil, fmt.Errorf("unable to open write db: %w", err)
-	}
-	// always create new connection for write queries
-	// we switch schemas during writes and failure to switch back to default schema can lead to query failures
-	db.write.SetMaxIdleConns(0)
-	// limit the number of open connections to the write db which limits the number of concurrent ingestions
-	limit := db.opts.WritePoolSize
-	if limit <= 0 {
-		limit = 5
-	}
-	db.write.SetMaxOpenConns(limit)
 
 	go db.localDBMonitor()
 	return db, nil
@@ -312,25 +295,16 @@ type db struct {
 	localPath string
 	remote    *blob.Bucket
 
-	// read serves executes meta queries and serves read queries
-	read *sqlx.DB
-	// write executes write queries
-	write *sqlx.DB
-	// writeMetaSem ensures only one meta operation can run on the duckb write handle.
-	// Meta operations are pulling from remote, pushing to remote, attach detach etc.
-	writeMetaSem *semaphore.Weighted
-	// readMetaSem enures only one meta operation can run on the duckb read handle.
+	// dbHandle serves executes meta queries and serves read queries
+	dbHandle *sqlx.DB
+	// writeSem ensures only one write operation is allowed at a time
+	writeSem *semaphore.Weighted
+	// metaSem enures only one meta operation can run on a duckb handle.
 	// Meta operations are attach, detach, create view queries done on the db handle
-	readMetaSem *semaphore.Weighted
+	metaSem *semaphore.Weighted
 	// localDirty is set to true when a change is committed to the remote but not yet reflected in the local db
 	localDirty bool
 	catalog    *catalog
-
-	// writeInProgress tracks table names for which there is a write operation in progress.
-	// This is to prevent concurrent writes operating on the same table which can corrupt the database.
-	// Using a separate mutex and not writeMetaSem to allow calling untrackWrite without acquiring writeMetaSem.
-	writesInProgress   map[string]any
-	writesInProgressMu sync.Mutex
 
 	logger *zap.Logger
 
@@ -344,13 +318,13 @@ var _ DB = &db{}
 func (d *db) Close() error {
 	// close background operations
 	d.cancel()
-	return errors.Join(d.read.Close(), d.write.Close())
+	return d.dbHandle.Close()
 }
 
 func (d *db) AcquireReadConnection(ctx context.Context) (*sqlx.Conn, func() error, error) {
 	snapshot := d.catalog.acquireSnapshot()
 
-	conn, err := d.read.Connx(ctx)
+	conn, err := d.dbHandle.Connx(ctx)
 	if err != nil {
 		d.catalog.releaseSnapshot(snapshot)
 		return nil, nil, err
@@ -379,25 +353,11 @@ func (d *db) CreateTableAsSelect(ctx context.Context, name, query string, opts *
 	defer span.End()
 
 	d.logger.Debug("create: create table", zap.String("name", name), zap.Bool("view", opts.View), observability.ZapCtx(ctx))
-	// track write operation
-	err := d.trackWrite(name)
+	err := d.writeSem.Acquire(ctx, 1)
 	if err != nil {
 		return nil, err
 	}
-	defer d.untrackWrite(name)
-
-	// acquire write lock
-	err = d.writeMetaSem.Acquire(ctx, 1)
-	if err != nil {
-		return nil, err
-	}
-
-	writeSemAcquired := true
-	defer func() {
-		if writeSemAcquired {
-			d.writeMetaSem.Release(1)
-		}
-	}()
+	defer d.writeSem.Release(1)
 
 	// pull latest changes from remote
 	err = d.pullFromRemote(ctx, true)
@@ -418,8 +378,9 @@ func (d *db) CreateTableAsSelect(ctx context.Context, name, query string, opts *
 		Version:        newVersion,
 		CreatedVersion: newVersion,
 	}
-	var dbPath string
+	var dsn string
 	if opts.View {
+		dsn = ""
 		newMeta.SQL = query
 		err = d.initLocalTable(name, "")
 		if err != nil {
@@ -430,7 +391,7 @@ func (d *db) CreateTableAsSelect(ctx context.Context, name, query string, opts *
 		if err != nil {
 			return nil, fmt.Errorf("create: unable to create dir %q: %w", name, err)
 		}
-		dbPath = d.localDBPath(name, newVersion)
+		dsn = d.localDBPath(name, newVersion)
 		defer func() {
 			if createErr != nil {
 				_ = d.deleteLocalTableFiles(name, newVersion)
@@ -440,7 +401,7 @@ func (d *db) CreateTableAsSelect(ctx context.Context, name, query string, opts *
 
 	t := time.Now()
 	// need to attach existing table so that any views dependent on this table are correctly attached
-	conn, release, err := d.acquireWriteConn(ctx, dbPath, name, true)
+	conn, release, err := d.acquireWriteConn(ctx, dsn, name, opts.InitQueries, true)
 	if err != nil {
 		return nil, err
 	}
@@ -449,13 +410,6 @@ func (d *db) CreateTableAsSelect(ctx context.Context, name, query string, opts *
 		_ = release()
 	}()
 
-	// start running user queries
-	//
-	// given runnning user queries is the most intensive operation and assuming following constraints, we can release the lock and run user queries concurrently:
-	// 1. A table write attaches all other databases in read only mode and writes to a different database
-	// 2. Reconciler makes sure that dependent resources are not reconciled concurrently
-	d.writeMetaSem.Release(1)
-	writeSemAcquired = false
 	t = time.Now()
 	safeName := safeSQLName(name)
 	var typ string
@@ -499,13 +453,6 @@ func (d *db) CreateTableAsSelect(ctx context.Context, name, query string, opts *
 		return nil, err
 	}
 
-	// acquire the handle again
-	err = d.writeMetaSem.Acquire(ctx, 1)
-	if err != nil {
-		return nil, err
-	}
-	writeSemAcquired = true
-
 	// update remote data and metadata
 	if err := d.pushToRemote(ctx, name, oldMeta, newMeta); err != nil {
 		return nil, fmt.Errorf("create: replicate failed: %w", err)
@@ -530,24 +477,11 @@ func (d *db) MutateTable(ctx context.Context, name string, initQueries []string,
 	defer span.End()
 
 	d.logger.Debug("mutate table", zap.String("name", name), observability.ZapCtx(ctx))
-
-	// track write operation
-	err := d.trackWrite(name)
+	err := d.writeSem.Acquire(ctx, 1)
 	if err != nil {
 		return nil, err
 	}
-	defer d.untrackWrite(name)
-
-	writeSemAcquired := true
-	err = d.writeMetaSem.Acquire(ctx, 1)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if writeSemAcquired {
-			d.writeMetaSem.Release(1)
-		}
-	}()
+	defer d.writeSem.Release(1)
 
 	// pull latest changes from remote
 	err = d.pullFromRemote(ctx, true)
@@ -575,16 +509,13 @@ func (d *db) MutateTable(ctx context.Context, name string, initQueries []string,
 	// acquire write connection
 	// need to ignore attaching table since it is already present in the db file
 	t := time.Now()
-	conn, release, err := d.acquireWriteConn(ctx, d.localDBPath(name, newVersion), name, false)
+	conn, release, err := d.acquireWriteConn(ctx, d.localDBPath(name, newVersion), name, initQueries, false)
 	if err != nil {
 		_ = os.RemoveAll(newDir)
 		return nil, err
 	}
 	span.SetAttributes(attribute.Float64("acquire_write_conn_duration", time.Since(t).Seconds()))
 
-	// run user queries
-	d.writeMetaSem.Release(1)
-	writeSemAcquired = false
 	t = time.Now()
 	err = mutateFn(ctx, conn)
 	if err != nil {
@@ -595,15 +526,6 @@ func (d *db) MutateTable(ctx context.Context, name string, initQueries []string,
 
 	duration := time.Since(t)
 	span.SetAttributes(attribute.Float64("query_duration", duration.Seconds()))
-
-	// acquire write mutex again
-	err = d.writeMetaSem.Acquire(ctx, 1)
-	if err != nil {
-		_ = os.RemoveAll(newDir)
-		_ = release()
-		return nil, err
-	}
-	writeSemAcquired = true
 
 	// push to remote
 	err = release()
@@ -643,19 +565,11 @@ func (d *db) DropTable(ctx context.Context, name string) error {
 	defer span.End()
 
 	d.logger.Debug("drop table", zap.String("name", name), observability.ZapCtx(ctx))
-
-	// track write operation
-	err := d.trackWrite(name)
+	err := d.writeSem.Acquire(ctx, 1)
 	if err != nil {
 		return err
 	}
-	d.untrackWrite(name)
-
-	err = d.writeMetaSem.Acquire(ctx, 1)
-	if err != nil {
-		return err
-	}
-	defer d.writeMetaSem.Release(1)
+	defer d.writeSem.Release(1)
 
 	// pull latest changes from remote
 	err = d.pullFromRemote(ctx, true)
@@ -693,24 +607,11 @@ func (d *db) RenameTable(ctx context.Context, oldName, newName string) error {
 	if strings.EqualFold(oldName, newName) {
 		return fmt.Errorf("rename: Table with name %q already exists", newName)
 	}
-
-	// track write for both old and new table
-	err := d.trackWrite(oldName)
+	err := d.writeSem.Acquire(ctx, 1)
 	if err != nil {
 		return err
 	}
-	defer d.untrackWrite(oldName)
-	err = d.trackWrite(newName)
-	if err != nil {
-		return err
-	}
-	defer d.untrackWrite(newName)
-
-	err = d.writeMetaSem.Acquire(ctx, 1)
-	if err != nil {
-		return err
-	}
-	defer d.writeMetaSem.Release(1)
+	defer d.writeSem.Release(1)
 
 	// pull latest changes from remote
 	err = d.pullFromRemote(ctx, true)
@@ -807,13 +708,13 @@ func (d *db) localDBMonitor() {
 		case <-d.ctx.Done():
 			return
 		case <-ticker.C:
-			// We do not want the localDBMonitor to compete with write operations so we return early if writeMetaSem is not available.
+			// We do not want the localDBMonitor to compete with write operations so we return early if writeSem is not available.
 			// Anyways if a write operation is in progress it will sync the local db
-			if !d.writeMetaSem.TryAcquire(1) {
+			if !d.writeSem.TryAcquire(1) {
 				continue
 			}
 			if !d.localDirty {
-				d.writeMetaSem.Release(1)
+				d.writeSem.Release(1)
 				// all good
 				continue
 			}
@@ -822,7 +723,7 @@ func (d *db) localDBMonitor() {
 				d.logger.Error("localDBMonitor: error in pulling from remote", zap.Error(err))
 			}
 			d.localDirty = false
-			d.writeMetaSem.Release(1)
+			d.writeSem.Release(1)
 		}
 	}
 }
@@ -840,76 +741,112 @@ func (d *db) Size() int64 {
 	return fileSize(paths)
 }
 
-func (d *db) acquireWriteConn(ctx context.Context, dbPath, table string, attachExisting bool) (conn *sqlx.Conn, rel func() error, resErr error) {
-	conn, err := d.write.Connx(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	s := d.catalog.acquireSnapshot()
-	defer func() {
-		if resErr != nil {
-			d.catalog.releaseSnapshot(s)
-			_ = conn.Close()
-		}
-	}()
-
-	var attachName string
-	if dbPath != "" {
-		attachName = safeSQLName(dbName(table, newVersion()))
-		_, err = conn.ExecContext(ctx, fmt.Sprintf("ATTACH %s AS %s", safeSQLString(dbPath), attachName))
-		if err != nil {
-			return nil, nil, err
-		}
-
-		_, err = conn.ExecContext(ctx, "USE "+attachName)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-
+// acquireWriteConn syncs the write database, initializes the write handle and returns a write connection.
+// The release function should be called to release the connection.
+// It should be called with the writeMu locked.
+func (d *db) acquireWriteConn(ctx context.Context, dsn, table string, initQueries []string, attachExisting bool) (*sqlx.Conn, func() error, error) {
 	var ignoreTable string
 	if !attachExisting {
 		ignoreTable = table
 	}
-	err = d.attachTables(ctx, conn, s.tables, ignoreTable)
+	db, err := d.openDBAndAttach(ctx, dsn, ignoreTable, initQueries, false)
 	if err != nil {
 		return nil, nil, err
 	}
+	conn, err := db.Connx(ctx)
+	if err != nil {
+		_ = db.Close()
+		return nil, nil, err
+	}
+
 	if attachExisting {
 		_, err = conn.ExecContext(ctx, "DROP VIEW IF EXISTS "+safeSQLName(table))
 		if err != nil {
+			_ = conn.Close()
+			_ = db.Close()
 			return nil, nil, err
 		}
 	}
 
-	var released bool
-	releaseFn := func() error {
-		// reject duplicate calls to release
-		if released {
-			return nil
-		}
-		released = true
-
-		d.catalog.releaseSnapshot(s)
-		if attachName == "" {
-			return conn.Close()
-		}
-
-		// revert to default database which is memory
-		_, err = conn.ExecContext(context.Background(), "USE memory")
+	// We can leave the attached databases and views in the db but we don't need them once data has been ingested in the table.
+	// This can lead to performance issues when running catalog queries across whole database.
+	// So it is better to drop all views and detach all databases before closing the write handle.
+	dropViews := func() error {
+		// remove all views created on top of attached table
+		rows, err := conn.QueryxContext(ctx, "SELECT view_name FROM duckdb_views WHERE database_name = current_database() AND internal = false")
 		if err != nil {
-			return errors.Join(err, conn.Close())
+			return err
 		}
 
-		// detach can take long time if duckdb runs compaction so we need to set a timeout to not block the caller for too long
-		ctx, cancel := graceful.WithMinimumDuration(ctx, 15*time.Second)
-		defer cancel()
-
-		_, err := conn.ExecContext(ctx, "DETACH "+attachName)
-		return errors.Join(err, conn.Close())
+		var names []string
+		for rows.Next() {
+			var name string
+			err = rows.Scan(&name)
+			if err != nil {
+				rows.Close()
+				return err
+			}
+			names = append(names, name)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		for _, name := range names {
+			_, err = conn.ExecContext(ctx, "DROP VIEW "+safeSQLName(name))
+			if err != nil {
+				return err
+			}
+		}
+		return nil
 	}
-	return conn, releaseFn, nil
+
+	detach := func() error {
+		// detach all attached databases
+		rows, err := conn.QueryxContext(ctx, "SELECT database_name FROM duckdb_databases() WHERE database_name != current_database() AND internal = false AND type NOT LIKE 'motherduck%'")
+		if err != nil {
+			return err
+		}
+
+		var names []string
+		for rows.Next() {
+			var name string
+			err = rows.Scan(&name)
+			if err != nil {
+				rows.Close()
+				return err
+			}
+			names = append(names, name)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		for _, name := range names {
+			_, err = conn.ExecContext(ctx, "DETACH DATABASE "+safeSQLName(name))
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	release := func() (err error) {
+		defer func() {
+			// close the connection and db handle
+			err = errors.Join(err, conn.Close(), db.Close())
+		}()
+		err = dropViews()
+		if err != nil {
+			return err
+		}
+		err = detach()
+		if err != nil {
+			return err
+		}
+		return err
+	}
+	return conn, release, nil
 }
 
 func (d *db) openDBAndAttach(ctx context.Context, uri, ignoreTable string, initQueries []string, read bool) (db *sqlx.DB, dbErr error) {
@@ -983,6 +920,13 @@ func (d *db) openDBAndAttach(ctx context.Context, uri, ignoreTable string, initQ
 	// Run init queries specific to this table
 	for _, qry := range initQueries {
 		_, err := db.ExecContext(ctx, qry)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !read {
+		// at the end disable any more configuration changes on the write handle via pre_exec sql
+		_, err = db.ExecContext(ctx, "SET lock_configuration TO true", nil)
 		if err != nil {
 			return nil, err
 		}
@@ -1200,29 +1144,13 @@ func (d *db) initLocalTable(name, version string) error {
 
 // removeTableVersion removes the table version from the catalog and deletes the local table files.
 func (d *db) removeTableVersion(ctx context.Context, name, version string) error {
-	detachWrite := func() error {
-		err := d.writeMetaSem.Acquire(ctx, 1)
-		if err != nil {
-			return err
-		}
-		defer d.writeMetaSem.Release(1)
-
-		_, err = d.write.ExecContext(ctx, "DETACH DATABASE IF EXISTS "+safeSQLName(dbName(name, version)))
+	err := d.metaSem.Acquire(ctx, 1)
+	if err != nil {
 		return err
 	}
+	defer d.metaSem.Release(1)
 
-	detachRead := func() error {
-		err := d.readMetaSem.Acquire(ctx, 1)
-		if err != nil {
-			return err
-		}
-		defer d.readMetaSem.Release(1)
-
-		_, err = d.read.ExecContext(ctx, "DETACH DATABASE IF EXISTS "+safeSQLName(dbName(name, version)))
-		return err
-	}
-
-	err := errors.Join(detachWrite(), detachRead())
+	_, err = d.dbHandle.ExecContext(ctx, "DETACH DATABASE IF EXISTS "+safeSQLName(dbName(name, version)))
 	if err != nil {
 		return err
 	}
@@ -1284,11 +1212,11 @@ func (d *db) iterateLocalTables(cleanup bool, fn func(name string, meta *tableMe
 }
 
 func (d *db) prepareSnapshot(ctx context.Context, conn *sqlx.Conn, s *snapshot) error {
-	err := d.readMetaSem.Acquire(ctx, 1)
+	err := d.metaSem.Acquire(ctx, 1)
 	if err != nil {
 		return err
 	}
-	defer d.readMetaSem.Release(1)
+	defer d.metaSem.Release(1)
 
 	if s.ready {
 		_, err = conn.ExecContext(ctx, "USE "+schemaName(s.id))
@@ -1314,13 +1242,13 @@ func (d *db) prepareSnapshot(ctx context.Context, conn *sqlx.Conn, s *snapshot) 
 }
 
 func (d *db) removeSnapshot(ctx context.Context, id int) error {
-	err := d.readMetaSem.Acquire(ctx, 1)
+	err := d.metaSem.Acquire(ctx, 1)
 	if err != nil {
 		return err
 	}
-	defer d.readMetaSem.Release(1)
+	defer d.metaSem.Release(1)
 
-	_, err = d.read.ExecContext(ctx, fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", schemaName(id)))
+	_, err = d.dbHandle.ExecContext(ctx, fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", schemaName(id)))
 	return err
 }
 
@@ -1454,27 +1382,6 @@ func (d *db) duckdbOnGCS() (bool, error) {
 		return false, err
 	}
 	return strings.TrimSpace(string(contents)) == "true", nil
-}
-
-// trackWrite tracks the write operation for the given table name.
-// It returns an error if a write operation is already in progress for the same table name.
-func (d *db) trackWrite(name string) error {
-	d.writesInProgressMu.Lock()
-	defer d.writesInProgressMu.Unlock()
-	_, ok := d.writesInProgress[name]
-	if ok {
-		return fmt.Errorf("write operation already in progress for table %q", name)
-	}
-	d.writesInProgress[name] = nil
-	return nil
-}
-
-// untrackWrite untracks the write operation for the given table name.
-// It is expected to be called after the write operation is completed and just before returning to the caller.
-func (d *db) untrackWrite(name string) {
-	d.writesInProgressMu.Lock()
-	defer d.writesInProgressMu.Unlock()
-	delete(d.writesInProgress, name)
 }
 
 type tableMeta struct {

--- a/runtime/pkg/rduckdb/db_test.go
+++ b/runtime/pkg/rduckdb/db_test.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
@@ -481,113 +479,16 @@ func TestViews(t *testing.T) {
 	require.NoError(t, testDB.Close())
 }
 
-func TestConcurrentWrites(t *testing.T) {
-	localDir := filepath.Join(t.TempDir(), "directory with space's and sp$ci@l chars")
-	require.NoError(t, os.MkdirAll(localDir, 0755))
-	defer os.RemoveAll(localDir)
-
+func TestNoConfigUpdate(t *testing.T) {
+	db, _, _ := prepareDB(t)
 	ctx := context.Background()
-	db, err := NewDB(ctx, &DBOptions{
-		LocalPath:      localDir,
-		MemoryLimitGB:  2,
-		CPU:            1,
-		ReadWriteRatio: 0.5,
-		DBInitQueries:  []string{"SET autoinstall_known_extensions=true", "SET autoload_known_extensions=true"},
-		Logger:         zap.NewNop(),
+	_, err := db.CreateTableAsSelect(ctx, "test", "SELECT 1 AS id, 'India' AS country", &CreateTableOptions{
+		BeforeCreateFn: func(ctx context.Context, conn *sqlx.Conn) error {
+			_, err := conn.ExecContext(ctx, "SET secret_directory = '/tmp'")
+			return err
+		},
 	})
-	require.NoError(t, err)
-
-	// create 3 tables concurrently
-	var wg sync.WaitGroup
-	wg.Add(3)
-	for i := range 3 {
-		go func() {
-			defer wg.Done()
-			_, err := db.CreateTableAsSelect(ctx, fmt.Sprintf("test%d", i), "WITH cte AS (SELECT * FROM range(1, 10_000)) SELECT unnest(range(1, cte.range)) FROM cte", &CreateTableOptions{})
-			require.NoError(t, err)
-		}()
-	}
-	wg.Wait()
-	tables, err := db.Schema(ctx, "", "")
-	require.NoError(t, err)
-	require.Len(t, tables, 3)
-
-	// mutate all 3 tables concurrently
-	wg.Add(3)
-	for i := range 3 {
-		go func() {
-			defer wg.Done()
-			_, err := db.MutateTable(ctx, fmt.Sprintf("test%d", i), nil, func(ctx context.Context, conn *sqlx.Conn) error {
-				_, err := conn.ExecContext(ctx, fmt.Sprintf("INSERT INTO test%d WITH cte AS (SELECT * FROM range(1, 10_000)) SELECT unnest(range(1, cte.range)) FROM cte", i))
-				return err
-			})
-			require.NoError(t, err)
-		}()
-	}
-	wg.Wait()
-	tables, err = db.Schema(ctx, "", "")
-	require.NoError(t, err)
-	require.Len(t, tables, 3)
-
-	// rename all 3 tables concurrently
-	wg.Add(3)
-	for i := range 3 {
-		go func() {
-			defer wg.Done()
-			err := db.RenameTable(ctx, fmt.Sprintf("test%d", i), fmt.Sprintf("test%d_renamed", i))
-			require.NoError(t, err)
-		}()
-	}
-	wg.Wait()
-	tables, err = db.Schema(ctx, "", "")
-	require.NoError(t, err)
-	require.Len(t, tables, 3)
-
-	// drop all 3 tables concurrently
-	wg.Add(3)
-	for i := range 3 {
-		go func() {
-			defer wg.Done()
-			err := db.DropTable(ctx, fmt.Sprintf("test%d_renamed", i))
-			require.NoError(t, err)
-		}()
-	}
-	wg.Wait()
-	tables, err = db.Schema(ctx, "", "")
-	require.NoError(t, err)
-	require.Len(t, tables, 0)
-}
-
-func TestConcurrentWritesFail(t *testing.T) {
-	localDir := t.TempDir()
-	ctx := context.Background()
-	db, err := NewDB(ctx, &DBOptions{
-		LocalPath:      localDir,
-		MemoryLimitGB:  2,
-		CPU:            1,
-		ReadWriteRatio: 0.5,
-		DBInitQueries:  []string{"SET autoinstall_known_extensions=true", "SET autoload_known_extensions=true"},
-		Logger:         zap.NewNop(),
-	})
-	require.NoError(t, err)
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-	ctx, cancel := context.WithCancel(ctx)
-	go func() {
-		defer wg.Done()
-		_, _ = db.CreateTableAsSelect(ctx, "test", "WITH cte AS (SELECT * FROM range(1, 1000_000_000)) SELECT unnest(range(1, cte.range)) FROM cte", &CreateTableOptions{})
-	}()
-
-	time.Sleep(100 * time.Millisecond)
-
-	go func() {
-		defer wg.Done()
-		_, err := db.CreateTableAsSelect(ctx, "test", "WITH cte AS (SELECT * FROM range(1, 1000_000_000)) SELECT unnest(range(1, cte.range)) FROM cte", &CreateTableOptions{})
-		require.Error(t, err, "write operation already in progress for table 'test'")
-	}()
-	cancel()
-	wg.Wait()
+	require.Error(t, err, "the configuration has been locked")
 }
 
 func prepareDB(t *testing.T) (db DB, localDir, remoteDir string) {

--- a/runtime/resolvers/testdata/azure_connector.yaml
+++ b/runtime/resolvers/testdata/azure_connector.yaml
@@ -2,10 +2,6 @@ connectors:
   - clickhouse
   - azure
 project_files:
-  duckdb.yaml:
-    type: connector
-    connector: duckdb
-    init_sql: INSTALL AZURE; LOAD AZURE;
   all_datatypes_clickhouse_csv.yaml:
     type: model
     connector: clickhouse
@@ -25,19 +21,19 @@ project_files:
     type: model
     connector: duckdb
     materialize: true
-    pre_exec: "CREATE SECRET IF NOT EXISTS secret1 (TYPE azure, CONNECTION_STRING '{{.env.connector.azure.azure_storage_connection_string}}')"
+    pre_exec: "CREATE SECRET secret1 (TYPE azure, CONNECTION_STRING '{{.env.connector.azure.azure_storage_connection_string}}')"
     sql: "select * from read_csv('azure://integration-test/csv_test/all_datatypes.csv', auto_detect=true, ignore_errors=1, header=true)"
   all_datatypes_duckdb_model_glob.yaml:
     type: model
     connector: duckdb
     materialize: true
-    pre_exec: "CREATE SECRET IF NOT EXISTS secret1 (TYPE azure, CONNECTION_STRING '{{.env.connector.azure.azure_storage_connection_string}}')"
+    pre_exec: "CREATE SECRET secret1 (TYPE azure, CONNECTION_STRING '{{.env.connector.azure.azure_storage_connection_string}}')"
     sql: "select * from read_csv('azure://integration-test/glob_test/y=202*/a*.csv', auto_detect=true, ignore_errors=1, header=true)"
   all_datatypes_duckdb_model_parquet.yaml:
     type: model
     connector: duckdb
     materialize: true
-    pre_exec: "CREATE SECRET IF NOT EXISTS secret1 (TYPE azure, CONNECTION_STRING '{{.env.connector.azure.azure_storage_connection_string}}')"
+    pre_exec: "CREATE SECRET secret1 (TYPE azure, CONNECTION_STRING '{{.env.connector.azure.azure_storage_connection_string}}')"
     sql: "select * from read_parquet('azure://integration-test/parquet_test/all_datatypes.parquet')"
   all_datatypes_duckdb_source_csv.yaml:
     type: source

--- a/runtime/resolvers/testdata/gcs_connector.yaml
+++ b/runtime/resolvers/testdata/gcs_connector.yaml
@@ -22,19 +22,19 @@ project_files:
     type: model
     connector: duckdb
     materialize: true
-    pre_exec: "CREATE SECRET IF NOT EXISTS secret1 (TYPE gcs, KEY_ID '{{.env.connector.gcs_s3_compat.key_id}}', SECRET '{{.env.connector.gcs_s3_compat.secret}}', REGION 'us-east-1')"
+    pre_exec: "CREATE SECRET secret1 (TYPE gcs, KEY_ID '{{.env.connector.gcs_s3_compat.key_id}}', SECRET '{{.env.connector.gcs_s3_compat.secret}}', REGION 'us-east-1')"
     sql: "select * from read_csv('gs://integration-test.rilldata.com/csv_test/all_datatypes.csv', auto_detect=true, ignore_errors=1, header=true)"
   all_datatypes_duckdb_model_glob.yaml:
     type: model
     connector: duckdb
     materialize: true
-    pre_exec: "CREATE SECRET IF NOT EXISTS secret1 (TYPE gcs, KEY_ID '{{.env.connector.gcs_s3_compat.key_id}}', SECRET '{{.env.connector.gcs_s3_compat.secret}}', REGION 'us-east-1')"
+    pre_exec: "CREATE SECRET secret1 (TYPE gcs, KEY_ID '{{.env.connector.gcs_s3_compat.key_id}}', SECRET '{{.env.connector.gcs_s3_compat.secret}}', REGION 'us-east-1')"
     sql: "select * from read_csv('gs://integration-test.rilldata.com/glob_test/y=202*/a*.csv', auto_detect=true, ignore_errors=1, header=true)"
   all_datatypes_duckdb_model_parquet.yaml:
     type: model
     connector: duckdb
     materialize: true
-    pre_exec: "CREATE SECRET IF NOT EXISTS secret1 (TYPE gcs, KEY_ID '{{.env.connector.gcs_s3_compat.key_id}}', SECRET '{{.env.connector.gcs_s3_compat.secret}}', REGION 'us-east-1')"
+    pre_exec: "CREATE SECRET secret1 (TYPE gcs, KEY_ID '{{.env.connector.gcs_s3_compat.key_id}}', SECRET '{{.env.connector.gcs_s3_compat.secret}}', REGION 'us-east-1')"
     sql: "select * from read_parquet('gs://integration-test.rilldata.com/parquet_test/all_datatypes.parquet')"
   all_datatypes_duckdb_source_csv.yaml:
     type: source

--- a/runtime/resolvers/testdata/s3_connector.yaml
+++ b/runtime/resolvers/testdata/s3_connector.yaml
@@ -21,19 +21,19 @@ project_files:
     type: model
     connector: duckdb
     materialize: true
-    pre_exec: "CREATE SECRET IF NOT EXISTS secret1 (TYPE s3, KEY_ID '{{.env.connector.s3.aws_access_key_id}}', SECRET '{{.env.connector.s3.aws_secret_access_key}}', REGION 'us-east-1')"
+    pre_exec: "CREATE SECRET secret1 (TYPE s3, KEY_ID '{{.env.connector.s3.aws_access_key_id}}', SECRET '{{.env.connector.s3.aws_secret_access_key}}', REGION 'us-east-1')"
     sql: "select * from read_csv('s3://integration-test.rilldata.com/csv_test/all_datatypes.csv', auto_detect=true, ignore_errors=1, header=true)"
   all_datatypes_duckdb_model_glob.yaml:
     type: model
     connector: duckdb
     materialize: true
-    pre_exec: "CREATE SECRET IF NOT EXISTS secret1 (TYPE s3, KEY_ID '{{.env.connector.s3.aws_access_key_id}}', SECRET '{{.env.connector.s3.aws_secret_access_key}}', REGION 'us-east-1')"
+    pre_exec: "CREATE SECRET secret1 (TYPE s3, KEY_ID '{{.env.connector.s3.aws_access_key_id}}', SECRET '{{.env.connector.s3.aws_secret_access_key}}', REGION 'us-east-1')"
     sql: "select * from read_csv('s3://integration-test.rilldata.com/glob_test/y=202*/a*.csv', auto_detect=true, ignore_errors=1, header=true)"
   all_datatypes_duckdb_model_partitions.yaml:
     type: model
     connector: duckdb
     materialize: true
-    pre_exec: "CREATE SECRET IF NOT EXISTS secret1 (TYPE s3, KEY_ID '{{.env.connector.s3.aws_access_key_id}}', SECRET '{{.env.connector.s3.aws_secret_access_key}}', REGION 'us-east-1')"
+    pre_exec: "CREATE SECRET secret1 (TYPE s3, KEY_ID '{{.env.connector.s3.aws_access_key_id}}', SECRET '{{.env.connector.s3.aws_secret_access_key}}', REGION 'us-east-1')"
     partitions:
       glob:
         path: s3://integration-test.rilldata.com/glob_test/y=202*/a*.csv
@@ -45,7 +45,7 @@ project_files:
     type: model
     connector: duckdb
     materialize: true
-    pre_exec: "CREATE SECRET IF NOT EXISTS secret1 (TYPE s3, KEY_ID '{{.env.connector.s3.aws_access_key_id}}', SECRET '{{.env.connector.s3.aws_secret_access_key}}', REGION 'us-east-1')"
+    pre_exec: "CREATE SECRET secret1 (TYPE s3, KEY_ID '{{.env.connector.s3.aws_access_key_id}}', SECRET '{{.env.connector.s3.aws_secret_access_key}}', REGION 'us-east-1')"
     sql: "select * from read_parquet('s3://integration-test.rilldata.com/parquet_test/all_datatypes.parquet')"
   all_datatypes_duckdb_source_csv.yaml:
     type: source

--- a/scripts/embed_duckdb_ext/main.go
+++ b/scripts/embed_duckdb_ext/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 // DuckDB extensions Rill depends on
-var extensions = []string{"json", "icu", "parquet", "httpfs", "sqlite_scanner", "motherduck", "aws"}
+var extensions = []string{"json", "icu", "parquet", "httpfs", "sqlite_scanner", "motherduck"}
 
 // DuckDB platforms to download extensions for
 var platforms = []string{"linux_amd64", "linux_arm64", "osx_amd64", "osx_arm64"}


### PR DESCRIPTION
Facing some race condition wrt wal file deletion in duckdb on concurrent writes.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
