### PR TITLE
bug: Fix connectors not immediately resolving on model creation

### DIFF
--- a/runtime/server/controller.go
+++ b/runtime/server/controller.go
@@ -448,6 +448,7 @@ func (s *Server) WatchResourcesHandler(w http.ResponseWriter, r *http.Request) {
 		}, shim)
 		if err != nil {
 			s.logger.Warn("failed to watch resources", zap.String("instance_id", instanceID), zap.String("kind", kind), zap.Error(err))
+			eventServer.Close()
 		}
 	}()
 

--- a/runtime/server/repos.go
+++ b/runtime/server/repos.go
@@ -99,6 +99,7 @@ func (s *Server) WatchFilesHandler(w http.ResponseWriter, req *http.Request) {
 		err := s.WatchFiles(watchReq, shim)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			s.logger.Info("watch error", zap.Error(err))
+			eventServer.Close()
 		}
 	}()
 

--- a/web-local/tests/olap-connectors.spec.ts
+++ b/web-local/tests/olap-connectors.spec.ts
@@ -94,9 +94,6 @@ test.describe("ClickHouse connector", () => {
       'password: "{{ .env.connector.clickhouse.password }}"',
     );
 
-    // refresh the page to ensure the file is saved
-    await page.reload();
-
     // Assert that the connector explorer now has a ClickHouse connector
     await expect(
       page
@@ -159,9 +156,6 @@ test.describe("ClickHouse connector", () => {
       .getByLabel("codemirror editor")
       .getByRole("textbox");
     await expect(rillYamlEditor).toContainText("olap_connector: clickhouse");
-
-    // refresh the page to ensure the file is saved
-    await page.reload();
 
     // Assert that the connector explorer now has a ClickHouse connector
     await expect(


### PR DESCRIPTION
Fixes connectors not immediately resolving on model creation. Added close event server on watch errors in WatchResourcesHandler and WatchFilesHandler. 

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes [PLAT-80](https://linear.app/rilldata/issue/PLAT-80/nightly-release-does-not-create-a-duckdb-connector-by-default)
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
