### PR TITLE
fix: alerts and reports not honouring execution time when "Opened in browser"

### DIFF
--- a/web-admin/src/features/dashboards/query-mappers/utils.ts
+++ b/web-admin/src/features/dashboards/query-mappers/utils.ts
@@ -1,5 +1,5 @@
-import { createInExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
 import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
+import { createInExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
 import { getTimeControlState } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 import { PreviousCompleteRangeMap } from "@rilldata/web-common/features/dashboards/time-controls/time-range-mappers";
 import { convertPartialExploreStateToUrlParams } from "@rilldata/web-common/features/dashboards/url-state/convert-partial-explore-state-to-url-params";
@@ -115,6 +115,11 @@ export function getSelectedTimeRange(
       new Date(timeRangeSummary.min),
       new Date(executionTime),
     );
+    // Convert the range to a custom one with resolved start and end.
+    // This retains the resolved range with `executionTime` incorporated into the range.
+    // TODO: Once we have rill-time do `<syntax> as of <executionTime>` as time range.
+    //       Note we need to have the new drop down out of feature flag as well.
+    selectedTimeRange.name = TimeRangePreset.CUSTOM;
   } else {
     return undefined;
   }


### PR DESCRIPTION
When alert/report is opened in browser, execution time is not persisted in the url state. So the dashboard has the latest data instead of when the alert/report was triggered.

We do not have the support for `<time_range> as of <timestamp>` support just yet. So until that support is merged and out of feature flag we need to convert the range to custom time range.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
