### PR TITLE
Fix rename of distributed Clickhouse table

### DIFF
--- a/runtime/drivers/clickhouse/crud.go
+++ b/runtime/drivers/clickhouse/crud.go
@@ -448,7 +448,7 @@ func (c *Connection) createTable(ctx context.Context, name, sql string, outputPr
 	var distributed strings.Builder
 	database := "currentDatabase()"
 	if c.config.Database != "" {
-		database = safeSQLName(c.config.Database)
+		database = safeSQLString(c.config.Database)
 	}
 	fmt.Fprintf(&distributed, "CREATE OR REPLACE TABLE %s %s AS %s", safeSQLName(name), onClusterClause, safeSQLName(localTableName(name)))
 	fmt.Fprintf(&distributed, " ENGINE = Distributed(%s, %s, %s", safeSQLString(c.config.Cluster), database, safeSQLString(localTableName(name)))

--- a/runtime/drivers/clickhouse/crud.go
+++ b/runtime/drivers/clickhouse/crud.go
@@ -227,7 +227,7 @@ func (c *Connection) dropTable(ctx context.Context, name string) error {
 		// then drop the local table in case of cluster
 		if onCluster && !strings.HasSuffix(name, "_local") {
 			return c.Exec(ctx, &drivers.Statement{
-				Query:    fmt.Sprintf("DROP TABLE %s %s", safelocalTableName(name), onClusterClause),
+				Query:    fmt.Sprintf("DROP TABLE %s %s", safeSQLName(localTableName(name)), onClusterClause),
 				Priority: 100,
 			})
 		}
@@ -283,7 +283,7 @@ func (c *Connection) renameEntity(ctx context.Context, oldName, newName string) 
 			return err
 		}
 		res.Close()
-		engineFull = strings.ReplaceAll(engineFull, localTableName(oldName), safelocalTableName(newName))
+		engineFull = strings.ReplaceAll(engineFull, localTableName(oldName), localTableName(newName))
 
 		// build the column type clause
 		columnClause, err := c.columnClause(ctx, oldName)
@@ -396,7 +396,7 @@ func (c *Connection) createTable(ctx context.Context, name, sql string, outputPr
 	create.WriteString("CREATE OR REPLACE TABLE ")
 	if c.config.Cluster != "" {
 		// need to create a local table on the cluster first
-		fmt.Fprintf(&create, "%s %s", safelocalTableName(name), onClusterClause)
+		fmt.Fprintf(&create, "%s %s", safeSQLName(localTableName(name)), onClusterClause)
 	} else {
 		create.WriteString(safeSQLName(name))
 	}
@@ -448,9 +448,9 @@ func (c *Connection) createTable(ctx context.Context, name, sql string, outputPr
 	var distributed strings.Builder
 	database := "currentDatabase()"
 	if c.config.Database != "" {
-		database = safeSQLString(c.config.Database)
+		database = safeSQLName(c.config.Database)
 	}
-	fmt.Fprintf(&distributed, "CREATE OR REPLACE TABLE %s %s AS %s", safeSQLName(name), onClusterClause, safelocalTableName(name))
+	fmt.Fprintf(&distributed, "CREATE OR REPLACE TABLE %s %s AS %s", safeSQLName(name), onClusterClause, safeSQLName(localTableName(name)))
 	fmt.Fprintf(&distributed, " ENGINE = Distributed(%s, %s, %s", safeSQLString(c.config.Cluster), database, safeSQLString(localTableName(name)))
 	if outputProps.DistributedShardingKey != "" {
 		fmt.Fprintf(&distributed, ", %s", outputProps.DistributedShardingKey)
@@ -601,10 +601,6 @@ func (c *Connection) getTablePartitions(ctx context.Context, name string) ([]str
 		return nil, err
 	}
 	return partitions, nil
-}
-
-func safelocalTableName(name string) string {
-	return safeSQLName(name + "_local")
 }
 
 func localTableName(name string) string {

--- a/runtime/resolvers/testdata/athena_connector.yaml
+++ b/runtime/resolvers/testdata/athena_connector.yaml
@@ -1,3 +1,4 @@
+expensive: true
 connectors:
   - athena
 project_files:

--- a/runtime/resolvers/testdata/clickhouse_cluster.yaml
+++ b/runtime/resolvers/testdata/clickhouse_cluster.yaml
@@ -1,0 +1,26 @@
+expensive: true
+connectors:
+  - clickhouse_cluster
+variables:
+  rill.stage_changes: true
+project_files:
+  clickhouse_cluster.yaml:
+    type: connector
+    driver: clickhouse
+    cluster: ch_cluster_2S_2R
+  one.yaml:
+    type: model
+    materialize: true
+    connector: clickhouse_cluster
+    sql: SELECT 1 AS one
+    output:
+      connector: clickhouse_cluster
+tests:
+  - name: query_all_datatypes_star_duckdb
+    resolver: sql
+    properties:
+      connector: clickhouse_cluster
+      sql: "select * from one"
+    result_csv: |
+      one
+      1

--- a/runtime/resolvers/testdata/models_clickhouse_cluster.yaml
+++ b/runtime/resolvers/testdata/models_clickhouse_cluster.yaml
@@ -1,7 +1,9 @@
+# Tests end-to-end creation of a distributed model on a test ClickHouse cluster.
 expensive: true
 connectors:
   - clickhouse_cluster
 variables:
+  # Enable stage_changes to test that renames of distributed tables are handled correctly.
   rill.stage_changes: true
 project_files:
   clickhouse_cluster.yaml:

--- a/runtime/resolvers/testdata/snowflake_connector.yaml
+++ b/runtime/resolvers/testdata/snowflake_connector.yaml
@@ -1,3 +1,4 @@
+expensive: true
 connectors:
   - clickhouse
   - snowflake

--- a/runtime/testruntime/connectors.go
+++ b/runtime/testruntime/connectors.go
@@ -50,6 +50,11 @@ var Connectors = map[string]ConnectorAcquireFunc{
 		dsn := testclickhouse.Start(t)
 		return map[string]string{"dsn": dsn}
 	},
+	// clickhouse_cluster starts multiple test containers and configures them as a ClickHouse cluster.
+	"clickhouse_cluster": func(t TestingT) map[string]string {
+		dsn, cluster := testclickhouse.StartCluster(t)
+		return map[string]string{"dsn": dsn, "cluster": cluster}
+	},
 	// Bigquery connector connects to a real bigquery cluster using the credentials json in RILL_RUNTIME_BIGQUERY_TEST_GOOGLE_APPLICATION_CREDENTIALS_JSON.
 	// The service account must have the following permissions:
 	// - BigQuery Data Viewer

--- a/runtime/testruntime/testruntime.go
+++ b/runtime/testruntime/testruntime.go
@@ -108,7 +108,9 @@ func NewInstanceWithOptions(t TestingT, opts InstanceOptions) (*runtime.Runtime,
 
 	vars := make(map[string]string)
 	maps.Copy(vars, opts.Variables)
-	vars["rill.stage_changes"] = strconv.FormatBool(opts.StageChanges)
+	if vars["rill.stage_changes"] == "" {
+		vars["rill.stage_changes"] = strconv.FormatBool(opts.StageChanges)
+	}
 
 	for _, conn := range opts.TestConnectors {
 		acquire, ok := Connectors[conn]


### PR DESCRIPTION
When the temp table is renamed, it currently ends up declaring the distributed table with too many quotes, i.e. `'"mymodel"'` instead of `'mymodel'`:
```
CREATE OR REPLACE TABLE "mymodel" ON CLUSTER "mycluster" (...) Engine = Distributed('mycluster', 'default', '"mymodel"', rand())
```

**Checklist:**
- [x] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
