### PR TITLE
fix: move vega utils out of canvas utils

### DIFF
--- a/web-common/src/components/vega/util.ts
+++ b/web-common/src/components/vega/util.ts
@@ -1,0 +1,42 @@
+import { V1TimeGrain } from "@rilldata/web-common/runtime-client";
+
+export const timeGrainToVegaTimeUnitMap: Record<V1TimeGrain, string> = {
+  [V1TimeGrain.TIME_GRAIN_MILLISECOND]: "yearmonthdatehoursminutesseconds",
+  [V1TimeGrain.TIME_GRAIN_SECOND]: "yearmonthdatehoursminutesseconds",
+  [V1TimeGrain.TIME_GRAIN_MINUTE]: "yearmonthdatehoursminutes",
+  [V1TimeGrain.TIME_GRAIN_HOUR]: "yearmonthdatehours",
+  [V1TimeGrain.TIME_GRAIN_DAY]: "yearmonthdate",
+  [V1TimeGrain.TIME_GRAIN_WEEK]: "yearweek",
+  [V1TimeGrain.TIME_GRAIN_MONTH]: "yearmonth",
+  [V1TimeGrain.TIME_GRAIN_QUARTER]: "yearquarter",
+  [V1TimeGrain.TIME_GRAIN_YEAR]: "year",
+  [V1TimeGrain.TIME_GRAIN_UNSPECIFIED]: "yearmonthdate",
+};
+
+export function sanitizeValueForVega(value: unknown) {
+  if (typeof value === "string") {
+    // Escape all special characters including quotes, brackets, operators, etc.
+    return value.replace(
+      /[!@#$%^&*()+=\-[\]\\';,./{}|:<>?~]/g,
+      (match) => `\\${match}`,
+    );
+  } else {
+    return String(value);
+  }
+}
+
+export function sanitizeValuesForSpec(values: unknown[]) {
+  return values.map((value) => sanitizeValueForVega(value));
+}
+
+export function sanitizeFieldName(fieldName: string) {
+  const specialCharactersRemoved = sanitizeValueForVega(fieldName);
+  const sanitizedFieldName = specialCharactersRemoved.replace(" ", "__");
+
+  /**
+   * Add a prefix to the beginning of the field
+   * name to avoid variables starting with a special
+   * character or number.
+   */
+  return `rill_${sanitizedFieldName}`;
+}

--- a/web-common/src/features/canvas/components/charts/Chart.svelte
+++ b/web-common/src/features/canvas/components/charts/Chart.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { sanitizeFieldName } from "@rilldata/web-common/components/vega/util";
   import { getRillTheme } from "@rilldata/web-common/components/vega/vega-config";
   import VegaLiteRenderer from "@rilldata/web-common/components/vega/VegaLiteRenderer.svelte";
   import ComponentHeader from "@rilldata/web-common/features/canvas/ComponentHeader.svelte";
@@ -11,7 +12,7 @@
   import type { ChartSpec } from "./";
   import type { BaseChart } from "./BaseChart";
   import { getChartData } from "./selector";
-  import { generateSpec, isChartLineLike, sanitizeFieldName } from "./util";
+  import { generateSpec, isChartLineLike } from "./util";
   import { validateChartSchema } from "./validate";
 
   export let component: BaseChart<ChartSpec>;

--- a/web-common/src/features/canvas/components/charts/builder.ts
+++ b/web-common/src/features/canvas/components/charts/builder.ts
@@ -1,14 +1,14 @@
+import {
+  sanitizeFieldName,
+  sanitizeValueForVega,
+} from "@rilldata/web-common/components/vega/util";
 import type { ChartSpec } from "@rilldata/web-common/features/canvas/components/charts";
 import type { CartesianChartSpec } from "@rilldata/web-common/features/canvas/components/charts/cartesian-charts/CartesianChart";
 import type {
   FieldConfig,
   TooltipValue,
 } from "@rilldata/web-common/features/canvas/components/charts/types";
-import {
-  mergedVlConfig,
-  sanitizeFieldName,
-} from "@rilldata/web-common/features/canvas/components/charts/util";
-import { sanitizeValueForVega } from "@rilldata/web-common/features/templates/charts/utils";
+import { mergedVlConfig } from "@rilldata/web-common/features/canvas/components/charts/util";
 import type { VisualizationSpec } from "svelte-vega";
 import type { Config } from "vega-lite";
 import type {

--- a/web-common/src/features/canvas/components/charts/cartesian-charts/area/spec.ts
+++ b/web-common/src/features/canvas/components/charts/cartesian-charts/area/spec.ts
@@ -1,6 +1,8 @@
+import {
+  sanitizeFieldName,
+  sanitizeValueForVega,
+} from "@rilldata/web-common/components/vega/util";
 import type { TooltipValue } from "@rilldata/web-common/features/canvas/components/charts/types";
-import { sanitizeFieldName } from "@rilldata/web-common/features/canvas/components/charts/util";
-import { sanitizeValueForVega } from "@rilldata/web-common/features/templates/charts/utils";
 import type { VisualizationSpec } from "svelte-vega";
 import {
   createColorEncoding,

--- a/web-common/src/features/canvas/components/charts/cartesian-charts/line-chart/spec.ts
+++ b/web-common/src/features/canvas/components/charts/cartesian-charts/line-chart/spec.ts
@@ -1,6 +1,8 @@
+import {
+  sanitizeFieldName,
+  sanitizeValueForVega,
+} from "@rilldata/web-common/components/vega/util";
 import type { TooltipValue } from "@rilldata/web-common/features/canvas/components/charts/types";
-import { sanitizeFieldName } from "@rilldata/web-common/features/canvas/components/charts/util";
-import { sanitizeValueForVega } from "@rilldata/web-common/features/templates/charts/utils";
 import type { VisualizationSpec } from "svelte-vega";
 import {
   createColorEncoding,

--- a/web-common/src/features/canvas/components/charts/selector.ts
+++ b/web-common/src/features/canvas/components/charts/selector.ts
@@ -1,3 +1,4 @@
+import { timeGrainToVegaTimeUnitMap } from "@rilldata/web-common/components/vega/util";
 import type { ChartSpec } from "@rilldata/web-common/features/canvas/components/charts";
 import type { BaseChart } from "@rilldata/web-common/features/canvas/components/charts/BaseChart";
 import type { CanvasStore } from "@rilldata/web-common/features/canvas/state-managers/state-managers";
@@ -9,11 +10,7 @@ import {
 } from "@rilldata/web-common/runtime-client";
 import { derived, type Readable } from "svelte/store";
 import type { ChartDataResult, TimeDimensionDefinition } from "./types";
-import {
-  adjustDataForTimeZone,
-  getFieldsByType,
-  timeGrainToVegaTimeUnitMap,
-} from "./util";
+import { adjustDataForTimeZone, getFieldsByType } from "./util";
 
 export function getChartData(
   ctx: CanvasStore,

--- a/web-common/src/features/canvas/components/charts/util.ts
+++ b/web-common/src/features/canvas/components/charts/util.ts
@@ -1,6 +1,5 @@
 import { mergeFilters } from "@rilldata/web-common/features/dashboards/pivot/pivot-merge-filters";
 import { createInExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
-import { sanitizeValueForVega } from "@rilldata/web-common/features/templates/charts/utils";
 import { adjustOffsetForZone } from "@rilldata/web-common/lib/convertTimestampPreview";
 import { timeGrainToDuration } from "@rilldata/web-common/lib/time/grains";
 import {
@@ -50,31 +49,6 @@ export function mergedVlConfig(
   return merge(validSpecConfig, parsedConfig, {
     arrayMerge: replaceByClonedSource,
   });
-}
-
-export const timeGrainToVegaTimeUnitMap: Record<V1TimeGrain, string> = {
-  [V1TimeGrain.TIME_GRAIN_MILLISECOND]: "yearmonthdatehoursminutesseconds",
-  [V1TimeGrain.TIME_GRAIN_SECOND]: "yearmonthdatehoursminutesseconds",
-  [V1TimeGrain.TIME_GRAIN_MINUTE]: "yearmonthdatehoursminutes",
-  [V1TimeGrain.TIME_GRAIN_HOUR]: "yearmonthdatehours",
-  [V1TimeGrain.TIME_GRAIN_DAY]: "yearmonthdate",
-  [V1TimeGrain.TIME_GRAIN_WEEK]: "yearweek",
-  [V1TimeGrain.TIME_GRAIN_MONTH]: "yearmonth",
-  [V1TimeGrain.TIME_GRAIN_QUARTER]: "yearquarter",
-  [V1TimeGrain.TIME_GRAIN_YEAR]: "year",
-  [V1TimeGrain.TIME_GRAIN_UNSPECIFIED]: "yearmonthdate",
-};
-
-export function sanitizeFieldName(fieldName: string) {
-  const specialCharactersRemoved = sanitizeValueForVega(fieldName);
-  const sanitizedFieldName = specialCharactersRemoved.replace(" ", "__");
-
-  /**
-   * Add a prefix to the beginning of the field
-   * name to avoid variables starting with a special
-   * character or number.
-   */
-  return `rill_${sanitizedFieldName}`;
 }
 
 export interface FieldsByType {

--- a/web-common/src/features/canvas/stores/canvas-component.ts
+++ b/web-common/src/features/canvas/stores/canvas-component.ts
@@ -1,9 +1,9 @@
 import type { CanvasSpecResponseStore } from "@rilldata/web-common/features/canvas/types";
 import { type Writable } from "svelte/store";
+import type { ComponentSpec } from "../components/types";
 import { Filters } from "./filters";
 import type { CanvasResolvedSpec } from "./spec";
 import { TimeControls } from "./time-control";
-import type { ComponentSpec } from "../components/types";
 
 export class CanvasComponentState<T = ComponentSpec> {
   localFilters: Filters;

--- a/web-common/src/features/dashboards/time-dimension-details/charts/patch-vega-spec.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/charts/patch-vega-spec.ts
@@ -1,4 +1,4 @@
-import { timeGrainToVegaTimeUnitMap } from "@rilldata/web-common/features/canvas/components/charts/util";
+import { timeGrainToVegaTimeUnitMap } from "@rilldata/web-common/components/vega/util";
 import { COMPARIONS_COLORS } from "@rilldata/web-common/features/dashboards/config";
 import {
   MainAreaColorGradientDark,

--- a/web-common/src/features/templates/charts/grouped-comparison-bar.ts
+++ b/web-common/src/features/templates/charts/grouped-comparison-bar.ts
@@ -1,6 +1,7 @@
+import { sanitizeValueForVega } from "@rilldata/web-common/components/vega/util";
 import { ScrubBoxColor } from "@rilldata/web-common/features/dashboards/time-series/chart-colors";
 import type { ChartField } from "./build-template";
-import { sanitizeValueForVega, singleLayerBaseSpec } from "./utils";
+import { singleLayerBaseSpec } from "./utils";
 
 export function buildGroupedComparisonBar(
   timeFields: ChartField[],

--- a/web-common/src/features/templates/charts/stacked-area.ts
+++ b/web-common/src/features/templates/charts/stacked-area.ts
@@ -1,11 +1,11 @@
+import {
+  sanitizeValueForVega,
+  sanitizeValuesForSpec,
+} from "@rilldata/web-common/components/vega/util";
 import type { TooltipValue } from "@rilldata/web-common/features/canvas/components/charts/types";
 import { ScrubBoxColor } from "@rilldata/web-common/features/dashboards/time-series/chart-colors";
 import type { ChartField } from "./build-template";
-import {
-  multiLayerBaseSpec,
-  sanitizeValueForVega,
-  sanitizeValuesForSpec,
-} from "./utils";
+import { multiLayerBaseSpec } from "./utils";
 
 export function buildStackedArea(
   timeField: ChartField,

--- a/web-common/src/features/templates/charts/stacked-grouped-bar.ts
+++ b/web-common/src/features/templates/charts/stacked-grouped-bar.ts
@@ -1,6 +1,7 @@
+import { sanitizeValueForVega } from "@rilldata/web-common/components/vega/util";
 import { ScrubBoxColor } from "@rilldata/web-common/features/dashboards/time-series/chart-colors";
 import type { ChartField } from "./build-template";
-import { sanitizeValueForVega, singleLayerBaseSpec } from "./utils";
+import { singleLayerBaseSpec } from "./utils";
 
 export function buildStackedGroupedBar(
   timeFields: ChartField[],

--- a/web-common/src/features/templates/charts/utils.ts
+++ b/web-common/src/features/templates/charts/utils.ts
@@ -23,22 +23,6 @@ export function multiLayerBaseSpec() {
   return baseSpec;
 }
 
-export function sanitizeValueForVega(value: unknown) {
-  if (typeof value === "string") {
-    // Escape all special characters including quotes, brackets, operators, etc.
-    return value.replace(
-      /[!@#$%^&*()+=\-[\]\\';,./{}|:<>?~]/g,
-      (match) => `\\${match}`,
-    );
-  } else {
-    return String(value);
-  }
-}
-
-export function sanitizeValuesForSpec(values: unknown[]) {
-  return values.map((value) => sanitizeValueForVega(value));
-}
-
 export const templateNameToChartEnumMap = {
   bar_chart: ChartType.BAR,
   grouped_bar_chart: ChartType.GROUPED_BAR,


### PR DESCRIPTION
Explore on `main` branch was crashing due to a dependency error originating from `web-common/src/features/canvas/components/util.ts`. This PR moves shared util methods out of canvas utils.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
