### PR TITLE
fix : allow empty commits while creating rill managed repo first time

### DIFF
--- a/cli/cmd/project/connect_github.go
+++ b/cli/cmd/project/connect_github.go
@@ -405,7 +405,7 @@ func createGithubRepoFlow(ctx context.Context, ch *cmdutil.Helper, localGitPath 
 	} else {
 		branch = "main"
 	}
-	err = gitutil.CommitAndForcePush(ctx, localGitPath, *githubRepository.CloneURL, "x-access-token", pollRes.AccessToken, branch, author)
+	err = gitutil.CommitAndForcePush(ctx, localGitPath, *githubRepository.CloneURL, "x-access-token", pollRes.AccessToken, branch, author, true)
 	if err != nil {
 		return fmt.Errorf("failed to push local project to Github: %w", err)
 	}

--- a/cli/pkg/cmdutil/githelper.go
+++ b/cli/pkg/cmdutil/githelper.go
@@ -91,7 +91,7 @@ func (g *GitHelper) PushToNewManagedRepo(ctx context.Context) (*adminv1.CreateMa
 	if err != nil {
 		return nil, err
 	}
-	err = gitutil.CommitAndForcePush(ctx, g.localPath, gitRepo.Remote, gitRepo.Username, gitRepo.Password, gitRepo.DefaultBranch, author)
+	err = gitutil.CommitAndForcePush(ctx, g.localPath, gitRepo.Remote, gitRepo.Username, gitRepo.Password, gitRepo.DefaultBranch, author, true)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (g *GitHelper) PushToManagedRepo(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	err = gitutil.CommitAndForcePush(ctx, g.localPath, gitConfig.Remote, gitConfig.Username, gitConfig.Password, gitConfig.DefaultBranch, author)
+	err = gitutil.CommitAndForcePush(ctx, g.localPath, gitConfig.Remote, gitConfig.Username, gitConfig.Password, gitConfig.DefaultBranch, author, false)
 	if err != nil {
 		return err
 	}

--- a/cli/pkg/gitutil/gitutil.go
+++ b/cli/pkg/gitutil/gitutil.go
@@ -241,7 +241,7 @@ func GetSyncStatus(repoPath, branch, remote string) (SyncStatus, error) {
 	return SyncStatusSynced, nil
 }
 
-func CommitAndForcePush(ctx context.Context, projectPath, remote, username, password, branch string, author *object.Signature) error {
+func CommitAndForcePush(ctx context.Context, projectPath, remote, username, password, branch string, author *object.Signature, allowEmptyCommits bool) error {
 	// init git repo
 	repo, err := git.PlainInitWithOptions(projectPath, &git.PlainInitOptions{
 		InitOptions: git.InitOptions{
@@ -270,7 +270,7 @@ func CommitAndForcePush(ctx context.Context, projectPath, remote, username, pass
 	}
 
 	// git commit -m
-	_, err = wt.Commit("Auto committed by Rill", &git.CommitOptions{All: true, Author: author})
+	_, err = wt.Commit("Auto committed by Rill", &git.CommitOptions{All: true, Author: author, AllowEmptyCommits: allowEmptyCommits})
 	if err != nil {
 		if !errors.Is(err, git.ErrEmptyCommit) {
 			return fmt.Errorf("failed to commit files to git: %w", err)


### PR DESCRIPTION
**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
