### PR TITLE
fix (Alerts UI): Handle spaces in Explore names

### DIFF
--- a/web-admin/src/features/alerts/metadata/AlertMetadata.svelte
+++ b/web-admin/src/features/alerts/metadata/AlertMetadata.svelte
@@ -141,7 +141,7 @@
               </div>
             {:else}
               <a
-                href={`/${organization}/${project}/explore/${$dashboardName.data}`}
+                href={`/${organization}/${project}/explore/${encodeURIComponent($dashboardName.data)}`}
               >
                 {dashboardTitle}
               </a>

--- a/web-admin/src/features/dashboards/query-mappers/utils.ts
+++ b/web-admin/src/features/dashboards/query-mappers/utils.ts
@@ -129,11 +129,14 @@ export function getSelectedTimeRange(
   return selectedTimeRange;
 }
 
-const ExploreNameRegex = /\/explore\/((?:\w|-)+)/;
+const ExploreNameRegex = /\/explore\/((?:[\w-]|%[0-9A-Fa-f]{2})+)/;
+
 export function getExploreName(webOpenPath: string) {
   const matches = ExploreNameRegex.exec(webOpenPath);
+
   if (!matches || matches.length < 1) return "";
-  return matches[1];
+
+  return decodeURIComponent(matches[1]);
 }
 
 export async function convertQueryFilterToToplistQuery(

--- a/web-admin/src/routes/[organization]/[project]/-/alerts/[alert]/open/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/alerts/[alert]/open/+page.svelte
@@ -57,7 +57,7 @@
 
   async function gotoExplorePage() {
     const url = new URL(
-      `/${organization}/${project}/explore/${exploreName}`,
+      `/${organization}/${project}/explore/${encodeURIComponent(exploreName)}`,
       window.location.origin,
     );
     url.search = (

--- a/web-common/src/features/alerts/CreateAlertForm.svelte
+++ b/web-common/src/features/alerts/CreateAlertForm.svelte
@@ -150,7 +150,7 @@
                 : undefined,
               renotify: !!values.snooze,
               renotifyAfterSeconds: values.snooze ? Number(values.snooze) : 0,
-              webOpenPath: `/explore/${$exploreName}`,
+              webOpenPath: `/explore/${encodeURIComponent($exploreName)}`,
               webOpenState: getProtoFromDashboardState(
                 $dashboardStore,
                 exploreSpec,


### PR DESCRIPTION
Closes [ENG-784](https://linear.app/rilldata/issue/ENG-784/spaces-in-dashboard-name-causes-alert-to-not-link-back)

Note: I've checked Scheduled Reports, and we do not have this same issue.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
