### PR TITLE
better unnest handling for clickhouse

### DIFF
--- a/runtime/metricsview/astsql.go
+++ b/runtime/metricsview/astsql.go
@@ -143,8 +143,7 @@ func (b *sqlBuilder) writeSelect(n *SelectNode) error {
 
 		// Add unnest joins. We only and always apply these against FromTable (ensuring they are already unnested when referenced in outer SELECTs).
 		for _, u := range n.Unnests {
-			b.out.WriteString(", ")
-			b.out.WriteString(u)
+			b.out.WriteString(b.ast.dialect.UnnestSQLSuffix(u))
 		}
 	} else if n.FromSelect != nil {
 		if !n.FromSelect.IsCTE {

--- a/runtime/metricsview/executor_rewrite_approx_comparisons.go
+++ b/runtime/metricsview/executor_rewrite_approx_comparisons.go
@@ -54,7 +54,7 @@ func (e *Executor) rewriteApproxComparisonNode(a *AST, n *SelectNode, isMultiPha
 		// if there are unnests in the query, we can't rewrite the query for Druid
 		// it fails with join on cte having multi value dimension, issue - https://github.com/apache/druid/issues/16896
 		for _, dim := range n.FromSelect.DimFields {
-			if dim.AutoUnnest {
+			if dim.Unnest {
 				return false
 			}
 		}


### PR DESCRIPTION
Fixes https://linear.app/rilldata/issue/PLAT-13/error-when-applying-dynamic-filter-in-disco-dashboard

Its an alternate way of handling arrays and workaround for https://github.com/ClickHouse/ClickHouse/issues/80703

Ref - https://clickhouse.com/docs/sql-reference/statements/select/array-join

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
