### PR TITLE
Enable PostHog session redaction for non-US and California users only

### DIFF
--- a/web-common/src/lib/analytics/posthog.ts
+++ b/web-common/src/lib/analytics/posthog.ts
@@ -4,33 +4,65 @@ const POSTHOG_API_KEY = import.meta.env.RILL_UI_PUBLIC_POSTHOG_API_KEY;
 
 export function initPosthog(rillVersion: string, sessionId?: string | null) {
   // No need to proceed if PostHog is already initialized
-  if (posthog.__loaded) return;
+  if ((posthog as any).__loaded) return;
 
   if (!POSTHOG_API_KEY) {
     console.warn("PostHog API Key not found");
     return;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-  posthog.init(POSTHOG_API_KEY, {
-    api_host: "https://us.i.posthog.com", // TODO: use a reverse proxy https://posthog.com/docs/advanced/proxy
-    session_recording: {
-      maskAllInputs: true,
-      maskTextSelector: "*",
-      recordHeaders: true,
-      recordBody: false,
-    },
-    autocapture: true,
-    enable_heatmaps: true,
-    bootstrap: {
-      sessionID: sessionId ?? undefined,
-    },
-    loaded: (posthog) => {
-      posthog.register_for_session({
-        "Rill version": rillVersion,
+  fetch("https://ipapi.co/json/")
+    .then((res) => res.json())
+    .then((data) => {
+      const isUS = data && data.country_code === "US";
+      const isCalifornia =
+        isUS && (data.region_code === "CA" || data.region === "California");
+      const shouldRedact = !isUS || isCalifornia;
+
+      posthog.init(POSTHOG_API_KEY, {
+        api_host: "https://us.i.posthog.com",
+        session_recording: shouldRedact
+          ? {
+              maskAllInputs: true,
+              maskTextSelector: "*",
+              recordHeaders: true,
+              recordBody: false,
+            }
+          : {}, // No redaction for non-California US users
+        autocapture: true,
+        enable_heatmaps: true,
+        bootstrap: {
+          sessionID: sessionId ?? undefined,
+        },
+        loaded: (posthog) => {
+          posthog.register_for_session({
+            "Rill version": rillVersion,
+          });
+        },
       });
-    },
-  });
+    })
+    .catch(() => {
+      // Fallback: initialize with redaction if GeoIP fails
+      posthog.init(POSTHOG_API_KEY, {
+        api_host: "https://us.i.posthog.com",
+        session_recording: {
+          maskAllInputs: true,
+          maskTextSelector: "*",
+          recordHeaders: true,
+          recordBody: false,
+        },
+        autocapture: true,
+        enable_heatmaps: true,
+        bootstrap: {
+          sessionID: sessionId ?? undefined,
+        },
+        loaded: (posthog) => {
+          posthog.register_for_session({
+            "Rill version": rillVersion,
+          });
+        },
+      });
+    });
 }
 
 export function posthogIdentify(userID: string, userProperties?: Properties) {


### PR DESCRIPTION
Mike's request to remove redaction of data in Session Replays for non-US and California users

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
