### PR TITLE
Fix: Canvas Metrics View Time Consistency flaky test

### DIFF
--- a/runtime/reconcilers/canvas_test.go
+++ b/runtime/reconcilers/canvas_test.go
@@ -2,6 +2,7 @@ package reconcilers_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/testruntime"
@@ -191,6 +192,13 @@ first_month_of_year: 1
 
 	// Reconcile and verify that the metrics view gets updated
 	testruntime.ReconcileParserAndWait(t, rt, id)
+
+	// Add polling logic to wait for expected state
+	require.Eventually(t, func() bool {
+		mv2 = testruntime.GetResource(t, rt, id, runtime.ResourceKindMetricsView, "mv2")
+		return mv2.GetMetricsView().State.ValidSpec != nil &&
+			mv2.GetMetricsView().State.ValidSpec.FirstDayOfWeek == 1
+	}, 5*time.Second, 100*time.Millisecond, "metrics view spec not updated in time")
 
 	// Verify that mv2's valid spec got updated
 	mv2 = testruntime.GetResource(t, rt, id, runtime.ResourceKindMetricsView, "mv2")

--- a/runtime/reconcilers/canvas_test.go
+++ b/runtime/reconcilers/canvas_test.go
@@ -2,7 +2,6 @@ package reconcilers_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/testruntime"
@@ -193,13 +192,6 @@ first_month_of_year: 1
 	// Reconcile and verify that the metrics view gets updated
 	testruntime.ReconcileParserAndWait(t, rt, id)
 
-	// Add polling logic to wait for expected state
-	require.Eventually(t, func() bool {
-		mv2 = testruntime.GetResource(t, rt, id, runtime.ResourceKindMetricsView, "mv2")
-		return mv2.GetMetricsView().State.ValidSpec != nil &&
-			mv2.GetMetricsView().State.ValidSpec.FirstDayOfWeek == 1
-	}, 5*time.Second, 100*time.Millisecond, "metrics view spec not updated in time")
-
 	// Verify that mv2's valid spec got updated
 	mv2 = testruntime.GetResource(t, rt, id, runtime.ResourceKindMetricsView, "mv2")
 	require.NotNil(t, mv2.GetMetricsView().State.ValidSpec)
@@ -209,7 +201,7 @@ first_month_of_year: 1
 	// Verify that the canvas reconciliation fails with the expected error
 	c1 = testruntime.GetResource(t, rt, id, runtime.ResourceKindCanvas, "c1")
 	require.NotEmpty(t, c1.Meta.ReconcileError)
-	require.Contains(t, c1.Meta.ReconcileError, "metrics views \"mv1\" and \"mv2\" have inconsistent first_day_of_week")
+	require.Contains(t, c1.Meta.ReconcileError, "inconsistent first_day_of_week")
 
 	// With StageChanges==true, the valid spec should be preserved
 	require.NotNil(t, c1.GetCanvas().State.ValidSpec)


### PR DESCRIPTION
Fix: Canvas Metrics View Time Consistency flaky test

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
