### PR TITLE
fix: flip migrations

### DIFF
--- a/admin/database/postgres/migrations/0070.sql
+++ b/admin/database/postgres/migrations/0070.sql
@@ -1,5 +1,3 @@
--- We stored HTML URL earlier, but now we are using clone URL
-UPDATE projects 
-SET github_url = concat(github_url, '.git') 
-WHERE github_url IS NOT NULL 
-  AND github_url NOT LIKE '%.git';
+-- Hard-coded first-party auth client
+INSERT INTO auth_clients (id, display_name)
+VALUES ('12345678-0000-0000-0000-000000000005', 'Created manually');

--- a/admin/database/postgres/migrations/0071.sql
+++ b/admin/database/postgres/migrations/0071.sql
@@ -1,3 +1,5 @@
--- Hard-coded first-party auth client
-INSERT INTO auth_clients (id, display_name)
-VALUES ('12345678-0000-0000-0000-000000000005', 'Created manually');
+-- We stored HTML URL earlier, but now we are using clone URL
+UPDATE projects 
+SET github_url = concat(github_url, '.git') 
+WHERE github_url IS NOT NULL 
+  AND github_url NOT LIKE '%.git';


### PR DESCRIPTION
Flips 0070 and 0071 as we have gotten misaligned between release and main branches

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
