### PR TITLE
Fix golangci tenv warning

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,7 @@ linters:
     - revive
     - staticcheck
     - stylecheck
-    - tenv
+    - usetesting
     - testpackage
     - tparallel
     - typecheck

--- a/admin/pkg/pgtestcontainer/pgtestcontainer.go
+++ b/admin/pkg/pgtestcontainer/pgtestcontainer.go
@@ -1,7 +1,6 @@
 package pgtestcontainer
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -19,7 +18,7 @@ type Container struct {
 
 // New creates and starts a new Postgres testcontainer. Call Terminate() when done using it.
 func New(t *testing.T) Container {
-	ctx := context.Background()
+	ctx := t.Context()
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		Started: true,
 		ContainerRequest: testcontainers.ContainerRequest{
@@ -49,7 +48,7 @@ func New(t *testing.T) Container {
 
 // Terminate stops and removes the container.
 func (c Container) Terminate(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	err := c.Container.Terminate(ctx)
 	require.NoError(t, err)
 }

--- a/admin/testadmin/testadmin.go
+++ b/admin/testadmin/testadmin.go
@@ -53,7 +53,7 @@ type Fixture struct {
 // New creates an ephemeral admin service and server for testing.
 // See the docstring for the returned Fixture for details.
 func New(t *testing.T) *Fixture {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Postgres
 	pg := pgtestcontainer.New(t)
@@ -166,7 +166,7 @@ func (f *Fixture) NewUser(t *testing.T) (*database.User, *client.Client) {
 // NewSuperuser creates a new user with superuser permission in the fixture's admin service.
 func (f *Fixture) NewSuperuser(t *testing.T) (*database.User, *client.Client) {
 	u, c := f.NewUserWithDomain(t, "test-superuser.com")
-	err := f.Admin.DB.UpdateSuperuser(context.Background(), u.ID, true)
+	err := f.Admin.DB.UpdateSuperuser(t.Context(), u.ID, true)
 	require.NoError(t, err)
 	return u, c
 }
@@ -180,12 +180,13 @@ func (f *Fixture) NewUserWithDomain(t *testing.T, domain string) (*database.User
 
 // NewUserWithEmail creates a new user with the given email in the fixture's admin service.
 func (f *Fixture) NewUserWithEmail(t *testing.T, emailAddr string) (*database.User, *client.Client) {
+	ctx := t.Context()
 	name := fmt.Sprintf("Test %s", strings.Split(emailAddr, "@")[0])
 
-	u, err := f.Admin.CreateOrUpdateUser(context.Background(), emailAddr, name, "")
+	u, err := f.Admin.CreateOrUpdateUser(ctx, emailAddr, name, "")
 	require.NoError(t, err)
 
-	tkn, err := f.Admin.IssueUserAuthToken(context.Background(), u.ID, database.AuthClientIDRillWeb, "Test session", nil, nil)
+	tkn, err := f.Admin.IssueUserAuthToken(ctx, u.ID, database.AuthClientIDRillWeb, "Test session", nil, nil)
 	require.NoError(t, err)
 
 	return u, f.NewClient(t, tkn.Token().String())

--- a/cli/testcli/testcli.go
+++ b/cli/testcli/testcli.go
@@ -2,7 +2,6 @@ package testcli
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	"github.com/rilldata/rill/admin/testadmin"
@@ -72,7 +71,7 @@ func (f *Fixture) RunWithInput(t *testing.T, input string, args ...string) Resul
 	root.SetArgs(args)
 
 	// Execute the command (mirrors the logic in cli/cmd.Run)
-	err = root.ExecuteContext(context.Background())
+	err = root.ExecuteContext(t.Context())
 	code := cmd.HandleExecuteError(ch, err)
 
 	return Result{

--- a/runtime/testruntime/olap.go
+++ b/runtime/testruntime/olap.go
@@ -1,7 +1,6 @@
 package testruntime
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -11,32 +10,35 @@ import (
 )
 
 func RequireOLAPTable(t testing.TB, rt *runtime.Runtime, id, name string) {
-	olap, release, err := rt.OLAP(context.Background(), id, "")
+	ctx := t.Context()
+	olap, release, err := rt.OLAP(ctx, id, "")
 	require.NoError(t, err)
 	defer release()
 
-	_, err = olap.InformationSchema().Lookup(context.Background(), "", "", name)
+	_, err = olap.InformationSchema().Lookup(ctx, "", "", name)
 	require.NoError(t, err)
 }
 
 func RequireNoOLAPTable(t testing.TB, rt *runtime.Runtime, id, name string) {
-	olap, release, err := rt.OLAP(context.Background(), id, "")
+	ctx := t.Context()
+	olap, release, err := rt.OLAP(ctx, id, "")
 	require.NoError(t, err)
 	defer release()
 
-	_, err = olap.InformationSchema().Lookup(context.Background(), "", "", name)
+	_, err = olap.InformationSchema().Lookup(ctx, "", "", name)
 	require.ErrorIs(t, err, drivers.ErrNotFound)
 }
 
 func RequireOLAPTableCount(t testing.TB, rt *runtime.Runtime, id, name string, count int) {
-	olap, release, err := rt.OLAP(context.Background(), id, "")
+	ctx := t.Context()
+	olap, release, err := rt.OLAP(ctx, id, "")
 	require.NoError(t, err)
 	defer release()
 
-	_, err = olap.InformationSchema().Lookup(context.Background(), "", "", name)
+	_, err = olap.InformationSchema().Lookup(ctx, "", "", name)
 	require.NoError(t, err)
 
-	rows, err := olap.Query(context.Background(), &drivers.Statement{Query: fmt.Sprintf(`SELECT count(*) FROM %s`, drivers.DialectDuckDB.EscapeIdentifier(name))})
+	rows, err := olap.Query(ctx, &drivers.Statement{Query: fmt.Sprintf(`SELECT count(*) FROM %s`, drivers.DialectDuckDB.EscapeIdentifier(name))})
 	require.NoError(t, err)
 	defer rows.Close()
 
@@ -50,7 +52,7 @@ func RequireOLAPTableCount(t testing.TB, rt *runtime.Runtime, id, name string, c
 }
 
 func RequireIsView(t testing.TB, olap drivers.OLAPStore, tableName string, isView bool) {
-	table, err := olap.InformationSchema().Lookup(context.Background(), "", "", tableName)
+	table, err := olap.InformationSchema().Lookup(t.Context(), "", "", tableName)
 	require.NoError(t, err)
 	// Assert that the model is a table now
 	require.Equal(t, table.View, isView)

--- a/runtime/testruntime/reconcile.go
+++ b/runtime/testruntime/reconcile.go
@@ -2,7 +2,6 @@ package testruntime
 
 import (
 	"bytes"
-	"context"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -17,7 +16,7 @@ import (
 )
 
 func PutFiles(t testing.TB, rt *runtime.Runtime, id string, files map[string]string) {
-	ctx := context.Background()
+	ctx := t.Context()
 	repo, release, err := rt.Repo(ctx, id)
 	require.NoError(t, err)
 	defer release()
@@ -29,7 +28,7 @@ func PutFiles(t testing.TB, rt *runtime.Runtime, id string, files map[string]str
 }
 
 func RenameFile(t testing.TB, rt *runtime.Runtime, id, from, to string) {
-	ctx := context.Background()
+	ctx := t.Context()
 	repo, release, err := rt.Repo(ctx, id)
 	require.NoError(t, err)
 	defer release()
@@ -38,7 +37,7 @@ func RenameFile(t testing.TB, rt *runtime.Runtime, id, from, to string) {
 }
 
 func DeleteFiles(t testing.TB, rt *runtime.Runtime, id string, files ...string) {
-	ctx := context.Background()
+	ctx := t.Context()
 	repo, release, err := rt.Repo(ctx, id)
 	require.NoError(t, err)
 	defer release()
@@ -54,27 +53,29 @@ func ReconcileParserAndWait(t testing.TB, rt *runtime.Runtime, id string) {
 }
 
 func ReconcileAndWait(t testing.TB, rt *runtime.Runtime, id string, n *runtimev1.ResourceName) {
-	ctrl, err := rt.Controller(context.Background(), id)
+	ctx := t.Context()
+	ctrl, err := rt.Controller(ctx, id)
 	require.NoError(t, err)
 
-	err = ctrl.Reconcile(context.Background(), n)
+	err = ctrl.Reconcile(ctx, n)
 	require.NoError(t, err)
 
-	err = ctrl.WaitUntilIdle(context.Background(), false)
+	err = ctrl.WaitUntilIdle(ctx, false)
 	require.NoError(t, err)
 }
 
 func RefreshAndWait(t testing.TB, rt *runtime.Runtime, id string, n *runtimev1.ResourceName) {
-	ctrl, err := rt.Controller(context.Background(), id)
+	ctx := t.Context()
+	ctrl, err := rt.Controller(ctx, id)
 	require.NoError(t, err)
 
 	// Get resource before refresh
-	rPrev, err := ctrl.Get(context.Background(), n, false)
+	rPrev, err := ctrl.Get(ctx, n, false)
 	require.NoError(t, err)
 
 	// Create refresh trigger
 	trgName := &runtimev1.ResourceName{Kind: runtime.ResourceKindRefreshTrigger, Name: time.Now().String()}
-	err = ctrl.Create(context.Background(), trgName, nil, nil, nil, false, &runtimev1.Resource{
+	err = ctrl.Create(ctx, trgName, nil, nil, nil, false, &runtimev1.Resource{
 		Resource: &runtimev1.Resource_RefreshTrigger{
 			RefreshTrigger: &runtimev1.RefreshTrigger{
 				Spec: &runtimev1.RefreshTriggerSpec{
@@ -86,11 +87,11 @@ func RefreshAndWait(t testing.TB, rt *runtime.Runtime, id string, n *runtimev1.R
 	require.NoError(t, err)
 
 	// Wait for refresh to complete
-	err = ctrl.WaitUntilIdle(context.Background(), false)
+	err = ctrl.WaitUntilIdle(ctx, false)
 	require.NoError(t, err)
 
 	// Get resource after refresh
-	rNew, err := ctrl.Get(context.Background(), n, false)
+	rNew, err := ctrl.Get(ctx, n, false)
 	require.NoError(t, err)
 
 	// Check the resource's spec version has increased
@@ -98,10 +99,11 @@ func RefreshAndWait(t testing.TB, rt *runtime.Runtime, id string, n *runtimev1.R
 }
 
 func RequireReconcileState(t testing.TB, rt *runtime.Runtime, id string, lenResources, lenReconcileErrs, lenParseErrs int) {
-	ctrl, err := rt.Controller(context.Background(), id)
+	ctx := t.Context()
+	ctrl, err := rt.Controller(ctx, id)
 	require.NoError(t, err)
 
-	rs, err := ctrl.List(context.Background(), "", "", false)
+	rs, err := ctrl.List(ctx, "", "", false)
 	require.NoError(t, err)
 
 	var reconcileErrs, parseErrs []string
@@ -134,20 +136,22 @@ func RequireReconcileState(t testing.TB, rt *runtime.Runtime, id string, lenReso
 }
 
 func GetResource(t testing.TB, rt *runtime.Runtime, id, kind, name string) *runtimev1.Resource {
-	ctrl, err := rt.Controller(context.Background(), id)
+	ctx := t.Context()
+	ctrl, err := rt.Controller(ctx, id)
 	require.NoError(t, err)
 
-	r, err := ctrl.Get(context.Background(), &runtimev1.ResourceName{Kind: kind, Name: name}, true)
+	r, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: kind, Name: name}, true)
 	require.NoError(t, err)
 
 	return r
 }
 
 func RequireResource(t testing.TB, rt *runtime.Runtime, id string, a *runtimev1.Resource) {
-	ctrl, err := rt.Controller(context.Background(), id)
+	ctx := t.Context()
+	ctrl, err := rt.Controller(ctx, id)
 	require.NoError(t, err)
 
-	b, err := ctrl.Get(context.Background(), a.Meta.Name, true) // Set clone=true because we may manipulate it before comparing
+	b, err := ctrl.Get(ctx, a.Meta.Name, true) // Set clone=true because we may manipulate it before comparing
 	require.NoError(t, err)
 
 	require.True(t, proto.Equal(a.Meta.Name, b.Meta.Name), "expected: %v\nactual: %v", a.Meta.Name, b.Meta.Name)
@@ -227,10 +231,11 @@ func RequireResource(t testing.TB, rt *runtime.Runtime, id string, a *runtimev1.
 }
 
 func DumpResources(t testing.TB, rt *runtime.Runtime, id string) {
-	ctrl, err := rt.Controller(context.Background(), id)
+	ctx := t.Context()
+	ctrl, err := rt.Controller(ctx, id)
 	require.NoError(t, err)
 
-	rs, err := ctrl.List(context.Background(), "", "", false)
+	rs, err := ctrl.List(ctx, "", "", false)
 	require.NoError(t, err)
 
 	for _, r := range rs {
@@ -239,10 +244,11 @@ func DumpResources(t testing.TB, rt *runtime.Runtime, id string) {
 }
 
 func RequireParseErrors(t testing.TB, rt *runtime.Runtime, id string, expectedParseErrors map[string]string) {
-	ctrl, err := rt.Controller(context.Background(), id)
+	ctx := t.Context()
+	ctrl, err := rt.Controller(ctx, id)
 	require.NoError(t, err)
 
-	pp, err := ctrl.Get(context.Background(), runtime.GlobalProjectParserName, true)
+	pp, err := ctrl.Get(ctx, runtime.GlobalProjectParserName, true)
 	require.NoError(t, err)
 
 	parseErrs := map[string]string{}
@@ -272,7 +278,7 @@ type RequireResolveOptions struct {
 
 func RequireResolve(t testing.TB, rt *runtime.Runtime, id string, opts *RequireResolveOptions) {
 	// Run the resolver.
-	ctx := context.Background()
+	ctx := t.Context()
 	res, err := rt.Resolve(ctx, &runtime.ResolveOptions{
 		InstanceID:         id,
 		Resolver:           opts.Resolver,


### PR DESCRIPTION
Resolves

```
WARN The linter 'tenv' is deprecated (since v1.64.0) due to: Duplicate feature in another linter. Replaced by usetesting.
```

Replaced `tenv` with `usetesting`, re-ran and fixed the errors 


**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
