### PR TITLE
tweak: default to donut instead of pie chart

### DIFF
--- a/docs/docs/reference/project-files/canvas-dashboards.md
+++ b/docs/docs/reference/project-files/canvas-dashboards.md
@@ -30,7 +30,7 @@ In your Rill project directory, create a explore dashboard, `<dashboard_name>.ya
       - **`image`** - provide a `url` to embed into canvas dashboard
       - **`table`** - similar to Pivot table, add dimensions and measures to visual your data.
       - **`heatmap`** - Heat Map chart to visualize distribution of data.
-      - **`pie_chart`** - Pie or Donut chart to displays sums of total.
+      - **`donut_chart`** - Pie or Donut chart to displays sums of total.
   
   :::tip 
         Each component varies slightly on what keys are required. For the most part, each component will require a `metrics_view` (except for text and image.) The charts will require a `x` and `y` valeu To build a successful component via code, take a look at what gets generated in the YAML file when select various features in the visual canvas editor.

--- a/docs/docs/reference/project-files/canvas-dashboards.md
+++ b/docs/docs/reference/project-files/canvas-dashboards.md
@@ -30,7 +30,7 @@ In your Rill project directory, create a explore dashboard, `<dashboard_name>.ya
       - **`image`** - provide a `url` to embed into canvas dashboard
       - **`table`** - similar to Pivot table, add dimensions and measures to visual your data.
       - **`heatmap`** - Heat Map chart to visualize distribution of data.
-      - **`donut_chart`** - Pie or Donut chart to displays sums of total.
+      - **`donut_chart`** - Donut or Pie chart to displays sums of total.
   
   :::tip 
         Each component varies slightly on what keys are required. For the most part, each component will require a `metrics_view` (except for text and image.) The charts will require a `x` and `y` valeu To build a successful component via code, take a look at what gets generated in the YAML file when select various features in the visual canvas editor.

--- a/web-common/src/features/canvas/components/charts/circular-charts/CircularChart.ts
+++ b/web-common/src/features/canvas/components/charts/circular-charts/CircularChart.ts
@@ -156,7 +156,7 @@ export class CircularChartComponent extends BaseChart<CircularChartSpec> {
 
     return {
       metrics_view: metricsViewName,
-      innerRadius: 0,
+      innerRadius: 50,
       color: {
         type: "nominal",
         field: randomDimension,

--- a/web-common/src/features/canvas/components/charts/index.ts
+++ b/web-common/src/features/canvas/components/charts/index.ts
@@ -50,6 +50,7 @@ export function getChartComponent(
     case "stacked_bar_normalized":
       return CartesianChartComponent;
     case "donut_chart":
+    case "pie_chart":
       return CircularChartComponent;
     case "heatmap":
       return HeatmapChartComponent;
@@ -63,6 +64,7 @@ export interface ChartMetadataConfig {
   icon: ComponentType<SvelteComponent>;
   component: BaseCanvasComponentConstructor;
   generateSpec: (config: ChartSpec, data: ChartDataResult) => VisualizationSpec;
+  hideFromSelector?: boolean;
 }
 
 export const CHART_CONFIG: Record<ChartType, ChartMetadataConfig> = {
@@ -102,6 +104,13 @@ export const CHART_CONFIG: Record<ChartType, ChartMetadataConfig> = {
     component: CircularChartComponent,
     generateSpec: generateVLPieChartSpec,
   },
+  pie_chart: {
+    title: "Pie",
+    icon: Donut,
+    component: CircularChartComponent,
+    generateSpec: generateVLPieChartSpec,
+    hideFromSelector: true,
+  },
   heatmap: {
     title: "Heatmap",
     icon: Heatmap,
@@ -111,3 +120,7 @@ export const CHART_CONFIG: Record<ChartType, ChartMetadataConfig> = {
 };
 
 export const CHART_TYPES = Object.keys(CHART_CONFIG) as ChartType[];
+
+export const VISIBLE_CHART_TYPES = CHART_TYPES.filter(
+  (type) => !CHART_CONFIG[type].hideFromSelector,
+);

--- a/web-common/src/features/canvas/components/charts/index.ts
+++ b/web-common/src/features/canvas/components/charts/index.ts
@@ -49,7 +49,7 @@ export function getChartComponent(
     case "stacked_bar":
     case "stacked_bar_normalized":
       return CartesianChartComponent;
-    case "pie_chart":
+    case "donut_chart":
       return CircularChartComponent;
     case "heatmap":
       return HeatmapChartComponent;
@@ -96,8 +96,8 @@ export const CHART_CONFIG: Record<ChartType, ChartMetadataConfig> = {
     component: CartesianChartComponent,
     generateSpec: generateVLStackedBarNormalizedSpec,
   },
-  pie_chart: {
-    title: "Pie",
+  donut_chart: {
+    title: "Donut",
     icon: Donut,
     component: CircularChartComponent,
     generateSpec: generateVLPieChartSpec,

--- a/web-common/src/features/canvas/components/charts/types.ts
+++ b/web-common/src/features/canvas/components/charts/types.ts
@@ -19,7 +19,7 @@ export type ChartType =
   | "area_chart"
   | "stacked_bar"
   | "stacked_bar_normalized"
-  | "pie_chart"
+  | "donut_chart"
   | "heatmap";
 
 export type ChartDataQuery = CreateQueryResult<

--- a/web-common/src/features/canvas/components/charts/types.ts
+++ b/web-common/src/features/canvas/components/charts/types.ts
@@ -20,6 +20,7 @@ export type ChartType =
   | "stacked_bar"
   | "stacked_bar_normalized"
   | "donut_chart"
+  | "pie_chart"
   | "heatmap";
 
 export type ChartDataQuery = CreateQueryResult<

--- a/web-common/src/features/canvas/components/charts/util.ts
+++ b/web-common/src/features/canvas/components/charts/util.ts
@@ -18,7 +18,7 @@ export function generateSpec(
   data: ChartDataResult,
 ) {
   if (data.isFetching || data.error) return {};
-  return CHART_CONFIG[chartType].generateSpec(rillChartSpec, data);
+  return CHART_CONFIG[chartType]?.generateSpec(rillChartSpec, data);
 }
 
 export function isChartLineLike(chartType: ChartType) {

--- a/web-common/src/features/canvas/components/util.ts
+++ b/web-common/src/features/canvas/components/util.ts
@@ -66,7 +66,7 @@ const CHART_TYPES = [
   "stacked_bar",
   "stacked_bar_normalized",
   "area_chart",
-  "pie_chart",
+  "donut_chart",
   "heatmap",
 ] as const;
 const NON_CHART_TYPES = [

--- a/web-common/src/features/canvas/components/util.ts
+++ b/web-common/src/features/canvas/components/util.ts
@@ -67,6 +67,7 @@ const CHART_TYPES = [
   "stacked_bar_normalized",
   "area_chart",
   "donut_chart",
+  "pie_chart",
   "heatmap",
 ] as const;
 const NON_CHART_TYPES = [

--- a/web-common/src/features/canvas/inspector/chart/ChartTypeSelector.svelte
+++ b/web-common/src/features/canvas/inspector/chart/ChartTypeSelector.svelte
@@ -5,7 +5,7 @@
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import {
     CHART_CONFIG,
-    CHART_TYPES,
+    VISIBLE_CHART_TYPES,
     type ChartSpec,
   } from "@rilldata/web-common/features/canvas/components/charts";
   import type { BaseChart } from "@rilldata/web-common/features/canvas/components/charts/BaseChart";
@@ -34,7 +34,7 @@
 <div class="section">
   <InputLabel small label="Chart type" id="chart-components" />
   <div class="chart-icons">
-    {#each CHART_TYPES as chart, i (i)}
+    {#each VISIBLE_CHART_TYPES as chart, i (i)}
       <Tooltip distance={8} location="right">
         <Button
           square

--- a/web-common/src/features/canvas/layout-util.ts
+++ b/web-common/src/features/canvas/layout-util.ts
@@ -20,6 +20,7 @@ export const initialHeights: Record<CanvasComponentType, number> = {
   stacked_bar: 320,
   stacked_bar_normalized: 320,
   donut_chart: 320,
+  pie_chart: 320,
   heatmap: 320,
   markdown: 40,
   kpi_grid: 128,

--- a/web-common/src/features/canvas/layout-util.ts
+++ b/web-common/src/features/canvas/layout-util.ts
@@ -19,7 +19,7 @@ export const initialHeights: Record<CanvasComponentType, number> = {
   area_chart: 320,
   stacked_bar: 320,
   stacked_bar_normalized: 320,
-  pie_chart: 320,
+  donut_chart: 320,
   heatmap: 320,
   markdown: 40,
   kpi_grid: 128,

--- a/web-local/tests/canvas/charts.spec.ts
+++ b/web-local/tests/canvas/charts.spec.ts
@@ -17,7 +17,7 @@ test.describe("canvas charts", () => {
       .locator("canvas")
       .click();
 
-    await page.locator(".chart-icons").getByLabel("Pie").click();
+    await page.locator(".chart-icons").getByLabel("Donut").click();
     await page
       .getByLabel("A arc chart with embedded")
       .locator("canvas")


### PR DESCRIPTION
Default to donut chart instead of pie when a circular chart is added.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
