### PR TITLE
Add event truncation for oversized telemetry data

### DIFF
--- a/runtime/pkg/activity/client.go
+++ b/runtime/pkg/activity/client.go
@@ -11,8 +11,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const maxSize = 1048576 // 1MB in bytes
-
 // Client constructs telemetry events and sends them to a sink.
 type Client struct {
 	logger    *zap.Logger

--- a/runtime/pkg/activity/client.go
+++ b/runtime/pkg/activity/client.go
@@ -2,7 +2,6 @@ package activity
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -287,24 +286,4 @@ func (c *Client) resolveAttrs(ctx context.Context, extraAttrs []attribute.KeyVal
 	}
 
 	return data
-}
-
-// truncateEvent truncates the event data if it exceeds maxSize.
-func truncateEvent(e *Event) {
-	if e == nil || e.Data == nil {
-		return
-	}
-
-	b, err := json.Marshal(e)
-	if err != nil {
-		return
-	}
-	if len(b) <= maxSize {
-		return
-	}
-
-	e.Data = map[string]any{
-		"truncated": true,
-		"reason":    "event data exceeded 1MB and was truncated",
-	}
 }

--- a/runtime/pkg/activity/client.go
+++ b/runtime/pkg/activity/client.go
@@ -248,7 +248,6 @@ func (c *Client) RecordRaw(data map[string]any) error {
 
 // emitRaw sends an event to the sink.
 func (c *Client) emitRaw(e Event) {
-	truncateEvent(&e)
 	err := c.sink.Emit(e)
 	if err != nil {
 		c.logger.Error("Failed to emit event", zap.Error(err))

--- a/runtime/pkg/activity/event.go
+++ b/runtime/pkg/activity/event.go
@@ -43,7 +43,7 @@ func (e Event) MarshalJSON() ([]byte, error) {
 		"event_type": e.EventType,
 		"event_name": e.EventName,
 		"truncated":  true,
-		"reason":     "event data exceeded 1MB and was truncated",
+		"reason":     "event data exceeded 32KB and was truncated",
 	}
 	return json.Marshal(truncated)
 }

--- a/runtime/pkg/activity/event.go
+++ b/runtime/pkg/activity/event.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-const maxSize = 1048576 // 1MB in bytes
+const maxSize = 32 * 1024 // 32 KB
 
 // Event is a telemetry event. It consists of a few required fields that are common to all events and a payload of type-specific data.
 // All the common fields are prefixed with "event_" to avoid conflicts with the payload data.
@@ -18,16 +18,17 @@ type Event struct {
 }
 
 func (e Event) MarshalJSON() ([]byte, error) {
-	data := make(map[string]any, len(e.Data)+4)
-	for k, v := range e.Data {
-		data[k] = v
+	// Add the common fields to the map.
+	if e.Data == nil {
+		e.Data = make(map[string]any)
 	}
-	data["event_id"] = e.EventID
-	data["event_time"] = e.EventTime.UTC().Format(time.RFC3339Nano)
-	data["event_type"] = e.EventType
-	data["event_name"] = e.EventName
 
-	b, err := json.Marshal(data)
+	e.Data["event_id"] = e.EventID
+	e.Data["event_time"] = e.EventTime.UTC().Format(time.RFC3339Nano)
+	e.Data["event_type"] = e.EventType
+	e.Data["event_name"] = e.EventName
+
+	b, err := json.Marshal(e.Data)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/pkg/activity/event_test.go
+++ b/runtime/pkg/activity/event_test.go
@@ -40,7 +40,7 @@ func TestEventMarshalJSON_Truncate(t *testing.T) {
 		assert.Equal(t, activity.EventTypeLog, result["event_type"])
 		assert.Equal(t, "test_event", result["event_name"])
 		assert.True(t, result["truncated"].(bool))
-		assert.Equal(t, "event data exceeded 1MB and was truncated", result["reason"])
+		assert.Equal(t, "event data exceeded 32KB and was truncated", result["reason"])
 
 		// {"event_id":"12345","event_name":"test_event","event_time":"2023-10-01T12:00:00Z","event_type":"log","reason":"event data exceeded 1MB and was truncated","truncated":true}
 	})

--- a/runtime/pkg/activity/event_test.go
+++ b/runtime/pkg/activity/event_test.go
@@ -1,0 +1,79 @@
+package activity_test
+
+// test MarshalJSON
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rilldata/rill/runtime/pkg/activity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventMarshalJSON_Truncate(t *testing.T) {
+	t.Run("truncated event", func(t *testing.T) {
+		// Create a large event data to exceed the max size
+		data := make(map[string]any)
+		for i := 0; i < 100000; i++ {
+			data[fmt.Sprintf("key-%d", i)] = "x"
+		}
+
+		event := activity.Event{
+			EventID:   "12345",
+			EventTime: time.Date(2023, 10, 1, 12, 0, 0, 0, time.UTC),
+			EventType: activity.EventTypeLog,
+			EventName: "test_event",
+			Data:      data,
+		}
+
+		dataBytes, err := json.Marshal(event)
+		assert.NoError(t, err)
+
+		var result map[string]any
+		err = json.Unmarshal(dataBytes, &result)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "12345", result["event_id"])
+		assert.Equal(t, "2023-10-01T12:00:00Z", result["event_time"])
+		assert.Equal(t, activity.EventTypeLog, result["event_type"])
+		assert.Equal(t, "test_event", result["event_name"])
+		assert.True(t, result["truncated"].(bool))
+		assert.Equal(t, "event data exceeded 1MB and was truncated", result["reason"])
+
+		// {"event_id":"12345","event_name":"test_event","event_time":"2023-10-01T12:00:00Z","event_type":"log","reason":"event data exceeded 1MB and was truncated","truncated":true}
+	})
+
+	t.Run("non-truncated event", func(t *testing.T) {
+		// Create a small event data to stay under the max size
+		data := map[string]any{
+			"foo": "bar",
+			"baz": 123,
+		}
+
+		event := activity.Event{
+			EventID:   "67890",
+			EventTime: time.Date(2023, 11, 1, 12, 0, 0, 0, time.UTC),
+			EventType: activity.EventTypeMetric,
+			EventName: "small_event",
+			Data:      data,
+		}
+
+		dataBytes, err := json.Marshal(event)
+		assert.NoError(t, err)
+
+		var result map[string]any
+		err = json.Unmarshal(dataBytes, &result)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "67890", result["event_id"])
+		assert.Equal(t, "2023-11-01T12:00:00Z", result["event_time"])
+		assert.Equal(t, activity.EventTypeMetric, result["event_type"])
+		assert.Equal(t, "small_event", result["event_name"])
+		assert.Equal(t, "bar", result["foo"])
+		assert.EqualValues(t, 123, result["baz"])
+		_, truncated := result["truncated"]
+		assert.False(t, truncated)
+	})
+}


### PR DESCRIPTION
https://linear.app/rilldata/issue/ENG-758/truncate-large-events-before-emitting-metrics
Fixes events are too large errors

**Checklist:**
- [x] Covered by tests - added test cases.
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
