### PR TITLE
Org table avatar and columns width hotfix

### DIFF
--- a/web-admin/src/features/organizations/users/OrgGroupsTable.svelte
+++ b/web-admin/src/features/organizations/users/OrgGroupsTable.svelte
@@ -18,7 +18,7 @@
       accessorKey: "groupName",
       header: "Group",
       meta: {
-        widthPercent: 5,
+        widthPercent: 50,
       },
     },
     {
@@ -31,7 +31,7 @@
           role: row.original.roleName,
         }),
       meta: {
-        widthPercent: 5,
+        widthPercent: 40,
         marginLeft: "8px",
       },
     },
@@ -47,7 +47,7 @@
           searchUsersList: searchUsersList,
         }),
       meta: {
-        widthPercent: 0,
+        widthPercent: 5,
       },
     },
   ];

--- a/web-admin/src/features/organizations/users/OrgUsersTable.svelte
+++ b/web-admin/src/features/organizations/users/OrgUsersTable.svelte
@@ -81,7 +81,7 @@
           role: row.original.roleName,
         }),
       meta: {
-        widthPercent: 5,
+        widthPercent: 50,
       },
     },
     {
@@ -97,7 +97,7 @@
           onAttemptChangeBillingContactUserRole,
         }),
       meta: {
-        widthPercent: 5,
+        widthPercent: 40,
         marginLeft: "8px",
       },
     },
@@ -115,7 +115,7 @@
           onAttemptRemoveBillingContactUser,
         }),
       meta: {
-        widthPercent: 0,
+        widthPercent: 5,
       },
     },
   ];

--- a/web-common/src/components/avatar/Avatar.svelte
+++ b/web-common/src/components/avatar/Avatar.svelte
@@ -27,7 +27,7 @@
 >
   <div
     class={cn(
-      `flex h-full w-full items-center justify-center overflow-hidden rounded-full border`,
+      `flex h-7 w-7 items-center justify-center overflow-hidden rounded-full border`,
       {
         "border-dashed bg-transparent border-slate-400": !src && !alt,
         [`border-transparent ${bgColor}`]:


### PR DESCRIPTION
This pull request sets an intrinsic dimension to the avatar when the avatar URL is being loaded so that users won't see the shrunk avatar size. Additionally, the column percentage widths in the organization tables have been adjusted. Closes https://github.com/rilldata/rill/issues/7250

![CleanShot 2025-05-01 at 12 14 07@2x](https://github.com/user-attachments/assets/e2d4ecdc-3375-413e-b924-e51dafbac5c0)


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
