### PR TITLE
fix: no big number for dashbaord without timestamp column

### DIFF
--- a/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasuresContainer.svelte
@@ -152,10 +152,12 @@
     calculateGridColumns();
   }
 
-  function getValue(key: string | undefined): number | null {
+  $: totalsQueryRow = totalsQueryResult.data?.data?.[0];
+  // Make this reactive to totalsQueryRow so that data is updated if query is refetched
+  $: getValue = (key: string | undefined): number | null => {
     if (!key) return null;
-    return totalsQueryResult.data?.data?.[0]?.[key] as number | null;
-  }
+    return totalsQueryRow?.[key] as number | null;
+  };
 </script>
 
 <svelte:window on:resize={() => calculateGridColumns()} />


### PR DESCRIPTION
The code that gets the big number value for dashboards without timestamp column is not reactive to response. Update the component so that it re-renders on a re-fetch.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
