### PR TITLE
Fix org permissions for org tabs

### DIFF
--- a/web-admin/src/features/organizations/OrganizationTabs.svelte
+++ b/web-admin/src/features/organizations/OrganizationTabs.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-  import { type V1OrganizationPermissions } from "@rilldata/web-admin/client";
+  import {
+    createAdminServiceListRoles,
+    type V1OrganizationPermissions,
+  } from "@rilldata/web-admin/client";
   import Tab from "@rilldata/web-admin/components/nav/Tab.svelte";
   import {
     width,
@@ -14,8 +17,16 @@
   export let organizationPermissions: V1OrganizationPermissions;
   export let pathname: string;
 
-  $: isAdmin = isOrgAdmin(organizationPermissions);
-  $: isEditor = isOrgEditor(organizationPermissions);
+  const listRoles = createAdminServiceListRoles();
+
+  $: isAdmin = isOrgAdmin(
+    organizationPermissions,
+    $listRoles?.data?.organizationRoles,
+  );
+  $: isEditor = isOrgEditor(
+    organizationPermissions,
+    $listRoles?.data?.organizationRoles,
+  );
 
   $: tabs = [
     {

--- a/web-admin/src/features/organizations/OrganizationTabs.svelte
+++ b/web-admin/src/features/organizations/OrganizationTabs.svelte
@@ -4,11 +4,18 @@
   import {
     width,
     position,
-  } from "@rilldata/web-admin//components/nav/Tab.svelte";
+  } from "@rilldata/web-admin/components/nav/Tab.svelte";
+  import {
+    isOrgAdmin,
+    isOrgEditor,
+  } from "@rilldata/web-admin/features/organizations/users/permissions";
 
   export let organization: string;
   export let organizationPermissions: V1OrganizationPermissions;
   export let pathname: string;
+
+  $: isAdmin = isOrgAdmin(organizationPermissions);
+  $: isEditor = isOrgEditor(organizationPermissions);
 
   $: tabs = [
     {
@@ -19,18 +26,16 @@
     {
       route: `/${organization}/-/users`,
       label: "Users",
-      hasPermission: organizationPermissions.manageOrgMembers,
+      hasPermission: isAdmin || isEditor,
     },
     {
       route: `/${organization}/-/settings`,
       label: "Settings",
-      hasPermission: organizationPermissions.manageOrg,
+      hasPermission: isAdmin,
     },
   ];
 
-  $: showTabs =
-    organizationPermissions.manageOrg ||
-    organizationPermissions.manageOrgMembers;
+  $: showTabs = isAdmin || isEditor;
 
   $: selectedIndex = tabs?.findLastIndex((t) => pathname.startsWith(t.route));
 </script>

--- a/web-admin/src/features/organizations/users/permissions.ts
+++ b/web-admin/src/features/organizations/users/permissions.ts
@@ -1,12 +1,41 @@
-import type { V1OrganizationPermissions } from "@rilldata/web-admin/client";
+import type {
+  V1OrganizationPermissions,
+  V1OrganizationRole,
+} from "@rilldata/web-admin/client";
+
+/**
+ * Gets the organization role from the list of roles based on the permissions
+ */
+export function getOrgRole(
+  permissions?: V1OrganizationPermissions,
+  roles?: V1OrganizationRole[],
+): V1OrganizationRole | undefined {
+  if (!permissions || !roles) return undefined;
+
+  // Find the role that matches the user's permissions
+  return roles.find((role) => {
+    const rolePerms = role.permissions;
+    if (!rolePerms) return false;
+
+    // Check if all permissions in the role match the user's permissions
+    return Object.entries(rolePerms).every(
+      ([key, value]) =>
+        permissions[key as keyof V1OrganizationPermissions] === value,
+    );
+  });
+}
 
 /**
  * @source https://docs.rilldata.com/manage/roles-permissions#organization-level-permissions
  *
  * Checks if a user has admin permissions for an organization
  */
-export function isOrgAdmin(permissions?: V1OrganizationPermissions): boolean {
-  return !!permissions?.admin;
+export function isOrgAdmin(
+  permissions?: V1OrganizationPermissions,
+  roles?: V1OrganizationRole[],
+): boolean {
+  const role = getOrgRole(permissions, roles);
+  return role?.name === "admin";
 }
 
 /**
@@ -14,14 +43,12 @@ export function isOrgAdmin(permissions?: V1OrganizationPermissions): boolean {
  *
  * Checks if a user has editor permissions for an organization
  */
-export function isOrgEditor(permissions?: V1OrganizationPermissions): boolean {
-  return !!(
-    permissions?.readOrg &&
-    permissions?.readProjects &&
-    permissions?.createProjects &&
-    permissions?.readOrgMembers &&
-    permissions?.manageOrgMembers
-  );
+export function isOrgEditor(
+  permissions?: V1OrganizationPermissions,
+  roles?: V1OrganizationRole[],
+): boolean {
+  const role = getOrgRole(permissions, roles);
+  return role?.name === "editor";
 }
 
 /**
@@ -29,8 +56,12 @@ export function isOrgEditor(permissions?: V1OrganizationPermissions): boolean {
  *
  * Checks if a user has viewer permissions for an organization
  */
-export function isOrgViewer(permissions?: V1OrganizationPermissions): boolean {
-  return !!(permissions?.readOrg && permissions?.readProjects);
+export function isOrgViewer(
+  permissions?: V1OrganizationPermissions,
+  roles?: V1OrganizationRole[],
+): boolean {
+  const role = getOrgRole(permissions, roles);
+  return role?.name === "viewer";
 }
 
 /**
@@ -38,6 +69,10 @@ export function isOrgViewer(permissions?: V1OrganizationPermissions): boolean {
  *
  * Checks if a user has guest permissions for an organization
  */
-export function isOrgGuest(permissions?: V1OrganizationPermissions): boolean {
-  return !!permissions?.guest;
+export function isOrgGuest(
+  permissions?: V1OrganizationPermissions,
+  roles?: V1OrganizationRole[],
+): boolean {
+  const role = getOrgRole(permissions, roles);
+  return role?.name === "guest";
 }

--- a/web-admin/src/features/organizations/users/permissions.ts
+++ b/web-admin/src/features/organizations/users/permissions.ts
@@ -1,0 +1,43 @@
+import type { V1OrganizationPermissions } from "@rilldata/web-admin/client";
+
+/**
+ * @source https://docs.rilldata.com/manage/roles-permissions#organization-level-permissions
+ *
+ * Checks if a user has admin permissions for an organization
+ */
+export function isOrgAdmin(permissions?: V1OrganizationPermissions): boolean {
+  return !!permissions?.admin;
+}
+
+/**
+ * @source https://docs.rilldata.com/manage/roles-permissions#organization-level-permissions
+ *
+ * Checks if a user has editor permissions for an organization
+ */
+export function isOrgEditor(permissions?: V1OrganizationPermissions): boolean {
+  return !!(
+    permissions?.readOrg &&
+    permissions?.readProjects &&
+    permissions?.createProjects &&
+    permissions?.readOrgMembers &&
+    permissions?.manageOrgMembers
+  );
+}
+
+/**
+ * @source https://docs.rilldata.com/manage/roles-permissions#organization-level-permissions
+ *
+ * Checks if a user has viewer permissions for an organization
+ */
+export function isOrgViewer(permissions?: V1OrganizationPermissions): boolean {
+  return !!(permissions?.readOrg && permissions?.readProjects);
+}
+
+/**
+ * @source https://docs.rilldata.com/manage/roles-permissions#organization-level-permissions
+ *
+ * Checks if a user has guest permissions for an organization
+ */
+export function isOrgGuest(permissions?: V1OrganizationPermissions): boolean {
+  return !!permissions?.guest;
+}


### PR DESCRIPTION
This pull request ensures the correctness of org roles' permissions to the organization tabs. Closes https://github.com/rilldata/rill-private-issues/issues/1651

- `/users` can be accessed by org admin + editor
- `/settings` can be accessed by org admin

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
