### PR TITLE
trim glob pattern path

### DIFF
--- a/runtime/resolvers/glob.go
+++ b/runtime/resolvers/glob.go
@@ -117,6 +117,8 @@ func newGlob(ctx context.Context, opts *runtime.ResolverOptions) (runtime.Resolv
 		return nil, err
 	}
 
+	props.Path = strings.TrimSpace(props.Path)
+
 	// set props to span attributes
 	span := trace.SpanFromContext(ctx)
 	if span.SpanContext().IsValid() {

--- a/runtime/resolvers/glob_test.go
+++ b/runtime/resolvers/glob_test.go
@@ -44,6 +44,35 @@ func TestGlobUnpartitioned(t *testing.T) {
 	require.Equal(t, "file1.csv", rows[2]["path"])
 }
 
+func TestGlobTrimsWhitespace(t *testing.T) {
+	rt, instanceID := prepareGlobTest(t, "mock", map[string]string{
+		"file1.csv":     ``,
+		"dir/file2.csv": ``,
+		"dir/file3.csv": ``,
+	})
+
+	res, err := rt.Resolve(context.Background(), &runtime.ResolveOptions{
+		InstanceID: instanceID,
+		Resolver:   "glob",
+		ResolverProperties: map[string]any{
+			"connector": "mock",
+			"path":      "\n mock://bucket/**/*.csv \n",
+		},
+		Args:   nil,
+		Claims: &runtime.SecurityClaims{},
+	})
+	require.NoError(t, err)
+	defer res.Close()
+
+	var rows []map[string]interface{}
+	require.NoError(t, json.Unmarshal(must(res.MarshalJSON()), &rows))
+
+	require.Len(t, rows, 3)
+	require.Equal(t, "dir/file2.csv", rows[0]["path"])
+	require.Equal(t, "dir/file3.csv", rows[1]["path"])
+	require.Equal(t, "file1.csv", rows[2]["path"])
+}
+
 func TestGlobDirectoryPartitioned(t *testing.T) {
 	rt, instanceID := prepareGlobTest(t, "mock", map[string]string{
 		"dir/file1.csv":        ``,

--- a/runtime/resolvers/testdata/s3_connector.yaml
+++ b/runtime/resolvers/testdata/s3_connector.yaml
@@ -333,3 +333,13 @@ tests:
       4,True,123,45678901234,1.23,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,2025-01-01T00:02:03.456Z,2025-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,[1 2 3],['apple' 'banana' 'cherry'],"[('key1', 10), ('key2', 20)]","{'field_int_col': 42, 'field_float_col': 3.140000104904175, 'field_string_col': 'example'}"
       5,False,0,0,0,0,,0000000000000000,,0,1970-01-01,2025-01-01T00:00:00Z,2025-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0000000000000000,[],[],[],"{'field_int_col': 0, 'field_float_col': 0.0, 'field_string_col': ''}"
       6,,,,,,,,,,,,,,,,,,,
+  - name: glob_trim_whitespace
+    resolver: glob
+    properties:
+      connector: s3
+      path: |
+        s3://integration-test.rilldata.com/glob_test/y=202*/a*.csv
+    result_csv: |
+      uri,path,updated_on
+      s3://integration-test.rilldata.com/glob_test/y=2023/aab.csv,glob_test/y=2023/aab.csv,2025-06-13T16:26:56Z
+      s3://integration-test.rilldata.com/glob_test/y=2024/aaa.csv,glob_test/y=2024/aaa.csv,2025-06-13T16:26:56Z


### PR DESCRIPTION
Trimmed whitespace from glob resolver properties to avoid parsing issues when multi-line YAML includes spaces or newlines

This PR enables the users to have formatted paths when declared with different environments

```yaml
partitions:
  glob:
    path: >
      {{ if dev }}
        s3://bucket/2025/06/12/0[0-2]/*.parquet
      {{ else if .qa }}
        s3://bucket/2025/06/1[0-9]/*/*.parquet
      {{ else }}
        s3://bucket/2025/0[5-9]/**/*.parquet
      {{ end }}
    partition: directory
```

**Checklist:**
- [x] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
