### PR TITLE
hotfix: include pending invites when all is filtered in org users table

### DIFF
--- a/web-admin/src/routes/[organization]/-/users/+page.svelte
+++ b/web-admin/src/routes/[organization]/-/users/+page.svelte
@@ -99,8 +99,8 @@
       let matchesRole = false;
 
       if (filterSelection === "all") {
-        // All org users (members + guests)
-        matchesRole = !("invitedBy" in user);
+        // All org users (members + guests + pending invites)
+        matchesRole = true;
       } else if (filterSelection === "members") {
         // Only members (org admin, editor, viewer)
         matchesRole =


### PR DESCRIPTION
Include the org invites when all is selected

https://github.com/user-attachments/assets/f4c88587-463e-4ab2-a1b5-5501c53e1407

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
