### PR TITLE
Support DSN from environment variable in Clickhouse provisioner

### DIFF
--- a/admin/provisioner/clickhousestatic/provisioner_test.go
+++ b/admin/provisioner/clickhousestatic/provisioner_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -145,4 +146,90 @@ func provisionClickHouse(t *testing.T, p provisioner.Provisioner) (*provisioner.
 	require.NoError(t, err)
 
 	return out, db
+}
+
+func TestClickHouseStaticWithEnvVar(t *testing.T) {
+	// Create a test ClickHouse cluster
+	container, err := testcontainersclickhouse.Run(
+		context.Background(),
+		"clickhouse/clickhouse-server:24.11.1.2557",
+		// Add a user config file that enables access management for the "default" user
+		testcontainers.CustomizeRequestOption(func(req *testcontainers.GenericContainerRequest) error {
+			req.Files = append(req.Files, testcontainers.ContainerFile{
+				Reader:            strings.NewReader(`<clickhouse><users><default><access_management>1</access_management></default></users></clickhouse>`),
+				ContainerFilePath: "/etc/clickhouse-server/users.d/default.xml",
+				FileMode:          0o755,
+			})
+			return nil
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := container.Terminate(context.Background())
+		require.NoError(t, err)
+	})
+	host, err := container.Host(context.Background())
+	require.NoError(t, err)
+	port, err := container.MappedPort(context.Background(), "9000/tcp")
+	require.NoError(t, err)
+	dsn := fmt.Sprintf("clickhouse://default:default@%v:%v", host, port.Port())
+
+	// Set environment variable
+	envVar := "TEST_CLICKHOUSE_DSN"
+	err = os.Setenv(envVar, dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.Unsetenv(envVar)
+	})
+
+	// Create the provisioner using environment variable
+	specJSON, err := json.Marshal(&Spec{
+		DSNEnv: envVar,
+	})
+	require.NoError(t, err)
+	p, err := New(specJSON, nil, zap.NewNop())
+	require.NoError(t, err)
+
+	// Provision a resource
+	r, db := provisionClickHouse(t, p)
+	defer db.Close()
+
+	// Verify the resource works
+	_, err = db.Exec("CREATE TABLE test (id UInt64) ENGINE = Memory")
+	require.NoError(t, err)
+	_, err = db.Exec("INSERT INTO test VALUES (1)")
+	require.NoError(t, err)
+
+	// Cleanup
+	err = p.Deprovision(context.Background(), r)
+	require.NoError(t, err)
+}
+
+func TestClickHouseStaticEnvVarNotSet(t *testing.T) {
+	// Test with environment variable that doesn't exist
+	specJSON, err := json.Marshal(&Spec{
+		DSNEnv: "NONEXISTENT_CLICKHOUSE_DSN",
+	})
+	require.NoError(t, err)
+	_, err = New(specJSON, nil, zap.NewNop())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "environment variable NONEXISTENT_CLICKHOUSE_DSN is not set or empty")
+}
+
+func TestClickHouseStaticEnvVarEmpty(t *testing.T) {
+	// Test with empty environment variable
+	envVar := "EMPTY_CLICKHOUSE_DSN"
+	err := os.Setenv(envVar, "")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.Unsetenv(envVar)
+	})
+
+	specJSON, err := json.Marshal(&Spec{
+		DSNEnv: envVar,
+	})
+	require.NoError(t, err)
+	_, err = New(specJSON, nil, zap.NewNop())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "environment variable EMPTY_CLICKHOUSE_DSN is not set or empty")
 }


### PR DESCRIPTION
Support DSN from environment variable in ClickHouse provisioner

```
{"clickhouse":{"spec":{"dsn_env":"RILL_MANAGED_CLICKHOUSE"}, ...snip
```

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
