### PR TITLE
Filtered dimension filters

### DIFF
--- a/web-common/src/features/canvas/filters/CanvasFilters.svelte
+++ b/web-common/src/features/canvas/filters/CanvasFilters.svelte
@@ -351,7 +351,6 @@
                 timeControlsReady={!!$timeRangeStateStore}
                 excludeMode={$isFilterExcludeMode(name)}
                 whereFilter={$whereFilter}
-                dimensionThresholdFilters={[]}
                 onRemove={() => removeDimensionFilter(name)}
                 onToggleFilterMode={() => toggleDimensionFilterMode(name)}
                 onSelect={(value) =>

--- a/web-common/src/features/canvas/filters/CanvasFilters.svelte
+++ b/web-common/src/features/canvas/filters/CanvasFilters.svelte
@@ -350,6 +350,8 @@
                 {timeEnd}
                 timeControlsReady={!!$timeRangeStateStore}
                 excludeMode={$isFilterExcludeMode(name)}
+                whereFilter={$whereFilter}
+                dimensionThresholdFilters={[]}
                 onRemove={() => removeDimensionFilter(name)}
                 onToggleFilterMode={() => toggleDimensionFilterMode(name)}
                 onSelect={(value) =>

--- a/web-common/src/features/canvas/inspector/filters/DimensionFiltersInput.svelte
+++ b/web-common/src/features/canvas/inspector/filters/DimensionFiltersInput.svelte
@@ -172,7 +172,6 @@
                   timeControlsReady
                   excludeMode={$isFilterExcludeMode(name)}
                   whereFilter={$whereFilter}
-                  dimensionThresholdFilters={[]}
                   onRemove={() => removeDimensionFilter(name)}
                   onToggleFilterMode={() => toggleDimensionFilterMode(name)}
                   onSelect={(value) =>

--- a/web-common/src/features/canvas/inspector/filters/DimensionFiltersInput.svelte
+++ b/web-common/src/features/canvas/inspector/filters/DimensionFiltersInput.svelte
@@ -56,6 +56,7 @@
     getMeasureFilterItems,
     getAllMeasureFilterItems,
     measureHasFilter,
+    dimensionThresholdFilters,
   } = componentStore.localFilters);
 
   $: dimensionIdMap = getMapFromArray(
@@ -171,6 +172,8 @@
                   timeEnd={new Date().toISOString()}
                   timeControlsReady
                   excludeMode={$isFilterExcludeMode(name)}
+                  whereFilter={$whereFilter}
+                  dimensionThresholdFilters={$dimensionThresholdFilters}
                   onRemove={() => removeDimensionFilter(name)}
                   onToggleFilterMode={() => toggleDimensionFilterMode(name)}
                   onSelect={(value) =>

--- a/web-common/src/features/canvas/inspector/filters/DimensionFiltersInput.svelte
+++ b/web-common/src/features/canvas/inspector/filters/DimensionFiltersInput.svelte
@@ -56,7 +56,6 @@
     getMeasureFilterItems,
     getAllMeasureFilterItems,
     measureHasFilter,
-    dimensionThresholdFilters,
   } = componentStore.localFilters);
 
   $: dimensionIdMap = getMapFromArray(
@@ -173,7 +172,7 @@
                   timeControlsReady
                   excludeMode={$isFilterExcludeMode(name)}
                   whereFilter={$whereFilter}
-                  dimensionThresholdFilters={$dimensionThresholdFilters}
+                  dimensionThresholdFilters={[]}
                   onRemove={() => removeDimensionFilter(name)}
                   onToggleFilterMode={() => toggleDimensionFilterMode(name)}
                   onSelect={(value) =>

--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -392,6 +392,8 @@
           <div animate:flip={{ duration: 200 }}>
             {#if dimensionName}
               <DimensionFilter
+                whereFilter={$dashboardStore.whereFilter}
+                dimensionThresholdFilters={[]}
                 metricsViewNames={[metricsViewName]}
                 {readOnly}
                 {name}

--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -393,7 +393,6 @@
             {#if dimensionName}
               <DimensionFilter
                 whereFilter={$dashboardStore.whereFilter}
-                dimensionThresholdFilters={[]}
                 metricsViewNames={[metricsViewName]}
                 {readOnly}
                 {name}

--- a/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
+++ b/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
@@ -45,7 +45,6 @@
   export let timeControlsReady: boolean | undefined;
   export let smallChip = false;
   export let whereFilter: V1Expression;
-  export let dimensionThresholdFilters: DimensionThresholdFilter[];
   export let onRemove: () => void;
   export let onApplyInList: (values: string[]) => void;
   export let onSelect: (value: string) => void;
@@ -88,7 +87,7 @@
       additionalFilter: sanitiseExpression(
         mergeDimensionAndMeasureFilters(
           getFiltersForOtherDimensions(whereFilter, name),
-          dimensionThresholdFilters,
+          [],
         ),
         undefined,
       ),
@@ -121,7 +120,7 @@
       additionalFilter: sanitiseExpression(
         mergeDimensionAndMeasureFilters(
           getFiltersForOtherDimensions(whereFilter, name),
-          dimensionThresholdFilters,
+          [],
         ),
         undefined,
       ),

--- a/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
+++ b/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
@@ -25,6 +25,11 @@
     useDimensionSearch,
     useAllSearchResultsCount,
   } from "web-common/src/features/dashboards/filters/dimension-filters/dimension-filter-values";
+  import { mergeDimensionAndMeasureFilters } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
+  import { getFiltersForOtherDimensions } from "@rilldata/web-common/features/dashboards/selectors";
+  import { sanitiseExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
+  import type { V1Expression } from "@rilldata/web-common/runtime-client";
+  import type { DimensionThresholdFilter } from "../../stores/metrics-explorer-entity";
 
   export let name: string;
   export let metricsViewNames: string[];
@@ -39,6 +44,8 @@
   export let timeEnd: string | undefined;
   export let timeControlsReady: boolean | undefined;
   export let smallChip = false;
+  export let whereFilter: V1Expression;
+  export let dimensionThresholdFilters: DimensionThresholdFilter[];
   export let onRemove: () => void;
   export let onApplyInList: (values: string[]) => void;
   export let onSelect: (value: string) => void;
@@ -78,6 +85,13 @@
       timeStart,
       timeEnd,
       enabled: enableSearchQuery,
+      additionalFilter: sanitiseExpression(
+        mergeDimensionAndMeasureFilters(
+          getFiltersForOtherDimensions(whereFilter, name),
+          dimensionThresholdFilters,
+        ),
+        undefined,
+      ),
     },
   );
   $: ({
@@ -104,6 +118,13 @@
       timeStart,
       timeEnd,
       enabled: enableSearchCountQuery,
+      additionalFilter: sanitiseExpression(
+        mergeDimensionAndMeasureFilters(
+          getFiltersForOtherDimensions(whereFilter, name),
+          dimensionThresholdFilters,
+        ),
+        undefined,
+      ),
     },
   );
   $: ({

--- a/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
+++ b/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
@@ -29,7 +29,6 @@
   import { getFiltersForOtherDimensions } from "@rilldata/web-common/features/dashboards/selectors";
   import { sanitiseExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
   import type { V1Expression } from "@rilldata/web-common/runtime-client";
-  import type { DimensionThresholdFilter } from "../../stores/metrics-explorer-entity";
 
   export let name: string;
   export let metricsViewNames: string[];


### PR DESCRIPTION
This pull request fixes an issue where the dimension filter dropdown wasn't respecting active filters from other dimensions and measure thresholds. When opening a dimension filter dropdown, it should show values that are consistent with all other active filters. Closes https://github.com/rilldata/rill-private-issues/issues/1608

https://github.com/user-attachments/assets/c8df74e9-9765-4f54-844d-81d38a7fc3c2

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
