### PR TITLE
fix: canvas refresh time in rill cloud

### DIFF
--- a/web-admin/src/features/dashboards/listing/selectors.ts
+++ b/web-admin/src/features/dashboards/listing/selectors.ts
@@ -83,7 +83,6 @@ export function useDashboardsV2(
   });
 }
 
-// Super naive heuristic for now.
 function getCanvasRefreshedOn(
   dashboard: V1Resource,
   allResources: Map<string, V1Resource>,
@@ -93,7 +92,7 @@ function getCanvasRefreshedOn(
   // Find the max refresh time of all the resources that are referenced by the components in the dashboard
   const maxRefresh = dashboard.meta.refs
     .map((r) => allResources.get(`${r?.kind}_${r?.name}`))
-    .filter((c) => c.meta.refs.length)
+    .filter((c) => c.meta.refs.length) // filter out resources that don't have refs such as markdown and image
     .map((m) => allResources.get(`${m.meta.refs[0].kind}_${m.meta.refs[0].name}`))
     .map((m) => m.metricsView.state?.modelRefreshedOn)
     .reduce((max, c) => c > max ? c : max)

--- a/web-admin/src/features/dashboards/listing/selectors.ts
+++ b/web-admin/src/features/dashboards/listing/selectors.ts
@@ -90,17 +90,15 @@ function getCanvasRefreshedOn(
 ): string | undefined {
   if (!dashboard) return undefined;
 
-  // First, get the first referenced resource for the canvas
-  const refResourceName = dashboard.meta.refs[0];
-  const refResource = allResources.get(
-    `${refResourceName?.kind}_${refResourceName?.name}`,
-  );
+  // Find the max refresh time of all the resources that are referenced by the components in the dashboard
+  const maxRefresh = dashboard.meta.refs
+    .map((r) => allResources.get(`${r?.kind}_${r?.name}`))
+    .filter((c) => c.meta.refs.length)
+    .map((m) => allResources.get(`${m.meta.refs[0].kind}_${m.meta.refs[0].name}`))
+    .map((m) => m.metricsView.state?.modelRefreshedOn)
+    .reduce((max, c) => c > max ? c : max)
 
-  // Second, get the refreshedOn from the referenced resource
-  return (
-    refResource?.model?.state.refreshedOn ||
-    refResource?.source?.state.refreshedOn
-  );
+  return maxRefresh;
 }
 
 function getExploreRefreshedOn(

--- a/web-admin/src/features/dashboards/listing/selectors.ts
+++ b/web-admin/src/features/dashboards/listing/selectors.ts
@@ -93,9 +93,11 @@ function getCanvasRefreshedOn(
   const maxRefresh = dashboard.meta.refs
     .map((r) => allResources.get(`${r?.kind}_${r?.name}`))
     .filter((c) => c.meta.refs.length) // filter out resources that don't have refs such as markdown and image
-    .map((m) => allResources.get(`${m.meta.refs[0].kind}_${m.meta.refs[0].name}`))
+    .map((m) =>
+      allResources.get(`${m.meta.refs[0].kind}_${m.meta.refs[0].name}`),
+    )
     .map((m) => m.metricsView.state?.modelRefreshedOn)
-    .reduce((max, c) => c > max ? c : max)
+    .reduce((max, c) => (c > max ? c : max));
 
   return maxRefresh;
 }


### PR DESCRIPTION
Iterates over components to find the latest underlying refresh time of a model.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
