### PR TITLE
fix: broken project page for certain users.

### DIFF
--- a/web-admin/src/features/dashboards/listing/selectors.ts
+++ b/web-admin/src/features/dashboards/listing/selectors.ts
@@ -96,7 +96,7 @@ function getCanvasRefreshedOn(
     .map((m) =>
       allResources.get(`${m.meta.refs[0].kind}_${m.meta.refs[0].name}`),
     )
-    .map((m) => m.metricsView.state?.modelRefreshedOn)
+    .map((m) => m?.metricsView?.state?.modelRefreshedOn)
     .reduce((max, c) => (c > max ? c : max));
 
   return maxRefresh;


### PR DESCRIPTION
Only certain users face issues where the project pages breaks with `Error loading dashboards`. The query to fetch resources succeeds. One possible reason is there is an error in the selector that is emitted as query error.

Adding a null check to possibly fix it.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
