### PR TITLE
Fix for no child processes error when closing rill

### DIFF
--- a/runtime/drivers/clickhouse/embed.go
+++ b/runtime/drivers/clickhouse/embed.go
@@ -104,10 +104,6 @@ func (e *embedClickHouse) start() (*clickhouse.Options, error) {
 			_ = e.cmd.Process.Kill()
 			return
 		}
-
-		if err := e.cmd.Wait(); err != nil {
-			e.logger.Error("clickhouse server exited with an error", zap.Error(err))
-		}
 	}()
 
 	if err := <-ready; err != nil {
@@ -154,6 +150,7 @@ func (e *embedClickHouse) stop() error {
 	if err != nil {
 		return err
 	}
+	_ = e.cmd.Wait()
 	e.opts = nil
 	e.cmd = nil
 	return nil


### PR DESCRIPTION
Not need to wait in start(as already we wait until it start) and also we are already waiting in stop. Calling wait 2 times causing this error.
Closes [#1621](https://github.com/rilldata/rill-private-issues/issues/1621)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
