### PR TITLE
Fixed calendar popover for public url

### DIFF
--- a/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
+++ b/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
@@ -193,7 +193,7 @@
                   <Pencil size="14px" class="text-primary-600" />
                 </IconButton>
               </PopoverTrigger>
-              <PopoverContent align="end" class="p-0">
+              <PopoverContent align="end" class="p-0" strategy="fixed">
                 <Calendar
                   selection={DateTime.fromISO($form.expiresAt)}
                   singleDaySelection

--- a/web-common/src/components/forms/Select.svelte
+++ b/web-common/src/components/forms/Select.svelte
@@ -113,7 +113,12 @@
       />
     </Select.Trigger>
 
-    <Select.Content {sameWidth} align="start" class="max-h-80 overflow-y-auto">
+    <Select.Content
+      {sameWidth}
+      align="start"
+      class="max-h-80 overflow-y-auto"
+      strategy="fixed"
+    >
       {#if enableSearch}
         <div class="px-2 py-1.5">
           <Search bind:value={searchText} showBorderOnFocus={false} />

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
@@ -114,7 +114,7 @@
   }}
 />
 
-<Popover.Content align="start" class="p-2 px-3 w-[250px]">
+<Popover.Content align="start" class="p-2 px-3 w-[250px]" strategy="fixed">
   <form
     use:enhance
     autocomplete="off"


### PR DESCRIPTION
This pull request addresses a bug where the popover goes out of view when the "set expiration" action is triggered.﻿

Before

https://github.com/user-attachments/assets/5fc7f113-f4ab-43a6-ace4-cfadde509b27

After

https://github.com/user-attachments/assets/97ca360f-624b-4bb6-a0b7-20845248e5c3


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
