### PR TITLE
[APP-66] Leaderboard tooltip

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -328,7 +328,6 @@
       {allowExpandTable}
       {hovered}
       displayName={displayName || dimensionName}
-      dimensionDescription={description}
       {dimensionName}
       {isBeingCompared}
       isFetching={isLoading}

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -105,12 +105,7 @@
   $: queryLimit = slice + 1;
   $: maxValuesToShow = slice * 2;
 
-  $: ({
-    name: dimensionName = "",
-    description = "",
-    displayName = "",
-    uri,
-  } = dimension);
+  $: ({ name: dimensionName = "", displayName = "", uri } = dimension);
 
   $: atLeastOneActive = Boolean($selectedValues.data?.length);
 

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
   import ArrowDown from "@rilldata/web-common/components/icons/ArrowDown.svelte";
   import Spacer from "@rilldata/web-common/components/icons/Spacer.svelte";
-  import Shortcut from "@rilldata/web-common/components/tooltip/Shortcut.svelte";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
-  import TooltipShortcutContainer from "@rilldata/web-common/components/tooltip/TooltipShortcutContainer.svelte";
-  import TooltipTitle from "@rilldata/web-common/components/tooltip/TooltipTitle.svelte";
   import DelayedSpinner from "@rilldata/web-common/features/entity-management/DelayedSpinner.svelte";
   import { fly } from "svelte/transition";
   import DeltaChange from "../dimension-table/DeltaChange.svelte";

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
@@ -18,7 +18,6 @@
   export let isFetching: boolean;
   export let isValidPercentOfTotal: (measureName: string) => boolean;
   export let isTimeComparisonActive: boolean;
-  export let dimensionDescription: string;
   export let isBeingCompared: boolean;
   export let sortedAscending: boolean;
   export let displayName: string;
@@ -74,7 +73,7 @@
         </button>
         <TooltipContent slot="tooltip-content">
           <div class="pointer-events-none items-baseline">
-            <div class="truncate" aria-label="tooltip-name">
+            <div aria-label="tooltip-name">
               {displayName}
             </div>
           </div>

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
@@ -79,10 +79,11 @@
           >
         </button>
         <TooltipContent slot="tooltip-content">
-          <div class="pointer-events-none items-baseline">
-            <div aria-label="tooltip-name">
-              {displayName}
-            </div>
+          <div
+            class="pointer-events-none items-baseline"
+            aria-label="tooltip-name"
+          >
+            {displayName}
           </div>
         </TooltipContent>
       </Tooltip>

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
@@ -35,11 +35,19 @@
   ) => void;
   export let measureLabel: (measureName: string) => string;
 
+  let dimensionHeaderSpan: HTMLSpanElement;
+  let isTruncated = false;
+
   function shouldShowContextColumns(measureName: string): boolean {
     return (
       leaderboardShowContextForAllMeasures ||
       measureName === leaderboardSortByMeasureName
     );
+  }
+
+  $: if (dimensionHeaderSpan) {
+    isTruncated =
+      dimensionHeaderSpan.scrollHeight > dimensionHeaderSpan.clientHeight;
   }
 </script>
 
@@ -60,7 +68,7 @@
     </th>
 
     <th data-dimension-header>
-      <Tooltip location="top">
+      <Tooltip location="top" suppress={!isTruncated}>
         <button
           disabled={!allowExpandTable}
           class="text-slate-600 text-left {allowExpandTable
@@ -69,7 +77,9 @@
           aria-label="Open dimension details"
           on:click={() => setPrimaryDimension(dimensionName)}
         >
-          <span class="line-clamp-2">{displayName}</span>
+          <span bind:this={dimensionHeaderSpan} class="line-clamp-2"
+            >{displayName}</span
+          >
         </button>
         <TooltipContent slot="tooltip-content">
           <div class="pointer-events-none items-baseline">

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
@@ -61,38 +61,23 @@
     </th>
 
     <th data-dimension-header>
-      <Tooltip distance={16} location="top">
+      <Tooltip location="top">
         <button
           disabled={!allowExpandTable}
-          class="text-slate-600 {allowExpandTable
+          class="text-slate-600 text-left {allowExpandTable
             ? 'hover:text-primary-700'
             : ''}"
           aria-label="Open dimension details"
           on:click={() => setPrimaryDimension(dimensionName)}
         >
-          {displayName}
+          <span class="line-clamp-2">{displayName}</span>
         </button>
         <TooltipContent slot="tooltip-content">
-          <TooltipTitle>
-            <svelte:fragment slot="name">
+          <div class="pointer-events-none items-baseline">
+            <div class="truncate" aria-label="tooltip-name">
               {displayName}
-            </svelte:fragment>
-            <svelte:fragment slot="description" />
-          </TooltipTitle>
-          <TooltipShortcutContainer>
-            <div class="line-clamp-2">
-              {#if dimensionDescription}
-                {dimensionDescription}
-              {:else}
-                The leaderboard metrics for {displayName}
-              {/if}
             </div>
-            <Shortcut />
-            {#if allowExpandTable}
-              <div>Expand leaderboard</div>
-              <Shortcut>Click</Shortcut>
-            {/if}
-          </TooltipShortcutContainer>
+          </div>
         </TooltipContent>
       </Tooltip>
     </th>


### PR DESCRIPTION
This pull request improves the tooltips on dimension headers, making them appear only when the header text is truncated.

https://github.com/user-attachments/assets/ddfbe87a-7805-45a5-93a8-5b7d712bf7f7

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
