### PR TITLE
fix: min time grain derivation

### DIFF
--- a/web-common/src/features/canvas/stores/time-control.ts
+++ b/web-common/src/features/canvas/stores/time-control.ts
@@ -100,13 +100,14 @@ export class TimeControls {
         (min: V1TimeGrain, metricsView) => {
           const timeGrain = metricsView?.state?.validSpec?.smallestTimeGrain;
 
+          console.log({ timeGrain });
           if (!timeGrain || timeGrain === V1TimeGrain.TIME_GRAIN_UNSPECIFIED) {
             return min;
           }
 
           return isGrainBigger(min, timeGrain) ? timeGrain : min;
         },
-        V1TimeGrain.TIME_GRAIN_YEAR, // Use max time grain as starting point
+        V1TimeGrain.TIME_GRAIN_UNSPECIFIED,
       );
 
       return minTimeGrain;

--- a/web-common/src/features/canvas/stores/time-control.ts
+++ b/web-common/src/features/canvas/stores/time-control.ts
@@ -100,12 +100,15 @@ export class TimeControls {
         (min: V1TimeGrain, metricsView) => {
           const timeGrain = metricsView?.state?.validSpec?.smallestTimeGrain;
 
-          console.log({ timeGrain });
           if (!timeGrain || timeGrain === V1TimeGrain.TIME_GRAIN_UNSPECIFIED) {
             return min;
           }
 
-          return isGrainBigger(min, timeGrain) ? timeGrain : min;
+          if (min === V1TimeGrain.TIME_GRAIN_UNSPECIFIED) {
+            return timeGrain;
+          }
+
+          return isGrainBigger(timeGrain, min) ? min : timeGrain;
         },
         V1TimeGrain.TIME_GRAIN_UNSPECIFIED,
       );

--- a/web-common/src/features/canvas/stores/time-control.ts
+++ b/web-common/src/features/canvas/stores/time-control.ts
@@ -108,7 +108,7 @@ export class TimeControls {
             return timeGrain;
           }
 
-          return isGrainBigger(timeGrain, min) ? min : timeGrain;
+          return isGrainBigger(timeGrain, min) ? timeGrain : min;
         },
         V1TimeGrain.TIME_GRAIN_UNSPECIFIED,
       );


### PR DESCRIPTION
Fixes an issue with appropriately determining the minimum time grain for multiple metrics views.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
