### PR TITLE
Fix: Remove extra div from tooltip

### DIFF
--- a/web-common/src/components/tooltip/Tooltip.svelte
+++ b/web-common/src/components/tooltip/Tooltip.svelte
@@ -57,22 +57,22 @@ FIXME: In the future, we should also be listening to focus events from the child
   );
 </script>
 
-<div class="contents">
-  <div
-    bind:this={parent}
-    use:hoverIntent={{
-      threshold: hoverIntentThreshold,
-      timeout: hoverIntentTimeout,
-      activeDelay,
-      hideDelay,
-      onActiveChange: (value) => (active = value),
-    }}
-  >
-    <slot />
-  </div>
-  {#if active && !suppress && !$childRequestedTooltipSuppression}
-    <FloatingElement target={parent} {location} {alignment} {distance} {pad}>
-      <slot name="tooltip-content" />
-    </FloatingElement>
-  {/if}
+<div
+  role="tooltip"
+  class="contents"
+  bind:this={parent}
+  use:hoverIntent={{
+    threshold: hoverIntentThreshold,
+    timeout: hoverIntentTimeout,
+    activeDelay,
+    hideDelay,
+    onActiveChange: (value) => (active = value),
+  }}
+>
+  <slot />
 </div>
+{#if active && !suppress && !$childRequestedTooltipSuppression}
+  <FloatingElement target={parent} {location} {alignment} {distance} {pad}>
+    <slot name="tooltip-content" />
+  </FloatingElement>
+{/if}


### PR DESCRIPTION
Address https://rilldata.slack.com/archives/C04AGHL77PS/p1748606730991179

This pull request removes the extra div that was wrapping `<Tooltip />`, causing a misalignment in the Chip.

![CleanShot 2025-05-30 at 11 44 36@2x](https://github.com/user-attachments/assets/7437c09f-f776-43a6-a83c-15fadf89bac7)


**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
