### PR TITLE
hacky way to limit the database listed in table list for clickhouse

### DIFF
--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -125,6 +125,10 @@ type configProperties struct {
 	Password string `mapstructure:"password"`
 	// Database configuration. Should not be set if DSN is set.
 	Database string `mapstructure:"database"`
+	// DatabaseWhitelist is a comma separated list of databases to fetch in information_schema all calls.
+	// This is just a *quick hack* to avoid fetching all databases in the table list till we have a better solution.
+	// This does not list queries to other databases.
+	DatabaseWhitelist string `mapstructure:"database_whitelist"`
 	// SSL determines whether secured connection need to be established. Should not be set if DSN is set.
 	SSL bool `mapstructure:"ssl"`
 	// Cluster name. If a cluster is configured, Rill will create all models in the cluster as distributed tables.


### PR DESCRIPTION
**This is just a quick fix till we can fix this properly via UI**

Sample YAML :

```
type: connector

driver: clickhouse
host: "localhost"
port: 9000
database_whitelist: default, system, information_schema
```

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
