### PR TITLE
Clickhouse human readable error message and design improvement

### DIFF
--- a/web-common/src/components/forms/SubmissionError.svelte
+++ b/web-common/src/components/forms/SubmissionError.svelte
@@ -3,6 +3,12 @@
 
   export let message: string;
   export let details: string | undefined = undefined;
+
+  let showDetails = true;
+
+  function toggleDetails() {
+    showDetails = !showDetails;
+  }
 </script>
 
 <div class="error-container">
@@ -13,9 +19,44 @@
     <div class="flex-1">
       <div class="message text-gray-700 font-normal text-sm">{message}</div>
       {#if details}
-        <div class="details-section">
-          <pre class="details">{details}</pre>
-        </div>
+        <button
+          class="flex items-center mt-2 cursor-pointer select-none"
+          on:click={toggleDetails}
+        >
+          <span class="text-xs font-semibold text-gray-500 uppercase"
+            >Details</span
+          >
+          <div class="icon-wrapper ml-1">
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 10 10"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              style="transform: rotate({showDetails
+                ? 180
+                : 0}deg); transition: transform 0.2s;"
+            >
+              <g clip-path="url(#clip0_1706_319718)">
+                <rect width="10" height="10" fill="white" fill-opacity="0.01" />
+                <path
+                  d="M8.13793 3.20105C8.31782 3.20142 8.41243 3.41467 8.29223 3.54871L4.99828 7.22156L1.71313 3.54871C1.59309 3.41449 1.68834 3.20105 1.8684 3.20105H8.13793Z"
+                  fill="#6B7280"
+                />
+              </g>
+              <defs>
+                <clipPath id="clip0_1706_319718">
+                  <rect width="10" height="10" fill="white" />
+                </clipPath>
+              </defs>
+            </svg>
+          </div>
+        </button>
+        {#if showDetails}
+          <div class="details-section border-l border-gray-300">
+            <pre class="details whitespace-pre-wrap break-words">{details}</pre>
+          </div>
+        {/if}
       {/if}
     </div>
   </div>
@@ -29,10 +70,10 @@
 
   .details-section {
     @apply mt-2 text-xs;
+    @apply pl-2;
   }
 
   .details {
-    @apply bg-gray-50 p-2 rounded text-gray-600 whitespace-pre-wrap break-words;
-    @apply border border-gray-200;
+    @apply text-gray-600 whitespace-pre-wrap break-words;
   }
 </style>

--- a/web-common/src/components/forms/SubmissionError.svelte
+++ b/web-common/src/components/forms/SubmissionError.svelte
@@ -23,7 +23,7 @@
           class="flex items-center mt-2 cursor-pointer select-none"
           on:click={toggleDetails}
         >
-          <span class="text-xs font-semibold text-gray-500 uppercase"
+          <span class="text-xs font-semibold text-gray-500 capitalize"
             >Connection error</span
           >
           <div class="icon-wrapper ml-1">

--- a/web-common/src/components/forms/SubmissionError.svelte
+++ b/web-common/src/components/forms/SubmissionError.svelte
@@ -1,19 +1,38 @@
 <script lang="ts">
-  import AlertTriangle from "../icons/AlertTriangle.svelte";
+  import { AlertCircleIcon } from "lucide-svelte";
 
   export let message: string;
+  export let details: string | undefined = undefined;
 </script>
 
-<div>
-  <AlertTriangle size="16px" className="shrink-0" />
-  <p class="ml-2">
-    {message}
-  </p>
+<div class="error-container">
+  <div class="flex items-start gap-1">
+    <div class="flex-shrink-0 flex items-start">
+      <AlertCircleIcon size={22} class="text-red-600" />
+    </div>
+    <div class="flex-1">
+      <div class="message text-gray-700 font-normal text-sm">{message}</div>
+      {#if details}
+        <div class="details-section">
+          <pre class="details">{details}</pre>
+        </div>
+      {/if}
+    </div>
+  </div>
 </div>
 
 <style lang="postcss">
-  div {
-    @apply text-red-800 bg-red-100 border-red-300;
-    @apply p-2 flex border-2 rounded-md;
+  .error-container {
+    @apply border-red-600;
+    @apply p-2 flex border rounded mb-3;
+  }
+
+  .details-section {
+    @apply mt-2 text-xs;
+  }
+
+  .details {
+    @apply bg-gray-50 p-2 rounded text-gray-600 whitespace-pre-wrap break-words;
+    @apply border border-gray-200;
   }
 </style>

--- a/web-common/src/components/forms/SubmissionError.svelte
+++ b/web-common/src/components/forms/SubmissionError.svelte
@@ -24,7 +24,7 @@
           on:click={toggleDetails}
         >
           <span class="text-xs font-semibold text-gray-500 uppercase"
-            >Details</span
+            >Connection error</span
           >
           <div class="icon-wrapper ml-1">
             <svg
@@ -53,7 +53,7 @@
           </div>
         </button>
         {#if showDetails}
-          <div class="details-section border-l border-gray-300">
+          <div class="details-section border-l-2 border-gray-300">
             <pre class="details whitespace-pre-wrap break-words">{details}</pre>
           </div>
         {/if}
@@ -64,7 +64,7 @@
 
 <style lang="postcss">
   .error-container {
-    @apply border-red-600;
+    @apply border-red-600 bg-red-50;
     @apply p-2 flex border rounded mb-3;
   }
 

--- a/web-common/src/features/connectors/olap/test-connection.ts
+++ b/web-common/src/features/connectors/olap/test-connection.ts
@@ -30,13 +30,6 @@ export async function testOLAPConnector(
     await queryClient.fetchQuery({ queryKey, queryFn });
     return { success: true };
   } catch (e) {
-    // // UNCOMMENT TO DEBUG
-    // console.error(`${newConnectorName} connection error:`, {
-    //   code: e?.response?.data?.code,
-    //   message: e?.response?.data?.message,
-    //   error: e,
-    // });
-
     return {
       success: false,
       error: humanReadableErrorMessage(

--- a/web-common/src/features/connectors/olap/test-connection.ts
+++ b/web-common/src/features/connectors/olap/test-connection.ts
@@ -3,7 +3,7 @@ import {
   connectorServiceOLAPListTables,
   getConnectorServiceOLAPListTablesQueryKey,
 } from "../../../runtime-client";
-import { humanReadableErrorMessage } from "../../sources/modal/errors";
+import { humanReadableErrorMessage } from "../../sources/errors/errors";
 
 interface TestConnectorResult {
   success: boolean;

--- a/web-common/src/features/connectors/olap/test-connection.ts
+++ b/web-common/src/features/connectors/olap/test-connection.ts
@@ -8,6 +8,7 @@ import { humanReadableErrorMessage } from "../../sources/errors/errors";
 interface TestConnectorResult {
   success: boolean;
   error?: string;
+  details?: string;
 }
 
 export async function testOLAPConnector(
@@ -30,13 +31,15 @@ export async function testOLAPConnector(
     await queryClient.fetchQuery({ queryKey, queryFn });
     return { success: true };
   } catch (e) {
+    const originalMessage = e?.response?.data?.message;
     return {
       success: false,
       error: humanReadableErrorMessage(
         newConnectorName,
         e?.response?.data?.code,
-        e?.response?.data?.message,
+        originalMessage,
       ),
+      details: originalMessage,
     };
   }
 }

--- a/web-common/src/features/connectors/olap/test-connection.ts
+++ b/web-common/src/features/connectors/olap/test-connection.ts
@@ -30,6 +30,13 @@ export async function testOLAPConnector(
     await queryClient.fetchQuery({ queryKey, queryFn });
     return { success: true };
   } catch (e) {
+    // // UNCOMMENT TO DEBUG
+    // console.error(`${newConnectorName} connection error:`, {
+    //   code: e?.response?.data?.code,
+    //   message: e?.response?.data?.message,
+    //   error: e,
+    // });
+
     return {
       success: false,
       error: humanReadableErrorMessage(

--- a/web-common/src/features/sources/errors/ErrorPane.svelte
+++ b/web-common/src/features/sources/errors/ErrorPane.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import CancelCircle from "../../../components/icons/CancelCircle.svelte";
   import { runtime } from "../../../runtime-client/runtime-store";
-  import { humanReadableErrorMessage } from "../modal/errors";
+  import { humanReadableErrorMessage } from "./errors";
   import { useSourceFromYaml } from "../selectors";
 
   export let filePath: string;

--- a/web-common/src/features/sources/errors/constants.ts
+++ b/web-common/src/features/sources/errors/constants.ts
@@ -1,0 +1,8 @@
+// Source: https://pkg.go.dev/google.golang.org/grpc@v1.49.0/codes
+export const GRPC_ERROR_CODES = {
+  Unknown: 2,
+  InvalidArgument: 3,
+  DeadlineExceeded: 4,
+  Unauthenticated: 16,
+  PermissionDenied: 7,
+};

--- a/web-common/src/features/sources/errors/errors.ts
+++ b/web-common/src/features/sources/errors/errors.ts
@@ -82,7 +82,7 @@ const errorTelemetryMap = {
 };
 
 const DEFAULT_CONNECTOR_ERROR_TEMPLATE =
-  "We got the following error when trying to connect to CONNECTOR_NAME. Please check your connection details and user permissions, then try again.";
+  "We received the following error when trying to connect to CONNECTOR_NAME. Please check your connection details and user permissions, then try again.";
 
 export function humanReadableErrorMessage(
   connectorName: string | undefined,

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -207,7 +207,7 @@
       transition:slide={{ duration: FORM_TRANSITION_DURATION }}
     >
       {#if paramsError}
-        <SubmissionError message={paramsError} />
+        <SubmissionError message={paramsError} details={"paramsError"} />
       {/if}
 
       {#each properties as property (property.key)}
@@ -258,7 +258,7 @@
       transition:slide={{ duration: FORM_TRANSITION_DURATION }}
     >
       {#if dsnError}
-        <SubmissionError message={dsnError} />
+        <SubmissionError message={dsnError} details={"dsbError"} />
       {/if}
 
       {#each dsnProperties as property (property.key)}

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -19,7 +19,7 @@
   import { yup } from "sveltekit-superforms/adapters";
   import { ButtonGroup, SubButton } from "../../../components/button-group";
   import { inferSourceName } from "../sourceUtils";
-  import { humanReadableErrorMessage } from "./errors";
+  import { humanReadableErrorMessage } from "../errors/errors";
   import {
     submitAddOLAPConnectorForm,
     submitAddSourceForm,

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -61,6 +61,7 @@
     resetForm: false,
   });
   let paramsError: string | null = null;
+  let paramsErrorDetails: string | undefined = undefined;
 
   // Form 2: DSN
   // SuperForms are not meant to have dynamic schemas, so we use a different form instance for the DSN form
@@ -87,6 +88,7 @@
     resetForm: false,
   });
   let dsnError: string | null = null;
+  let dsnErrorDetails: string | undefined = undefined;
 
   // Active form
   $: formId = useDsn ? dsnFormId : paramsFormId;
@@ -146,25 +148,35 @@
       onClose();
     } catch (e) {
       let error: string;
+      let details: string | undefined = undefined;
 
       // Handle different error types
       if (e instanceof Error) {
         error = e.message;
+        details = e.message;
+      } else if (e?.message && e?.details) {
+        error = e.message;
+        details = e.details;
       } else if (e?.response?.data) {
+        const originalMessage = e.response.data.message;
         error = humanReadableErrorMessage(
           connector.name,
           e.response.data.code,
-          e.response.data.message,
+          originalMessage,
         );
+        details = originalMessage;
       } else {
         error = "Unknown error";
+        details = "Unknown error";
       }
 
       // Keep error state for each form
       if (useDsn) {
         dsnError = error;
+        dsnErrorDetails = details;
       } else {
         paramsError = error;
+        paramsErrorDetails = details;
       }
     }
   }
@@ -207,7 +219,7 @@
       transition:slide={{ duration: FORM_TRANSITION_DURATION }}
     >
       {#if paramsError}
-        <SubmissionError message={paramsError} details={"paramsError"} />
+        <SubmissionError message={paramsError} details={paramsErrorDetails} />
       {/if}
 
       {#each properties as property (property.key)}
@@ -258,7 +270,7 @@
       transition:slide={{ duration: FORM_TRANSITION_DURATION }}
     >
       {#if dsnError}
-        <SubmissionError message={dsnError} details={"dsbError"} />
+        <SubmissionError message={dsnError} details={dsnErrorDetails} />
       {/if}
 
       {#each dsnProperties as property (property.key)}

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -153,10 +153,10 @@
       // Handle different error types
       if (e instanceof Error) {
         error = e.message;
-        details = e.message;
+        details = undefined;
       } else if (e?.message && e?.details) {
         error = e.message;
-        details = e.details;
+        details = e.details !== e.message ? e.details : undefined;
       } else if (e?.response?.data) {
         const originalMessage = e.response.data.message;
         const humanReadable = humanReadableErrorMessage(
@@ -169,7 +169,7 @@
           humanReadable !== originalMessage ? originalMessage : undefined;
       } else {
         error = "Unknown error";
-        details = "Unknown error";
+        details = undefined;
       }
 
       // Keep error state for each form

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -213,6 +213,9 @@
 
   {#if !useDsn}
     <!-- Form 1: Individual parameters -->
+    {#if paramsError}
+      <SubmissionError message={paramsError} details={paramsErrorDetails} />
+    {/if}
     <form
       id={paramsFormId}
       class="pb-5 flex-grow overflow-y-auto"
@@ -220,10 +223,6 @@
       on:submit|preventDefault={paramsSubmit}
       transition:slide={{ duration: FORM_TRANSITION_DURATION }}
     >
-      {#if paramsError}
-        <SubmissionError message={paramsError} details={paramsErrorDetails} />
-      {/if}
-
       {#each properties as property (property.key)}
         {@const propertyKey = property.key ?? ""}
         {@const label =
@@ -264,6 +263,9 @@
     </form>
   {:else}
     <!-- Form 2: DSN -->
+    {#if dsnError}
+      <SubmissionError message={dsnError} details={dsnErrorDetails} />
+    {/if}
     <form
       id={dsnFormId}
       class="pb-5 flex-grow overflow-y-auto"
@@ -271,10 +273,6 @@
       on:submit|preventDefault={dsnSubmit}
       transition:slide={{ duration: FORM_TRANSITION_DURATION }}
     >
-      {#if dsnError}
-        <SubmissionError message={dsnError} details={dsnErrorDetails} />
-      {/if}
-
       {#each dsnProperties as property (property.key)}
         {@const propertyKey = property.key ?? ""}
         <div class="py-1.5">

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -159,12 +159,14 @@
         details = e.details;
       } else if (e?.response?.data) {
         const originalMessage = e.response.data.message;
-        error = humanReadableErrorMessage(
+        const humanReadable = humanReadableErrorMessage(
           connector.name,
           e.response.data.code,
           originalMessage,
         );
-        details = originalMessage;
+        error = humanReadable;
+        details =
+          humanReadable !== originalMessage ? originalMessage : undefined;
       } else {
         error = "Unknown error";
         details = "Unknown error";

--- a/web-common/src/features/sources/modal/submitAddDataForm.ts
+++ b/web-common/src/features/sources/modal/submitAddDataForm.ts
@@ -169,7 +169,7 @@ export async function submitAddOLAPConnectorForm(
 
   // Test the connection to the OLAP database
   // If the connection test fails, rollback the changes
-  const result = await testOLAPConnector(instanceId, newConnectorName);
+  const result = await testOLAPConnector(instanceId, connector.name as string);
   if (!result.success) {
     await rollbackConnectorChanges(
       instanceId,

--- a/web-common/src/features/sources/modal/submitAddDataForm.ts
+++ b/web-common/src/features/sources/modal/submitAddDataForm.ts
@@ -176,7 +176,10 @@ export async function submitAddOLAPConnectorForm(
       newConnectorFilePath,
       originalEnvBlob,
     );
-    throw new Error(result.error || "Unable to establish a connection");
+    throw {
+      message: result.error || "Unable to establish a connection",
+      details: result.details,
+    };
   }
 
   /**

--- a/web-common/src/features/sources/source-telemetry.ts
+++ b/web-common/src/features/sources/source-telemetry.ts
@@ -1,4 +1,4 @@
-import { categorizeSourceError } from "@rilldata/web-common/features/sources/modal/errors";
+import { categorizeSourceError } from "@rilldata/web-common/features/sources/errors/errors";
 import { getFileTypeFromPath } from "@rilldata/web-common/features/sources/sourceUtils";
 import {
   behaviourEvent,


### PR DESCRIPTION
Closes https://linear.app/rilldata/issue/APP-88/improve-connector-form-errors and https://linear.app/rilldata/issue/APP-87/improve-error-handling-in-rd-for-connector

Reference from https://www.notion.so/rilldata/Improve-Connector-form-errors-1f2ba33c8f5780db892cf59cea5f9726

This pull request improves the ClickHouse error messages reported by users. We've updated the `testOLAPConnector` to receive the connector name rather than the new connector name. This ensures that when we test the connection. We're testing against the exact connector name rather than the incremented names. In addition to adding human readable error message handling for ClickHouse, we've also modified the SubmissionError component according to [the design](https://www.notion.so/rilldata/Improve-Connector-form-errors-1f2ba33c8f5780db892cf59cea5f9726).

Reviewers - If you are aware of any clickhouse error message, let me know!

![CleanShot 2025-06-11 at 18 03 38@2x](https://github.com/user-attachments/assets/48e4a37b-d79d-4c07-8ec3-8b623abcaf1d)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
