### PR TITLE
Increase default slots to 4

### DIFF
--- a/cli/pkg/local/slots.go
+++ b/cli/pkg/local/slots.go
@@ -2,9 +2,15 @@ package local
 
 import "github.com/rilldata/rill/cli/pkg/cmdutil"
 
+// DefaultProdSlots returns the default number of slots for production environments.
+//
+// A slot represents the following resources:
+//   - 1 CPU core
+//   - 4 GB of memory
+//   - 40 GB of storage
 func DefaultProdSlots(ch *cmdutil.Helper) int {
 	if ch.IsDev() {
 		return 1
 	}
-	return 2
+	return 4
 }


### PR DESCRIPTION
Increases default slots to `4`

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] [Linked the issues it closes](https://linear.app/rilldata/issue/PLAT-89/increase-default-slots-to-4)
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
