### PR TITLE
Updates reactive options in combobox

### DIFF
--- a/web-common/src/components/combobox/Combobox.svelte
+++ b/web-common/src/components/combobox/Combobox.svelte
@@ -50,12 +50,10 @@
     : options;
 
   // Update initialSelectedItems when selectedValues changes
-  $: if (selectedValues && selectedValues.length > 0) {
-    initialSelectedItems = selectedValues.map((value) => ({
-      value,
-      label: options.find((opt) => opt.value === value)?.label || value,
-    }));
-  }
+  $: initialSelectedItems = selectedValues.map((value) => ({
+    value,
+    label: options.find((opt) => opt.value === value)?.label || value,
+  }));
 
   function handleSelectedChange(selected: Selected<string>[] | undefined) {
     if (disabled) return;


### PR DESCRIPTION
Resolves https://linear.app/rilldata/issue/APP-144/removing-all-users-from-user-group-doesnt-uncheck-options-in-the

This pull request updates reactive selection logic so the combobox always reflects the current selection, including when the selection is empty. This fixes an issue where removing all users from a user group did not visually uncheck all options in the dropdown.

https://github.com/user-attachments/assets/878a1b21-4989-471a-81b9-a24e16542b80

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
