### PR TITLE
[APP-65] Tweak big number measure tooltip

### DIFF
--- a/web-common/src/features/dashboards/big-number/BigNumberTooltipContent.svelte
+++ b/web-common/src/features/dashboards/big-number/BigNumberTooltipContent.svelte
@@ -1,48 +1,27 @@
 <script lang="ts">
-  import Shortcut from "@rilldata/web-common/components/tooltip/Shortcut.svelte";
-  import StackingWord from "@rilldata/web-common/components/tooltip/StackingWord.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
-  import TooltipDescription from "@rilldata/web-common/components/tooltip/TooltipDescription.svelte";
-  import TooltipShortcutContainer from "@rilldata/web-common/components/tooltip/TooltipShortcutContainer.svelte";
-  import TooltipTitle from "@rilldata/web-common/components/tooltip/TooltipTitle.svelte";
   import type { MetricsViewSpecMeasure } from "@rilldata/web-common/runtime-client";
-  import { isClipboardApiSupported } from "../../../lib/actions/copy-to-clipboard";
 
   export let measure: MetricsViewSpecMeasure;
-  export let isMeasureExpanded = false;
   export let value = "";
 
-  $: description =
-    measure?.description || measure?.displayName || measure?.expression;
   $: name = measure?.displayName || measure?.expression;
 </script>
 
-<TooltipContent maxWidth="280px">
-  <TooltipTitle>
-    <svelte:fragment slot="name">
+<TooltipContent>
+  <div
+    class="grid gap-x-4 pointer-events-none pt-1 pb-1 items-baseline"
+    style="grid-template-columns: auto max-content"
+  >
+    <div class="truncate" aria-label="tooltip-name">
       {name}
-    </svelte:fragment>
-    <svelte:fragment slot="description">
-      {value}
-    </svelte:fragment>
-  </TooltipTitle>
-  <TooltipDescription>
-    {description}
-  </TooltipDescription>
+    </div>
 
-  <TooltipShortcutContainer>
-    {#if !isMeasureExpanded}
-      <div>Expand measure</div>
-      <Shortcut>Click</Shortcut>
-    {/if}
-    {#if isClipboardApiSupported()}
-      <div>
-        <StackingWord key="shift">Copy</StackingWord>
-        number
-      </div>
-      <Shortcut>
-        <span style="font-family: var(--system);">⇧</span> + Click
-      </Shortcut>
-    {/if}
-  </TooltipShortcutContainer>
+    <div
+      class="text-gray-300 justify-self-end"
+      aria-label="tooltip-name-description"
+    >
+      {value}
+    </div>
+  </div>
 </TooltipContent>

--- a/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
@@ -102,7 +102,6 @@
   <BigNumberTooltipContent
     slot="tooltip-content"
     {measure}
-    isMeasureExpanded={useDiv}
     value={tooltipValue}
   />
 


### PR DESCRIPTION
This pull request shrinks the big number tooltip to only the first line, unbolded.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
