### PR TITLE
feat: add canvas and api to defaults

### DIFF
--- a/runtime/parser/parse_rillyaml.go
+++ b/runtime/parser/parse_rillyaml.go
@@ -90,7 +90,7 @@ type rillYAML struct {
 	// Default YAML values for canvases
 	Canvases yaml.Node `yaml:"canvases"`
 	// Default YAML values for custom apis
-	CustomAPIs yaml.Node `yaml:"custom_apis"`
+	APIs yaml.Node `yaml:"apis"`
 	// Default YAML values for migrations
 	Migrations yaml.Node `yaml:"migrations"`
 	// Feature flags (preferably a map[string]bool, but can also be a []string for backwards compatibility)
@@ -229,8 +229,8 @@ func (p *Parser) parseRillYAML(ctx context.Context, path string) error {
 			return newYAMLError(err)
 		}
 	}
-	if !tmp.CustomAPIs.IsZero() {
-		if err := tmp.CustomAPIs.Decode(&APIYAML{}); err != nil {
+	if !tmp.APIs.IsZero() {
+		if err := tmp.APIs.Decode(&APIYAML{}); err != nil {
 			return newYAMLError(err)
 		}
 	}
@@ -274,7 +274,7 @@ func (p *Parser) parseRillYAML(ctx context.Context, path string) error {
 		ResourceKindExplore:     tmp.Explores,
 		ResourceKindMigration:   tmp.Migrations,
 		ResourceKindCanvas:      tmp.Canvases,
-		ResourceKindAPI:         tmp.CustomAPIs,
+		ResourceKindAPI:         tmp.APIs,
 	}
 	if !tmp.MetricsViewsLegacy.IsZero() {
 		defaults[ResourceKindMetricsView] = tmp.MetricsViewsLegacy

--- a/runtime/parser/parse_rillyaml.go
+++ b/runtime/parser/parse_rillyaml.go
@@ -87,6 +87,10 @@ type rillYAML struct {
 	MetricsViewsLegacy yaml.Node `yaml:"dashboards"`
 	// Default YAML values for explores
 	Explores yaml.Node `yaml:"explores"`
+	// Default YAML values for canvases
+	Canvases yaml.Node `yaml:"canvases"`
+	// Default YAML values for custom apis
+	CustomAPIs yaml.Node `yaml:"custom_apis"`
 	// Default YAML values for migrations
 	Migrations yaml.Node `yaml:"migrations"`
 	// Feature flags (preferably a map[string]bool, but can also be a []string for backwards compatibility)
@@ -220,6 +224,16 @@ func (p *Parser) parseRillYAML(ctx context.Context, path string) error {
 			return newYAMLError(err)
 		}
 	}
+	if !tmp.Canvases.IsZero() {
+		if err := tmp.Canvases.Decode(&CanvasYAML{}); err != nil {
+			return newYAMLError(err)
+		}
+	}
+	if !tmp.CustomAPIs.IsZero() {
+		if err := tmp.CustomAPIs.Decode(&APIYAML{}); err != nil {
+			return newYAMLError(err)
+		}
+	}
 	if !tmp.Migrations.IsZero() {
 		if err := tmp.Migrations.Decode(&MigrationYAML{}); err != nil {
 			return newYAMLError(err)
@@ -259,6 +273,8 @@ func (p *Parser) parseRillYAML(ctx context.Context, path string) error {
 		ResourceKindMetricsView: tmp.MetricsViews,
 		ResourceKindExplore:     tmp.Explores,
 		ResourceKindMigration:   tmp.Migrations,
+		ResourceKindCanvas:      tmp.Canvases,
+		ResourceKindAPI:         tmp.CustomAPIs,
 	}
 	if !tmp.MetricsViewsLegacy.IsZero() {
 		defaults[ResourceKindMetricsView] = tmp.MetricsViewsLegacy


### PR DESCRIPTION
Adds canvas and api resource types to rill.yaml defaults

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
