### PR TITLE
feat (MCP): Add comparison query example to `query_metrics_view` tool context

### DIFF
--- a/runtime/server/mcp.go
+++ b/runtime/server/mcp.go
@@ -277,6 +277,27 @@ Example: Get the total revenue by country and month for 2024:
             {"name": "total_revenue", "desc": true},
         ],
     }
+
+Example: Get the top 10 demographic segments (by country, gender, and age group) with the largest absolute revenue difference comparing May 2025 (base period) to April 2025 (comparison period):
+		{
+			"metrics_view": "ecommerce_financials",
+			"measures": [
+				{"name": "total_revenue"},
+				{"name": "total_revenue__delta_abs", "compute": {"comparison_delta": {"measure": "total_revenue"}}},
+				{"name": "total_revenue__delta_rel", "compute": {"comparison_ratio": {"measure": "total_revenue"}}},
+			],
+			"dimensions": [{"name": "country"}, {"name": "gender"}, {"name": "age_group"}],
+			"time_range": {
+				"start": "2025-05-01T00:00:00Z",
+				"end": "2025-05-31T23:59:59Z"
+			},
+			"comparison_time_range": {
+				"start": "2025-04-01T00:00:00Z",
+				"end": "2025-04-30T23:59:59Z"
+			},
+			"sort": [{"name": "total_revenue__delta_abs", "desc": true}],
+			"limit": 10
+		}
 `
 
 	tool := mcp.NewToolWithRawSchema("query_metrics_view", description, json.RawMessage(metricsview.QueryJSONSchema))


### PR DESCRIPTION
This PR adds an example comparison query to the `query_metrics_view` tool description. This helps the LLM delegate comparison analysis to Rill instead of calculating the delta itself.

Test query used:
> "Comparing May 18th and May 19th, what was the device state, ad position, and publisher combo with the biggest drop in requests?"

Before this, Claude issued two queries and computed the delta with its own Javascript tool. Now, Claude runs a single comparison query and uses the result directly.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
