### PR TITLE
Deprecate boot_queries and run init_sql per handle instead of per connection

### DIFF
--- a/docs/docs/build/advanced-models/advanced-models.md
+++ b/docs/docs/build/advanced-models/advanced-models.md
@@ -74,7 +74,7 @@ Another example is attaching a database to DuckDB, running some queries against 
 ```yaml
 pre_exec: ATTACH IF NOT EXISTS 'dbname=postgres host=localhost port=5432 user=postgres password=postgres' AS postgres_db (TYPE POSTGRES);
 sql: SELECT * FROM postgres_query('postgres_db', 'SELECT * FROM USERS')
-post_exec: DETACH postgres_db # Note : this is not mandatory but nice to have 
+post_exec: DETACH DATABASE IF EXISTS postgres_db # Note : this is not mandatory but nice to have 
 ```
 
 ## Similar Considerations to Note

--- a/docs/docs/hidden/yaml/connector.md
+++ b/docs/docs/hidden/yaml/connector.md
@@ -68,31 +68,43 @@ _[string]_ - Refers to the driver type and must be driver `athena` _(required)_
 
 ### `aws_access_key_id`
 
-_[string]_ - AWS Access Key ID for Athena access 
+_[string]_ - AWS Access Key ID used for authentication. Required when using static credentials directly or as base credentials for assuming a role. 
 
 ### `aws_secret_access_key`
 
-_[string]_ - AWS Secret Access Key for Athena access 
+_[string]_ - AWS Secret Access Key paired with the Access Key ID. Required when using static credentials directly or as base credentials for assuming a role. 
 
 ### `aws_access_token`
 
-_[string]_ - Optional AWS session token for temporary credentials 
-
-### `external_id`
-
-_[string]_ - Optional External ID for assuming a role 
+_[string]_ - AWS session token used with temporary credentials. Required only if the Access Key and Secret Key are part of a temporary session credentials. 
 
 ### `role_arn`
 
-_[string]_ - Optional AWS Role ARN to assume when accessing Athena 
+_[string]_ - ARN of the IAM role to assume. When specified, the SDK uses the base credentials to call STS AssumeRole and obtain temporary credentials scoped to this role. 
 
 ### `role_session_name`
 
-_[string]_ - Optional Session name when assuming the role 
+_[string]_ - Session name to associate with the STS AssumeRole session. Used only if 'role_arn' is specified. Useful for identifying and auditing the session. 
+
+### `external_id`
+
+_[string]_ - External ID required by some roles when assuming them, typically for cross-account access. Used only if 'role_arn' is specified and the role's trust policy requires it. 
+
+### `workgroup`
+
+_[string]_ - Athena workgroup to use for query execution. Defaults to 'primary' if not specified. 
+
+### `output_location`
+
+_[string]_ - S3 URI where Athena query results should be stored (e.g., s3://your-bucket/athena/results/). Optional if the selected workgroup has a default result configuration. 
+
+### `aws_region`
+
+_[string]_ - AWS region where Athena and the result S3 bucket are located (e.g., us-east-1). Defaults to 'us-east-1' if not specified. 
 
 ### `allow_host_access`
 
-_[boolean]_ - Allow access to host environment configuration 
+_[boolean]_ - Allow the Athena client to access host environment configurations such as environment variables or local AWS credential files. Defaults to true, enabling use of credentials and settings from the host environment unless explicitly disabled. 
 
 ## azure
 
@@ -118,6 +130,10 @@ _[string]_ - Optional azure SAS token for authentication
 
 _[string]_ - Optional azure connection string for storage account 
 
+### `azure_storage_bucket`
+
+_[string]_ - Name of the Azure Blob Storage container (equivalent to an S3 bucket) _(required)_
+
 ### `allow_host_access`
 
 _[boolean]_ - Allow access to host environment configuration 
@@ -132,11 +148,15 @@ _[string]_ - Refers to the driver type and must be driver `bigquery` _(required)
 
 ### `google_application_credentials`
 
-_[string]_ - Path to the Google Cloud credentials JSON file 
+_[string]_ - Raw contents of the Google Cloud service account key (in JSON format) used for authentication. 
+
+### `project_id`
+
+_[string]_ - ID of the Google Cloud project to use for BigQuery operations. This can be omitted only if the project ID is included in the service account key. 
 
 ### `allow_host_access`
 
-_[boolean]_ - Allow access to host environment configuration 
+_[boolean]_ - Enable the BigQuery client to use credentials from the host environment when no service account JSON is provided. This includes Application Default Credentials from environment variables, local credential files, or the Google Compute Engine metadata server. Defaults to true, allowing seamless authentication in GCP environments. 
 
 ## clickhouse
 
@@ -290,13 +310,13 @@ _[integer]_ - Amount of memory in GB available to the database
 
 _[number]_ - Ratio of resources allocated to the read database; used to divide CPU and memory 
 
-### `boot_queries`
-
-_[string]_ - SQL to run when initializing a new connection, before extensions and defaults 
-
 ### `init_sql`
 
-_[string]_ - SQL to run when initializing a new connection, after extensions and defaults 
+_[string]_ - is executed during database initialization. 
+
+### `conn_init_sql`
+
+_[string]_ - is executed when a new connection is initialized. 
 
 ### `log_queries`
 
@@ -313,6 +333,10 @@ _[string]_ - Refers to the driver type and must be driver `gcs` _(required)_
 ### `google_application_credentials`
 
 _[string]_ - Google Cloud credentials JSON string 
+
+### `bucket`
+
+_[string]_ - Name of gcs bucket _(required)_
 
 ### `allow_host_access`
 
@@ -456,19 +480,31 @@ _[string]_ - Refers to the driver type and must be driver `redshift` _(required)
 
 ### `aws_access_key_id`
 
-_[string]_ - AWS access key ID for authentication 
+_[string]_ - AWS Access Key ID used for authenticating with Redshift. _(required)_
 
 ### `aws_secret_access_key`
 
-_[string]_ - AWS secret access key for authentication 
+_[string]_ - AWS Secret Access Key used for authenticating with Redshift. _(required)_
 
 ### `aws_access_token`
 
-_[string]_ - AWS session token for temporary credentials (optional) 
+_[string]_ - AWS Session Token for temporary credentials (optional). 
 
-### `allow_host_access`
+### `region`
 
-_[boolean]_ - Allow access to host environment configuration 
+_[string]_ - AWS region where the Redshift cluster or workgroup is hosted (e.g., 'us-east-1'). 
+
+### `database`
+
+_[string]_ - Name of the Redshift database to query. _(required)_
+
+### `workgroup`
+
+_[string]_ - Workgroup name for Redshift Serverless, in case of provisioned Redshift clusters use 'cluster_identifier'. 
+
+### `cluster_identifier`
+
+_[string]_ - Cluster identifier for provisioned Redshift clusters, in case of Redshift Serverless use 'workgroup' . 
 
 ## s3
 
@@ -489,6 +525,10 @@ _[string]_ - AWS Secret Access Key used for authentication
 ### `aws_access_token`
 
 _[string]_ - Optional AWS session token for temporary credentials 
+
+### `bucket`
+
+_[string]_ - Name of s3 bucket _(required)_
 
 ### `endpoint`
 

--- a/docs/docs/hidden/yaml/model.md
+++ b/docs/docs/hidden/yaml/model.md
@@ -267,11 +267,17 @@ _[string]_ - Format of the data source (e.g., csv, json, parquet).
 
 ### `pre_exec`
 
-_[string]_ - refers to a SQL queries to run before the main query, available for DuckDB based models 
+_[string]_ - refers to SQL queries to run before the main query, available for DuckDB-based models. _(optional)_. Ensure `pre_exec` queries are idempotent. Use `IF NOT EXISTS` statements when applicable. 
 
 ### `post_exec`
 
-_[string]_ - refers to a SQL query that is run after the main query, available for DuckDB based models 
+_[string]_ - refers to a SQL query that is run after the main query, available for DuckDB-based models. _(optional)_. Ensure `post_exec` queries are idempotent. Use `IF EXISTS` statements when applicable. 
+
+```yaml
+pre_exec: ATTACH IF NOT EXISTS 'dbname=postgres host=localhost port=5432 user=postgres password=postgres' AS postgres_db (TYPE POSTGRES);
+sql: SELECT * FROM postgres_query('postgres_db', 'SELECT * FROM USERS')
+post_exec: DETACH DATABASE IF EXISTS postgres_db
+```
 
 ## Additional properties when `connector` is `gcs` or [named connector](./connector.md#name) of gcs
 

--- a/docs/docs/reference/project-files/advanced-models.md
+++ b/docs/docs/reference/project-files/advanced-models.md
@@ -46,19 +46,19 @@ partitions:
     path: [s3/gs]://path/to/file/**/*.parquet[.csv]
 ```
 
-**`pre_exec`** - refers to a SQL queries to run before the main query, available for DuckDB based models _(optional)_. 
-
-**`post_exec`** - refers to a SQL query that is run after the main query, available for DuckDB based models _(optional)_. 
+**`pre_exec`** – refers to SQL queries to run before the main query, available for DuckDB-based models. _(optional)_. Ensure `pre_exec` queries are idempotent. Use `IF NOT EXISTS` statements when applicable.
 
 **`sql`** - refers to the SQL query for your model. _(required)_.
 
+**`post_exec`** – refers to a SQL query that is run after the main query, available for DuckDB-based models. _(optional)_. Ensure `post_exec` queries are dempotent. Use `IF EXISTS` statements when applicable.
+
 
 ```yaml
-pre_exec: ATTACH 'dbname=postgres host=localhost port=5432 user=postgres password=postgres' AS postgres_db (TYPE POSTGRES);
+pre_exec: ATTACH IF NOT EXISTS 'dbname=postgres host=localhost port=5432 user=postgres password=postgres' AS postgres_db (TYPE POSTGRES)
 
 sql: SELECT * FROM postgres_query('postgres_db', 'SELECT * FROM USERS')
 
-post_exec: DETACH postgres_db 
+post_exec: DETACH DATABASE IF EXISTS postgres_db
 ```
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
         "docs",
         "web-admin",
         "web-common",
-        "web-local",
-        "web-integration"
+        "web-integration",
+        "web-local"
       ],
       "devDependencies": {
         "@types/eslint": "^8.56.9",

--- a/runtime/drivers/duckdb/config.go
+++ b/runtime/drivers/duckdb/config.go
@@ -23,13 +23,14 @@ type config struct {
 	MemoryLimitGB int `mapstructure:"memory_limit_gb"`
 	// ReadWriteRatio is the ratio of resources to allocate to the read DB. If set, CPU and MemoryLimitGB are distributed based on this ratio.
 	ReadWriteRatio float64 `mapstructure:"read_write_ratio"`
-	// BootQueries is SQL to execute when initializing a new connection. It runs before any extensions are loaded or default settings are set.
+	// BootQueries is deprecated. Use InitSQL instead. Retained for backward compatibility.
 	BootQueries string `mapstructure:"boot_queries"`
-	// InitSQL is SQL to execute when initializing a new connection. It runs after extensions are loaded and and default settings are set.
+	// InitSQL is the SQL executed during database initialization.
 	InitSQL string `mapstructure:"init_sql"`
+	// ConnInitSQL is the SQL executed when a new connection is initialized.
+	ConnInitSQL string `mapstructure:"conn_init_sql"`
 	// LogQueries controls whether to log the raw SQL passed to OLAP.Execute. (Internal queries will not be logged.)
 	LogQueries bool `mapstructure:"log_queries"`
-
 	// Path switches the implementation to use a generic rduckdb implementation backed by the db used in the Path
 	Path string `mapstructure:"path"`
 	// Attach allows user to pass a full ATTACH statement to attach a DuckDB database.

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -460,10 +460,15 @@ func (c *connection) reopenDB(ctx context.Context) error {
 		connInitQueries []string
 	)
 
-	// Add custom boot queries before any other (e.g. to override the extensions repository)
+	// Add custom InitSQL queries before any other (e.g. to override the extensions repository)
+	// BootQueries is deprecated. Use InitSQL instead. Retained for backward compatibility.
 	if c.config.BootQueries != "" {
 		dbInitQueries = append(dbInitQueries, c.config.BootQueries)
 	}
+	if c.config.InitSQL != "" {
+		dbInitQueries = append(dbInitQueries, c.config.InitSQL)
+	}
+
 	dbInitQueries = append(dbInitQueries,
 		"INSTALL 'json'",
 		"INSTALL 'sqlite'",
@@ -493,8 +498,8 @@ func (c *connection) reopenDB(ctx context.Context) error {
 	}
 
 	// Add init SQL if provided
-	if c.config.InitSQL != "" {
-		connInitQueries = append(connInitQueries, c.config.InitSQL)
+	if c.config.ConnInitSQL != "" {
+		connInitQueries = append(connInitQueries, c.config.ConnInitSQL)
 	}
 	connInitQueries = append(connInitQueries, "SET max_expression_depth TO 250")
 

--- a/runtime/parser/schema/project.schema.yaml
+++ b/runtime/parser/schema/project.schema.yaml
@@ -610,12 +610,12 @@ definitions:
           read_write_ratio:
             type: number
             description: Ratio of resources allocated to the read database; used to divide CPU and memory
-          boot_queries:
-            type: string
-            description: SQL to run when initializing a new connection, before extensions and defaults
           init_sql:
             type: string
-            description: SQL to run when initializing a new connection, after extensions and defaults
+            description: is executed during database initialization.
+          conn_init_sql:
+            type: string
+            description: is executed when a new connection is initialized.
           log_queries:
             type: boolean
             description: Whether to log raw SQL queries executed through OLAP
@@ -1547,10 +1547,14 @@ definitions:
             description: 'Format of the data source (e.g., csv, json, parquet).'
           pre_exec:
             type: string
-            description: refers to a SQL queries to run before the main query, available for DuckDB based models
+            description: 'refers to SQL queries to run before the main query, available for DuckDB-based models. _(optional)_. Ensure `pre_exec` queries are idempotent. Use `IF NOT EXISTS` statements when applicable.'
           post_exec:
             type: string
-            description: refers to a SQL query that is run after the main query, available for DuckDB based models
+            description: 'refers to a SQL query that is run after the main query, available for DuckDB-based models. _(optional)_. Ensure `post_exec` queries are idempotent. Use `IF EXISTS` statements when applicable.'
+            examples:
+            - pre_exec: ATTACH IF NOT EXISTS 'dbname=postgres host=localhost port=5432 user=postgres password=postgres' AS postgres_db (TYPE POSTGRES);
+              sql: SELECT * FROM postgres_query('postgres_db', 'SELECT * FROM USERS')
+              post_exec: DETACH DATABASE IF EXISTS postgres_db 
       gcs:
         type: object
         properties:


### PR DESCRIPTION
Closes [#PLAT-17](https://linear.app/rilldata/issue/PLAT-17/deprecate-boot-queries-and-run-init-sql-per-handle-instead-of-per)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
