### PR TITLE
fix: yaml defaults not loaded in embed

### DIFF
--- a/web-common/src/features/dashboards/state-managers/loaders/DashboardStateDataLoader.ts
+++ b/web-common/src/features/dashboards/state-managers/loaders/DashboardStateDataLoader.ts
@@ -10,7 +10,7 @@ import { getExploreStateFromYAMLConfig } from "@rilldata/web-common/features/das
 import { getRillDefaultExploreState } from "@rilldata/web-common/features/dashboards/stores/get-rill-default-explore-state";
 import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import { normalizeWeekday } from "@rilldata/web-common/features/dashboards/time-controls/new-time-controls";
-import { cleanUrlParamsForEmbed } from "@rilldata/web-common/features/dashboards/url-state/clean-url-params";
+import { cleanEmbedUrlParams } from "@rilldata/web-common/features/dashboards/url-state/clean-url-params";
 import { convertURLSearchParamsToExploreState } from "@rilldata/web-common/features/dashboards/url-state/convertURLSearchParamsToExploreState";
 import { useExploreValidSpec } from "@rilldata/web-common/features/explores/selectors";
 import {
@@ -293,7 +293,7 @@ export class DashboardStateDataLoader {
     rillDefaultExploreState: ExploreState;
     backButtonUsed: boolean;
   }) {
-    urlSearchParams = cleanUrlParamsForEmbed(urlSearchParams);
+    urlSearchParams = cleanEmbedUrlParams(urlSearchParams);
 
     const skipSessionStorage = backButtonUsed;
     const exploreStateFromSessionStorage = skipSessionStorage

--- a/web-common/src/features/dashboards/state-managers/loaders/DashboardStateDataLoader.ts
+++ b/web-common/src/features/dashboards/state-managers/loaders/DashboardStateDataLoader.ts
@@ -10,6 +10,7 @@ import { getExploreStateFromYAMLConfig } from "@rilldata/web-common/features/das
 import { getRillDefaultExploreState } from "@rilldata/web-common/features/dashboards/stores/get-rill-default-explore-state";
 import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
 import { normalizeWeekday } from "@rilldata/web-common/features/dashboards/time-controls/new-time-controls";
+import { cleanUrlParamsForEmbed } from "@rilldata/web-common/features/dashboards/url-state/clean-url-params";
 import { convertURLSearchParamsToExploreState } from "@rilldata/web-common/features/dashboards/url-state/convertURLSearchParamsToExploreState";
 import { useExploreValidSpec } from "@rilldata/web-common/features/explores/selectors";
 import {
@@ -292,6 +293,8 @@ export class DashboardStateDataLoader {
     rillDefaultExploreState: ExploreState;
     backButtonUsed: boolean;
   }) {
+    urlSearchParams = cleanUrlParamsForEmbed(urlSearchParams);
+
     const skipSessionStorage = backButtonUsed;
     const exploreStateFromSessionStorage = skipSessionStorage
       ? null

--- a/web-common/src/features/dashboards/url-state/clean-url-params.ts
+++ b/web-common/src/features/dashboards/url-state/clean-url-params.ts
@@ -40,3 +40,20 @@ export function cleanUrlParams(
   });
   return cleanedParams;
 }
+
+/**
+ * Temporary fix for embed where non-dashboard params are cleaned.
+ * TODO: we should do a complete fix for embed
+ */
+export function cleanUrlParamsForEmbed(searchParams: URLSearchParams) {
+  const cleanedParams = new URLSearchParams(searchParams);
+  [
+    "access_token",
+    "instance_id",
+    "kind",
+    "resource",
+    "runtime_host",
+    "type",
+  ].forEach((p) => cleanedParams.delete(p));
+  return cleanedParams;
+}

--- a/web-common/src/features/dashboards/url-state/clean-url-params.ts
+++ b/web-common/src/features/dashboards/url-state/clean-url-params.ts
@@ -42,10 +42,13 @@ export function cleanUrlParams(
 }
 
 /**
- * Temporary fix for embed where non-dashboard params are cleaned.
- * TODO: we should do a complete fix for embed
+ * Temporary fix to clean non-dashboard parameters from embed URLs.
+ * When URL parameters exist, they are loaded exclusively from the URL, bypassing dashboard yaml defaults.
+ * Since non-dashboard parameters are already removed in DashboardStateSync during URL state sync, we remove them here preemptively.
+ *
+ * TODO: Implement permanent solution for embed URLs, possibly by ignoring non-dashboard parameters in DashboardStateSync.
  */
-export function cleanUrlParamsForEmbed(searchParams: URLSearchParams) {
+export function cleanEmbedUrlParams(searchParams: URLSearchParams) {
   const cleanedParams = new URLSearchParams(searchParams);
   [
     "access_token",


### PR DESCRIPTION
Temporary fix for embeds where yaml defaults are not loaded.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
