### PR TITLE
[APP-143] feat: add limit to all canvas chart dimensions

### DIFF
--- a/web-common/src/features/canvas/components/charts/cartesian-charts/CartesianChart.ts
+++ b/web-common/src/features/canvas/components/charts/cartesian-charts/CartesianChart.ts
@@ -20,18 +20,16 @@ import type {
   ComponentPath,
 } from "../../../stores/canvas-entity";
 import { BaseChart, type BaseChartConfig } from "../BaseChart";
-import type {
-  ChartDataQuery,
-  ChartFieldsMap,
-  ChartSortDirection,
-  FieldConfig,
-} from "../types";
+import type { ChartDataQuery, ChartFieldsMap, FieldConfig } from "../types";
 
 export type CartesianChartSpec = BaseChartConfig & {
   x?: FieldConfig;
   y?: FieldConfig;
   color?: FieldConfig | string;
 };
+
+const DEFAULT_NOMINAL_LIMIT = 20;
+const DEFAULT_SPLIT_LIMIT = 10;
 
 export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
   static chartInputParams: Record<string, ComponentInputParam> = {
@@ -43,7 +41,7 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
           type: "dimension",
           axisTitleSelector: true,
           sortSelector: true,
-          limitSelector: true,
+          limitSelector: { defaultLimit: DEFAULT_NOMINAL_LIMIT },
           nullSelector: true,
           labelAngleSelector: true,
         },
@@ -69,6 +67,8 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
         chartFieldInput: {
           type: "dimension",
           defaultLegendOrientation: "top",
+          limitSelector: { defaultLimit: DEFAULT_SPLIT_LIMIT },
+          nullSelector: true,
         },
       },
     },
@@ -95,27 +95,31 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
       measures = [{ name: config.y?.field }];
     }
 
-    let sort: V1MetricsViewAggregationSort | undefined;
+    let xAxisSort: V1MetricsViewAggregationSort | undefined;
     let limit: number | undefined;
     let hasColorDimension = false;
+    let colorDimensionName = "";
+    let colorLimit: number | undefined;
 
     const dimensionName = config.x?.field;
 
     if (config.x?.type === "nominal" && dimensionName) {
       limit = config.x.limit ?? 100;
-      sort = this.vegaSortToAggregationSort(config.x?.sort, config);
+      xAxisSort = this.vegaSortToAggregationSort("x", config);
       dimensions = [{ name: dimensionName }];
     } else if (config.x?.type === "temporal" && dimensionName) {
       dimensions = [{ name: dimensionName }];
     }
 
     if (typeof config.color === "object" && config.color?.field) {
-      dimensions = [...dimensions, { name: config.color.field }];
+      colorDimensionName = config.color.field;
+      colorLimit = config.color.limit ?? DEFAULT_SPLIT_LIMIT;
+      dimensions = [...dimensions, { name: colorDimensionName }];
       hasColorDimension = true;
     }
 
-    // Create topN query options store
-    const topNQueryOptionsStore = derived(
+    // Create topN query for x dimension
+    const topNXQueryOptionsStore = derived(
       [ctx.runtime, timeAndFilterStore],
       ([runtime, $timeAndFilterStore]) => {
         const { timeRange, where } = $timeAndFilterStore;
@@ -123,7 +127,8 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
           !!timeRange?.start &&
           !!timeRange?.end &&
           hasColorDimension &&
-          config.x?.type === "nominal";
+          config.x?.type === "nominal" &&
+          !!dimensionName;
 
         const topNWhere = getFilterWithNullHandling(where, config.x);
 
@@ -133,7 +138,7 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
           {
             measures,
             dimensions: [{ name: dimensionName }],
-            sort: sort ? [sort] : undefined,
+            sort: xAxisSort ? [xAxisSort] : undefined,
             where: topNWhere,
             timeRange,
             limit: limit?.toString(),
@@ -148,32 +153,91 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
       },
     );
 
-    const topNQuery = createQuery(topNQueryOptionsStore);
+    const topNXQuery = createQuery(topNXQueryOptionsStore);
+
+    // Create topN query for color dimension
+    const topNColorQueryOptionsStore = derived(
+      [ctx.runtime, timeAndFilterStore],
+      ([runtime, $timeAndFilterStore]) => {
+        const { timeRange, where } = $timeAndFilterStore;
+        const enabled =
+          !!timeRange?.start &&
+          !!timeRange?.end &&
+          hasColorDimension &&
+          !!colorDimensionName &&
+          !!colorLimit;
+
+        const topNWhere = getFilterWithNullHandling(
+          where,
+          typeof config.color === "object" ? config.color : undefined,
+        );
+
+        return getQueryServiceMetricsViewAggregationQueryOptions(
+          runtime.instanceId,
+          config.metrics_view,
+          {
+            measures,
+            dimensions: [{ name: colorDimensionName }],
+            sort: config?.y?.field
+              ? [{ name: config.y.field, desc: true }]
+              : undefined,
+            where: topNWhere,
+            timeRange,
+            limit: colorLimit?.toString(),
+          },
+          {
+            query: {
+              enabled,
+              placeholderData: keepPreviousData,
+            },
+          },
+        );
+      },
+    );
+
+    const topNColorQuery = createQuery(topNColorQueryOptionsStore);
 
     const queryOptionsStore = derived(
-      [ctx.runtime, timeAndFilterStore, topNQuery],
-      ([runtime, $timeAndFilterStore, $topNQuery]) => {
+      [ctx.runtime, timeAndFilterStore, topNXQuery, topNColorQuery],
+      ([runtime, $timeAndFilterStore, $topNXQuery, $topNColorQuery]) => {
         const { timeRange, where, timeGrain } = $timeAndFilterStore;
-        const topNData = $topNQuery?.data?.data;
+        const topNXData = $topNXQuery?.data?.data;
+        const topNColorData = $topNColorQuery?.data?.data;
         const enabled =
           !!timeRange?.start &&
           !!timeRange?.end &&
           (hasColorDimension && config.x?.type === "nominal"
-            ? !!topNData?.length
+            ? !!topNXData?.length
+            : true) &&
+          (hasColorDimension && colorDimensionName && colorLimit
+            ? !!topNColorData?.length
             : true);
 
         let combinedWhere: V1Expression | undefined = getFilterWithNullHandling(
           where,
           config.x,
         );
-        if (topNData?.length && dimensionName) {
-          const topValues = topNData.map((d) => d[dimensionName] as string);
-          const filterForTopValues = createInExpression(
-            dimensionName,
-            topValues,
-          );
 
-          combinedWhere = mergeFilters(where, filterForTopValues);
+        // Apply topN filter for x dimension
+        if (topNXData?.length && dimensionName) {
+          const topXValues = topNXData.map((d) => d[dimensionName] as string);
+          const filterForTopXValues = createInExpression(
+            dimensionName,
+            topXValues,
+          );
+          combinedWhere = mergeFilters(combinedWhere, filterForTopXValues);
+        }
+
+        // Apply topN filter for color dimension
+        if (topNColorData?.length && colorDimensionName) {
+          const topColorValues = topNColorData.map(
+            (d) => d[colorDimensionName] as string,
+          );
+          const filterForTopColorValues = createInExpression(
+            colorDimensionName,
+            topColorValues,
+          );
+          combinedWhere = mergeFilters(combinedWhere, filterForTopColorValues);
         }
 
         // Update dimensions with timeGrain if temporal
@@ -189,7 +253,7 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
           {
             measures,
             dimensions,
-            sort: sort ? [sort] : undefined,
+            sort: xAxisSort ? [xAxisSort] : undefined,
             where: combinedWhere,
             timeRange,
             limit: hasColorDimension || !limit ? "5000" : limit?.toString(),
@@ -234,7 +298,7 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
         type: timeDimension ? "temporal" : "nominal",
         field: timeDimension || randomDimension,
         sort: "-y",
-        limit: 20,
+        limit: DEFAULT_NOMINAL_LIMIT,
       },
       y: {
         type: "quantitative",
@@ -245,17 +309,30 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
   }
 
   private vegaSortToAggregationSort(
-    sort: ChartSortDirection | undefined,
+    encoder: "x" | "color",
     config: CartesianChartSpec,
   ): V1MetricsViewAggregationSort | undefined {
+    const encoderConfig = config[encoder];
+
+    if (typeof encoderConfig === "string") {
+      return undefined;
+    }
+
+    const sort = encoderConfig?.sort;
     if (!sort) return undefined;
+
+    const encoderField = encoderConfig?.field;
+
     const field =
-      sort === "x" || sort === "-x" ? config.x?.field : config.y?.field;
+      sort === "color" || sort === "-color" || sort === "x" || sort === "-x"
+        ? encoderField
+        : config?.y?.field;
+
     if (!field) return undefined;
 
     return {
       name: field,
-      desc: sort === "-x" || sort === "-y",
+      desc: sort === "-x" || sort === "-y" || sort === "-color",
     };
   }
 

--- a/web-common/src/features/canvas/components/charts/circular-charts/CircularChart.ts
+++ b/web-common/src/features/canvas/components/charts/circular-charts/CircularChart.ts
@@ -29,6 +29,9 @@ type CircularChartEncoding = {
   color?: FieldConfig;
   innerRadius?: number;
 };
+
+const DEFAULT_COLOR_LIMIT = 20;
+
 export type CircularChartSpec = BaseChartConfig & CircularChartEncoding;
 
 export class CircularChartComponent extends BaseChart<CircularChartSpec> {
@@ -40,7 +43,7 @@ export class CircularChartComponent extends BaseChart<CircularChartSpec> {
         chartFieldInput: {
           type: "dimension",
           nullSelector: true,
-          limitSelector: true,
+          limitSelector: { defaultLimit: DEFAULT_COLOR_LIMIT },
           hideTimeDimension: true,
           defaultLegendOrientation: "right",
         },
@@ -84,7 +87,7 @@ export class CircularChartComponent extends BaseChart<CircularChartSpec> {
 
     let limit: number;
     if (config.color?.field) {
-      limit = config.color.limit ?? 20;
+      limit = config.color.limit ?? DEFAULT_COLOR_LIMIT;
       dimensions = [{ name: config.color.field }];
     }
 
@@ -161,7 +164,7 @@ export class CircularChartComponent extends BaseChart<CircularChartSpec> {
       color: {
         type: "nominal",
         field: randomDimension,
-        limit: 10,
+        limit: DEFAULT_COLOR_LIMIT,
       },
       measure: {
         type: "quantitative",

--- a/web-common/src/features/canvas/components/charts/heatmap-charts/HeatmapChart.ts
+++ b/web-common/src/features/canvas/components/charts/heatmap-charts/HeatmapChart.ts
@@ -21,6 +21,8 @@ import { BaseChart, type BaseChartConfig } from "../BaseChart";
 import { getFilterWithNullHandling } from "../query-utils";
 import type { ChartDataQuery, ChartFieldsMap, FieldConfig } from "../types";
 
+const DEFAULT_NOMINAL_LIMIT = 40;
+
 export type HeatmapChartSpec = BaseChartConfig & {
   x?: FieldConfig;
   y?: FieldConfig;
@@ -35,7 +37,7 @@ export class HeatmapChartComponent extends BaseChart<HeatmapChartSpec> {
       meta: {
         chartFieldInput: {
           type: "dimension",
-          limitSelector: true,
+          limitSelector: { defaultLimit: DEFAULT_NOMINAL_LIMIT },
           axisTitleSelector: true,
           nullSelector: true,
           labelAngleSelector: true,
@@ -48,8 +50,7 @@ export class HeatmapChartComponent extends BaseChart<HeatmapChartSpec> {
       meta: {
         chartFieldInput: {
           type: "dimension",
-          limitSelector: true,
-          axisTitleSelector: true,
+          limitSelector: { defaultLimit: DEFAULT_NOMINAL_LIMIT },
           nullSelector: true,
         },
       },
@@ -99,7 +100,7 @@ export class HeatmapChartComponent extends BaseChart<HeatmapChartSpec> {
 
         const xWhere = getFilterWithNullHandling(where, config.x);
 
-        let limit = "100";
+        let limit = DEFAULT_NOMINAL_LIMIT.toString();
         if (config.x?.limit) {
           limit = config.x.limit.toString();
         }
@@ -140,7 +141,7 @@ export class HeatmapChartComponent extends BaseChart<HeatmapChartSpec> {
 
         const yWhere = getFilterWithNullHandling(where, config.y);
 
-        let limit = "100";
+        let limit = DEFAULT_NOMINAL_LIMIT.toString();
         if (config.y?.limit) {
           limit = config.y.limit.toString();
         }
@@ -271,12 +272,12 @@ export class HeatmapChartComponent extends BaseChart<HeatmapChartSpec> {
       x: {
         type: "nominal",
         field: randomDimension1,
-        limit: 20,
+        limit: DEFAULT_NOMINAL_LIMIT,
       },
       y: {
         type: "nominal",
         field: randomDimension2,
-        limit: 20,
+        limit: DEFAULT_NOMINAL_LIMIT,
       },
       color: {
         type: "quantitative",

--- a/web-common/src/features/canvas/components/charts/types.ts
+++ b/web-common/src/features/canvas/components/charts/types.ts
@@ -50,7 +50,7 @@ export interface TimeDimensionDefinition {
   format?: string;
 }
 
-export type ChartSortDirection = "x" | "y" | "-x" | "-y";
+export type ChartSortDirection = "x" | "y" | "-x" | "-y" | "color" | "-color";
 
 export type ChartLegend = "none" | "top" | "bottom" | "left" | "right";
 

--- a/web-common/src/features/canvas/inspector/chart/FieldConfigPopover.svelte
+++ b/web-common/src/features/canvas/inspector/chart/FieldConfigPopover.svelte
@@ -20,7 +20,8 @@
   $: isDimension = fieldConfig?.type === "nominal";
   $: isMeasure = fieldConfig?.type === "quantitative";
 
-  let limit = fieldConfig?.limit || 5000;
+  let limit =
+    fieldConfig?.limit || chartFieldInput?.limitSelector?.defaultLimit || 5000;
   let labelAngle =
     fieldConfig?.labelAngle ?? (fieldConfig?.type === "temporal" ? 0 : -90);
   let isDropdownOpen = false;
@@ -60,6 +61,20 @@
       <span class="text-xs font-medium">{label} Configuration</span>
     </div>
     <div class="px-3.5 pb-1.5">
+      {#if showLegend}
+        <div class="py-1 flex items-center justify-between">
+          <span class="text-xs">Legend orientation</span>
+          <Select
+            size="sm"
+            id="legend-orientation-select"
+            width={180}
+            options={legendOptions}
+            value={fieldConfig?.legendOrientation ||
+              chartFieldInput?.defaultLegendOrientation}
+            on:change={(e) => onChange("legendOrientation", e.detail)}
+          />
+        </div>
+      {/if}
       {#if showAxisTitle}
         <div class="py-1.5 flex items-center justify-between">
           <span class="text-xs">Show axis title</span>
@@ -144,20 +159,6 @@
             onEnter={() => {
               onChange("labelAngle", labelAngle);
             }}
-          />
-        </div>
-      {/if}
-      {#if showLegend}
-        <div class="py-1 flex items-center justify-between">
-          <span class="text-xs">Legend orientation</span>
-          <Select
-            size="sm"
-            id="legend-orientation-select"
-            width={180}
-            options={legendOptions}
-            value={fieldConfig?.legendOrientation ||
-              chartFieldInput?.defaultLegendOrientation}
-            on:change={(e) => onChange("legendOrientation", e.detail)}
           />
         </div>
       {/if}

--- a/web-common/src/features/canvas/inspector/chart/MarkSelector.svelte
+++ b/web-common/src/features/canvas/inspector/chart/MarkSelector.svelte
@@ -23,6 +23,9 @@
 
   function updateFieldConfig(property: keyof FieldConfig, value: any) {
     if (typeof markConfig !== "string") {
+      if (markConfig[property] === value) {
+        return;
+      }
       const updatedConfig: FieldConfig = {
         ...markConfig,
         [property]: value,
@@ -41,12 +44,14 @@
   <div class="flex justify-between items-center">
     <InputLabel small label={config.label ?? key} id={key} />
     {#if Object.keys(chartFieldInput ?? {}).length > 1 && typeof markConfig !== "string"}
-      <FieldConfigPopover
-        fieldConfig={markConfig}
-        label={config.label ?? key}
-        onChange={updateFieldConfig}
-        {chartFieldInput}
-      />
+      {#key markConfig}
+        <FieldConfigPopover
+          fieldConfig={markConfig}
+          label={config.label ?? key}
+          onChange={updateFieldConfig}
+          {chartFieldInput}
+        />
+      {/key}
     {/if}
   </div>
 

--- a/web-common/src/features/canvas/inspector/chart/PositionalFieldConfig.svelte
+++ b/web-common/src/features/canvas/inspector/chart/PositionalFieldConfig.svelte
@@ -48,6 +48,10 @@
   }
 
   function updateFieldProperty(property: keyof FieldConfig, value: any) {
+    if (fieldConfig[property] === value) {
+      return;
+    }
+
     const updatedConfig: FieldConfig = {
       ...fieldConfig,
       [property]: value,
@@ -61,12 +65,14 @@
   <div class="flex justify-between items-center">
     <InputLabel small label={config.label ?? key} id={key} />
     {#if Object.keys(chartFieldInput ?? {}).length > 1}
-      <FieldConfigPopover
-        {fieldConfig}
-        label={config.label ?? key}
-        onChange={updateFieldProperty}
-        {chartFieldInput}
-      />
+      {#key fieldConfig}
+        <FieldConfigPopover
+          {fieldConfig}
+          label={config.label ?? key}
+          onChange={updateFieldProperty}
+          {chartFieldInput}
+        />
+      {/key}
     {/if}
   </div>
 

--- a/web-common/src/features/canvas/inspector/types.ts
+++ b/web-common/src/features/canvas/inspector/types.ts
@@ -24,7 +24,7 @@ export type ChartFieldInput = {
   hideTimeDimension?: boolean;
   originSelector?: boolean;
   sortSelector?: boolean;
-  limitSelector?: boolean;
+  limitSelector?: { defaultLimit: number };
   nullSelector?: boolean;
   labelAngleSelector?: boolean;
   /**


### PR DESCRIPTION
https://linear.app/rilldata/issue/APP-143/introduce-order-by-and-limit-n-to-spit-by-dimensions

-  Add default limit for all dimension fields
- For cartesian color encoding add limit and show null toggle

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
