### PR TITLE
fix: maintain low saturation in theme colors

### DIFF
--- a/web-common/src/components/color-picker/ColorInput.svelte
+++ b/web-common/src/components/color-picker/ColorInput.svelte
@@ -195,13 +195,19 @@
       <button
         class="trigger"
         use:builder.action
+        class:open
         {...builder}
-        style:background-color={hsl}
-      />
+        style:--hsl={hsl}
+      >
+      </button>
     </Popover.Trigger>
 
-    <Popover.Content class="w-[270px] space-y-2" align="start" sideOffset={10}>
-      <div class="space-y-1">
+    <Popover.Content
+      class="w-[270px] space-y-1.5"
+      align="start"
+      sideOffset={10}
+    >
+      <div class="space-y-0.5 -mt-1">
         <InputLabel label="Hue" id="hue" />
         <ColorSlider
           mode="hue"
@@ -209,12 +215,12 @@
           {hue}
           color={hsl}
           onChange={() => {
-            stringColor = `hsl(${hue}, ${saturation}%, 50%)`;
+            stringColor = `hsl(${hue}, ${saturation}%, ${lightness}%)`;
             onChange(stringColor);
           }}
         />
       </div>
-      <div class="space-y-1">
+      <div class="space-y-0.5">
         <InputLabel label="Saturation" id="saturation" />
         <ColorSlider
           mode="saturation"
@@ -222,7 +228,20 @@
           {hue}
           color={hsl}
           onChange={() => {
-            stringColor = `hsl(${hue}, ${saturation}%, 50%)`;
+            stringColor = `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+            onChange(stringColor);
+          }}
+        />
+      </div>
+      <div class="space-y-0.5">
+        <InputLabel label="Lightness" id="lightness" />
+        <ColorSlider
+          mode="lightness"
+          bind:value={lightness}
+          {hue}
+          color={hsl}
+          onChange={() => {
+            stringColor = `hsl(${hue}, ${saturation}%, ${lightness}%)`;
             onChange(stringColor);
           }}
         />
@@ -252,7 +271,14 @@
 <style lang="postcss">
   .trigger {
     @apply h-full aspect-square;
-    @apply rounded-[2px];
+    @apply rounded-[2px] overflow-hidden flex-none;
+    background-color: var(--hsl);
+  }
+
+  .trigger:hover,
+  .trigger.open {
+    border: 1.5px solid;
+    border-color: color-mix(in oklch, var(--hsl), black 40%);
   }
 
   .color-wrapper {

--- a/web-common/src/features/themes/actions.ts
+++ b/web-common/src/features/themes/actions.ts
@@ -13,14 +13,15 @@ export function createDarkVariation(colors: Color[]) {
 
 function generatePalette(
   refColor: Color,
+  neutralizeGray: boolean = true,
   stepCount: number = 11,
   gamma: number = 1.12,
 ) {
   const [l, c, h] = refColor.oklch();
 
-  const isGray = c < 0.1;
+  const isGray = c < 0.05;
 
-  if (isGray) {
+  if (isGray && neutralizeGray) {
     const spectrum = chroma
       .scale([chroma("black"), refColor, chroma("white")])
       .mode(MODE)
@@ -139,7 +140,7 @@ export function updateThemeVariables(theme: V1ThemeSpec | undefined) {
       (theme.primaryColor.blue ?? 1) * 256,
     );
 
-    const { light, dark } = generatePalette(chromaColor);
+    const { light, dark } = generatePalette(chromaColor, false);
 
     setVariables(root, "theme", "light", light);
     setVariables(root, "theme", "dark", dark);
@@ -155,7 +156,7 @@ export function updateThemeVariables(theme: V1ThemeSpec | undefined) {
       (theme.secondaryColor.blue ?? 1) * 256,
     );
 
-    const { light, dark } = generatePalette(chromaColor);
+    const { light, dark } = generatePalette(chromaColor, false);
 
     setVariables(root, "theme-secondary", "light", light);
     setVariables(root, "theme-secondary", "dark", dark);


### PR DESCRIPTION
This PR adds a flag for desaturating gray colors during palette generation and ensures that this is not applied when generating custom themes for dashboards. Previously, colors with low saturation/chroma would be fully desaturated.

Additionally, it adds a UI control for lightness to the color picker and makes the fact that the swatch is clickable slightly more obvious.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
