### PR TITLE
Make models output to the default OLAP by default

### DIFF
--- a/runtime/metricsview/executor_validate_test.go
+++ b/runtime/metricsview/executor_validate_test.go
@@ -49,7 +49,7 @@ func TestValidateMetricsViewClickHouseNames(t *testing.T) {
 	rt, instanceID := testruntime.NewInstanceWithOptions(t, testruntime.InstanceOptions{
 		TestConnectors: []string{"clickhouse"},
 		Files: map[string]string{
-			"rill.yaml": "",
+			"rill.yaml": "olap_connector: clickhouse",
 			"model.sql": `
 -- @connector: clickhouse
 select parseDateTimeBestEffort('2024-01-01T00:00:00Z') as time, 'DK' as country, 1 as val union all

--- a/runtime/parser/parse_model.go
+++ b/runtime/parser/parse_model.go
@@ -105,7 +105,7 @@ func (p *Parser) parseModel(ctx context.Context, node *Node) error {
 	// Build output details
 	outputConnector := tmp.Output.Connector
 	if outputConnector == "" {
-		outputConnector = inputConnector
+		outputConnector = p.defaultOLAPConnector()
 	}
 	outputProps := tmp.Output.Properties
 

--- a/runtime/parser/parse_model.go
+++ b/runtime/parser/parse_model.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rilldata/rill/runtime/pkg/duckdbsql"
 	"github.com/rilldata/rill/runtime/pkg/fileutil"
 	"google.golang.org/protobuf/types/known/structpb"
+	"gopkg.in/yaml.v3"
 )
 
 // ModelYAML is the raw structure of a Model resource defined in YAML (does not include common fields)
@@ -30,12 +31,40 @@ type ModelYAML struct {
 		Connector  string         `yaml:"connector"`
 		Properties map[string]any `yaml:",inline" mapstructure:",remain"`
 	} `yaml:"stage"`
-	Output struct {
-		Connector  string         `yaml:"connector"`
-		Properties map[string]any `yaml:",inline" mapstructure:",remain"`
-	} `yaml:"output"`
-	Materialize     *bool `yaml:"materialize"`
-	DefinedAsSource bool  `yaml:"defined_as_source"`
+	Output          ModelOutputYAML `yaml:"output"`
+	Materialize     *bool           `yaml:"materialize"`
+	DefinedAsSource bool            `yaml:"defined_as_source"`
+}
+
+// ModelOutputYAML parses the `output:` property of a model.
+// It supports either a string connector name or a mapping with a connector and arbitrary output properties.
+type ModelOutputYAML struct {
+	Connector  string
+	Properties map[string]any
+}
+
+func (y *ModelOutputYAML) UnmarshalYAML(v *yaml.Node) error {
+	if v == nil {
+		return nil
+	}
+	switch v.Kind {
+	case yaml.ScalarNode:
+		y.Connector = v.Value
+	case yaml.MappingNode:
+		tmp := &struct {
+			Connector  string         `yaml:"connector"`
+			Properties map[string]any `yaml:",inline" mapstructure:",remain"`
+		}{}
+		err := v.Decode(tmp)
+		if err != nil {
+			return err
+		}
+		y.Connector = tmp.Connector
+		y.Properties = tmp.Properties
+	default:
+		return fmt.Errorf("expected connector name or mapping of output properties, got type %q", v.Kind)
+	}
+	return nil
 }
 
 // parseModel parses a model definition and adds the resulting resource to p.Resources.

--- a/runtime/parser/parse_model_test.go
+++ b/runtime/parser/parse_model_test.go
@@ -1,0 +1,125 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestModelOutput(t *testing.T) {
+	files := map[string]string{
+		`rill.yaml`: ``,
+		`m1.sql`: `
+SELECT 1
+`,
+		`m2.yaml`: `
+type: model
+sql: SELECT 1
+`,
+		`m3.yaml`: `
+type: model
+connector: bigquery
+sql: SELECT 1
+`,
+		`m4.yaml`: `
+type: model
+connector: bigquery
+sql: SELECT 1
+output:
+  table: foobar
+`,
+		`m5.yaml`: `
+type: model
+connector: bigquery
+sql: SELECT 1
+output: clickhouse
+`,
+		`m6.yaml`: `
+type: model
+connector: bigquery
+sql: SELECT 1
+output:
+  connector: clickhouse
+`,
+	}
+	resources := []*Resource{
+		// model m1
+		{
+			Name:  ResourceName{Kind: ResourceKindModel, Name: "m1"},
+			Paths: []string{"/m1.sql"},
+			ModelSpec: &runtimev1.ModelSpec{
+				RefreshSchedule: &runtimev1.Schedule{RefUpdate: true},
+				InputConnector:  "duckdb",
+				InputProperties: must(structpb.NewStruct(map[string]any{"sql": "SELECT 1"})),
+				OutputConnector: "duckdb",
+			},
+		},
+		// model m2
+		{
+			Name:  ResourceName{Kind: ResourceKindModel, Name: "m2"},
+			Paths: []string{"/m2.yaml"},
+			ModelSpec: &runtimev1.ModelSpec{
+				RefreshSchedule: &runtimev1.Schedule{RefUpdate: true},
+				InputConnector:  "duckdb",
+				InputProperties: must(structpb.NewStruct(map[string]any{"sql": "SELECT 1"})),
+				OutputConnector: "duckdb",
+			},
+		},
+		// model m3
+		{
+			Name:  ResourceName{Kind: ResourceKindModel, Name: "m3"},
+			Paths: []string{"/m3.yaml"},
+			ModelSpec: &runtimev1.ModelSpec{
+				RefreshSchedule: &runtimev1.Schedule{RefUpdate: true},
+				InputConnector:  "bigquery",
+				InputProperties: must(structpb.NewStruct(map[string]any{"sql": "SELECT 1"})),
+				OutputConnector: "duckdb",
+			},
+		},
+		// model m4
+		{
+			Name:  ResourceName{Kind: ResourceKindModel, Name: "m4"},
+			Paths: []string{"/m4.yaml"},
+			ModelSpec: &runtimev1.ModelSpec{
+				RefreshSchedule: &runtimev1.Schedule{RefUpdate: true},
+				InputConnector:  "bigquery",
+				InputProperties: must(structpb.NewStruct(map[string]any{"sql": "SELECT 1"})),
+				OutputConnector: "duckdb",
+				OutputProperties: must(structpb.NewStruct(map[string]any{
+					"table": "foobar",
+				})),
+			},
+		},
+		// model m5
+		{
+			Name:  ResourceName{Kind: ResourceKindModel, Name: "m5"},
+			Paths: []string{"/m5.yaml"},
+			ModelSpec: &runtimev1.ModelSpec{
+				RefreshSchedule: &runtimev1.Schedule{RefUpdate: true},
+				InputConnector:  "bigquery",
+				InputProperties: must(structpb.NewStruct(map[string]any{"sql": "SELECT 1"})),
+				OutputConnector: "clickhouse",
+			},
+		},
+		// model m6
+		{
+			Name:  ResourceName{Kind: ResourceKindModel, Name: "m6"},
+			Paths: []string{"/m6.yaml"},
+			ModelSpec: &runtimev1.ModelSpec{
+				RefreshSchedule: &runtimev1.Schedule{RefUpdate: true},
+				InputConnector:  "bigquery",
+				InputProperties: must(structpb.NewStruct(map[string]any{"sql": "SELECT 1"})),
+				OutputConnector: "clickhouse",
+			},
+		},
+	}
+
+	ctx := context.Background()
+	repo := makeRepo(t, files)
+	p, err := Parse(ctx, repo, "", "", "duckdb")
+	require.NoError(t, err)
+	requireResourcesAndErrors(t, p, resources, nil)
+}

--- a/runtime/resolvers/testdata/azure_connector.yaml
+++ b/runtime/resolvers/testdata/azure_connector.yaml
@@ -4,18 +4,21 @@ connectors:
 project_files:
   all_datatypes_clickhouse_csv.yaml:
     type: model
-    connector: clickhouse
     materialize: true
+    connector: clickhouse
+    output: clickhouse
     sql: "SELECT * FROM azureBlobStorage('{{.env.connector.azure.azure_storage_connection_string_ip}}', 'integration-test', 'csv_test/all_datatypes.csv', 'CSVWithNames')"
   all_datatypes_clickhouse_glob.yaml:
     type: model
-    connector: clickhouse
     materialize: true
+    connector: clickhouse
+    output: clickhouse
     sql: "SELECT * FROM azureBlobStorage('{{.env.connector.azure.azure_storage_connection_string_ip}}', 'integration-test', 'glob_test/y=202*/a*.csv', 'CSVWithNames')"
   all_datatypes_clickhouse_parquet.yaml:
     type: model
-    connector: clickhouse
     materialize: true
+    connector: clickhouse
+    output: clickhouse
     sql: "SELECT * FROM azureBlobStorage('{{.env.connector.azure.azure_storage_connection_string_ip}}', 'integration-test', 'parquet_test/all_datatypes.parquet' ,'Parquet')"
   all_datatypes_duckdb_model_csv.yaml:
     type: model
@@ -124,8 +127,8 @@ tests:
   - name: query_all_result_clickhouse_csv
     resolver: sql
     properties:
-      sql: "select * from all_datatypes_clickhouse_csv order by id"
       connector: clickhouse
+      sql: "select * from all_datatypes_clickhouse_csv order by id"
       # time is converted to datetime like 2025-01-01T00:02:03.456Z but should be 1970-01-01T00:02:03.456Z, which is wrong.
     result_csv: |
       id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col
@@ -135,9 +138,9 @@ tests:
   - name: query_all_datatypes_clickhouse_csv
     resolver: sql
     properties:
+      connector: clickhouse
       sql: |
         select name, type from system.columns where `table` = 'all_datatypes_clickhouse_csv'
-      connector: clickhouse
     result_csv: |
       name,type
       id,Nullable(Int64)
@@ -163,8 +166,8 @@ tests:
   - name: query_table_type_clickhouse_csv
     resolver: sql
     properties:
-      sql: "select name, engine from system.tables where name = 'all_datatypes_clickhouse_csv'"
       connector: clickhouse
+      sql: "select name, engine from system.tables where name = 'all_datatypes_clickhouse_csv'"
     result_csv: |
       name,engine
       all_datatypes_clickhouse_csv,MergeTree
@@ -241,8 +244,8 @@ tests:
   - name: query_all_result_clickhouse_parquet
     resolver: sql
     properties:
-      sql: "select * from all_datatypes_clickhouse_parquet order by id"
       connector: clickhouse
+      sql: "select * from all_datatypes_clickhouse_parquet order by id"
     result_csv: |
       id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col
       1,true,123,45678901234,1.2300000190734863,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,1970-01-01T00:02:03.456Z,1970-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,"[1,2,3]","[""apple"",""banana"",""cherry""]","{""key1"":10,""key2"":20}","{""FIELD_FLOAT_COL"":null,""FIELD_INT_COL"":null,""FIELD_STRING_COL"":null,""field_float_col"":3.14,""field_int_col"":42,""field_string_col"":""example""}"
@@ -251,9 +254,9 @@ tests:
   - name: query_all_datatypes_clickhouse_parquet
     resolver: sql
     properties:
+      connector: clickhouse
       sql: |
         select name, type from system.columns where `table` = 'all_datatypes_clickhouse_parquet'
-      connector: clickhouse
     result_csv: |
       name,type
       id,Nullable(Int32)
@@ -303,8 +306,8 @@ tests:
   - name: query_all_result_clickhouse_glob
     resolver: sql
     properties:
-      sql: "select * from all_datatypes_clickhouse_glob order by id"
       connector: clickhouse
+      sql: "select * from all_datatypes_clickhouse_glob order by id"
       # time is converted to datetime like 2025-01-01T00:02:03.456Z but should be 1970-01-01T00:02:03.456Z, which is wrong.
     result_csv: |
       id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col

--- a/runtime/resolvers/testdata/gcs_connector.yaml
+++ b/runtime/resolvers/testdata/gcs_connector.yaml
@@ -5,18 +5,21 @@ connectors:
 project_files:
   all_datatypes_clickhouse_csv.yaml:
     type: model
-    connector: clickhouse
     materialize: true
+    connector: clickhouse
+    output: clickhouse
     sql: "SELECT * FROM gcs('gs://integration-test.rilldata.com/csv_test/all_datatypes.csv', '{{.env.connector.gcs_s3_compat.key_id}}', '{{.env.connector.gcs_s3_compat.secret}}', 'CSVWithNames')"
   all_datatypes_clickhouse_glob.yaml:
     type: model
-    connector: clickhouse
     materialize: true
+    connector: clickhouse
+    output: clickhouse
     sql: "SELECT * FROM gcs('gs://integration-test.rilldata.com/glob_test/y=202*/a*.csv', '{{.env.connector.gcs_s3_compat.key_id}}', '{{.env.connector.gcs_s3_compat.secret}}', 'CSVWithNames')"
   all_datatypes_clickhouse_parquet.yaml:
     type: model
-    connector: clickhouse
     materialize: true
+    connector: clickhouse
+    output: clickhouse
     sql: "SELECT * FROM gcs('gs://integration-test.rilldata.com/parquet_test/all_datatypes.parquet', '{{.env.connector.gcs_s3_compat.key_id}}', '{{.env.connector.gcs_s3_compat.secret}}', 'Parquet')"
   all_datatypes_duckdb_model_csv.yaml:
     type: model

--- a/runtime/resolvers/testdata/metrics_comparisons.yaml
+++ b/runtime/resolvers/testdata/metrics_comparisons.yaml
@@ -5,6 +5,7 @@ project_files:
   clickhouse_data.yaml:
     type: model
     connector: clickhouse
+    output: clickhouse
     sql: |
       select parseDateTimeBestEffort('2024-01-01T00:00:00Z') as time, 'DK' as country, 1 as val union all
       select parseDateTimeBestEffort('2024-01-02T00:00:00Z') as time, 'US' as country, 2 as val union all

--- a/runtime/resolvers/testdata/metrics_null_filling.yaml
+++ b/runtime/resolvers/testdata/metrics_null_filling.yaml
@@ -5,6 +5,7 @@ project_files:
   clickhouse_data.yaml:
     type: model
     connector: clickhouse
+    output: clickhouse
     sql: |
       select parseDateTimeBestEffort('2024-01-01T00:00:00Z') as time, 'DK' as country, 1 as val union all
       select parseDateTimeBestEffort('2024-01-02T00:00:00Z') as time, 'US' as country, 2 as val union all

--- a/runtime/resolvers/testdata/metrics_sql_clickhouse.yaml
+++ b/runtime/resolvers/testdata/metrics_sql_clickhouse.yaml
@@ -3,8 +3,9 @@ connectors:
 project_files:
   ad_bids_mini.yaml:
     type: model
-    connector: clickhouse
     materialize: true
+    connector: clickhouse
+    output: clickhouse
     sql: |
       SELECT 0::UInt32 AS id, parseDateTimeBestEffort('2022-01-01T14:49:50.459Z') AS timestamp, NULL::Nullable(varchar) AS publisher, 'msn.com'::varchar AS domain, 2::Float32 AS bid_price, 1::UInt8 AS volume, 2::UInt8 AS impressions, 'cars'::varchar AS ad_words, NULL::Nullable(Float32) AS clicks, 'iphone'::Nullable(varchar) AS device
       UNION ALL

--- a/runtime/resolvers/testdata/mysql_connector.yaml
+++ b/runtime/resolvers/testdata/mysql_connector.yaml
@@ -4,8 +4,9 @@ connectors:
 project_files:
   all_datatypes_clickhouse.yaml:
     type: model
-    connector: clickhouse
     materialize: true
+    connector: clickhouse
+    output: clickhouse
     sql: "SELECT * FROM mysql('{{.env.connector.mysql.ip}}:3306', 'mysql', 'all_datatypes', 'mysql', 'mysql')"
   all_datatypes_duckdb.yaml:
     type: model
@@ -77,9 +78,9 @@ tests:
   - name: query_all_datatypes_clickhouse
     resolver: sql
     properties:
+      connector: clickhouse
       sql: |
         select name, type from system.columns where `table` = 'all_datatypes_clickhouse'
-      connector: clickhouse
     result_csv: |
       name,type
       tinyint_col,Nullable(Int8)

--- a/runtime/resolvers/testdata/postgres_connector.yaml
+++ b/runtime/resolvers/testdata/postgres_connector.yaml
@@ -11,8 +11,9 @@ project_files:
       connector: duckdb
   all_datatypes_clickhouse.yaml:
     type: model
-    connector: clickhouse
     materialize: true
+    connector: clickhouse
+    output: clickhouse
     sql: "SELECT * FROM postgresql('{{.env.connector.postgres.ip}}:5432', 'postgres', 'all_datatypes', 'postgres', 'postgres')"
 tests:
   - name: query_all_result_duckdb
@@ -62,8 +63,8 @@ tests:
   - name: query_all_result_clickhouse
     resolver: sql
     properties:
-      sql: "select * from all_datatypes_clickhouse order by id"
       connector: clickhouse
+      sql: "select * from all_datatypes_clickhouse order by id"
     result_csv: |
       id,uuid,name,age,is_married,date_of_birth,time_of_day,created_at,personal_info,personal_info2,is_alive,binary_data,gender,gender_full,nickname,num_of_dependents,biography,last_login,weight,height,sibling_rank,credit_score,net_worth,salary_history,login_history,emp_salary,country
       1,8a25ac46-8ad6-4415-9a2e-12aa3962c144,John Doe,30,1,1983-03-08,12:35:00,2023-09-12T12:46:55Z,"{""hobbies"": ""Travel, Tech""}","{""job"": ""Software Engineer""}",1,10101010,M,Male,abcd      ,2,John is a software engineer who loves to travel and explore new places.,2023-09-12T07:16:55Z,75.4000015258789,180.5,1,720,1234567,"[1234567,7654312]","[""2023-09-12T12:46:55Z"",""2023-10-12T12:46:55Z""]",385000.71,IND
@@ -74,9 +75,9 @@ tests:
   - name: query_all_datatypes_clickhouse
     resolver: sql
     properties:
+      connector: clickhouse
       sql: |
         select name, type from system.columns where `table` = 'all_datatypes_clickhouse'
-      connector: clickhouse
     result_csv: |
       name,type
       id,Int32

--- a/runtime/resolvers/testdata/s3_connector.yaml
+++ b/runtime/resolvers/testdata/s3_connector.yaml
@@ -4,18 +4,21 @@ connectors:
 project_files:
   all_datatypes_clickhouse_csv.yaml:
     type: model
-    connector: clickhouse
     materialize: true
+    connector: clickhouse
+    output: clickhouse
     sql: "SELECT * FROM s3('s3://integration-test.rilldata.com/csv_test/all_datatypes.csv', '{{.env.connector.s3.aws_access_key_id}}', '{{.env.connector.s3.aws_secret_access_key}}', 'CSVWithNames')"
   all_datatypes_clickhouse_glob.yaml:
     type: model
-    connector: clickhouse
     materialize: true
+    connector: clickhouse
+    output: clickhouse
     sql: "SELECT * FROM s3('s3://integration-test.rilldata.com/glob_test/y=202*/a*.csv', '{{.env.connector.s3.aws_access_key_id}}', '{{.env.connector.s3.aws_secret_access_key}}', 'CSVWithNames')"
   all_datatypes_clickhouse_parquet.yaml:
     type: model
-    connector: clickhouse
     materialize: true
+    connector: clickhouse
+    output: clickhouse
     sql: "SELECT * FROM s3('s3://integration-test.rilldata.com/parquet_test/all_datatypes.parquet', '{{.env.connector.s3.aws_access_key_id}}', '{{.env.connector.s3.aws_secret_access_key}}', 'Parquet')"
   all_datatypes_duckdb_model_csv.yaml:
     type: model
@@ -133,8 +136,8 @@ tests:
   - name: query_all_result_clickhouse_csv
     resolver: sql
     properties:
-      sql: "select * from all_datatypes_clickhouse_csv order by id"
       connector: clickhouse
+      sql: "select * from all_datatypes_clickhouse_csv order by id"
       # time is converted to datetime like 2025-01-01T00:02:03.456Z but should be 1970-01-01T00:02:03.456Z, which is wrong.
     result_csv: |
       id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col
@@ -144,17 +147,17 @@ tests:
   - name: query_table_type_clickhouse_csv
     resolver: sql
     properties:
-      sql: "select name, engine from system.tables where name = 'all_datatypes_clickhouse_csv'"
       connector: clickhouse
+      sql: "select name, engine from system.tables where name = 'all_datatypes_clickhouse_csv'"
     result_csv: |
       name,engine
       all_datatypes_clickhouse_csv,MergeTree
   - name: query_all_datatypes_clickhouse_csv
     resolver: sql
     properties:
+      connector: clickhouse
       sql: |
         select name, type from system.columns where `table` = 'all_datatypes_clickhouse_csv'
-      connector: clickhouse
     result_csv: |
       name,type
       id,Nullable(Int64)
@@ -250,8 +253,8 @@ tests:
   - name: query_all_result_clickhouse_parquet
     resolver: sql
     properties:
-      sql: "select * from all_datatypes_clickhouse_parquet order by id"
       connector: clickhouse
+      sql: "select * from all_datatypes_clickhouse_parquet order by id"
     result_csv: |
       id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col
       1,true,123,45678901234,1.2300000190734863,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,1970-01-01T00:02:03.456Z,1970-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,"[1,2,3]","[""apple"",""banana"",""cherry""]","{""key1"":10,""key2"":20}","{""FIELD_FLOAT_COL"":null,""FIELD_INT_COL"":null,""FIELD_STRING_COL"":null,""field_float_col"":3.14,""field_int_col"":42,""field_string_col"":""example""}"
@@ -260,9 +263,9 @@ tests:
   - name: query_all_datatypes_clickhouse_parquet
     resolver: sql
     properties:
+      connector: clickhouse
       sql: |
         select name, type from system.columns where `table` = 'all_datatypes_clickhouse_parquet'
-      connector: clickhouse
     result_csv: |
       name,type
       id,Nullable(Int32)
@@ -319,8 +322,8 @@ tests:
   - name: query_all_result_clickhouse_glob
     resolver: sql
     properties:
-      sql: "select * from all_datatypes_clickhouse_glob order by id"
       connector: clickhouse
+      sql: "select * from all_datatypes_clickhouse_glob order by id"
       # time is converted to datetime like 2025-01-01T00:02:03.456Z but should be 1970-01-01T00:02:03.456Z, which is wrong.
     result_csv: |
       id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col

--- a/runtime/resolvers/testdata/snowflake_connector.yaml
+++ b/runtime/resolvers/testdata/snowflake_connector.yaml
@@ -103,8 +103,8 @@ tests:
   - name: query_all_result_clickhouse
     resolver: sql
     properties:
-      sql: "select * from all_datatypes_clickhouse order by ID"
       connector: clickhouse
+      sql: "select * from all_datatypes_clickhouse order by ID"
     result_csv: |
       ID,BOOLEAN_COL,TINYINT_COL,SMALLINT_COL,INT32_COL,INT64_COL,NUMBER_COL,FLOAT_COL,DOUBLE_COL,DECIMAL_COL,STRING_COL,TEXT_COL,DATE_COL,TIME_COL,TIMESTAMP_NTZ_COL,VARIANT_COL,ARRAY_COL,OBJECT_COL,BINARY_COL,GEOGRAPHY_COL,GEOMETRY_COL
       1,true,127,32767,2147483647,9223372036854776000,12345.6789,3.14,2.718,456.789,Sample String,Large text data,2024-03-26,1970-01-01T14:30:00Z,2025-03-26T03:35:51.195Z,"{""key"":""value""}","[1,2,3]","{""city"":""New York""}",Hello,"{""coordinates"":[-122.4194,37.7749],""type"":""Point""}","{""coordinates"":[[0.000000000000000e+00,0.000000000000000e+00],[1.000000000000000e+00,1.000000000000000e+00],[2.000000000000000e+00,2.000000000000000e+00]],""type"":""LineString""}"
@@ -113,9 +113,9 @@ tests:
   - name: query_all_datatypes_clickhouse
     resolver: sql
     properties:
+      connector: clickhouse
       sql: |
         select name, type from system.columns where `table` = 'all_datatypes_clickhouse'
-      connector: clickhouse
     result_csv: |
       name,type
       ID,"Nullable(Decimal(38, 0))"

--- a/runtime/testruntime/connectors.go
+++ b/runtime/testruntime/connectors.go
@@ -304,7 +304,6 @@ func uploadDirectory(ctx context.Context, client *azblob.Client, containerName, 
 			return err
 		}
 
-		fmt.Printf("Uploaded: %s\n", blobName)
 		return nil
 	})
 }


### PR DESCRIPTION
A model's output connector currently defaults to the input connector. This PR changes that default to the project's OLAP connector.

After this change, a model like this outputs to DuckDB:
```yaml
type: model
connector: bigquery
sql: SELECT * FROM `project.dataset.table`
```

This makes it equivalent to the `type: source` statement (which is implemented as a model that outputs to the project's default OLAP), enabling `type: source` to be deprecated entirely.

If you are using multiple OLAPs, you now need to always specify an `output.connector` when building models on non-default OLAPs:
```yaml
type: model
connector: clickhouse
sql: SELECT ... FROM tbl
output:
  connector: clickhouse
```

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
