### PR TITLE
fix: dimension table spacing

### DIFF
--- a/web-common/src/components/BarAndLabel.svelte
+++ b/web-common/src/components/BarAndLabel.svelte
@@ -62,7 +62,6 @@
     display: inline-block;
     width: calc((100% - 32px) * var(--width));
     position: absolute;
-    left: 16px;
     top: 0;
     height: 100%;
     pointer-events: none;

--- a/web-common/src/components/virtualized-table/core/Cell.svelte
+++ b/web-common/src/components/virtualized-table/core/Cell.svelte
@@ -138,6 +138,7 @@
     style:left="{column.start}px"
     style:top="{row.start}px"
     style:width="{column.size}px"
+    style:padding-right="10px"
     tabindex="0"
   >
     <BarAndLabel

--- a/web-common/src/components/virtualized-table/core/StickyHeader.svelte
+++ b/web-common/src/components/virtualized-table/core/StickyHeader.svelte
@@ -55,7 +55,8 @@
   on:blur={blur}
   on:click={modified({ shift: onShiftClick, click: onClick })}
   style:transform="translate{position === 'left' ? 'Y' : 'X'}({header.start}px)"
-  style:width="{header.size}px"
+  style:padding-right={position === "left" ? "0px" : "10px"}
+  style:width="{position === 'top-left' ? header.size + 1 : header.size}px"
   style:height="{position === 'left'
     ? config.rowHeight
     : config.columnHeaderHeight}px"
@@ -66,7 +67,7 @@
     class="
     ui-copy
     text-ellipsis overflow-hidden
-    {isDimensionTable ? (position === 'left' ? '' : 'px-1') : 'px-4'}
+    {isDimensionTable ? (position === 'left' ? '' : '') : 'px-4'}
     {borderClassesInnerDiv}
     {position === 'top' && `text-left`}
     {position === 'top-left' &&

--- a/web-common/src/features/dashboards/dimension-table/DimensionValueHeader.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionValueHeader.svelte
@@ -71,7 +71,7 @@
     header={{ size: width, start: 0 }}
     enableResize={true}
     position="top-left"
-    borderRight={horizontalScrolling}
+    borderRight={true}
     bgClass="bg-white"
     onClick={sortByDimensionValue}
     on:keydown={sortByDimensionValue}


### PR DESCRIPTION
* Shows left border for top-left dimension in dimension table, easier to grab for resize
* Separates measure columns with 10px padding
* Fixes dimension table when in model inspector

![image](https://github.com/user-attachments/assets/180bb9e4-8b9f-4095-a78f-cce9db545b51)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
