### PR TITLE
fix: min time grain reduction for multiple metrics views

### DIFF
--- a/web-common/src/features/canvas/stores/time-control.ts
+++ b/web-common/src/features/canvas/stores/time-control.ts
@@ -83,32 +83,32 @@ export class TimeControls {
 
     this.minTimeGrain = derived(specStore, (spec) => {
       let metricsViews = spec?.data?.metricsViews || {};
-      const metricsViewName = getComponentMetricsViewFromSpec(
-        componentName,
-        spec,
-      );
-      if (metricsViewName && metricsViews[metricsViewName]) {
-        metricsViews = {
-          [metricsViewName]: metricsViews[metricsViewName],
-        };
+
+      if (componentName) {
+        const metricsViewName = getComponentMetricsViewFromSpec(
+          componentName,
+          spec,
+        );
+
+        if (metricsViewName && metricsViews[metricsViewName]) {
+          metricsViews = {
+            [metricsViewName]: metricsViews[metricsViewName],
+          };
+        }
       }
+      const minTimeGrain = Object.values(metricsViews).reduce<V1TimeGrain>(
+        (min: V1TimeGrain, metricsView) => {
+          const timeGrain = metricsView?.state?.validSpec?.smallestTimeGrain;
 
-      const minTimeGrain = Object.keys(metricsViews).reduce<V1TimeGrain>(
-        (min: V1TimeGrain, metricView) => {
-          const metricsViewSpec = metricsViews[metricView]?.state?.validSpec;
-
-          if (
-            !metricsViewSpec?.smallestTimeGrain ||
-            metricsViewSpec.smallestTimeGrain ===
-              V1TimeGrain.TIME_GRAIN_UNSPECIFIED
-          )
+          if (!timeGrain || timeGrain === V1TimeGrain.TIME_GRAIN_UNSPECIFIED) {
             return min;
-          const timeGrain = metricsViewSpec.smallestTimeGrain;
+          }
 
-          return !isGrainBigger(min, timeGrain) ? timeGrain : min;
+          return isGrainBigger(min, timeGrain) ? timeGrain : min;
         },
-        V1TimeGrain.TIME_GRAIN_UNSPECIFIED,
+        V1TimeGrain.TIME_GRAIN_YEAR, // Use max time grain as starting point
       );
+
       return minTimeGrain;
     });
 

--- a/web-common/src/lib/time/grains/index.ts
+++ b/web-common/src/lib/time/grains/index.ts
@@ -103,6 +103,14 @@ export function isGrainBigger(
   possiblyBiggerGrain: V1TimeGrain,
   possiblySmallerGrain: V1TimeGrain,
 ): boolean {
+  if (possiblyBiggerGrain === V1TimeGrain.TIME_GRAIN_UNSPECIFIED) {
+    return false;
+  }
+
+  if (possiblySmallerGrain === V1TimeGrain.TIME_GRAIN_UNSPECIFIED) {
+    return true;
+  }
+
   const biggerGrainConfig = TIME_GRAIN[possiblyBiggerGrain];
   const smallerGrainConfig = TIME_GRAIN[possiblySmallerGrain];
 


### PR DESCRIPTION
Fixes https://linear.app/rilldata/issue/APP-41/fix-empty-dropdown-for-grain-in-canvas-dashboard

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
