### PR TITLE
fix: updating footer to 2025

### DIFF
--- a/runtime/pkg/email/templates/alert_fail.mjml
+++ b/runtime/pkg/email/templates/alert_fail.mjml
@@ -47,7 +47,7 @@
         </mj-text>
         
         <mj-text align="center" font-size="12px" line-height="1.5">
-          © 2024 Rill Data, Inc<br />
+          © 2025 Rill Data, Inc<br />
           18 Bartol St. • San Francisco • CA<br />
           <a href="https://www.rilldata.com/contact">Contact us</a> •
           <a href="https://bit.ly/3unvA05">Community</a> •

--- a/runtime/pkg/email/templates/alert_status.mjml
+++ b/runtime/pkg/email/templates/alert_status.mjml
@@ -47,7 +47,7 @@
         </mj-text>
         
         <mj-text align="center" font-size="12px" line-height="1.5">
-          © 2024 Rill Data, Inc<br />
+          © 2025 Rill Data, Inc<br />
           18 Bartol St. • San Francisco • CA<br />
           <a href="https://www.rilldata.com/contact">Contact us</a> •
           <a href="https://bit.ly/3unvA05">Community</a> •

--- a/runtime/pkg/email/templates/call_to_action.mjml
+++ b/runtime/pkg/email/templates/call_to_action.mjml
@@ -49,7 +49,7 @@
         <mj-spacer height="20px" />
 
         <mj-text align="center" font-size="12px" line-height="1.5">
-          © 2024 Rill Data, Inc<br />
+          © 2025 Rill Data, Inc<br />
           18 Bartol St. • San Francisco • CA<br />
           <a href="https://www.rilldata.com/contact">Contact us</a> •
           <a href="https://bit.ly/3unvA05">Community</a> •

--- a/runtime/pkg/email/templates/gen/alert_fail.html
+++ b/runtime/pkg/email/templates/gen/alert_fail.html
@@ -179,7 +179,7 @@
                     </tr>
                     <tr>
                       <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2024 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
+                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2025 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
                           <a href="https://www.rilldata.com/contact">Contact us</a> • <a href="https://bit.ly/3unvA05">Community</a> • <a href="https://www.rilldata.com/legal/privacy">Privacy Policy</a>
                         </div>
                       </td>

--- a/runtime/pkg/email/templates/gen/alert_status.html
+++ b/runtime/pkg/email/templates/gen/alert_status.html
@@ -172,7 +172,7 @@
                     </tr>
                     <tr>
                       <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2024 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
+                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2025 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
                           <a href="https://www.rilldata.com/contact">Contact us</a> • <a href="https://bit.ly/3unvA05">Community</a> • <a href="https://www.rilldata.com/legal/privacy">Privacy Policy</a>
                         </div>
                       </td>

--- a/runtime/pkg/email/templates/gen/call_to_action.html
+++ b/runtime/pkg/email/templates/gen/call_to_action.html
@@ -220,7 +220,7 @@
                             </tr>
                             <tr>
                               <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#4b5563;">© 2024 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
+                                <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#4b5563;">© 2025 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
                                   <a href="https://www.rilldata.com/contact">Contact us</a> • <a href="https://bit.ly/3unvA05">Community</a> • <a href="https://www.rilldata.com/legal/privacy">Privacy Policy</a>
                                 </div>
                               </td>

--- a/runtime/pkg/email/templates/gen/informational.html
+++ b/runtime/pkg/email/templates/gen/informational.html
@@ -200,7 +200,7 @@
                             </tr>
                             <tr>
                               <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#4b5563;">© 2024 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
+                                <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#4b5563;">© 2025 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
                                   <a href="https://www.rilldata.com/contact">Contact us</a> • <a href="https://bit.ly/3unvA05">Community</a> • <a href="https://www.rilldata.com/legal/privacy">Privacy Policy</a>
                                 </div>
                               </td>

--- a/runtime/pkg/email/templates/gen/project_access_request.html
+++ b/runtime/pkg/email/templates/gen/project_access_request.html
@@ -167,7 +167,7 @@
                     </tr>
                     <tr>
                       <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2024 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
+                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2025 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
                           <a href="https://www.rilldata.com/contact">Contact us</a> • <a href="https://bit.ly/3unvA05">Community</a> • <a href="https://www.rilldata.com/legal/privacy">Privacy Policy</a>
                         </div>
                       </td>

--- a/runtime/pkg/email/templates/gen/scheduled_report.html
+++ b/runtime/pkg/email/templates/gen/scheduled_report.html
@@ -192,7 +192,7 @@
                     </tr>
                     <tr>
                       <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2024 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
+                        <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#000000;">© 2025 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
                           <a href="https://www.rilldata.com/contact">Contact us</a> • <a href="https://bit.ly/3unvA05">Community</a> • <a href="https://www.rilldata.com/legal/privacy">Privacy Policy</a>
                         </div>
                       </td>

--- a/runtime/pkg/email/templates/gen/welcome_to_team.html
+++ b/runtime/pkg/email/templates/gen/welcome_to_team.html
@@ -265,7 +265,7 @@
                             </tr>
                             <tr>
                               <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#4b5563;">© 2024 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
+                                <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#4b5563;">© 2025 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
                                   <a href="https://www.rilldata.com/contact">Contact us</a> • <a href="https://bit.ly/3unvA05">Community</a> • <a href="https://www.rilldata.com/legal/privacy">Privacy Policy</a>
                                 </div>
                               </td>

--- a/runtime/pkg/email/templates/gen/welcome_to_trial.html
+++ b/runtime/pkg/email/templates/gen/welcome_to_trial.html
@@ -283,7 +283,7 @@
                             </tr>
                             <tr>
                               <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#4b5563;">© 2024 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
+                                <div style="font-family:Helvetica;font-size:12px;line-height:1.5;text-align:center;color:#4b5563;">© 2025 Rill Data, Inc<br /> 18 Bartol St. • San Francisco • CA<br />
                                   <a href="https://www.rilldata.com/contact">Contact us</a> • <a href="https://bit.ly/3unvA05">Community</a> • <a href="https://www.rilldata.com/legal/privacy">Privacy Policy</a>
                                 </div>
                               </td>

--- a/runtime/pkg/email/templates/informational.mjml
+++ b/runtime/pkg/email/templates/informational.mjml
@@ -41,7 +41,7 @@
         <mj-spacer height="20px" />
 
         <mj-text align="center" font-size="12px" line-height="1.5">
-          © 2024 Rill Data, Inc<br />
+          © 2025 Rill Data, Inc<br />
           18 Bartol St. • San Francisco • CA<br />
           <a href="https://www.rilldata.com/contact">Contact us</a> •
           <a href="https://bit.ly/3unvA05">Community</a> •

--- a/runtime/pkg/email/templates/project_access_request.mjml
+++ b/runtime/pkg/email/templates/project_access_request.mjml
@@ -37,7 +37,7 @@
                 <mj-spacer height="20px" />
 
                 <mj-text align="center" font-size="12px" line-height="1.5">
-                    © 2024 Rill Data, Inc<br />
+                    © 2025 Rill Data, Inc<br />
                     18 Bartol St. • San Francisco • CA<br />
                     <a href="https://www.rilldata.com/contact">Contact us</a> •
                     <a href="https://bit.ly/3unvA05">Community</a> •

--- a/runtime/pkg/email/templates/scheduled_report.mjml
+++ b/runtime/pkg/email/templates/scheduled_report.mjml
@@ -51,7 +51,7 @@
         </mj-text>
 
         <mj-text align="center" font-size="12px" line-height="1.5">
-          © 2024 Rill Data, Inc<br />
+          © 2025 Rill Data, Inc<br />
           18 Bartol St. • San Francisco • CA<br />
           <a href="https://www.rilldata.com/contact">Contact us</a> •
           <a href="https://bit.ly/3unvA05">Community</a> •

--- a/runtime/pkg/email/templates/welcome_to_team.mjml
+++ b/runtime/pkg/email/templates/welcome_to_team.mjml
@@ -49,7 +49,7 @@
         <mj-spacer height="20px" />
 
         <mj-text align="center" font-size="12px" line-height="1.5">
-          © 2024 Rill Data, Inc<br />
+          © 2025 Rill Data, Inc<br />
           18 Bartol St. • San Francisco • CA<br />
           <a href="https://www.rilldata.com/contact">Contact us</a> •
           <a href="https://bit.ly/3unvA05">Community</a> •

--- a/runtime/pkg/email/templates/welcome_to_trial.mjml
+++ b/runtime/pkg/email/templates/welcome_to_trial.mjml
@@ -57,7 +57,7 @@
         <mj-spacer height="20px" />
 
         <mj-text align="center" font-size="12px" line-height="1.5">
-          © 2024 Rill Data, Inc<br />
+          © 2025 Rill Data, Inc<br />
           18 Bartol St. • San Francisco • CA<br />
           <a href="https://www.rilldata.com/contact">Contact us</a> •
           <a href="https://bit.ly/3unvA05">Community</a> •


### PR DESCRIPTION
Updates email footers to 2025

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
