### PR TITLE
Fix race condition when parser refresh and model refresh run concurrently

### DIFF
--- a/runtime/reconcilers/refresh_trigger.go
+++ b/runtime/reconcilers/refresh_trigger.go
@@ -183,6 +183,8 @@ func (r *RefreshTriggerReconciler) Reconcile(ctx context.Context, n *runtimev1.R
 	return runtime.ReconcileResult{}
 }
 
+// UpdateTriggerTrue sets the Trigger spec property of the resource to true.
+// NOTE: If you edit this logic, also update the checks in newResourceIfModified in project_parser.go accordingly (they need to incorporate triggers in their modified checks).
 func (r *RefreshTriggerReconciler) UpdateTriggerTrue(ctx context.Context, res *runtimev1.Resource, full bool) error {
 	switch res.Meta.Name.Kind {
 	case runtime.ResourceKindSource:


### PR DESCRIPTION
This problem surfaced due to a recent change that makes the `rill project refresh` trigger parser refreshes in addition to the usual source and model refreshes.

The problem is that the parser always writes model specs with `trigger == false`, which may override a concurrent refresh trigger that has just set `trigger = true`.

I will add tests to cover this issue in a follow up PR.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
