### PR TITLE
Skip organization check in local mode

### DIFF
--- a/cli/pkg/cmdutil/check.go
+++ b/cli/pkg/cmdutil/check.go
@@ -33,6 +33,11 @@ func CheckAuth(ch *Helper) PreRunCheck {
 
 func CheckOrganization(ch *Helper) PreRunCheck {
 	return func(cmd *cobra.Command, args []string) error {
+		// If the command is run in local mode, skip the check.
+		if cmd.Flags().Lookup("local").Changed {
+			return nil
+		}
+
 		if ch.Org != "" {
 			return nil
 		}


### PR DESCRIPTION
Resolves: Support --local in CLI even when not logged in: https://github.com/rilldata/rill-private-issues/issues/1711


Before
```bash
➜  rill git:(gplata/local-flag) ✗ rill project refresh --local --model auction_data_model
Error: no organization is set, pass `--org` or run `rill org switch`
```

After
```
➜  rill git:(gplata/local-flag) ✗ rill project refresh --local --model auction_data_model
Running in local mode, skipping organization checkRefresh initiated. Check the project logs for status updates.
```

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
