### PR TITLE
fix (Incremental models): don't pass invalid `pageToken` on first load of partitions

### DIFF
--- a/web-common/orval.config.ts
+++ b/web-common/orval.config.ts
@@ -115,6 +115,12 @@ export default defineConfig({
               useMutation: false,
             },
           },
+          RuntimeService_GetModelPartitions: {
+            query: {
+              useInfinite: true,
+              useInfiniteQueryParam: "pageToken",
+            },
+          },
         },
       },
     },

--- a/web-common/src/runtime-client/fetchWrapper.ts
+++ b/web-common/src/runtime-client/fetchWrapper.ts
@@ -45,7 +45,9 @@ export async function fetchWrapper({
   if (params) {
     const paramParts: string[] = [];
     for (const p in params) {
-      paramParts.push(`${p}=${encodeURIComponent(params[p] as string)}`);
+      if (params[p] !== undefined) {
+        paramParts.push(`${p}=${encodeURIComponent(params[p] as string)}`);
+      }
     }
     if (paramParts.length) {
       url = `${url}?${paramParts.join("&")}`;

--- a/web-common/src/runtime-client/gen/runtime-service/runtime-service.ts
+++ b/web-common/src/runtime-client/gen/runtime-service/runtime-service.ts
@@ -4,17 +4,24 @@
  * rill/runtime/v1/schema.proto
  * OpenAPI spec version: version not set
  */
-import { createMutation, createQuery } from "@tanstack/svelte-query";
 import type {
+  CreateInfiniteQueryOptions,
+  CreateInfiniteQueryResult,
   CreateMutationOptions,
   CreateMutationResult,
   CreateQueryOptions,
   CreateQueryResult,
   DataTag,
+  InfiniteData,
   MutationFunction,
   QueryClient,
   QueryFunction,
   QueryKey,
+} from "@tanstack/svelte-query";
+import {
+  createInfiniteQuery,
+  createMutation,
+  createQuery,
 } from "@tanstack/svelte-query";
 
 import type {
@@ -83,8 +90,8 @@ import type {
   V1UnpackExampleResponse,
 } from "../index.schemas";
 
-import { httpClient } from "../../http-client";
 import type { ErrorType } from "../../http-client";
+import { httpClient } from "../../http-client";
 
 type AwaitedInput<T> = PromiseLike<T> | T;
 
@@ -2539,6 +2546,119 @@ export const getRuntimeServiceGetModelPartitionsQueryKey = (
     ...(params ? [params] : []),
   ] as const;
 };
+
+export const getRuntimeServiceGetModelPartitionsInfiniteQueryOptions = <
+  TData = InfiniteData<
+    Awaited<ReturnType<typeof runtimeServiceGetModelPartitions>>,
+    RuntimeServiceGetModelPartitionsParams["pageToken"]
+  >,
+  TError = ErrorType<RpcStatus>,
+>(
+  instanceId: string,
+  model: string,
+  params?: RuntimeServiceGetModelPartitionsParams,
+  options?: {
+    query?: Partial<
+      CreateInfiniteQueryOptions<
+        Awaited<ReturnType<typeof runtimeServiceGetModelPartitions>>,
+        TError,
+        TData,
+        Awaited<ReturnType<typeof runtimeServiceGetModelPartitions>>,
+        QueryKey,
+        RuntimeServiceGetModelPartitionsParams["pageToken"]
+      >
+    >;
+  },
+) => {
+  const { query: queryOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ??
+    getRuntimeServiceGetModelPartitionsQueryKey(instanceId, model, params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof runtimeServiceGetModelPartitions>>,
+    QueryKey,
+    RuntimeServiceGetModelPartitionsParams["pageToken"]
+  > = ({ signal, pageParam }) => {
+    console.log("pageParam", pageParam);
+    return runtimeServiceGetModelPartitions(
+      instanceId,
+      model,
+      { ...params, pageToken: pageParam || params?.["pageToken"] },
+      signal,
+    );
+  };
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: !!(instanceId && model),
+    ...queryOptions,
+  } as CreateInfiniteQueryOptions<
+    Awaited<ReturnType<typeof runtimeServiceGetModelPartitions>>,
+    TError,
+    TData,
+    Awaited<ReturnType<typeof runtimeServiceGetModelPartitions>>,
+    QueryKey,
+    RuntimeServiceGetModelPartitionsParams["pageToken"]
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type RuntimeServiceGetModelPartitionsInfiniteQueryResult = NonNullable<
+  Awaited<ReturnType<typeof runtimeServiceGetModelPartitions>>
+>;
+export type RuntimeServiceGetModelPartitionsInfiniteQueryError =
+  ErrorType<RpcStatus>;
+
+/**
+ * @summary GetModelPartitions returns the partitions of a model
+ */
+
+export function createRuntimeServiceGetModelPartitionsInfinite<
+  TData = InfiniteData<
+    Awaited<ReturnType<typeof runtimeServiceGetModelPartitions>>,
+    RuntimeServiceGetModelPartitionsParams["pageToken"]
+  >,
+  TError = ErrorType<RpcStatus>,
+>(
+  instanceId: string,
+  model: string,
+  params?: RuntimeServiceGetModelPartitionsParams,
+  options?: {
+    query?: Partial<
+      CreateInfiniteQueryOptions<
+        Awaited<ReturnType<typeof runtimeServiceGetModelPartitions>>,
+        TError,
+        TData,
+        Awaited<ReturnType<typeof runtimeServiceGetModelPartitions>>,
+        QueryKey,
+        RuntimeServiceGetModelPartitionsParams["pageToken"]
+      >
+    >;
+  },
+  queryClient?: QueryClient,
+): CreateInfiniteQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getRuntimeServiceGetModelPartitionsInfiniteQueryOptions(
+    instanceId,
+    model,
+    params,
+    options,
+  );
+
+  const query = createInfiniteQuery(
+    queryOptions,
+    queryClient,
+  ) as CreateInfiniteQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  query.queryKey = queryOptions.queryKey;
+
+  return query;
+}
 
 export const getRuntimeServiceGetModelPartitionsQueryOptions = <
   TData = Awaited<ReturnType<typeof runtimeServiceGetModelPartitions>>,

--- a/web-local/tests/models/incremental.spec.ts
+++ b/web-local/tests/models/incremental.spec.ts
@@ -1,0 +1,37 @@
+import { expect } from "@playwright/test";
+import { test } from "../setup/base";
+import { updateCodeEditor, waitForProfiling } from "../utils/commonHelpers";
+import { createModel } from "../utils/modelHelpers";
+import { waitForFileNavEntry } from "../utils/waitHelpers";
+test.describe("Incremental models", () => {
+  test.use({ project: "Blank" });
+
+  test("partitions browser should display model partitions", async ({
+    page,
+  }) => {
+    // Create a partitioned model
+    await createModel(page, "partitioned_model.yaml");
+    await waitForFileNavEntry(page, "/models/partitioned_model.yaml", true);
+    await updateCodeEditor(
+      page,
+      `
+# This model produces a range of numbers with the current timestamp.
+# It is not incremental, which means:
+#  - All rows will be replaced on each refresh
+#  - You cannot refresh a single partition
+type: model
+refresh:
+  cron: 0 0 * * *
+partitions:
+  sql: SELECT range AS num FROM range(0,10)
+sql: SELECT {{ .partition.num }} AS num, now() AS inserted_on
+`,
+    );
+    await waitForProfiling(page, "partitioned_model", ["inserted_on", "num"]);
+
+    // Check that the partitions browser displays the model's partitions
+    await page.getByRole("button", { name: "View partitions" }).click();
+    await expect(page.getByText("num: 0")).toBeVisible();
+    await expect(page.getByText("num: 1")).toBeVisible();
+  });
+});

--- a/web-local/tests/models/models.spec.ts
+++ b/web-local/tests/models/models.spec.ts
@@ -1,14 +1,14 @@
-import { test } from "./setup/base";
+import { test } from "../setup/base";
 import {
   deleteFile,
   renameFileUsingMenu,
   updateCodeEditor,
   waitForProfiling,
   wrapRetryAssertion,
-} from "./utils/commonHelpers";
-import { createModel, modelHasError } from "./utils/modelHelpers";
-import { createSource } from "./utils/sourceHelpers";
-import { fileNotPresent, waitForFileNavEntry } from "./utils/waitHelpers";
+} from "../utils/commonHelpers";
+import { createModel, modelHasError } from "../utils/modelHelpers";
+import { createSource } from "../utils/sourceHelpers";
+import { fileNotPresent, waitForFileNavEntry } from "../utils/waitHelpers";
 
 test.describe("models", () => {
   test.use({ project: "Blank" });


### PR DESCRIPTION
Previously, the infinite query for model partitions would pass `pageToken=1` on the first page request, which is invalid—`1` is not a valid page token. This caused the first page to fail with the error `failed to parse page token: illegal base64 data at input byte 0`. [Reported in Slack here](https://rilldata.slack.com/archives/C02T907FEUB/p1747052031539429).

This PR:
- Updates the query logic to omit `pageToken` entirely on the first page. 
- Improves error handling to actually surface the API errors in the UI.
- Adds an e2e test to prevent basic regressions of the Partitions Browser

**Before**

Request URL: `http://localhost:9009/v1/instances/default/models/model/partitions?pageToken=1`

<img width="1282" alt="image" src="https://github.com/user-attachments/assets/99a56176-4c4d-484c-937d-27b42503038c" />

**After**

Request URL: `http://localhost:9009/v1/instances/default/models/model/partitions`

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/594523e4-259e-4beb-b221-a7bcf014cb44" />


**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
