### PR TITLE
Fix reconcile status accessor fn

### DIFF
--- a/web-admin/src/features/projects/status/ProjectResourcesTable.svelte
+++ b/web-admin/src/features/projects/status/ProjectResourcesTable.svelte
@@ -4,7 +4,10 @@
     prettyResourceKind,
     ResourceKind,
   } from "@rilldata/web-common/features/entity-management/resource-selectors";
-  import type { V1Resource } from "@rilldata/web-common/runtime-client";
+  import {
+    V1ReconcileStatus,
+    type V1Resource,
+  } from "@rilldata/web-common/runtime-client";
   import ResourceErrorMessage from "./ResourceErrorMessage.svelte";
   import { getResourceKindTagColor } from "./display-utils";
   import { flexRender } from "@tanstack/svelte-table";
@@ -42,6 +45,27 @@
     {
       accessorFn: (row) => row.meta.reconcileStatus,
       header: "Status",
+      sortingFn: (rowA, rowB) => {
+        // Priority order: Running (highest) -> Pending -> Idle -> Unknown (lowest)
+        const getStatusPriority = (status: V1ReconcileStatus) => {
+          switch (status) {
+            case V1ReconcileStatus.RECONCILE_STATUS_RUNNING:
+              return 4;
+            case V1ReconcileStatus.RECONCILE_STATUS_PENDING:
+              return 3;
+            case V1ReconcileStatus.RECONCILE_STATUS_IDLE:
+              return 2;
+            case V1ReconcileStatus.RECONCILE_STATUS_UNSPECIFIED:
+            default:
+              return 1;
+          }
+        };
+
+        return (
+          getStatusPriority(rowB.original.meta.reconcileStatus) -
+          getStatusPriority(rowA.original.meta.reconcileStatus)
+        );
+      },
       cell: ({ row }) =>
         flexRender(ResourceErrorMessage, {
           message: row.original.meta.reconcileError,


### PR DESCRIPTION
Resolves https://linear.app/rilldata/issue/APP-172/inconsistent-sorting-in-project-resources-reconcile-status

This pull request addresses an issue with the accessor function for the Status column. Previously, sorting by `reconcileError` (error message strings) resulted in inconsistent ordering. With this update, sorting by `reconcileStatus` now ensures a more logical and consistent order.

Ref https://tanstack.com/table/v8/docs/api/features/sorting

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
