### PR TITLE
Revert the change needed for refactor not in 64

### DIFF
--- a/web-admin/src/features/projects/github/ConnectToGithubButton.svelte
+++ b/web-admin/src/features/projects/github/ConnectToGithubButton.svelte
@@ -82,7 +82,7 @@
       <Button type="secondary" on:click={() => (open = false)}>Cancel</Button>
       <Button
         type="primary"
-        onClick={handleContinue}
+        on:click={handleContinue}
         disabled={!githubRepoCreated}
       >
         Continue


### PR DESCRIPTION
A refactor that changed the button API had missed a button in deploy journey: https://github.com/rilldata/rill/pull/7394
A bugfix updated this as the flow was broken on main: https://github.com/rilldata/rill/pull/7421
But only the bugfix was cherry picked hence the flow was broken.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
