### PR TITLE
fix: preserve leaderboard dimension order in canvas

### DIFF
--- a/web-common/src/features/canvas/components/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/canvas/components/leaderboard/LeaderboardDisplay.svelte
@@ -77,9 +77,11 @@
   $: allDimensions = getDimensionsForMetricView(metricsViewName);
   $: allMeasures = getMeasuresForMetricView(metricsViewName);
 
-  $: visibleDimensions = $allDimensions.filter((d) =>
-    dimensionNames.includes(d.name || (d.column as string)),
-  );
+  $: visibleDimensions = dimensionNames
+    .map((name) =>
+      $allDimensions.find((d) => (d.name || (d.column as string)) === name),
+    )
+    .filter((d) => d !== undefined);
 
   $: visibleMeasures = $allMeasures.filter((m) =>
     leaderboardMeasureNames.includes(m.name as string),


### PR DESCRIPTION
Maintain the original order of dimensions in the leaderboards on Canvas.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
