### PR TITLE
Add SSE support for log streaming in WatchLogsHandler

### DIFF
--- a/runtime/server/server.go
+++ b/runtime/server/server.go
@@ -213,6 +213,9 @@ func (s *Server) HTTPHandler(ctx context.Context, registerAdditionalHandlers fun
 	// Add HTTP handler for watching resources
 	httpMux.Handle("/v1/instances/{instance_id}/resources/-/watch", auth.HTTPMiddleware(s.aud, http.HandlerFunc(s.WatchResourcesHandler)))
 
+	// Add HTTP handler for watching logs
+	httpMux.Handle("/v1/instances/{instance_id}/logs/watch", auth.HTTPMiddleware(s.aud, http.HandlerFunc(s.WatchLogsHandler)))
+
 	// Add Prometheus
 	if s.opts.ServePrometheus {
 		httpMux.Handle("/metrics", promhttp.Handler())


### PR DESCRIPTION
Enables use of Server Side Events support for log streaming in WatchLogsHandler

```
./rill project logs --project dev-project --follow
{"level":"LOG_LEVEL_INFO", "time":"2025-06-12T18:26:59.989235Z", "message":"Reconciling resource", "jsonPayload":"{\"name\":\"trigger_51b62bd4b664e499\",\"type\":\"RefreshTrigger\"}"}
{"level":"LOG_LEVEL_INFO", "time":"2025-06-12T18:26:59.990098Z", "message":"Reconciling resource", "jsonPayload":"{\"name\":\"parser\",\"type\":\"ProjectParser\"}"}
{"level":"LOG_LEVEL_INFO", "time":"2025-06-12T18:26:59.990567Z", "message":"Reconciled resource", "jsonPayload":"{\"name\":\"trigger_51b62bd4b664e499\",\"type\":\"RefreshTrigger\",\"elapsed\":\"1ms\",\"deleted\":true}"}
{"level":"LOG_LEVEL_INFO", "time":"2025-06-12T18:27:00.000850Z", "message":"Executing model", "jsonPayload":"{\"model\":\"test\",\"trace_id\":\"e30256774c6765c9f549f9c0af06f7a7\",\"span_id\":\"3d683258b46b2c91\",\"run_type\":\"reset\",\"input_connector\":\"local_file\",\"output_connector\":\"duckdb\"}"}
{"level":"LOG_LEVEL_INFO", "time":"2025-06-12T18:27:00.170385Z", "message":"Reconciled resource", "jsonPayload":"{\"name\":\"parser\",\"type\":\"ProjectParser\",\"elapsed\":\"180ms\"}"}
{"level":"LOG_LEVEL_INFO", "time":"2025-06-12T18:27:00.238529Z", "message":"Reconciled resource", "jsonPayload":"{\"name\":\"test\",\"type\":\"Model\",\"elapsed\":\"248ms\"}"}
{"level":"LOG_LEVEL_INFO", "time":"2025-06-12T18:27:00.242408Z", "message":"Executing model", "jsonPayload":"{\"model\":\"bar\",\"trace_id\":\"83339f1e6bc73771eb48943bd859086c\",\"span_id\":\"9ea937e5cb9fe1ca\",\"run_type\":\"reset\",\"connector\":\"duckdb\"}"}
{"level":"LOG_LEVEL_INFO", "time":"2025-06-12T18:27:00.242717Z", "message":"Reconciled resource", "jsonPayload":"{\"name\":\"metrics_view\",\"type\":\"MetricsView\",\"elapsed\":\"4ms\"}"}
{"level":"LOG_LEVEL_INFO", "time":"2025-06-12T18:27:00.242800Z", "message":"Reconciling resource", "jsonPayload":"{\"name\":\"canvas--component-0-0\",\"type\":\"Component\"}"}
{"level":"LOG_LEVEL_INFO", "time":"2025-06-12T18:27:00.242877Z", "message":"Reconciled resource", "jsonPayload":"{\"name\":\"canvas--component-0-0\",\"type\":\"Component\"}"}
{"level":"LOG_LEVEL_INFO", "time":"2025-06-12T18:27:00.242926Z", "message":"Reconciling resource", "jsonPayload":"{\"name\":\"canvas\",\"type\":\"Canvas\"}"}
{"level":"LOG_LEVEL_INFO", "time":"2025-06-12T18:27:00.242959Z", "message":"Reconciled resource", "jsonPayload":"{\"name\":\"canvas\",\"type\":\"Canvas\"}"}
{"level":"LOG_LEVEL_INFO", "time":"2025-06-12T18:27:00.285193Z", "message":"Reconciled resource", "jsonPayload":"{\"name\":\"bar\",\"type\":\"Model\",\"elapsed\":\"47ms\"}"}
{"level":"LOG_LEVEL_INFO", "time":"2025-06-12T18:27:00.288711Z", "message":"Reconciled resource", "jsonPayload":"{\"name\":\"bar_metrics\",\"type\":\"MetricsView\",\"elapsed\":\"3ms\"}"}
{"level":"LOG_LEVEL_INFO", "time":"2025-06-12T18:27:00.288844Z", "message":"Reconciled resource", "jsonPayload":"{\"name\":\"bar_metrics_explore\",\"type\":\"Explore\"}"}
```


**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
