### PR TITLE
Stable keys for draggable list

### DIFF
--- a/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
+++ b/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
@@ -268,7 +268,7 @@
               : `No ${type === "measure" ? "measures" : "dimensions"} shown`}
           </div>
         {:else}
-          {#each filteredSelectedItems as id, i (i)}
+          {#each filteredSelectedItems as id, i (id)}
             {@const elementId = `visible-${type === "measure" ? "measures" : "dimensions"}-${id}`}
             {@const isDragItem = dragId === elementId}
             {#if allItemsMap.get(id)?.description || selectedItems.length === 1}
@@ -431,7 +431,7 @@
                 : `No hidden ${type === "measure" ? "measures" : "dimensions"}`}
             </div>
           {:else}
-            {#each filteredHiddenItems as [id = "", item], i (i)}
+            {#each filteredHiddenItems as [id = "", item], i (id)}
               {@const elementId = `hidden-${type === "measure" ? "measures" : "dimensions"}-${id}`}
               {@const isDragItem = dragId === elementId}
               {#if item.description}


### PR DESCRIPTION
This pull request addresses a bug where hiding or showing a dimension or measure would not immediately update the list in the UI.

When toggling the visibility of dimensions or measures in the "Shown dimensions" or "Hidden dimensions" lists, the UI would sometimes not update correctly. This was due to the use of array indices as keys in Svelte's {#each} blocks, which can cause DOM update issues when the list changes.

- Changed the {#each} blocks for `filteredSelectedItems` and `filteredHiddenItems` in `DashboardMetricsDraggableList.svelte` to use the unique dimension/measure ID as the key instead of the index.
- This ensures Svelte can correctly track and update each item, so the UI always reflects the current state after toggling.

Resolves https://linear.app/rilldata/issue/APP-131/ui-bug-hide-dimension-in-preview-not-working

---

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
