### PR TITLE
Make rill upgrade command forward compatible

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -129,6 +129,15 @@ jobs:
           headers: |-
             cache-control: no-store
 
+      - name: Release - Upload install script to latest CDN bucket
+        if: env.PUBLISH_RELEASE == 'true'
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: scripts/install.sh
+          destination: prod-cdn.rilldata.com/rill/latest/install.sh
+          headers: |-
+            cache-control: no-store
+
       - name: Release - Upload latest version file to CDN bucket
         if: env.PUBLISH_RELEASE == 'true'
         uses: google-github-actions/upload-cloud-storage@v2

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -120,6 +120,15 @@ jobs:
           headers: |-
             cache-control: no-store
 
+      - name: Release - Upload install script to versioned CDN bucket
+        if: env.PUBLISH_RELEASE == 'true'
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: scripts/install.sh
+          destination: prod-cdn.rilldata.com/rill/${{ github.ref_name }}/install.sh
+          headers: |-
+            cache-control: no-store
+
       - name: Release - Upload latest version file to CDN bucket
         if: env.PUBLISH_RELEASE == 'true'
         uses: google-github-actions/upload-cloud-storage@v2
@@ -149,6 +158,15 @@ jobs:
         with:
           path: nightly/
           destination: prod-cdn.rilldata.com/rill/
+          headers: |-
+            cache-control: no-store
+
+      - name: Nightly - Upload install script to nightly CDN bucket
+        if: env.PUBLISH_NIGHTLY == 'true'
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: scripts/install.sh
+          destination: prod-cdn.rilldata.com/rill/nightly/install.sh
           headers: |-
             cache-control: no-store
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ all: cli
 
 .PHONE: cli-only
 cli-only:
-	cp scripts/install.sh cli/pkg/installscript/embed/install.sh
 	go run scripts/embed_duckdb_ext/main.go
 	go build -o rill cli/main.go
 
@@ -22,7 +21,6 @@ cli.prepare:
 	mkdir -p runtime/pkg/examples/embed/dist
 	git clone --quiet https://github.com/rilldata/rill-examples.git runtime/pkg/examples/embed/dist
 	rm -rf runtime/pkg/examples/embed/dist/.git
-	cp scripts/install.sh cli/pkg/installscript/embed/install.sh
 	go run scripts/embed_duckdb_ext/main.go
 
 .PHONY: coverage.go

--- a/cli/pkg/installscript/installscript.go
+++ b/cli/pkg/installscript/installscript.go
@@ -10,7 +10,7 @@ import (
 	"os/exec"
 )
 
-//go:embed embed/install.sh
+//go:embed embed/*
 var embedFS embed.FS
 
 func Install(ctx context.Context, version string) error {

--- a/cli/pkg/installscript/installscript.go
+++ b/cli/pkg/installscript/installscript.go
@@ -5,59 +5,97 @@ import (
 	"embed"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 )
 
-//go:embed embed/*
+//go:embed embed/install.sh
 var embedFS embed.FS
 
 func Install(ctx context.Context, version string) error {
-	if version != "" {
-		return execScript(ctx, "--version", version)
-	}
-	return execScript(ctx)
+	return execScript(ctx, version, "--version", version)
 }
 
 func Uninstall(ctx context.Context) error {
-	return execScript(ctx, "--uninstall")
+	return execScript(ctx, "", "--uninstall")
 }
 
-func execScript(ctx context.Context, args ...string) error {
-	script, err := createScriptFile()
+func execScript(ctx context.Context, version string, args ...string) error {
+	script, err := createScriptFile(ctx, version)
 	if err != nil {
 		return err
 	}
 	defer os.Remove(script)
 
-	// Execute the script with bash
-	args = append([]string{script}, args...)
-	cmd := exec.CommandContext(ctx, "/bin/sh", args...)
+	scriptArgs := append([]string{script}, args...)
+	cmd := exec.CommandContext(ctx, "/bin/sh", scriptArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
 
-func createScriptFile() (string, error) {
-	// Open the embedded install script file
-	in, err := embedFS.Open("embed/install.sh")
-	if err != nil {
-		return "", fmt.Errorf("install script not embedded (is this a dev build?): %w", err)
-	}
-	defer in.Close()
+func createScriptFile(ctx context.Context, version string) (string, error) {
+	var reader io.Reader
+	var err error
 
-	// Write the install script to a temporary file
+	if version == "" {
+		reader, err = getEmbeddedScript()
+	} else {
+		// Download script for specific version
+		reader, err = downloadScript(ctx, version)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	// Write script to temporary file
 	out, err := os.CreateTemp("", "install*.sh")
 	if err != nil {
 		return "", err
 	}
 	defer out.Close()
 
-	_, err = io.Copy(out, in)
+	_, err = io.Copy(out, reader)
 	if err != nil {
 		return "", err
 	}
 
-	// Return the temp script path
 	return out.Name(), nil
+}
+
+func getEmbeddedScript() (io.Reader, error) {
+	file, err := embedFS.Open("embed/install.sh")
+	if err != nil {
+		return nil, fmt.Errorf("install script not embedded (is this a dev build?): %w", err)
+	}
+	return file, nil
+}
+
+func downloadScript(ctx context.Context, version string) (io.Reader, error) {
+	var url string
+	if version == "nightly" {
+		url = "https://raw.githubusercontent.com/rilldata/rill/main/scripts/install.sh"
+	} else {
+		url = fmt.Sprintf("https://raw.githubusercontent.com/rilldata/rill/%s/scripts/install.sh", version)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download install script from %s: %w", url, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("failed to download install script from %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	return resp.Body, nil
 }

--- a/cli/pkg/installscript/installscript.go
+++ b/cli/pkg/installscript/installscript.go
@@ -36,14 +36,14 @@ func execScript(ctx context.Context, version string, args ...string) error {
 }
 
 func createScriptFile(ctx context.Context, version string) (string, error) {
-	var reader io.Reader
+	var in io.Reader
 	var err error
 
 	if version == "" {
-		reader, err = getEmbeddedScript()
+		in, err = getEmbeddedScript()
 	} else {
 		// Download script for specific version
-		reader, err = downloadScript(ctx, version)
+		in, err = downloadScript(ctx, version)
 	}
 
 	if err != nil {
@@ -57,7 +57,7 @@ func createScriptFile(ctx context.Context, version string) (string, error) {
 	}
 	defer out.Close()
 
-	_, err = io.Copy(out, reader)
+	_, err = io.Copy(out, in)
 	if err != nil {
 		return "", err
 	}

--- a/cli/pkg/installscript/installscript.go
+++ b/cli/pkg/installscript/installscript.go
@@ -9,8 +9,6 @@ import (
 	"os/exec"
 )
 
-const cdnBaseURL = "https://cdn.rilldata.com/rill"
-
 func Install(ctx context.Context, version string) error {
 	return execScript(ctx, version, "--version", version)
 }
@@ -38,13 +36,13 @@ func createScriptFile(ctx context.Context, version string) (string, error) {
 	switch version {
 	case "nightly":
 		// https://cdn.rilldata.com/rill/nightly/install.sh
-		url = fmt.Sprintf("%s/nightly/install.sh", cdnBaseURL)
+		url = "https://cdn.rilldata.com/rill/nightly/install.sh"
 	case "latest":
 		// https://cdn.rilldata.com/rill/latest/install.sh
-		url = fmt.Sprintf("%s/latest/install.sh", cdnBaseURL)
+		url = "https://cdn.rilldata.com/rill/latest/install.sh"
 	default:
-		// https://cdn.rilldata.com/rill/<version>/install.sh
-		url = fmt.Sprintf("%s/%s/install.sh", cdnBaseURL, version)
+		// https://raw.githubusercontent.com/rilldata/rill/<version>/scripts/install.sh
+		url = fmt.Sprintf("https://raw.githubusercontent.com/rilldata/rill/%s/scripts/install.sh", version)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)


### PR DESCRIPTION
Make rill upgrade forward compatible

```bash
# Upgrade to specific version (downloads script from that version)
rill upgrade --version v0.65.4

# Downgrade to previous version (downloads script from that version)
rill upgrade --version v0.58.7

# Install nightly (downloads script from main branch)
rill upgrade --nightly
```

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] [Linked the issues it closes ](https://linear.app/rilldata/issue/PLAT-87/make-rill-upgrade-forward-compatible)
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
