### PR TITLE
Updates all usages of MetricsExploreEntity => ExploreState

### DIFF
--- a/web-admin/src/features/alerts/metadata/AlertFilters.svelte
+++ b/web-admin/src/features/alerts/metadata/AlertFilters.svelte
@@ -7,7 +7,7 @@
   import { useMetricsView } from "@rilldata/web-common/features/dashboards/selectors";
   import { getDimensionFilters } from "@rilldata/web-common/features/dashboards/state-managers/selectors/dimension-filters";
   import { getMeasureFilters } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measure-filters";
-  import type { DimensionThresholdFilter } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+  import type { DimensionThresholdFilter } from "@rilldata/web-common/features/dashboards/stores/explore-state";
   import { getMapFromArray } from "@rilldata/web-common/lib/arrayUtils";
   import type {
     V1Expression,

--- a/web-admin/src/features/alerts/selectors.ts
+++ b/web-admin/src/features/alerts/selectors.ts
@@ -1,7 +1,7 @@
 import { createAdminServiceSearchProjectUsers } from "@rilldata/web-admin/client";
 import { getExploreName } from "@rilldata/web-admin/features/dashboards/query-mappers/utils";
 import { getDashboardStateFromUrl } from "@rilldata/web-common/features/dashboards/proto-state/fromProto";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
 import {
   createRuntimeServiceGetExplore,
@@ -109,7 +109,7 @@ export function useAlertDashboardState(
 ) {
   if (!alertSpec) {
     return readable({
-      data: <Partial<MetricsExplorerEntity>>{},
+      data: <Partial<ExploreState>>{},
     });
   }
 
@@ -119,7 +119,7 @@ export function useAlertDashboardState(
   const webState = alertSpec.annotations?.web_open_state ?? "";
   if (!webState) {
     return readable({
-      data: <Partial<MetricsExplorerEntity>>{},
+      data: <Partial<ExploreState>>{},
     });
   }
 

--- a/web-admin/src/features/bookmarks/getBookmarkDataForDashboard.ts
+++ b/web-admin/src/features/bookmarks/getBookmarkDataForDashboard.ts
@@ -1,27 +1,27 @@
 import { getProtoFromDashboardState } from "@rilldata/web-common/features/dashboards/proto-state/toProto";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import type { TimeControlState } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import { TimeRangePreset } from "@rilldata/web-common/lib/time/types";
 import type { V1ExploreSpec } from "@rilldata/web-common/runtime-client";
 
 /**
  * Returns the bookmark data to be stored.
- * Converts the dashboard to base64 protobuf string using {@link getProtoFromDashboardState}
+ * Converts the explore state to base64 protobuf string using {@link getProtoFromDashboardState}
  *
- * @param dashboard
+ * @param exploreState
  * @param exploreSpec
  * @param filtersOnly Only dimension/measure filters and the selected time range is stored.
  * @param absoluteTimeRange Time ranges is treated as absolute.
  * @param timeControlState Time control state to derive the time range from.
  */
 export function getBookmarkDataForDashboard(
-  dashboard: MetricsExplorerEntity,
+  exploreState: ExploreState,
   exploreSpec: V1ExploreSpec,
   filtersOnly?: boolean,
   absoluteTimeRange?: boolean,
   timeControlState?: TimeControlState,
 ): string {
-  const newDashboard = structuredClone(dashboard);
+  const newDashboard = structuredClone(exploreState);
 
   if (absoluteTimeRange && timeControlState) {
     if (
@@ -55,7 +55,7 @@ export function getBookmarkDataForDashboard(
         whereFilter: newDashboard.whereFilter,
         dimensionThresholdFilters: newDashboard.dimensionThresholdFilters,
         selectedTimeRange: newDashboard.selectedTimeRange,
-      } as MetricsExplorerEntity,
+      } as ExploreState,
       exploreSpec,
     );
   } else {

--- a/web-admin/src/features/bookmarks/selectors.ts
+++ b/web-admin/src/features/bookmarks/selectors.ts
@@ -12,7 +12,7 @@ import {
 import { getDashboardStateFromUrl } from "@rilldata/web-common/features/dashboards/proto-state/fromProto";
 import { useMetricsViewTimeRange } from "@rilldata/web-common/features/dashboards/selectors";
 import { useExploreState } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import {
   getTimeControlState,
   timeControlStateSelector,
@@ -77,7 +77,7 @@ export function categorizeBookmarks(
   metricsSpec: V1MetricsViewSpec,
   exploreSpec: V1ExploreSpec,
   schema: V1StructType,
-  exploreState: MetricsExplorerEntity,
+  exploreState: ExploreState,
   timeRangeSummary: V1TimeRangeSummary | undefined,
 ) {
   const bookmarks: Bookmarks = {
@@ -120,7 +120,7 @@ export function getHomeBookmarkExploreState(
   instanceId: string,
   metricsViewName: string,
   exploreName: string,
-): CompoundQueryResult<Partial<MetricsExplorerEntity> | null> {
+): CompoundQueryResult<Partial<ExploreState> | null> {
   return getCompoundQuery(
     [
       getBookmarks(projectId, exploreName),
@@ -196,7 +196,7 @@ function parseBookmark(
   metricsViewSpec: V1MetricsViewSpec,
   exploreSpec: V1ExploreSpec,
   schema: V1StructType,
-  exploreState: MetricsExplorerEntity,
+  exploreState: ExploreState,
   timeRangeSummary: V1TimeRangeSummary | undefined,
   rillDefaultExploreURLParams: URLSearchParams,
 ): BookmarkEntry {
@@ -210,7 +210,7 @@ function parseBookmark(
   const finalExploreState = {
     ...(exploreState ?? {}),
     ...exploreStateFromBookmark,
-  } as MetricsExplorerEntity;
+  } as ExploreState;
 
   const url = new URL(get(page).url);
 
@@ -255,7 +255,7 @@ const filterOnlyParams = new Set([
 ]) as Set<string>;
 
 function isFilterOnlyBookmark(
-  bookmarkState: Partial<MetricsExplorerEntity>,
+  bookmarkState: Partial<ExploreState>,
   metricsViewSpec: V1MetricsViewSpec,
   exploreSpec: V1ExploreSpec,
   timeRangeSummary: V1TimeRangeSummary | undefined,
@@ -264,12 +264,12 @@ function isFilterOnlyBookmark(
   // We need to remove defaults like time grain and timezone otherwise we will have extra fields here
   const searchParams = getCleanedUrlParamsForGoto(
     exploreSpec,
-    bookmarkState as MetricsExplorerEntity,
+    bookmarkState as ExploreState,
     getTimeControlState(
       metricsViewSpec,
       exploreSpec,
       timeRangeSummary,
-      bookmarkState as MetricsExplorerEntity,
+      bookmarkState as ExploreState,
     ),
     rillDefaultExploreURLParams,
   );

--- a/web-admin/src/features/dashboards/query-mappers/getDashboardFromAggregationRequest.ts
+++ b/web-admin/src/features/dashboards/query-mappers/getDashboardFromAggregationRequest.ts
@@ -23,7 +23,7 @@ import {
   forEachIdentifier,
   getAllIdentifiers,
 } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import { TDDChart } from "@rilldata/web-common/features/dashboards/time-dimension-details/types";
 import { DashboardState_ActivePage } from "@rilldata/web-common/proto/gen/rill/ui/v1/dashboard_pb";
 import {
@@ -178,7 +178,7 @@ function exprHasComparison(expr: V1Expression) {
 async function mergeDashboardFromUrlState(
   queryClient: QueryClient,
   instanceId: string,
-  dashboard: MetricsExplorerEntity,
+  exploreState: ExploreState,
   metricsViewSpec: V1MetricsViewSpec,
   exploreSpec: V1ExploreSpec,
   urlState: string,
@@ -186,9 +186,9 @@ async function mergeDashboardFromUrlState(
   const schemaResp = await queryClient.fetchQuery({
     queryKey: getQueryServiceMetricsViewSchemaQueryKey(
       instanceId,
-      dashboard.name,
+      exploreState.name,
     ),
-    queryFn: () => queryServiceMetricsViewSchema(instanceId, dashboard.name),
+    queryFn: () => queryServiceMetricsViewSchema(instanceId, exploreState.name),
   });
   if (!schemaResp.schema) return;
 
@@ -199,6 +199,6 @@ async function mergeDashboardFromUrlState(
     schemaResp.schema,
   );
   for (const k in parsedDashboard) {
-    dashboard[k] = parsedDashboard[k];
+    exploreState[k] = parsedDashboard[k];
   }
 }

--- a/web-admin/src/features/dashboards/query-mappers/mapQueryToDashboard.ts
+++ b/web-admin/src/features/dashboards/query-mappers/mapQueryToDashboard.ts
@@ -5,7 +5,7 @@ import type {
   QueryRequests,
 } from "@rilldata/web-admin/features/dashboards/query-mappers/types";
 import { getFullInitExploreState } from "@rilldata/web-common/features/dashboards/stores/dashboard-store-defaults";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import { convertPresetToExploreState } from "@rilldata/web-common/features/dashboards/url-state/convertPresetToExploreState";
 import { getDefaultExplorePreset } from "@rilldata/web-common/features/dashboards/url-state/getDefaultExplorePreset";
 import { useExploreValidSpec } from "@rilldata/web-common/features/explores/selectors";
@@ -32,7 +32,7 @@ export function mapQueryToDashboard(
   isFetching: boolean;
   isLoading: boolean;
   error: Error;
-  data?: { exploreState: MetricsExplorerEntity; exploreName: string };
+  data?: { exploreState: ExploreState; exploreName: string };
 }> {
   if (!queryName || !queryArgsJson || !executionTime)
     return readable({
@@ -47,7 +47,7 @@ export function mapQueryToDashboard(
   );
   let getDashboardState: (
     args: QueryMapperArgs<QueryRequests>,
-  ) => Promise<MetricsExplorerEntity>;
+  ) => Promise<ExploreState>;
 
   // get metrics view name and the query mapper function based on the query name.
   switch (queryName) {

--- a/web-admin/src/features/dashboards/query-mappers/types.ts
+++ b/web-admin/src/features/dashboards/query-mappers/types.ts
@@ -1,4 +1,4 @@
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import type {
   V1ExploreSpec,
   V1MetricsViewAggregationRequest,
@@ -21,7 +21,7 @@ export type QueryRequests =
 export type QueryMapperArgs<R extends QueryRequests> = {
   queryClient: QueryClient;
   instanceId: string;
-  dashboard: MetricsExplorerEntity;
+  dashboard: ExploreState;
   req: R;
   metricsView: V1MetricsViewSpec;
   explore: V1ExploreSpec;

--- a/web-admin/src/features/dashboards/query-mappers/utils.ts
+++ b/web-admin/src/features/dashboards/query-mappers/utils.ts
@@ -1,5 +1,5 @@
 import { createInExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import { getTimeControlState } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import { PreviousCompleteRangeMap } from "@rilldata/web-common/features/dashboards/time-controls/time-range-mappers";
 import { convertPartialExploreStateToUrlParams } from "@rilldata/web-common/features/dashboards/url-state/convert-partial-explore-state-to-url-params";
@@ -37,14 +37,14 @@ for (const preset in PreviousCompleteRangeMap) {
 }
 
 export function fillTimeRange(
-  dashboard: MetricsExplorerEntity,
+  exploreState: ExploreState,
   reqTimeRange: V1TimeRange | undefined,
   reqComparisonTimeRange: V1TimeRange | undefined,
   timeRangeSummary: V1TimeRangeSummary,
   executionTime: string,
 ) {
   if (reqTimeRange) {
-    dashboard.selectedTimeRange = getSelectedTimeRange(
+    exploreState.selectedTimeRange = getSelectedTimeRange(
       reqTimeRange,
       timeRangeSummary,
       reqTimeRange.isoDuration ?? "",
@@ -59,13 +59,13 @@ export function fillTimeRange(
       (reqComparisonTimeRange.isoOffset &&
         reqComparisonTimeRange.isoOffset === reqComparisonTimeRange.isoDuration)
     ) {
-      dashboard.selectedComparisonTimeRange = {
+      exploreState.selectedComparisonTimeRange = {
         name: TimeComparisonOption.CONTIGUOUS,
         start: undefined as unknown as Date,
         end: undefined as unknown as Date,
       };
     } else {
-      dashboard.selectedComparisonTimeRange = getSelectedTimeRange(
+      exploreState.selectedComparisonTimeRange = getSelectedTimeRange(
         reqComparisonTimeRange,
         timeRangeSummary,
         reqComparisonTimeRange.isoOffset,
@@ -74,18 +74,19 @@ export function fillTimeRange(
       // temporary fix to not lead to an uncaught error.
       // TODO: we should a single custom label when we move to rill-time syntax
       if (
-        dashboard.selectedComparisonTimeRange?.name === TimeRangePreset.CUSTOM
+        exploreState.selectedComparisonTimeRange?.name ===
+        TimeRangePreset.CUSTOM
       ) {
-        dashboard.selectedComparisonTimeRange.name =
+        exploreState.selectedComparisonTimeRange.name =
           TimeComparisonOption.CUSTOM;
       }
     }
 
-    if (dashboard.selectedComparisonTimeRange) {
-      dashboard.selectedComparisonTimeRange.interval =
-        dashboard.selectedTimeRange?.interval;
+    if (exploreState.selectedComparisonTimeRange) {
+      exploreState.selectedComparisonTimeRange.interval =
+        exploreState.selectedTimeRange?.interval;
     }
-    dashboard.showTimeComparison = true;
+    exploreState.showTimeComparison = true;
   }
 }
 
@@ -156,7 +157,7 @@ export async function convertQueryFilterToToplistQuery(
 
 export async function getExplorePageUrlSearchParams(
   exploreName: string,
-  exploreState: MetricsExplorerEntity,
+  exploreState: ExploreState,
 ): Promise<URLSearchParams> {
   const instanceId = get(runtime).instanceId;
   const { explore, metricsView } = await queryClient.fetchQuery({

--- a/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
+++ b/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
@@ -30,7 +30,7 @@
   import {
     convertDateToMinutes,
     getExploreFields,
-    getSanitizedDashboardStateParam,
+    getSanitizedExploreStateParam,
     hasDashboardDimensionThresholdFilter,
     hasDashboardWhereFilter,
   } from "./form-utils";
@@ -60,7 +60,7 @@
     $visibleMeasures,
   );
 
-  $: sanitizedState = getSanitizedDashboardStateParam(
+  $: sanitizedState = getSanitizedExploreStateParam(
     $dashboardStore,
     exploreFields,
     $validSpecStore.data?.explore,

--- a/web-admin/src/routes/[organization]/[project]/-/reports/[report]/open/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/reports/[report]/open/+page.svelte
@@ -6,7 +6,7 @@
   import CtaContentContainer from "@rilldata/web-common/components/calls-to-action/CTAContentContainer.svelte";
   import CtaLayoutContainer from "@rilldata/web-common/components/calls-to-action/CTALayoutContainer.svelte";
   import CtaMessage from "@rilldata/web-common/components/calls-to-action/CTAMessage.svelte";
-  import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+  import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
   import Spinner from "@rilldata/web-common/features/entity-management/Spinner.svelte";
   import { EntityStatus } from "@rilldata/web-common/features/entity-management/types";
   import type { PageData } from "./$types";
@@ -41,7 +41,7 @@
 
   async function gotoExplorePage(
     exploreName: string,
-    exploreState: MetricsExplorerEntity,
+    exploreState: ExploreState,
   ) {
     const url = new URL(window.location.origin);
     if (token) {

--- a/web-common/src/features/alerts/extract-alert-form-values.ts
+++ b/web-common/src/features/alerts/extract-alert-form-values.ts
@@ -5,7 +5,7 @@ import {
   type MeasureFilterEntry,
 } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry";
 import { splitWhereFilter } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import { TimeRangePreset } from "@rilldata/web-common/lib/time/types";
 import {
   type V1AlertSpec,
@@ -36,7 +36,7 @@ export function extractAlertFormValues(
   queryArgs: V1MetricsViewAggregationRequest,
   metricsViewSpec: V1MetricsViewSpec,
   allTimeRange: V1MetricsViewTimeRangeResponse,
-  partialExploreState: Partial<MetricsExplorerEntity>,
+  partialExploreState: Partial<ExploreState>,
 ): AlertFormValuesSubset {
   if (!queryArgs) return {} as AlertFormValuesSubset;
 

--- a/web-common/src/features/alerts/form-utils.ts
+++ b/web-common/src/features/alerts/form-utils.ts
@@ -8,7 +8,7 @@ import {
 import { MeasureFilterType } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-options";
 import { mergeDimensionAndMeasureFilters } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
 import { sanitiseExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
-import type { DimensionThresholdFilter } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { DimensionThresholdFilter } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import type {
   V1Expression,
   V1MetricsViewAggregationRequest,

--- a/web-common/src/features/canvas/stores/filters.ts
+++ b/web-common/src/features/canvas/stores/filters.ts
@@ -26,7 +26,7 @@ import {
   negateExpression,
   sanitiseExpression,
 } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
-import type { DimensionThresholdFilter } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { DimensionThresholdFilter } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import {
   convertExpressionToFilterParam,
   convertFilterParamToExpression,

--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -23,7 +23,7 @@
   import { getMeasuresForDimensionOrLeaderboardDisplay } from "../state-managers/selectors/dashboard-queries";
   import { dimensionSearchText } from "../stores/dashboard-stores";
   import { sanitiseExpression } from "../stores/filter-utils";
-  import type { DimensionThresholdFilter } from "../stores/metrics-explorer-entity";
+  import type { DimensionThresholdFilter } from "web-common/src/features/dashboards/stores/explore-state";
   import DimensionHeader from "./DimensionHeader.svelte";
   import DimensionTable from "./DimensionTable.svelte";
   import { getDimensionFilterWithSearch } from "./dimension-table-utils";

--- a/web-common/src/features/dashboards/dimension-table/dimension-table-export.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-export.ts
@@ -5,7 +5,7 @@ import {
 } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry";
 import { SortDirection } from "@rilldata/web-common/features/dashboards/proto-state/derived-types";
 import type { StateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import {
   mapSelectedComparisonTimeRangeToV1TimeRange,
@@ -81,18 +81,18 @@ export function getDimensionTableExportQuery(
 
 export function getDimensionTableAggregationRequestForTime(
   metricsView: string,
-  dashboardState: MetricsExplorerEntity,
+  exploreState: ExploreState,
   timeRange: V1TimeRange,
   comparisonTimeRange: V1TimeRange | undefined,
   dimensionSearchText: string,
 ): V1MetricsViewAggregationRequest {
   const measures: V1MetricsViewAggregationMeasure[] =
-    dashboardState.visibleMeasures.map((name) => ({
+    exploreState.visibleMeasures.map((name) => ({
       name: name,
     }));
 
-  let apiSortName = dashboardState.leaderboardSortByMeasureName;
-  if (!dashboardState.visibleMeasures.includes(apiSortName)) {
+  let apiSortName = exploreState.leaderboardSortByMeasureName;
+  if (!exploreState.visibleMeasures.includes(apiSortName)) {
     // if selected sort measure is not visible add it to list
     measures.push({ name: apiSortName });
   }
@@ -103,7 +103,7 @@ export function getDimensionTableAggregationRequestForTime(
       0,
       ...getComparisonRequestMeasures(apiSortName),
     );
-    switch (dashboardState.dashboardSortType) {
+    switch (exploreState.dashboardSortType) {
       case DashboardState_LeaderboardSortType.DELTA_ABSOLUTE:
         apiSortName += ComparisonDeltaAbsoluteSuffix;
         break;
@@ -114,9 +114,9 @@ export function getDimensionTableAggregationRequestForTime(
   }
 
   const where = buildWhereParamForDimensionTableAndTDDExports(
-    dashboardState.whereFilter,
-    dashboardState.dimensionThresholdFilters,
-    dashboardState.selectedDimensionName!, // must exist when viewing a dimension table
+    exploreState.whereFilter,
+    exploreState.dimensionThresholdFilters,
+    exploreState.selectedDimensionName!, // must exist when viewing a dimension table
     dimensionSearchText,
   );
 
@@ -125,7 +125,7 @@ export function getDimensionTableAggregationRequestForTime(
     metricsView,
     dimensions: [
       {
-        name: dashboardState.selectedDimensionName,
+        name: exploreState.selectedDimensionName,
       },
     ],
     measures,
@@ -134,7 +134,7 @@ export function getDimensionTableAggregationRequestForTime(
     sort: [
       {
         name: apiSortName,
-        desc: dashboardState.sortDirection === SortDirection.DESCENDING,
+        desc: exploreState.sortDirection === SortDirection.DESCENDING,
       },
     ],
     where,

--- a/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
@@ -35,7 +35,7 @@ import { formatMeasurePercentageDifference } from "@rilldata/web-common/lib/numb
 import type { SvelteComponent } from "svelte";
 import { SortType } from "../proto-state/derived-types";
 import { getFiltersForOtherDimensions } from "../selectors";
-import type { MetricsExplorerEntity } from "../stores/metrics-explorer-entity";
+import type { ExploreState } from "web-common/src/features/dashboards/stores/explore-state";
 import type { DimensionTableRow } from "./dimension-table-types";
 import type { DimensionTableConfig } from "./DimensionTableConfig";
 
@@ -237,7 +237,7 @@ export function estimateColumnSizes(
 }
 
 export function prepareVirtualizedDimTableColumns(
-  dash: MetricsExplorerEntity,
+  exploreState: ExploreState,
   allMeasures: MetricsViewSpecMeasure[],
   measureTotals: { [key: string]: number },
   dimension: MetricsViewSpecDimension,
@@ -245,11 +245,12 @@ export function prepareVirtualizedDimTableColumns(
   validPercentOfTotal: boolean,
   activeMeasures?: string[],
 ): VirtualizedTableColumns[] {
-  const sortType = dash.dashboardSortType;
-  const sortDirection = dash.sortDirection;
+  const sortType = exploreState.dashboardSortType;
+  const sortDirection = exploreState.sortDirection;
 
   const measureNames = allMeasures.map((m) => m.name);
-  const leaderboardSortByMeasureName = dash.leaderboardSortByMeasureName;
+  const leaderboardSortByMeasureName =
+    exploreState.leaderboardSortByMeasureName;
   const selectedMeasure = allMeasures.find(
     (m) => m.name === leaderboardSortByMeasureName,
   );
@@ -257,14 +258,17 @@ export function prepareVirtualizedDimTableColumns(
   const dimensionColumn = dimension.name ?? "";
 
   // copy column names so we don't mutate the original
-  const columnNames = dash.visibleMeasures.filter((m) =>
+  const columnNames = exploreState.visibleMeasures.filter((m) =>
     allMeasures.some((am) => am.name === m),
   );
 
   // Show context columns based on selected context columns and time comparison settings
   if (selectedMeasure) {
     // If activeMeasures is provided and leaderboardShowContextForAllMeasures is true, add context columns for each active measure
-    if (activeMeasures?.length && dash.leaderboardShowContextForAllMeasures) {
+    if (
+      activeMeasures?.length &&
+      exploreState.leaderboardShowContextForAllMeasures
+    ) {
       activeMeasures.forEach((measureName) => {
         const measure = allMeasures.find((m) => m.name === measureName);
         if (measure) {

--- a/web-common/src/features/dashboards/filters/FilterChipsReadOnly.svelte
+++ b/web-common/src/features/dashboards/filters/FilterChipsReadOnly.svelte
@@ -5,7 +5,7 @@ The main feature-set component for dashboard filters
   import TimeRangeReadOnly from "@rilldata/web-common/features/dashboards/filters/TimeRangeReadOnly.svelte";
   import { allDimensions } from "@rilldata/web-common/features/dashboards/state-managers/selectors/dimensions";
   import { allMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
-  import type { DimensionThresholdFilter } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+  import type { DimensionThresholdFilter } from "@rilldata/web-common/features/dashboards/stores/explore-state";
   import { useExploreValidSpec } from "@rilldata/web-common/features/explores/selectors";
   import { getMapFromArray } from "@rilldata/web-common/lib/arrayUtils";
   import type {

--- a/web-common/src/features/dashboards/filters/measure-filters/measure-filter-utils.ts
+++ b/web-common/src/features/dashboards/filters/measure-filters/measure-filter-utils.ts
@@ -9,7 +9,7 @@ import {
   isExpressionUnsupported,
   removeWrapperAndOrExpression,
 } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
-import type { DimensionThresholdFilter } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { DimensionThresholdFilter } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import type { V1Expression } from "@rilldata/web-common/runtime-client";
 
 export function mergeDimensionAndMeasureFilters(

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -26,7 +26,7 @@
     isExpressionUnsupported,
     sanitiseExpression,
   } from "../stores/filter-utils";
-  import type { DimensionThresholdFilter } from "../stores/metrics-explorer-entity";
+  import type { DimensionThresholdFilter } from "web-common/src/features/dashboards/stores/explore-state";
   import DelayedLoadingRows from "./DelayedLoadingRows.svelte";
   import LeaderboardHeader from "./LeaderboardHeader.svelte";
   import LeaderboardRow from "./LeaderboardRow.svelte";

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
@@ -32,7 +32,7 @@
 
   let isLeaderboardActionsOpen = false;
 
-  $: metricsExplorer = $metricsExplorerStore.entities[exploreName];
+  $: exploreState = $metricsExplorerStore.entities[exploreName];
 
   $: activeLeaderboardMeasure = $getMeasureByName(
     $leaderboardSortByMeasureName,
@@ -51,8 +51,7 @@
   // but it is not valid for this measure, then turn it off
   $: if (
     !validPercentOfTotal &&
-    metricsExplorer?.leaderboardContextColumn ===
-      LeaderboardContextColumn.PERCENT
+    exploreState?.leaderboardContextColumn === LeaderboardContextColumn.PERCENT
   ) {
     setContextColumn(LeaderboardContextColumn.HIDDEN);
   }

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -6,7 +6,7 @@
     V1TimeRange,
   } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
-  import type { DimensionThresholdFilter } from "../stores/metrics-explorer-entity";
+  import type { DimensionThresholdFilter } from "web-common/src/features/dashboards/stores/explore-state";
   import Leaderboard from "./Leaderboard.svelte";
   import LeaderboardControls from "./LeaderboardControls.svelte";
   import { COMPARISON_COLUMN_WIDTH, valueColumn } from "./leaderboard-widths";

--- a/web-common/src/features/dashboards/pivot/pivot-export.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-export.ts
@@ -1,6 +1,6 @@
 import { mergeDimensionAndMeasureFilters } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
 import { sanitiseExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import { mapSelectedTimeRangeToV1TimeRange } from "@rilldata/web-common/features/dashboards/time-controls/time-range-mappers";
 import { type TimeRangeString } from "@rilldata/web-common/lib/time/types";
@@ -81,7 +81,7 @@ export function getPivotExportQuery(ctx: StateManagers, isScheduled: boolean) {
 function getPivotAggregationRequest(
   metricsView: string,
   timeDimension: string,
-  dashboardState: MetricsExplorerEntity,
+  exploreState: ExploreState,
   timeRange: V1TimeRange,
   rows: PivotChipData[],
   columns: { dimension: PivotChipData[]; measure: PivotChipData[] },
@@ -109,7 +109,7 @@ function getPivotAggregationRequest(
       ? {
           name: timeDimension,
           timeGrain: d.id as V1TimeGrain,
-          timeZone: dashboardState.selectedTimezone,
+          timeZone: exploreState.selectedTimezone,
           alias: isFlat ? `${timeDimension}_rill_${d.id}` : `Time ${d.title}`,
         }
       : {
@@ -128,7 +128,7 @@ function getPivotAggregationRequest(
       ? {
           name: timeDimension,
           timeGrain: d.id as V1TimeGrain,
-          timeZone: dashboardState.selectedTimezone,
+          timeZone: exploreState.selectedTimezone,
           alias: `Time ${d.title}`,
         }
       : {
@@ -175,8 +175,8 @@ function getPivotAggregationRequest(
     dimensions: allDimensions,
     where: sanitiseExpression(
       mergeDimensionAndMeasureFilters(
-        dashboardState.whereFilter,
-        dashboardState.dimensionThresholdFilters,
+        exploreState.whereFilter,
+        exploreState.dimensionThresholdFilters,
       ),
       undefined,
     ),

--- a/web-common/src/features/dashboards/proto-state/fromProto.ts
+++ b/web-common/src/features/dashboards/proto-state/fromProto.ts
@@ -20,7 +20,7 @@ import {
   createAndExpression,
   filterIdentifiers,
 } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import { TDDChart } from "@rilldata/web-common/features/dashboards/time-dimension-details/types";
 import { getMapFromArray } from "@rilldata/web-common/lib/arrayUtils";
 import {
@@ -85,7 +85,7 @@ export function getDashboardStateFromUrl(
   metricsView: V1MetricsViewSpec,
   explore: V1ExploreSpec,
   schema: V1StructType,
-): Partial<MetricsExplorerEntity> {
+): Partial<ExploreState> {
   // backwards compatibility for older urls that had encoded state
   urlState = urlState.includes("%") ? decodeURIComponent(urlState) : urlState;
   return getDashboardStateFromProto(
@@ -101,9 +101,9 @@ export function getDashboardStateFromProto(
   metricsView: V1MetricsViewSpec,
   explore: V1ExploreSpec,
   schema: V1StructType,
-): Partial<MetricsExplorerEntity> {
+): Partial<ExploreState> {
   const dashboard = DashboardState.fromBinary(binary);
-  const entity: Partial<MetricsExplorerEntity> = {};
+  const entity: Partial<ExploreState> = {};
 
   if (dashboard.filters) {
     // backwards compatibility for our older filter format
@@ -489,9 +489,7 @@ function fromTimeProto(timestamp: Timestamp) {
 
 function fromActivePageProto(
   dashboard: DashboardState,
-): Partial<
-  Pick<MetricsExplorerEntity, "activePage" | "selectedDimensionName">
-> {
+): Partial<Pick<ExploreState, "activePage" | "selectedDimensionName">> {
   switch (dashboard.activePage) {
     case DashboardState_ActivePage.UNSPECIFIED:
       // backwards compatibility

--- a/web-common/src/features/dashboards/proto-state/proto.spec.ts
+++ b/web-common/src/features/dashboards/proto-state/proto.spec.ts
@@ -28,7 +28,7 @@ import { describe, expect, it } from "vitest";
 
 describe("toProto/fromProto", () => {
   it("backwards compatibility for time controls", () => {
-    const metricsExplorer = getFullInitExploreState(
+    const exploreState = getFullInitExploreState(
       AD_BIDS_NAME,
       getInitExploreStateForTest(
         AD_BIDS_METRICS_INIT_WITH_TIME,
@@ -41,12 +41,12 @@ describe("toProto/fromProto", () => {
         },
       ),
     );
-    metricsExplorer.selectedTimeRange = {
+    exploreState.selectedTimeRange = {
       name: "LAST_SIX_HOURS",
       interval: V1TimeGrain.TIME_GRAIN_HOUR,
     } as any;
     const newState = getDashboardStateFromUrl(
-      getProtoFromDashboardState(metricsExplorer, AD_BIDS_EXPLORE_INIT),
+      getProtoFromDashboardState(exploreState, AD_BIDS_EXPLORE_INIT),
       AD_BIDS_METRICS_INIT_WITH_TIME,
       AD_BIDS_EXPLORE_INIT,
       AD_BIDS_SCHEMA,

--- a/web-common/src/features/dashboards/proto-state/sparse-proto.spec.ts
+++ b/web-common/src/features/dashboards/proto-state/sparse-proto.spec.ts
@@ -1,7 +1,7 @@
 import { getProtoFromDashboardState } from "@rilldata/web-common/features/dashboards/proto-state/toProto";
 import { getFullInitExploreState } from "@rilldata/web-common/features/dashboards/stores/dashboard-store-defaults";
 import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import {
   AD_BIDS_EXPLORE_INIT,
   AD_BIDS_EXPLORE_NAME,
@@ -39,7 +39,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 const TestCases: {
   title: string;
   mutations: TestDashboardMutation[];
-  keys: (keyof MetricsExplorerEntity)[];
+  keys: (keyof ExploreState)[];
 }[] = [
   {
     title: "filters",
@@ -151,14 +151,14 @@ describe("sparse proto", () => {
   });
 });
 
-function assertDashboardEquals(name: string, expected: MetricsExplorerEntity) {
+function assertDashboardEquals(name: string, expectedState: ExploreState) {
   expect(cleanDashboard(get(metricsExplorerStore).entities[name])).toEqual(
-    cleanDashboard(expected),
+    cleanDashboard(expectedState),
   );
 }
 
-function cleanDashboard(dashboard: MetricsExplorerEntity) {
-  const newDash = deepClone(dashboard);
+function cleanDashboard(exploreState: ExploreState) {
+  const newDash = deepClone(exploreState);
   delete newDash.proto;
   if (newDash.selectedTimeRange) {
     delete (newDash.selectedTimeRange as any).start;

--- a/web-common/src/features/dashboards/proto-state/toProto.ts
+++ b/web-common/src/features/dashboards/proto-state/toProto.ts
@@ -19,7 +19,7 @@ import {
   ToProtoTimeGrainMap,
 } from "@rilldata/web-common/features/dashboards/proto-state/enum-maps";
 import { createAndExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import { TDDChart } from "@rilldata/web-common/features/dashboards/time-dimension-details/types";
 import { arrayOrderedEquals } from "@rilldata/web-common/lib/arrayUtils";
 import type {
@@ -71,20 +71,20 @@ const TDDChartTypeMap: Record<TDDChart, string> = {
 };
 
 export function getProtoFromDashboardState(
-  metrics: MetricsExplorerEntity,
+  exploreState: ExploreState,
   exploreSpec: V1ExploreSpec,
 ): string {
-  if (!metrics) return "";
+  if (!exploreState) return "";
 
   const state: PartialMessage<DashboardState> = {};
-  if (metrics.whereFilter) {
-    state.where = toExpressionProto(metrics.whereFilter);
+  if (exploreState.whereFilter) {
+    state.where = toExpressionProto(exploreState.whereFilter);
   }
-  if (metrics.dimensionsWithInlistFilter) {
-    state.dimensionsWithInlistFilter = metrics.dimensionsWithInlistFilter;
+  if (exploreState.dimensionsWithInlistFilter) {
+    state.dimensionsWithInlistFilter = exploreState.dimensionsWithInlistFilter;
   }
-  if (metrics.dimensionThresholdFilters?.length) {
-    state.having = metrics.dimensionThresholdFilters.map(
+  if (exploreState.dimensionThresholdFilters?.length) {
+    state.having = exploreState.dimensionThresholdFilters.map(
       ({ name, filters }) =>
         new DashboardDimensionFilter({
           name,
@@ -98,86 +98,89 @@ export function getProtoFromDashboardState(
         }),
     );
   }
-  if (metrics.selectedTimeRange) {
-    state.timeRange = toTimeRangeProto(metrics.selectedTimeRange);
-    if (metrics.selectedTimeRange.interval) {
+  if (exploreState.selectedTimeRange) {
+    state.timeRange = toTimeRangeProto(exploreState.selectedTimeRange);
+    if (exploreState.selectedTimeRange.interval) {
       state.timeGrain =
-        ToProtoTimeGrainMap[metrics.selectedTimeRange.interval] ??
+        ToProtoTimeGrainMap[exploreState.selectedTimeRange.interval] ??
         V1TimeGrain.TIME_GRAIN_UNSPECIFIED;
     }
   }
-  if (metrics.selectedComparisonTimeRange) {
+  if (exploreState.selectedComparisonTimeRange) {
     state.compareTimeRange = toTimeRangeProto(
-      metrics.selectedComparisonTimeRange,
+      exploreState.selectedComparisonTimeRange,
     );
   }
-  if (metrics.lastDefinedScrubRange) {
-    state.scrubRange = toScrubProto(metrics.lastDefinedScrubRange);
+  if (exploreState.lastDefinedScrubRange) {
+    state.scrubRange = toScrubProto(exploreState.lastDefinedScrubRange);
   }
-  state.showTimeComparison = Boolean(metrics.showTimeComparison);
-  if (metrics.selectedComparisonDimension) {
-    state.comparisonDimension = metrics.selectedComparisonDimension;
-  }
-
-  state.selectedTimezone = metrics.selectedTimezone;
-
-  if (metrics.leaderboardSortByMeasureName) {
-    state.leaderboardMeasure = metrics.leaderboardSortByMeasureName;
+  state.showTimeComparison = Boolean(exploreState.showTimeComparison);
+  if (exploreState.selectedComparisonDimension) {
+    state.comparisonDimension = exploreState.selectedComparisonDimension;
   }
 
-  if (metrics.leaderboardShowContextForAllMeasures) {
+  state.selectedTimezone = exploreState.selectedTimezone;
+
+  if (exploreState.leaderboardSortByMeasureName) {
+    state.leaderboardMeasure = exploreState.leaderboardSortByMeasureName;
+  }
+
+  if (exploreState.leaderboardShowContextForAllMeasures) {
     state.leaderboardShowContextForAllMeasures =
-      metrics.leaderboardShowContextForAllMeasures;
+      exploreState.leaderboardShowContextForAllMeasures;
   }
 
-  if (metrics.leaderboardMeasureNames) {
-    state.leaderboardMeasures = metrics.leaderboardMeasureNames;
+  if (exploreState.leaderboardMeasureNames) {
+    state.leaderboardMeasures = exploreState.leaderboardMeasureNames;
   }
 
-  if (metrics.tdd?.pinIndex !== undefined) {
-    state.pinIndex = metrics.tdd.pinIndex;
+  if (exploreState.tdd?.pinIndex !== undefined) {
+    state.pinIndex = exploreState.tdd.pinIndex;
   }
-  if (metrics.tdd?.chartType !== undefined) {
-    state.chartType = TDDChartTypeMap[metrics.tdd.chartType];
+  if (exploreState.tdd?.chartType !== undefined) {
+    state.chartType = TDDChartTypeMap[exploreState.tdd.chartType];
   }
 
   const measuresMatchExactly =
-    exploreSpec?.measures && metrics.visibleMeasures
-      ? arrayOrderedEquals(exploreSpec.measures, metrics.visibleMeasures)
-      : metrics.allMeasuresVisible;
+    exploreSpec?.measures && exploreState.visibleMeasures
+      ? arrayOrderedEquals(exploreSpec.measures, exploreState.visibleMeasures)
+      : exploreState.allMeasuresVisible;
   if (measuresMatchExactly) {
     state.allMeasuresVisible = true;
-  } else if (metrics.visibleMeasures) {
-    state.visibleMeasures = [...metrics.visibleMeasures];
+  } else if (exploreState.visibleMeasures) {
+    state.visibleMeasures = [...exploreState.visibleMeasures];
   }
 
   const dimensionsMatchExactly =
-    exploreSpec?.dimensions && metrics.visibleDimensions
-      ? arrayOrderedEquals(exploreSpec.dimensions, metrics.visibleDimensions)
-      : metrics.allDimensionsVisible;
+    exploreSpec?.dimensions && exploreState.visibleDimensions
+      ? arrayOrderedEquals(
+          exploreSpec.dimensions,
+          exploreState.visibleDimensions,
+        )
+      : exploreState.allDimensionsVisible;
   if (dimensionsMatchExactly) {
     state.allDimensionsVisible = true;
-  } else if (metrics.visibleDimensions) {
-    state.visibleDimensions = [...metrics.visibleDimensions];
+  } else if (exploreState.visibleDimensions) {
+    state.visibleDimensions = [...exploreState.visibleDimensions];
   }
 
-  if (metrics.leaderboardContextColumn) {
+  if (exploreState.leaderboardContextColumn) {
     state.leaderboardContextColumn =
-      LeaderboardContextColumnMap[metrics.leaderboardContextColumn];
+      LeaderboardContextColumnMap[exploreState.leaderboardContextColumn];
   }
 
-  if (metrics.sortDirection) {
-    state.leaderboardSortDirection = metrics.sortDirection;
+  if (exploreState.sortDirection) {
+    state.leaderboardSortDirection = exploreState.sortDirection;
   }
-  if (metrics.dashboardSortType) {
-    state.leaderboardSortType = metrics.dashboardSortType;
-  }
-
-  if (metrics.pivot) {
-    Object.assign(state, toPivotProto(metrics.pivot));
+  if (exploreState.dashboardSortType) {
+    state.leaderboardSortType = exploreState.dashboardSortType;
   }
 
-  Object.assign(state, toActivePageProto(metrics));
+  if (exploreState.pivot) {
+    Object.assign(state, toPivotProto(exploreState.pivot));
+  }
+
+  Object.assign(state, toActivePageProto(exploreState));
 
   const message = new DashboardState(state);
   return protoToBase64(message.toBinary());
@@ -331,25 +334,25 @@ function toPivotProto(pivotState: PivotState): PartialMessage<DashboardState> {
 }
 
 function toActivePageProto(
-  metrics: MetricsExplorerEntity,
+  exploreState: ExploreState,
 ): PartialMessage<DashboardState> {
-  switch (metrics.activePage) {
+  switch (exploreState.activePage) {
     case DashboardState_ActivePage.DEFAULT:
     case DashboardState_ActivePage.PIVOT:
       return {
-        activePage: metrics.activePage,
+        activePage: exploreState.activePage,
       };
 
     case DashboardState_ActivePage.DIMENSION_TABLE:
       return {
-        activePage: metrics.activePage,
-        selectedDimension: metrics.selectedDimensionName,
+        activePage: exploreState.activePage,
+        selectedDimension: exploreState.selectedDimensionName,
       };
 
     case DashboardState_ActivePage.TIME_DIMENSIONAL_DETAIL:
       return {
-        activePage: metrics.activePage,
-        expandedMeasure: metrics.tdd.expandedMeasureName,
+        activePage: exploreState.activePage,
+        expandedMeasure: exploreState.tdd.expandedMeasureName,
       };
   }
 

--- a/web-common/src/features/dashboards/selectors.ts
+++ b/web-common/src/features/dashboards/selectors.ts
@@ -27,7 +27,7 @@ import {
 } from "@tanstack/svelte-query";
 import { derived } from "svelte/store";
 import type { ErrorType } from "../../runtime-client/http-client";
-import type { DimensionThresholdFilter } from "./stores/metrics-explorer-entity";
+import type { DimensionThresholdFilter } from "web-common/src/features/dashboards/stores/explore-state";
 
 export function useMetricsView(
   instanceId: string,

--- a/web-common/src/features/dashboards/state-managers/actions/index.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/index.ts
@@ -1,6 +1,6 @@
 import { filterActions } from "@rilldata/web-common/features/dashboards/state-managers/actions/filters";
 import { measureFilterActions } from "@rilldata/web-common/features/dashboards/state-managers/actions/measure-filters";
-import type { MetricsExplorerEntity } from "../../stores/metrics-explorer-entity";
+import type { ExploreState } from "web-common/src/features/dashboards/stores/explore-state";
 import { comparisonActions } from "./comparison";
 import { contextColActions } from "./context-columns";
 import { dimensionFilterActions } from "./dimension-filters";
@@ -99,10 +99,10 @@ function dashboardMutatorToUpdater<T extends unknown[]>(
   mutator: DashboardMutatorFn<T>,
 ): (...params: T) => void {
   return (...x) => {
-    const callback = (dash: MetricsExplorerEntity) =>
+    const callback = (exploreState: ExploreState) =>
       mutator(
         {
-          dashboard: dash,
+          dashboard: exploreState,
         },
         ...x,
       );

--- a/web-common/src/features/dashboards/state-managers/actions/measure-filters.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/measure-filters.ts
@@ -1,6 +1,6 @@
 import type { MeasureFilterEntry } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry";
 import type { DashboardMutables } from "@rilldata/web-common/features/dashboards/state-managers/actions/types";
-import type { DimensionThresholdFilter } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { DimensionThresholdFilter } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 
 export function setMeasureFilter(
   { dashboard }: DashboardMutables,

--- a/web-common/src/features/dashboards/state-managers/actions/types.ts
+++ b/web-common/src/features/dashboards/state-managers/actions/types.ts
@@ -1,4 +1,4 @@
-import type { MetricsExplorerEntity } from "../../stores/metrics-explorer-entity";
+import type { ExploreState } from "web-common/src/features/dashboards/stores/explore-state";
 import type { Expand } from "../types";
 
 // Note: the types below are helper types to simplify the type inference
@@ -12,9 +12,7 @@ import type { Expand } from "../types";
  * This will often be a closure over other parameters
  * that are relevant to the mutation.
  */
-export type DashboardMutatorCallback = (
-  metricsExplorer: MetricsExplorerEntity,
-) => void;
+export type DashboardMutatorCallback = (exploreState: ExploreState) => void;
 
 /**
  * DashboardCallbackExecutor is a function that takes a
@@ -37,7 +35,7 @@ export type DashboardCallbackExecutor = (
  * code, so in components these mutables will be hidden.
  */
 export type DashboardMutables = {
-  dashboard: MetricsExplorerEntity;
+  dashboard: ExploreState;
 };
 
 /**

--- a/web-common/src/features/dashboards/state-managers/cascading-explore-state-merge.ts
+++ b/web-common/src/features/dashboards/state-managers/cascading-explore-state-merge.ts
@@ -1,6 +1,6 @@
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 
-const ShallowMergeOneLevelDeepKeys = new Set<keyof MetricsExplorerEntity>([
+const ShallowMergeOneLevelDeepKeys = new Set<keyof ExploreState>([
   "selectedTimeRange",
   "selectedComparisonTimeRange",
   "tdd",
@@ -26,14 +26,14 @@ const ShallowMergeOneLevelDeepKeys = new Set<keyof MetricsExplorerEntity>([
  * Then we could offload the specific merging logic to the class methods.
  */
 export function cascadingExploreStateMerge(
-  exploreStatesInOrder: Partial<MetricsExplorerEntity>[],
+  exploreStatesInOrder: Partial<ExploreState>[],
 ) {
-  const mergedExploreState: Partial<MetricsExplorerEntity> = {};
+  const mergedExploreState: Partial<ExploreState> = {};
 
   const keyProcessed = new Set<string>();
   // Merge all keys not part of ShallowMergeOneLevelDeepKeys. This allows for future keys to be merged without changes.
   exploreStatesInOrder.forEach((state) => {
-    Object.keys(state).forEach((key: keyof MetricsExplorerEntity) => {
+    Object.keys(state).forEach((key: keyof ExploreState) => {
       // Since the states are in order a key found 1st should only be merged once.
       // So ignore keys we have already seen
       const isKeyAlreadyProcessed = keyProcessed.has(key);

--- a/web-common/src/features/dashboards/state-managers/cascading-explore-state.merge.spec.ts
+++ b/web-common/src/features/dashboards/state-managers/cascading-explore-state.merge.spec.ts
@@ -1,5 +1,5 @@
 import { cascadingExploreStateMerge } from "@rilldata/web-common/features/dashboards/state-managers/cascading-explore-state-merge";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import {
   AD_BIDS_BID_PRICE_MEASURE,
   AD_BIDS_COUNTRY_DIMENSION,
@@ -54,7 +54,7 @@ describe("cascadingExploreStateMerge", () => {
   });
 });
 
-const StateFromURL: Partial<MetricsExplorerEntity> = {
+const StateFromURL: Partial<ExploreState> = {
   selectedTimeRange: {
     name: TimeRangePreset.LAST_SIX_HOURS,
   } as DashboardTimeControls,
@@ -67,14 +67,14 @@ const StateFromURL: Partial<MetricsExplorerEntity> = {
   allMeasuresVisible: false,
 };
 
-const MostRecentState: Partial<MetricsExplorerEntity> = {
+const MostRecentState: Partial<ExploreState> = {
   visibleMeasures: [AD_BIDS_BID_PRICE_MEASURE],
   allMeasuresVisible: false,
   visibleDimensions: [AD_BIDS_DOMAIN_DIMENSION],
   allDimensionsVisible: false,
 };
 
-const YAMLConfigState: Partial<MetricsExplorerEntity> = {
+const YAMLConfigState: Partial<ExploreState> = {
   selectedTimeRange: {
     name: TimeRangePreset.LAST_24_HOURS,
     interval: V1TimeGrain.TIME_GRAIN_HOUR,
@@ -93,7 +93,7 @@ const YAMLConfigState: Partial<MetricsExplorerEntity> = {
   leaderboardSortByMeasureName: AD_BIDS_PUBLISHER_COUNT_MEASURE,
 };
 
-const RillDefaultState: Partial<MetricsExplorerEntity> = {
+const RillDefaultState: Partial<ExploreState> = {
   selectedTimeRange: {
     name: TimeRangePreset.LAST_7_DAYS,
     interval: V1TimeGrain.TIME_GRAIN_DAY,

--- a/web-common/src/features/dashboards/state-managers/loaders/DashboardStateDataLoader.ts
+++ b/web-common/src/features/dashboards/state-managers/loaders/DashboardStateDataLoader.ts
@@ -8,7 +8,7 @@ import { getPartialExploreStateFromSessionStorage } from "@rilldata/web-common/f
 import { getMostRecentPartialExploreState } from "@rilldata/web-common/features/dashboards/state-managers/loaders/most-recent-explore-state";
 import { getExploreStateFromYAMLConfig } from "@rilldata/web-common/features/dashboards/stores/get-explore-state-from-yaml-config";
 import { getRillDefaultExploreState } from "@rilldata/web-common/features/dashboards/stores/get-rill-default-explore-state";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import { normalizeWeekday } from "@rilldata/web-common/features/dashboards/time-controls/new-time-controls";
 import { convertURLSearchParamsToExploreState } from "@rilldata/web-common/features/dashboards/url-state/convertURLSearchParamsToExploreState";
 import { useExploreValidSpec } from "@rilldata/web-common/features/explores/selectors";
@@ -34,10 +34,10 @@ export class DashboardStateDataLoader {
   public readonly fullTimeRangeQuery: CompoundQueryResult<V1MetricsViewTimeRangeResponse>;
 
   // Default explore state show when there is no data in session/local storage or a home bookmark.
-  public readonly rillDefaultExploreState: CompoundQueryResult<MetricsExplorerEntity>;
+  public readonly rillDefaultExploreState: CompoundQueryResult<ExploreState>;
   // Explore state from yaml config
   public readonly exploreStateFromYAMLConfig: CompoundQueryResult<
-    Partial<MetricsExplorerEntity>
+    Partial<ExploreState>
   >;
 
   /**
@@ -50,14 +50,14 @@ export class DashboardStateDataLoader {
    * 5. Rill opinionated defaults.
    */
   public readonly initExploreState: CompoundQueryResult<
-    MetricsExplorerEntity | undefined
+    ExploreState | undefined
   >;
 
   public constructor(
     instanceId: string,
     private readonly exploreName: string,
     private readonly storageNamespacePrefix: string | undefined,
-    private readonly bookmarkOrTokenExploreState?: CompoundQueryResult<Partial<MetricsExplorerEntity> | null>,
+    private readonly bookmarkOrTokenExploreState?: CompoundQueryResult<Partial<ExploreState> | null>,
   ) {
     this.validSpecQuery = useExploreValidSpec(instanceId, exploreName);
     this.fullTimeRangeQuery = this.useFullTimeRangeQuery(
@@ -287,12 +287,9 @@ export class DashboardStateDataLoader {
     metricsViewSpec: V1MetricsViewSpec;
     exploreSpec: V1ExploreSpec;
     urlSearchParams: URLSearchParams;
-    bookmarkOrTokenExploreState:
-      | Partial<MetricsExplorerEntity>
-      | null
-      | undefined;
-    exploreStateFromYAMLConfig: Partial<MetricsExplorerEntity>;
-    rillDefaultExploreState: MetricsExplorerEntity;
+    bookmarkOrTokenExploreState: Partial<ExploreState> | null | undefined;
+    exploreStateFromYAMLConfig: Partial<ExploreState>;
+    rillDefaultExploreState: ExploreState;
     backButtonUsed: boolean;
   }) {
     const skipSessionStorage = backButtonUsed;
@@ -347,10 +344,10 @@ export class DashboardStateDataLoader {
 
     const nonEmptyExploreStateOrder = exploreStateOrder.filter(
       Boolean,
-    ) as Partial<MetricsExplorerEntity>[];
+    ) as Partial<ExploreState>[];
     const finalExploreState = cascadingExploreStateMerge(
       nonEmptyExploreStateOrder,
-    ) as MetricsExplorerEntity;
+    ) as ExploreState;
 
     return finalExploreState;
   }

--- a/web-common/src/features/dashboards/state-managers/loaders/DashboardStateManager.spec.ts
+++ b/web-common/src/features/dashboards/state-managers/loaders/DashboardStateManager.spec.ts
@@ -8,7 +8,7 @@ import {
   PageMockForExploreTests,
 } from "@rilldata/web-common/features/dashboards/state-managers/loaders/test/PageMockForExploreTests";
 import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import {
   AD_BIDS_BID_PRICE_MEASURE,
   AD_BIDS_COUNTRY_DIMENSION,
@@ -94,32 +94,28 @@ describe("DashboardStateManager", () => {
   });
 
   describe("Dashboards with timeseries", () => {
-    const ExploreStateSubsetForRillDefaultState: Partial<MetricsExplorerEntity> =
-      {
-        selectedTimeRange: {
-          name: "rill-QTD",
-          interval: V1TimeGrain.TIME_GRAIN_WEEK,
-        } as DashboardTimeControls,
-        showTimeComparison: false,
-        selectedComparisonTimeRange: undefined,
+    const ExploreStateSubsetForRillDefaultState: Partial<ExploreState> = {
+      selectedTimeRange: {
+        name: "rill-QTD",
+        interval: V1TimeGrain.TIME_GRAIN_WEEK,
+      } as DashboardTimeControls,
+      showTimeComparison: false,
+      selectedComparisonTimeRange: undefined,
 
-        visibleMeasures: [
-          AD_BIDS_IMPRESSIONS_MEASURE,
-          AD_BIDS_BID_PRICE_MEASURE,
-        ],
-        allMeasuresVisible: true,
-        visibleDimensions: [
-          AD_BIDS_PUBLISHER_DIMENSION,
-          AD_BIDS_DOMAIN_DIMENSION,
-        ],
-        allDimensionsVisible: true,
+      visibleMeasures: [AD_BIDS_IMPRESSIONS_MEASURE, AD_BIDS_BID_PRICE_MEASURE],
+      allMeasuresVisible: true,
+      visibleDimensions: [
+        AD_BIDS_PUBLISHER_DIMENSION,
+        AD_BIDS_DOMAIN_DIMENSION,
+      ],
+      allDimensionsVisible: true,
 
-        leaderboardSortByMeasureName: AD_BIDS_IMPRESSIONS_MEASURE,
-        leaderboardMeasureNames: [AD_BIDS_IMPRESSIONS_MEASURE],
-        dashboardSortType: DashboardState_LeaderboardSortType.VALUE,
-        sortDirection: DashboardState_LeaderboardSortDirection.DESCENDING,
-      };
-    const ExploreStateSubsetForYAMLState: Partial<MetricsExplorerEntity> = {
+      leaderboardSortByMeasureName: AD_BIDS_IMPRESSIONS_MEASURE,
+      leaderboardMeasureNames: [AD_BIDS_IMPRESSIONS_MEASURE],
+      dashboardSortType: DashboardState_LeaderboardSortType.VALUE,
+      sortDirection: DashboardState_LeaderboardSortDirection.DESCENDING,
+    };
+    const ExploreStateSubsetForYAMLState: Partial<ExploreState> = {
       selectedTimeRange: {
         name: "P7D",
         interval: V1TimeGrain.TIME_GRAIN_DAY,
@@ -298,29 +294,25 @@ describe("DashboardStateManager", () => {
   });
 
   describe("Dashboards without timeseries", () => {
-    const ExploreStateSubsetForRillDefaultState: Partial<MetricsExplorerEntity> =
-      {
-        selectedTimeRange: undefined,
-        showTimeComparison: false,
-        selectedComparisonTimeRange: undefined,
+    const ExploreStateSubsetForRillDefaultState: Partial<ExploreState> = {
+      selectedTimeRange: undefined,
+      showTimeComparison: false,
+      selectedComparisonTimeRange: undefined,
 
-        visibleMeasures: [
-          AD_BIDS_IMPRESSIONS_MEASURE,
-          AD_BIDS_BID_PRICE_MEASURE,
-        ],
-        allMeasuresVisible: true,
-        visibleDimensions: [
-          AD_BIDS_PUBLISHER_DIMENSION,
-          AD_BIDS_DOMAIN_DIMENSION,
-        ],
-        allDimensionsVisible: true,
+      visibleMeasures: [AD_BIDS_IMPRESSIONS_MEASURE, AD_BIDS_BID_PRICE_MEASURE],
+      allMeasuresVisible: true,
+      visibleDimensions: [
+        AD_BIDS_PUBLISHER_DIMENSION,
+        AD_BIDS_DOMAIN_DIMENSION,
+      ],
+      allDimensionsVisible: true,
 
-        leaderboardSortByMeasureName: AD_BIDS_IMPRESSIONS_MEASURE,
-        leaderboardMeasureNames: [AD_BIDS_IMPRESSIONS_MEASURE],
-        sortDirection: DashboardState_LeaderboardSortDirection.DESCENDING,
-        dashboardSortType: DashboardState_LeaderboardSortType.VALUE,
-      };
-    const ExploreStateSubsetForYAMLState: Partial<MetricsExplorerEntity> = {
+      leaderboardSortByMeasureName: AD_BIDS_IMPRESSIONS_MEASURE,
+      leaderboardMeasureNames: [AD_BIDS_IMPRESSIONS_MEASURE],
+      sortDirection: DashboardState_LeaderboardSortDirection.DESCENDING,
+      dashboardSortType: DashboardState_LeaderboardSortType.VALUE,
+    };
+    const ExploreStateSubsetForYAMLState: Partial<ExploreState> = {
       visibleMeasures: [AD_BIDS_IMPRESSIONS_MEASURE],
       allMeasuresVisible: false,
       visibleDimensions: [AD_BIDS_PUBLISHER_DIMENSION],
@@ -482,7 +474,7 @@ describe("DashboardStateManager", () => {
 // TODO: find if there is a way to share code.
 function renderDashboardStateManager(
   bookmarkOrTokenExploreState:
-    | CompoundQueryResult<Partial<MetricsExplorerEntity> | undefined>
+    | CompoundQueryResult<Partial<ExploreState> | undefined>
     | undefined = undefined,
 ) {
   const renderResults = render(DashboardStateManagerTest, {
@@ -498,11 +490,9 @@ function renderDashboardStateManager(
   return { queryClient, renderResults };
 }
 
-function assertExploreStateSubset(
-  exploreStateSubset: Partial<MetricsExplorerEntity>,
-) {
+function assertExploreStateSubset(exploreStateSubset: Partial<ExploreState>) {
   const curExploreState = getCleanMetricsExploreForAssertion();
-  const curExploreStateSubset: Partial<MetricsExplorerEntity> = {
+  const curExploreStateSubset: Partial<ExploreState> = {
     selectedTimeRange: curExploreState.selectedTimeRange,
     showTimeComparison: curExploreState.showTimeComparison,
     selectedComparisonTimeRange: curExploreState.selectedComparisonTimeRange,

--- a/web-common/src/features/dashboards/state-managers/loaders/DashboardStateManager.svelte
+++ b/web-common/src/features/dashboards/state-managers/loaders/DashboardStateManager.svelte
@@ -5,7 +5,7 @@
   import { DashboardStateDataLoader } from "@rilldata/web-common/features/dashboards/state-managers/loaders/DashboardStateDataLoader";
   import { DashboardStateSync } from "@rilldata/web-common/features/dashboards/state-managers/loaders/DashboardStateSync";
   import { useExploreState } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
-  import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+  import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
   import DashboardLoading from "@rilldata/web-common/features/dashboards/state-managers/loaders/DashboardLoading.svelte";
   import { useExploreValidSpec } from "@rilldata/web-common/features/explores/selectors";
   import type { HTTPError } from "@rilldata/web-common/runtime-client/fetchWrapper";
@@ -15,7 +15,7 @@
   export let exploreName: string;
   export let storageNamespacePrefix: string | undefined = undefined;
   export let bookmarkOrTokenExploreState:
-    | CompoundQueryResult<Partial<MetricsExplorerEntity> | null>
+    | CompoundQueryResult<Partial<ExploreState> | null>
     | undefined = undefined;
 
   $: ({ instanceId } = $runtime);
@@ -44,7 +44,7 @@
   }
 
   let initExploreState:
-    | CompoundQueryResult<MetricsExplorerEntity | undefined>
+    | CompoundQueryResult<ExploreState | undefined>
     | undefined;
   $: if (dataLoader) ({ initExploreState } = dataLoader);
 

--- a/web-common/src/features/dashboards/state-managers/loaders/DashboardStateSync.ts
+++ b/web-common/src/features/dashboards/state-managers/loaders/DashboardStateSync.ts
@@ -6,7 +6,7 @@ import {
   metricsExplorerStore,
   useExploreState,
 } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import {
   createTimeControlStoreFromName,
   type TimeControlStore,
@@ -25,7 +25,7 @@ import type { CompoundQueryResult } from "@rilldata/web-common/features/compound
  * prevUrl is used to make sure there is no redirect loop.
  */
 export class DashboardStateSync {
-  private readonly exploreStore: Readable<MetricsExplorerEntity | undefined>;
+  private readonly exploreStore: Readable<ExploreState | undefined>;
   private readonly timeControlStore: TimeControlStore;
   // Cached url params for a rill opinionated dashboard defaults. Used to remove params from url.
   // To avoid converting the default explore state to url evey time it is needed we maintain a cached version here.
@@ -86,7 +86,7 @@ export class DashboardStateSync {
    * Initializes the dashboard store.
    * If the url needs to change to match the init then we replace the current url with the new url.
    */
-  private handleExploreInit(initExploreState: MetricsExplorerEntity) {
+  private handleExploreInit(initExploreState: ExploreState) {
     // If this is re-triggered any of the dependant query was refetched, then we need to make sure this is not run again.
     if (this.initialized) return;
 
@@ -234,7 +234,7 @@ export class DashboardStateSync {
    *
    * This will check if the url needs to be changed and will navigate to the new url.
    */
-  private gotoNewState(exploreState: MetricsExplorerEntity) {
+  private gotoNewState(exploreState: ExploreState) {
     // Updating state either in handleExploreInit or handleURLChange will synchronously update the state triggering this function.
     // Since those methods handle redirect themselves we need to skip this logic.
     // Those methods need to replace the current URL while this does a direct navigation.

--- a/web-common/src/features/dashboards/state-managers/loaders/explore-web-view-store.ts
+++ b/web-common/src/features/dashboards/state-managers/loaders/explore-web-view-store.ts
@@ -1,4 +1,4 @@
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import type { TimeControlState } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import { TDDChart } from "@rilldata/web-common/features/dashboards/time-dimension-details/types";
 import { convertPartialExploreStateToUrlParams } from "@rilldata/web-common/features/dashboards/url-state/convert-partial-explore-state-to-url-params";
@@ -33,7 +33,7 @@ export function getKeyForSessionStore(
 export function updateExploreSessionStore(
   exploreName: string,
   storageNamespacePrefix: string | undefined,
-  exploreState: MetricsExplorerEntity,
+  exploreState: ExploreState,
   exploreSpec: V1ExploreSpec,
   timeControlsState: TimeControlState | undefined,
 ) {

--- a/web-common/src/features/dashboards/state-managers/loaders/most-recent-explore-state.ts
+++ b/web-common/src/features/dashboards/state-managers/loaders/most-recent-explore-state.ts
@@ -4,7 +4,7 @@ import type {
   V1ExploreSpec,
   V1MetricsViewSpec,
 } from "@rilldata/web-common/runtime-client";
-import type { MetricsExplorerEntity } from "../../stores/metrics-explorer-entity";
+import type { ExploreState } from "web-common/src/features/dashboards/stores/explore-state";
 
 function getKeyForLocalStore(
   exploreName: string,
@@ -29,7 +29,7 @@ export function getMostRecentPartialExploreState(
 
     const stateFromLocalStorage = JSON.parse(
       rawExploreState,
-    ) as Partial<MetricsExplorerEntity>;
+    ) as Partial<ExploreState>;
     const errors = validateAndCleanExploreState(
       metricsViewSpec,
       exploreSpec,
@@ -50,7 +50,7 @@ export function getMostRecentPartialExploreState(
 export function saveMostRecentPartialExploreState(
   exploreName: string,
   storageNamespacePrefix: string | undefined,
-  exploreState: MetricsExplorerEntity,
+  exploreState: ExploreState,
 ) {
   if (
     exploreState.activePage !== DashboardState_ActivePage.DEFAULT &&
@@ -96,7 +96,7 @@ export function clearMostRecentExploreState(
 export function setMostRecentExploreStateInLocalStorage(
   exploreName: string,
   storageNamespacePrefix: string | undefined,
-  exploreState: Partial<MetricsExplorerEntity>,
+  exploreState: Partial<ExploreState>,
 ) {
   localStorage.setItem(
     getKeyForLocalStore(exploreName, storageNamespacePrefix),

--- a/web-common/src/features/dashboards/state-managers/loaders/test/DashboardStateManagerTest.svelte
+++ b/web-common/src/features/dashboards/state-managers/loaders/test/DashboardStateManagerTest.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
   import type { CompoundQueryResult } from "@rilldata/web-common/features/compound-query-result";
   import DashboardStateManager from "@rilldata/web-common/features/dashboards/state-managers/loaders/DashboardStateManager.svelte";
-  import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+  import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 
   /**
    * Test component that adds some text to assert dashboard load.
    */
   export let exploreName: string;
   export let bookmarkOrTokenExploreState:
-    | CompoundQueryResult<Partial<MetricsExplorerEntity> | null>
+    | CompoundQueryResult<Partial<ExploreState> | null>
     | undefined = undefined;
 </script>
 

--- a/web-common/src/features/dashboards/state-managers/most-recent-explore-state.spec.ts
+++ b/web-common/src/features/dashboards/state-managers/most-recent-explore-state.spec.ts
@@ -5,7 +5,7 @@ import {
   PageMockForExploreTests,
 } from "@rilldata/web-common/features/dashboards/state-managers/loaders/test/PageMockForExploreTests";
 import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import {
   AD_BIDS_BID_PRICE_MEASURE,
   AD_BIDS_EXPLORE_INIT,
@@ -56,7 +56,7 @@ const TestCases: {
   mutations: TestDashboardMutation[];
 
   expectedUrlSearch: string;
-  expectedExplore: Partial<MetricsExplorerEntity>;
+  expectedExplore: Partial<ExploreState>;
 }[] = [
   {
     title: "Changes to dashboard using actions",

--- a/web-common/src/features/dashboards/state-managers/selectors/dashboard-queries.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/dashboard-queries.ts
@@ -1,5 +1,5 @@
 import { additionalMeasures } from "../../selectors";
-import type { DimensionThresholdFilter } from "../../stores/metrics-explorer-entity";
+import type { DimensionThresholdFilter } from "web-common/src/features/dashboards/stores/explore-state";
 
 export function getMeasuresForDimensionOrLeaderboardDisplay(
   sortByMeasureName: string | null,

--- a/web-common/src/features/dashboards/state-managers/selectors/index.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/index.ts
@@ -7,7 +7,7 @@ import type {
 } from "@rilldata/web-common/runtime-client";
 import type { QueryClient, QueryObserverResult } from "@tanstack/svelte-query";
 import { derived, type Readable } from "svelte/store";
-import type { MetricsExplorerEntity } from "../../stores/metrics-explorer-entity";
+import type { ExploreState } from "web-common/src/features/dashboards/stores/explore-state";
 import { activeMeasureSelectors } from "./active-measure";
 import { comparisonSelectors } from "./comparisons";
 import { contextColSelectors } from "./context-column";
@@ -23,7 +23,7 @@ import type { ReadablesObj, SelectorFnsObj } from "./types";
 import { leaderboardSelectors } from "./leaderboard";
 
 export type DashboardDataReadables = {
-  dashboardStore: Readable<MetricsExplorerEntity>;
+  dashboardStore: Readable<ExploreState>;
   validSpecStore: Readable<
     QueryObserverResult<ExploreValidSpecResponse, RpcStatus>
   >;

--- a/web-common/src/features/dashboards/state-managers/selectors/measure-filters.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/measure-filters.ts
@@ -2,7 +2,7 @@ import { getMeasureDisplayName } from "@rilldata/web-common/features/dashboards/
 import type { MeasureFilterEntry } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry";
 import type { DashboardDataSources } from "@rilldata/web-common/features/dashboards/state-managers/selectors/types";
 import type { AtLeast } from "@rilldata/web-common/features/dashboards/state-managers/types";
-import type { DimensionThresholdFilter } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { DimensionThresholdFilter } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import {
   type MetricsViewSpecDimension,
   type MetricsViewSpecMeasure,

--- a/web-common/src/features/dashboards/state-managers/selectors/measures.spec.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/measures.spec.ts
@@ -1,5 +1,5 @@
 import { removeSomeAdvancedMeasures } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measures";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import {
   type V1MetricsViewSpec,
   V1TimeGrain,
@@ -104,7 +104,7 @@ describe("measures selectors", () => {
               selectedTimeRange: {
                 interval: timeGrain,
               },
-            } as MetricsExplorerEntity,
+            } as ExploreState,
             MetricsView,
             measures,
             true,
@@ -120,7 +120,7 @@ describe("measures selectors", () => {
             selectedTimeRange: {
               interval: V1TimeGrain.TIME_GRAIN_UNSPECIFIED,
             },
-          } as MetricsExplorerEntity,
+          } as ExploreState,
           MetricsView,
           ["mes", "window_mes"],
           false,

--- a/web-common/src/features/dashboards/state-managers/selectors/measures.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/measures.ts
@@ -1,4 +1,4 @@
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import {
   MetricsViewSpecMeasureType,
   type MetricsViewSpecMeasure,
@@ -102,7 +102,7 @@ export const filteredSimpleMeasures = ({
  * 3. Window measures if includeWindowMeasures=false. Right now totals query does not support these.
  */
 export const removeSomeAdvancedMeasures = (
-  exploreState: MetricsExplorerEntity,
+  exploreState: ExploreState,
   metricsViewSpec: V1MetricsViewSpec,
   measureNames: string[],
   includeWindowMeasures: boolean,

--- a/web-common/src/features/dashboards/state-managers/selectors/types.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/types.ts
@@ -5,7 +5,7 @@ import type {
 } from "@rilldata/web-common/runtime-client";
 import type { QueryClient, QueryObserverResult } from "@tanstack/svelte-query";
 import type { Readable } from "svelte/store";
-import type { MetricsExplorerEntity } from "../../stores/metrics-explorer-entity";
+import type { ExploreState } from "web-common/src/features/dashboards/stores/explore-state";
 import type { Expand } from "../types";
 
 /**
@@ -22,7 +22,7 @@ import type { Expand } from "../types";
  * and utimately wrapped in Readables for use in components.
  */
 export type DashboardDataSources = {
-  dashboard: MetricsExplorerEntity;
+  dashboard: ExploreState;
   validMetricsView: V1MetricsViewSpec | undefined;
   validExplore: V1ExploreSpec | undefined;
   timeRangeSummary: QueryObserverResult<

--- a/web-common/src/features/dashboards/state-managers/state-managers.ts
+++ b/web-common/src/features/dashboards/state-managers/state-managers.ts
@@ -1,4 +1,4 @@
-import { type MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import { type ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import { getDefaultExplorePreset } from "@rilldata/web-common/features/dashboards/url-state/getDefaultExplorePreset";
 import {
   type ExploreValidSpecResponse,
@@ -43,7 +43,7 @@ export type StateManagers = {
   metricsViewName: Writable<string>;
   exploreName: Writable<string>;
   metricsStore: Readable<MetricsExplorerStoreType>;
-  dashboardStore: Readable<MetricsExplorerEntity>;
+  dashboardStore: Readable<ExploreState>;
   timeRangeSummaryStore: Readable<
     QueryObserverResult<V1MetricsViewTimeRangeResponse, unknown>
   >;
@@ -88,7 +88,7 @@ export function createStateManagers({
   const metricsViewNameStore = writable(metricsViewName);
   const exploreNameStore = writable(exploreName);
 
-  const dashboardStore: Readable<MetricsExplorerEntity> = derived(
+  const dashboardStore: Readable<ExploreState> = derived(
     [exploreNameStore],
     ([name], set) => {
       const exploreState = useExploreState(name);
@@ -127,9 +127,7 @@ export function createStateManagers({
       ).subscribe(set),
   );
 
-  const updateDashboard = (
-    callback: (metricsExplorer: MetricsExplorerEntity) => void,
-  ) => {
+  const updateDashboard = (callback: (exploreState: ExploreState) => void) => {
     const name = get(dashboardStore).name;
 
     // TODO: Remove dependency on MetricsExplorerStore singleton and its exports

--- a/web-common/src/features/dashboards/stores/dashboard-store-defaults.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-store-defaults.ts
@@ -2,13 +2,13 @@ import {
   contextColWidthDefaults,
   LeaderboardContextColumn,
 } from "@rilldata/web-common/features/dashboards/leaderboard-context-column";
-import { type MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import { type ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 
 // TODO: Remove this in favour of just `getDefaultExplorePreset`
 export function getFullInitExploreState(
   name: string,
-  partialInitState: Partial<MetricsExplorerEntity>,
-): MetricsExplorerEntity {
+  partialInitState: Partial<ExploreState>,
+): ExploreState {
   return {
     // fields filled here are the ones that are not stored and loaded to/from URL
     name,
@@ -21,5 +21,5 @@ export function getFullInitExploreState(
     lastDefinedScrubRange: undefined,
 
     ...partialInitState,
-  } as MetricsExplorerEntity;
+  } as ExploreState;
 }

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -71,83 +71,80 @@ function includeExcludeModeFromFilters(filters: V1Expression | undefined) {
   return map;
 }
 
-function syncMeasures(explore: V1ExploreSpec, metricsExplorer: ExploreState) {
+function syncMeasures(explore: V1ExploreSpec, exploreState: ExploreState) {
   const measuresSet = new Set(explore.measures ?? []);
 
   // sync measures with selected leaderboard measure and ensure default measure is set
   if (explore.measures?.length) {
     const defaultMeasure = explore.measures[0];
-    if (!measuresSet.has(metricsExplorer.leaderboardSortByMeasureName)) {
-      metricsExplorer.leaderboardSortByMeasureName = defaultMeasure;
+    if (!measuresSet.has(exploreState.leaderboardSortByMeasureName)) {
+      exploreState.leaderboardSortByMeasureName = defaultMeasure;
     }
-    if (!metricsExplorer.leaderboardMeasureNames?.length) {
-      metricsExplorer.leaderboardMeasureNames = [defaultMeasure];
+    if (!exploreState.leaderboardMeasureNames?.length) {
+      exploreState.leaderboardMeasureNames = [defaultMeasure];
     }
   }
 
   if (
-    metricsExplorer.tdd.expandedMeasureName &&
-    !measuresSet.has(metricsExplorer.tdd.expandedMeasureName)
+    exploreState.tdd.expandedMeasureName &&
+    !measuresSet.has(exploreState.tdd.expandedMeasureName)
   ) {
-    metricsExplorer.tdd.expandedMeasureName = undefined;
+    exploreState.tdd.expandedMeasureName = undefined;
   }
 
-  metricsExplorer.pivot.columns = metricsExplorer.pivot.columns.filter(
-    (measure) => measuresSet.has(measure.id),
+  exploreState.pivot.columns = exploreState.pivot.columns.filter((measure) =>
+    measuresSet.has(measure.id),
   );
 
-  if (metricsExplorer.allMeasuresVisible) {
+  if (exploreState.allMeasuresVisible) {
     // this makes sure that the visible keys is in sync with list of measures
-    metricsExplorer.visibleMeasures = [...measuresSet];
+    exploreState.visibleMeasures = [...measuresSet];
   } else {
     // remove any visible measures that doesn't exist anymore
-    metricsExplorer.visibleMeasures = metricsExplorer.visibleMeasures.filter(
-      (m) => measuresSet.has(m),
+    exploreState.visibleMeasures = exploreState.visibleMeasures.filter((m) =>
+      measuresSet.has(m),
     );
     // If there are no visible measures, make the first measure visible
-    if (
-      explore.measures?.length &&
-      metricsExplorer.visibleMeasures.length === 0
-    ) {
-      metricsExplorer.visibleMeasures = [explore.measures[0]];
+    if (explore.measures?.length && exploreState.visibleMeasures.length === 0) {
+      exploreState.visibleMeasures = [explore.measures[0]];
     }
   }
 }
 
-function syncDimensions(explore: V1ExploreSpec, metricsExplorer: ExploreState) {
+function syncDimensions(explore: V1ExploreSpec, exploreState: ExploreState) {
   // Having a map here improves the lookup for existing dimension name
   const dimensionsSet = new Set(explore.dimensions ?? []);
-  metricsExplorer.whereFilter =
-    filterExpressions(metricsExplorer.whereFilter, (e) => {
+  exploreState.whereFilter =
+    filterExpressions(exploreState.whereFilter, (e) => {
       if (!e.cond?.exprs?.length) return true;
       return dimensionsSet.has(e.cond.exprs[0].ident!);
     }) ?? createAndExpression([]);
 
   if (
-    metricsExplorer.selectedDimensionName &&
-    !dimensionsSet.has(metricsExplorer.selectedDimensionName)
+    exploreState.selectedDimensionName &&
+    !dimensionsSet.has(exploreState.selectedDimensionName)
   ) {
-    metricsExplorer.selectedDimensionName = undefined;
-    metricsExplorer.activePage = DashboardState_ActivePage.DEFAULT;
+    exploreState.selectedDimensionName = undefined;
+    exploreState.activePage = DashboardState_ActivePage.DEFAULT;
   }
 
-  metricsExplorer.pivot.rows = metricsExplorer.pivot.rows.filter(
+  exploreState.pivot.rows = exploreState.pivot.rows.filter(
     (dimension) =>
       dimensionsSet.has(dimension.id) || dimension.type === PivotChipType.Time,
   );
 
-  metricsExplorer.pivot.columns = metricsExplorer.pivot.columns.filter(
+  exploreState.pivot.columns = exploreState.pivot.columns.filter(
     (dimension) =>
       dimensionsSet.has(dimension.id) || dimension.type === PivotChipType.Time,
   );
 
-  if (metricsExplorer.allDimensionsVisible) {
+  if (exploreState.allDimensionsVisible) {
     // this makes sure that the visible keys is in sync with list of dimensions
-    metricsExplorer.visibleDimensions = [...dimensionsSet];
+    exploreState.visibleDimensions = [...dimensionsSet];
   } else {
     // remove any visible dimensions that doesn't exist anymore
-    metricsExplorer.visibleDimensions = metricsExplorer.visibleDimensions
-      ? metricsExplorer.visibleDimensions.filter((d) => dimensionsSet.has(d))
+    exploreState.visibleDimensions = exploreState.visibleDimensions
+      ? exploreState.visibleDimensions.filter((d) => dimensionsSet.has(d))
       : [];
   }
 }
@@ -184,18 +181,19 @@ const metricsViewReducers = {
     );
     if (!partial) return;
 
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
+    updateMetricsExplorerByName(name, (exploreState) => {
       for (const key in partial) {
-        metricsExplorer[key] = partial[key];
+        exploreState[key] = partial[key];
       }
       // this hack is needed since what is shown for comparison is not a single source
       // TODO: use an enum and get rid of this
       if (!partial.showTimeComparison) {
-        metricsExplorer.showTimeComparison = false;
+        exploreState.showTimeComparison = false;
       }
-      metricsExplorer.dimensionFilterExcludeMode =
-        includeExcludeModeFromFilters(partial.whereFilter);
-      AdvancedMeasureCorrector.correct(metricsExplorer, metricsView);
+      exploreState.dimensionFilterExcludeMode = includeExcludeModeFromFilters(
+        partial.whereFilter,
+      );
+      AdvancedMeasureCorrector.correct(exploreState, metricsView);
     });
   },
 
@@ -206,51 +204,52 @@ const metricsViewReducers = {
   ) {
     partialExploreState = structuredClone(partialExploreState);
 
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
+    updateMetricsExplorerByName(name, (exploreState) => {
       for (const key in partialExploreState) {
-        metricsExplorer[key] = partialExploreState[key];
+        exploreState[key] = partialExploreState[key];
       }
       // this hack is needed since what is shown for comparison is not a single source
       // TODO: use an enum and get rid of this
       if (!partialExploreState.showTimeComparison) {
-        metricsExplorer.showTimeComparison = false;
+        exploreState.showTimeComparison = false;
       }
-      metricsExplorer.dimensionFilterExcludeMode =
-        includeExcludeModeFromFilters(partialExploreState.whereFilter);
-      AdvancedMeasureCorrector.correct(metricsExplorer, metricsView);
+      exploreState.dimensionFilterExcludeMode = includeExcludeModeFromFilters(
+        partialExploreState.whereFilter,
+      );
+      AdvancedMeasureCorrector.correct(exploreState, metricsView);
     });
   },
 
   sync(name: string, explore: V1ExploreSpec) {
     if (!name || !explore || !explore.measures) return;
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
+    updateMetricsExplorerByName(name, (exploreState) => {
       // remove references to non existent measures
-      syncMeasures(explore, metricsExplorer);
+      syncMeasures(explore, exploreState);
 
       // remove references to non existent dimensions
-      syncDimensions(explore, metricsExplorer);
+      syncDimensions(explore, exploreState);
     });
   },
 
   setPivotMode(name: string, mode: boolean) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
+    updateMetricsExplorerByName(name, (exploreState) => {
       if (mode) {
-        metricsExplorer.activePage = DashboardState_ActivePage.PIVOT;
-      } else if (metricsExplorer.selectedDimensionName) {
-        metricsExplorer.activePage = DashboardState_ActivePage.DIMENSION_TABLE;
-      } else if (metricsExplorer.tdd.expandedMeasureName) {
-        metricsExplorer.activePage =
+        exploreState.activePage = DashboardState_ActivePage.PIVOT;
+      } else if (exploreState.selectedDimensionName) {
+        exploreState.activePage = DashboardState_ActivePage.DIMENSION_TABLE;
+      } else if (exploreState.tdd.expandedMeasureName) {
+        exploreState.activePage =
           DashboardState_ActivePage.TIME_DIMENSIONAL_DETAIL;
       } else {
-        metricsExplorer.activePage = DashboardState_ActivePage.DEFAULT;
+        exploreState.activePage = DashboardState_ActivePage.DEFAULT;
       }
     });
   },
 
   setPivotRows(name: string, value: PivotChipData[]) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.pivot.rowPage = 1;
-      metricsExplorer.pivot.activeCell = null;
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.pivot.rowPage = 1;
+      exploreState.pivot.activeCell = null;
 
       const dimensions: PivotChipData[] = [];
 
@@ -260,75 +259,75 @@ const metricsViewReducers = {
         }
       });
 
-      if (metricsExplorer.pivot.sorting.length) {
-        const accessor = metricsExplorer.pivot.sorting[0].id;
+      if (exploreState.pivot.sorting.length) {
+        const accessor = exploreState.pivot.sorting[0].id;
         const anchorDimension = dimensions?.[0]?.id;
         if (accessor !== anchorDimension) {
-          metricsExplorer.pivot.sorting = [];
+          exploreState.pivot.sorting = [];
         }
       }
 
-      metricsExplorer.pivot.rows = dimensions;
+      exploreState.pivot.rows = dimensions;
     });
   },
 
   setPivotColumns(name: string, value: PivotChipData[]) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.pivot.rowPage = 1;
-      metricsExplorer.pivot.activeCell = null;
-      metricsExplorer.pivot.expanded = {};
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.pivot.rowPage = 1;
+      exploreState.pivot.activeCell = null;
+      exploreState.pivot.expanded = {};
 
-      if (metricsExplorer.pivot.sorting.length) {
-        const accessor = metricsExplorer.pivot.sorting[0].id;
+      if (exploreState.pivot.sorting.length) {
+        const accessor = exploreState.pivot.sorting[0].id;
 
-        if (metricsExplorer.pivot.tableMode === "flat") {
+        if (exploreState.pivot.tableMode === "flat") {
           const validAccessors = value.map((d) => d.id);
           if (!validAccessors.includes(accessor)) {
-            metricsExplorer.pivot.sorting = [];
+            exploreState.pivot.sorting = [];
           }
         } else {
-          const anchorDimension = metricsExplorer.pivot.rows?.[0]?.id;
+          const anchorDimension = exploreState.pivot.rows?.[0]?.id;
           if (accessor !== anchorDimension) {
-            metricsExplorer.pivot.sorting = [];
+            exploreState.pivot.sorting = [];
           }
         }
       }
-      metricsExplorer.pivot.columns = value;
+      exploreState.pivot.columns = value;
     });
   },
 
   addPivotField(name: string, value: PivotChipData, rows: boolean) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.pivot.rowPage = 1;
-      metricsExplorer.pivot.activeCell = null;
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.pivot.rowPage = 1;
+      exploreState.pivot.activeCell = null;
       if (value.type === PivotChipType.Measure) {
-        metricsExplorer.pivot.columns.push(value);
+        exploreState.pivot.columns.push(value);
       } else {
         if (rows) {
-          metricsExplorer.pivot.rows.push(value);
+          exploreState.pivot.rows.push(value);
         } else {
-          metricsExplorer.pivot.columns.push(value);
+          exploreState.pivot.columns.push(value);
         }
       }
     });
   },
 
   setPivotExpanded(name: string, expanded: ExpandedState) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.pivot = { ...metricsExplorer.pivot, expanded };
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.pivot = { ...exploreState.pivot, expanded };
     });
   },
 
   setPivotComparison(name: string, enableComparison: boolean) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.pivot = { ...metricsExplorer.pivot, enableComparison };
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.pivot = { ...exploreState.pivot, enableComparison };
     });
   },
 
   setPivotSort(name: string, sorting: SortingState) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.pivot = {
-        ...metricsExplorer.pivot,
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.pivot = {
+        ...exploreState.pivot,
         sorting,
         rowPage: 1,
         expanded: {},
@@ -338,40 +337,40 @@ const metricsViewReducers = {
   },
 
   setPivotColumnPage(name: string, pageNumber: number) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.pivot = {
-        ...metricsExplorer.pivot,
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.pivot = {
+        ...exploreState.pivot,
         columnPage: pageNumber,
       };
     });
   },
 
   setPivotRowPage(name: string, pageNumber: number) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.pivot = {
-        ...metricsExplorer.pivot,
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.pivot = {
+        ...exploreState.pivot,
         rowPage: pageNumber,
       };
     });
   },
 
   setPivotActiveCell(name: string, rowId: string, columnId: string) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.pivot.activeCell = { rowId, columnId };
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.pivot.activeCell = { rowId, columnId };
     });
   },
 
   removePivotActiveCell(name: string) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.pivot.activeCell = null;
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.pivot.activeCell = null;
     });
   },
 
   createPivot(name: string, rows: PivotChipData[], columns: PivotChipData[]) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.activePage = DashboardState_ActivePage.PIVOT;
-      metricsExplorer.pivot = {
-        ...metricsExplorer.pivot,
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.activePage = DashboardState_ActivePage.PIVOT;
+      exploreState.pivot = {
+        ...exploreState.pivot,
         rows,
         columns,
         expanded: {},
@@ -384,75 +383,75 @@ const metricsViewReducers = {
   },
 
   setExpandedMeasureName(name: string, measureName: string | undefined) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.tdd.expandedMeasureName = measureName;
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.tdd.expandedMeasureName = measureName;
       if (measureName) {
-        metricsExplorer.activePage =
+        exploreState.activePage =
           DashboardState_ActivePage.TIME_DIMENSIONAL_DETAIL;
       } else {
-        metricsExplorer.activePage = DashboardState_ActivePage.DEFAULT;
+        exploreState.activePage = DashboardState_ActivePage.DEFAULT;
       }
 
       // If going into TDD view and already having a comparison dimension,
       // then set the pinIndex
-      if (metricsExplorer.selectedComparisonDimension) {
-        metricsExplorer.tdd.pinIndex = getPinIndexForDimension(
-          metricsExplorer,
-          metricsExplorer.selectedComparisonDimension,
+      if (exploreState.selectedComparisonDimension) {
+        exploreState.tdd.pinIndex = getPinIndexForDimension(
+          exploreState,
+          exploreState.selectedComparisonDimension,
         );
       }
     });
   },
 
   setPinIndex(name: string, index: number) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.tdd.pinIndex = index;
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.tdd.pinIndex = index;
     });
   },
 
   setTDDChartType(name: string, type: TDDChart) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.tdd.chartType = type;
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.tdd.chartType = type;
     });
   },
 
   setSelectedTimeRange(name: string, timeRange: DashboardTimeControls) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      setSelectedScrubRange(metricsExplorer, undefined);
-      metricsExplorer.selectedTimeRange = timeRange;
+    updateMetricsExplorerByName(name, (exploreState) => {
+      setSelectedScrubRange(exploreState, undefined);
+      exploreState.selectedTimeRange = timeRange;
     });
   },
 
   setSelectedScrubRange(name: string, scrubRange: ScrubRange | undefined) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      setSelectedScrubRange(metricsExplorer, scrubRange);
+    updateMetricsExplorerByName(name, (exploreState) => {
+      setSelectedScrubRange(exploreState, scrubRange);
     });
   },
 
   setMetricDimensionName(name: string, dimensionName: string | null) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.selectedDimensionName = dimensionName ?? undefined;
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.selectedDimensionName = dimensionName ?? undefined;
       if (dimensionName) {
-        metricsExplorer.activePage = DashboardState_ActivePage.DIMENSION_TABLE;
+        exploreState.activePage = DashboardState_ActivePage.DIMENSION_TABLE;
       } else {
-        metricsExplorer.activePage = DashboardState_ActivePage.DEFAULT;
+        exploreState.activePage = DashboardState_ActivePage.DEFAULT;
       }
     });
   },
 
   setComparisonDimension(name: string, dimensionName: string) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.selectedComparisonDimension = dimensionName;
-      metricsExplorer.tdd.pinIndex = getPinIndexForDimension(
-        metricsExplorer,
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.selectedComparisonDimension = dimensionName;
+      exploreState.tdd.pinIndex = getPinIndexForDimension(
+        exploreState,
         dimensionName,
       );
     });
   },
 
   disableAllComparisons(name: string) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.selectedComparisonDimension = undefined;
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.selectedComparisonDimension = undefined;
     });
   },
 
@@ -461,27 +460,27 @@ const metricsViewReducers = {
     comparisonTimeRange: DashboardTimeControls,
     metricsViewSpec: V1MetricsViewSpec,
   ) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
+    updateMetricsExplorerByName(name, (exploreState) => {
       if (comparisonTimeRange) {
-        metricsExplorer.showTimeComparison = true;
+        exploreState.showTimeComparison = true;
       }
-      metricsExplorer.selectedComparisonTimeRange = comparisonTimeRange;
-      AdvancedMeasureCorrector.correct(metricsExplorer, metricsViewSpec);
+      exploreState.selectedComparisonTimeRange = comparisonTimeRange;
+      AdvancedMeasureCorrector.correct(exploreState, metricsViewSpec);
     });
   },
 
   setTimeZone(name: string, zoneIANA: string) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
+    updateMetricsExplorerByName(name, (exploreState) => {
       // Reset scrub when timezone changes
-      setSelectedScrubRange(metricsExplorer, undefined);
+      setSelectedScrubRange(exploreState, undefined);
 
-      metricsExplorer.selectedTimezone = zoneIANA;
+      exploreState.selectedTimezone = zoneIANA;
     });
   },
 
   displayTimeComparison(name: string, showTimeComparison: boolean) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.showTimeComparison = showTimeComparison;
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.showTimeComparison = showTimeComparison;
     });
   },
 
@@ -492,24 +491,24 @@ const metricsViewReducers = {
     comparisonTimeRange: DashboardTimeControls | undefined,
     metricsViewSpec: V1MetricsViewSpec,
   ) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
+    updateMetricsExplorerByName(name, (exploreState) => {
       if (!timeRange.name) return;
 
       // Reset scrub when range changes
-      setSelectedScrubRange(metricsExplorer, undefined);
+      setSelectedScrubRange(exploreState, undefined);
 
       if (timeRange.name === TimeRangePreset.ALL_TIME) {
-        metricsExplorer.showTimeComparison = false;
+        exploreState.showTimeComparison = false;
       }
 
-      metricsExplorer.selectedTimeRange = {
+      exploreState.selectedTimeRange = {
         ...timeRange,
         interval: timeGrain,
       };
 
-      metricsExplorer.selectedComparisonTimeRange = comparisonTimeRange;
+      exploreState.selectedComparisonTimeRange = comparisonTimeRange;
 
-      AdvancedMeasureCorrector.correct(metricsExplorer, metricsViewSpec);
+      AdvancedMeasureCorrector.correct(exploreState, metricsViewSpec);
     });
   },
 
@@ -526,9 +525,9 @@ const metricsViewReducers = {
     rows: PivotChipData[],
     columns: PivotChipData[],
   ) {
-    updateMetricsExplorerByName(name, (metricsExplorer) => {
-      metricsExplorer.pivot = {
-        ...metricsExplorer.pivot,
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.pivot = {
+        ...exploreState.pivot,
         tableMode,
         rows,
         columns,

--- a/web-common/src/features/dashboards/stores/explore-state.ts
+++ b/web-common/src/features/dashboards/stores/explore-state.ts
@@ -21,7 +21,7 @@ export interface DimensionThresholdFilter {
   filters: MeasureFilterEntry[];
 }
 
-export interface MetricsExplorerEntity {
+export interface ExploreState {
   name: string;
 
   /**

--- a/web-common/src/features/dashboards/stores/filter-utils.ts
+++ b/web-common/src/features/dashboards/stores/filter-utils.ts
@@ -1,5 +1,5 @@
 import { mergeDimensionAndMeasureFilters } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
-import type { DimensionThresholdFilter } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { DimensionThresholdFilter } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import {
   V1Operation,
   type MetricsViewSpecDimension,

--- a/web-common/src/features/dashboards/stores/get-explore-state-from-yaml-config.ts
+++ b/web-common/src/features/dashboards/stores/get-explore-state-from-yaml-config.ts
@@ -1,6 +1,6 @@
 import { SortDirection } from "@rilldata/web-common/features/dashboards/proto-state/derived-types";
 import { getGrainForRange } from "@rilldata/web-common/features/dashboards/stores/get-rill-default-explore-state";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import { getValidComparisonOption } from "@rilldata/web-common/features/dashboards/time-controls/time-range-store";
 import { ToLegacySortTypeMap } from "@rilldata/web-common/features/dashboards/url-state/legacyMappers";
 import { FromURLParamTimeGrainMap } from "@rilldata/web-common/features/dashboards/url-state/mappers";
@@ -23,7 +23,7 @@ export function getExploreStateFromYAMLConfig(
   timeRangeSummary: V1TimeRangeSummary | undefined,
 ) {
   // TODO: support all fields from V1ExplorePreset. Not urgent since we do not parse them in backend.
-  return <Partial<MetricsExplorerEntity>>{
+  return <Partial<ExploreState>>{
     activePage: DashboardState_ActivePage.DEFAULT,
 
     ...getExploreTimeStateFromYAMLConfig(exploreSpec, timeRangeSummary),
@@ -34,8 +34,8 @@ export function getExploreStateFromYAMLConfig(
 function getExploreTimeStateFromYAMLConfig(
   exploreSpec: V1ExploreSpec,
   timeRangeSummary: V1TimeRangeSummary | undefined,
-): Partial<MetricsExplorerEntity> {
-  const exploreTimeState: Partial<MetricsExplorerEntity> = {};
+): Partial<ExploreState> {
+  const exploreTimeState: Partial<ExploreState> = {};
   if (!exploreSpec.defaultPreset || !timeRangeSummary) {
     return exploreTimeState;
   }
@@ -122,8 +122,8 @@ function getDefaultComparisonTimeRangeName(
 
 function getExploreViewStateFromYAMLConfig(
   exploreSpec: V1ExploreSpec,
-): Partial<MetricsExplorerEntity> {
-  const exploreViewState: Partial<MetricsExplorerEntity> = {};
+): Partial<ExploreState> {
+  const exploreViewState: Partial<ExploreState> = {};
   if (!exploreSpec.defaultPreset) return exploreViewState;
   const defaultPreset = exploreSpec.defaultPreset;
 

--- a/web-common/src/features/dashboards/stores/get-rill-default-explore-state.ts
+++ b/web-common/src/features/dashboards/stores/get-rill-default-explore-state.ts
@@ -20,7 +20,7 @@ import {
   type V1TimeRangeSummary,
 } from "@rilldata/web-common/runtime-client";
 import { DateTime, IANAZone, Interval } from "luxon";
-import type { MetricsExplorerEntity } from "./metrics-explorer-entity";
+import type { ExploreState } from "web-common/src/features/dashboards/stores/explore-state";
 import {
   DashboardState_ActivePage,
   DashboardState_LeaderboardSortDirection,
@@ -34,7 +34,7 @@ export function getRillDefaultExploreState(
   exploreSpec: V1ExploreSpec,
   timeRangeSummary: V1TimeRangeSummary | undefined,
 ) {
-  return <MetricsExplorerEntity>{
+  return <ExploreState>{
     activePage: DashboardState_ActivePage.DEFAULT,
 
     whereFilter: createAndExpression([]),
@@ -65,7 +65,7 @@ function getRillDefaultExploreTimeState(
   metricsViewSpec: V1MetricsViewSpec,
   exploreSpec: V1ExploreSpec,
   timeRangeSummary: V1TimeRangeSummary | undefined,
-): Partial<MetricsExplorerEntity> {
+): Partial<ExploreState> {
   if (!timeRangeSummary?.min || !timeRangeSummary?.max) {
     return {
       // for consistency with fromUrl
@@ -99,7 +99,7 @@ function getRillDefaultExploreTimeState(
 
 function getRillDefaultExploreViewState(
   exploreSpec: V1ExploreSpec,
-): Partial<MetricsExplorerEntity> {
+): Partial<ExploreState> {
   const defaultMeasure = exploreSpec.measures?.[0];
 
   return {
@@ -213,7 +213,7 @@ export function getDefaultTimeZone(explore: V1ExploreSpec) {
 }
 
 function getRillDefaultTDDViewState() {
-  return <Partial<MetricsExplorerEntity>>{
+  return <Partial<ExploreState>>{
     tdd: {
       expandedMeasureName: "",
       chartType: TDDChart.DEFAULT,
@@ -223,7 +223,7 @@ function getRillDefaultTDDViewState() {
 }
 
 function getRillDefaultPivotViewState() {
-  return <Partial<MetricsExplorerEntity>>{
+  return <Partial<ExploreState>>{
     pivot: {
       active: false,
       rows: [],

--- a/web-common/src/features/dashboards/stores/test-data/data.ts
+++ b/web-common/src/features/dashboards/stores/test-data/data.ts
@@ -3,7 +3,7 @@ import {
   createAndExpression,
   createInExpression,
 } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import { getDefaultExplorePreset } from "@rilldata/web-common/features/dashboards/url-state/getDefaultExplorePreset";
 import { getLocalIANA } from "@rilldata/web-common/lib/time/timezone";
 import {
@@ -380,7 +380,7 @@ export const CUSTOM_TEST_CONTROLS = {
   end: TestTimeConstants.LAST_12_HOURS,
 } as DashboardTimeControls;
 
-export const AD_BIDS_PIVOT_ENTITY: Partial<MetricsExplorerEntity> = {
+export const AD_BIDS_PIVOT_ENTITY: Partial<ExploreState> = {
   activePage: DashboardState_ActivePage.PIVOT,
   pivot: {
     rows: [

--- a/web-common/src/features/dashboards/stores/test-data/helpers.ts
+++ b/web-common/src/features/dashboards/stores/test-data/helpers.ts
@@ -2,7 +2,7 @@ import { QueryClient } from "@tanstack/svelte-query";
 import { createStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
 import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
 import { createAndExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import {
   AD_BIDS_DEFAULT_TIME_RANGE,
   AD_BIDS_EXPLORE_INIT,
@@ -73,7 +73,7 @@ export function getInitExploreStateForTest(
     exploreSpec,
     defaultExplorePreset,
   );
-  return partialExploreState as MetricsExplorerEntity;
+  return partialExploreState as ExploreState;
 }
 
 export function createAdBidsMirrorInStore({
@@ -149,10 +149,10 @@ export function initStateManagers(metricsViewName?: string) {
 
 export function getPartialDashboard(
   name: string,
-  keys: (keyof MetricsExplorerEntity)[],
+  keys: (keyof ExploreState)[],
 ) {
   const dashboard = get(metricsExplorerStore).entities[name];
-  const partialDashboard = {} as MetricsExplorerEntity;
+  const partialDashboard = {} as ExploreState;
   keys.forEach(
     (key) => ((partialDashboard as any)[key] = deepClone(dashboard[key])),
   );

--- a/web-common/src/features/dashboards/stores/validate-and-clean-explore-state.spec.ts
+++ b/web-common/src/features/dashboards/stores/validate-and-clean-explore-state.spec.ts
@@ -1,5 +1,5 @@
 import { validateAndCleanExploreState } from "@rilldata/web-common/features/dashboards/stores/validate-and-clean-explore-state";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import {
   AD_BIDS_BID_PRICE_MEASURE,
   AD_BIDS_DOMAIN_DIMENSION,
@@ -17,8 +17,8 @@ import { describe, expect, it } from "vitest";
 
 const TestCases: {
   title: string;
-  exploreState: Partial<MetricsExplorerEntity>;
-  expectedState: Partial<MetricsExplorerEntity>;
+  exploreState: Partial<ExploreState>;
+  expectedState: Partial<ExploreState>;
   expectedErrorMessages: string[];
 }[] = [
   {

--- a/web-common/src/features/dashboards/stores/validate-and-clean-explore-state.ts
+++ b/web-common/src/features/dashboards/stores/validate-and-clean-explore-state.ts
@@ -1,4 +1,4 @@
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import {
   getMultiFieldError,
   getSingleFieldError,
@@ -29,7 +29,7 @@ import type {
 export function validateAndCleanExploreState(
   metricsViewSpec: V1MetricsViewSpec,
   exploreSpec: V1ExploreSpec,
-  exploreState: Partial<MetricsExplorerEntity>,
+  exploreState: Partial<ExploreState>,
 ) {
   const errors: Error[] = [];
 
@@ -68,7 +68,7 @@ function validateAndCleanExploreViewState(
   measures: Map<string, MetricsViewSpecMeasure>,
   dimensions: Map<string, MetricsViewSpecDimension>,
   exploreSpec: V1ExploreSpec,
-  exploreState: Partial<MetricsExplorerEntity>,
+  exploreState: Partial<ExploreState>,
 ) {
   const errors: Error[] = [];
 
@@ -117,7 +117,7 @@ function validateAndCleanExploreViewState(
 function validateAndCleanMeasureRelatedExploreState(
   measures: Map<string, MetricsViewSpecMeasure>,
   exploreSpec: V1ExploreSpec,
-  exploreState: Partial<MetricsExplorerEntity>,
+  exploreState: Partial<ExploreState>,
 ) {
   if (!exploreState.visibleMeasures) {
     // Each source is meant to have relevant fields.

--- a/web-common/src/features/dashboards/time-controls/time-control-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.ts
@@ -1,7 +1,7 @@
 import { useMetricsViewTimeRange } from "@rilldata/web-common/features/dashboards/selectors";
 import type { StateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
 import { useExploreState } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import { getValidComparisonOption } from "@rilldata/web-common/features/dashboards/time-controls/time-range-store";
 import { getOrderedStartEnd } from "@rilldata/web-common/features/dashboards/time-series/utils";
 import { useExploreValidSpec } from "@rilldata/web-common/features/explores/selectors";
@@ -90,7 +90,7 @@ export const timeControlStateSelector = ([
   V1MetricsViewSpec | undefined,
   V1ExploreSpec | undefined,
   QueryObserverResult<V1MetricsViewTimeRangeResponse, unknown>,
-  MetricsExplorerEntity,
+  ExploreState,
 ]): TimeControlState => {
   const hasTimeSeries = Boolean(metricsView?.timeDimension);
   if (
@@ -137,7 +137,7 @@ export function getTimeControlState(
   metricsViewSpec: V1MetricsViewSpec,
   exploreSpec: V1ExploreSpec,
   timeRangeSummary: V1TimeRangeSummary | undefined,
-  exploreState: MetricsExplorerEntity,
+  exploreState: ExploreState,
 ) {
   const hasTimeSeries = Boolean(metricsViewSpec.timeDimension);
   const timeDimension = metricsViewSpec.timeDimension;
@@ -502,7 +502,7 @@ export function selectedTimeRangeSelector([
 ]: [
   V1ExploreSpec | undefined,
   QueryObserverResult<V1MetricsViewTimeRangeResponse, unknown>,
-  MetricsExplorerEntity,
+  ExploreState,
 ]) {
   if (
     !exploreSpec ||

--- a/web-common/src/features/dashboards/time-controls/time-control-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.ts
@@ -85,7 +85,7 @@ export const timeControlStateSelector = ([
   metricsView,
   explore,
   timeRangeResponse,
-  metricsExplorer,
+  exploreState,
 ]: [
   V1MetricsViewSpec | undefined,
   V1ExploreSpec | undefined,
@@ -96,14 +96,14 @@ export const timeControlStateSelector = ([
   if (
     !metricsView ||
     !explore ||
-    !metricsExplorer ||
+    !exploreState ||
     !timeRangeResponse ||
     !timeRangeResponse.isSuccess ||
     !hasTimeSeries
   ) {
     return {
       isFetching: timeRangeResponse.isRefetching,
-      ready: !metricsExplorer || !hasTimeSeries,
+      ready: !exploreState || !hasTimeSeries,
     } as TimeControlState;
   }
 
@@ -111,7 +111,7 @@ export const timeControlStateSelector = ([
     metricsView,
     explore,
     timeRangeResponse.data?.timeRangeSummary,
-    metricsExplorer,
+    exploreState,
   );
 
   if (!state) {

--- a/web-common/src/features/dashboards/time-controls/time-range-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-range-store.ts
@@ -1,4 +1,4 @@
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import {
   getAvailableComparisonsForTimeRange,
   getComparisonRange,
@@ -45,7 +45,7 @@ export function timeRangeSelectionsSelector([
   V1MetricsViewSpec | undefined,
   V1ExploreSpec | undefined,
   QueryObserverResult<V1MetricsViewTimeRangeResponse, unknown>,
-  MetricsExplorerEntity,
+  ExploreState,
 ]): TimeRangeControlsState {
   if (!metricsView || !explore || !timeRangeResponse?.data?.timeRangeSummary)
     return {
@@ -144,7 +144,7 @@ export function timeComparisonOptionsSelector([
   V1MetricsViewSpec | undefined,
   V1ExploreSpec | undefined,
   QueryObserverResult<V1MetricsViewTimeRangeResponse, unknown>,
-  MetricsExplorerEntity,
+  ExploreState,
   DashboardTimeControls | undefined,
 ]): Array<{
   name: TimeComparisonOption;

--- a/web-common/src/features/dashboards/time-dimension-details/tdd-export.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/tdd-export.ts
@@ -1,6 +1,6 @@
 import { SortDirection } from "@rilldata/web-common/features/dashboards/proto-state/derived-types";
 import type { StateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import {
   type TimeControlState,
   useTimeControlStore,
@@ -46,7 +46,7 @@ export function getTDDExportQuery(
 
 function getTDDAggregationRequest(
   metricsViewName: string,
-  dashboardState: MetricsExplorerEntity,
+  exploreState: ExploreState,
   timeControlState: TimeControlState,
   metricsView: V1MetricsViewSpec | undefined,
   explore: V1ExploreSpec | undefined,
@@ -57,7 +57,7 @@ function getTDDAggregationRequest(
     !metricsView ||
     !explore ||
     !timeControlState.ready ||
-    !dashboardState.tdd.expandedMeasureName
+    !exploreState.tdd.expandedMeasureName
   )
     return undefined;
 
@@ -65,7 +65,7 @@ function getTDDAggregationRequest(
   if (isScheduled) {
     timeRange = mapSelectedTimeRangeToV1TimeRange(
       timeControlState,
-      dashboardState.selectedTimezone,
+      exploreState.selectedTimezone,
       explore,
     );
   } else {
@@ -77,11 +77,11 @@ function getTDDAggregationRequest(
   if (!timeRange) return undefined;
 
   const measures: V1MetricsViewAggregationMeasure[] = [
-    { name: dashboardState.tdd.expandedMeasureName },
+    { name: exploreState.tdd.expandedMeasureName },
   ];
 
   // CAST SAFETY: exports are only available in TDD when a comparison dimension is selected
-  const dimensionName = dashboardState.selectedComparisonDimension as string;
+  const dimensionName = exploreState.selectedComparisonDimension as string;
   const timeDimension = metricsView.timeDimension ?? "";
 
   return {
@@ -91,8 +91,8 @@ function getTDDAggregationRequest(
       { name: dimensionName },
       {
         name: metricsView.timeDimension ?? "",
-        timeGrain: dashboardState.selectedTimeRange?.interval,
-        timeZone: dashboardState.selectedTimezone,
+        timeGrain: exploreState.selectedTimeRange?.interval,
+        timeZone: exploreState.selectedTimezone,
       },
     ],
     measures,
@@ -101,12 +101,12 @@ function getTDDAggregationRequest(
     sort: [
       {
         name: dimensionName,
-        desc: dashboardState.sortDirection === SortDirection.DESCENDING,
+        desc: exploreState.sortDirection === SortDirection.DESCENDING,
       },
     ],
     where: buildWhereParamForDimensionTableAndTDDExports(
-      dashboardState.whereFilter,
-      dashboardState.dimensionThresholdFilters,
+      exploreState.whereFilter,
+      exploreState.dimensionThresholdFilters,
       dimensionName,
       dimensionSearchText,
     ),

--- a/web-common/src/features/dashboards/url-state/convert-partial-explore-state-to-url-params.ts
+++ b/web-common/src/features/dashboards/url-state/convert-partial-explore-state-to-url-params.ts
@@ -4,7 +4,7 @@ import {
   PivotChipType,
 } from "@rilldata/web-common/features/dashboards/pivot/types";
 import { SortDirection } from "@rilldata/web-common/features/dashboards/proto-state/derived-types";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import type { TimeControlState } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import {
   compressUrlParams,
@@ -42,7 +42,7 @@ import { type V1ExploreSpec } from "@rilldata/web-common/runtime-client";
  */
 export function getCleanedUrlParamsForGoto(
   exploreSpec: V1ExploreSpec,
-  partialExploreState: Partial<MetricsExplorerEntity>,
+  partialExploreState: Partial<ExploreState>,
   timeControlsState: TimeControlState | undefined,
   defaultExploreUrlParams: URLSearchParams,
   urlForCompressionCheck?: URL,
@@ -75,7 +75,7 @@ export function getCleanedUrlParamsForGoto(
 
 export function convertPartialExploreStateToUrlParams(
   exploreSpec: V1ExploreSpec,
-  partialExploreState: Partial<MetricsExplorerEntity>,
+  partialExploreState: Partial<ExploreState>,
   // We have quite a bit of logic in TimeControlState to validate selections and update them
   // Eg: if a selected grain is not applicable for the current grain then we change it
   // But it is only available in TimeControlState and not MetricsExplorerEntity
@@ -149,7 +149,7 @@ export function convertPartialExploreStateToUrlParams(
 }
 
 function toTimeRangesUrl(
-  partialExploreState: Partial<MetricsExplorerEntity>,
+  partialExploreState: Partial<ExploreState>,
   timeControlsState: TimeControlState,
 ) {
   const searchParams = new URLSearchParams();
@@ -218,7 +218,7 @@ export function toTimeRangeParam(timeRange: TimeRange | undefined) {
 }
 
 function toExploreUrlParams(
-  partialExploreState: Partial<MetricsExplorerEntity>,
+  partialExploreState: Partial<ExploreState>,
   exploreSpec: V1ExploreSpec,
 ) {
   const searchParams = new URLSearchParams();
@@ -276,7 +276,7 @@ function toExploreUrlParams(
 }
 
 function toVisibleMeasuresUrlParam(
-  partialExploreState: Partial<MetricsExplorerEntity>,
+  partialExploreState: Partial<ExploreState>,
   exploreSpec: V1ExploreSpec,
 ) {
   if (!partialExploreState.visibleMeasures) return undefined;
@@ -296,7 +296,7 @@ function toVisibleMeasuresUrlParam(
 }
 
 function toVisibleDimensionsUrlParam(
-  partialExploreState: Partial<MetricsExplorerEntity>,
+  partialExploreState: Partial<ExploreState>,
   exploreSpec: V1ExploreSpec,
 ) {
   if (!partialExploreState.visibleDimensions) return undefined;
@@ -315,9 +315,7 @@ function toVisibleDimensionsUrlParam(
   return partialExploreState.visibleDimensions.join(",");
 }
 
-function toTimeDimensionUrlParams(
-  partialExploreState: Partial<MetricsExplorerEntity>,
-) {
+function toTimeDimensionUrlParams(partialExploreState: Partial<ExploreState>) {
   const searchParams = new URLSearchParams();
   if (!partialExploreState.tdd) return searchParams;
 
@@ -334,7 +332,7 @@ function toTimeDimensionUrlParams(
   return searchParams;
 }
 
-function toPivotUrlParams(partialExploreState: Partial<MetricsExplorerEntity>) {
+function toPivotUrlParams(partialExploreState: Partial<ExploreState>) {
   const searchParams = new URLSearchParams();
   if (
     !partialExploreState.pivot ||
@@ -378,13 +376,12 @@ function toPivotUrlParams(partialExploreState: Partial<MetricsExplorerEntity>) {
   return searchParams;
 }
 
-function maybeSetParam<K extends keyof MetricsExplorerEntity>(
+function maybeSetParam<K extends keyof ExploreState>(
   searchParams: URLSearchParams,
-  partialExploreState: Partial<MetricsExplorerEntity>,
+  partialExploreState: Partial<ExploreState>,
   key: K,
-  mapper: (value: Partial<MetricsExplorerEntity>[K]) => string | undefined = (
-    x,
-  ) => x?.toString(),
+  mapper: (value: Partial<ExploreState>[K]) => string | undefined = (x) =>
+    x?.toString(),
 ) {
   const param = ExploreStateKeyToURLParamMap[key];
   if (

--- a/web-common/src/features/dashboards/url-state/convertPresetToExploreState.ts
+++ b/web-common/src/features/dashboards/url-state/convertPresetToExploreState.ts
@@ -5,7 +5,7 @@ import {
   type PivotTableMode,
 } from "@rilldata/web-common/features/dashboards/pivot/types";
 import { SortDirection } from "@rilldata/web-common/features/dashboards/proto-state/derived-types";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import { TDDChart } from "@rilldata/web-common/features/dashboards/time-dimension-details/types";
 import {
   getMultiFieldError,
@@ -51,7 +51,7 @@ export function convertPresetToExploreState(
   explore: V1ExploreSpec,
   preset: V1ExplorePreset,
 ) {
-  const partialExploreState: Partial<MetricsExplorerEntity> = {};
+  const partialExploreState: Partial<ExploreState> = {};
   const errors: Error[] = [];
 
   const measures = getMapFromArray(
@@ -111,7 +111,7 @@ function fromTimeRangesParams(
   preset: V1ExplorePreset,
   dimensions: Map<string, MetricsViewSpecDimension>,
 ) {
-  const partialExploreState: Partial<MetricsExplorerEntity> = {};
+  const partialExploreState: Partial<ExploreState> = {};
   const errors: Error[] = [];
 
   if (preset.timeRange) {
@@ -223,7 +223,7 @@ function fromExploreUrlParams(
   explore: V1ExploreSpec,
   preset: V1ExplorePreset,
 ) {
-  const partialExploreState: Partial<MetricsExplorerEntity> = {};
+  const partialExploreState: Partial<ExploreState> = {};
   const errors: Error[] = [];
 
   if (preset.measures?.length) {
@@ -322,7 +322,7 @@ function fromTimeDimensionUrlParams(
   measures: Map<string, MetricsViewSpecMeasure>,
   preset: V1ExplorePreset,
 ): {
-  partialExploreState: Partial<MetricsExplorerEntity>;
+  partialExploreState: Partial<ExploreState>;
   errors: Error[];
 } {
   if (!preset.timeDimensionMeasure) {
@@ -346,7 +346,7 @@ function fromTimeDimensionUrlParams(
     errors.push(getSingleFieldError("expanded measure", expandedMeasureName));
   }
 
-  const partialExploreState: Partial<MetricsExplorerEntity> = {
+  const partialExploreState: Partial<ExploreState> = {
     tdd: {
       expandedMeasureName,
       chartType: preset.timeDimensionChartType
@@ -367,7 +367,7 @@ function fromPivotUrlParams(
   dimensions: Map<string, MetricsViewSpecDimension>,
   preset: V1ExplorePreset,
 ): {
-  partialExploreState: Partial<MetricsExplorerEntity>;
+  partialExploreState: Partial<ExploreState>;
   errors: Error[];
 } {
   const errors: Error[] = [];

--- a/web-common/src/features/dashboards/url-state/invalid-url-state-variations.spec.ts
+++ b/web-common/src/features/dashboards/url-state/invalid-url-state-variations.spec.ts
@@ -3,7 +3,7 @@ import {
   createAndExpression,
   createInExpression,
 } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import {
   AD_BIDS_EXPLORE_INIT,
   AD_BIDS_EXPLORE_NAME,
@@ -25,7 +25,7 @@ const TestCases: {
   title: string;
   url: string;
   errors: string[];
-  entity: Partial<MetricsExplorerEntity>;
+  entity: Partial<ExploreState>;
 }[] = [
   {
     title: "Invalid filter syntax: unknown syntax",

--- a/web-common/src/features/dashboards/url-state/url-params.ts
+++ b/web-common/src/features/dashboards/url-state/url-params.ts
@@ -1,4 +1,4 @@
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 
 export enum ExploreStateURLParams {
   WebView = "view",
@@ -34,7 +34,7 @@ export enum ExploreStateURLParams {
 }
 
 export const ExploreStateKeyToURLParamMap: Partial<
-  Record<keyof MetricsExplorerEntity, ExploreStateURLParams>
+  Record<keyof ExploreState, ExploreStateURLParams>
 > = {
   activePage: ExploreStateURLParams.WebView,
 

--- a/web-common/src/features/dashboards/url-state/url-state-variations.spec.ts
+++ b/web-common/src/features/dashboards/url-state/url-state-variations.spec.ts
@@ -1,6 +1,6 @@
 import { getProtoFromDashboardState } from "@rilldata/web-common/features/dashboards/proto-state/toProto";
 import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
-import type { MetricsExplorerEntity } from "@rilldata/web-common/features/dashboards/stores/metrics-explorer-entity";
+import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import {
   AD_BIDS_DIMENSION_TABLE_PRESET,
   AD_BIDS_EXPLORE_INIT,
@@ -87,7 +87,7 @@ const TestCases: {
   preset?: V1ExplorePreset;
   expectedSearch: string;
   // This is to assert edge case when some state gets populated from timeControlStore
-  extraExploreState?: Partial<MetricsExplorerEntity>;
+  extraExploreState?: Partial<ExploreState>;
   // Mainly tests that close certain views.
   // Closing view would retain some state of the old view in protobuf state
   legacyNotSupported?: boolean;
@@ -541,8 +541,7 @@ describe("Human readable URL state variations", () => {
 
         const initState = getCleanMetricsExploreForAssertion();
         applyMutationsToDashboard(AD_BIDS_EXPLORE_NAME, mutations);
-        const curState =
-          getCleanMetricsExploreForAssertion() as MetricsExplorerEntity;
+        const curState = getCleanMetricsExploreForAssertion() as ExploreState;
 
         const url = new URL("http://localhost");
         // load url with legacy protobuf state
@@ -666,7 +665,7 @@ export function getCleanMetricsExploreForAssertion() {
   // clone the existing state so that any mutations do affect the copy during assertion
   const cleanedState = deepClone(
     get(metricsExplorerStore).entities[AD_BIDS_EXPLORE_NAME],
-  ) as Partial<MetricsExplorerEntity>;
+  ) as Partial<ExploreState>;
 
   delete cleanedState.name;
   delete cleanedState.proto;

--- a/web-common/src/features/exports/export-filters.ts
+++ b/web-common/src/features/exports/export-filters.ts
@@ -2,7 +2,7 @@ import type { V1Expression } from "@rilldata/web-admin/client/gen/index.schemas"
 import { getDimensionFilterWithSearch } from "../dashboards/dimension-table/dimension-table-utils";
 import { mergeDimensionAndMeasureFilters } from "../dashboards/filters/measure-filters/measure-filter-utils";
 import { sanitiseExpression } from "../dashboards/stores/filter-utils";
-import type { DimensionThresholdFilter } from "../dashboards/stores/metrics-explorer-entity";
+import type { DimensionThresholdFilter } from "web-common/src/features/dashboards/stores/explore-state";
 
 /**
  * If there's input in the search field, then all search results will be included in the export.


### PR DESCRIPTION
As a 1st step to standardise our naming for explore state this PR updates the main state type from `MetricsExploreEntity` to `ExploreState`

This does not rename most of other sources of the name like function name or variables part of the `StateManagers`

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
