### PR TITLE
fix (Exports): Simplify time ranges for on-demand exports

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/dimension-table-export.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-export.ts
@@ -20,6 +20,7 @@ import type {
 } from "@rilldata/web-common/runtime-client";
 import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
 import { get } from "svelte/store";
+import { LATEST_WINDOW_TIME_RANGES } from "../../../lib/time/config";
 import { buildWhereParamForDimensionTableAndTDDExports } from "../../exports/export-filters";
 import { dimensionSearchText as dimensionSearchTextStore } from "../stores/dashboard-stores";
 
@@ -46,8 +47,13 @@ export function getDimensionTableExportQuery(
     timeRange,
   );
   if (!timeRange) return undefined;
-  if (!isScheduled) {
-    // To match the UI's time range, we must explicitly specify `timeEnd` for on-demand exports
+
+  const isLatestTimeRange =
+    timeControlState.selectedTimeRange?.name &&
+    LATEST_WINDOW_TIME_RANGES[timeControlState.selectedTimeRange?.name];
+
+  if (!isScheduled && isLatestTimeRange) {
+    // For on-demand exports of "latest" time ranges, we must explicitly specify `timeEnd` to match the UI's time range
     timeRange.end = timeControlState.timeEnd;
     if (comparisonTimeRange) {
       comparisonTimeRange.end = timeControlState.timeEnd;

--- a/web-common/src/features/dashboards/pivot/pivot-export.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-export.ts
@@ -3,7 +3,7 @@ import { sanitiseExpression } from "@rilldata/web-common/features/dashboards/sto
 import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
 import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import { mapSelectedTimeRangeToV1TimeRange } from "@rilldata/web-common/features/dashboards/time-controls/time-range-mappers";
-import type { TimeRangeString } from "@rilldata/web-common/lib/time/types";
+import { type TimeRangeString } from "@rilldata/web-common/lib/time/types";
 import {
   V1TimeGrain,
   type V1MetricsViewAggregationRequest,
@@ -12,6 +12,7 @@ import {
   type V1TimeRange,
 } from "@rilldata/web-common/runtime-client";
 import { get } from "svelte/store";
+import { LATEST_WINDOW_TIME_RANGES } from "../../../lib/time/config";
 import { runtime } from "../../../runtime-client/runtime-store";
 import type { StateManagers } from "../state-managers/state-managers";
 import { getPivotConfig } from "./pivot-data-config";
@@ -49,9 +50,15 @@ export function getPivotExportQuery(ctx: StateManagers, isScheduled: boolean) {
     dashboardState.selectedTimezone,
     exploreSpec,
   );
+
   if (!timeRange) return undefined;
-  if (!isScheduled) {
-    // To match the UI's time range, we must explicitly specify `timeEnd` for on-demand exports
+
+  const isLatestTimeRange =
+    timeControlState.selectedTimeRange?.name &&
+    LATEST_WINDOW_TIME_RANGES[timeControlState.selectedTimeRange?.name];
+
+  if (!isScheduled && isLatestTimeRange) {
+    // For on-demand exports of "latest" time ranges, we must explicitly specify `timeEnd` to match the UI's time range
     timeRange.end = timeControlState.timeEnd;
   }
 

--- a/web-common/src/features/dashboards/time-dimension-details/tdd-export.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/tdd-export.ts
@@ -12,10 +12,10 @@ import type {
   V1MetricsViewAggregationRequest,
   V1MetricsViewSpec,
   V1Query,
+  V1TimeRange,
 } from "@rilldata/web-common/runtime-client";
 import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
 import { get } from "svelte/store";
-import { LATEST_WINDOW_TIME_RANGES } from "../../../lib/time/config";
 import { buildWhereParamForDimensionTableAndTDDExports } from "../../exports/export-filters";
 import { dimensionSearchText as dimensionSearchTextStore } from "../stores/dashboard-stores";
 
@@ -61,21 +61,20 @@ function getTDDAggregationRequest(
   )
     return undefined;
 
-  const timeRange = mapSelectedTimeRangeToV1TimeRange(
-    timeControlState,
-    dashboardState.selectedTimezone,
-    explore,
-  );
-  if (!timeRange) return undefined;
-
-  const isLatestTimeRange =
-    timeControlState.selectedTimeRange?.name &&
-    LATEST_WINDOW_TIME_RANGES[timeControlState.selectedTimeRange?.name];
-
-  if (!isScheduled && isLatestTimeRange) {
-    // For on-demand exports of "latest" time ranges, we must explicitly specify `timeEnd` to match the UI's time range
-    timeRange.end = timeControlState.timeEnd;
+  let timeRange: V1TimeRange | undefined;
+  if (isScheduled) {
+    timeRange = mapSelectedTimeRangeToV1TimeRange(
+      timeControlState,
+      dashboardState.selectedTimezone,
+      explore,
+    );
+  } else {
+    timeRange = {
+      start: timeControlState.timeStart,
+      end: timeControlState.timeEnd,
+    };
   }
+  if (!timeRange) return undefined;
 
   const measures: V1MetricsViewAggregationMeasure[] = [
     { name: dashboardState.tdd.expandedMeasureName },

--- a/web-common/src/features/dashboards/time-dimension-details/tdd-export.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/tdd-export.ts
@@ -15,6 +15,7 @@ import type {
 } from "@rilldata/web-common/runtime-client";
 import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
 import { get } from "svelte/store";
+import { LATEST_WINDOW_TIME_RANGES } from "../../../lib/time/config";
 import { buildWhereParamForDimensionTableAndTDDExports } from "../../exports/export-filters";
 import { dimensionSearchText as dimensionSearchTextStore } from "../stores/dashboard-stores";
 
@@ -66,8 +67,13 @@ function getTDDAggregationRequest(
     explore,
   );
   if (!timeRange) return undefined;
-  if (!isScheduled) {
-    // To match the UI's time range, we must explicitly specify `timeEnd` for on-demand exports
+
+  const isLatestTimeRange =
+    timeControlState.selectedTimeRange?.name &&
+    LATEST_WINDOW_TIME_RANGES[timeControlState.selectedTimeRange?.name];
+
+  if (!isScheduled && isLatestTimeRange) {
+    // For on-demand exports of "latest" time ranges, we must explicitly specify `timeEnd` to match the UI's time range
     timeRange.end = timeControlState.timeEnd;
   }
 


### PR DESCRIPTION
This PR changes the way we provide time ranges to the `Export` API _for on-demand (non-scheduled) exports_. 

Previously, we provided a time range expression (e.g. `P7D`, `rill-MTD`) and amended it by also specifying an `endDate`.  (This amendment attempted to ensure consistency with the data shown in the UI, but the approach was faulty).

Now, we pass in the `startTime` and `endTime` from the `timeControlsStore`. Currently, the `timeControlsStore` resolves time range expressions client-side. However, in the future, we should use the backend's `MetricsViewTimeRanges` API to resolve time ranges.

Closes https://github.com/rilldata/rill-private-issues/issues/1650

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
