### PR TITLE
Fix minor race condition in Clickhouse driver

### DIFF
--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -437,7 +437,6 @@ func (c *Connection) AsAI(instanceID string) (drivers.AIService, bool) {
 
 // OLAP implements drivers.Connection.
 func (c *Connection) AsOLAP(instanceID string) (drivers.OLAPStore, bool) {
-	c.instanceID = instanceID
 	return c, true
 }
 


### PR DESCRIPTION
The assignment is redundant because it is already assigned in `Open`, and leads to simultaneous reads and writes of `c.instanceID`, which causes race condition tests to fail.

**Checklist:**
- [x] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
