### PR TITLE
Clickhouse: partition overwrite by default + refactors

### DIFF
--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -224,7 +224,9 @@ func (d driver) Open(instanceID string, config map[string]any, st *storage.Clien
 	}
 
 	// max_idle_conns
-	opts.MaxIdleConns = conf.MaxIdleConns
+	if conf.MaxIdleConns != 0 {
+		opts.MaxIdleConns = conf.MaxIdleConns
+	}
 
 	// conn_max_lifetime
 	if conf.ConnMaxLifetime != "" {

--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -131,9 +131,9 @@ type configProperties struct {
 	Cluster string `mapstructure:"cluster"`
 	// LogQueries controls whether to log the raw SQL passed to OLAP.Execute.
 	LogQueries bool `mapstructure:"log_queries"`
-	// QuerySettings overrides the default query settings used for OLAP SELECT queries.
+	// QuerySettingsOverride overrides the default query settings used for OLAP SELECT queries.
 	// Use cases include disabling settings or setting `readonly = 1` when using read-only user.
-	QuerySettings string `mapstructure:"query_settings"`
+	QuerySettingsOverride string `mapstructure:"query_settings_override"`
 	// EmbedPort is the port to run Clickhouse locally (0 is random port).
 	EmbedPort int `mapstructure:"embed_port"`
 	// CanScaleToZero indicates if the underlying Clickhouse service may scale to zero when idle.

--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -35,6 +35,16 @@ var spec = drivers.Spec{
 	// Important: Any edits to the below properties must be accompanied by changes to the client-side form validation schemas.
 	ConfigProperties: []*drivers.PropertySpec{
 		{
+			Key:         "managed",
+			Type:        drivers.BooleanPropertyType,
+			Required:    false,
+			DisplayName: "Managed",
+			Description: "Use a managed ClickHouse instance. This will start an embedded ClickHouse server in development.",
+			Placeholder: "false",
+			Default:     "false",
+			NoPrompt:    true,
+		},
+		{
 			Key:         "dsn",
 			Type:        drivers.StringPropertyType,
 			Required:    false,
@@ -77,6 +87,14 @@ var spec = drivers.Spec{
 			Secret:      true,
 		},
 		{
+			Key:         "database",
+			Type:        drivers.StringPropertyType,
+			Required:    false,
+			DisplayName: "Database",
+			Description: "Name of the ClickHouse database to connect to",
+			Placeholder: "default",
+		},
+		{
 			Key:         "ssl",
 			Type:        drivers.BooleanPropertyType,
 			Required:    true,
@@ -96,26 +114,33 @@ type configProperties struct {
 	// (In practice, this gets set on local and means we should start an embedded Clickhouse server).
 	Provision bool `mapstructure:"provision"`
 	// DSN is the connection string. Either DSN can be passed or the individual properties below can be set.
-	DSN      string `mapstructure:"dsn"`
+	DSN string `mapstructure:"dsn"`
+	// Host configuration. Should not be set if DSN is set.
+	Host string `mapstructure:"host"`
+	// Port configuration. Should not be set if DSN is set.
+	Port int `mapstructure:"port"`
+	// Username configuration. Should not be set if DSN is set.
 	Username string `mapstructure:"username"`
+	// Password configuration. Should not be set if DSN is set.
 	Password string `mapstructure:"password"`
-	Host     string `mapstructure:"host"`
-	Port     int    `mapstructure:"port"`
-	// Database specifies the name of the ClickHouse database within the cluster.
+	// Database configuration. Should not be set if DSN is set.
 	Database string `mapstructure:"database"`
-	// SSL determines whether secured connection need to be established. To be set when setting individual fields.
+	// SSL determines whether secured connection need to be established. Should not be set if DSN is set.
 	SSL bool `mapstructure:"ssl"`
-	// Cluster name. Required for running distributed queries.
+	// Cluster name. If a cluster is configured, Rill will create all models in the cluster as distributed tables.
 	Cluster string `mapstructure:"cluster"`
 	// LogQueries controls whether to log the raw SQL passed to OLAP.Execute.
 	LogQueries bool `mapstructure:"log_queries"`
-	// SettingsOverride override the default settings used in queries. One use case is to disable settings and set `readonly = 1` when using read-only user.
-	SettingsOverride string `mapstructure:"settings_override"`
+	// QuerySettings overrides the default query settings used for OLAP SELECT queries.
+	// Use cases include disabling settings or setting `readonly = 1` when using read-only user.
+	QuerySettings string `mapstructure:"query_settings"`
 	// EmbedPort is the port to run Clickhouse locally (0 is random port).
-	EmbedPort      int  `mapstructure:"embed_port"`
+	EmbedPort int `mapstructure:"embed_port"`
+	// CanScaleToZero indicates if the underlying Clickhouse service may scale to zero when idle.
+	// When set to true, we try to avoid too frequent non-user queries to the database (such as alert checks and fetching metrics).
 	CanScaleToZero bool `mapstructure:"can_scale_to_zero"`
 	// MaxOpenConns is the maximum number of open connections to the database.
-	// https://github.com/ClickHouse/clickhouse-go/blob/main/clickhouse_options.go
+	// See https://github.com/ClickHouse/clickhouse-go/blob/main/clickhouse_options.go
 	MaxOpenConns int `mapstructure:"max_open_conns"`
 	// MaxIdleConns is the maximum number of connections in the idle connection pool. Default is 5s.
 	MaxIdleConns int `mapstructure:"max_idle_conns"`
@@ -145,7 +170,6 @@ func (d driver) Open(instanceID string, config map[string]any, st *storage.Clien
 	// build clickhouse options
 	var opts *clickhouse.Options
 	var embed *embedClickHouse
-	maxOpenConnections := 20 // based on observations
 	if conf.DSN != "" {
 		opts, err = clickhouse.ParseDSN(conf.DSN)
 		if err != nil {
@@ -171,54 +195,11 @@ func (d driver) Open(instanceID string, config map[string]any, st *storage.Clien
 		}
 
 		// username password
-		if conf.Password != "" {
-			opts.Auth.Username = conf.Username
-			opts.Auth.Password = conf.Password
-		} else if conf.Username != "" {
-			opts.Auth.Username = conf.Username
-		}
+		opts.Auth.Username = conf.Username
+		opts.Auth.Password = conf.Password
 
 		// database
-		if conf.Database != "" {
-			opts.Auth.Database = conf.Database
-		}
-
-		// max_open_conns
-		if conf.MaxOpenConns != 0 {
-			maxOpenConnections = conf.MaxOpenConns
-		}
-
-		// max_idle_conns
-		if conf.MaxIdleConns != 0 {
-			opts.MaxIdleConns = conf.MaxIdleConns
-		}
-
-		// dial_timeout
-		if conf.DialTimeout != "" {
-			d, err := time.ParseDuration(conf.DialTimeout)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse dial_timeout: %w", err)
-			}
-			opts.DialTimeout = d
-		}
-
-		// conn_max_lifetime
-		if conf.ConnMaxLifetime != "" {
-			d, err := time.ParseDuration(conf.ConnMaxLifetime)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse conn_max_lifetime: %w", err)
-			}
-			opts.ConnMaxLifetime = d
-		}
-
-		// read_timeout
-		if conf.ReadTimeout != "" {
-			d, err := time.ParseDuration(conf.ReadTimeout)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse read_timeout: %w", err)
-			}
-			opts.ReadTimeout = d
-		}
+		opts.Auth.Database = conf.Database
 	} else if conf.Provision {
 		// run clickhouse locally
 		dataDir, err := st.DataDir(instanceID)
@@ -242,16 +223,40 @@ func (d driver) Open(instanceID string, config map[string]any, st *storage.Clien
 		return nil, errors.New("no clickhouse connection configured: 'dsn', 'host' or 'managed: true' must be set")
 	}
 
-	// Apply our own defaults for the options.
-	// We increase timeouts to decrease the chance of dropped connections with scaled-to-zero ClickHouse.
-	if opts.DialTimeout == 0 {
+	// max_idle_conns
+	opts.MaxIdleConns = conf.MaxIdleConns
+
+	// conn_max_lifetime
+	if conf.ConnMaxLifetime != "" {
+		d, err := time.ParseDuration(conf.ConnMaxLifetime)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse conn_max_lifetime: %w", err)
+		}
+		opts.ConnMaxLifetime = d
+	}
+
+	// dial_timeout
+	if conf.DialTimeout != "" {
+		d, err := time.ParseDuration(conf.DialTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse dial_timeout: %w", err)
+		}
+		opts.DialTimeout = d
+	}
+	if opts.DialTimeout == 0 { // Apply an increased default to reduce the chance of dropped connections with scaled-to-zero ClickHouse.
 		opts.DialTimeout = time.Second * 60
 	}
-	if opts.ReadTimeout == 0 {
-		opts.ReadTimeout = time.Second * 300
+
+	// read_timeout
+	if conf.ReadTimeout != "" {
+		d, err := time.ParseDuration(conf.ReadTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse read_timeout: %w", err)
+		}
+		opts.ReadTimeout = d
 	}
-	if opts.ConnMaxLifetime == 0 {
-		opts.ConnMaxLifetime = time.Hour
+	if opts.ReadTimeout == 0 { // Apply an increased default to reduce the chance of dropped connections with scaled-to-zero ClickHouse.
+		opts.ReadTimeout = time.Second * 300
 	}
 
 	db := sqlx.NewDb(otelsql.OpenDB(clickhouse.Connector(opts)), "clickhouse")
@@ -271,10 +276,16 @@ func (d driver) Open(instanceID string, config map[string]any, st *storage.Clien
 			return nil, err
 		}
 		// connection with http protocol is successful
-		logger.Warn("clickHouse connection is established with HTTP protocol. Use native port for better performance")
+		logger.Warn("ClickHouse connection was established with the HTTP protocol, consider using the native port for better performance")
 	}
-	db.SetMaxOpenConns(maxOpenConnections)
 
+	// Limit the number of concurrent connections
+	if conf.MaxOpenConns == 0 {
+		conf.MaxOpenConns = 20 // based on observations
+	}
+	db.SetMaxOpenConns(conf.MaxOpenConns)
+
+	// Capture database stats with OpenTelemetry
 	err = otelsql.RegisterDBStatsMetrics(db.DB, otelsql.WithAttributes(semconv.DBSystemClickhouse, attribute.String("instance_id", instanceID)))
 	if err != nil {
 		return nil, fmt.Errorf("registering db stats metrics: %w", err)
@@ -282,11 +293,11 @@ func (d driver) Open(instanceID string, config map[string]any, st *storage.Clien
 
 	// group by positional args are supported post 22.7 and we use them heavily in our queries
 	row := db.QueryRow(`
-	WITH
-    	splitByChar('.', version()) AS parts,
-    	toInt32(parts[1]) AS major,
-    	toInt32(parts[2]) AS minor
-	SELECT (major > 22) OR ((major = 22) AND (minor >= 7)) AS is_supported
+		WITH
+			splitByChar('.', version()) AS parts,
+			toInt32(parts[1]) AS major,
+			toInt32(parts[2]) AS minor
+		SELECT (major > 22) OR ((major = 22) AND (minor >= 7)) AS is_supported
 `)
 	var isSupported bool
 	if err := row.Scan(&isSupported); err != nil {
@@ -306,7 +317,7 @@ func (d driver) Open(instanceID string, config map[string]any, st *storage.Clien
 		ctx:        ctx,
 		cancel:     cancel,
 		metaSem:    semaphore.NewWeighted(1),
-		olapSem:    priorityqueue.NewSemaphore(maxOpenConnections - 1),
+		olapSem:    priorityqueue.NewSemaphore(conf.MaxOpenConns - 1),
 		opts:       opts,
 		embed:      embed,
 	}

--- a/runtime/drivers/clickhouse/context.go
+++ b/runtime/drivers/clickhouse/context.go
@@ -45,6 +45,7 @@ func (c *Connection) sessionAwareContext(ctx context.Context) context.Context {
 	return ctx
 }
 
+// contextWithQueryID adds the current trace ID as a query ID to the context.
 func contextWithQueryID(ctx context.Context) context.Context {
 	traceID := observability.TraceID(ctx)
 	if traceID == "" {

--- a/runtime/drivers/clickhouse/model_executor_localfile_self.go
+++ b/runtime/drivers/clickhouse/model_executor_localfile_self.go
@@ -15,20 +15,16 @@ import (
 	"github.com/rilldata/rill/runtime/pkg/fileutil"
 )
 
+type localInputProps struct {
+	Format string `mapstructure:"format"`
+}
+
 type localFileToSelfExecutor struct {
 	fileStore drivers.Handle
 	c         *Connection
 }
 
 var _ drivers.ModelExecutor = &selfToSelfExecutor{}
-
-type localInputProps struct {
-	Format string `mapstructure:"format"`
-}
-
-func (p *localInputProps) Validate() error {
-	return nil
-}
 
 func (e *localFileToSelfExecutor) Concurrency(desired int) (int, bool) {
 	if desired > 1 {
@@ -43,26 +39,33 @@ func (e *localFileToSelfExecutor) Execute(ctx context.Context, opts *drivers.Mod
 		return nil, fmt.Errorf("input handle %q does not implement filestore", opts.InputHandle.Driver())
 	}
 
-	// parse and validate input properties
+	if opts.IncrementalRun {
+		return nil, fmt.Errorf("clickhouse: incremental models are not supported for local_file connector")
+	}
+
+	// Parse the input and output properties
 	inputProps := &localInputProps{}
 	if err := mapstructure.WeakDecode(opts.InputProperties, inputProps); err != nil {
 		return nil, fmt.Errorf("failed to parse input properties: %w", err)
 	}
-	if err := inputProps.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid input properties: %w", err)
-	}
-
-	// parse and validate output properties
 	outputProps := &ModelOutputProperties{}
 	if err := mapstructure.WeakDecode(opts.OutputProperties, outputProps); err != nil {
 		return nil, fmt.Errorf("failed to parse output properties: %w", err)
 	}
-	if outputProps.Typ == "" && outputProps.Materialize == nil {
-		outputProps.Materialize = boolptr(true)
+
+	// Require materialization for local_file
+	if outputProps.Materialize != nil && !*outputProps.Materialize {
+		return nil, fmt.Errorf("models with input connector `local_file` must be materialized")
 	}
-	if err := outputProps.Validate(opts); err != nil {
-		return nil, fmt.Errorf("invalid output properties: %w", err)
+	outputProps.Materialize = boolptr(true)
+
+	// Validate the output properties
+	err := e.c.validateAndApplyDefaults(opts, nil, outputProps)
+	if err != nil {
+		return nil, fmt.Errorf("invalid model properties: %w", err)
 	}
+
+	// Extra validation: the model should be a table or dictionary
 	if outputProps.Typ != "TABLE" && outputProps.Typ != "DICTIONARY" {
 		return nil, fmt.Errorf("models with input connector `local_file` must be materialized as `TABLE` or `DICTIONARY`")
 	}
@@ -76,6 +79,7 @@ func (e *localFileToSelfExecutor) Execute(ctx context.Context, opts *drivers.Mod
 		return nil, fmt.Errorf("no files to ingest")
 	}
 
+	// Infer the format if not provided
 	if inputProps.Format == "" {
 		inputProps.Format, err = fileExtToFormat(fileutil.FullExt(localPaths[0]))
 		if err != nil {
@@ -83,6 +87,7 @@ func (e *localFileToSelfExecutor) Execute(ctx context.Context, opts *drivers.Mod
 		}
 	}
 
+	// Infer the schema if not provided
 	if outputProps.Columns == "" {
 		outputProps.Columns, err = e.inferColumns(ctx, opts, inputProps.Format, localPaths)
 		if err != nil {

--- a/runtime/drivers/clickhouse/model_executor_self.go
+++ b/runtime/drivers/clickhouse/model_executor_self.go
@@ -22,26 +22,20 @@ func (e *selfToSelfExecutor) Concurrency(desired int) (int, bool) {
 }
 
 func (e *selfToSelfExecutor) Execute(ctx context.Context, opts *drivers.ModelExecuteOptions) (*drivers.ModelResult, error) {
+	// Parse the input and output properties
 	inputProps := &ModelInputProperties{}
 	if err := mapstructure.WeakDecode(opts.InputProperties, inputProps); err != nil {
 		return nil, fmt.Errorf("failed to parse input properties: %w", err)
 	}
-	if err := inputProps.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid input properties: %w", err)
-	}
-
 	outputProps := &ModelOutputProperties{}
 	if err := mapstructure.WeakDecode(opts.OutputProperties, outputProps); err != nil {
 		return nil, fmt.Errorf("failed to parse output properties: %w", err)
 	}
-	if outputProps.Typ == "" && outputProps.Materialize == nil {
-		outputProps.Materialize = &opts.Env.DefaultMaterialize
-	}
-	if err := outputProps.Validate(opts); err != nil {
-		return nil, fmt.Errorf("invalid output properties: %w", err)
-	}
-	if outputProps.Typ != "DICTIONARY" && inputProps.SQL == "" {
-		return nil, fmt.Errorf("input SQL is required")
+
+	// Validate the output properties
+	err := e.c.validateAndApplyDefaults(opts, inputProps, outputProps)
+	if err != nil {
+		return nil, fmt.Errorf("invalid model properties: %w", err)
 	}
 
 	usedModelName := false
@@ -52,15 +46,8 @@ func (e *selfToSelfExecutor) Execute(ctx context.Context, opts *drivers.ModelExe
 
 	asView := outputProps.Typ == "VIEW"
 	tableName := outputProps.Table
-	if outputProps.QuerySettings != "" {
-		// Note: This will lead to failures if user sets settings both in query and output properties
-		inputProps.SQL = inputProps.SQL + " SETTINGS " + outputProps.QuerySettings
-	}
 
-	var (
-		metrics *tableWriteMetrics
-		err     error
-	)
+	var metrics *tableWriteMetrics
 	if !opts.IncrementalRun {
 		stagingTableName := tableName
 		if opts.Env.StageChanges {
@@ -72,7 +59,8 @@ func (e *selfToSelfExecutor) Execute(ctx context.Context, opts *drivers.ModelExe
 		_ = e.c.dropTable(ctx, stagingTableName)
 
 		// Create the table
-		metrics, err = e.c.createTableAsSelect(ctx, stagingTableName, inputProps.SQL, mustToMap(outputProps))
+		var err error
+		metrics, err = e.c.createTableAsSelect(ctx, stagingTableName, inputProps.SQL, outputProps)
 		if err != nil {
 			_ = e.c.dropTable(ctx, stagingTableName)
 			return nil, fmt.Errorf("failed to create model: %w", err)
@@ -87,6 +75,7 @@ func (e *selfToSelfExecutor) Execute(ctx context.Context, opts *drivers.ModelExe
 		}
 	} else {
 		// Insert into the table
+		var err error
 		metrics, err = e.c.insertTableAsSelect(ctx, tableName, inputProps.SQL, &InsertTableOptions{
 			Strategy: outputProps.IncrementalStrategy,
 		})
@@ -115,13 +104,4 @@ func (e *selfToSelfExecutor) Execute(ctx context.Context, opts *drivers.ModelExe
 		Table:        tableName,
 		ExecDuration: metrics.duration,
 	}, nil
-}
-
-func mustToMap(o *ModelOutputProperties) map[string]any {
-	m := make(map[string]any)
-	err := mapstructure.WeakDecode(o, &m)
-	if err != nil {
-		panic(fmt.Errorf("failed to encode output properties: %w", err))
-	}
-	return m
 }

--- a/runtime/drivers/clickhouse/model_executor_self_test.go
+++ b/runtime/drivers/clickhouse/model_executor_self_test.go
@@ -4,10 +4,14 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/testruntime"
 	"github.com/stretchr/testify/require"
+
+	_ "github.com/rilldata/rill/runtime/resolvers"
 )
 
 func TestMaterializeType(t *testing.T) {
@@ -68,4 +72,80 @@ func TestMaterializeType(t *testing.T) {
 			require.Equal(t, c.wantType, typ, c.name)
 		}
 	}
+}
+
+func TestPartitionOverwrite(t *testing.T) {
+	files := map[string]string{
+		"rill.yaml": "olap_connector: clickhouse",
+		// Model that creates 10 distinct partitions with 10 rows each.
+		// We'll expect the output to have 100 rows.
+		"partition_overwrite1.yaml": `
+type: model
+incremental: true
+partitions:
+  sql: SELECT number as id, now() as watermark FROM numbers(0, 10)
+partitions_watermark: watermark
+sql: SELECT {{.partition.id}} as partition_id, number as num FROM numbers(10)
+output:
+  incremental_strategy: partition_overwrite
+  partition_by: partition_id
+`,
+		// Model that creates 10 partitions that are inserted with the same partition_id. Each partition has 10 rows.
+		// We'll expect the partitions to keep overwriting each other, so the output has 10 rows.
+		"partition_overwrite2.yaml": `
+type: model
+incremental: true
+partitions:
+  sql: SELECT number as id, now() as watermark FROM numbers(0, 10)
+partitions_watermark: watermark
+sql: SELECT 1 as partition_id, number as num FROM numbers(10)
+output:
+  incremental_strategy: partition_overwrite
+  partition_by: partition_id
+`,
+		// Model similar to partition_overwrite1, but testing the implicit default partition overwrite strategy.
+		"partition_overwrite3.yaml": `
+type: model
+incremental: true
+partitions:
+  sql: SELECT number as id, now() as watermark FROM numbers(0, 10)
+partitions_watermark: watermark
+sql: SELECT number as num FROM numbers(10)
+`,
+	}
+
+	rt, id := testruntime.NewInstanceWithOptions(t, testruntime.InstanceOptions{
+		TestConnectors: []string{"clickhouse"},
+		Files:          files,
+	})
+	testruntime.ReconcileParserAndWait(t, rt, id)
+	testruntime.RequireReconcileState(t, rt, id, 4, 0, 0)
+
+	// Wait a second for the current_timestamp watermark to advance, then refresh the models.
+	// This causes all partitions to be re-processed enabling more rigourous testing of partition overwrites.
+	time.Sleep(time.Second)
+	testruntime.RefreshAndWait(t, rt, id, &runtimev1.ResourceName{Kind: runtime.ResourceKindModel, Name: "partition_overwrite1"})
+	testruntime.RefreshAndWait(t, rt, id, &runtimev1.ResourceName{Kind: runtime.ResourceKindModel, Name: "partition_overwrite2"})
+	testruntime.RefreshAndWait(t, rt, id, &runtimev1.ResourceName{Kind: runtime.ResourceKindModel, Name: "partition_overwrite3"})
+
+	// partition_overwrite should have 100 rows
+	testruntime.RequireResolve(t, rt, id, &testruntime.RequireResolveOptions{
+		Resolver:   "sql",
+		Properties: map[string]any{"sql": `SELECT COUNT(*) AS count, MIN(num) AS min, MAX(num) AS max FROM partition_overwrite1`},
+		Result:     []map[string]any{{"count": 100, "min": 0, "max": 9}},
+	})
+
+	// partition_overwrite2 should have 10 rows
+	testruntime.RequireResolve(t, rt, id, &testruntime.RequireResolveOptions{
+		Resolver:   "sql",
+		Properties: map[string]any{"sql": `SELECT COUNT(*) AS count, MIN(num) AS min, MAX(num) AS max FROM partition_overwrite2`},
+		Result:     []map[string]any{{"count": 10, "min": 0, "max": 9}},
+	})
+
+	// partition_overwrite3 should have 100 rows and a __rill_partition column
+	testruntime.RequireResolve(t, rt, id, &testruntime.RequireResolveOptions{
+		Resolver:   "sql",
+		Properties: map[string]any{"sql": `SELECT COUNT(*) AS count, COUNT(DISTINCT __rill_partition) AS partitions, MIN(num) AS min_num, MAX(num) AS max_num FROM partition_overwrite3`},
+		Result:     []map[string]any{{"count": 100, "partitions": 10, "min_num": 0, "max_num": 9}},
+	})
 }

--- a/runtime/drivers/clickhouse/model_manager.go
+++ b/runtime/drivers/clickhouse/model_manager.go
@@ -15,15 +15,17 @@ type ModelInputProperties struct {
 	SQL string `mapstructure:"sql"`
 }
 
-func (p *ModelInputProperties) Validate() error {
-	return nil
-}
-
 type ModelOutputProperties struct {
-	Table               string                      `mapstructure:"table"`
-	Materialize         *bool                       `mapstructure:"materialize"`
-	UniqueKey           []string                    `mapstructure:"unique_key"`
+	// Table is the name of the table to create. If not specified, the model name is used.
+	Table string `mapstructure:"table"`
+	// Materialize is a flag to indicate if the model should be materialized as a physical table or dictionary.
+	// If false, the model will be created as a view.
+	// If unspcecified, a default is selected based on context.
+	Materialize *bool `mapstructure:"materialize"`
+	// IncrementalStrategy is the strategy to use for incremental inserts.
 	IncrementalStrategy drivers.IncrementalStrategy `mapstructure:"incremental_strategy"`
+	// UniqueKey is the unique key for the model. This is used for the incremental strategy "merge".
+	UniqueKey []string `mapstructure:"unique_key"`
 	// Typ to materialize the model into. Possible values include `TABLE`, `VIEW` or `DICTIONARY`. Optional.
 	Typ string `mapstructure:"type"`
 	// Columns sets the column names and data types. If unspecified these are detected from the select query by clickhouse.
@@ -55,74 +57,121 @@ type ModelOutputProperties struct {
 	// QuerySettings sets the settings clause used in insert/create table as select queries.
 	QuerySettings string `mapstructure:"query_settings"`
 	// DistributedSettings is table settings for distributed table.
-	DistributedSettings string `mapstructure:"distributed.settings"`
+	DistributedSettings string `mapstructure:"distributed_settings"`
 	// DistributedShardingKey is the sharding key for distributed table.
-	DistributedShardingKey string `mapstructure:"distributed.sharding_key"`
+	DistributedShardingKey string `mapstructure:"distributed_sharding_key"`
 	// DictionarySourceUser is the user that case access the source dictionary table. Only used when typ is DICTIONARY.
 	DictionarySourceUser string `mapstructure:"dictionary_source_user"`
 	// DictionarySourcePassword is the password for the user that can access the source dictionary table. Only used when typ is DICTIONARY.
 	DictionarySourcePassword string `mapstructure:"dictionary_source_password"`
 }
 
-func (p *ModelOutputProperties) Validate(opts *drivers.ModelExecuteOptions) error {
-	if p.EngineFull != "" {
-		if p.Engine != "" || p.OrderBy != "" || p.PartitionBy != "" || p.PrimaryKey != "" || p.SampleBy != "" || p.TTL != "" || p.TableSettings != "" {
-			return fmt.Errorf("`engine_full ` property cannot be used with individual properties")
+// validateAndApplyDefaults validates the model input and output properties and applies defaults.
+// The inputProps may optionally be nil to allow for connectors that don't use the base SQL-centric input properties.
+// The outputProps may not be nil.
+func (c *Connection) validateAndApplyDefaults(opts *drivers.ModelExecuteOptions, ip *ModelInputProperties, op *ModelOutputProperties) error {
+	// EngineFull is not compatible with most other individual properties.
+	if op.EngineFull != "" {
+		if op.Engine != "" || op.OrderBy != "" || op.PartitionBy != "" || op.PrimaryKey != "" || op.SampleBy != "" || op.TTL != "" || op.TableSettings != "" || op.DictionarySourceUser != "" || op.DictionarySourcePassword != "" {
+			return fmt.Errorf("`engine_full` property cannot be used with individual properties")
 		}
 	}
 
 	// Handle materialize and type properties. We want to gracefully handle the cases where either or both are set in a non-contradictory way.
 	// This gets extra tricky since materialize=true is compatible with both TABLE and DICTIONARY types (just not VIEW).
-	p.Typ = strings.ToUpper(p.Typ)
-	if p.Materialize != nil {
-		if *p.Materialize {
-			if p.Typ == "VIEW" {
+	op.Typ = strings.ToUpper(op.Typ)
+	if op.Materialize != nil {
+		if *op.Materialize {
+			if op.Typ == "VIEW" {
 				return fmt.Errorf("the `type` and `materialize` properties contradict each other")
-			} else if p.Typ == "" {
-				p.Typ = "TABLE"
+			} else if op.Typ == "" {
+				op.Typ = "TABLE"
 			}
 		} else {
-			if p.Typ == "" {
-				p.Typ = "VIEW"
-			} else if p.Typ != "VIEW" {
+			if op.Typ == "" {
+				op.Typ = "VIEW"
+			} else if op.Typ != "VIEW" {
 				return fmt.Errorf("the `type` and `materialize` properties contradict each other")
 			}
 		}
 	}
 	if opts.Incremental || opts.PartitionRun { // Incremental or partitioned models default to TABLE.
-		if p.Typ != "" && p.Typ != "TABLE" {
+		if op.Typ != "" && op.Typ != "TABLE" {
 			return fmt.Errorf("incremental or partitioned models must be materialized as a table")
 		}
-		p.Typ = "TABLE"
+		op.Typ = "TABLE"
 	}
-	if p.Typ == "" { // Plain unannotated models default to VIEW.
-		p.Typ = "VIEW"
+	if op.Typ == "" { // Apply default for plain unannotated models.
+		if opts.Env.DefaultMaterialize {
+			op.Typ = "TABLE"
+		} else {
+			op.Typ = "VIEW"
+		}
 	}
-	if p.Typ != "TABLE" && p.Typ != "VIEW" && p.Typ != "DICTIONARY" {
-		return fmt.Errorf("invalid type %q, must be one of TABLE, VIEW or DICTIONARY", p.Typ)
+	if op.Typ != "TABLE" && op.Typ != "VIEW" && op.Typ != "DICTIONARY" {
+		return fmt.Errorf("invalid type %q, must be one of TABLE, VIEW or DICTIONARY", op.Typ)
 	}
 
-	switch p.IncrementalStrategy {
+	// For tables, apply a default table engine.
+	if op.Typ == "TABLE" && op.Engine == "" {
+		if c.config.Cluster != "" {
+			op.Engine = "ReplicatedMergeTree"
+		} else {
+			op.Engine = "MergeTree"
+		}
+	}
+
+	// Validate it's a known incremental strategy.
+	switch op.IncrementalStrategy {
 	case drivers.IncrementalStrategyUnspecified, drivers.IncrementalStrategyAppend, drivers.IncrementalStrategyPartitionOverwrite, drivers.IncrementalStrategyMerge:
 	default:
-		return fmt.Errorf("invalid incremental strategy %q", p.IncrementalStrategy)
+		return fmt.Errorf("invalid incremental strategy %q", op.IncrementalStrategy)
 	}
 
-	// if incremntal strategy is partition overwrite, partition_by is required
-	if p.IncrementalStrategy == drivers.IncrementalStrategyPartitionOverwrite && p.PartitionBy == "" {
-		return fmt.Errorf(`must specify a "partition_by" when "incremental_strategy" is %q`, p.IncrementalStrategy)
+	// partition_by is required for the partition_overwrite incremental strategy.
+	if op.IncrementalStrategy == drivers.IncrementalStrategyPartitionOverwrite && op.PartitionBy == "" {
+		return fmt.Errorf(`must specify a "partition_by" when "incremental_strategy" is %q`, op.IncrementalStrategy)
 	}
 
 	// ClickHouse enforces the requirement of either a primary key or an ORDER BY clause for the ReplacingMergeTree engine.
 	// When using the incremental strategy as 'merge', the engine must be ReplacingMergeTree.
 	// This ensures that duplicate rows are eventually replaced, maintaining data consistency.
-	if p.IncrementalStrategy == drivers.IncrementalStrategyMerge && !(strings.Contains(p.Engine, "ReplacingMergeTree") || strings.Contains(p.EngineFull, "ReplacingMergeTree")) {
-		return fmt.Errorf(`must use "ReplacingMergeTree" engine when "incremental_strategy" is %q`, p.IncrementalStrategy)
+	if op.IncrementalStrategy == drivers.IncrementalStrategyMerge && !(strings.Contains(op.Engine, "ReplacingMergeTree") || strings.Contains(op.EngineFull, "ReplacingMergeTree")) {
+		return fmt.Errorf(`must use "ReplacingMergeTree" engine when "incremental_strategy" is %q`, op.IncrementalStrategy)
 	}
 
-	if p.IncrementalStrategy == drivers.IncrementalStrategyUnspecified {
-		p.IncrementalStrategy = drivers.IncrementalStrategyAppend
+	// We want to use partition_overwrite as the default incremental strategy for models with partitions.
+	// This requires us to inject the partition key into the SQL query, so this only works for SQL models.
+	if op.IncrementalStrategy == drivers.IncrementalStrategyUnspecified && opts.PartitionRun && ip != nil && ip.SQL != "" {
+		if op.EngineFull != "" {
+			return fmt.Errorf("you must provide an explicit `incremental_strategy` when using `engine_full` with a partitioned model")
+		}
+		ip.SQL = fmt.Sprintf("SELECT %s AS __rill_partition, * FROM (%s\n)", safeSQLString(opts.PartitionKey), ip.SQL)
+		op.IncrementalStrategy = drivers.IncrementalStrategyPartitionOverwrite
+		op.PartitionBy = "__rill_partition"
 	}
+
+	// If we failed to apply a better incremental strategy, fall back to append.
+	if op.IncrementalStrategy == drivers.IncrementalStrategyUnspecified {
+		op.IncrementalStrategy = drivers.IncrementalStrategyAppend
+	}
+
+	// The input props are optional, but if set, check there's a valid SQL query.
+	if ip != nil {
+		if ip.SQL == "" && op.Typ != "DICTIONARY" {
+			return fmt.Errorf("input SQL is required")
+		}
+	}
+
+	// Add query settings to the SQL query.
+	// We do this last since the SQL query may be modified in some of the above steps.
+	if op.QuerySettings != "" {
+		if ip == nil || ip.SQL == "" {
+			return fmt.Errorf("cannot set query_settings without a SQL query")
+		}
+		ip.SQL = ip.SQL + " SETTINGS " + op.QuerySettings
+	}
+
 	return nil
 }
 
@@ -130,22 +179,18 @@ func (p *ModelOutputProperties) tblConfig() string {
 	if p.EngineFull != "" {
 		return p.EngineFull
 	}
+
 	var sb strings.Builder
+
 	// engine with default
-	var engine string
-	if p.Engine != "" {
-		engine = p.Engine
-	} else {
-		engine = "MergeTree"
-	}
-	fmt.Fprintf(&sb, "ENGINE = %s", engine)
+	fmt.Fprintf(&sb, "ENGINE = %s", p.Engine)
 
 	// order_by
 	if p.OrderBy != "" {
 		fmt.Fprintf(&sb, " ORDER BY %s", p.OrderBy)
 	} else if p.PrimaryKey != "" {
 		fmt.Fprintf(&sb, " ORDER BY %s", p.PrimaryKey)
-	} else if engine == "MergeTree" {
+	} else if p.Engine == "MergeTree" || p.Engine == "ReplicatedMergeTree" {
 		// need ORDER BY for MergeTree
 		// it is optional for many other engines
 		fmt.Fprintf(&sb, " ORDER BY tuple()")
@@ -173,8 +218,9 @@ func (p *ModelOutputProperties) tblConfig() string {
 
 	// settings
 	if p.TableSettings != "" {
-		fmt.Fprintf(&sb, " %s", p.TableSettings)
+		fmt.Fprintf(&sb, " SETTINGS %s", p.TableSettings)
 	}
+
 	return sb.String()
 }
 

--- a/runtime/drivers/clickhouse/model_manager.go
+++ b/runtime/drivers/clickhouse/model_manager.go
@@ -220,7 +220,11 @@ func (p *ModelOutputProperties) tblConfig() string {
 
 	// settings
 	if p.TableSettings != "" {
-		fmt.Fprintf(&sb, " SETTINGS %s", p.TableSettings)
+		if strings.HasPrefix(p.TableSettings, "SETTINGS") || strings.HasPrefix(p.TableSettings, "settings") {
+			fmt.Fprintf(&sb, " %s", p.TableSettings)
+		} else {
+			fmt.Fprintf(&sb, " SETTINGS %s", p.TableSettings)
+		}
 	}
 
 	return sb.String()

--- a/runtime/drivers/clickhouse/model_manager.go
+++ b/runtime/drivers/clickhouse/model_manager.go
@@ -113,7 +113,7 @@ func (c *Connection) validateAndApplyDefaults(opts *drivers.ModelExecuteOptions,
 	}
 
 	// For tables, apply a default table engine.
-	if op.Typ == "TABLE" && op.Engine == "" {
+	if op.Engine == "" && (op.Typ == "TABLE" || op.Typ == "DICTIONARY") {
 		if c.config.Cluster != "" {
 			op.Engine = "ReplicatedMergeTree"
 		} else {
@@ -182,8 +182,10 @@ func (p *ModelOutputProperties) tblConfig() string {
 
 	var sb strings.Builder
 
-	// engine with default
-	fmt.Fprintf(&sb, "ENGINE = %s", p.Engine)
+	// engine
+	if p.Engine != "" {
+		fmt.Fprintf(&sb, "ENGINE = %s", p.Engine)
+	}
 
 	// order_by
 	if p.OrderBy != "" {

--- a/runtime/drivers/clickhouse/model_manager.go
+++ b/runtime/drivers/clickhouse/model_manager.go
@@ -220,7 +220,9 @@ func (p *ModelOutputProperties) tblConfig() string {
 
 	// settings
 	if p.TableSettings != "" {
-		if strings.HasPrefix(p.TableSettings, "SETTINGS") || strings.HasPrefix(p.TableSettings, "settings") {
+		// Backwards compatibility: previously we did not automatically add the `SETTINGS` keyword.
+		// So we only add it if it's not already there.
+		if strings.HasPrefix(strings.TrimSpace(p.TableSettings), "SETTINGS") || strings.HasPrefix(strings.TrimSpace(p.TableSettings), "settings") {
 			fmt.Fprintf(&sb, " %s", p.TableSettings)
 		} else {
 			fmt.Fprintf(&sb, " SETTINGS %s", p.TableSettings)

--- a/runtime/drivers/clickhouse/olap.go
+++ b/runtime/drivers/clickhouse/olap.go
@@ -59,7 +59,6 @@ func (c *Connection) WithConnection(ctx context.Context, priority int, fn driver
 }
 
 func (c *Connection) Exec(ctx context.Context, stmt *drivers.Statement) error {
-	ctx = contextWithQueryID(ctx)
 	// Log query if enabled (usually disabled)
 	if c.config.LogQueries {
 		c.logger.Info("clickhouse query", zap.String("sql", c.Dialect().SanitizeQueryForLogging(stmt.Query)), zap.Any("args", stmt.Args), observability.ZapCtx(ctx))
@@ -72,6 +71,7 @@ func (c *Connection) Exec(ctx context.Context, stmt *drivers.Statement) error {
 		"session_timezone":          "UTC",
 		"join_use_nulls":            1,
 	}
+	ctx = contextWithQueryID(ctx)
 	ctx = clickhouse.Context(ctx, clickhouse.WithSettings(settings))
 
 	// We use the meta conn for dry run queries
@@ -90,24 +90,21 @@ func (c *Connection) Exec(ctx context.Context, stmt *drivers.Statement) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = release() }()
 
-	// TODO: should we use timeout to acquire connection as well ?
 	var cancelFunc context.CancelFunc
 	if stmt.ExecutionTimeout != 0 {
 		ctx, cancelFunc = context.WithTimeout(ctx, stmt.ExecutionTimeout)
+		defer cancelFunc()
 	}
-	defer func() {
-		if cancelFunc != nil {
-			cancelFunc()
-		}
-		_ = release()
-	}()
+
 	_, err = conn.ExecContext(ctx, stmt.Query, stmt.Args...)
 	return err
 }
 
 func (c *Connection) Query(ctx context.Context, stmt *drivers.Statement) (res *drivers.Result, outErr error) {
 	ctx = contextWithQueryID(ctx)
+
 	// Log query if enabled (usually disabled)
 	if c.config.LogQueries {
 		c.logger.Info("clickhouse query", zap.String("sql", c.Dialect().SanitizeQueryForLogging(stmt.Query)), zap.Any("args", stmt.Args))
@@ -125,8 +122,8 @@ func (c *Connection) Query(ctx context.Context, stmt *drivers.Statement) (res *d
 		return nil, err
 	}
 
-	if c.config.SettingsOverride != "" {
-		stmt.Query += "\n SETTINGS " + c.config.SettingsOverride
+	if c.config.QuerySettings != "" {
+		stmt.Query += "\n SETTINGS " + c.config.QuerySettings
 	} else {
 		stmt.Query += "\n SETTINGS cast_keep_nullable = 1, join_use_nulls = 1, session_timezone = 'UTC', prefer_global_in_and_join = 1, insert_distributed_sync = 1"
 	}

--- a/runtime/drivers/clickhouse/olap.go
+++ b/runtime/drivers/clickhouse/olap.go
@@ -122,8 +122,8 @@ func (c *Connection) Query(ctx context.Context, stmt *drivers.Statement) (res *d
 		return nil, err
 	}
 
-	if c.config.QuerySettings != "" {
-		stmt.Query += "\n SETTINGS " + c.config.QuerySettings
+	if c.config.QuerySettingsOverride != "" {
+		stmt.Query += "\n SETTINGS " + c.config.QuerySettingsOverride
 	} else {
 		stmt.Query += "\n SETTINGS cast_keep_nullable = 1, join_use_nulls = 1, session_timezone = 'UTC', prefer_global_in_and_join = 1, insert_distributed_sync = 1"
 	}

--- a/runtime/drivers/clickhouse/olap_test.go
+++ b/runtime/drivers/clickhouse/olap_test.go
@@ -400,8 +400,10 @@ func testInsertTableAsSelect_WithPartitionOverwrite_DatePartition(t *testing.T, 
 
 func testDictionary(t *testing.T, c *Connection, olap drivers.OLAPStore) {
 	_, err := c.createTableAsSelect(context.Background(), "dict", "SELECT 1 AS id, 'Earth' AS planet", &ModelOutputProperties{
-		Typ:        "DICTIONARY",
-		PrimaryKey: "id",
+		Typ:                      "DICTIONARY",
+		PrimaryKey:               "id",
+		DictionarySourceUser:     "clickhouse",
+		DictionarySourcePassword: "clickhouse",
 	})
 	require.NoError(t, err)
 

--- a/runtime/drivers/clickhouse/olap_test.go
+++ b/runtime/drivers/clickhouse/olap_test.go
@@ -36,7 +36,7 @@ func TestClickhouseSingle(t *testing.T) {
 	t.Run("InsertTableAsSelect_WithPartitionOverwrite", func(t *testing.T) { testInsertTableAsSelect_WithPartitionOverwrite(t, c, olap) })
 	t.Run("InsertTableAsSelect_WithPartitionOverwrite_DatePartition", func(t *testing.T) { testInsertTableAsSelect_WithPartitionOverwrite_DatePartition(t, c, olap) })
 	t.Run("TestDictionary", func(t *testing.T) { testDictionary(t, c, olap) })
-	t.Run("TestIntervalType", func(t *testing.T) { testIntervalType(t, c, olap) })
+	t.Run("TestIntervalType", func(t *testing.T) { testIntervalType(t, olap) })
 }
 
 func TestClickhouseCluster(t *testing.T) {
@@ -422,7 +422,7 @@ func testDictionary(t *testing.T, c *Connection, olap drivers.OLAPStore) {
 	require.NoError(t, c.dropTable(context.Background(), "dict1"))
 }
 
-func testIntervalType(t *testing.T, c *Connection, olap drivers.OLAPStore) {
+func testIntervalType(t *testing.T, olap drivers.OLAPStore) {
 	cases := []struct {
 		query string
 		ms    int64

--- a/runtime/drivers/duckdb/model_executor_localfile_self.go
+++ b/runtime/drivers/duckdb/model_executor_localfile_self.go
@@ -34,6 +34,10 @@ func (e *localFileToSelfExecutor) Concurrency(desired int) (int, bool) {
 }
 
 func (e *localFileToSelfExecutor) Execute(ctx context.Context, opts *drivers.ModelExecuteOptions) (*drivers.ModelResult, error) {
+	if opts.IncrementalRun {
+		return nil, fmt.Errorf("duckdb: incremental models are not supported for the local_file connector")
+	}
+
 	inputProps := &inputProps{}
 	if err := mapstructure.WeakDecode(opts.InputProperties, inputProps); err != nil {
 		return nil, fmt.Errorf("failed to parse input properties: %w", err)

--- a/runtime/drivers/models.go
+++ b/runtime/drivers/models.go
@@ -72,6 +72,9 @@ type ModelExecuteOptions struct {
 	IncrementalRun bool
 	// PartitionRun is true if the execution is a partition run.
 	PartitionRun bool
+	// PartitionKey is the unique key for the partition currently being run.
+	// It is empty when PartitionRun is false.
+	PartitionKey string
 	// PreviousResult is the result of a previous execution.
 	// For concurrent partition execution, it may not be the most recent previous result.
 	PreviousResult *ModelResult

--- a/runtime/reconcilers/model.go
+++ b/runtime/reconcilers/model.go
@@ -917,7 +917,7 @@ func (r *ModelReconciler) executeAll(ctx context.Context, self *runtimev1.Resour
 
 	// If we're not partitionting execution, run the executor directly and return
 	if !usePartitions {
-		res, err := r.executeSingle(ctx, executor, self, model, prevResult, incrementalRun, incrementalState, nil)
+		res, err := r.executeSingle(ctx, executor, self, model, prevResult, incrementalRun, incrementalState, "", nil)
 		if err != nil {
 			return "", nil, false, err
 		}
@@ -1116,7 +1116,7 @@ func (r *ModelReconciler) executePartition(ctx context.Context, catalog drivers.
 	// Execute the partition.
 	start := time.Now()
 	errStr := ""
-	res, err := r.executeSingle(ctx, executor, self, mdl, prevResult, incrementalRun, incrementalState, data)
+	res, err := r.executeSingle(ctx, executor, self, mdl, prevResult, incrementalRun, incrementalState, partition.Key, data)
 	if err != nil {
 		// Unless cancelled or explicitly told to return the error, we save the error in the partition and continue.
 		if returnErr {
@@ -1144,13 +1144,13 @@ func (r *ModelReconciler) executePartition(ctx context.Context, catalog drivers.
 }
 
 // executeSingle executes a single step of a model. Passing a previous result, incremental state, and/or a partition is optional.
-func (r *ModelReconciler) executeSingle(ctx context.Context, executor *wrappedModelExecutor, self *runtimev1.Resource, mdl *runtimev1.Model, prevResult *drivers.ModelResult, incrementalRun bool, incrementalState, partition map[string]any) (*drivers.ModelResult, error) {
+func (r *ModelReconciler) executeSingle(ctx context.Context, executor *wrappedModelExecutor, self *runtimev1.Resource, mdl *runtimev1.Model, prevResult *drivers.ModelResult, incrementalRun bool, incrementalState map[string]any, partitionKey string, partitionData map[string]any) (*drivers.ModelResult, error) {
 	// Resolve templating in the input and output props
-	inputProps, err := r.resolveTemplatedProps(ctx, self, incrementalState, partition, mdl.Spec.InputConnector, mdl.Spec.InputProperties.AsMap())
+	inputProps, err := r.resolveTemplatedProps(ctx, self, incrementalState, partitionData, mdl.Spec.InputConnector, mdl.Spec.InputProperties.AsMap())
 	if err != nil {
 		return nil, err
 	}
-	outputProps, err := r.resolveTemplatedProps(ctx, self, incrementalState, partition, mdl.Spec.OutputConnector, mdl.Spec.OutputProperties.AsMap())
+	outputProps, err := r.resolveTemplatedProps(ctx, self, incrementalState, partitionData, mdl.Spec.OutputConnector, mdl.Spec.OutputProperties.AsMap())
 	if err != nil {
 		return nil, err
 	}
@@ -1164,7 +1164,7 @@ func (r *ModelReconciler) executeSingle(ctx context.Context, executor *wrappedMo
 	var stageDuration time.Duration
 	if executor.stage != nil {
 		// Also resolve templating in the stage props
-		stageProps, err := r.resolveTemplatedProps(ctx, self, incrementalState, partition, mdl.Spec.StageConnector, mdl.Spec.StageProperties.AsMap())
+		stageProps, err := r.resolveTemplatedProps(ctx, self, incrementalState, partitionData, mdl.Spec.StageConnector, mdl.Spec.StageProperties.AsMap())
 		if err != nil {
 			return nil, err
 		}
@@ -1177,7 +1177,8 @@ func (r *ModelReconciler) executeSingle(ctx context.Context, executor *wrappedMo
 			Priority:             0,
 			Incremental:          mdl.Spec.Incremental,
 			IncrementalRun:       incrementalRun,
-			PartitionRun:         partition != nil,
+			PartitionRun:         partitionKey != "",
+			PartitionKey:         partitionKey,
 			PreviousResult:       prevResult,
 			TempDir:              tempDir,
 		})
@@ -1208,7 +1209,8 @@ func (r *ModelReconciler) executeSingle(ctx context.Context, executor *wrappedMo
 		Priority:             0,
 		Incremental:          mdl.Spec.Incremental,
 		IncrementalRun:       incrementalRun,
-		PartitionRun:         partition != nil,
+		PartitionRun:         partitionKey != "",
+		PartitionKey:         partitionKey,
 		PreviousResult:       prevResult,
 		TempDir:              tempDir,
 	})

--- a/runtime/resolvers/resolvers_test.go
+++ b/runtime/resolvers/resolvers_test.go
@@ -163,6 +163,9 @@ func TestResolvers(t *testing.T) {
 						Args:               args,
 						UserAttributes:     userAttributes,
 						SkipSecurityChecks: tc.SkipSecurityChecks,
+						Result:             tc.Result,
+						ResultCSV:          tc.ResultCSV,
+						ErrorContains:      tc.ErrorContains,
 						Update:             update,
 					}
 					testruntime.RequireResolve(t, rt, instanceID, opts)


### PR DESCRIPTION
This PR makes partitioned Clickhouse models use the `partition_overwrite` strategy by default. It does so by automatically injecting a column named `__rill_partition` with the current partition ID into the model's `SELECT` statement. After this change, the simplest possible incremental and partitioned Clickhouse model looks like this:
```yaml
type: model
incremental: true
partitions:
  glob: s3://bucket/path/**
sql: SELECT * FROM s3('{{.partition.uri}}')
```

Contributes to https://github.com/rilldata/rill-private-issues/issues/1632

**Other changes:**
- Fixes an issue where some config overrides where not handled when DSN was passed.
- Uses `ReplicatedMergeTree` by default instead of `MergeTree` for Clickhouse tables on clusters.
- Renames `connector.settings_override` to `connector.query_settings` (breaking change).
- Renames `distributed.settings` and `distributed.sharding_key` to `distributed_settings` and `distributed_sharding_key` (breaking change; confirmed not used in any production projects).
- Refactors validation and rewriting of input/output properties into a single function `validateAndApplyDefaults`.
- Moves the resolver test utilities into `testruntime` package so they can be used for driver tests.
- Various other minor refactors in the Clickhouse driver.

**Upcoming changes:**
The changes in this PR were made in preparation for a few other improvements, which I will be submitting as separate PRs. Sharing them here for context:
- [ ] Use `mapstructure.WeakDecodeMetadata` in `validateAndApplyDefaults` to error for unknown or unsupported properties
- [ ] Support partition overwrite by default in DuckDB

**Checklist:**
- [x] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated (note: not yet)
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
