### PR TITLE
fix: issues with gzip params being inconsistent causing some dashboard config not persisting

### DIFF
--- a/web-common/src/features/dashboards/url-state/compression.ts
+++ b/web-common/src/features/dashboards/url-state/compression.ts
@@ -9,7 +9,10 @@ export function shouldCompressParams(url: URL) {
 
 export function compressUrlParams(params: string) {
   const paramsAsUint8Array = new TextEncoder().encode(params);
-  const compressed = gzipSync(paramsAsUint8Array);
+  const compressed = gzipSync(paramsAsUint8Array, {
+    // Since we are not compression a file disable modified time to avoid output changing based on time.
+    mtime: 0,
+  });
   return protoBase64.enc(compressed).replaceAll("+", "-").replaceAll("/", "_");
 }
 


### PR DESCRIPTION
closes https://github.com/rilldata/rill-private-issues/issues/1653

By default the compression library we use added modified time. So running compression for the same input gave different values for different times.

This caused issues with our url state sync, since it things url changed and resets the dashboard state. Any state not stored in the url gets reset during this. Pivot's expanded state is one such state.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
