### PR TITLE
ENG-555: feat: add axis range selector for charts

### DIFF
--- a/web-common/src/components/forms/Input.svelte
+++ b/web-common/src/components/forms/Input.svelte
@@ -174,13 +174,13 @@
           name={id}
           class={size}
           {disabled}
-          value={value ?? (inputType === "number" ? 0 : "")}
+          value={value ?? (inputType === "number" ? null : "")}
           autocomplete={autocomplete ? "on" : "off"}
           bind:this={inputElement}
           on:input={(e) => {
             if (inputType === "number") {
               if (e.currentTarget.value === "") {
-                value = "";
+                value = undefined;
               } else {
                 value = e.currentTarget.valueAsNumber;
               }

--- a/web-common/src/features/canvas/components/charts/builder.ts
+++ b/web-common/src/features/canvas/components/charts/builder.ts
@@ -41,7 +41,7 @@ export function createSingleLayerBaseSpec(
   return {
     $schema: "https://vega.github.io/schema/vega-lite/v5.json",
     description: `A ${mark} chart with embedded data.`,
-    mark,
+    mark: { type: mark, clip: true },
     width: "container",
     data: { name: "metrics-view" },
     autosize: { type: "fit" },
@@ -60,12 +60,13 @@ export function createPositionEncoding(
     type: field.type,
     ...(metaData && "timeUnit" in metaData && { timeUnit: metaData.timeUnit }),
     ...(field.sort && field.type !== "temporal" && { sort: field.sort }),
-    ...(field.type === "quantitative" &&
-      field.zeroBasedOrigin !== true && {
-        scale: {
-          zero: false,
-        },
-      }),
+    ...(field.type === "quantitative" && {
+      scale: {
+        ...(field.zeroBasedOrigin !== true && { zero: false }),
+        ...(field.min !== undefined && { domainMin: field.min }),
+        ...(field.max !== undefined && { domainMax: field.max }),
+      },
+    }),
     axis: {
       ...(field.labelAngle !== undefined && { labelAngle: field.labelAngle }),
       ...(field.type === "quantitative" && {

--- a/web-common/src/features/canvas/components/charts/cartesian-charts/CartesianChart.ts
+++ b/web-common/src/features/canvas/components/charts/cartesian-charts/CartesianChart.ts
@@ -57,6 +57,7 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
           type: "measure",
           axisTitleSelector: true,
           originSelector: true,
+          axisRangeSelector: true,
         },
       },
     },

--- a/web-common/src/features/canvas/components/charts/types.ts
+++ b/web-common/src/features/canvas/components/charts/types.ts
@@ -64,6 +64,8 @@ interface NominalFieldConfig {
 
 interface QuantitativeFieldConfig {
   zeroBasedOrigin?: boolean; // Default is false
+  min?: number;
+  max?: number;
 }
 
 export interface FieldConfig

--- a/web-common/src/features/canvas/inspector/chart/FieldConfigPopover.svelte
+++ b/web-common/src/features/canvas/inspector/chart/FieldConfigPopover.svelte
@@ -21,6 +21,8 @@
   $: isMeasure = fieldConfig?.type === "quantitative";
 
   let limit = fieldConfig?.limit || 5000;
+  let min = fieldConfig?.min;
+  let max = fieldConfig?.max;
   let labelAngle =
     fieldConfig?.labelAngle ?? (fieldConfig?.type === "temporal" ? 0 : -90);
   let isDropdownOpen = false;
@@ -47,6 +49,7 @@
   $: showNull = chartFieldInput?.nullSelector ?? false;
   $: showLabelAngle = chartFieldInput?.labelAngleSelector ?? false;
   $: showLegend = chartFieldInput?.defaultLegendOrientation ?? false;
+  $: showAxisRange = chartFieldInput?.axisRangeSelector ?? false;
 </script>
 
 <Popover.Root bind:open={isDropdownOpen}>
@@ -117,17 +120,55 @@
           </div>
         {/if}
       {/if}
-      {#if isMeasure && showOrigin}
-        <div class="py-1.5 flex items-center justify-between">
-          <span class="text-xs">Zero based origin</span>
-          <Switch
-            small
-            checked={fieldConfig?.zeroBasedOrigin}
-            on:click={() => {
-              onChange("zeroBasedOrigin", !fieldConfig?.zeroBasedOrigin);
-            }}
-          />
-        </div>
+      {#if isMeasure}
+        {#if showOrigin}
+          <div class="py-1.5 flex items-center justify-between">
+            <span class="text-xs">Zero based origin</span>
+            <Switch
+              small
+              checked={fieldConfig?.zeroBasedOrigin}
+              on:click={() => {
+                onChange("zeroBasedOrigin", !fieldConfig?.zeroBasedOrigin);
+              }}
+            />
+          </div>
+        {/if}
+        {#if showAxisRange}
+          <div class="py-1.5 flex items-center justify-between">
+            <span class="text-xs">Min</span>
+            <Input
+              size="sm"
+              width="120px"
+              id="axis-min-value-select"
+              inputType="number"
+              placeholder="Enter a number"
+              bind:value={min}
+              onBlur={() => {
+                onChange("min", min);
+              }}
+              onEnter={() => {
+                onChange("min", min);
+              }}
+            />
+          </div>
+          <div class="py-1.5 flex items-center justify-between">
+            <span class="text-xs">Max</span>
+            <Input
+              size="sm"
+              width="120px"
+              id="axis-min-value-select"
+              inputType="number"
+              placeholder="Enter a number"
+              bind:value={max}
+              onBlur={() => {
+                onChange("max", max);
+              }}
+              onEnter={() => {
+                onChange("max", max);
+              }}
+            />
+          </div>
+        {/if}
       {/if}
       {#if showLabelAngle && fieldConfig?.type !== "temporal"}
         <div class="py-1 flex items-center justify-between">

--- a/web-common/src/features/canvas/inspector/types.ts
+++ b/web-common/src/features/canvas/inspector/types.ts
@@ -27,6 +27,7 @@ export type ChartFieldInput = {
   limitSelector?: boolean;
   nullSelector?: boolean;
   labelAngleSelector?: boolean;
+  axisRangeSelector?: boolean;
   /**
    * The default legend position for the chart.
    * If this key is not specified, legend selector will not be shown.


### PR DESCRIPTION
https://linear.app/rilldata/issue/ENG-555/set-minmax-for-y-axis

Adds min and max axis selector for bar and line charts.

![image](https://github.com/user-attachments/assets/021d6490-65fe-4b9d-9921-43fb20f7d735)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
