### PR TITLE
fix: time sorting for export in flat table

### DIFF
--- a/web-common/src/features/dashboards/pivot/pivot-export.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-export.ts
@@ -105,7 +105,7 @@ function getPivotAggregationRequest(
           name: timeDimension,
           timeGrain: d.id as V1TimeGrain,
           timeZone: dashboardState.selectedTimezone,
-          alias: `${timeDimension}_rill_${d.id}`,
+          alias: isFlat ? `${timeDimension}_rill_${d.id}` : `Time ${d.title}`,
         }
       : {
           name: d.id,

--- a/web-common/src/features/dashboards/pivot/pivot-export.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-export.ts
@@ -105,7 +105,7 @@ function getPivotAggregationRequest(
           name: timeDimension,
           timeGrain: d.id as V1TimeGrain,
           timeZone: dashboardState.selectedTimezone,
-          alias: `Time ${d.title}`,
+          alias: `${timeDimension}_rill_${d.id}`,
         }
       : {
           name: d.id,


### PR DESCRIPTION
This enables the ability to sort in time when exporting in flat table mode.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
