### PR TITLE
fix(canvas): moving items while editing

### DIFF
--- a/web-common/src/features/canvas/EditableCanvasRow.svelte
+++ b/web-common/src/features/canvas/EditableCanvasRow.svelte
@@ -40,7 +40,7 @@
     event: MouseEvent;
   }) => void;
   export let onDuplicate: (params: { columnIndex: number }) => void;
-  export let onDelete: (params: { columnIndex: number }) => void;
+  export let onDelete: (params: { component: BaseCanvasComponent }) => void;
   export let onDrop: (row: number, column: number | null) => void;
   export let initializeRow: (row: number, type: CanvasComponentType) => void;
   export let updateRowHeight: (newHeight: number, index: number) => void;
@@ -241,7 +241,7 @@
             onDuplicate({ columnIndex });
           }}
           onDelete={() => {
-            onDelete({ columnIndex });
+            onDelete({ component });
           }}
         />
       {:else}

--- a/web-common/src/features/canvas/inspector/ParamMapper.svelte
+++ b/web-common/src/features/canvas/inspector/ParamMapper.svelte
@@ -20,8 +20,6 @@
 
   export let component: BaseCanvasComponent;
 
-  $: console.log("YEAH", { component });
-
   $: ({
     specStore,
     parent: { name: canvasName },
@@ -70,11 +68,10 @@
             label={config.label ?? key}
             bind:value={$specStore[key]}
             onBlur={() => {
-              console.log("blur called", component, $specStore);
-              component.updateProperty(key, $specStore[key]);
+              component.updateProperty(key, localParamValues[key]);
             }}
             onEnter={() => {
-              component.updateProperty(key, $specStore[key]);
+              component.updateProperty(key, localParamValues[key]);
             }}
           />
 

--- a/web-common/src/features/canvas/inspector/ParamMapper.svelte
+++ b/web-common/src/features/canvas/inspector/ParamMapper.svelte
@@ -20,6 +20,8 @@
 
   export let component: BaseCanvasComponent;
 
+  $: console.log("YEAH", { component });
+
   $: ({
     specStore,
     parent: { name: canvasName },
@@ -68,10 +70,11 @@
             label={config.label ?? key}
             bind:value={$specStore[key]}
             onBlur={() => {
-              component.updateProperty(key, localParamValues[key]);
+              console.log("blur called", component, $specStore);
+              component.updateProperty(key, $specStore[key]);
             }}
             onEnter={() => {
-              component.updateProperty(key, localParamValues[key]);
+              component.updateProperty(key, $specStore[key]);
             }}
           />
 

--- a/web-common/src/features/canvas/layout-util.ts
+++ b/web-common/src/features/canvas/layout-util.ts
@@ -380,6 +380,7 @@ export function generateNewAssets(params: {
     newSpecRows: updatedSpecRows,
     newYamlRows: updatedYamlRows,
     newResolvedComponents: resolvedComponentsMap,
+    mover,
   };
 }
 


### PR DESCRIPTION
Edits in the `ComponentEditor` sidebar to values controlled by text inputs do not update the YAML until the input element is blurred. However, `preventDefault` was being called when selecting a widget (for a reason that is no longer necessary). 

Because of this, if a user changed the value of an input element, but then immediately selected a component to move, the input element would not be blurred until the widget was dropped in the new location. This update function was being called on an outdated version of the component (a symptom of not having stable IDs) and would place the update parameters in the wrong location in the YAML.

- [x] Remove `preventDefault` call when selecting canvas widget
- [x] Appropriately update `selectedComponent` identifier when moving widgets
- [x] Reset `selectedComponent` identifier when deleting widgets

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
