### PR TITLE
Allow `materialize: true` with `type: dictionary` in ClickHouse models

### DIFF
--- a/runtime/drivers/clickhouse/model_executor_localfile_self.go
+++ b/runtime/drivers/clickhouse/model_executor_localfile_self.go
@@ -146,6 +146,7 @@ func (e *localFileToSelfExecutor) Execute(ctx context.Context, opts *drivers.Mod
 	err = mapstructure.WeakDecode(&ModelResultProperties{
 		Table:         tableName,
 		View:          false,
+		Typ:           outputProps.Typ,
 		UsedModelName: usedModelName,
 	}, &resultPropsMap)
 	if err != nil {

--- a/runtime/drivers/clickhouse/model_executor_self.go
+++ b/runtime/drivers/clickhouse/model_executor_self.go
@@ -99,6 +99,7 @@ func (e *selfToSelfExecutor) Execute(ctx context.Context, opts *drivers.ModelExe
 	resultProps := &ModelResultProperties{
 		Table:         tableName,
 		View:          asView,
+		Typ:           outputProps.Typ,
 		UsedModelName: usedModelName,
 	}
 	resultPropsMap := map[string]interface{}{}

--- a/runtime/drivers/clickhouse/model_executor_self_test.go
+++ b/runtime/drivers/clickhouse/model_executor_self_test.go
@@ -1,0 +1,71 @@
+package clickhouse_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/rilldata/rill/runtime"
+	"github.com/rilldata/rill/runtime/testruntime"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaterializeType(t *testing.T) {
+	truth, falsity := true, false
+	cases := []struct {
+		name        string
+		materialize *bool
+		typ         string
+		wantType    string
+		wantErr     bool
+	}{
+		{"plain", nil, "", "view", false},
+		{"materialize-false", &falsity, "", "view", false},
+		{"materialize-true", &truth, "", "table", false},
+		{"materialize-false-view", &falsity, "view", "view", false},
+		{"materialize-true-view", &truth, "view", "", true},
+		{"materialize-false-table", &falsity, "table", "", true},
+		{"materialize-true-table", &truth, "table", "table", false},
+		{"materialize-false-dictionary", &falsity, "dictionary", "", true},
+		{"materialize-true-dictionary", &truth, "dictionary", "dictionary", false},
+		{"unknown-type", nil, "unknown", "", true},
+		{"unknown-type-materialize-false", &falsity, "unknown", "", true},
+		{"unknown-type-materialize-true", &truth, "unknown", "", true},
+	}
+
+	files := map[string]string{"rill.yaml": "olap_connector: clickhouse\n"}
+	for _, c := range cases {
+		data := "type: model\nsql: SELECT 1 AS id\n"
+		if c.materialize != nil {
+			data += fmt.Sprintf("materialize: %v\n", *c.materialize)
+		}
+		if c.typ != "" {
+			data += fmt.Sprintf("output:\n  type: %s\n", c.typ)
+			if c.typ == "dictionary" {
+				data += "  primary_key: id\n"
+			}
+		}
+		files[fmt.Sprintf("%s.yaml", c.name)] = data
+	}
+
+	rt, id := testruntime.NewInstanceWithOptions(t, testruntime.InstanceOptions{
+		TestConnectors: []string{"clickhouse"},
+		Files:          files,
+	})
+	testruntime.ReconcileParserAndWait(t, rt, id)
+
+	for _, c := range cases {
+		r := testruntime.GetResource(t, rt, id, runtime.ResourceKindModel, c.name)
+		require.NotNil(t, r, c.name)
+		if c.wantErr {
+			require.NotEmpty(t, r.Meta.ReconcileError, c.name)
+		} else {
+			require.Empty(t, r.Meta.ReconcileError, c.name)
+		}
+		if c.wantType != "" {
+			resultProps := r.GetModel().State.ResultProperties.AsMap()
+			typ := strings.ToLower(resultProps["type"].(string))
+			require.Equal(t, c.wantType, typ, c.name)
+		}
+	}
+}

--- a/runtime/drivers/clickhouse/model_manager.go
+++ b/runtime/drivers/clickhouse/model_manager.go
@@ -94,6 +94,9 @@ func (p *ModelOutputProperties) Validate(opts *drivers.ModelExecuteOptions) erro
 	if p.Typ == "" { // Plain unannotated models default to VIEW.
 		p.Typ = "VIEW"
 	}
+	if p.Typ != "TABLE" && p.Typ != "VIEW" && p.Typ != "DICTIONARY" {
+		return fmt.Errorf("invalid type %q, must be one of TABLE, VIEW or DICTIONARY", p.Typ)
+	}
 
 	switch p.IncrementalStrategy {
 	case drivers.IncrementalStrategyUnspecified, drivers.IncrementalStrategyAppend, drivers.IncrementalStrategyPartitionOverwrite, drivers.IncrementalStrategyMerge:
@@ -174,6 +177,7 @@ func (p *ModelOutputProperties) tblConfig() string {
 type ModelResultProperties struct {
 	Table         string `mapstructure:"table"`
 	View          bool   `mapstructure:"view"`
+	Typ           string `mapstructure:"type"`
 	UsedModelName bool   `mapstructure:"used_model_name"`
 }
 

--- a/runtime/testruntime/testruntime.go
+++ b/runtime/testruntime/testruntime.go
@@ -151,6 +151,10 @@ func NewInstanceWithOptions(t TestingT, opts InstanceOptions) (*runtime.Runtime,
 		WatchRepo: opts.WatchRepo,
 	}
 
+	if _, ok := opts.Files["rill.yaml"]; !ok {
+		opts.Files["rill.yaml"] = ""
+	}
+
 	for path, data := range opts.Files {
 		abs := filepath.Join(tmpDir, path)
 		require.NoError(t, os.MkdirAll(filepath.Dir(abs), os.ModePerm))


### PR DESCRIPTION
It's an easy mistake to make and since dictionaries can be considered a kind of materialization, I think we should just allow it.

**Checklist:**
- [x] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
