### PR TITLE
fix: duckdbsql traversal panics on parsing `read_..` fns with empty args

### DIFF
--- a/runtime/pkg/duckdbsql/ast_traversal.go
+++ b/runtime/pkg/duckdbsql/ast_traversal.go
@@ -217,6 +217,9 @@ func (a *AST) traverseTableFunction(parent astNode, childKey string) {
 		"read_parquet",
 		"read_json", "read_json_auto", "read_json_objects", "read_json_objects_auto",
 		"read_ndjson_objects", "read_ndjson", "read_ndjson_auto":
+		if len(arguments) == 0 {
+			return
+		}
 		ref.Paths = getListOfValues[string](arguments[0])
 	default:
 		// only read_... are supported for now


### PR DESCRIPTION
closes https://github.com/rilldata/rill-private-issues/issues/1684

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
