### PR TITLE
fix: locally scope dimension for heatmap queries

### DIFF
--- a/web-common/src/features/canvas/components/charts/heatmap-charts/HeatmapChart.ts
+++ b/web-common/src/features/canvas/components/charts/heatmap-charts/HeatmapChart.ts
@@ -81,7 +81,6 @@ export class HeatmapChartComponent extends BaseChart<HeatmapChartSpec> {
     const config = get(this.specStore);
 
     let measures: V1MetricsViewAggregationMeasure[] = [];
-    let dimensions: V1MetricsViewAggregationDimension[] = [];
 
     if (config.color?.field) {
       measures = [{ name: config.color.field }];
@@ -201,7 +200,7 @@ export class HeatmapChartComponent extends BaseChart<HeatmapChartSpec> {
           combinedWhere = mergeFilters(combinedWhere, yFilterForTopValues);
         }
 
-        dimensions = [
+        let dimensions: V1MetricsViewAggregationDimension[] = [
           ...(config.x?.field ? [{ name: config.x.field }] : []),
           ...(config.y?.field ? [{ name: config.y.field }] : []),
         ];


### PR DESCRIPTION
https://linear.app/rilldata/issue/APP-84/heatmap-chart-failing-when-an-unnested-dimension-is-used-on-the-x-axis

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
