### PR TITLE
Temporarily skip flaky ClickHouse lookup test

### DIFF
--- a/runtime/resolvers/resolvers_test.go
+++ b/runtime/resolvers/resolvers_test.go
@@ -29,6 +29,7 @@ import (
 // Each test in the file will be run in sequence against that runtime instance.
 // The available connectors are defined in runtime/testruntime/connectors.go.
 type TestFileYAML struct {
+	Skip         bool                 `yaml:"skip,omitempty"`
 	Expensive    bool                 `yaml:"expensive,omitempty"`
 	Connectors   []string             `yaml:"connectors,omitempty"`
 	Variables    map[string]string    `yaml:"variables,omitempty"`
@@ -99,9 +100,12 @@ func TestResolvers(t *testing.T) {
 			err = yaml.Unmarshal(data, &tf)
 			require.NoError(t, err)
 
-			// Handle short
+			// Handle skip and expensive
+			if tf.Skip {
+				t.Skip("skipping test because it is marked skip: true")
+			}
 			if testing.Short() && tf.Expensive {
-				t.Skip("skipping test in short mode")
+				t.Skip("skipping test in short mode because it is marked expensive: true")
 			}
 
 			// Create a map of project files for the runtime instance.

--- a/runtime/resolvers/testdata/metrics_lookup_clickhouse.yaml
+++ b/runtime/resolvers/testdata/metrics_lookup_clickhouse.yaml
@@ -1,3 +1,4 @@
+skip: true # TODO: Remove skip when this issue is resolved: https://github.com/rilldata/rill-private-issues/issues/1674
 connectors:
   - clickhouse
 project_files:


### PR DESCRIPTION
This is pending permanent resolution as tracked in https://github.com/rilldata/rill-private-issues/issues/1674