### PR TITLE
fix (Org page): show `403` for superusers lacking `readOrg` permission

### DIFF
--- a/web-admin/src/routes/[organization]/+layout.ts
+++ b/web-admin/src/routes/[organization]/+layout.ts
@@ -6,8 +6,12 @@ import { isAxiosError } from "axios";
 export const load = async ({ params: { organization }, parent }) => {
   const { user, organizationPermissions } = await parent();
 
+  if (!organizationPermissions.readOrg) {
+    throw error(403, "You do not have permission to access this organization");
+  }
+
   let issues: V1BillingIssue[] = [];
-  if (user && organizationPermissions.readOrg) {
+  if (user) {
     // only try to get issues if the user can read org
     // also public projects will not have a user but will have `readOrg` permission
     try {

--- a/web-admin/src/routes/[organization]/+layout.ts
+++ b/web-admin/src/routes/[organization]/+layout.ts
@@ -6,12 +6,8 @@ import { isAxiosError } from "axios";
 export const load = async ({ params: { organization }, parent }) => {
   const { user, organizationPermissions } = await parent();
 
-  if (!organizationPermissions.readOrg) {
-    throw error(403, "You do not have permission to access this organization");
-  }
-
   let issues: V1BillingIssue[] = [];
-  if (user) {
+  if (user && organizationPermissions.readOrg) {
     // only try to get issues if the user can read org
     // also public projects will not have a user but will have `readOrg` permission
     try {

--- a/web-admin/src/routes/[organization]/+page.ts
+++ b/web-admin/src/routes/[organization]/+page.ts
@@ -1,0 +1,9 @@
+import { error } from "@sveltejs/kit";
+
+export const load = async ({ parent }) => {
+  const { organizationPermissions } = await parent();
+
+  if (!organizationPermissions.readOrg) {
+    throw error(403, "You do not have permission to access this organization");
+  }
+};


### PR DESCRIPTION
When a superuser calls `GetOrganization` for an org they don’t belong to, the API returns a `200` with no org `permissions`. This leads to a broken org page:

<img width="1919" alt="image" src="https://github.com/user-attachments/assets/af3320dd-25ca-442e-a180-0c97f1f48c12" />

Previously, we had assumed the API would return a `403`, but it doesn't in this case. This PR adds an explicit check in the frontend for the `readOrg` permission. If it's `false`, we now show a `403` access denied page instead of rendering a broken UI:

<img width="1916" alt="image" src="https://github.com/user-attachments/assets/5c3e3942-9acf-499d-aa93-41295870f313" />

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
