### PR TITLE
Limit PostHog error tracking ( events) to ui.rilldata.com and localho…

### DIFF
--- a/web-common/src/lib/analytics/posthog.ts
+++ b/web-common/src/lib/analytics/posthog.ts
@@ -30,6 +30,20 @@ export function initPosthog(rillVersion: string, sessionId?: string | null) {
         "Rill version": rillVersion,
       });
     },
+    before_send: (event) => {
+      // Only filter $exception (error tracking) events by URL
+      if (!event) return null;
+      if (event.event === "$exception") {
+        const url = window.location.href;
+        if (url.includes("ui.rilldata.com") || url.includes("localhost")) {
+          return event;
+        }
+        // Drop $exception events for all other URLs
+        return null;
+      }
+      // Allow all other events
+      return event;
+    },
   });
 }
 


### PR DESCRIPTION
Limiting exception events to just ui.rilldata.com and localhost

INSERT DESCRIPTION HERE

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
