### PR TITLE
allow overriding pinot cluster query timeout

### DIFF
--- a/runtime/drivers/pinot/pinot.go
+++ b/runtime/drivers/pinot/pinot.go
@@ -114,6 +114,8 @@ type configProperties struct {
 	LogQueries bool `mapstructure:"log_queries"`
 	// MaxOpenConns is the maximum number of open connections to the database. Set to 0 to use the default value or -1 for unlimited.
 	MaxOpenConns int `mapstructure:"max_open_conns"`
+	// TimeoutMS is the timeout in milliseconds for queries. Set to 0 to use the cluster default.
+	TimeoutMS int64 `mapstructure:"timeout_ms"`
 }
 
 // Open a connection to Apache Pinot using HTTP API.
@@ -205,6 +207,7 @@ func (d driver) Open(instanceID string, config map[string]any, st *storage.Clien
 		schemaURL:  controller,
 		headers:    headers,
 		logQueries: conf.LogQueries,
+		timeoutMS:  conf.TimeoutMS,
 		logger:     logger,
 	}
 	return conn, nil
@@ -229,6 +232,7 @@ type connection struct {
 	schemaURL  string
 	headers    map[string]string
 	logQueries bool
+	timeoutMS  int64 // timeout in milliseconds for queries, 0 means use cluster default
 	logger     *zap.Logger
 }
 


### PR DESCRIPTION
Add option to override query timeout as cluster default timeout may be too small and we may not have control to change it

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
