### PR TITLE
Fix: remove unused svelte kit tsconfig ref

### DIFF
--- a/web-common/tsconfig.json
+++ b/web-common/tsconfig.json
@@ -2,5 +2,5 @@
   "compilerOptions": {
     "types": ["@testing-library/jest-dom"]
   },
-  "extends": ["./.svelte-kit/tsconfig.json", "../tsconfig.json"]
+  "extends": ["../tsconfig.json"]
 }


### PR DESCRIPTION
While debugging https://rilldata.slack.com/archives/C01190F1R1D/p1747342455986059, I came across this tsconfig bug.

![CleanShot 2025-05-15 at 18 39 32@2x](https://github.com/user-attachments/assets/a96937b9-04f9-4702-9931-65383f8ad007)

This pull request removes the reference of `./.svelte-kit/tsconfig.json` in `web-common/tsconfig.json`.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
