### PR TITLE
Fix inconsistent user group name validation

### DIFF
--- a/web-admin/src/features/organizations/constants.ts
+++ b/web-admin/src/features/organizations/constants.ts
@@ -27,3 +27,6 @@ export const ORG_ROLES_DESCRIPTION_MAP = {
   viewer: "Read-only access to all org projects",
   guest: "Access to invited projects only",
 };
+
+// Source: https://github.com/rilldata/rill/blob/main/admin/database/validate.go#L57
+export const SLUG_REGEX = /^[_a-zA-Z0-9][-_a-zA-Z0-9]*$/;

--- a/web-admin/src/features/organizations/users/CreateUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/users/CreateUserGroupDialog.svelte
@@ -25,6 +25,7 @@
   import { defaults, superForm } from "sveltekit-superforms";
   import { yup } from "sveltekit-superforms/adapters";
   import { object, string } from "yup";
+  import { SLUG_REGEX } from "../constants";
 
   export let open = false;
   export let groupName: string;
@@ -146,7 +147,7 @@
         .min(1, "Name must be at least 1 character")
         .max(40, "Name must be at most 40 characters")
         .matches(
-          /^[_a-zA-Z0-9][-_a-zA-Z0-9]*$/,
+          SLUG_REGEX,
           "Name can only include letters, numbers, underscores, and hyphens — no spaces or special characters",
         ),
     }),

--- a/web-admin/src/features/organizations/users/CreateUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/users/CreateUserGroupDialog.svelte
@@ -143,10 +143,11 @@
     object({
       name: string()
         .required("Name is required")
-        .min(3, "Name must be at least 3 characters")
+        .min(1, "Name must be at least 1 character")
+        .max(40, "Name must be at most 40 characters")
         .matches(
-          /^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$/,
-          "Name can only include letters, numbers, and hyphens — no spaces or special characters",
+          /^[_a-zA-Z0-9][-_a-zA-Z0-9]*$/,
+          "Name can only include letters, numbers, underscores, and hyphens — no spaces or special characters",
         ),
     }),
   );

--- a/web-admin/src/features/organizations/users/EditUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/users/EditUserGroupDialog.svelte
@@ -171,10 +171,11 @@
     object({
       newName: string()
         .required("Name is required")
-        .min(3, "Name must be at least 3 characters")
+        .min(1, "Name must be at least 1 character")
+        .max(40, "Name must be at most 40 characters")
         .matches(
-          /^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$/,
-          "Name can only include letters, numbers, and hyphens — no spaces or special characters",
+          /^[_a-zA-Z0-9][-_a-zA-Z0-9]*$/,
+          "Name can only include letters, numbers, underscores, and hyphens — no spaces or special characters",
         ),
     }),
   );

--- a/web-admin/src/features/organizations/users/EditUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/users/EditUserGroupDialog.svelte
@@ -27,6 +27,7 @@
   import { defaults, superForm } from "sveltekit-superforms";
   import { yup } from "sveltekit-superforms/adapters";
   import { object, string } from "yup";
+  import { SLUG_REGEX } from "../constants";
 
   export let open = false;
   export let groupName: string;
@@ -174,7 +175,7 @@
         .min(1, "Name must be at least 1 character")
         .max(40, "Name must be at most 40 characters")
         .matches(
-          /^[_a-zA-Z0-9][-_a-zA-Z0-9]*$/,
+          SLUG_REGEX,
           "Name can only include letters, numbers, underscores, and hyphens — no spaces or special characters",
         ),
     }),


### PR DESCRIPTION
Closes https://linear.app/rilldata/issue/ENG-818/cannot-add-users-to-user-group-when-group-name-has-underscores

This pull request aligns the user group validation in the edit and create user group dialogs with the slug validation used in the CLI.﻿

https://github.com/rilldata/rill/blob/main/admin/database/database.go#L622
https://github.com/rilldata/rill/blob/main/admin/database/validate.go#L57

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
