### PR TITLE
fix: dashboard settings persisting across page loads in embed

### DIFF
--- a/web-admin/src/features/embeds/ExploreEmbed.svelte
+++ b/web-admin/src/features/embeds/ExploreEmbed.svelte
@@ -1,3 +1,7 @@
+<script context="module">
+  export let EmbedStorageNamespacePrefix = "__rill_embed";
+</script>
+
 <script lang="ts">
   import { Dashboard } from "@rilldata/web-common/features/dashboards";
   import DashboardThemeProvider from "@rilldata/web-common/features/dashboards/DashboardThemeProvider.svelte";
@@ -38,7 +42,11 @@
   {:else if data}
     {#key exploreName}
       <StateManagersProvider {exploreName} {metricsViewName}>
-        <DashboardStateManager {exploreName}>
+        <DashboardStateManager
+          {exploreName}
+          storageNamespacePrefix={EmbedStorageNamespacePrefix}
+          disableMostRecentDashboardState
+        >
           <DashboardThemeProvider>
             <Dashboard {exploreName} {metricsViewName} isEmbedded />
           </DashboardThemeProvider>

--- a/web-common/src/features/dashboards/state-managers/loaders/DashboardStateDataLoader.ts
+++ b/web-common/src/features/dashboards/state-managers/loaders/DashboardStateDataLoader.ts
@@ -58,7 +58,10 @@ export class DashboardStateDataLoader {
     instanceId: string,
     private readonly exploreName: string,
     private readonly storageNamespacePrefix: string | undefined,
-    private readonly bookmarkOrTokenExploreState?: CompoundQueryResult<Partial<ExploreState> | null>,
+    private readonly bookmarkOrTokenExploreState:
+      | CompoundQueryResult<Partial<ExploreState> | null>
+      | undefined,
+    public readonly disableMostRecentDashboardState: boolean,
   ) {
     this.validSpecQuery = useExploreValidSpec(instanceId, exploreName);
     this.fullTimeRangeQuery = this.useFullTimeRangeQuery(
@@ -334,7 +337,9 @@ export class DashboardStateDataLoader {
       exploreStateFromSessionStorage ??
         (urlSearchParams.size > 0 ? partialExploreStateFromUrl : null),
       // Next priority is the most recent state user had visited. This is a small subset of the full state.
-      shouldSkipOtherSources ? null : mostRecentPartialExploreState,
+      shouldSkipOtherSources || this.disableMostRecentDashboardState
+        ? null
+        : mostRecentPartialExploreState,
       // Next priority is one of the other source defined.
       // For cloud dashboard it would be home bookmark if present.
       // For shared url it would be the saved state in token

--- a/web-common/src/features/dashboards/state-managers/loaders/DashboardStateManager.svelte
+++ b/web-common/src/features/dashboards/state-managers/loaders/DashboardStateManager.svelte
@@ -17,6 +17,7 @@
   export let bookmarkOrTokenExploreState:
     | CompoundQueryResult<Partial<ExploreState> | null>
     | undefined = undefined;
+  export let disableMostRecentDashboardState: boolean = false;
 
   $: ({ instanceId } = $runtime);
   $: exploreSpecQuery = useExploreValidSpec(instanceId, exploreName);
@@ -29,6 +30,7 @@
     exploreName,
     storageNamespacePrefix,
     bookmarkOrTokenExploreState,
+    disableMostRecentDashboardState,
   );
 
   let stateSync: DashboardStateSync | undefined;

--- a/web-common/src/features/dashboards/state-managers/loaders/DashboardStateSync.ts
+++ b/web-common/src/features/dashboards/state-managers/loaders/DashboardStateSync.ts
@@ -122,12 +122,14 @@ export class DashboardStateSync {
       exploreSpec,
       timeControlsState,
     );
-    // Update "most recent explore state" with the initial state
-    saveMostRecentPartialExploreState(
-      this.exploreName,
-      this.extraPrefix,
-      initExploreState,
-    );
+    if (!this.dataLoader.disableMostRecentDashboardState) {
+      // Update "most recent explore state" with the initial state
+      saveMostRecentPartialExploreState(
+        this.exploreName,
+        this.extraPrefix,
+        initExploreState,
+      );
+    }
 
     // If the current url same as the new url then there is no need to do anything
     if (redirectUrl.search === pageState.url.search) {
@@ -208,12 +210,14 @@ export class DashboardStateSync {
       exploreSpec,
       timeControlsState,
     );
-    // Update "most recent explore state" with updated state from url
-    saveMostRecentPartialExploreState(
-      this.exploreName,
-      this.extraPrefix,
-      updatedExploreState,
-    );
+    if (!this.dataLoader.disableMostRecentDashboardState) {
+      // Update "most recent explore state" with updated state from url
+      saveMostRecentPartialExploreState(
+        this.exploreName,
+        this.extraPrefix,
+        updatedExploreState,
+      );
+    }
 
     this.updating = false;
     // If the url doesn't need to be changed further then we can skip the goto
@@ -271,13 +275,15 @@ export class DashboardStateSync {
       exploreSpec,
       timeControlsState,
     );
-    // Update "most recent explore state" with updated state.
-    // Since we do not update the state per action we do it here as blanket update.
-    saveMostRecentPartialExploreState(
-      this.exploreName,
-      this.extraPrefix,
-      exploreState,
-    );
+    if (!this.dataLoader.disableMostRecentDashboardState) {
+      // Update "most recent explore state" with updated state.
+      // Since we do not update the state per action we do it here as blanket update.
+      saveMostRecentPartialExploreState(
+        this.exploreName,
+        this.extraPrefix,
+        exploreState,
+      );
+    }
 
     this.updating = false;
     // If the state didnt result in a new url then skip goto.


### PR DESCRIPTION
Dashboard settings in embed should not persist across page loads, including navigating to and from the embedded iframe in the same tab.

1. Disable local storage all together in embedded context.
2. Clear session storage when navigated to a dashboard for the 1st time.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
