### PR TITLE
fix: event listener for button component using old attribute

### DIFF
--- a/web-admin/src/features/projects/environment-variables/AddDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/AddDialog.svelte
@@ -438,7 +438,7 @@
     <DialogFooter>
       <Button
         type="plain"
-        on:click={() => {
+        onClick={() => {
           open = false;
           handleReset();
         }}

--- a/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
+++ b/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
@@ -288,7 +288,7 @@
     <h3>Success! A public URL has been created.</h3>
     <Button
       type="secondary"
-      on:click={onCopy}
+      onClick={onCopy}
       dataAttributes={{ "data-public-url": url }}
     >
       {#if copied}


### PR DESCRIPTION
We moved the click even to `onClick` from `on:click`. A couple of components were missed.

Used regex `<Button[^>]*on:click` to find them.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
