### PR TITLE
Consistent table header size

### DIFF
--- a/web-admin/src/components/table/ResourceHeader.svelte
+++ b/web-admin/src/components/table/ResourceHeader.svelte
@@ -29,7 +29,7 @@ Rounded table corners are tricky:
 -->
 <style lang="postcss">
   thead tr td {
-    @apply pl-[17px] pr-4 py-3  flex items-center gap-x-2 bg-slate-100;
+    @apply pl-[17px] pr-4 py-3 text-sm flex items-center gap-x-2 bg-slate-100;
     @apply font-semibold text-gray-500;
     @apply border-y;
   }

--- a/web-admin/src/features/organizations/users/OrgUsersTable.svelte
+++ b/web-admin/src/features/organizations/users/OrgUsersTable.svelte
@@ -211,7 +211,7 @@
                     style={`margin-left: ${marginLeft};`}
                     class:cursor-pointer={header.column.getCanSort()}
                     class:select-none={header.column.getCanSort()}
-                    class="font-semibold text-gray-500 flex flex-row items-center gap-x-1"
+                    class="font-semibold text-gray-500 flex flex-row items-center gap-x-1 text-sm"
                   >
                     <svelte:component
                       this={flexRender(

--- a/web-admin/src/features/public-urls/PublicURLsTable.svelte
+++ b/web-admin/src/features/public-urls/PublicURLsTable.svelte
@@ -178,7 +178,7 @@
                   <div
                     class:cursor-pointer={header.column.getCanSort()}
                     class:select-none={header.column.getCanSort()}
-                    class="font-semibold text-gray-500 flex flex-row items-center gap-x-1"
+                    class="font-semibold text-gray-500 flex flex-row items-center gap-x-1 text-sm"
                   >
                     <svelte:component
                       this={flexRender(

--- a/web-common/src/components/table/BasicTable.svelte
+++ b/web-common/src/components/table/BasicTable.svelte
@@ -80,7 +80,7 @@
           role="columnheader"
           tabindex="0"
           class="pl-{header.column.columnDef.meta?.marginLeft ||
-            '4'} py-2 font-semibold text-gray-500 text-left flex flex-row items-center gap-x-1 truncate"
+            '4'} py-2 font-semibold text-gray-500 text-left flex flex-row items-center gap-x-1 truncate text-sm"
           on:click={header.column.getToggleSortingHandler()}
         >
           {#if !header.isPlaceholder}


### PR DESCRIPTION
This pull request ensures the table headers have a consistent 14px font size.

![CleanShot 2025-05-06 at 09 48 16@2x](https://github.com/user-attachments/assets/1bba08c5-17c4-4c72-b933-54b7976a34a2)

![CleanShot 2025-05-06 at 09 48 37@2x](https://github.com/user-attachments/assets/7461574f-1f33-457a-83d3-fc3d252a1a9c)

![CleanShot 2025-05-06 at 09 52 44@2x](https://github.com/user-attachments/assets/aaaeb25b-9cab-4eb2-8860-b0d8a996ac87)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
