### PR TITLE
fix: hidden spinner

### DIFF
--- a/web-common/src/features/entity-management/Spinner.svelte
+++ b/web-common/src/features/entity-management/Spinner.svelte
@@ -3,61 +3,27 @@
 
   export let size = "1em";
   export let status: EntityStatus = EntityStatus.Idle;
-
   export let duration = 500;
+
+  $: idle = status === EntityStatus.Idle;
 </script>
 
 <div
   class="status bg-gradient-to-b from-primary-500 to-secondary-500"
-  class:running={status === EntityStatus.Running}
-  class:idle={status === EntityStatus.Idle}
-  style="
-    --status-transition: {duration}ms;
-    --size: {size};
-    width: {size};
-    height: {size};"
+  class:idle
+  style:--status-transition="{duration}ms"
+  style:width={size}
+  style:height={size}
 />
 
 <style>
   div {
-    border-radius: 0px;
+    transform-origin: center;
+    border-radius: 1px;
     transition:
       border-radius var(--status-transition),
       border-color var(--status-transition);
-    animation: spin calc(var(--status-transition) * 2) infinite;
-    background-color: transparent;
-  }
-
-  div::before {
-    content: " ";
-    display: block;
-    width: 100%;
-    height: 100%;
-    opacity: 0;
-    border-radius: 0px;
-    transition:
-      opacity var(--status-transition),
-      border-radius var(--status-transition),
-      transform var(--status-transition);
-    background: var(--background);
-    /* transform: rotate(0deg); */
-  }
-
-  div::after {
-    content: " ";
-  }
-
-  .running::before {
-    content: " ";
-    display: block;
-    width: 100%;
-    height: 100%;
-    opacity: 1;
-    border-radius: 0px;
-    transition:
-      opacity var(--status-transition),
-      border-radius var(--status-transition),
-      transform var(--status-transition);
+    animation: reverse-spin calc(var(--status-transition) * 2) infinite;
   }
 
   .idle {
@@ -65,25 +31,11 @@
     border-color: currentColor;
   }
 
-  .idle::before {
-    content: " ";
-    display: block;
-    width: 100%;
-    height: 100%;
-    opacity: 0;
-    border-radius: 10rem;
-    transform: rotate(-180deg);
-    transition:
-      opacity var(--status-transition),
-      border-radius var(--status-transition),
-      transform var(--status-transition);
-  }
-
-  @keyframes spin {
-    0% {
+  @keyframes reverse-spin {
+    from {
       transform: rotate(360deg);
     }
-    100% {
+    to {
       transform: rotate(0deg);
     }
   }


### PR DESCRIPTION
Prior to https://github.com/rilldata/rill/pull/7156, global variables were being set as raw HSL values rather than valid color strings. When used, this required templating them into a wrapper like `hsl(var(--background))`. Without this, they would be invalid colors and would show up as transparent.

The `Spinner` component was using two pseudo-elements (the purpose of which was not immediately clear), one of which was setting the `background` property with `var(--background)`, which showed up as transparent. When the global `--background` variable became a valid CSS color, this ended up turning this element opaque, blocking visibility of the loading spinners.

This PR removes the pseudo elements and simplifies the Spinner component.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
