### PR TITLE
fix: append timecolumns as dimensions

### DIFF
--- a/runtime/server/generate_metrics_view.go
+++ b/runtime/server/generate_metrics_view.go
@@ -414,7 +414,7 @@ func generateMetricsViewYAMLSimpleDimensions(schema *runtimev1.StructType) []*me
 	var dims []*metricsViewDimensionYAML
 	for _, f := range schema.Fields {
 		switch f.Type.Code {
-		case runtimev1.Type_CODE_BOOL, runtimev1.Type_CODE_STRING, runtimev1.Type_CODE_BYTES, runtimev1.Type_CODE_UUID:
+		case runtimev1.Type_CODE_BOOL, runtimev1.Type_CODE_STRING, runtimev1.Type_CODE_BYTES, runtimev1.Type_CODE_UUID, runtimev1.Type_CODE_DATE, runtimev1.Type_CODE_TIMESTAMP:
 			dims = append(dims, &metricsViewDimensionYAML{
 				Name:        f.Name,
 				DisplayName: identifierToDisplayName(f.Name),
@@ -559,7 +559,7 @@ func insertEmptyLinesInYaml(node *yaml.Node) {
 }
 
 func identifierToDisplayName(s string) string {
-	return cases.Title(language.English).String(strings.ReplaceAll(s, "_", " "))
+	return strings.TrimLeft(cases.Title(language.English).String(strings.ReplaceAll(s, "_", " ")), " ")
 }
 
 var alphanumericUnderscoreRegexp = regexp.MustCompile("^[_a-zA-Z0-9]+$")


### PR DESCRIPTION
Adds time columns as dimensions to auto generated metric views and explores.
Trims leading spaces from display names.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
