### PR TITLE
fix: Update token deletion queries to use addition for retention period

### DIFF
--- a/admin/database/postgres/postgres.go
+++ b/admin/database/postgres/postgres.go
@@ -1024,7 +1024,7 @@ func (c *connection) DeleteExpiredUserAuthTokens(ctx context.Context, retention 
 
 // DeleteInactiveUserAuthTokens deletes user authentication tokens that have not been used within the specified retention period.
 func (c *connection) DeleteInactiveUserAuthTokens(ctx context.Context, retention time.Duration) error {
-	_, err := c.getDB(ctx).ExecContext(ctx, `DELETE FROM user_auth_tokens WHERE used_on < (now() - $1) AND created_on < (now() - $1)`, retention)
+	_, err := c.getDB(ctx).ExecContext(ctx, `DELETE FROM user_auth_tokens WHERE used_on + $1 < now() AND created_on + $1 < now()`, retention)
 	return parseErr("auth token", err)
 }
 
@@ -1172,7 +1172,7 @@ func (c *connection) DeleteExpiredServiceAuthTokens(ctx context.Context, retenti
 
 // DeleteInactiveServiceAuthTokens deletes service authentication tokens that have not been used within the specified retention period.
 func (c *connection) DeleteInactiveServiceAuthTokens(ctx context.Context, retention time.Duration) error {
-	_, err := c.getDB(ctx).ExecContext(ctx, "DELETE FROM service_auth_tokens WHERE used_on < (now() - $1) AND created_on < (now() - $1)", retention)
+	_, err := c.getDB(ctx).ExecContext(ctx, "DELETE FROM service_auth_tokens WHERE used_on + $1 < now() AND created_on + $1 < now()", retention)
 	return parseErr("service auth token", err)
 }
 


### PR DESCRIPTION
Fixes issues with the token retention period in the Rill Admin job executor.

```log
{"level":"warn","ts":"2025-06-26T15:16:05.658-0400","caller":"jobexecutor/job_executor.go:343","msg":"JobExecutor: Job errored; retrying","error":"failed to delete unused service tokens: ERROR: operator does not exist: timestamp with time zone < interval (SQLSTATE 42883)","job_id":29,"job_kind":"delete_unused_service_tokens"}
{"level":"warn","ts":"2025-06-26T15:16:05.660-0400","caller":"jobexecutor/job_executor.go:343","msg":"JobExecutor: Job errored; retrying","error":"failed to delete unused user tokens: ERROR: operator does not exist: timestamp with time zone < interval (SQLSTATE 42883)","job_id":28,"job_kind":"delete_unused_user_tokens"}
```

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
