### PR TITLE
fix (telemetry): Ignore browser extension errors in JS error handlers

### DIFF
--- a/web-common/src/metrics/ErrorEventHandler.ts
+++ b/web-common/src/metrics/ErrorEventHandler.ts
@@ -48,7 +48,13 @@ export class ErrorEventHandler {
   }
 
   public addJavascriptErrorListeners() {
+    const isExtensionError = (filename: string | undefined) =>
+      filename?.startsWith("chrome-extension://") ||
+      filename?.startsWith("moz-extension://");
+
     const errorHandler = (errorEvt: ErrorEvent) => {
+      // Ignore errors originating from browser extensions to avoid reporting issues outside our control
+      if (isExtensionError(errorEvt.filename)) return;
       this.fireJavascriptErrorBoundaryEvent(
         errorEvt.error?.stack ?? "",
         errorEvt.message,
@@ -56,6 +62,7 @@ export class ErrorEventHandler {
         get(page).url.toString(),
       )?.catch(console.error);
     };
+
     const unhandledRejectionHandler = (
       rejectionEvent: PromiseRejectionEvent,
     ) => {


### PR DESCRIPTION
This PR filters out unhandled JavaScript errors and promise rejections caused by browser extensions (chrome-extension://* and moz-extension://*) from our telemetry reports. These errors are outside our control and pollute our error logs.

Context: [Slack thread](https://rilldata.slack.com/archives/C01190F1R1D/p1749489954472719).

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
