### PR TITLE
fix: grain not persisting when it is the only thing in url

### DIFF
--- a/web-common/src/features/dashboards/stores/test-data/store-mutations.ts
+++ b/web-common/src/features/dashboards/stores/test-data/store-mutations.ts
@@ -179,6 +179,17 @@ export const AD_BIDS_SET_PREVIOUS_WEEK_COMPARE_TIME_RANGE_FILTER: TestDashboardM
 export const AD_BIDS_DISABLE_COMPARE_TIME_RANGE_FILTER: TestDashboardMutation =
   () => metricsExplorerStore.displayTimeComparison(AD_BIDS_EXPLORE_NAME, false);
 
+export const AD_BIDS_SET_MINUTE_TIME_GRAIN: TestDashboardMutation = ({
+  dashboard,
+}) =>
+  metricsExplorerStore.selectTimeRange(
+    AD_BIDS_EXPLORE_NAME,
+    dashboard.selectedTimeRange!,
+    V1TimeGrain.TIME_GRAIN_MINUTE,
+    undefined,
+    AD_BIDS_METRICS_INIT,
+  );
+
 export const AD_BIDS_SET_PUBLISHER_COMPARE_DIMENSION: TestDashboardMutation =
   () =>
     metricsExplorerStore.setComparisonDimension(

--- a/web-common/src/features/dashboards/url-state/convertPresetToExploreState.ts
+++ b/web-common/src/features/dashboards/url-state/convertPresetToExploreState.ts
@@ -120,7 +120,8 @@ function fromTimeRangesParams(
     );
   }
 
-  if (preset.timeGrain && partialExploreState.selectedTimeRange) {
+  if (preset.timeGrain) {
+    partialExploreState.selectedTimeRange ??= {} as DashboardTimeControls;
     partialExploreState.selectedTimeRange.interval =
       FromURLParamTimeGrainMap[preset.timeGrain];
   }

--- a/web-common/src/features/dashboards/url-state/url-state-variations.spec.ts
+++ b/web-common/src/features/dashboards/url-state/url-state-variations.spec.ts
@@ -58,6 +58,7 @@ import {
   AD_BIDS_MEASURE_NAMES_BID_PRICE_AND_IMPRESSIONS,
   AD_BIDS_APPLY_IMP_COUNTRY_BETWEEN_MEASURE_FILTER,
   AD_BIDS_APPLY_IMP_COUNTRY_NOT_BETWEEN_MEASURE_FILTER,
+  AD_BIDS_SET_MINUTE_TIME_GRAIN,
 } from "@rilldata/web-common/features/dashboards/stores/test-data/store-mutations";
 import { getTimeControlState } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import { getCleanedUrlParamsForGoto } from "@rilldata/web-common/features/dashboards/url-state/convert-partial-explore-state-to-url-params";
@@ -201,6 +202,12 @@ const TestCases: {
     },
     expectedSearch: "tr=P9D&grain=day",
     legacyNotSupported: true,
+  },
+
+  {
+    title: "Only time grain different than default",
+    mutations: [AD_BIDS_SET_MINUTE_TIME_GRAIN],
+    expectedSearch: "grain=minute",
   },
 
   {


### PR DESCRIPTION
When there is only grain in the url then we are not adding it to the state. Since we have the cascading merge now, we can just keep the grain and the rest will be filled in.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
