### PR TITLE
[APP-69] Fix: Hover shows two tooltips in different formats

### DIFF
--- a/web-common/src/components/virtualized-table/core/Cell.svelte
+++ b/web-common/src/components/virtualized-table/core/Cell.svelte
@@ -1,16 +1,7 @@
 <script lang="ts">
   import { FormattedDataType } from "@rilldata/web-common/components/data-types";
-  import Shortcut from "@rilldata/web-common/components/tooltip/Shortcut.svelte";
-  import StackingWord from "@rilldata/web-common/components/tooltip/StackingWord.svelte";
-  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
-  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
-  import TooltipShortcutContainer from "@rilldata/web-common/components/tooltip/TooltipShortcutContainer.svelte";
-  import TooltipTitle from "@rilldata/web-common/components/tooltip/TooltipTitle.svelte";
   import { TOOLTIP_STRING_LIMIT } from "@rilldata/web-common/layout/config";
-  import {
-    copyToClipboard,
-    isClipboardApiSupported,
-  } from "@rilldata/web-common/lib/actions/copy-to-clipboard";
+  import { copyToClipboard } from "@rilldata/web-common/lib/actions/copy-to-clipboard";
   import { modified } from "@rilldata/web-common/lib/actions/modified-click";
   import { STRING_LIKES } from "@rilldata/web-common/lib/duckdb-data-types";
   import { formatDataTypeAsDuckDbQueryString } from "@rilldata/web-common/lib/formatters";
@@ -104,79 +95,60 @@
   const shiftClick = async () => {
     let exportedValue = formatDataTypeAsDuckDbQueryString(value, type);
     copyToClipboard(exportedValue);
-    // update this to set the active animation in the tooltip text
   };
 </script>
 
-<Tooltip
-  distance={16}
-  location="top"
-  suppress={suppressTooltip || !isClipboardApiSupported()}
+<div
+  class="
+    {positionStatic ? 'static' : 'absolute'}
+    z-9
+    text-ellipsis
+    whitespace-nowrap
+    {isDimensionTable ? '' : 'border-r border-b'}
+    {activityStatus}
+    "
+  on:blur={onBlur}
+  on:click={onSelectItem}
+  on:focus={onFocus}
+  on:keydown
+  on:mouseout={onBlur}
+  on:mouseover={onFocus}
+  role="gridcell"
+  style:height="{row.size}px"
+  style:left="{column.start}px"
+  style:top="{row.start}px"
+  style:width="{column.size}px"
+  tabindex="0"
+  title={!suppressTooltip ? tooltipValue : undefined}
 >
-  <div
-    class="
-      {positionStatic ? 'static' : 'absolute'}
-      z-9
-      text-ellipsis
-      whitespace-nowrap
-      {isDimensionTable ? '' : 'border-r border-b'}
-      {activityStatus}
-      "
-    on:blur={onBlur}
-    on:click={onSelectItem}
-    on:focus={onFocus}
-    on:keydown
-    on:mouseout={onBlur}
-    on:mouseover={onFocus}
-    role="gridcell"
-    style:height="{row.size}px"
-    style:left="{column.start}px"
-    style:top="{row.start}px"
-    style:width="{column.size}px"
-    tabindex="0"
+  <BarAndLabel
+    color={barColor}
+    customBackgroundColor="rgba(0,0,0,0)"
+    justify="left"
+    showBackground={false}
+    value={barValue}
+    compact={true}
   >
-    <BarAndLabel
-      color={barColor}
-      customBackgroundColor="rgba(0,0,0,0)"
-      justify="left"
-      showBackground={false}
-      value={barValue}
-      compact={true}
+    <button
+      aria-label={label}
+      class="
+        {isTextColumn ? 'text-left' : 'text-right'}
+        {isDimensionTable ? '' : 'px-4'}
+        w-full truncate
+        "
+      on:click={modified({
+        shift: shiftClick,
+      })}
+      style:height="{row.size}px"
     >
-      <button
-        aria-label={label}
-        class="
-          {isTextColumn ? 'text-left' : 'text-right'}
-          {isDimensionTable ? '' : 'px-4'}
-          w-full truncate
-          "
-        on:click={modified({
-          shift: shiftClick,
-        })}
-        style:height="{row.size}px"
-      >
-        <FormattedDataType
-          customStyle={formattedDataTypeStyle}
-          inTable
-          isNull={value === null || value === undefined}
-          {type}
-          value={formattedValue || value}
-          color="text-gray-500"
-        />
-      </button>
-    </BarAndLabel>
-  </div>
-  <TooltipContent maxWidth="360px" slot="tooltip-content">
-    <TooltipTitle>
-      <FormattedDataType dark slot="name" value={tooltipValue} />
-    </TooltipTitle>
-    <TooltipShortcutContainer>
-      <div>
-        <StackingWord key="shift">Copy</StackingWord> this value to clipboard
-      </div>
-      <Shortcut>
-        <span style="font-family: var(--system);">⇧</span> + Click
-      </Shortcut>
-    </TooltipShortcutContainer>
-  </TooltipContent>
-</Tooltip>
+      <FormattedDataType
+        customStyle={formattedDataTypeStyle}
+        inTable
+        isNull={value === null || value === undefined}
+        {type}
+        value={formattedValue || value}
+        color="text-gray-500"
+      />
+    </button>
+  </BarAndLabel>
+</div>

--- a/web-common/src/features/canvas/components/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/canvas/components/leaderboard/LeaderboardDisplay.svelte
@@ -28,7 +28,6 @@
   let numRows = 7;
 
   let parentElement: HTMLDivElement;
-  let suppressTooltip = false;
   let leaderboardWrapperWidth = 0;
 
   $: ({
@@ -146,12 +145,6 @@
       class="grid-wrapper gap-px overflow-x-auto"
       style:grid-template-columns="repeat(auto-fit, minmax({estimatedTableWidth +
         LEADERBOARD_WRAPPER_PADDING}px, 1fr))"
-      on:scroll={() => {
-        suppressTooltip = true;
-      }}
-      on:scrollend={() => {
-        suppressTooltip = false;
-      }}
     >
       {#if parentElement}
         {#each visibleDimensions as dimension (dimension.name)}
@@ -184,7 +177,6 @@
                   : undefined}
                 {dimension}
                 {parentElement}
-                {suppressTooltip}
                 timeControlsReady={true}
                 allowExpandTable={false}
                 allowDimensionComparison={false}

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -62,7 +62,6 @@
   export let filterExcludeMode: boolean;
   export let isBeingCompared: boolean;
   export let parentElement: HTMLElement;
-  export let suppressTooltip = false;
   export let allowExpandTable = true;
   export let allowDimensionComparison = true;
   export let formatters: Record<
@@ -355,7 +354,6 @@
       >
         {#each aboveTheFold as itemData (itemData.dimensionValue)}
           <LeaderboardRow
-            {suppressTooltip}
             {tableWidth}
             {isBeingCompared}
             {filterExcludeMode}
@@ -376,7 +374,6 @@
 
       {#each belowTheFoldRows as itemData, i (itemData.dimensionValue)}
         <LeaderboardRow
-          {suppressTooltip}
           {itemData}
           {tableWidth}
           {dimensionName}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -44,7 +44,6 @@
   } = StateManagers;
 
   let parentElement: HTMLDivElement;
-  let suppressTooltip = false;
 
   $: ({ instanceId } = $runtime);
 
@@ -74,16 +73,7 @@
   <div class="pl-2.5 pb-3">
     <LeaderboardControls exploreName={$exploreName} />
   </div>
-  <div
-    bind:this={parentElement}
-    class="overflow-y-auto leaderboard-display"
-    on:scroll={() => {
-      suppressTooltip = true;
-    }}
-    on:scrollend={() => {
-      suppressTooltip = false;
-    }}
-  >
+  <div bind:this={parentElement} class="overflow-y-auto leaderboard-display">
     {#if parentElement}
       <div class="leaderboard-grid overflow-hidden pb-4">
         {#each $visibleDimensions as dimension (dimension.name)}
@@ -106,7 +96,6 @@
               {comparisonTimeRange}
               {dimension}
               {parentElement}
-              {suppressTooltip}
               {timeControlsReady}
               selectedValues={selectedDimensionValues(
                 $runtime.instanceId,

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -10,7 +10,6 @@
   import { slide } from "svelte/transition";
   import { type LeaderboardItemData, makeHref } from "./leaderboard-utils";
   import LeaderboardItemFilterIcon from "./LeaderboardItemFilterIcon.svelte";
-  import LeaderboardTooltipContent from "./LeaderboardTooltipContent.svelte";
   import LongBarZigZag from "./LongBarZigZag.svelte";
   import {
     COMPARISON_COLUMN_WIDTH,
@@ -18,7 +17,6 @@
     valueColumn,
     deltaColumn,
   } from "./leaderboard-widths";
-  import FloatingElement from "@rilldata/web-common/components/floating-element/FloatingElement.svelte";
 
   export let itemData: LeaderboardItemData;
   export let dimensionName: string;
@@ -30,7 +28,6 @@
   export let atLeastOneActive: boolean;
   export let isTimeComparisonActive: boolean;
   export let leaderboardMeasureNames: string[] = [];
-  export let suppressTooltip: boolean;
   export let leaderboardShowContextForAllMeasures: boolean;
   export let leaderboardSortByMeasureName: string | null;
   export let isValidPercentOfTotal: (measureName: string) => boolean;
@@ -53,7 +50,6 @@
     );
   }
 
-  let hovered = false;
   let valueRect = new DOMRect(0, 0, DEFAULT_COLUMN_WIDTH);
   let deltaRect = new DOMRect(0, 0, COMPARISON_COLUMN_WIDTH);
   let parent: HTMLTableRowElement;
@@ -123,7 +119,7 @@
 
   $: barColor = excluded
     ? "rgb(243 244 246)"
-    : selected || hovered
+    : selected
       ? "var(--color-primary-200)"
       : "var(--color-primary-100)";
 
@@ -152,8 +148,6 @@
           }),
         );
 
-  $: showTooltip = hovered && !suppressTooltip;
-
   function shiftClickHandler(label: string) {
     let truncatedLabel = label?.toString();
     if (truncatedLabel?.length > TOOLTIP_STRING_LIMIT) {
@@ -174,8 +168,6 @@
   style:background={leaderboardMeasureNames.length === 1
     ? dimensionGradients
     : undefined}
-  on:mouseenter={() => (hovered = true)}
-  on:mouseleave={() => (hovered = false)}
   on:click={(e) => {
     if (e.shiftKey) return;
     toggleDimensionValueSelection(
@@ -203,10 +195,13 @@
     })}
     class="relative size-full flex flex-none justify-between items-center leaderboard-label"
     style:background={dimensionGradients}
+    title={!selected && atLeastOneActive
+      ? `Exclusively select ${dimensionValue}`
+      : dimensionValue}
   >
     <FormattedDataType value={dimensionValue} truncate />
 
-    {#if previousValueString && hovered}
+    {#if previousValueString && selected}
       <span
         class="opacity-50 whitespace-nowrap font-normal"
         transition:slide={{ axis: "x", duration: 200 }}
@@ -215,7 +210,7 @@
       </span>
     {/if}
 
-    {#if hovered && href}
+    {#if selected && href}
       <a
         target="_blank"
         rel="noopener noreferrer"
@@ -317,26 +312,6 @@
     {/if}
   {/each}
 </tr>
-
-{#if showTooltip}
-  {#await new Promise((r) => setTimeout(r, 600)) then}
-    <FloatingElement
-      target={parent}
-      location="left"
-      alignment="middle"
-      distance={0}
-      pad={0}
-    >
-      <LeaderboardTooltipContent
-        {atLeastOneActive}
-        {excluded}
-        {filterExcludeMode}
-        label={dimensionValue}
-        {selected}
-      />
-    </FloatingElement>
-  {/await}
-{/if}
 
 <style lang="postcss">
   td {

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -91,6 +91,45 @@
   $: valueColumn.update(valueElementWith);
   $: deltaColumn.update(deltaElementWidth);
 
+  $: formattedPctOfTotalTitles = Object.fromEntries(
+    Object.entries(pctOfTotals).map(([name, value]) => [
+      name,
+      value !== null ? formatMeasurePercentageDifference(value) : null,
+    ]),
+  );
+
+  $: formattedPctOfTotalStrings = Object.fromEntries(
+    Object.entries(formattedPctOfTotalTitles).map(([name, parts]) => [
+      name,
+      parts
+        ? `${parts.neg || ""}${parts.int}${parts.dot}${parts.frac}${parts.suffix}%`
+        : null,
+    ]),
+  );
+
+  $: formattedDeltaAbsTitles = Object.fromEntries(
+    Object.entries(deltaAbsMap).map(([name, value]) => [
+      name,
+      value !== null ? formatters[name]?.(value)?.toString() : null,
+    ]),
+  );
+
+  $: formattedDeltaRelTitles = Object.fromEntries(
+    Object.entries(deltaRels).map(([name, value]) => [
+      name,
+      value !== null ? formatMeasurePercentageDifference(value) : null,
+    ]),
+  );
+
+  $: formattedDeltaRelStrings = Object.fromEntries(
+    Object.entries(formattedDeltaRelTitles).map(([name, parts]) => [
+      name,
+      parts
+        ? `${parts.neg || ""}${parts.int}${parts.dot}${parts.frac}${parts.suffix}%`
+        : null,
+    ]),
+  );
+
   $: barLengths = Object.fromEntries(
     Object.entries(pctOfTotals).map(([name, pct]) => [
       name,
@@ -229,6 +268,7 @@
       on:click={modified({
         shift: () => shiftClickHandler(values[measureName]?.toString() || ""),
       })}
+      title={values[measureName]?.toString()}
       style:background={leaderboardMeasureNames.length === 1
         ? measureGradients
         : measureGradientMap?.[measureName]}
@@ -250,10 +290,10 @@
     {#if isValidPercentOfTotal(measureName) && shouldShowContextColumns(measureName)}
       <td
         data-comparison-cell
-        title={pctOfTotals[measureName]?.toString() || ""}
+        title={formattedPctOfTotalStrings[measureName]}
         on:click={modified({
           shift: () =>
-            shiftClickHandler(pctOfTotals[measureName]?.toString() || ""),
+            shiftClickHandler(formattedPctOfTotalStrings[measureName] || ""),
         })}
       >
         <PercentageChange
@@ -269,10 +309,10 @@
     {#if isTimeComparisonActive && shouldShowContextColumns(measureName)}
       <td
         data-comparison-cell
-        title={deltaAbsMap[measureName]?.toString() || ""}
+        title={formattedDeltaAbsTitles[measureName]}
         on:click={modified({
           shift: () =>
-            shiftClickHandler(deltaAbsMap[measureName]?.toString() || ""),
+            shiftClickHandler(formattedDeltaAbsTitles[measureName] || ""),
         })}
       >
         <FormattedDataType
@@ -293,16 +333,14 @@
     {#if isTimeComparisonActive && shouldShowContextColumns(measureName)}
       <td
         data-comparison-cell
-        title={deltaRels[measureName]?.toString() || ""}
+        title={formattedDeltaRelStrings[measureName]}
         on:click={modified({
           shift: () =>
-            shiftClickHandler(deltaRels[measureName]?.toString() || ""),
+            shiftClickHandler(formattedDeltaRelStrings[measureName] || ""),
         })}
       >
         <PercentageChange
-          value={deltaRels[measureName]
-            ? formatMeasurePercentageDifference(deltaRels[measureName])
-            : null}
+          value={deltaRels[measureName]}
           color="text-gray-500"
         />
         {#if showZigZags[measureName]}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardTooltipContent.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardTooltipContent.svelte
@@ -10,17 +10,12 @@ see more button
 <script lang="ts">
   import MetaKey from "@rilldata/web-common/components/tooltip/MetaKey.svelte";
   import Shortcut from "@rilldata/web-common/components/tooltip/Shortcut.svelte";
-  import StackingWord from "@rilldata/web-common/components/tooltip/StackingWord.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import TooltipShortcutContainer from "@rilldata/web-common/components/tooltip/TooltipShortcutContainer.svelte";
   import TooltipTitle from "@rilldata/web-common/components/tooltip/TooltipTitle.svelte";
-  import { isClipboardApiSupported } from "../../../lib/actions/copy-to-clipboard";
 
   export let label: string | number;
   export let selected: boolean;
-  export let excluded: boolean;
-  // false = include, true = exclude
-  export let filterExcludeMode: boolean;
   export let atLeastOneActive;
 </script>
 
@@ -31,31 +26,6 @@ see more button
     </svelte:fragment>
   </TooltipTitle>
 
-  <TooltipShortcutContainer>
-    {#if atLeastOneActive}
-      <div>
-        {excluded ? "Include" : "Exclude"}
-        this dimension value
-      </div>
-    {:else}
-      <div class="text-ellipsis overflow-hidden whitespace-nowrap">
-        Filter {filterExcludeMode ? "out" : "on"}
-        this dimension value
-      </div>
-    {/if}
-    <Shortcut>Click</Shortcut>
-  </TooltipShortcutContainer>
-  {#if isClipboardApiSupported()}
-    <TooltipShortcutContainer>
-      <div>
-        <StackingWord key="shift">Copy</StackingWord>
-        value to clipboard
-      </div>
-      <Shortcut>
-        <span style="font-family: var(--system);">⇧</span> + Click on cell
-      </Shortcut>
-    </TooltipShortcutContainer>
-  {/if}
   {#if !selected && atLeastOneActive}
     <TooltipShortcutContainer>
       <div>Exclusively select this dimension value</div>


### PR DESCRIPTION
This pull request consolidates 2 tooltips appearing in the leaderboard to only one `title` tooltip. See demo.

https://github.com/user-attachments/assets/2fc6b33e-1615-468b-b80d-69be54859a48

https://github.com/user-attachments/assets/39060a2c-1963-47b1-a810-9c13d701bc7f



**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
