### PR TITLE
fix: use en locale for time pill

### DIFF
--- a/web-common/src/features/dashboards/time-controls/super-pill/components/Timestamp.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/Timestamp.svelte
@@ -23,6 +23,7 @@
         .filter(([, value]) => value !== 0)
         .slice(0, 2),
     ),
+    { locale: "en" },
   ).toHuman({
     listStyle: "narrow",
     maximumFractionDigits: 0,

--- a/web-common/src/lib/time/ranges/iso-ranges.ts
+++ b/web-common/src/lib/time/ranges/iso-ranges.ts
@@ -82,7 +82,7 @@ export function humaniseISODuration(
   toUpper = true,
 ): string {
   if (!isoDuration) return "";
-  const duration = Duration.fromISO(isoDuration);
+  const duration = Duration.fromISO(isoDuration, { locale: 'en' });
   let humanISO = duration.toHuman({
     listStyle: "long",
   });
@@ -145,7 +145,7 @@ export function validateISODuration(isoDuration: string) {
 function getStartTimeTransformations(
   isoDuration: string,
 ): Array<RelativeTimeTransformation> {
-  const duration = Duration.fromISO(isoDuration);
+  const duration = Duration.fromISO(isoDuration, { locale: 'en' });
   const period = getSmallestUnit(duration);
   if (!period) return [];
 


### PR DESCRIPTION
Fixes time range selector and time metadata to en locale

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
