### PR TITLE
Move embed navigation to url params based navigation

### DIFF
--- a/web-admin/src/routes/-/embed/+page.svelte
+++ b/web-admin/src/routes/-/embed/+page.svelte
@@ -31,6 +31,12 @@
       name: resourceName,
       kind: resourceType,
     };
+  } else {
+    // Important! Do not set `activeResource` to `null` here.
+    // In `DashboardStateDataLoader` we are currently clearing the url of non-dashboard params since it will interfere with session storage extraction logic.
+    // So setting `activeResource` to `null` will make the navigation logic in this file to think there is no active resource everytime `DashboardStateDataLoader` cleaned the url.
+    // For going to home we manually set `activeResource` to `null` in `handleGoHome`.
+    // TODO: move to a route based approach to avoid this issues.
   }
 
   function handleSelectResource(event: CustomEvent<V1ResourceName>) {
@@ -43,7 +49,7 @@
     const newUrl = new URL($page.url);
     newUrl.search = "";
     void goto(newUrl);
-    // We need the null check while assigning activeResource a few lines above. So set activeResource to null explicitly here.
+    // To understand why we set `activeResource=null` here, see the comment above
     activeResource = null;
   }
 </script>

--- a/web-admin/src/routes/-/embed/+page.svelte
+++ b/web-admin/src/routes/-/embed/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { goto } from "$app/navigation";
   import { page } from "$app/stores";
   import ContentContainer from "@rilldata/web-admin/components/layout/ContentContainer.svelte";
   import DashboardsTable from "@rilldata/web-admin/features/dashboards/listing/DashboardsTable.svelte";
@@ -15,8 +16,8 @@
   featureFlags.set(false, "adminServer");
 
   const instanceId = $page.url.searchParams.get("instance_id");
-  const initialResourceName = $page.url.searchParams.get("resource");
-  const initialResourceType =
+  $: resourceName = $page.url.searchParams.get("resource");
+  $: resourceType =
     $page.url.searchParams.get("type") ?? $page.url.searchParams.get("kind"); // "kind" is for backwards compatibility
   const navigation = $page.url.searchParams.get("navigation");
   // Ignoring state and theme params for now
@@ -25,15 +26,17 @@
 
   // Manage active resource
   let activeResource: V1ResourceName | null = null;
-  if (initialResourceName && initialResourceType) {
+  $: if (resourceName && resourceType) {
     activeResource = {
-      name: initialResourceName,
-      kind: initialResourceType,
+      name: resourceName,
+      kind: resourceType,
     };
   }
 
   function handleSelectResource(event: CustomEvent<V1ResourceName>) {
-    activeResource = event.detail;
+    const newUrl = new URL($page.url);
+    newUrl.search = `resource=${event.detail.name}&type=${event.detail.kind}`;
+    void goto(newUrl);
   }
 
   function handleGoHome() {

--- a/web-admin/src/routes/-/embed/+page.svelte
+++ b/web-admin/src/routes/-/embed/+page.svelte
@@ -40,6 +40,10 @@
   }
 
   function handleGoHome() {
+    const newUrl = new URL($page.url);
+    newUrl.search = "";
+    void goto(newUrl);
+    // We need the null check while assigning activeResource a few lines above. So set activeResource to null explicitly here.
     activeResource = null;
   }
 </script>

--- a/web-admin/tests/embeds.spec.ts
+++ b/web-admin/tests/embeds.spec.ts
@@ -89,4 +89,51 @@ test.describe("Embeds", () => {
       logMessages.some((msg) => msg.includes(`{"id":1337,"result":true}`)),
     ).toBeTruthy();
   });
+
+  test("navigation works as expected", async ({ embedPage }) => {
+    const logMessages: string[] = [];
+    await waitForReadyMessage(embedPage, logMessages);
+    const frame = embedPage.frameLocator("iframe");
+
+    // Select "Last 6 Hours" as time range
+    // Open the menu
+    // (Note we cannot use the `interactWithTimeRangeMenu` helper here since its interface is to check the full page)
+    await frame.getByLabel("Select time range").click();
+    await frame.getByRole("menuitem", { name: "Last 14 Days" }).click();
+    // Wait for menu to close
+    await expect(
+      frame.getByRole("menu", { name: "Select time range" }),
+    ).not.toBeVisible();
+
+    // Go to the ` Programmatic Ads Auction ` dashboard using the breadcrumbs
+    await frame.getByLabel("Breadcrumb dropdown").click();
+    await frame
+      .getByRole("menuitem", { name: "Programmatic Ads Auction", exact: true })
+      .click();
+    // Time range is still the default
+    await expect(frame.getByText("Last 7 Days")).toBeVisible();
+
+    // Go back to the ` Programmatic Ads Bids ` dashboard using the breadcrumbs
+    await frame.getByLabel("Breadcrumb dropdown").click();
+    await frame
+      .getByRole("menuitem", { name: "Programmatic Ads Bids" })
+      .click();
+    // Old selection has persisted
+    await expect(frame.getByText("Last 14 Days")).toBeVisible();
+
+    // Go to `Home` using the breadcrumbs
+    await frame.getByText("Home").click();
+    // Check that the dashboards are listed
+    await expect(
+      frame.getByRole("button", { name: "Programmatic Ads Auction" }).first(),
+    ).toBeVisible();
+    await expect(
+      frame.getByRole("button", { name: "Programmatic Ads Bids" }),
+    ).toBeVisible();
+
+    // Go to `Programmatic Ads Auction` using the links on home
+    await frame.getByRole("button", { name: "Programmatic Ads Bids" }).click();
+    // Old selection has persisted
+    await expect(frame.getByText("Last 14 Days")).toBeVisible();
+  });
 });

--- a/web-common/src/components/navigation/breadcrumbs/BreadcrumbItem.svelte
+++ b/web-common/src/components/navigation/breadcrumbs/BreadcrumbItem.svelte
@@ -64,7 +64,12 @@
     {#if options.size > 1}
       <DropdownMenu.Root>
         <DropdownMenu.Trigger asChild let:builder>
-          <button use:builder.action {...builder} class="trigger">
+          <button
+            use:builder.action
+            {...builder}
+            class="trigger"
+            aria-label="Breadcrumb dropdown"
+          >
             <CaretDownIcon size="14px" />
           </button>
         </DropdownMenu.Trigger>


### PR DESCRIPTION
Url params sync assumes that the current url params are for the dashboard. For embed since we do not actually navigate the url params from previous dashboard will be loaded into the new navigated dashboard.

Adding basic url based navigation for embed. This cleans the url and retains just the resource and type.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
