### PR TITLE
fix (telemetry): Ignore `unhandledrejection` events that originate from browser extensions

### DIFF
--- a/web-common/src/metrics/ErrorEventHandler.ts
+++ b/web-common/src/metrics/ErrorEventHandler.ts
@@ -48,13 +48,15 @@ export class ErrorEventHandler {
   }
 
   public addJavascriptErrorListeners() {
-    const isExtensionError = (filename: string | undefined) =>
-      filename?.startsWith("chrome-extension://") ||
-      filename?.startsWith("moz-extension://");
+    // Helper to detect errors originating from browser extensions
+    const isExtensionError = (value: string | undefined) =>
+      value?.includes("chrome-extension://") ||
+      value?.includes("moz-extension://");
 
     const errorHandler = (errorEvt: ErrorEvent) => {
       // Ignore errors originating from browser extensions to avoid reporting issues outside our control
       if (isExtensionError(errorEvt.filename)) return;
+
       this.fireJavascriptErrorBoundaryEvent(
         errorEvt.error?.stack ?? "",
         errorEvt.message,
@@ -68,6 +70,7 @@ export class ErrorEventHandler {
     ) => {
       let stack = "";
       let message = "";
+
       if (typeof rejectionEvent.reason === "string") {
         message = rejectionEvent.reason;
       } else if (rejectionEvent.reason instanceof Error) {
@@ -76,6 +79,10 @@ export class ErrorEventHandler {
       } else {
         message = String.toString.apply(rejectionEvent.reason);
       }
+
+      // Ignore errors originating from browser extensions
+      if (isExtensionError(stack)) return;
+
       this.fireJavascriptErrorBoundaryEvent(
         stack,
         message,


### PR DESCRIPTION
Follows https://github.com/rilldata/rill/pull/7431

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
