### PR TITLE
Support Full and Incremental Model Refresh in Rill Cloud

### DIFF
--- a/web-admin/src/features/projects/status/ActionsCell.svelte
+++ b/web-admin/src/features/projects/status/ActionsCell.svelte
@@ -106,6 +106,7 @@
 <RefreshResourceConfirmDialog
   bind:open={isConfirmDialogOpen}
   name={resourceName}
+  {refreshType}
   onRefresh={() => {
     void refresh();
     isConfirmDialogOpen = false;

--- a/web-admin/src/features/projects/status/ActionsCell.svelte
+++ b/web-admin/src/features/projects/status/ActionsCell.svelte
@@ -25,8 +25,7 @@
     if (resourceKind === ResourceKind.Model) {
       await $createTrigger.mutateAsync({
         instanceId: $runtime.instanceId,
-        // NOTE: `RuntimeServiceCreateTriggerBody` allFull is only supported for models
-        data: refreshType === "full" ? { allFull: true } : {},
+        data: refreshType === "full" ? { allFull: true } : { all: true },
       });
     } else {
       await $createTrigger.mutateAsync({

--- a/web-admin/src/features/projects/status/ActionsCell.svelte
+++ b/web-admin/src/features/projects/status/ActionsCell.svelte
@@ -8,6 +8,7 @@
   import RefreshResourceConfirmDialog from "./RefreshResourceConfirmDialog.svelte";
   import { useQueryClient } from "@tanstack/svelte-query";
   import { getRuntimeServiceListResourcesQueryKey } from "@rilldata/web-common/runtime-client";
+  import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
 
   export let resourceKind: string;
   export let resourceName: string;
@@ -15,17 +16,26 @@
 
   let isConfirmDialogOpen = false;
   let isDropdownOpen = false;
+  let refreshType: "full" | "incremental" = "full";
 
   const createTrigger = createRuntimeServiceCreateTrigger();
   const queryClient = useQueryClient();
 
-  async function refresh(resourceKind: string, resourceName: string) {
-    await $createTrigger.mutateAsync({
-      instanceId: $runtime.instanceId,
-      data: {
-        resources: [{ kind: resourceKind, name: resourceName }],
-      },
-    });
+  async function refresh() {
+    if (resourceKind === ResourceKind.Model) {
+      await $createTrigger.mutateAsync({
+        instanceId: $runtime.instanceId,
+        // NOTE: `RuntimeServiceCreateTriggerBody` allFull is only supported for models
+        data: refreshType === "full" ? { allFull: true } : {},
+      });
+    } else {
+      await $createTrigger.mutateAsync({
+        instanceId: $runtime.instanceId,
+        data: {
+          resources: [{ kind: resourceKind, name: resourceName }],
+        },
+      });
+    }
 
     await queryClient.invalidateQueries({
       queryKey: getRuntimeServiceListResourcesQueryKey(
@@ -44,17 +54,45 @@
       </IconButton>
     </DropdownMenu.Trigger>
     <DropdownMenu.Content align="start">
-      <DropdownMenu.Item
-        class="font-normal flex items-center"
-        on:click={() => {
-          isConfirmDialogOpen = true;
-        }}
-      >
-        <div class="flex items-center">
-          <RefreshCcwIcon size="12px" />
-          <span class="ml-2">Refresh</span>
-        </div>
-      </DropdownMenu.Item>
+      {#if resourceKind === ResourceKind.Model}
+        <DropdownMenu.Item
+          class="font-normal flex items-center"
+          on:click={() => {
+            refreshType = "full";
+            isConfirmDialogOpen = true;
+          }}
+        >
+          <div class="flex items-center">
+            <RefreshCcwIcon size="12px" />
+            <span class="ml-2">Full Refresh</span>
+          </div>
+        </DropdownMenu.Item>
+        <DropdownMenu.Item
+          class="font-normal flex items-center"
+          on:click={() => {
+            refreshType = "incremental";
+            isConfirmDialogOpen = true;
+          }}
+        >
+          <div class="flex items-center">
+            <RefreshCcwIcon size="12px" />
+            <span class="ml-2">Incremental Refresh</span>
+          </div>
+        </DropdownMenu.Item>
+      {:else}
+        <DropdownMenu.Item
+          class="font-normal flex items-center"
+          on:click={() => {
+            refreshType = "full";
+            isConfirmDialogOpen = true;
+          }}
+        >
+          <div class="flex items-center">
+            <RefreshCcwIcon size="12px" />
+            <span class="ml-2">Full Refresh</span>
+          </div>
+        </DropdownMenu.Item>
+      {/if}
     </DropdownMenu.Content>
   </DropdownMenu.Root>
 {/if}
@@ -63,7 +101,7 @@
   bind:open={isConfirmDialogOpen}
   name={resourceName}
   onRefresh={() => {
-    void refresh(resourceKind, resourceName);
+    void refresh();
     isConfirmDialogOpen = false;
   }}
 />

--- a/web-admin/src/features/projects/status/ActionsCell.svelte
+++ b/web-admin/src/features/projects/status/ActionsCell.svelte
@@ -25,7 +25,14 @@
     if (resourceKind === ResourceKind.Model) {
       await $createTrigger.mutateAsync({
         instanceId: $runtime.instanceId,
-        data: refreshType === "full" ? { allFull: true } : { all: true },
+        data: {
+          models: [
+            {
+              model: resourceName,
+              full: refreshType === "full",
+            },
+          ],
+        },
       });
     } else {
       await $createTrigger.mutateAsync({

--- a/web-admin/src/features/projects/status/RefreshResourceConfirmDialog.svelte
+++ b/web-admin/src/features/projects/status/RefreshResourceConfirmDialog.svelte
@@ -12,6 +12,7 @@
   export let open = false;
   export let name: string;
   export let onRefresh: () => void;
+  export let refreshType: "full" | "incremental" = "full";
 
   function handleRefresh() {
     try {
@@ -26,7 +27,10 @@
 <AlertDialog bind:open>
   <AlertDialogContent>
     <AlertDialogHeader>
-      <AlertDialogTitle>Refresh {name}?</AlertDialogTitle>
+      <AlertDialogTitle>
+        {refreshType === "full" ? "Full Refresh" : "Incremental Refresh"}
+        {name}?
+      </AlertDialogTitle>
       <AlertDialogDescription>
         <div class="mt-1">
           Refreshing this resource will update all dependent resources.


### PR DESCRIPTION
Closes https://linear.app/rilldata/issue/APP-47/project-status-page-add-menu-item-for-incremental-model-refresh

References
https://github.com/rilldata/rill/blob/main/cli/cmd/project/refresh.go
https://docs.rilldata.com/reference/cli/project/refresh#rill-project-refresh

This pull request adds support for both "full refresh" and "incremental refresh" actions for models in Rill Cloud. The model refresh logic in the project resources status table is updated to use the correct API payload: instead of incorrectly using the all or allFull flags for individual model refreshes, the code now sends a models array with the model name and a full flag to indicate the refresh type. This ensures only the selected model is refreshed, matching backend expectations. Additionally, the refresh confirmation dialog title now clearly indicates whether a full or incremental refresh is being performed.

Option | Efficient | Use Case | Backend Flag
-- | -- | -- | --
Incremental | Yes | Routine updates, new data only | full: false
Full | No | Rebuild, schema/logic changes | full: true

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
