### PR TITLE
[ENG-769] Do not parse string with leading zeros as Number in Cell Inspector

### DIFF
--- a/web-common/src/components/CellInspector.svelte
+++ b/web-common/src/components/CellInspector.svelte
@@ -7,7 +7,7 @@
   import { cubicOut } from "svelte/easing";
   import Kbd from "./Kbd.svelte";
 
-  export let value: any = "";
+  export let value: any = null;
   export let isOpen: boolean = false;
 
   let hovered = false;
@@ -78,20 +78,26 @@
     unsubscribe();
   });
 
-  // TODO: Consider using a dedicated JSON pretty printing package like:
-  // - json-stringify-pretty-compact: For compact but readable JSON output
-  // - pretty-format: For more customizable formatting options
-  function formatValue(value: string): string {
+  function formatValue(value: any): string {
+    if (value === null || value === undefined) {
+      return "";
+    }
+
     // If the value is JSON, pretty print it
     if (isJson && parsedJson !== null) {
       return JSON.stringify(parsedJson, null, 2);
     }
+
+    // Convert to string first to handle all types
+    const stringValue = String(value);
+
     // If not JSON, check if it's a number
-    const num = Number(value);
-    if (!isNaN(num)) {
+    const num = Number(stringValue);
+    if (!isNaN(num) && stringValue.trim() !== "") {
       return formatInteger(num);
     }
-    return value;
+
+    return stringValue;
   }
 
   // Only update the value on hover, but don't open the inspector
@@ -143,10 +149,16 @@
         class:items-start={isJson}
         class:items-center={!isJson}
       >
-        <span
-          class="whitespace-pre-wrap break-words text-sm text-gray-800 dark:text-gray-200 flex-1"
-          class:font-mono={isJson}>{formatValue(value)}</span
-        >
+        {#if value === null}
+          <span class="text-sm text-gray-500 dark:text-gray-400 italic"
+            >No value</span
+          >
+        {:else}
+          <span
+            class="whitespace-pre-wrap break-words text-sm text-gray-800 dark:text-gray-200 flex-1"
+            class:font-mono={isJson}>{formatValue(value)}</span
+          >
+        {/if}
       </div>
       <div
         class="flex justify-between p-2 border-t border-gray-200 gap-1 text-[11px] text-gray-500"

--- a/web-common/src/components/CellInspector.svelte
+++ b/web-common/src/components/CellInspector.svelte
@@ -88,16 +88,13 @@
       return JSON.stringify(parsedJson, null, 2);
     }
 
-    // Convert to string first to handle all types
-    const stringValue = String(value);
-
-    // If not JSON, check if it's a number
-    const num = Number(stringValue);
-    if (!isNaN(num) && stringValue.trim() !== "") {
-      return formatInteger(num);
+    // Only format as number if the value is actually a number type
+    if (typeof value === "number") {
+      return formatInteger(value);
     }
 
-    return stringValue;
+    // For all other types, return as string
+    return String(value);
   }
 
   // Only update the value on hover, but don't open the inspector

--- a/web-common/src/components/CellInspector.svelte
+++ b/web-common/src/components/CellInspector.svelte
@@ -78,7 +78,8 @@
     unsubscribe();
   });
 
-  function formatValue(value: any): string {
+  export function formatValue(value: any): string {
+    // If the value is null or undefined, return an empty string
     if (value === null || value === undefined) {
       return "";
     }
@@ -88,12 +89,21 @@
       return JSON.stringify(parsedJson, null, 2);
     }
 
-    // Only format as number if the value is actually a number type
+    // Handle both number type and string numbers
     if (typeof value === "number") {
       return formatInteger(value);
     }
 
-    // For all other types, return as string
+    // For strings, check if it's a valid number without leading zeros
+    if (typeof value === "string") {
+      const num = Number(value);
+      // Only format if it's a valid number and doesn't have leading zeros
+      if (!isNaN(num) && value.trim() === String(num)) {
+        return formatInteger(num);
+      }
+    }
+
+    // For all other cases, return as string
     return String(value);
   }
 


### PR DESCRIPTION
This pull request provides a better default state handling and improves the parsing of values with leading zeros.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
