### PR TITLE
tweak: support percentage for pie chart inner radius

### DIFF
--- a/web-common/src/features/canvas/components/charts/circular-charts/CircularChart.ts
+++ b/web-common/src/features/canvas/components/charts/circular-charts/CircularChart.ts
@@ -56,7 +56,7 @@ export class CircularChartComponent extends BaseChart<CircularChartSpec> {
     },
     innerRadius: {
       type: "number",
-      label: "Inner Radius",
+      label: "Inner Radius (%)",
     },
   };
 

--- a/web-common/src/features/canvas/components/charts/circular-charts/pie.ts
+++ b/web-common/src/features/canvas/components/charts/circular-charts/pie.ts
@@ -13,7 +13,7 @@ import type { CircularChartSpec } from "./CircularChart";
 function getInnerRadius(innerRadiusPercentage: number | undefined) {
   if (!innerRadiusPercentage) return 0;
 
-  if (innerRadiusPercentage > 100 || innerRadiusPercentage < 0) {
+  if (innerRadiusPercentage >= 100 || innerRadiusPercentage < 0) {
     console.warn("Inner radius percentage must be between 0 and 100");
     return { expr: `0.5*min(width,height)/2` };
   }

--- a/web-common/src/features/canvas/components/charts/circular-charts/pie.ts
+++ b/web-common/src/features/canvas/components/charts/circular-charts/pie.ts
@@ -10,6 +10,18 @@ import {
 import type { ChartDataResult } from "../types";
 import type { CircularChartSpec } from "./CircularChart";
 
+function getInnerRadius(innerRadiusPercentage: number | undefined) {
+  if (!innerRadiusPercentage) return 0;
+
+  if (innerRadiusPercentage > 100 || innerRadiusPercentage < 0) {
+    console.warn("Inner radius percentage must be between 0 and 100");
+    return { expr: `0.5*min(width,height)/2` };
+  }
+
+  const decimal = innerRadiusPercentage / 100;
+  return { expr: `${decimal}*min(width,height)/2` };
+}
+
 /**
  * The layout property is not typed in the current version of Vega-Lite.
  * This will be fixed when we upgrade to Svelte 5 and subseqent Vega-Lite versions.
@@ -30,7 +42,7 @@ export function generateVLPieChartSpec(
 
   spec.mark = {
     type: "arc",
-    innerRadius: config.innerRadius || 0,
+    innerRadius: getInnerRadius(config.innerRadius),
   };
   const theta = createPositionEncoding(config.measure, data);
   const color = createColorEncoding(config.color, data);


### PR DESCRIPTION
Instead of `px` values, switch to percentage input for inner radius of circular charts. This ensures that the inner circle scales well as the container scales.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
