### PR TITLE
fix: home button when home bookmark is not present not applying yaml config.

### DIFF
--- a/web-admin/src/features/bookmarks/Bookmarks.svelte
+++ b/web-admin/src/features/bookmarks/Bookmarks.svelte
@@ -26,6 +26,7 @@
   import { useMetricsViewTimeRange } from "@rilldata/web-common/features/dashboards/selectors";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { useExploreState } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
+  import { createYAMLConfigExploreUrlSearch } from "@rilldata/web-common/features/dashboards/stores/get-explore-state-from-yaml-config";
   import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
   import { useExploreValidSpec } from "@rilldata/web-common/features/explores/selectors";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
@@ -62,6 +63,11 @@
   $: schemaResp = createQueryServiceMetricsViewSchema(
     instanceId,
     metricsViewName,
+  );
+
+  $: exploreUrlParamsFromYAMLConfig = createYAMLConfigExploreUrlSearch(
+    validExploreSpec,
+    metricsViewTimeRange,
   );
 
   $: categorizedBookmarks = categorizeBookmarks(
@@ -126,6 +132,7 @@
   {project}
   {exploreName}
   homeBookmark={categorizedBookmarks.home}
+  defaultExploreUrl={$exploreUrlParamsFromYAMLConfig ?? ""}
   onCreate={createHomeBookmark}
   onDelete={deleteBookmark}
   {manageProject}

--- a/web-admin/src/features/bookmarks/HomeBookmarkButton.svelte
+++ b/web-admin/src/features/bookmarks/HomeBookmarkButton.svelte
@@ -19,13 +19,12 @@
   export let project: string;
   export let exploreName: string;
   export let homeBookmark: BookmarkEntry | undefined;
+  export let defaultExploreUrl: string;
   export let manageProject: boolean;
   export let onCreate: () => void;
   export let onDelete: (bookmark: BookmarkEntry) => Promise<void>;
 
-  $: homeBookmarkUrl =
-    homeBookmark?.url ??
-    `${$page.url.protocol}//${$page.url.host}${$page.url.pathname}`;
+  $: homeBookmarkUrl = homeBookmark?.url ?? defaultExploreUrl;
   $: isHomeBookmarkActive = homeBookmarkUrl === $page.url.toString();
 
   function goToDashboardHome() {

--- a/web-common/src/features/dashboards/stores/get-explore-state-from-yaml-config.ts
+++ b/web-common/src/features/dashboards/stores/get-explore-state-from-yaml-config.ts
@@ -1,9 +1,12 @@
 import { SortDirection } from "@rilldata/web-common/features/dashboards/proto-state/derived-types";
 import { getGrainForRange } from "@rilldata/web-common/features/dashboards/stores/get-rill-default-explore-state";
 import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
+import { getTimeControlState } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import { getValidComparisonOption } from "@rilldata/web-common/features/dashboards/time-controls/time-range-store";
+import { convertPartialExploreStateToUrlParams } from "@rilldata/web-common/features/dashboards/url-state/convert-partial-explore-state-to-url-params";
 import { ToLegacySortTypeMap } from "@rilldata/web-common/features/dashboards/url-state/legacyMappers";
 import { FromURLParamTimeGrainMap } from "@rilldata/web-common/features/dashboards/url-state/mappers";
+import { useExploreValidSpec } from "@rilldata/web-common/features/explores/selectors";
 import { arrayUnorderedEquals } from "@rilldata/web-common/lib/arrayUtils";
 import { ISODurationToTimePreset } from "@rilldata/web-common/lib/time/ranges";
 import { isoDurationToFullTimeRange } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
@@ -15,8 +18,11 @@ import { DashboardState_ActivePage } from "@rilldata/web-common/proto/gen/rill/u
 import {
   V1ExploreComparisonMode,
   type V1ExploreSpec,
+  type V1MetricsViewTimeRangeResponse,
   type V1TimeRangeSummary,
 } from "@rilldata/web-common/runtime-client";
+import type { CreateQueryResult } from "@tanstack/svelte-query";
+import { derived } from "svelte/store";
 
 export function getExploreStateFromYAMLConfig(
   exploreSpec: V1ExploreSpec,
@@ -29,6 +35,39 @@ export function getExploreStateFromYAMLConfig(
     ...getExploreTimeStateFromYAMLConfig(exploreSpec, timeRangeSummary),
     ...getExploreViewStateFromYAMLConfig(exploreSpec),
   };
+}
+
+export function createYAMLConfigExploreUrlSearch(
+  validSpecQuery: ReturnType<typeof useExploreValidSpec>,
+  fullTimeRangeQuery: CreateQueryResult<V1MetricsViewTimeRangeResponse>,
+) {
+  return derived(
+    [validSpecQuery, fullTimeRangeQuery],
+    ([validSpec, fullTimeRange]) => {
+      const metricsViewSpec = validSpec.data?.metricsView ?? {};
+      const exploreSpec = validSpec.data?.explore ?? {};
+      const timeRangeSummary = fullTimeRange.data?.timeRangeSummary;
+
+      const exploreStateFromYAMLConfig = getExploreStateFromYAMLConfig(
+        exploreSpec,
+        timeRangeSummary,
+      );
+
+      const timeControlState = getTimeControlState(
+        metricsViewSpec,
+        exploreSpec,
+        timeRangeSummary,
+        exploreStateFromYAMLConfig as ExploreState,
+      );
+
+      const urlParams = convertPartialExploreStateToUrlParams(
+        exploreSpec,
+        exploreStateFromYAMLConfig,
+        timeControlState,
+      );
+      return `?${urlParams.toString()}`;
+    },
+  );
 }
 
 function getExploreTimeStateFromYAMLConfig(

--- a/web-common/src/features/dashboards/time-controls/time-control-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.ts
@@ -137,7 +137,7 @@ export function getTimeControlState(
   metricsViewSpec: V1MetricsViewSpec,
   exploreSpec: V1ExploreSpec,
   timeRangeSummary: V1TimeRangeSummary | undefined,
-  exploreState: ExploreState,
+  exploreState: Partial<ExploreState>,
 ) {
   const hasTimeSeries = Boolean(metricsViewSpec.timeDimension);
   const timeDimension = metricsViewSpec.timeDimension;
@@ -185,7 +185,7 @@ export function getTimeControlState(
     selectedComparisonTimeRange,
     selectedTimezone,
     lastDefinedScrubRange,
-    showTimeComparison,
+    !!showTimeComparison,
     timeRangeState,
   );
 
@@ -250,7 +250,7 @@ export function calculateTimeRangePartial(
   allTimeRange: DashboardTimeControls,
   currentSelectedTimeRange: DashboardTimeControls | undefined,
   lastDefinedScrubRange: ScrubRange | undefined,
-  selectedTimezone: string,
+  selectedTimezone: string | undefined,
   defaultTimeRange: DashboardTimeControls,
   minTimeGrain: V1TimeGrain,
 ): TimeRangeState | undefined {
@@ -304,7 +304,7 @@ export function calculateComparisonTimeRangePartial(
   timeRanges: V1ExploreTimeRange[] | undefined,
   allTimeRange: DashboardTimeControls,
   currentComparisonTimeRange: DashboardTimeControls | undefined,
-  selectedTimezone: string,
+  selectedTimezone: string | undefined,
   lastDefinedScrubRange: ScrubRange | undefined,
   showTimeComparison: boolean,
   timeRangeState: TimeRangeState,
@@ -365,7 +365,7 @@ export function calculateComparisonTimeRangePartial(
 
 export function getTimeRange(
   selectedTimeRange: DashboardTimeControls | undefined,
-  selectedTimezone: string,
+  selectedTimezone: string | undefined,
   allTimeRange: DashboardTimeControls,
   defaultTimeRange: DashboardTimeControls,
 ) {

--- a/web-common/src/lib/time/ranges/index.ts
+++ b/web-common/src/lib/time/ranges/index.ts
@@ -140,7 +140,7 @@ export function convertTimeRangePreset(
   timeRangePreset: TimeRangePreset | TimeComparisonOption,
   start: Date,
   end: Date,
-  zone: string,
+  zone: string | undefined,
 ): TimeRange {
   if (timeRangePreset === TimeRangePreset.ALL_TIME) {
     return {
@@ -330,7 +330,7 @@ export const prettyFormatTimeRange = (
 export function getAdjustedFetchTime(
   startTime: Date,
   endTime: Date,
-  zone: string,
+  zone: string | undefined,
   interval: V1TimeGrain | undefined,
 ) {
   if (!startTime || !endTime || !interval)

--- a/web-common/src/lib/time/transforms/index.ts
+++ b/web-common/src/lib/time/transforms/index.ts
@@ -106,7 +106,7 @@ export function relativePointInTimeToAbsolute(
   referenceTime: Date,
   start: string | RelativePointInTime,
   end: string | RelativePointInTime,
-  zone: string,
+  zone: string | undefined,
 ) {
   let startDate: Date;
   let endDate: Date;


### PR DESCRIPTION
We use an url with empty params for home button when home bookmark is not present. Since params for yaml config are explicitly added this means we do not apply any settings.

Updating the home button to add url params from yaml config.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
