### PR TITLE
chore: Replace `createEventDispatcher` with callback prop in `Button.svelte`

### DIFF
--- a/web-admin/src/features/authentication/SignIn.svelte
+++ b/web-admin/src/features/authentication/SignIn.svelte
@@ -3,4 +3,4 @@
   import { Button } from "@rilldata/web-common/components/button";
 </script>
 
-<Button type="primary" on:click={redirectToLogin}>Log In / Sign Up</Button>
+<Button type="primary" onClick={redirectToLogin}>Log In / Sign Up</Button>

--- a/web-admin/src/features/billing/Payment.svelte
+++ b/web-admin/src/features/billing/Payment.svelte
@@ -45,7 +45,7 @@
         Your payment method is valid and good to go.
       {/if}
     </div>
-    <Button slot="action" type="secondary" on:click={handleManagePayment}>
+    <Button slot="action" type="secondary" onClick={handleManagePayment}>
       Manage
     </Button>
   </SettingsContainer>

--- a/web-admin/src/features/billing/contact/BillingContactSetting.svelte
+++ b/web-admin/src/features/billing/contact/BillingContactSetting.svelte
@@ -27,7 +27,7 @@
   <Button
     slot="action"
     type="secondary"
-    on:click={() => (isUpdateBillingContactDialogOpen = true)}
+    onClick={() => (isUpdateBillingContactDialogOpen = true)}
   >
     Change billing contact
   </Button>

--- a/web-admin/src/features/billing/contact/ChangeBillingContactDialog.svelte
+++ b/web-admin/src/features/billing/contact/ChangeBillingContactDialog.svelte
@@ -4,8 +4,8 @@
     createAdminServiceUpdateOrganization,
     getAdminServiceGetOrganizationQueryKey,
   } from "@rilldata/web-admin/client";
-  import * as Dialog from "@rilldata/web-common/components/dialog";
   import { Button } from "@rilldata/web-common/components/button";
+  import * as Dialog from "@rilldata/web-common/components/dialog";
   import Select from "@rilldata/web-common/components/forms/Select.svelte";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
   import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
@@ -87,10 +87,10 @@
       </Dialog.Description>
     </Dialog.Header>
     <Dialog.Footer class="mt-3">
-      <Button type="secondary" on:click={() => (open = false)}>Cancel</Button>
+      <Button type="secondary" onClick={() => (open = false)}>Cancel</Button>
       <Button
         type="primary"
-        on:click={handleAssignAsBillingContact}
+        onClick={handleAssignAsBillingContact}
         loading={$updateOrg.isPending}
         disabled={!selectedDifferntBillingContact}
       >

--- a/web-admin/src/features/billing/plans/CancelledTeamPlan.svelte
+++ b/web-admin/src/features/billing/plans/CancelledTeamPlan.svelte
@@ -51,7 +51,7 @@
     <ContactUs />
   </svelte:fragment>
 
-  <Button type="primary" slot="action" on:click={() => (open = true)}>
+  <Button type="primary" slot="action" onClick={() => (open = true)}>
     Renew Team plan
   </Button>
 </SettingsContainer>

--- a/web-admin/src/features/billing/plans/POCPlan.svelte
+++ b/web-admin/src/features/billing/plans/POCPlan.svelte
@@ -15,7 +15,7 @@
 
 <SettingsContainer title={plan?.displayName}>
   <div slot="body">
-    <div>You’re currently on a custom contract.</div>
+    <div>You're currently on a custom contract.</div>
     <PlanQuotas {organization} />
   </div>
   <svelte:fragment slot="contact">
@@ -24,7 +24,7 @@
   </svelte:fragment>
   <svelte:fragment slot="action">
     {#if hasPayment}
-      <Button type="primary" on:click={() => (open = true)}>
+      <Button type="primary" onClick={() => (open = true)}>
         Start Team plan
       </Button>
     {/if}

--- a/web-admin/src/features/billing/plans/StartTeamPlanDialog.svelte
+++ b/web-admin/src/features/billing/plans/StartTeamPlanDialog.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
   import { page } from "$app/stores";
+  import {
+    createAdminServiceRenewBillingSubscription,
+    createAdminServiceUpdateBillingSubscription,
+  } from "@rilldata/web-admin/client/index.js";
   import { mergedQueryStatus } from "@rilldata/web-admin/client/utils";
   import { invalidateBillingInfo } from "@rilldata/web-admin/features/billing/invalidations";
   import {
@@ -12,7 +16,6 @@
     getSubscriptionResumedText,
     showWelcomeToRillDialog,
   } from "@rilldata/web-admin/features/billing/plans/utils";
-  import PricingDetails from "@rilldata/web-common/features/billing/PricingDetails.svelte";
   import { useCategorisedOrganizationBillingIssues } from "@rilldata/web-admin/features/billing/selectors";
   import {
     AlertDialog,
@@ -24,10 +27,7 @@
     AlertDialogTrigger,
   } from "@rilldata/web-common/components/alert-dialog/index.js";
   import { Button } from "@rilldata/web-common/components/button/index.js";
-  import {
-    createAdminServiceRenewBillingSubscription,
-    createAdminServiceUpdateBillingSubscription,
-  } from "@rilldata/web-admin/client/index.js";
+  import PricingDetails from "@rilldata/web-common/features/billing/PricingDetails.svelte";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
 
   export let organization: string;
@@ -156,10 +156,10 @@
       {/if}
     </AlertDialogHeader>
     <AlertDialogFooter class="mt-3">
-      <Button type="secondary" on:click={() => (open = false)}>Close</Button>
+      <Button type="secondary" onClick={() => (open = false)}>Close</Button>
       <Button
         type="primary"
-        on:click={handleUpgradePlan}
+        onClick={handleUpgradePlan}
         loading={loading || $allStatus.isLoading}
       >
         {buttonText}

--- a/web-admin/src/features/billing/plans/TeamPlan.svelte
+++ b/web-admin/src/features/billing/plans/TeamPlan.svelte
@@ -76,7 +76,7 @@
         <AlertDialogTitle>Are you sure you want to cancel?</AlertDialogTitle>
 
         <AlertDialogDescription>
-          If you cancel your plan, you’ll still be able to access your account
+          If you cancel your plan, you'll still be able to access your account
           through <span class="font-semibold"
             >{currentBillingCycleEndDate}.</span
           >
@@ -91,14 +91,12 @@
       <AlertDialogFooter class="mt-3">
         <Button
           type="secondary"
-          on:click={handleCancelPlan}
+          onClick={handleCancelPlan}
           loading={$planCanceller.isPending}
         >
           Cancel plan
         </Button>
-        <Button type="primary" on:click={() => (open = false)}>
-          Keep plan
-        </Button>
+        <Button type="primary" onClick={() => (open = false)}>Keep plan</Button>
       </AlertDialogFooter>
     </AlertDialogContent>
   </AlertDialog>

--- a/web-admin/src/features/billing/plans/TrialPlan.svelte
+++ b/web-admin/src/features/billing/plans/TrialPlan.svelte
@@ -69,7 +69,7 @@
     <ContactUs />
   </svelte:fragment>
 
-  <Button type="primary" slot="action" on:click={() => (open = true)}>
+  <Button type="primary" slot="action" onClick={() => (open = true)}>
     {#if trialEnded}
       Start Team plan
     {:else}

--- a/web-admin/src/features/billing/plans/WelcomeToRillCloudDialog.svelte
+++ b/web-admin/src/features/billing/plans/WelcomeToRillCloudDialog.svelte
@@ -35,7 +35,7 @@
       </AlertDialogHeader>
       <div class="grow"></div>
       <AlertDialogFooter class="mt-3">
-        <Button type="primary" on:click={() => (open = false)}>Got it</Button>
+        <Button type="primary" onClick={() => (open = false)}>Got it</Button>
       </AlertDialogFooter>
     </div>
   </AlertDialogContent>

--- a/web-admin/src/features/bookmarks/BookmarkDialog.svelte
+++ b/web-admin/src/features/bookmarks/BookmarkDialog.svelte
@@ -121,8 +121,8 @@
 
     <div class="flex flex-row mt-4 gap-2">
       <div class="grow" />
-      <Button on:click={onClose} type="secondary">Cancel</Button>
-      <Button on:click={handleSubmit} type="primary">Save</Button>
+      <Button onClick={onClose} type="secondary">Cancel</Button>
+      <Button onClick={handleSubmit} type="primary">Save</Button>
     </div>
   </Dialog.Content>
 </Dialog.Root>

--- a/web-admin/src/features/bookmarks/HomeBookmarkButton.svelte
+++ b/web-admin/src/features/bookmarks/HomeBookmarkButton.svelte
@@ -5,10 +5,10 @@
   import { Button } from "@rilldata/web-common/components/button";
   import {
     DropdownMenu,
-    DropdownMenuTrigger,
     DropdownMenuContent,
     DropdownMenuItem,
     DropdownMenuSeparator,
+    DropdownMenuTrigger,
   } from "@rilldata/web-common/components/dropdown-menu";
   import HomeBookmark from "@rilldata/web-common/components/icons/HomeBookmark.svelte";
   import HomeBookmarkPlus from "@rilldata/web-common/components/icons/HomeBookmarkPlus.svelte";
@@ -103,7 +103,7 @@
         compact
         preload={false}
         href={homeBookmarkUrl}
-        on:click={goToDashboardHome}
+        onClick={goToDashboardHome}
         class="border border-primary-300"
         builders={[builder]}
         label="Go to home bookmark"

--- a/web-admin/src/features/dashboards/share/ShareDashboardPopover.svelte
+++ b/web-admin/src/features/dashboards/share/ShareDashboardPopover.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import CreatePublicURLForm from "@rilldata/web-admin/features/public-urls/CreatePublicURLForm.svelte";
   import Button from "@rilldata/web-common/components/button/Button.svelte";
+  import Check from "@rilldata/web-common/components/icons/Check.svelte";
   import Link from "@rilldata/web-common/components/icons/Link.svelte";
   import {
     Popover,
@@ -13,7 +14,6 @@
     TabsList,
     TabsTrigger,
   } from "@rilldata/web-common/components/tabs";
-  import Check from "@rilldata/web-common/components/icons/Check.svelte";
   import { featureFlags } from "@rilldata/web-common/features/feature-flags";
 
   export let createMagicAuthTokens: boolean;
@@ -58,7 +58,7 @@
           </h3>
           <Button
             type="secondary"
-            on:click={() => {
+            onClick={() => {
               onCopy();
             }}
           >

--- a/web-admin/src/features/organizations/hibernating/OrganizationHibernatingForAdmins.svelte
+++ b/web-admin/src/features/organizations/hibernating/OrganizationHibernatingForAdmins.svelte
@@ -85,7 +85,7 @@
       <Button
         type="secondary"
         wide
-        on:click={() => billingCTAHandler.handle(issueForHibernation)}
+        onClick={() => billingCTAHandler.handle(issueForHibernation)}
       >
         {issueForHibernation.cta.text}
       </Button>

--- a/web-admin/src/features/organizations/settings/FaviconSettings.svelte
+++ b/web-admin/src/features/organizations/settings/FaviconSettings.svelte
@@ -66,7 +66,7 @@
     {#if organizationFaviconUrl}
       <Button
         type="secondary"
-        on:click={onRemove}
+        onClick={onRemove}
         loading={isLoading}
         disabled={isLoading}
       >

--- a/web-admin/src/features/organizations/settings/LogoSettings.svelte
+++ b/web-admin/src/features/organizations/settings/LogoSettings.svelte
@@ -66,7 +66,7 @@
     {#if organizationLogoUrl}
       <Button
         type="secondary"
-        on:click={onRemove}
+        onClick={onRemove}
         loading={isLoading}
         disabled={isLoading}
       >

--- a/web-admin/src/features/organizations/settings/OrgNameSettings.svelte
+++ b/web-admin/src/features/organizations/settings/OrgNameSettings.svelte
@@ -10,6 +10,7 @@
   import { parseUpdateOrgError } from "@rilldata/web-admin/features/organizations/settings/errors";
   import SettingsContainer from "@rilldata/web-admin/features/organizations/settings/SettingsContainer.svelte";
   import { Button } from "@rilldata/web-common/components/button";
+  import Input from "@rilldata/web-common/components/forms/Input.svelte";
   import { sanitizeOrgName } from "@rilldata/web-common/features/organization/sanitizeOrgName";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
   import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
@@ -17,7 +18,6 @@
   import { defaults, superForm } from "sveltekit-superforms";
   import { yup } from "sveltekit-superforms/adapters";
   import { object, string } from "yup";
-  import Input from "@rilldata/web-common/components/forms/Input.svelte";
 
   export let organization: string;
 
@@ -137,7 +137,7 @@
     </div>
   {/if}
   <Button
-    on:click={submit}
+    onClick={submit}
     type="primary"
     loading={$updateOrgMutation.isPending}
     disabled={!changed}

--- a/web-admin/src/features/organizations/settings/UploadImagePopover.svelte
+++ b/web-admin/src/features/organizations/settings/UploadImagePopover.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
   import { createAdminServiceCreateAsset } from "@rilldata/web-admin/client";
   import { CANONICAL_ADMIN_URL } from "@rilldata/web-admin/client/http-client";
+  import { Button } from "@rilldata/web-common/components/button/index.js";
+  import FileInput from "@rilldata/web-common/components/forms/FileInput.svelte";
+  import EditIcon from "@rilldata/web-common/components/icons/EditIcon.svelte";
   import {
     Popover,
     PopoverContent,
     PopoverTrigger,
   } from "@rilldata/web-common/components/popover/index.js";
-  import { Button } from "@rilldata/web-common/components/button/index.js";
-  import FileInput from "@rilldata/web-common/components/forms/FileInput.svelte";
-  import EditIcon from "@rilldata/web-common/components/icons/EditIcon.svelte";
   import { extractFileExtension } from "@rilldata/web-common/features/entity-management/file-path-utils";
-  import { getAttrs, builderActions } from "bits-ui";
+  import { builderActions, getAttrs } from "bits-ui";
 
   export let imageUrl: string;
   export let accept: string;
@@ -114,11 +114,11 @@
       </div>
     {/if}
     <div class="flex flex-row justify-end gap-x-2">
-      <Button type="secondary" on:click={onCancel}>Cancel</Button>
+      <Button type="secondary" onClick={onCancel}>Cancel</Button>
       {#if imageUrl}
         <Button
           type="secondary"
-          on:click={handleRemove}
+          onClick={handleRemove}
           {loading}
           disabled={loading}
         >
@@ -127,7 +127,7 @@
       {/if}
       <Button
         type="primary"
-        on:click={handleSave}
+        onClick={handleSave}
         {loading}
         disabled={loading || !assetId}
       >

--- a/web-admin/src/features/organizations/users/ChangingBillingContactRoleDialog.svelte
+++ b/web-admin/src/features/organizations/users/ChangingBillingContactRoleDialog.svelte
@@ -25,7 +25,7 @@
     <Alert.Footer>
       <Button
         type="plain"
-        on:click={() => {
+        onClick={() => {
           open = false;
         }}
       >
@@ -33,7 +33,7 @@
       </Button>
       <Button
         type="primary"
-        on:click={() => {
+        onClick={() => {
           open = false;
           onChange();
         }}

--- a/web-admin/src/features/organizations/users/CreateUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/users/CreateUserGroupDialog.svelte
@@ -2,8 +2,8 @@
   import { page } from "$app/stores";
   import type { V1OrganizationMemberUser } from "@rilldata/web-admin/client";
   import {
-    createAdminServiceCreateUsergroup,
     createAdminServiceAddUsergroupMemberUser,
+    createAdminServiceCreateUsergroup,
     getAdminServiceListOrganizationMemberUsergroupsQueryKey,
     getAdminServiceListOrganizationMemberUsersQueryKey,
     getAdminServiceListUsergroupMemberUsersQueryKey,
@@ -294,7 +294,7 @@
               <Button
                 type="text"
                 danger
-                on:click={() => handleRemove(user.userEmail)}
+                onClick={() => handleRemove(user.userEmail)}
               >
                 Remove
               </Button>
@@ -305,7 +305,7 @@
     </div>
 
     <DialogFooter>
-      <Button type="plain" on:click={handleClose}>Cancel</Button>
+      <Button type="plain" onClick={handleClose}>Cancel</Button>
       <Button
         type="primary"
         disabled={$submitting || $form.name.trim() === ""}

--- a/web-admin/src/features/organizations/users/DeleteUserGroupConfirmDialog.svelte
+++ b/web-admin/src/features/organizations/users/DeleteUserGroupConfirmDialog.svelte
@@ -77,11 +77,11 @@
     <AlertDialogFooter>
       <Button
         type="plain"
-        on:click={() => {
+        onClick={() => {
           open = false;
         }}>Cancel</Button
       >
-      <Button type="primary" status="error" on:click={handleDelete}
+      <Button type="primary" status="error" onClick={handleDelete}
         >Yes, delete</Button
       >
     </AlertDialogFooter>

--- a/web-admin/src/features/organizations/users/EditUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/users/EditUserGroupDialog.svelte
@@ -3,12 +3,12 @@
   import type { V1OrganizationMemberUser } from "@rilldata/web-admin/client";
   import {
     createAdminServiceAddUsergroupMemberUser,
+    createAdminServiceListUsergroupMemberUsers,
+    createAdminServiceRemoveUsergroupMemberUser,
+    createAdminServiceRenameUsergroup,
     getAdminServiceListOrganizationMemberUsergroupsQueryKey,
     getAdminServiceListOrganizationMemberUsersQueryKey,
     getAdminServiceListUsergroupMemberUsersQueryKey,
-    createAdminServiceRemoveUsergroupMemberUser,
-    createAdminServiceRenameUsergroup,
-    createAdminServiceListUsergroupMemberUsers,
   } from "@rilldata/web-admin/client";
   import Avatar from "@rilldata/web-common/components/avatar/Avatar.svelte";
   import { Button } from "@rilldata/web-common/components/button/index.js";
@@ -328,7 +328,7 @@
               <Button
                 type="text"
                 danger
-                on:click={() => handleRemove(user.userEmail)}
+                onClick={() => handleRemove(user.userEmail)}
               >
                 Remove
               </Button>
@@ -339,7 +339,7 @@
     </div>
 
     <DialogFooter>
-      <Button type="plain" on:click={handleClose}>Cancel</Button>
+      <Button type="plain" onClick={handleClose}>Cancel</Button>
       <Button
         type="primary"
         disabled={$submitting || $form.newName.trim() === ""}

--- a/web-admin/src/features/organizations/users/OrgUpgradeGuestConfirmDialog.svelte
+++ b/web-admin/src/features/organizations/users/OrgUpgradeGuestConfirmDialog.svelte
@@ -43,11 +43,11 @@
     <AlertDialogFooter>
       <Button
         type="plain"
-        on:click={() => {
+        onClick={() => {
           open = false;
         }}>Cancel</Button
       >
-      <Button type="primary" on:click={handleUpgrade}>Yes, upgrade</Button>
+      <Button type="primary" onClick={handleUpgrade}>Yes, upgrade</Button>
     </AlertDialogFooter>
   </AlertDialogContent>
 </AlertDialog>

--- a/web-admin/src/features/organizations/users/RemoveUserFromOrgConfirmDialog.svelte
+++ b/web-admin/src/features/organizations/users/RemoveUserFromOrgConfirmDialog.svelte
@@ -40,11 +40,11 @@
     <AlertDialogFooter>
       <Button
         type="plain"
-        on:click={() => {
+        onClick={() => {
           open = false;
         }}>Cancel</Button
       >
-      <Button type="primary" status="error" on:click={handleRemove}
+      <Button type="primary" status="error" onClick={handleRemove}
         >Yes, remove</Button
       >
     </AlertDialogFooter>

--- a/web-admin/src/features/organizations/users/RemovingBillingContactDialog.svelte
+++ b/web-admin/src/features/organizations/users/RemovingBillingContactDialog.svelte
@@ -25,7 +25,7 @@
     <Alert.Footer>
       <Button
         type="plain"
-        on:click={() => {
+        onClick={() => {
           open = false;
         }}
       >
@@ -33,7 +33,7 @@
       </Button>
       <Button
         type="primary"
-        on:click={() => {
+        onClick={() => {
           open = false;
           onChange();
         }}

--- a/web-admin/src/features/personal-access-tokens/PersonalAccessTokensSection.svelte
+++ b/web-admin/src/features/personal-access-tokens/PersonalAccessTokensSection.svelte
@@ -39,7 +39,7 @@
     <span class="font-medium">personal access token</span> to use in your MCP configuration.
     This token authenticates your requests.
   </p>
-  <Button type="primary" on:click={issueToken} disabled={issuing}>
+  <Button type="primary" onClick={issueToken} disabled={issuing}>
     {issuing ? "Issuing..." : "Create token"}
   </Button>
 

--- a/web-admin/src/features/projects/environment-variables/AddDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/AddDialog.svelte
@@ -313,7 +313,7 @@
           type="secondary"
           small
           class="w-fit flex flex-row items-center gap-x-2"
-          on:click={() => fileInput.click()}
+          onClick={() => fileInput.click()}
         >
           <UploadIcon size="14px" />
           <span>Import .env</span>
@@ -395,7 +395,7 @@
               </div>
             {/each}
           </div>
-          <Button type="dashed" class="w-full mt-4" on:click={handleAdd}>
+          <Button type="dashed" class="w-full mt-4" onClick={handleAdd}>
             <Plus size="16px" />
             <span>Add variable</span>
           </Button>

--- a/web-admin/src/features/projects/environment-variables/DeleteDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/DeleteDialog.svelte
@@ -86,13 +86,13 @@
     <AlertDialogFooter>
       <Button
         type="plain"
-        on:click={() => {
+        onClick={() => {
           open = false;
         }}
       >
         Cancel
       </Button>
-      <Button type="primary" status="error" on:click={handleDelete}>
+      <Button type="primary" status="error" onClick={handleDelete}>
         Yes, delete
       </Button>
     </AlertDialogFooter>

--- a/web-admin/src/features/projects/environment-variables/EditDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/EditDialog.svelte
@@ -362,7 +362,7 @@
     <DialogFooter>
       <Button
         type="plain"
-        on:click={() => {
+        onClick={() => {
           open = false;
           handleReset();
         }}>Cancel</Button

--- a/web-admin/src/features/projects/github/ConnectToGithubButton.svelte
+++ b/web-admin/src/features/projects/github/ConnectToGithubButton.svelte
@@ -60,7 +60,7 @@
           <Button
             type="link"
             href="#"
-            on:click={openGithubRepoCreator}
+            onClick={openGithubRepoCreator}
             forcedStyle="display:inline-block !important; padding: 0px !important; min-height:12px !important; height: 12px !important;"
           >
             <span class="text-sm">Create GitHub repo -></span>
@@ -79,7 +79,7 @@
       </AlertDialogDescription>
     </AlertDialogHeader>
     <AlertDialogFooter class="mt-3">
-      <Button type="secondary" on:click={() => (open = false)}>Cancel</Button>
+      <Button type="secondary" onClick={() => (open = false)}>Cancel</Button>
       <Button
         type="primary"
         on:click={handleContinue}

--- a/web-admin/src/features/projects/github/DisconnectProjectConfirmDialog.svelte
+++ b/web-admin/src/features/projects/github/DisconnectProjectConfirmDialog.svelte
@@ -87,12 +87,12 @@
     <AlertDialogFooter>
       <Button
         type="secondary"
-        on:click={() => (open = false)}
+        onClick={() => (open = false)}
         disabled={isPending}>Cancel</Button
       >
       <Button
         type="primary"
-        on:click={onDisconnect}
+        onClick={onDisconnect}
         loading={isPending}
         disabled={isPending}
       >

--- a/web-admin/src/features/projects/github/GithubOverwriteConfirmDialog.svelte
+++ b/web-admin/src/features/projects/github/GithubOverwriteConfirmDialog.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import type { extractGithubConnectError } from "@rilldata/web-admin/features/projects/github/github-errors";
-  import { getRepoNameFromGithubUrl } from "@rilldata/web-common/features/project/github-utils";
   import {
     AlertDialog,
     AlertDialogContent,
@@ -11,8 +10,9 @@
     AlertDialogTrigger,
   } from "@rilldata/web-common/components/alert-dialog/index.js";
   import { Button } from "@rilldata/web-common/components/button/index.js";
-  import AlertCircleOutline from "@rilldata/web-common/components/icons/AlertCircleOutline.svelte";
   import Input from "@rilldata/web-common/components/forms/Input.svelte";
+  import AlertCircleOutline from "@rilldata/web-common/components/icons/AlertCircleOutline.svelte";
+  import { getRepoNameFromGithubUrl } from "@rilldata/web-common/features/project/github-utils";
 
   export let open = false;
   export let loading: boolean;
@@ -55,7 +55,7 @@
       </AlertDialogTitle>
       <AlertDialogDescription class="flex flex-col gap-y-1.5">
         <div>
-          It appears that <b>{path}</b> is not empty. Rill will overwrite this repo’s
+          It appears that <b>{path}</b> is not empty. Rill will overwrite this repo's
           contents with this project.
         </div>
         <div class="mt-1">
@@ -70,10 +70,10 @@
       </AlertDialogDescription>
     </AlertDialogHeader>
     <AlertDialogFooter class="mt-5">
-      <Button type="secondary" on:click={close}>Cancel</Button>
+      <Button type="secondary" onClick={close}>Cancel</Button>
       <Button
         type="primary"
-        on:click={handleContinue}
+        onClick={handleContinue}
         disabled={!confirmed}
         {loading}
       >

--- a/web-admin/src/features/projects/github/GithubRepoSelectionDialog.svelte
+++ b/web-admin/src/features/projects/github/GithubRepoSelectionDialog.svelte
@@ -181,13 +181,13 @@
     <DialogFooter class="mt-3">
       <!-- temporarily show this only during edit. in the long run we will not have edit -->
       {#if $githubUrl}
-        <Button type="link" on:click={() => githubData.reselectRepos()}>
+        <Button type="link" onClick={() => githubData.reselectRepos()}>
           Choose other repos
         </Button>
       {/if}
       <Button
         type="secondary"
-        on:click={() => {
+        onClick={() => {
           open = false;
           handleDialogClose();
         }}>Cancel</Button
@@ -196,7 +196,7 @@
         type="primary"
         loading={$connectToGithubMutation.isPending}
         disabled={disableContinue}
-        on:click={() => updateGithubUrl(false)}>Continue</Button
+        onClick={() => updateGithubUrl(false)}>Continue</Button
       >
     </DialogFooter>
   </DialogContent>

--- a/web-admin/src/features/projects/github/ProjectGithubConnection.svelte
+++ b/web-admin/src/features/projects/github/ProjectGithubConnection.svelte
@@ -104,7 +104,7 @@
             <DropdownMenu.Content align="start">
               <!-- Disabling for now, until we figure out how to do this  -->
               <!--              <DropdownMenu.Item class="px-1 py-1">-->
-              <!--                <Button on:click={editGithubConnection} type="text" compact>-->
+              <!--                <Button onClick={editGithubConnection} type="text" compact>-->
               <!--                  <div class="flex flex-row items-center gap-x-2">-->
               <!--                    <EditIcon size="14px" />-->
               <!--                    <span class="text-xs">Edit</span>-->
@@ -112,7 +112,7 @@
               <!--                </Button>-->
               <!--              </DropdownMenu.Item>-->
               <DropdownMenu.Item class="px-1 py-1">
-                <Button on:click={disconnectGithubConnect} type="text" compact>
+                <Button onClick={disconnectGithubConnect} type="text" compact>
                   <div class="flex flex-row items-center gap-x-2">
                     <DisconnectIcon size="14px" />
                     <span class="text-xs">Disconnect</span>

--- a/web-admin/src/features/projects/status/ProjectResources.svelte
+++ b/web-admin/src/features/projects/status/ProjectResources.svelte
@@ -9,12 +9,12 @@
     type V1ListResourcesResponse,
     type V1Resource,
   } from "@rilldata/web-common/runtime-client";
+  import type { HTTPError } from "@rilldata/web-common/runtime-client/fetchWrapper";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { useQueryClient, type Query } from "@tanstack/svelte-query";
   import Button from "web-common/src/components/button/Button.svelte";
   import ProjectResourcesTable from "./ProjectResourcesTable.svelte";
   import RefreshAllSourcesAndModelsConfirmDialog from "./RefreshAllSourcesAndModelsConfirmDialog.svelte";
-  import type { HTTPError } from "@rilldata/web-common/runtime-client/fetchWrapper";
 
   const queryClient = useQueryClient();
   const createTrigger = createRuntimeServiceCreateTrigger();
@@ -125,7 +125,7 @@
     <h2 class="text-lg font-medium">Resources</h2>
     <Button
       type="secondary"
-      on:click={() => {
+      onClick={() => {
         isConfirmDialogOpen = true;
       }}
       disabled={isRefreshButtonDisabled}

--- a/web-admin/src/features/projects/status/RefreshAllSourcesAndModelsConfirmDialog.svelte
+++ b/web-admin/src/features/projects/status/RefreshAllSourcesAndModelsConfirmDialog.svelte
@@ -40,11 +40,11 @@
     <AlertDialogFooter>
       <Button
         type="plain"
-        on:click={() => {
+        onClick={() => {
           open = false;
         }}>Cancel</Button
       >
-      <Button type="primary" on:click={handleRefresh}>Yes, refresh</Button>
+      <Button type="primary" onClick={handleRefresh}>Yes, refresh</Button>
     </AlertDialogFooter>
   </AlertDialogContent>
 </AlertDialog>

--- a/web-admin/src/features/projects/status/RefreshResourceConfirmDialog.svelte
+++ b/web-admin/src/features/projects/status/RefreshResourceConfirmDialog.svelte
@@ -36,11 +36,11 @@
     <AlertDialogFooter>
       <Button
         type="plain"
-        on:click={() => {
+        onClick={() => {
           open = false;
         }}>Cancel</Button
       >
-      <Button type="primary" on:click={handleRefresh}>Yes, refresh</Button>
+      <Button type="primary" onClick={handleRefresh}>Yes, refresh</Button>
     </AlertDialogFooter>
   </AlertDialogContent>
 </AlertDialog>

--- a/web-admin/src/features/projects/user-management/CopyInviteLinkButton.svelte
+++ b/web-admin/src/features/projects/user-management/CopyInviteLinkButton.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { Button } from "@rilldata/web-common/components/button";
-  import Link from "@rilldata/web-common/components/icons/Link.svelte";
   import Check from "@rilldata/web-common/components/icons/Check.svelte";
+  import Link from "@rilldata/web-common/components/icons/Link.svelte";
   import { isClipboardApiSupported } from "@rilldata/web-common/lib/actions/copy-to-clipboard";
 
   export let copyLink: string;
@@ -29,7 +29,7 @@
       type="secondary"
       class="flex flex-row items-center"
       forcedStyle="min-height: 24px !important; height: 24px !important;  "
-      on:click={onCopy}
+      onClick={onCopy}
       compact
     >
       <Link size="12px" />

--- a/web-admin/src/features/public-urls/DeletePublicURLConfirmDialog.svelte
+++ b/web-admin/src/features/public-urls/DeletePublicURLConfirmDialog.svelte
@@ -40,11 +40,11 @@
     <AlertDialogFooter>
       <Button
         type="plain"
-        on:click={() => {
+        onClick={() => {
           open = false;
         }}>Cancel</Button
       >
-      <Button type="primary" status="error" on:click={handleDelete}
+      <Button type="primary" status="error" onClick={handleDelete}
         >Yes, delete</Button
       >
     </AlertDialogFooter>

--- a/web-admin/src/features/scheduled-reports/metadata/RunNowButton.svelte
+++ b/web-admin/src/features/scheduled-reports/metadata/RunNowButton.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { createAdminServiceTriggerReport } from "@rilldata/web-admin/client";
   import { Button } from "@rilldata/web-common/components/button";
-  import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
+  import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
   import { getRuntimeServiceGetResourceQueryKey } from "@rilldata/web-common/runtime-client";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { useQueryClient } from "@tanstack/svelte-query";
@@ -55,7 +55,7 @@
 <Tooltip distance={8}>
   <Button
     type="primary"
-    on:click={handleRunNow}
+    onClick={handleRunNow}
     disabled={$triggerReport.isPending}
   >
     Run now

--- a/web-admin/src/routes/-/auth/device/+page.svelte
+++ b/web-admin/src/routes/-/auth/device/+page.svelte
@@ -93,7 +93,7 @@
     <div class="flex flex-col gap-y-4 w-[400px]">
       <CtaButton
         variant="primary"
-        on:click={() => {
+        onClick={() => {
           actionTaken = true;
           confirmUserCode();
         }}
@@ -101,7 +101,7 @@
       >
       <CtaButton
         variant="secondary"
-        on:click={() => {
+        onClick={() => {
           actionTaken = true;
           rejectUserCode();
         }}

--- a/web-admin/src/routes/-/github/connect/retry-auth/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/retry-auth/+page.svelte
@@ -30,7 +30,7 @@
     <CtaMessage>
       Click the button below to re-authorize/authorize another account.
     </CtaMessage>
-    <CtaButton variant="primary" on:click={() => redirectToGithubLogin(remote)}>
+    <CtaButton variant="primary" onClick={() => redirectToGithubLogin(remote)}>
       Connect to GitHub
     </CtaButton>
   </CtaContentContainer>

--- a/web-admin/src/routes/-/github/connect/retry-install/+page.svelte
+++ b/web-admin/src/routes/-/github/connect/retry-install/+page.svelte
@@ -33,7 +33,7 @@
       <KeyboardKey label="Control" /> + <KeyboardKey label="C" /> in the CLI to cancel
       the connect request.)
     </CtaMessage>
-    <CtaButton variant="primary" on:click={() => redirectToGithubLogin(remote)}>
+    <CtaButton variant="primary" onClick={() => redirectToGithubLogin(remote)}>
       Connect to GitHub
     </CtaButton>
   </CtaContentContainer>

--- a/web-admin/src/routes/-/request-project-access/+page.svelte
+++ b/web-admin/src/routes/-/request-project-access/+page.svelte
@@ -6,8 +6,8 @@
   } from "@rilldata/web-admin/client";
   import AccessRequestContainer from "@rilldata/web-admin/features/access-request/AccessRequestContainer.svelte";
   import { Button } from "@rilldata/web-common/components/button";
-  import Lock from "@rilldata/web-common/components/icons/Lock.svelte";
   import Check from "@rilldata/web-common/components/icons/Check.svelte";
+  import Lock from "@rilldata/web-common/components/icons/Lock.svelte";
   import type { AxiosError } from "axios";
 
   $: organization = $page.url.searchParams.get("organization");
@@ -51,7 +51,7 @@
   <Button
     type="primary"
     wide
-    on:click={onRequestAccess}
+    onClick={onRequestAccess}
     loading={isPending}
     disabled={requested}
   >

--- a/web-admin/src/routes/[organization]/-/users/+page.svelte
+++ b/web-admin/src/routes/[organization]/-/users/+page.svelte
@@ -10,10 +10,10 @@
   import { getOrganizationBillingContactUser } from "@rilldata/web-admin/features/billing/contact/selectors";
   import AddUsersDialog from "@rilldata/web-admin/features/organizations/users/AddUsersDialog.svelte";
   import ChangingBillingContactRoleDialog from "@rilldata/web-admin/features/organizations/users/ChangingBillingContactRoleDialog.svelte";
+  import OrgUsersFilters from "@rilldata/web-admin/features/organizations/users/OrgUsersFilters.svelte";
   import OrgUsersTable from "@rilldata/web-admin/features/organizations/users/OrgUsersTable.svelte";
   import RemovingBillingContactDialog from "@rilldata/web-admin/features/organizations/users/RemovingBillingContactDialog.svelte";
   import Button from "@rilldata/web-common/components/button/Button.svelte";
-  import OrgUsersFilters from "@rilldata/web-admin/features/organizations/users/OrgUsersFilters.svelte";
   import { Search } from "@rilldata/web-common/components/search";
   import DelayedSpinner from "@rilldata/web-common/features/entity-management/DelayedSpinner.svelte";
   import { Plus } from "lucide-svelte";
@@ -164,7 +164,7 @@
         <Button
           type="primary"
           large
-          on:click={() => (isAddUserDialogOpen = true)}
+          onClick={() => (isAddUserDialogOpen = true)}
         >
           <Plus size="16px" />
           <span>Add users</span>

--- a/web-admin/src/routes/[organization]/-/users/groups/+page.svelte
+++ b/web-admin/src/routes/[organization]/-/users/groups/+page.svelte
@@ -5,13 +5,13 @@
     createAdminServiceListOrganizationMemberUsergroups,
     createAdminServiceListOrganizationMemberUsers,
   } from "@rilldata/web-admin/client";
-  import DelayedSpinner from "@rilldata/web-common/features/entity-management/DelayedSpinner.svelte";
+  import CreateUserGroupDialog from "@rilldata/web-admin/features/organizations/users/CreateUserGroupDialog.svelte";
+  import EditUserGroupDialog from "@rilldata/web-admin/features/organizations/users/EditUserGroupDialog.svelte";
   import OrgGroupsTable from "@rilldata/web-admin/features/organizations/users/OrgGroupsTable.svelte";
   import Button from "@rilldata/web-common/components/button/Button.svelte";
-  import { Plus } from "lucide-svelte";
-  import CreateUserGroupDialog from "@rilldata/web-admin/features/organizations/users/CreateUserGroupDialog.svelte";
   import { Search } from "@rilldata/web-common/components/search";
-  import EditUserGroupDialog from "@rilldata/web-admin/features/organizations/users/EditUserGroupDialog.svelte";
+  import DelayedSpinner from "@rilldata/web-common/features/entity-management/DelayedSpinner.svelte";
+  import { Plus } from "lucide-svelte";
 
   const PAGE_SIZE = 20;
 
@@ -90,7 +90,7 @@
         <Button
           type="primary"
           large
-          on:click={() => (isCreateUserGroupDialogOpen = true)}
+          onClick={() => (isCreateUserGroupDialogOpen = true)}
         >
           <Plus size="16px" />
           <span>Create group</span>

--- a/web-admin/src/routes/[organization]/[project]/-/invite/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/invite/+page.svelte
@@ -105,7 +105,7 @@
   {/if}
   <Button
     type="primary"
-    on:click={onContinue}
+    onClick={onContinue}
     loading={$addToAllowlist.isPending}
     wide
     class="mx-auto"

--- a/web-admin/src/routes/[organization]/[project]/-/request-access/[id]/approve/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/request-access/[id]/approve/+page.svelte
@@ -5,11 +5,11 @@
     createAdminServiceApproveProjectAccess,
     createAdminServiceGetProjectAccessRequest,
   } from "@rilldata/web-admin/client";
+  import AccessRequestContainer from "@rilldata/web-admin/features/access-request/AccessRequestContainer.svelte";
   import { parseAccessRequestError } from "@rilldata/web-admin/features/access-request/utils";
   import { Button } from "@rilldata/web-common/components/button";
-  import AccessRequestContainer from "@rilldata/web-admin/features/access-request/AccessRequestContainer.svelte";
-  import CheckCircle from "@rilldata/web-common/components/icons/CheckCircle.svelte";
   import Select from "@rilldata/web-common/components/forms/Select.svelte";
+  import CheckCircle from "@rilldata/web-common/components/icons/CheckCircle.svelte";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
   import type { AxiosError } from "axios";
 
@@ -89,7 +89,7 @@
     <Button
       type="primary"
       wide
-      on:click={onApprove}
+      onClick={onApprove}
       loading={$approveAccess.isPending}
       disabled={requested}
     >

--- a/web-admin/src/routes/[organization]/[project]/-/settings/environment-variables/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/settings/environment-variables/+page.svelte
@@ -1,21 +1,21 @@
 <script lang="ts">
   import { page } from "$app/stores";
   import { createAdminServiceGetProjectVariables } from "@rilldata/web-admin/client";
-  import EnvironmentVariablesTable from "@rilldata/web-admin/features/projects/environment-variables/EnvironmentVariablesTable.svelte";
-  import DelayedSpinner from "@rilldata/web-common/features/entity-management/DelayedSpinner.svelte";
-  import Button from "@rilldata/web-common/components/button/Button.svelte";
-  import { Plus } from "lucide-svelte";
-  import { Search } from "@rilldata/web-common/components/search";
-  import RadixLarge from "@rilldata/web-common/components/typography/RadixLarge.svelte";
   import AddDialog from "@rilldata/web-admin/features/projects/environment-variables/AddDialog.svelte";
-  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
-  import CaretUpIcon from "@rilldata/web-common/components/icons/CaretUpIcon.svelte";
-  import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
+  import EnvironmentVariablesTable from "@rilldata/web-admin/features/projects/environment-variables/EnvironmentVariablesTable.svelte";
   import {
     EnvironmentType,
     type EnvironmentTypes,
   } from "@rilldata/web-admin/features/projects/environment-variables/types";
   import { getEnvironmentType } from "@rilldata/web-admin/features/projects/environment-variables/utils";
+  import Button from "@rilldata/web-common/components/button/Button.svelte";
+  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
+  import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
+  import CaretUpIcon from "@rilldata/web-common/components/icons/CaretUpIcon.svelte";
+  import { Search } from "@rilldata/web-common/components/search";
+  import RadixLarge from "@rilldata/web-common/components/typography/RadixLarge.svelte";
+  import DelayedSpinner from "@rilldata/web-common/features/entity-management/DelayedSpinner.svelte";
+  import { Plus } from "lucide-svelte";
 
   let open = false;
   let searchText = "";
@@ -165,7 +165,7 @@
               </DropdownMenu.CheckboxItem>
             </DropdownMenu.Content>
           </DropdownMenu.Root>
-          <Button type="primary" large on:click={() => (open = true)}>
+          <Button type="primary" large onClick={() => (open = true)}>
             <Plus size="16px" />
             <!-- <span>Add environment variable</span> -->
           </Button>

--- a/web-common/src/components/alert-dialog/alert-dialog-guarded-confirmation.svelte
+++ b/web-common/src/components/alert-dialog/alert-dialog-guarded-confirmation.svelte
@@ -9,8 +9,8 @@
     AlertDialogTrigger,
   } from "@rilldata/web-common/components/alert-dialog/index.js";
   import { Button } from "@rilldata/web-common/components/button/index.js";
-  import AlertCircleOutline from "@rilldata/web-common/components/icons/AlertCircleOutline.svelte";
   import Input from "@rilldata/web-common/components/forms/Input.svelte";
+  import AlertCircleOutline from "@rilldata/web-common/components/icons/AlertCircleOutline.svelte";
 
   export let open = false;
 
@@ -63,10 +63,10 @@
       </AlertDialogDescription>
     </AlertDialogHeader>
     <AlertDialogFooter class="mt-5">
-      <Button type="secondary" on:click={close}>Cancel</Button>
+      <Button type="secondary" onClick={close}>Cancel</Button>
       <Button
         type="primary"
-        on:click={handleContinue}
+        onClick={handleContinue}
         disabled={!confirmed}
         {loading}
       >

--- a/web-common/src/components/banner/__stories__/Banner.stories.svelte
+++ b/web-common/src/components/banner/__stories__/Banner.stories.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
+  import BannerCenter from "@rilldata/web-common/components/banner/BannerCenter.svelte";
   import {
     BillingBannerID,
     BillingBannerPriority,
   } from "@rilldata/web-common/components/banner/constants";
-  import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
-  import { Story, Template } from "@storybook/addon-svelte-csf";
-  import BannerCenter from "@rilldata/web-common/components/banner/BannerCenter.svelte";
   import { Button } from "@rilldata/web-common/components/button/index.js";
   import Input from "@rilldata/web-common/components/forms/Input.svelte";
   import Select from "@rilldata/web-common/components/forms/Select.svelte";
+  import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
+  import { Story, Template } from "@storybook/addon-svelte-csf";
 
   let message: string;
   let type: string;
@@ -62,7 +62,7 @@
       options={iconTypeOptions}
       bind:value={iconType}
     />
-    <Button type="primary" on:click={showBanner}>Show</Button>
+    <Button type="primary" onClick={showBanner}>Show</Button>
   </div>
 </Template>
 

--- a/web-common/src/components/button/Button.svelte
+++ b/web-common/src/components/button/Button.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
   import { builderActions, getAttrs, type Builder } from "bits-ui";
-  import { createEventDispatcher } from "svelte";
   import LoadingSpinner from "../icons/LoadingSpinner.svelte";
-
-  const dispatch = createEventDispatcher();
 
   type ButtonType =
     | "primary"
@@ -18,6 +15,7 @@
     | "toolbar";
 
   export let type: ButtonType = "plain";
+  export let onClick: ((event: MouseEvent) => void) | undefined = undefined;
   export let status: "info" | "error" = "info";
   export let disabled = false;
   export let compact = false;
@@ -52,8 +50,8 @@
   export { className as class };
 
   const handleClick = (event: MouseEvent) => {
-    if (!disabled) {
-      dispatch("click", event);
+    if (!disabled && onClick) {
+      onClick(event);
     }
   };
 </script>

--- a/web-common/src/components/calls-to-action/CTAButton.svelte
+++ b/web-common/src/components/calls-to-action/CTAButton.svelte
@@ -2,6 +2,7 @@
   import Button from "../button/Button.svelte";
 
   export let variant: "primary" | "secondary" = "primary";
+  export let onClick: ((event: MouseEvent) => void) | undefined = undefined;
   export let href: string | null = null;
   export let rel: string | undefined = undefined;
   export let disabled = false;
@@ -17,7 +18,7 @@
   wide
   {gray}
   {submitForm}
-  on:click
+  {onClick}
 >
   <slot />
 </Button>

--- a/web-common/src/components/code-block/CodeBlock.svelte
+++ b/web-common/src/components/code-block/CodeBlock.svelte
@@ -35,7 +35,7 @@
   {#if showCopyButton}
     <Button
       type="secondary"
-      on:click={copyCode}
+      onClick={copyCode}
       small
       class="absolute top-2 right-2"
     >

--- a/web-common/src/components/dialog/GuardedDialog.svelte
+++ b/web-common/src/components/dialog/GuardedDialog.svelte
@@ -67,10 +67,10 @@
       </AlertDialogDescription>
     </AlertDialogHeader>
     <AlertDialogFooter>
-      <Button type="secondary" on:click={() => (showCancelDialog = false)}>
+      <Button type="secondary" onClick={() => (showCancelDialog = false)}>
         {cancelLabel}
       </Button>
-      <Button type="primary" on:click={onConfirmCancel}>
+      <Button type="primary" onClick={onConfirmCancel}>
         {confirmLabel}
       </Button>
     </AlertDialogFooter>

--- a/web-common/src/components/forms/InputArray.svelte
+++ b/web-common/src/components/forms/InputArray.svelte
@@ -94,7 +94,7 @@
         {/if}
       </div>
     {/each}
-    <Button on:click={handleAddItem} type="dashed">
+    <Button onClick={handleAddItem} type="dashed">
       <div class="flex gap-x-2">
         <Add className="text-gray-700" />
         {addItemLabel}

--- a/web-common/src/components/forms/InputWithConfirm.svelte
+++ b/web-common/src/components/forms/InputWithConfirm.svelte
@@ -89,7 +89,7 @@
           square
           small
           type="ghost"
-          on:click={() => {
+          onClick={() => {
             editing = !editing;
           }}
         >

--- a/web-common/src/components/forms/InputWithConfirm.svelte
+++ b/web-common/src/components/forms/InputWithConfirm.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import Button from "@rilldata/web-common/components/button/Button.svelte";
   import Input from "@rilldata/web-common/components/forms/Input.svelte";
-  import Pencil from "svelte-radix/Pencil1.svelte";
   import Check from "@rilldata/web-common/components/icons/Check.svelte";
-  import { scale } from "svelte/transition";
+  import Pencil from "svelte-radix/Pencil1.svelte";
   import { cubicOut } from "svelte/easing";
+  import { scale } from "svelte/transition";
 
   export let value: string | undefined = "";
   export let onConfirm: (newValue: string) => void | Promise<void> = () => {};
@@ -64,7 +64,7 @@
       small
       square
       label="Save title"
-      on:click={triggerConfirm}
+      onClick={triggerConfirm}
     >
       <Check size="16px" />
     </Button>

--- a/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
+++ b/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
-  import * as Popover from "@rilldata/web-common/components/popover";
+  import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
   import DragHandle from "@rilldata/web-common/components/icons/DragHandle.svelte";
+  import EyeIcon from "@rilldata/web-common/components/icons/Eye.svelte";
+  import EyeOffIcon from "@rilldata/web-common/components/icons/EyeInvisible.svelte";
+  import * as Popover from "@rilldata/web-common/components/popover";
   import { clamp } from "@rilldata/web-common/lib/clamp";
   import type {
-    MetricsViewSpecMeasure,
     MetricsViewSpecDimension,
+    MetricsViewSpecMeasure,
   } from "@rilldata/web-common/runtime-client";
-  import { Button } from "../button";
-  import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
-  import EyeOffIcon from "@rilldata/web-common/components/icons/EyeInvisible.svelte";
-  import EyeIcon from "@rilldata/web-common/components/icons/Eye.svelte";
-  import Search from "../search/Search.svelte";
   import { Tooltip } from "bits-ui";
+  import { Button } from "../button";
+  import Search from "../search/Search.svelte";
 
   const UPPER_BOUND = 12 + 28 + 25;
   const ITEM_HEIGHT = 28;
@@ -203,7 +203,7 @@
 
 <Popover.Root bind:open={active}>
   <Popover.Trigger asChild let:builder>
-    <Button builders={[builder]} type="text" label={tooltipText} on:click>
+    <Button builders={[builder]} type="text" label={tooltipText}>
       <div
         class="flex items-center gap-x-0.5 px-1 text-gray-700 hover:text-inherit"
       >

--- a/web-common/src/components/menu/DashboardVisibilityDropdown.svelte
+++ b/web-common/src/components/menu/DashboardVisibilityDropdown.svelte
@@ -5,8 +5,8 @@
   import { fly } from "svelte/transition";
   import Button from "../button/Button.svelte";
   import CaretDownIcon from "../icons/CaretDownIcon.svelte";
-  import TooltipContent from "../tooltip/TooltipContent.svelte";
   import SearchableMenuContent from "../searchable-filter-menu/SearchableMenuContent.svelte";
+  import TooltipContent from "../tooltip/TooltipContent.svelte";
 
   export let selectableItems: SearchableFilterSelectableItem[];
   export let selectedItems: string[];
@@ -38,7 +38,7 @@
       location="bottom"
       suppress={active}
     >
-      <Button builders={[builder]} type="text" label={tooltipText} on:click>
+      <Button builders={[builder]} type="text" label={tooltipText}>
         <div
           class="flex items-center gap-x-0.5 px-1 text-gray-700 hover:text-inherit"
         >

--- a/web-common/src/components/notifications/Notification.svelte
+++ b/web-common/src/components/notifications/Notification.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  import { scale } from "svelte/transition";
   import { portal } from "@rilldata/web-common/lib/actions/portal";
   import type { NotificationMessage } from "@rilldata/web-common/lib/event-bus/events";
-  import Close from "../icons/Close.svelte";
-  import Check from "../icons/Check.svelte";
-  import Button from "../button/Button.svelte";
   import { onMount } from "svelte";
-  import WarningIcon from "../icons/WarningIcon.svelte";
+  import { scale } from "svelte/transition";
+  import Button from "../button/Button.svelte";
+  import Check from "../icons/Check.svelte";
+  import Close from "../icons/Close.svelte";
   import LoadingSpinner from "../icons/LoadingSpinner.svelte";
+  import WarningIcon from "../icons/WarningIcon.svelte";
   import { NOTIFICATION_TIMEOUT } from "./constants";
 
   export let location: "top" | "bottom" | "middle" = "bottom";
@@ -53,7 +53,7 @@
 
     {#if options?.persisted && type !== "loading"}
       <div class="px-2 py-2 border-l">
-        <Button on:click={onClose} square>
+        <Button onClick={onClose} square>
           <Close size="18px" color="#fff" />
         </Button>
       </div>

--- a/web-common/src/components/searchable-filter-menu/SearchableMenuContent.svelte
+++ b/web-common/src/components/searchable-filter-menu/SearchableMenuContent.svelte
@@ -131,7 +131,7 @@
 
   {#if allowSelectAll && allowMultiSelect}
     <footer>
-      <Button on:click={onToggleSelectAll} type="plain">
+      <Button onClick={onToggleSelectAll} type="plain">
         {#if allSelected}
           Deselect all
         {:else}

--- a/web-common/src/features/alerts/BaseAlertForm.svelte
+++ b/web-common/src/features/alerts/BaseAlertForm.svelte
@@ -93,7 +93,7 @@
     class="px-6 py-4 text-gray-900 text-lg font-semibold leading-7 flex flex-row items-center justify-between"
   >
     <div>{dialogTitle}</div>
-    <Button type="link" noStroke compact on:click={handleCancel}>
+    <Button type="link" noStroke compact onClick={handleCancel}>
       <X strokeWidth={3} size={16} class="text-black" />
     </Button>
   </DialogTitle>
@@ -121,12 +121,12 @@
   <div class="px-6 py-3 flex items-center gap-x-2">
     <div class="grow" />
     {#if currentTabIndex === 0}
-      <Button on:click={handleCancel} type="secondary">Cancel</Button>
+      <Button onClick={handleCancel} type="secondary">Cancel</Button>
     {:else}
-      <Button on:click={handleBack} type="secondary">Back</Button>
+      <Button onClick={handleBack} type="secondary">Back</Button>
     {/if}
     {#if currentTabIndex !== 2}
-      <Button type="primary" on:click={handleNextTab}>Next</Button>
+      <Button type="primary" onClick={handleNextTab}>Next</Button>
     {:else}
       <Button type="primary" disabled={$isSubmitting} form={formId} submitForm>
         {isEditForm ? "Update" : "Create"}

--- a/web-common/src/features/alerts/criteria-tab/CriteriaGroup.svelte
+++ b/web-common/src/features/alerts/criteria-tab/CriteriaGroup.svelte
@@ -50,6 +50,6 @@
         <CriteriaForm {formState} {index} />
       </div>
     {/each}
-    <Button type="dashed" on:click={handleAddCriteria}>+ Add Criteria</Button>
+    <Button type="dashed" onClick={handleAddCriteria}>+ Add Criteria</Button>
   </div>
 {/if}

--- a/web-common/src/features/billing/TrialDetailsDialog.svelte
+++ b/web-common/src/features/billing/TrialDetailsDialog.svelte
@@ -42,10 +42,10 @@
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter class="mt-5">
-          <Button on:click={() => (open = false)} type="secondary">Back</Button>
+          <Button onClick={() => (open = false)} type="secondary">Back</Button>
           {#if deployCTAUrl}
             <Button
-              on:click={() => (open = false)}
+              onClick={() => (open = false)}
               type="primary"
               href={deployCTAUrl}
               target="_blank"
@@ -54,7 +54,7 @@
             </Button>
           {:else}
             <Button
-              on:click={() => {
+              onClick={() => {
                 open = false;
                 onContinue();
               }}

--- a/web-common/src/features/canvas/CreateCanvasDialog.svelte
+++ b/web-common/src/features/canvas/CreateCanvasDialog.svelte
@@ -68,7 +68,7 @@
           large
           builders={[builder]}
           type="primary"
-          on:click={createResource}
+          onClick={createResource}
         >
           Continue
         </Button>

--- a/web-common/src/features/canvas/filters/CanvasFilters.svelte
+++ b/web-common/src/features/canvas/filters/CanvasFilters.svelte
@@ -390,7 +390,7 @@
         <!-- if filters are present, place a chip at the end of the flex container 
       that enables clearing all filters -->
         {#if hasFilters}
-          <Button type="text" on:click={clearAllFilters}>Clear filters</Button>
+          <Button type="text" onClick={clearAllFilters}>Clear filters</Button>
         {/if}
       {/if}
     </div>

--- a/web-common/src/features/canvas/inspector/chart/ChartTypeSelector.svelte
+++ b/web-common/src/features/canvas/inspector/chart/ChartTypeSelector.svelte
@@ -42,7 +42,7 @@
           type="secondary"
           label={CHART_CONFIG[chart].title}
           selected={type === chart}
-          on:click={() => selectChartType(chart)}
+          onClick={() => selectChartType(chart)}
         >
           <svelte:component this={CHART_CONFIG[chart].icon} size="20px" />
         </Button>

--- a/web-common/src/features/canvas/inspector/filters/DimensionFiltersInput.svelte
+++ b/web-common/src/features/canvas/inspector/filters/DimensionFiltersInput.svelte
@@ -207,7 +207,7 @@
       </div>
       <div class="ml-auto">
         {#if hasFilters}
-          <Button type="text" on:click={clearAllFilters}>Clear filters</Button>
+          <Button type="text" onClick={clearAllFilters}>Clear filters</Button>
         {/if}
       </div>
     </div>

--- a/web-common/src/features/connectors/olap/TableWorkspaceHeader.svelte
+++ b/web-common/src/features/connectors/olap/TableWorkspaceHeader.svelte
@@ -10,9 +10,9 @@
   import { BehaviourEventMedium } from "../../../metrics/service/BehaviourEventTypes";
   import { MetricsEventSpace } from "../../../metrics/service/MetricsTypes";
   import { runtime } from "../../../runtime-client/runtime-store";
+  import { ResourceKind } from "../../entity-management/resource-selectors";
   import { featureFlags } from "../../feature-flags";
   import { useCreateMetricsViewFromTableUIAction } from "../../metrics-views/ai-generation/generateMetricsView";
-  import { ResourceKind } from "../../entity-management/resource-selectors";
 
   export let connector: string;
   export let database: string = "";
@@ -51,7 +51,7 @@
     <svelte:fragment let:width={headerWidth} slot="cta">
       {@const collapse = isHeaderWidthSmall(headerWidth)}
       <PanelCTA side="right">
-        <Button on:click={createMetricsViewFromTable} type="primary">
+        <Button onClick={createMetricsViewFromTable} type="primary">
           <IconSpaceFixer pullLeft pullRight={collapse}>
             <Add />
           </IconSpaceFixer>

--- a/web-common/src/features/dashboards/dimension-search/GlobalDimensionSearch.svelte
+++ b/web-common/src/features/dashboards/dimension-search/GlobalDimensionSearch.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { Button } from "@rilldata/web-common/components/button";
   import Cancel from "@rilldata/web-common/components/icons/Cancel.svelte";
+  import SearchIcon from "@rilldata/web-common/components/icons/Search.svelte";
   import { Search } from "@rilldata/web-common/components/search";
   import GlobalDimensionSearchResults from "@rilldata/web-common/features/dashboards/dimension-search/GlobalDimensionSearchResults.svelte";
   import { slideRight } from "@rilldata/web-common/lib/transitions";
-  import SearchIcon from "@rilldata/web-common/components/icons/Search.svelte";
 
   let searchBarOpen = false;
   let searchText = "";
@@ -42,7 +42,7 @@
   {:else}
     <Button
       class="flex items-center gap-x-2 p-1.5 text-gray-700"
-      on:click={() => (searchBarOpen = !searchBarOpen)}
+      onClick={() => (searchBarOpen = !searchBarOpen)}
       type="secondary"
       compact
     >

--- a/web-common/src/features/dashboards/dimension-search/GlobalDimensionSearchResult.svelte
+++ b/web-common/src/features/dashboards/dimension-search/GlobalDimensionSearchResult.svelte
@@ -2,8 +2,8 @@
   import { Button } from "@rilldata/web-common/components/button";
   import {
     DropdownMenuGroup,
-    DropdownMenuLabel,
     DropdownMenuItem,
+    DropdownMenuLabel,
   } from "@rilldata/web-common/components/dropdown-menu";
 
   export let dimension: string;
@@ -40,7 +40,7 @@
       <Button
         type="link"
         noStroke
-        on:click={() => (expanded = !expanded)}
+        onClick={() => (expanded = !expanded)}
         class="justify-items-start"
       >
         {expanded ? "See less" : "See more"}

--- a/web-common/src/features/dashboards/dimension-table/DimensionHeader.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionHeader.svelte
@@ -141,7 +141,7 @@
     <Button
       type="link"
       forcedStyle="padding: 0; gap: 4px;"
-      on:click={() => goBackToLeaderboard()}
+      onClick={() => goBackToLeaderboard()}
     >
       <Back size="16px" />
       <span>All Dimensions</span>

--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -7,40 +7,40 @@
   import type { MeasureFilterEntry } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry";
   import { isExpressionUnsupported } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
   import { getMapFromArray } from "@rilldata/web-common/lib/arrayUtils";
-  import { flip } from "svelte/animate";
-  import { fly } from "svelte/transition";
-  import { getStateManagers } from "../state-managers/state-managers";
-  import ComparisonPill from "../time-controls/comparison-pill/ComparisonPill.svelte";
-  import SuperPill from "../time-controls/super-pill/SuperPill.svelte";
-  import { useTimeControlStore } from "../time-controls/time-control-store";
-  import FilterButton from "./FilterButton.svelte";
-  import DimensionFilter from "./dimension-filters/DimensionFilter.svelte";
-  import type {
-    V1ExploreTimeRange,
-    V1TimeGrain,
-  } from "@rilldata/web-common/runtime-client";
-  import {
-    ALL_TIME_RANGE_ALIAS,
-    CUSTOM_TIME_RANGE_ALIAS,
-    deriveInterval,
-  } from "../time-controls/new-time-controls";
+  import type { TimeRange } from "@rilldata/web-common/lib/time/types";
   import {
     TimeComparisonOption,
     TimeRangePreset,
     type DashboardTimeControls,
   } from "@rilldata/web-common/lib/time/types";
+  import type {
+    V1ExploreTimeRange,
+    V1TimeGrain,
+  } from "@rilldata/web-common/runtime-client";
+  import { DateTime, Interval } from "luxon";
+  import { flip } from "svelte/animate";
+  import { fly } from "svelte/transition";
+  import { getStateManagers } from "../state-managers/state-managers";
   import {
     metricsExplorerStore,
     useExploreState,
   } from "../stores/dashboard-stores";
-  import type { TimeRange } from "@rilldata/web-common/lib/time/types";
-  import { DateTime, Interval } from "luxon";
+  import ComparisonPill from "../time-controls/comparison-pill/ComparisonPill.svelte";
+  import {
+    ALL_TIME_RANGE_ALIAS,
+    CUSTOM_TIME_RANGE_ALIAS,
+    deriveInterval,
+  } from "../time-controls/new-time-controls";
+  import SuperPill from "../time-controls/super-pill/SuperPill.svelte";
+  import { useTimeControlStore } from "../time-controls/time-control-store";
+  import FilterButton from "./FilterButton.svelte";
+  import DimensionFilter from "./dimension-filters/DimensionFilter.svelte";
 
-  import { getDefaultTimeGrain } from "@rilldata/web-common/lib/time/grains";
-  import { getValidComparisonOption } from "../time-controls/time-range-store";
-  import { Tooltip } from "bits-ui";
   import Timestamp from "@rilldata/web-common/features/dashboards/time-controls/super-pill/components/Timestamp.svelte";
+  import { getDefaultTimeGrain } from "@rilldata/web-common/lib/time/grains";
+  import { Tooltip } from "bits-ui";
   import Metadata from "../time-controls/super-pill/components/Metadata.svelte";
+  import { getValidComparisonOption } from "../time-controls/time-range-store";
   import { getPinnedTimeZones } from "../url-state/getDefaultExplorePreset";
 
   export let readOnly = false;
@@ -443,7 +443,7 @@
         <!-- if filters are present, place a chip at the end of the flex container 
       that enables clearing all filters -->
         {#if hasFilters}
-          <Button type="text" on:click={clearAllFilters}>Clear filters</Button>
+          <Button type="text" onClick={clearAllFilters}>Clear filters</Button>
         {/if}
       {/if}
     </div>

--- a/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
+++ b/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   import { Button } from "@rilldata/web-common/components/button";
   import { Chip } from "@rilldata/web-common/components/chip";
+  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
   import Label from "@rilldata/web-common/components/forms/Label.svelte";
   import Select from "@rilldata/web-common/components/forms/Select.svelte";
   import Switch from "@rilldata/web-common/components/forms/Switch.svelte";
-  import DimensionFilterChipBody from "@rilldata/web-common/features/dashboards/filters/dimension-filters/DimensionFilterChipBody.svelte";
-  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
   import LoadingSpinner from "@rilldata/web-common/components/icons/LoadingSpinner.svelte";
   import { Search } from "@rilldata/web-common/components/search";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
@@ -19,16 +18,17 @@
     mergeDimensionSearchValues,
     splitDimensionSearchText,
   } from "@rilldata/web-common/features/dashboards/filters/dimension-filters/dimension-search-text-utils";
-  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
-  import { fly } from "svelte/transition";
-  import {
-    useDimensionSearch,
-    useAllSearchResultsCount,
-  } from "web-common/src/features/dashboards/filters/dimension-filters/dimension-filter-values";
+  import DimensionFilterChipBody from "@rilldata/web-common/features/dashboards/filters/dimension-filters/DimensionFilterChipBody.svelte";
   import { mergeDimensionAndMeasureFilters } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
   import { getFiltersForOtherDimensions } from "@rilldata/web-common/features/dashboards/selectors";
   import { sanitiseExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
   import type { V1Expression } from "@rilldata/web-common/runtime-client";
+  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
+  import { fly } from "svelte/transition";
+  import {
+    useAllSearchResultsCount,
+    useDimensionSearch,
+  } from "web-common/src/features/dashboards/filters/dimension-filters/dimension-filter-values";
 
   export let name: string;
   export let metricsViewNames: string[];
@@ -443,7 +443,7 @@
         <Label class="font-normal text-xs" for="include-exclude">Exclude</Label>
       </div>
       {#if curMode === DimensionFilterMode.Select}
-        <Button on:click={onToggleSelectAll} type="plain" class="justify-end">
+        <Button onClick={onToggleSelectAll} type="plain" class="justify-end">
           {#if allSelected}
             Deselect all
           {:else}
@@ -452,7 +452,7 @@
         </Button>
       {:else}
         <Button
-          on:click={onApply}
+          onClick={onApply}
           type="primary"
           class="justify-end"
           disabled={!enableSearchCountQuery}

--- a/web-common/src/features/dashboards/pivot/DragList.svelte
+++ b/web-common/src/features/dashboards/pivot/DragList.svelte
@@ -8,6 +8,7 @@
   import { getStateManagers } from "../state-managers/state-managers";
   import { metricsExplorerStore } from "../stores/dashboard-stores";
   import AddField from "./AddField.svelte";
+  import PivotChip from "./PivotChip.svelte";
   import PivotPortalItem from "./PivotPortalItem.svelte";
   import { swapListener } from "./swapListener";
   import {
@@ -15,7 +16,6 @@
     PivotChipType,
     type PivotTableMode,
   } from "./types";
-  import PivotChip from "./PivotChip.svelte";
 
   export type Zone = "rows" | "columns" | "Time" | "Measures" | "Dimensions";
 
@@ -282,7 +282,7 @@
     {#if items.length}
       <Button
         type="text"
-        on:click={() => {
+        onClick={() => {
           onUpdate([]);
         }}
       >

--- a/web-common/src/features/dashboards/pivot/PivotToolbar.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotToolbar.svelte
@@ -66,6 +66,10 @@
     ]);
   }
 
+  function blurCurrentTarget(e: MouseEvent) {
+    (e.currentTarget as HTMLButtonElement | null)?.blur();
+  }
+
   // function expandVisible() {
   //   // const lowestVisibleRow = 0;
   //   const nestedLevels = 4;
@@ -103,7 +107,7 @@
     selected={showPanels}
     onClick={(e) => {
       showPanels = !showPanels;
-      e.detail.currentTarget.blur();
+      blurCurrentTarget(e);
     }}
   >
     <PivotPanel size="18px" open={showPanels} />

--- a/web-common/src/features/dashboards/pivot/PivotToolbar.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotToolbar.svelte
@@ -101,7 +101,7 @@
     square
     type="secondary"
     selected={showPanels}
-    on:click={(e) => {
+    onClick={(e) => {
       showPanels = !showPanels;
       e.detail.currentTarget.blur();
     }}
@@ -113,7 +113,7 @@
     <Tooltip location="bottom" alignment="start" distance={8}>
       <Button
         type="toolbar"
-        on:click={() => togglePivotType($isFlat ? "nest" : "flat")}
+        onClick={() => togglePivotType($isFlat ? "nest" : "flat")}
       >
         {#if $isFlat}
           <TableIcon size="16px" />
@@ -130,7 +130,7 @@
     <!-- <Button
     compact
     type="text"
-    on:click={() => {
+    onClick={() => {
       expandVisible();
     }}
   >
@@ -138,7 +138,7 @@
   </Button> -->
     <Button
       type="toolbar"
-      on:click={() => {
+      onClick={() => {
         metricsExplorerStore.setPivotExpanded($exploreName, {});
       }}
       disabled={Object.keys(expanded).length === 0}

--- a/web-common/src/features/dashboards/pivot/ReplacePivotDialog.svelte
+++ b/web-common/src/features/dashboards/pivot/ReplacePivotDialog.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { Button } from "@rilldata/web-common/components/button";
   import * as AlertDialog from "@rilldata/web-common/components/alert-dialog";
+  import { Button } from "@rilldata/web-common/components/button";
 
   export let open;
   export let onCancel: () => void;
@@ -18,13 +18,13 @@
 
     <AlertDialog.Footer>
       <AlertDialog.Cancel asChild let:builder>
-        <Button large builders={[builder]} type="secondary" on:click={onCancel}>
+        <Button large builders={[builder]} type="secondary" onClick={onCancel}>
           Cancel
         </Button>
       </AlertDialog.Cancel>
 
       <AlertDialog.Action asChild let:builder>
-        <Button large builders={[builder]} type="primary" on:click={onReplace}>
+        <Button large builders={[builder]} type="primary" onClick={onReplace}>
           Replace
         </Button>
       </AlertDialog.Action>

--- a/web-common/src/features/dashboards/time-controls/super-pill/components/CalendarPlusDateInput.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/CalendarPlusDateInput.svelte
@@ -1,10 +1,9 @@
 <script context="module" lang="ts">
-  import { Interval } from "luxon";
-  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu/";
-  import Calendar from "@rilldata/web-common/components/date-picker/Calendar.svelte";
-  import { DateTime } from "luxon";
   import Button from "@rilldata/web-common/components/button/Button.svelte";
+  import Calendar from "@rilldata/web-common/components/date-picker/Calendar.svelte";
   import DateInput from "@rilldata/web-common/components/date-picker/DateInput.svelte";
+  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu/";
+  import { DateTime, Interval } from "luxon";
 </script>
 
 <script lang="ts">
@@ -99,7 +98,7 @@
     fit
     compact
     type="primary"
-    on:click={() => {
+    onClick={() => {
       const mapped = calendarInterval?.set({
         end: calendarInterval.end?.plus({ day: 1 }).startOf("day"),
       });

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -34,9 +34,9 @@
     TimeRangePreset,
     type AvailableTimeGrain,
   } from "@rilldata/web-common/lib/time/types";
+  import type { MetricsViewSpecMeasure } from "@rilldata/web-common/runtime-client";
   import { Button } from "../../../components/button";
   import Pivot from "../../../components/icons/Pivot.svelte";
-  import type { MetricsViewSpecMeasure } from "@rilldata/web-common/runtime-client";
   import { TIME_GRAIN } from "../../../lib/time/config";
   import { DashboardState_ActivePage } from "../../../proto/gen/rill/ui/v1/dashboard_pb";
   import Spinner from "../../entity-management/Spinner.svelte";
@@ -324,7 +324,7 @@
         <div class="grow" />
         <Button
           type="toolbar"
-          on:click={() => {
+          onClick={() => {
             startPivotForTimeseries();
           }}
         >

--- a/web-common/src/features/dashboards/toolbars/ExcludeButton.svelte
+++ b/web-common/src/features/dashboards/toolbars/ExcludeButton.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <Tooltip distance={8} location="top">
-  <Button type="toolbar" on:click={onClick}>
+  <Button type="toolbar" {onClick}>
     <Switch checked={excludeMode}>Exclude</Switch>
   </Button>
   <TooltipContent slot="tooltip-content">

--- a/web-common/src/features/dashboards/toolbars/SearchButton.svelte
+++ b/web-common/src/features/dashboards/toolbars/SearchButton.svelte
@@ -20,7 +20,7 @@
 {#if !isSearchElementOpen}
   <Button
     type="toolbar"
-    on:click={() => (isSearchElementOpen = !isSearchElementOpen)}
+    onClick={() => (isSearchElementOpen = !isSearchElementOpen)}
   >
     <SearchIcon size="16px" />
     <span>Search</span>

--- a/web-common/src/features/dashboards/toolbars/SelectAllButton.svelte
+++ b/web-common/src/features/dashboards/toolbars/SelectAllButton.svelte
@@ -28,7 +28,7 @@
   </TooltipContent>
   <Button
     type="toolbar"
-    on:click={() => dispatch("toggle-all-search-items")}
+    onClick={() => dispatch("toggle-all-search-items")}
     {disabled}
   >
     <div class="ui-copy-icon">

--- a/web-common/src/features/dashboards/toolbars/StartPivotButton.svelte
+++ b/web-common/src/features/dashboards/toolbars/StartPivotButton.svelte
@@ -5,7 +5,7 @@
   export let onClick: () => void;
 </script>
 
-<Button compact type="toolbar" on:click={onClick}>
+<Button compact type="toolbar" {onClick}>
   <Pivot size="16px" />
   Start Pivot
 </Button>

--- a/web-common/src/features/dashboards/workspace/DeployProjectCTA.svelte
+++ b/web-common/src/features/dashboards/workspace/DeployProjectCTA.svelte
@@ -94,7 +94,7 @@
   <Tooltip distance={8}>
     <Button
       loading={$currentProject.isLoading}
-      on:click={onShowDeploy}
+      onClick={onShowDeploy}
       type={hasValidDashboard ? "primary" : "secondary"}
     >
       <Rocket size="16px" />

--- a/web-common/src/features/editor/DiffBar.svelte
+++ b/web-common/src/features/editor/DiffBar.svelte
@@ -18,7 +18,7 @@
       loadingCopy="Saving"
       danger={!!errorMessage && !saving}
       disabled={saving}
-      on:click={onAcceptCurrent}
+      onClick={onAcceptCurrent}
     >
       {#if errorMessage}
         <Alert size="14px" />
@@ -31,7 +31,7 @@
 
   <div>
     <h2>Incoming content</h2>
-    <Button type="primary" on:click={onAcceptIncoming}>Accept incoming</Button>
+    <Button type="primary" onClick={onAcceptIncoming}>Accept incoming</Button>
   </div>
 </header>
 

--- a/web-common/src/features/editor/Editor.svelte
+++ b/web-common/src/features/editor/Editor.svelte
@@ -1,22 +1,22 @@
 <script lang="ts">
+  import type { Extension } from "@codemirror/state";
+  import { EditorView } from "@codemirror/view";
+  import * as AlertDialog from "@rilldata/web-common/components/alert-dialog/";
   import Button from "@rilldata/web-common/components/button/Button.svelte";
   import Label from "@rilldata/web-common/components/forms/Label.svelte";
   import Switch from "@rilldata/web-common/components/forms/Switch.svelte";
+  import Alert from "@rilldata/web-common/components/icons/Alert.svelte";
   import Check from "@rilldata/web-common/components/icons/Check.svelte";
   import UndoIcon from "@rilldata/web-common/components/icons/UndoIcon.svelte";
-  import type { Extension } from "@codemirror/state";
-  import { EditorView } from "@codemirror/view";
+  import MetaKey from "@rilldata/web-common/components/tooltip/MetaKey.svelte";
+  import Shortcut from "@rilldata/web-common/components/tooltip/Shortcut.svelte";
+  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
+  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
+  import TooltipShortcutContainer from "@rilldata/web-common/components/tooltip/TooltipShortcutContainer.svelte";
   import { debounce } from "../../lib/create-debouncer";
-  import { FILE_SAVE_DEBOUNCE_TIME } from "./config";
   import { FileArtifact } from "../entity-management/file-artifact";
   import Codespace from "./Codespace.svelte";
-  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
-  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
-  import TooltipShortcutContainer from "@rilldata/web-common/components/tooltip/TooltipShortcutContainer.svelte";
-  import Shortcut from "@rilldata/web-common/components/tooltip/Shortcut.svelte";
-  import MetaKey from "@rilldata/web-common/components/tooltip/MetaKey.svelte";
-  import * as AlertDialog from "@rilldata/web-common/components/alert-dialog/";
-  import Alert from "@rilldata/web-common/components/icons/Alert.svelte";
+  import { FILE_SAVE_DEBOUNCE_TIME } from "./config";
   import DiffBar from "./DiffBar.svelte";
 
   export let fileArtifact: FileArtifact;
@@ -104,7 +104,7 @@
               danger={!!$error && !$saving}
               loadingCopy="Saving"
               {disabled}
-              on:click={() => save()}
+              onClick={() => save()}
             >
               {#if $error}
                 <Alert size="14px" />
@@ -128,7 +128,7 @@
             </TooltipContent>
           </Tooltip>
 
-          <Button type="text" {disabled} on:click={revertContent}>
+          <Button type="text" {disabled} onClick={revertContent}>
             <UndoIcon size="14px" />
             Revert changes
           </Button>
@@ -167,7 +167,7 @@
             builders={[builder]}
             type="primary"
             large
-            on:click={() => {
+            onClick={() => {
               merging.set(true);
             }}
           >
@@ -178,7 +178,7 @@
             builders={[builder]}
             type="secondary"
             large
-            on:click={revertContent}
+            onClick={revertContent}
           >
             Overwrite
           </Button>

--- a/web-common/src/features/entity-management/CreateExploreDialog.svelte
+++ b/web-common/src/features/entity-management/CreateExploreDialog.svelte
@@ -63,7 +63,7 @@
           large
           builders={[builder]}
           type="primary"
-          on:click={createResource}
+          onClick={createResource}
         >
           Continue
         </Button>

--- a/web-common/src/features/entity-management/RenameAssetModal.svelte
+++ b/web-common/src/features/entity-management/RenameAssetModal.svelte
@@ -150,7 +150,7 @@
       />
     </form>
     <Dialog.Footer class="gap-x-2">
-      <Button large type="text" on:click={closeModal}>Cancel</Button>
+      <Button large type="text" onClick={closeModal}>Cancel</Button>
       <Button large type="primary" submitForm form="rename-asset-form">
         Change Name
       </Button>

--- a/web-common/src/features/explores/PreviewButton.svelte
+++ b/web-common/src/features/explores/PreviewButton.svelte
@@ -48,7 +48,7 @@
     {loading}
     {href}
     {disabled}
-    on:click={viewDashboard}
+    onClick={viewDashboard}
   >
     <div class="flex gap-x-1 items-center">
       <Play size="14px" />

--- a/web-common/src/features/file-explorer/ForceDeleteConfirmationDialog.svelte
+++ b/web-common/src/features/file-explorer/ForceDeleteConfirmationDialog.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { Button } from "@rilldata/web-common/components/button";
   import * as AlertDialog from "@rilldata/web-common/components/alert-dialog/index";
+  import { Button } from "@rilldata/web-common/components/button";
 
   export let open: boolean;
   export let onDelete: () => void;
@@ -32,7 +32,7 @@
         <Button
           large
           builders={[builder]}
-          on:click={() => {
+          onClick={() => {
             handleClose();
             onDelete();
           }}
@@ -44,7 +44,7 @@
       </AlertDialog.Action>
 
       <AlertDialog.Cancel asChild let:builder>
-        <Button large builders={[builder]} on:click={handleClose} type="plain">
+        <Button large builders={[builder]} onClick={handleClose} type="plain">
           Cancel
         </Button>
       </AlertDialog.Cancel>

--- a/web-common/src/features/metrics-views/GoToDashboardButton.svelte
+++ b/web-common/src/features/metrics-views/GoToDashboardButton.svelte
@@ -28,7 +28,7 @@
   <Button
     type={$allowPrimary ? "primary" : "secondary"}
     disabled={!resource}
-    on:click={async () => {
+    onClick={async () => {
       if (resource)
         await createAndPreviewExplore(queryClient, instanceId, resource);
     }}

--- a/web-common/src/features/models/incremental/ModelRefreshButton.svelte
+++ b/web-common/src/features/models/incremental/ModelRefreshButton.svelte
@@ -69,7 +69,7 @@
       disabled={hasUnsavedChanges}
       type="secondary"
       label="Refresh Model"
-      on:click={() => refreshModel(true)}
+      onClick={() => refreshModel(true)}
     >
       <RefreshIcon size="14px" />
     </Button>

--- a/web-common/src/features/models/partitions/TriggerPartition.svelte
+++ b/web-common/src/features/models/partitions/TriggerPartition.svelte
@@ -41,7 +41,7 @@
 
 <Button
   type="secondary"
-  on:click={trigger}
+  onClick={trigger}
   disabled={resource?.meta?.reconcileStatus ===
     V1ReconcileStatus.RECONCILE_STATUS_RUNNING}
   noWrap

--- a/web-common/src/features/models/workspace/CreateDashboardButton.svelte
+++ b/web-common/src/features/models/workspace/CreateDashboardButton.svelte
@@ -6,13 +6,13 @@
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { BehaviourEventMedium } from "@rilldata/web-common/metrics/service/BehaviourEventTypes";
   import { MetricsEventSpace } from "@rilldata/web-common/metrics/service/MetricsTypes";
+  import { Wand } from "lucide-svelte";
   import { V1ReconcileStatus } from "../../../runtime-client";
   import { runtime } from "../../../runtime-client/runtime-store";
+  import { allowPrimary } from "../../dashboards/workspace/DeployProjectCTA.svelte";
   import { featureFlags } from "../../feature-flags";
   import { useCreateMetricsViewFromTableUIAction } from "../../metrics-views/ai-generation/generateMetricsView";
   import { useModel } from "../selectors";
-  import { Wand } from "lucide-svelte";
-  import { allowPrimary } from "../../dashboards/workspace/DeployProjectCTA.svelte";
 
   export let modelName: string;
   export let hasError = false;
@@ -43,7 +43,7 @@
 <Tooltip distance={8} location="bottom">
   <Button
     disabled={!modelIsIdle || hasError}
-    on:click={createMetricsViewFromModel}
+    onClick={createMetricsViewFromModel}
     type={$allowPrimary ? "primary" : "secondary"}
   >
     <IconSpaceFixer pullLeft pullRight={collapse}>

--- a/web-common/src/features/onboarding/OnboardingWorkspace.svelte
+++ b/web-common/src/features/onboarding/OnboardingWorkspace.svelte
@@ -92,7 +92,7 @@
               <p>{step.description}</p>
             </div>
             {#if step.id === "source"}
-              <Button type="secondary" on:click={addSourceModal.open}>
+              <Button type="secondary" onClick={addSourceModal.open}>
                 <IconSpaceFixer pullLeft><Add /></IconSpaceFixer>
                 <span>Add data</span>
               </Button>

--- a/web-common/src/features/project/DeployError.svelte
+++ b/web-common/src/features/project/DeployError.svelte
@@ -35,13 +35,13 @@
     <PricingDetails extraText={error.message} />
   </p>
   <Button type="primary" href={upgradeHref} wide>Upgrade</Button>
-  <Button type="secondary" noStroke wide on:click={onBack}>Back</Button>
+  <Button type="secondary" noStroke wide onClick={onBack}>Back</Button>
 {:else}
   <CancelCircleInverse size="7rem" className="text-gray-200" />
   <CTAHeader variant="bold">{error.title}</CTAHeader>
   <CTAMessage>{error.message}</CTAMessage>
   {#if error.type === DeployErrorType.Unknown}
-    <CTAButton variant="secondary" on:click={onRetry}>Retry</CTAButton>
+    <CTAButton variant="secondary" onClick={onRetry}>Retry</CTAButton>
   {/if}
 {/if}
 <CTAPylonHelp />

--- a/web-common/src/features/project/OrgSelector.svelte
+++ b/web-common/src/features/project/OrgSelector.svelte
@@ -30,4 +30,4 @@
   options={orgs.map((o) => ({ value: o, label: o }))}
   width={400}
 />
-<Button wide type="primary" on:click={selectHandler}>Continue</Button>
+<Button wide type="primary" onClick={selectHandler}>Continue</Button>

--- a/web-common/src/features/project/ProjectRedeployConfirmDialog.svelte
+++ b/web-common/src/features/project/ProjectRedeployConfirmDialog.svelte
@@ -48,13 +48,13 @@
     <AlertDialogFooter>
       <Button
         type="plain"
-        on:click={() => {
+        onClick={() => {
           open = false;
         }}
       >
         Cancel
       </Button>
-      <Button type="primary" on:click={onRedeploy}>Yes, update</Button>
+      <Button type="primary" onClick={onRedeploy}>Yes, update</Button>
     </AlertDialogFooter>
   </AlertDialogContent>
 </AlertDialog>

--- a/web-common/src/features/project/PushToGitForDeployDialog.svelte
+++ b/web-common/src/features/project/PushToGitForDeployDialog.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { getRepoNameFromGithubUrl } from "@rilldata/web-common/features/project/github-utils";
   import {
     AlertDialog,
     AlertDialogContent,
@@ -11,6 +10,7 @@
   } from "@rilldata/web-common/components/alert-dialog";
   import { Button } from "@rilldata/web-common/components/button";
   import Github from "@rilldata/web-common/components/icons/Github.svelte";
+  import { getRepoNameFromGithubUrl } from "@rilldata/web-common/features/project/github-utils";
 
   export let open = false;
   export let githubUrl: string;
@@ -62,7 +62,7 @@
       </AlertDialogDescription>
     </AlertDialogHeader>
     <AlertDialogFooter>
-      <Button on:click={() => (open = false)} type="secondary">Close</Button>
+      <Button onClick={() => (open = false)} type="secondary">Close</Button>
     </AlertDialogFooter>
   </AlertDialogContent>
 </AlertDialog>

--- a/web-common/src/features/scheduled-reports/ScheduledReportDialog.svelte
+++ b/web-common/src/features/scheduled-reports/ScheduledReportDialog.svelte
@@ -209,7 +209,7 @@
         <div class="text-red-500">{$mutation.error.message}</div>
       {/if}
       <div class="grow" />
-      <Button on:click={() => (open = false)} type="secondary">Cancel</Button>
+      <Button onClick={() => (open = false)} type="secondary">Cancel</Button>
       <Button
         disabled={$submitting || $form["emailRecipients"]?.length === 0}
         form="scheduled-report-form"

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -280,7 +280,7 @@
   {/if}
 
   <div class="flex items-center space-x-2 ml-auto">
-    <Button on:click={onBack} type="secondary">Back</Button>
+    <Button onClick={onBack} type="secondary">Back</Button>
     <Button disabled={submitting} form={formId} submitForm type="primary">
       {#if isConnectorForm}
         {#if submitting}

--- a/web-common/src/features/sources/modal/DuplicateSource.svelte
+++ b/web-common/src/features/sources/modal/DuplicateSource.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
+  import Button from "@rilldata/web-common/components/button/Button.svelte";
+  import * as Dialog from "@rilldata/web-common/components/dialog";
   import { onDestroy } from "svelte";
   import {
     DuplicateActions,
     duplicateSourceAction,
     duplicateSourceName,
   } from "../sources-store";
-  import Button from "@rilldata/web-common/components/button/Button.svelte";
-  import * as Dialog from "@rilldata/web-common/components/dialog";
 
   export let onComplete: () => void;
   export let onCancel: () => void;
@@ -39,11 +39,9 @@
 </Dialog.Description>
 
 <Dialog.Footer>
-  <Button type="text" on:click={cancel}>Cancel</Button>
+  <Button type="text" onClick={cancel}>Cancel</Button>
 
-  <Button type="text" on:click={overwriteSource}>
-    Replace Existing Source
-  </Button>
+  <Button type="text" onClick={overwriteSource}>Replace Existing Source</Button>
 
-  <Button type="primary" on:click={keepBoth}>Keep Both</Button>
+  <Button type="primary" onClick={keepBoth}>Keep Both</Button>
 </Dialog.Footer>

--- a/web-common/src/features/sources/modal/LocalSourceUpload.svelte
+++ b/web-common/src/features/sources/modal/LocalSourceUpload.svelte
@@ -64,11 +64,11 @@
 </script>
 
 <div class="grid place-items-center h-44">
-  <Button on:click={handleOpenFileDialog} type="primary"
+  <Button onClick={handleOpenFileDialog} type="primary"
     >Upload a CSV, JSON or Parquet file
   </Button>
 </div>
 <div class="flex">
   <div class="grow" />
-  <Button on:click={() => dispatch("back")} type="secondary">Back</Button>
+  <Button onClick={() => dispatch("back")} type="secondary">Back</Button>
 </div>

--- a/web-common/src/features/sources/modal/RequestConnectorForm.svelte
+++ b/web-common/src/features/sources/modal/RequestConnectorForm.svelte
@@ -77,7 +77,7 @@
   />
   <div class="flex gap-x-2">
     <div class="grow" />
-    <Button on:click={() => dispatch("back")} type="secondary">Back</Button>
+    <Button onClick={() => dispatch("back")} type="secondary">Back</Button>
     <Button
       type="primary"
       submitForm

--- a/web-common/src/features/sources/modal/SourceImportedModal.svelte
+++ b/web-common/src/features/sources/modal/SourceImportedModal.svelte
@@ -79,7 +79,7 @@
     <AlertDialog.Footer>
       <AlertDialog.Action asChild let:builder>
         <AlertDialog.Cancel asChild let:builder>
-          <Button builders={[builder]} on:click={goToSource} type="secondary">
+          <Button builders={[builder]} onClick={goToSource} type="secondary">
             View this source
           </Button>
         </AlertDialog.Cancel>
@@ -87,7 +87,7 @@
         <Button
           builders={[builder]}
           disabled={createExploreFromTable === null}
-          on:click={generateMetrics}
+          onClick={generateMetrics}
           type="primary"
         >
           Generate dashboard

--- a/web-common/src/features/sources/workspace/SourceCTAs.svelte
+++ b/web-common/src/features/sources/workspace/SourceCTAs.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
   import { Button } from "@rilldata/web-common/components/button";
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu/";
-  import { createEventDispatcher } from "svelte";
+  import Add from "@rilldata/web-common/components/icons/Add.svelte";
+  import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
+  import RefreshIcon from "@rilldata/web-common/components/icons/RefreshIcon.svelte";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
-  import RefreshIcon from "@rilldata/web-common/components/icons/RefreshIcon.svelte";
-  import { allowPrimary } from "../../dashboards/workspace/DeployProjectCTA.svelte";
-  import { useModels } from "../../models/selectors";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
-  import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
+  import { createEventDispatcher } from "svelte";
+  import { allowPrimary } from "../../dashboards/workspace/DeployProjectCTA.svelte";
   import { removeLeadingSlash } from "../../entity-management/entity-mappers";
   import {
     resourceColorMapping,
     resourceIconMapping,
   } from "../../entity-management/resource-icon-mapping";
-  import Add from "@rilldata/web-common/components/icons/Add.svelte";
+  import { useModels } from "../../models/selectors";
 
   const dispatch = createEventDispatcher();
 
@@ -36,7 +36,7 @@
   <Tooltip distance={8}>
     <Button
       square
-      on:click={() => {
+      onClick={() => {
         if (isLocalFileConnector && !hasUnsavedChanges) return;
         if (hasUnsavedChanges) {
           dispatch("save-source");
@@ -92,7 +92,7 @@
 {#if modelsForSource.length === 0}
   <Button
     disabled={hasUnsavedChanges || hasErrors}
-    on:click={() => dispatch("create-model")}
+    onClick={() => dispatch("create-model")}
     type={$allowPrimary ? "primary" : "secondary"}
   >
     Create model

--- a/web-common/src/features/visual-editing/SelectionDropdown.svelte
+++ b/web-common/src/features/visual-editing/SelectionDropdown.svelte
@@ -106,7 +106,7 @@
     <footer>
       {#if excludable}
         <Button
-          on:click={() => {
+          onClick={() => {
             setItems(Array.from(selectedItems), !excludeMode);
           }}
           type="secondary"
@@ -120,7 +120,7 @@
       {/if}
 
       <Button
-        on:click={() => {
+        onClick={() => {
           if (selectedItems.size === allItems.size) {
             setItems([]);
           } else {

--- a/web-common/src/features/visual-metrics-editing/AlertConfirmation.svelte
+++ b/web-common/src/features/visual-metrics-editing/AlertConfirmation.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import * as AlertDialog from "@rilldata/web-common/components/alert-dialog";
-  import type { Confirmation } from "./lib";
   import Button from "@rilldata/web-common/components/button/Button.svelte";
+  import type { Confirmation } from "./lib";
 
   export let confirmation: Confirmation;
   export let onCancel: () => void;
@@ -45,7 +45,7 @@
           type="secondary"
           large
           gray={confirmation.action === "delete"}
-          on:click={onCancel}
+          onClick={onCancel}
         >
           {#if confirmation.action === "cancel"}Keep editing{:else}Cancel{/if}
         </Button>
@@ -57,7 +57,7 @@
           builders={[builder]}
           status={confirmation.action === "delete" ? "error" : "info"}
           type="primary"
-          on:click={onConfirm}
+          onClick={onConfirm}
         >
           {#if confirmation.action === "delete"}
             Yes, delete

--- a/web-common/src/features/visual-metrics-editing/EditControls.svelte
+++ b/web-common/src/features/visual-metrics-editing/EditControls.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import Button from "@rilldata/web-common/components/button/Button.svelte";
-  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
+  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import {
-    ArrowUpToLineIcon,
     ArrowDownToLineIcon,
-    Pen,
+    ArrowUpToLineIcon,
     CopyIcon,
+    Pen,
     Trash2Icon,
   } from "lucide-svelte";
 
@@ -32,7 +32,7 @@
     noStroke
     gray={!selected}
     square
-    on:click={onEdit}
+    onClick={onEdit}
     label="Edit {singularType} {name}"
   >
     <Pen size="14px" />
@@ -48,7 +48,7 @@
     noStroke
     square
     gray={!selected}
-    on:click={onDelete}
+    onClick={onDelete}
     label="Delete {singularType} {name}"
   >
     <Trash2Icon size="14px" />
@@ -64,7 +64,7 @@
     noStroke
     square
     gray={!selected}
-    on:click={onDuplicate}
+    onClick={onDuplicate}
     label="Duplicate {singularType} {name}"
   >
     <CopyIcon size="14px" />
@@ -82,7 +82,7 @@
     gray={!selected}
     disabled={first}
     label="Move {singularType} {name} to top"
-    on:click={() => onMoveTo(true)}
+    onClick={() => onMoveTo(true)}
   >
     <ArrowUpToLineIcon size="14px" />
   </Button>
@@ -99,7 +99,7 @@
     gray={!selected}
     disabled={last}
     label="Move {singularType} {name} to bottom"
-    on:click={() => onMoveTo(false)}
+    onClick={() => onMoveTo(false)}
   >
     <ArrowDownToLineIcon size="14px" />
   </Button>

--- a/web-common/src/features/visual-metrics-editing/VisualMetricsSidebar.svelte
+++ b/web-common/src/features/visual-metrics-editing/VisualMetricsSidebar.svelte
@@ -349,12 +349,12 @@
     </p>
     <div class="flex justify-{editing ? 'between' : 'end'}">
       {#if editing}
-        <Button type="text" on:click={onDelete}>Delete</Button>
+        <Button type="text" onClick={onDelete}>Delete</Button>
       {/if}
       <div class="flex gap-x-2 self-end">
         <Button
           type="secondary"
-          on:click={() => {
+          onClick={() => {
             onCancel(unsavedChanges);
           }}
         >
@@ -367,7 +367,7 @@
         >
           <Button
             type="primary"
-            on:click={saveChanges}
+            onClick={saveChanges}
             disabled={requiredPropertiesUnfilled.length > 0 || !unsavedChanges}
           >
             {editing ? "Save changes" : "Add " + type.slice(0, -1)}

--- a/web-common/src/features/workspaces/VisualExploreEditing.svelte
+++ b/web-common/src/features/workspaces/VisualExploreEditing.svelte
@@ -518,7 +518,7 @@
             type="subtle"
             gray={viewingDefaults}
             large
-            on:click={() => {
+            onClick={() => {
               if (viewingDefaults) {
                 updateProperties({}, ["defaults"]);
               } else {

--- a/web-common/src/features/workspaces/VisualMetrics.svelte
+++ b/web-common/src/features/workspaces/VisualMetrics.svelte
@@ -706,7 +706,7 @@
               square
               gray
               noStroke
-              on:click={() => {
+              onClick={() => {
                 collapsed[type] = !collapsed[type];
               }}
             >
@@ -728,7 +728,7 @@
               gray
               noStroke
               label="Add new {type.slice(0, -1)}"
-              on:click={() => {
+              onClick={() => {
                 editingItemData.set({
                   type,
                   index: -1,

--- a/web-common/src/layout/navigation/SurfaceControlButton.svelte
+++ b/web-common/src/layout/navigation/SurfaceControlButton.svelte
@@ -26,7 +26,7 @@
     gray={!navOpen}
     selected={navOpen}
     square
-    on:click={onClick}
+    {onClick}
   >
     {#if navOpen}
       <HideSidebar side="left" open={navOpen} size="18px" />

--- a/web-common/src/layout/workspace/WorkspaceHeader.svelte
+++ b/web-common/src/layout/workspace/WorkspaceHeader.svelte
@@ -1,23 +1,23 @@
 <script lang="ts">
+  import Button from "@rilldata/web-common/components/button/Button.svelte";
+  import InputWithConfirm from "@rilldata/web-common/components/forms/InputWithConfirm.svelte";
+  import File from "@rilldata/web-common/components/icons/File.svelte";
+  import HideBottomPane from "@rilldata/web-common/components/icons/HideBottomPane.svelte";
   import HideSidebar from "@rilldata/web-common/components/icons/HideSidebar.svelte";
   import SlidingWords from "@rilldata/web-common/components/tooltip/SlidingWords.svelte";
-  import { workspaces } from "./workspace-stores";
-  import { navigationOpen } from "../navigation/Navigation.svelte";
-  import HideBottomPane from "@rilldata/web-common/components/icons/HideBottomPane.svelte";
-  import Button from "@rilldata/web-common/components/button/Button.svelte";
+  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
+  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import {
     resourceColorMapping,
     resourceIconMapping,
   } from "@rilldata/web-common/features/entity-management/resource-icon-mapping";
-  import InputWithConfirm from "@rilldata/web-common/components/forms/InputWithConfirm.svelte";
-  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
-  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import type { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
-  import { Settings } from "lucide-svelte";
-  import File from "@rilldata/web-common/components/icons/File.svelte";
+  import CodeToggle from "@rilldata/web-common/features/visual-editing/CodeToggle.svelte";
   import WorkspaceBreadcrumbs from "@rilldata/web-common/features/workspaces/WorkspaceBreadcrumbs.svelte";
   import type { V1Resource } from "@rilldata/web-common/runtime-client";
-  import CodeToggle from "@rilldata/web-common/features/visual-editing/CodeToggle.svelte";
+  import { Settings } from "lucide-svelte";
+  import { navigationOpen } from "../navigation/Navigation.svelte";
+  import { workspaces } from "./workspace-stores";
 
   export let resourceKind: ResourceKind | undefined;
   export let titleInput: string;
@@ -95,7 +95,7 @@
             square
             selected={$tableVisible}
             label="Toggle table visibility"
-            on:click={workspaceLayout.table.toggle}
+            onClick={workspaceLayout.table.toggle}
           >
             <HideBottomPane size="18px" open={$tableVisible} />
           </Button>
@@ -114,7 +114,7 @@
             square
             selected={$inspectorVisible}
             label="Toggle inspector visibility"
-            on:click={workspaceLayout.inspector.toggle}
+            onClick={workspaceLayout.inspector.toggle}
           >
             <HideSidebar open={$inspectorVisible} size="18px" />
           </Button>


### PR DESCRIPTION
To prepare for our Svelte 5 upgrade, this PR removes the use of `createEventDispatcher` from `Button.svelte`. Instead of dispatching a `click` event, the component now accepts an `onClick` callback prop, aligning with Svelte 5's recommended pattern for component events.

**Note**: I initially attempted a full deprecation of `createEventDispatcher` using Cursor’s Claude-4-Opus MAX agent, but the refactor was too broad to land cleanly. So this PR focuses solely on `Button.svelte`.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
