### PR TITLE
fix (Model inspector): Show inspector even when some model partitions have errors

### DIFF
--- a/web-common/src/features/models/inspector/WorkspaceInspector.svelte
+++ b/web-common/src/features/models/inspector/WorkspaceInspector.svelte
@@ -165,7 +165,7 @@
 
   $: columnDelta = profileColumnsCount - $sourceColumns;
   $: isIncremental = model?.spec?.incremental;
-  $: isPartition = !!model?.state?.partitionsModelId;
+  $: isPartitioned = !!model?.state?.partitionsModelId;
 </script>
 
 <Inspector {filePath}>
@@ -178,8 +178,6 @@
       <div class="size-full flex items-center justify-center">
         <ReconcilingSpinner />
       </div>
-    {:else if hasErrors}
-      <SimpleMessage message="Fix the errors in the file to continue." />
     {:else if !!resource && !!connector && !!tableName}
       <InspectorHeaderGrid>
         <svelte:fragment slot="top-left">
@@ -288,7 +286,7 @@
       </div>
 
       {#if model}
-        {#if isPartition}
+        {#if isPartitioned}
           <hr />
           <PartitionsBrowser {resource} />
         {:else if isIncremental}
@@ -296,6 +294,8 @@
           <IncrementalProcessing {resource} />
         {/if}
       {/if}
+    {:else if hasErrors}
+      <SimpleMessage message="Fix the errors in the file to continue." />
     {/if}
   </div>
 </Inspector>


### PR DESCRIPTION
Addresses [this bug report from Slack](https://rilldata.slack.com/archives/C02T907FEUB/p1747683960103729)

Before:
<img width="1370" alt="image" src="https://github.com/user-attachments/assets/61f455a1-e45c-4519-ae45-903fe3641b21" />

After:
<img width="1369" alt="image" src="https://github.com/user-attachments/assets/75ded865-8961-45fd-9325-4fa9005766cc" />


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
