### PR TITLE
Enable `refetchIntervalInBackground ` to all resource tables

### DIFF
--- a/web-admin/src/features/dashboards/listing/DashboardsTable.svelte
+++ b/web-admin/src/features/dashboards/listing/DashboardsTable.svelte
@@ -10,12 +10,18 @@
   import { useDashboardsV2, type DashboardResource } from "./selectors";
   import NoResourceCTA from "@rilldata/web-admin/features/projects/NoResourceCTA.svelte";
   import ResourceError from "@rilldata/web-admin/features/projects/ResourceError.svelte";
+  import { isDashboardPage } from "../../navigation/nav-utils";
+  import { page } from "$app/stores";
 
   export let isEmbedded = false;
 
   $: ({ instanceId } = $runtime);
 
-  $: dashboards = useDashboardsV2(instanceId);
+  $: onDashboardPage = isDashboardPage($page);
+
+  $: dashboards = useDashboardsV2(instanceId, {
+    enableBackgroundRefetch: onDashboardPage,
+  });
 
   /**
    * Table column definitions.

--- a/web-admin/src/features/dashboards/listing/selectors.ts
+++ b/web-admin/src/features/dashboards/listing/selectors.ts
@@ -3,7 +3,7 @@ import { useValidExplores } from "@rilldata/web-common/features/dashboards/selec
 import { getMapFromArray } from "@rilldata/web-common/lib/arrayUtils";
 import type { V1Resource } from "@rilldata/web-common/runtime-client";
 import { createRuntimeServiceListResources } from "@rilldata/web-common/runtime-client";
-import type { CreateQueryResult } from "@tanstack/svelte-query";
+import type { CreateQueryResult, Query } from "@tanstack/svelte-query";
 import { derived } from "svelte/store";
 
 export function useDashboardsLastUpdated(
@@ -49,6 +49,9 @@ export interface DashboardResource {
 // This iteration of `useDashboards` returns the above `DashboardResource` type, which includes `refreshedOn`
 export function useDashboardsV2(
   instanceId: string,
+  options?: {
+    enableBackgroundRefetch?: boolean;
+  },
 ): CreateQueryResult<DashboardResource[]> {
   return createRuntimeServiceListResources(instanceId, undefined, {
     query: {
@@ -79,6 +82,7 @@ export function useDashboardsV2(
         );
         return allDashboards;
       },
+      refetchIntervalInBackground: options?.enableBackgroundRefetch,
     },
   });
 }

--- a/web-admin/src/features/navigation/nav-utils.ts
+++ b/web-admin/src/features/navigation/nav-utils.ts
@@ -13,6 +13,10 @@ export function withinOrganization(page: Page): boolean {
   return !!page.route?.id?.startsWith("/[organization]");
 }
 
+export function isDashboardPage(page: Page): boolean {
+  return !!(page.route.id === "/[organization]/[project]");
+}
+
 export function isProjectPage(page: Page): boolean {
   return (
     page.route.id === "/[organization]/[project]" ||


### PR DESCRIPTION
Closes https://github.com/rilldata/rill/issues/6667

In [this pull request](https://github.com/rilldata/rill/pull/6175), we introduced a custom refetch interval to repeatedly reload a resource until its status was marked as complete. However, for dashboards, reports, and alerts tables, this approach isn't required. We can instead utilize a built-in TanStack function, `refetchIntervalInBackground`, which ensures data is refetched even when the tab is in the background.

The current changeset only includes updates to the `dashboards` query. Seeking @ericpgreen2 thoughts before implementing reports and alerts.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
