### PR TITLE
chore: Remove unused CSS to fix Vite build warning

### DIFF
--- a/web-common/src/features/exports/ExportMenu.svelte
+++ b/web-common/src/features/exports/ExportMenu.svelte
@@ -127,13 +127,3 @@
     }}
   />
 {/if}
-
-<style lang="postcss">
-  button {
-    @apply h-6 px-1.5 py-px flex items-center gap-[3px] rounded-sm text-slate-600 pointer-events-auto;
-  }
-
-  button:hover {
-    @apply bg-gray-200;
-  }
-</style>


### PR DESCRIPTION
Fixes this warning:
<img width="1310" alt="image" src="https://github.com/user-attachments/assets/a85e9c24-97fe-4d19-b65c-a9f1011292d5" />