### PR TITLE
Toggle rill managed in ClickHouse form

### DIFF
--- a/web-common/src/features/scheduled-reports/BaseScheduledReportForm.svelte
+++ b/web-common/src/features/scheduled-reports/BaseScheduledReportForm.svelte
@@ -117,7 +117,7 @@
       bind:checked={$data["exportIncludeHeader"]}
       id="exportIncludeHeader"
       onCheckedChange={(checked) => {
-        $data["exportIncludeHeader"] = checked;
+        $data["exportIncludeHeader"] = Boolean(checked);
       }}
       inverse
       disabled={$data["exportFormat"] === V1ExportFormat.EXPORT_FORMAT_PARQUET}

--- a/web-common/src/features/sources/modal/AddClickHouseForm.svelte
+++ b/web-common/src/features/sources/modal/AddClickHouseForm.svelte
@@ -1,0 +1,306 @@
+<script lang="ts">
+  import { Button } from "@rilldata/web-common/components/button";
+  import InformationalField from "@rilldata/web-common/components/forms/InformationalField.svelte";
+  import Input from "@rilldata/web-common/components/forms/Input.svelte";
+  import SubmissionError from "@rilldata/web-common/components/forms/SubmissionError.svelte";
+  import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
+  import {
+    ConnectorDriverPropertyType,
+    type V1ConnectorDriver,
+  } from "@rilldata/web-common/runtime-client";
+  import { createEventDispatcher } from "svelte";
+  import { slide } from "svelte/transition";
+  import {
+    defaults,
+    superForm,
+    type SuperValidated,
+  } from "sveltekit-superforms";
+  import { yup } from "sveltekit-superforms/adapters";
+  import { ButtonGroup, SubButton } from "../../../components/button-group";
+  import { inferSourceName } from "../sourceUtils";
+  import { humanReadableErrorMessage } from "../errors/errors";
+  import {
+    submitAddOLAPConnectorForm,
+    submitAddSourceForm,
+  } from "./submitAddDataForm";
+  import type { AddDataFormType } from "./types";
+  import { dsnSchema, getYupSchema } from "./yupSchemas";
+
+  const FORM_TRANSITION_DURATION = 150;
+  const dispatch = createEventDispatcher();
+
+  export let connector: V1ConnectorDriver;
+  export let formType: AddDataFormType;
+  export let onBack: () => void;
+  export let onClose: () => void;
+
+  // Always include 'managed' in the schema for ClickHouse
+  const clickhouseSchema = yup(getYupSchema["clickhouse"]);
+  const paramsFormId = `add-data-${connector.name}-form`;
+  const {
+    form: paramsForm,
+    errors: paramsErrors,
+    enhance: paramsEnhance,
+    tainted: paramsTainted,
+    submit: paramsSubmit,
+    submitting: paramsSubmitting,
+  } = superForm(defaults(clickhouseSchema), {
+    SPA: true,
+    validators: clickhouseSchema,
+    onUpdate: handleOnUpdate,
+    resetForm: false,
+  });
+  let paramsError: string | null = null;
+  let paramsErrorDetails: string | undefined = undefined;
+
+  // DSN form
+  let useDsn = false;
+
+  const dsnFormId = `add-data-${connector.name}-dsn-form`;
+  const dsnProperties =
+    connector.configProperties?.filter((property) => property.key === "dsn") ??
+    [];
+  const dsnYupSchema = yup(dsnSchema);
+  const {
+    form: dsnForm,
+    errors: dsnErrors,
+    enhance: dsnEnhance,
+    tainted: dsnTainted,
+    submit: dsnSubmit,
+    submitting: dsnSubmitting,
+  } = superForm(defaults(dsnYupSchema), {
+    SPA: true,
+    validators: dsnYupSchema,
+    onUpdate: handleOnUpdate,
+    resetForm: false,
+  });
+  let dsnError: string | null = null;
+  let dsnErrorDetails: string | undefined = undefined;
+
+  // Managed toggle
+  $: submitting = useDsn ? $dsnSubmitting : $paramsSubmitting;
+  $: formId = useDsn ? dsnFormId : paramsFormId;
+
+  // Reset useDsn if switching to Rill-managed
+  $: if ($paramsForm.managed) {
+    useDsn = false;
+  }
+
+  // Reset errors when form is modified
+  $: if (useDsn) {
+    if ($dsnTainted) dsnError = null;
+  } else {
+    if ($paramsTainted) paramsError = null;
+  }
+
+  // Emit the submitting state to the parent
+  $: dispatch("submitting", { submitting });
+
+  function handleConnectionTypeChange(e: CustomEvent<any>): void {
+    useDsn = e.detail === "dsn";
+  }
+
+  function onStringInputChange(event: Event) {
+    const target = event.target as HTMLInputElement;
+    const { name, value } = target;
+    if (name === "path") {
+      if ($paramsTainted?.name) return;
+      const nameVal = inferSourceName(connector, value);
+      if (nameVal)
+        paramsForm.update(
+          ($form) => {
+            $form.name = nameVal;
+            return $form;
+          },
+          { taint: false },
+        );
+    }
+  }
+
+  async function handleOnUpdate<
+    T extends Record<string, unknown>,
+    M = any,
+    In extends Record<string, unknown> = T,
+  >(event: {
+    form: SuperValidated<T, M, In>;
+    formEl: HTMLFormElement;
+    cancel: () => void;
+    result: Extract<
+      import("@sveltejs/kit").ActionResult,
+      { type: "success" | "failure" }
+    >;
+  }) {
+    if (!event.form.valid) return;
+    const values = event.form.data;
+    try {
+      if (formType === "source") {
+        await submitAddSourceForm(queryClient, connector, values);
+      } else {
+        await submitAddOLAPConnectorForm(queryClient, connector, values);
+      }
+      onClose();
+    } catch (e) {
+      let error: string;
+      let details: string | undefined = undefined;
+      if (e instanceof Error) {
+        error = e.message;
+        details = undefined;
+      } else if (e?.message && e?.details) {
+        error = e.message;
+        details = e.details !== e.message ? e.details : undefined;
+      } else if (e?.response?.data) {
+        const originalMessage = e.response.data.message;
+        const humanReadable = humanReadableErrorMessage(
+          connector.name,
+          e.response.data.code,
+          originalMessage,
+        );
+        error = humanReadable;
+        details =
+          humanReadable !== originalMessage ? originalMessage : undefined;
+      } else {
+        error = "Unknown error";
+        details = undefined;
+      }
+      if (useDsn) {
+        dsnError = error;
+        dsnErrorDetails = details;
+      } else {
+        paramsError = error;
+        paramsErrorDetails = details;
+      }
+    }
+  }
+
+  $: properties = $paramsForm.managed
+    ? (connector.sourceProperties ?? [])
+    : (connector.configProperties?.filter((p) =>
+        !useDsn ? p.key !== "dsn" : true,
+      ) ?? []);
+  $: filteredProperties = properties.filter((property) => !property.noPrompt);
+</script>
+
+<div class="h-full w-full flex flex-col">
+  <!-- Managed toggle -->
+  <div class="pt-3">
+    <div class="text-sm font-medium mb-2">Connector type</div>
+    <select id="managed" bind:value={$paramsForm.managed} class="form-select">
+      <option value={true}>Rill-managed ClickHouse</option>
+      <option value={false}>Self-managed ClickHouse</option>
+    </select>
+  </div>
+
+  <!-- Connection method selector -->
+  {#if !$paramsForm.managed}
+    <div class="py-3">
+      <div class="text-sm font-medium mb-2">Connection method</div>
+      <ButtonGroup
+        selected={[useDsn ? "dsn" : "parameters"]}
+        on:subbutton-click={handleConnectionTypeChange}
+      >
+        <SubButton value="parameters" ariaLabel="Enter parameters">
+          <span class="px-2">Enter parameters</span>
+        </SubButton>
+        <SubButton value="dsn" ariaLabel="Use connection string">
+          <span class="px-2">Enter connection string</span>
+        </SubButton>
+      </ButtonGroup>
+    </div>
+  {/if}
+
+  <!-- Parameters form -->
+  {#if !useDsn}
+    <!-- Form 1: Individual parameters -->
+    {#if paramsError}
+      <SubmissionError message={paramsError} details={paramsErrorDetails} />
+    {/if}
+    <form
+      id={paramsFormId}
+      class="pb-5 flex-grow overflow-y-auto"
+      use:paramsEnhance
+      on:submit|preventDefault={paramsSubmit}
+      transition:slide={{ duration: FORM_TRANSITION_DURATION }}
+    >
+      {#each filteredProperties as property (property.key)}
+        {@const propertyKey = property.key ?? ""}
+        {@const label =
+          property.displayName + (property.required ? "" : " (optional)")}
+        <div class="py-1.5">
+          {#if property.type === ConnectorDriverPropertyType.TYPE_STRING || property.type === ConnectorDriverPropertyType.TYPE_NUMBER}
+            <Input
+              id={propertyKey}
+              label={property.displayName}
+              placeholder={property.placeholder}
+              optional={!property.required}
+              secret={property.secret}
+              hint={property.hint}
+              errors={$paramsErrors[propertyKey]}
+              bind:value={$paramsForm[propertyKey]}
+              onInput={(_, e) => onStringInputChange(e)}
+              alwaysShowError
+            />
+          {:else if property.type === ConnectorDriverPropertyType.TYPE_BOOLEAN}
+            <label for={property.key} class="flex items-center">
+              <input
+                id={propertyKey}
+                type="checkbox"
+                bind:checked={$paramsForm[propertyKey]}
+                class="h-5 w-5"
+              />
+              <span class="ml-2 text-sm">{label}</span>
+            </label>
+          {:else if property.type === ConnectorDriverPropertyType.TYPE_INFORMATIONAL}
+            <InformationalField
+              description={property.description}
+              hint={property.hint}
+              href={property.docsUrl}
+            />
+          {/if}
+        </div>
+      {/each}
+    </form>
+  {:else}
+    <!-- Connection string form -->
+    {#if dsnError}
+      <SubmissionError message={dsnError} details={dsnErrorDetails} />
+    {/if}
+    <form
+      id={dsnFormId}
+      class="pb-5 flex-grow overflow-y-auto"
+      use:dsnEnhance
+      on:submit|preventDefault={dsnSubmit}
+      transition:slide={{ duration: FORM_TRANSITION_DURATION }}
+    >
+      {#each dsnProperties as property (property.key)}
+        {@const propertyKey = property.key ?? ""}
+        <div class="py-1.5">
+          <Input
+            id={propertyKey}
+            label={property.displayName}
+            placeholder={property.placeholder}
+            secret={property.secret}
+            hint={property.hint}
+            errors={$dsnErrors[propertyKey]}
+            bind:value={$dsnForm[propertyKey]}
+            alwaysShowError
+          />
+        </div>
+      {/each}
+    </form>
+  {/if}
+
+  <div class="flex items-center space-x-2 ml-auto">
+    <Button onClick={onBack} type="secondary">Back</Button>
+    <Button disabled={submitting} form={formId} submitForm type="primary">
+      {#if formType === "connector"}
+        {#if submitting}
+          Testing connection...
+        {:else}
+          Connect
+        {/if}
+      {:else}
+        Add data
+      {/if}
+    </Button>
+  </div>
+</div>

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -194,6 +194,15 @@
     > for more information.
   </div>
 
+  {#if connector.name === "clickhouse"}
+    <div class="pt-3">
+      <select id="managed" bind:value={$paramsForm.managed} class="form-select">
+        <option value={true}>Rill-managed ClickHouse</option>
+        <option value={false}>Self-managed ClickHouse</option>
+      </select>
+    </div>
+  {/if}
+
   {#if hasDsnFormOption}
     <div class="py-3">
       <div class="text-sm font-medium mb-2">Connection method</div>

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -205,76 +205,75 @@
         <option value={false}>Self-managed ClickHouse</option>
       </select>
     </div>
+  {/if}
 
-    {#if !$paramsForm.managed}
-      <div class="py-3">
-        <div class="text-sm font-medium mb-2">Connection method</div>
-        <ButtonGroup
-          selected={[useDsn ? "dsn" : "parameters"]}
-          on:subbutton-click={handleConnectionTypeChange}
-        >
-          <SubButton value="parameters" ariaLabel="Enter parameters">
-            <span class="px-2">Enter parameters</span>
-          </SubButton>
-          <SubButton value="dsn" ariaLabel="Use connection string">
-            <span class="px-2">Enter connection string</span>
-          </SubButton>
-        </ButtonGroup>
-      </div>
-    {/if}
+  {#if hasDsnFormOption}
+    <div class="py-3">
+      <div class="text-sm font-medium mb-2">Connection method</div>
+      <ButtonGroup
+        selected={[useDsn ? "dsn" : "parameters"]}
+        on:subbutton-click={handleConnectionTypeChange}
+      >
+        <SubButton value="parameters" ariaLabel="Enter parameters">
+          <span class="px-2">Enter parameters</span>
+        </SubButton>
+        <SubButton value="dsn" ariaLabel="Use connection string">
+          <span class="px-2">Enter connection string</span>
+        </SubButton>
+      </ButtonGroup>
+    </div>
   {/if}
 
   {#if !useDsn}
-    {#if connector.name !== "clickhouse" || !$paramsForm.managed}
-      {#if paramsError}
-        <SubmissionError message={paramsError} details={paramsErrorDetails} />
-      {/if}
-      <form
-        id={paramsFormId}
-        class="pb-5 flex-grow overflow-y-auto"
-        use:paramsEnhance
-        on:submit|preventDefault={paramsSubmit}
-        transition:slide={{ duration: FORM_TRANSITION_DURATION }}
-      >
-        {#each filteredProperties as property (property.key)}
-          {@const propertyKey = property.key ?? ""}
-          {@const label =
-            property.displayName + (property.required ? "" : " (optional)")}
-          <div class="py-1.5">
-            {#if property.type === ConnectorDriverPropertyType.TYPE_STRING || property.type === ConnectorDriverPropertyType.TYPE_NUMBER}
-              <Input
-                id={propertyKey}
-                label={property.displayName}
-                placeholder={property.placeholder}
-                optional={!property.required}
-                secret={property.secret}
-                hint={property.hint}
-                errors={$paramsErrors[propertyKey]}
-                bind:value={$paramsForm[propertyKey]}
-                onInput={(_, e) => onStringInputChange(e)}
-                alwaysShowError
-              />
-            {:else if property.type === ConnectorDriverPropertyType.TYPE_BOOLEAN}
-              <label for={property.key} class="flex items-center">
-                <input
-                  id={propertyKey}
-                  type="checkbox"
-                  bind:checked={$paramsForm[propertyKey]}
-                  class="h-5 w-5"
-                />
-                <span class="ml-2 text-sm">{label}</span>
-              </label>
-            {:else if property.type === ConnectorDriverPropertyType.TYPE_INFORMATIONAL}
-              <InformationalField
-                description={property.description}
-                hint={property.hint}
-                href={property.docsUrl}
-              />
-            {/if}
-          </div>
-        {/each}
-      </form>
+    <!-- Form 1: Individual parameters -->
+    {#if paramsError}
+      <SubmissionError message={paramsError} details={paramsErrorDetails} />
     {/if}
+    <form
+      id={paramsFormId}
+      class="pb-5 flex-grow overflow-y-auto"
+      use:paramsEnhance
+      on:submit|preventDefault={paramsSubmit}
+      transition:slide={{ duration: FORM_TRANSITION_DURATION }}
+    >
+      {#each filteredProperties as property (property.key)}
+        {@const propertyKey = property.key ?? ""}
+        {@const label =
+          property.displayName + (property.required ? "" : " (optional)")}
+        <div class="py-1.5">
+          {#if property.type === ConnectorDriverPropertyType.TYPE_STRING || property.type === ConnectorDriverPropertyType.TYPE_NUMBER}
+            <Input
+              id={propertyKey}
+              label={property.displayName}
+              placeholder={property.placeholder}
+              optional={!property.required}
+              secret={property.secret}
+              hint={property.hint}
+              errors={$paramsErrors[propertyKey]}
+              bind:value={$paramsForm[propertyKey]}
+              onInput={(_, e) => onStringInputChange(e)}
+              alwaysShowError
+            />
+          {:else if property.type === ConnectorDriverPropertyType.TYPE_BOOLEAN}
+            <label for={property.key} class="flex items-center">
+              <input
+                id={propertyKey}
+                type="checkbox"
+                bind:checked={$paramsForm[propertyKey]}
+                class="h-5 w-5"
+              />
+              <span class="ml-2 text-sm">{label}</span>
+            </label>
+          {:else if property.type === ConnectorDriverPropertyType.TYPE_INFORMATIONAL}
+            <InformationalField
+              description={property.description}
+              hint={property.hint}
+              href={property.docsUrl}
+            />
+          {/if}
+        </div>
+      {/each}
+    </form>
   {:else}
     <!-- Form 2: DSN -->
     {#if dsnError}

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -205,75 +205,76 @@
         <option value={false}>Self-managed ClickHouse</option>
       </select>
     </div>
-  {/if}
 
-  {#if hasDsnFormOption}
-    <div class="py-3">
-      <div class="text-sm font-medium mb-2">Connection method</div>
-      <ButtonGroup
-        selected={[useDsn ? "dsn" : "parameters"]}
-        on:subbutton-click={handleConnectionTypeChange}
-      >
-        <SubButton value="parameters" ariaLabel="Enter parameters">
-          <span class="px-2">Enter parameters</span>
-        </SubButton>
-        <SubButton value="dsn" ariaLabel="Use connection string">
-          <span class="px-2">Enter connection string</span>
-        </SubButton>
-      </ButtonGroup>
-    </div>
+    {#if !$paramsForm.managed}
+      <div class="py-3">
+        <div class="text-sm font-medium mb-2">Connection method</div>
+        <ButtonGroup
+          selected={[useDsn ? "dsn" : "parameters"]}
+          on:subbutton-click={handleConnectionTypeChange}
+        >
+          <SubButton value="parameters" ariaLabel="Enter parameters">
+            <span class="px-2">Enter parameters</span>
+          </SubButton>
+          <SubButton value="dsn" ariaLabel="Use connection string">
+            <span class="px-2">Enter connection string</span>
+          </SubButton>
+        </ButtonGroup>
+      </div>
+    {/if}
   {/if}
 
   {#if !useDsn}
-    <!-- Form 1: Individual parameters -->
-    {#if paramsError}
-      <SubmissionError message={paramsError} details={paramsErrorDetails} />
-    {/if}
-    <form
-      id={paramsFormId}
-      class="pb-5 flex-grow overflow-y-auto"
-      use:paramsEnhance
-      on:submit|preventDefault={paramsSubmit}
-      transition:slide={{ duration: FORM_TRANSITION_DURATION }}
-    >
-      {#each filteredProperties as property (property.key)}
-        {@const propertyKey = property.key ?? ""}
-        {@const label =
-          property.displayName + (property.required ? "" : " (optional)")}
-        <div class="py-1.5">
-          {#if property.type === ConnectorDriverPropertyType.TYPE_STRING || property.type === ConnectorDriverPropertyType.TYPE_NUMBER}
-            <Input
-              id={propertyKey}
-              label={property.displayName}
-              placeholder={property.placeholder}
-              optional={!property.required}
-              secret={property.secret}
-              hint={property.hint}
-              errors={$paramsErrors[propertyKey]}
-              bind:value={$paramsForm[propertyKey]}
-              onInput={(_, e) => onStringInputChange(e)}
-              alwaysShowError
-            />
-          {:else if property.type === ConnectorDriverPropertyType.TYPE_BOOLEAN}
-            <label for={property.key} class="flex items-center">
-              <input
+    {#if connector.name !== "clickhouse" || !$paramsForm.managed}
+      {#if paramsError}
+        <SubmissionError message={paramsError} details={paramsErrorDetails} />
+      {/if}
+      <form
+        id={paramsFormId}
+        class="pb-5 flex-grow overflow-y-auto"
+        use:paramsEnhance
+        on:submit|preventDefault={paramsSubmit}
+        transition:slide={{ duration: FORM_TRANSITION_DURATION }}
+      >
+        {#each filteredProperties as property (property.key)}
+          {@const propertyKey = property.key ?? ""}
+          {@const label =
+            property.displayName + (property.required ? "" : " (optional)")}
+          <div class="py-1.5">
+            {#if property.type === ConnectorDriverPropertyType.TYPE_STRING || property.type === ConnectorDriverPropertyType.TYPE_NUMBER}
+              <Input
                 id={propertyKey}
-                type="checkbox"
-                bind:checked={$paramsForm[propertyKey]}
-                class="h-5 w-5"
+                label={property.displayName}
+                placeholder={property.placeholder}
+                optional={!property.required}
+                secret={property.secret}
+                hint={property.hint}
+                errors={$paramsErrors[propertyKey]}
+                bind:value={$paramsForm[propertyKey]}
+                onInput={(_, e) => onStringInputChange(e)}
+                alwaysShowError
               />
-              <span class="ml-2 text-sm">{label}</span>
-            </label>
-          {:else if property.type === ConnectorDriverPropertyType.TYPE_INFORMATIONAL}
-            <InformationalField
-              description={property.description}
-              hint={property.hint}
-              href={property.docsUrl}
-            />
-          {/if}
-        </div>
-      {/each}
-    </form>
+            {:else if property.type === ConnectorDriverPropertyType.TYPE_BOOLEAN}
+              <label for={property.key} class="flex items-center">
+                <input
+                  id={propertyKey}
+                  type="checkbox"
+                  bind:checked={$paramsForm[propertyKey]}
+                  class="h-5 w-5"
+                />
+                <span class="ml-2 text-sm">{label}</span>
+              </label>
+            {:else if property.type === ConnectorDriverPropertyType.TYPE_INFORMATIONAL}
+              <InformationalField
+                description={property.description}
+                hint={property.hint}
+                href={property.docsUrl}
+              />
+            {/if}
+          </div>
+        {/each}
+      </form>
+    {/if}
   {:else}
     <!-- Form 2: DSN -->
     {#if dsnError}

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -196,6 +196,7 @@
 
   {#if connector.name === "clickhouse"}
     <div class="pt-3">
+      <div class="text-sm font-medium mb-2">Connector type</div>
       <select id="managed" bind:value={$paramsForm.managed} class="form-select">
         <option value={true}>Rill-managed ClickHouse</option>
         <option value={false}>Self-managed ClickHouse</option>

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -207,7 +207,7 @@
     </div>
   {/if}
 
-  {#if hasDsnFormOption}
+  {#if connector.name === "clickhouse" && !$paramsForm.managed}
     <div class="py-3">
       <div class="text-sm font-medium mb-2">Connection method</div>
       <ButtonGroup
@@ -240,38 +240,40 @@
         {@const propertyKey = property.key ?? ""}
         {@const label =
           property.displayName + (property.required ? "" : " (optional)")}
-        <div class="py-1.5">
-          {#if property.type === ConnectorDriverPropertyType.TYPE_STRING || property.type === ConnectorDriverPropertyType.TYPE_NUMBER}
-            <Input
-              id={propertyKey}
-              label={property.displayName}
-              placeholder={property.placeholder}
-              optional={!property.required}
-              secret={property.secret}
-              hint={property.hint}
-              errors={$paramsErrors[propertyKey]}
-              bind:value={$paramsForm[propertyKey]}
-              onInput={(_, e) => onStringInputChange(e)}
-              alwaysShowError
-            />
-          {:else if property.type === ConnectorDriverPropertyType.TYPE_BOOLEAN}
-            <label for={property.key} class="flex items-center">
-              <input
+        {#if !(connector.name === "clickhouse" && $paramsForm.managed && propertyKey !== "managed")}
+          <div class="py-1.5">
+            {#if property.type === ConnectorDriverPropertyType.TYPE_STRING || property.type === ConnectorDriverPropertyType.TYPE_NUMBER}
+              <Input
                 id={propertyKey}
-                type="checkbox"
-                bind:checked={$paramsForm[propertyKey]}
-                class="h-5 w-5"
+                label={property.displayName}
+                placeholder={property.placeholder}
+                optional={!property.required}
+                secret={property.secret}
+                hint={property.hint}
+                errors={$paramsErrors[propertyKey]}
+                bind:value={$paramsForm[propertyKey]}
+                onInput={(_, e) => onStringInputChange(e)}
+                alwaysShowError
               />
-              <span class="ml-2 text-sm">{label}</span>
-            </label>
-          {:else if property.type === ConnectorDriverPropertyType.TYPE_INFORMATIONAL}
-            <InformationalField
-              description={property.description}
-              hint={property.hint}
-              href={property.docsUrl}
-            />
-          {/if}
-        </div>
+            {:else if property.type === ConnectorDriverPropertyType.TYPE_BOOLEAN}
+              <label for={property.key} class="flex items-center">
+                <input
+                  id={propertyKey}
+                  type="checkbox"
+                  bind:checked={$paramsForm[propertyKey]}
+                  class="h-5 w-5"
+                />
+                <span class="ml-2 text-sm">{label}</span>
+              </label>
+            {:else if property.type === ConnectorDriverPropertyType.TYPE_INFORMATIONAL}
+              <InformationalField
+                description={property.description}
+                hint={property.hint}
+                href={property.docsUrl}
+              />
+            {/if}
+          </div>
+        {/if}
       {/each}
     </form>
   {:else}

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -185,9 +185,6 @@
       }
     }
   }
-
-  $: console.log("useDsn: ", useDsn);
-  $: console.log("managed: ", $paramsForm.managed);
 </script>
 
 <div class="h-full w-full flex flex-col">
@@ -314,8 +311,8 @@
         {/if}
       {/each}
     </form>
-  {:else if !(connector.name === "clickhouse" && $paramsForm.managed)}
-    <!-- Show DSN form only if NOT clickhouse managed -->
+  {:else if hasDsnFormOption && !(connector.name === "clickhouse" && $paramsForm.managed)}
+    <!-- Show DSN form only if DSN is supported and NOT clickhouse managed -->
     {#if dsnError}
       <SubmissionError message={dsnError} details={dsnErrorDetails} />
     {/if}

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -185,6 +185,9 @@
       }
     }
   }
+
+  $: console.log("useDsn: ", useDsn);
+  $: console.log("managed: ", $paramsForm.managed);
 </script>
 
 <div class="h-full w-full flex flex-col">
@@ -240,7 +243,42 @@
         {@const propertyKey = property.key ?? ""}
         {@const label =
           property.displayName + (property.required ? "" : " (optional)")}
-        {#if !(connector.name === "clickhouse" && $paramsForm.managed && propertyKey !== "managed")}
+        {#if connector.name === "clickhouse"}
+          {#if !$paramsForm.managed || propertyKey === "managed"}
+            <div class="py-1.5">
+              {#if property.type === ConnectorDriverPropertyType.TYPE_STRING || property.type === ConnectorDriverPropertyType.TYPE_NUMBER}
+                <Input
+                  id={propertyKey}
+                  label={property.displayName}
+                  placeholder={property.placeholder}
+                  optional={!property.required}
+                  secret={property.secret}
+                  hint={property.hint}
+                  errors={$paramsErrors[propertyKey]}
+                  bind:value={$paramsForm[propertyKey]}
+                  onInput={(_, e) => onStringInputChange(e)}
+                  alwaysShowError
+                />
+              {:else if property.type === ConnectorDriverPropertyType.TYPE_BOOLEAN}
+                <label for={property.key} class="flex items-center">
+                  <input
+                    id={propertyKey}
+                    type="checkbox"
+                    bind:checked={$paramsForm[propertyKey]}
+                    class="h-5 w-5"
+                  />
+                  <span class="ml-2 text-sm">{label}</span>
+                </label>
+              {:else if property.type === ConnectorDriverPropertyType.TYPE_INFORMATIONAL}
+                <InformationalField
+                  description={property.description}
+                  hint={property.hint}
+                  href={property.docsUrl}
+                />
+              {/if}
+            </div>
+          {/if}
+        {:else}
           <div class="py-1.5">
             {#if property.type === ConnectorDriverPropertyType.TYPE_STRING || property.type === ConnectorDriverPropertyType.TYPE_NUMBER}
               <Input
@@ -276,8 +314,8 @@
         {/if}
       {/each}
     </form>
-  {:else}
-    <!-- Form 2: DSN -->
+  {:else if !(connector.name === "clickhouse" && $paramsForm.managed)}
+    <!-- Show DSN form only if NOT clickhouse managed -->
     {#if dsnError}
       <SubmissionError message={dsnError} details={dsnErrorDetails} />
     {/if}

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -47,9 +47,6 @@
       : connector.configProperties?.filter(
           (property) => property.key !== "dsn",
         )) ?? [];
-  const filteredProperties = properties.filter(
-    (property) => !property.noPrompt,
-  );
   const schema = yup(getYupSchema[connector.name as keyof typeof getYupSchema]);
   const {
     form: paramsForm,

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -26,6 +26,7 @@
   } from "./submitAddDataForm";
   import type { AddDataFormType } from "./types";
   import { dsnSchema, getYupSchema } from "./yupSchemas";
+  import AddClickHouseForm from "./AddClickHouseForm.svelte";
 
   const FORM_TRANSITION_DURATION = 150;
   const dispatch = createEventDispatcher();
@@ -194,88 +195,55 @@
       href={connector.docsUrl || "https://docs.rilldata.com/build/connect/"}
       rel="noreferrer noopener"
       target="_blank">docs</a
-    > for more information.
+    >
+    for more information.
   </div>
 
+  <!-- ClickHouse has a special form that handles the managed flag -->
   {#if connector.name === "clickhouse"}
-    <div class="pt-3">
-      <div class="text-sm font-medium mb-2">Connector type</div>
-      <select id="managed" bind:value={$paramsForm.managed} class="form-select">
-        <option value={true}>Rill-managed ClickHouse</option>
-        <option value={false}>Self-managed ClickHouse</option>
-      </select>
-    </div>
-  {/if}
-
-  {#if connector.name === "clickhouse" && !$paramsForm.managed}
-    <div class="py-3">
-      <div class="text-sm font-medium mb-2">Connection method</div>
-      <ButtonGroup
-        selected={[useDsn ? "dsn" : "parameters"]}
-        on:subbutton-click={handleConnectionTypeChange}
-      >
-        <SubButton value="parameters" ariaLabel="Enter parameters">
-          <span class="px-2">Enter parameters</span>
-        </SubButton>
-        <SubButton value="dsn" ariaLabel="Use connection string">
-          <span class="px-2">Enter connection string</span>
-        </SubButton>
-      </ButtonGroup>
-    </div>
-  {/if}
-
-  {#if !useDsn}
-    <!-- Form 1: Individual parameters -->
-    {#if paramsError}
-      <SubmissionError message={paramsError} details={paramsErrorDetails} />
+    <AddClickHouseForm
+      {connector}
+      {formType}
+      {onBack}
+      {onClose}
+      on:submitting
+    />
+  {:else}
+    <!-- For all other connectors, we show a connection method selector -->
+    {#if hasDsnFormOption}
+      <div class="py-3">
+        <div class="text-sm font-medium mb-2">Connection method</div>
+        <ButtonGroup
+          selected={[useDsn ? "dsn" : "parameters"]}
+          on:subbutton-click={handleConnectionTypeChange}
+        >
+          <SubButton value="parameters" ariaLabel="Enter parameters">
+            <span class="px-2">Enter parameters</span>
+          </SubButton>
+          <SubButton value="dsn" ariaLabel="Use connection string">
+            <span class="px-2">Enter connection string</span>
+          </SubButton>
+        </ButtonGroup>
+      </div>
     {/if}
-    <form
-      id={paramsFormId}
-      class="pb-5 flex-grow overflow-y-auto"
-      use:paramsEnhance
-      on:submit|preventDefault={paramsSubmit}
-      transition:slide={{ duration: FORM_TRANSITION_DURATION }}
-    >
-      {#each filteredProperties as property (property.key)}
-        {@const propertyKey = property.key ?? ""}
-        {@const label =
-          property.displayName + (property.required ? "" : " (optional)")}
-        {#if connector.name === "clickhouse"}
-          {#if !$paramsForm.managed || propertyKey === "managed"}
-            <div class="py-1.5">
-              {#if property.type === ConnectorDriverPropertyType.TYPE_STRING || property.type === ConnectorDriverPropertyType.TYPE_NUMBER}
-                <Input
-                  id={propertyKey}
-                  label={property.displayName}
-                  placeholder={property.placeholder}
-                  optional={!property.required}
-                  secret={property.secret}
-                  hint={property.hint}
-                  errors={$paramsErrors[propertyKey]}
-                  bind:value={$paramsForm[propertyKey]}
-                  onInput={(_, e) => onStringInputChange(e)}
-                  alwaysShowError
-                />
-              {:else if property.type === ConnectorDriverPropertyType.TYPE_BOOLEAN}
-                <label for={property.key} class="flex items-center">
-                  <input
-                    id={propertyKey}
-                    type="checkbox"
-                    bind:checked={$paramsForm[propertyKey]}
-                    class="h-5 w-5"
-                  />
-                  <span class="ml-2 text-sm">{label}</span>
-                </label>
-              {:else if property.type === ConnectorDriverPropertyType.TYPE_INFORMATIONAL}
-                <InformationalField
-                  description={property.description}
-                  hint={property.hint}
-                  href={property.docsUrl}
-                />
-              {/if}
-            </div>
-          {/if}
-        {:else}
+
+    <!-- If the user has selected to enter parameters, we show the parameters form -->
+    {#if !useDsn}
+      <!-- Form 1: Individual parameters -->
+      {#if paramsError}
+        <SubmissionError message={paramsError} details={paramsErrorDetails} />
+      {/if}
+      <form
+        id={paramsFormId}
+        class="pb-5 flex-grow overflow-y-auto"
+        use:paramsEnhance
+        on:submit|preventDefault={paramsSubmit}
+        transition:slide={{ duration: FORM_TRANSITION_DURATION }}
+      >
+        {#each properties as property (property.key)}
+          {@const propertyKey = property.key ?? ""}
+          {@const label =
+            property.displayName + (property.required ? "" : " (optional)")}
           <div class="py-1.5">
             {#if property.type === ConnectorDriverPropertyType.TYPE_STRING || property.type === ConnectorDriverPropertyType.TYPE_NUMBER}
               <Input
@@ -308,51 +276,52 @@
               />
             {/if}
           </div>
-        {/if}
-      {/each}
-    </form>
-  {:else if hasDsnFormOption && !(connector.name === "clickhouse" && $paramsForm.managed)}
-    <!-- Show DSN form only if DSN is supported and NOT clickhouse managed -->
-    {#if dsnError}
-      <SubmissionError message={dsnError} details={dsnErrorDetails} />
-    {/if}
-    <form
-      id={dsnFormId}
-      class="pb-5 flex-grow overflow-y-auto"
-      use:dsnEnhance
-      on:submit|preventDefault={dsnSubmit}
-      transition:slide={{ duration: FORM_TRANSITION_DURATION }}
-    >
-      {#each dsnProperties as property (property.key)}
-        {@const propertyKey = property.key ?? ""}
-        <div class="py-1.5">
-          <Input
-            id={propertyKey}
-            label={property.displayName}
-            placeholder={property.placeholder}
-            secret={property.secret}
-            hint={property.hint}
-            errors={$dsnErrors[propertyKey]}
-            bind:value={$dsnForm[propertyKey]}
-            alwaysShowError
-          />
-        </div>
-      {/each}
-    </form>
-  {/if}
-
-  <div class="flex items-center space-x-2 ml-auto">
-    <Button onClick={onBack} type="secondary">Back</Button>
-    <Button disabled={submitting} form={formId} submitForm type="primary">
-      {#if isConnectorForm}
-        {#if submitting}
-          Testing connection...
-        {:else}
-          Connect
-        {/if}
-      {:else}
-        Add data
+        {/each}
+      </form>
+      <!-- If the user has selected to enter a connection string, we show the connection string form -->
+    {:else}
+      <!-- Form 2: DSN -->
+      {#if dsnError}
+        <SubmissionError message={dsnError} details={dsnErrorDetails} />
       {/if}
-    </Button>
-  </div>
+      <form
+        id={dsnFormId}
+        class="pb-5 flex-grow overflow-y-auto"
+        use:dsnEnhance
+        on:submit|preventDefault={dsnSubmit}
+        transition:slide={{ duration: FORM_TRANSITION_DURATION }}
+      >
+        {#each dsnProperties as property (property.key)}
+          {@const propertyKey = property.key ?? ""}
+          <div class="py-1.5">
+            <Input
+              id={propertyKey}
+              label={property.displayName}
+              placeholder={property.placeholder}
+              secret={property.secret}
+              hint={property.hint}
+              errors={$dsnErrors[propertyKey]}
+              bind:value={$dsnForm[propertyKey]}
+              alwaysShowError
+            />
+          </div>
+        {/each}
+      </form>
+    {/if}
+
+    <div class="flex items-center space-x-2 ml-auto">
+      <Button onClick={onBack} type="secondary">Back</Button>
+      <Button disabled={submitting} form={formId} submitForm type="primary">
+        {#if isConnectorForm}
+          {#if submitting}
+            Testing connection...
+          {:else}
+            Connect
+          {/if}
+        {:else}
+          Add data
+        {/if}
+      </Button>
+    </div>
+  {/if}
 </div>

--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -46,6 +46,9 @@
       : connector.configProperties?.filter(
           (property) => property.key !== "dsn",
         )) ?? [];
+  const filteredProperties = properties.filter(
+    (property) => !property.noPrompt,
+  );
   const schema = yup(getYupSchema[connector.name as keyof typeof getYupSchema]);
   const {
     form: paramsForm,
@@ -233,7 +236,7 @@
       on:submit|preventDefault={paramsSubmit}
       transition:slide={{ duration: FORM_TRANSITION_DURATION }}
     >
-      {#each properties as property (property.key)}
+      {#each filteredProperties as property (property.key)}
         {@const propertyKey = property.key ?? ""}
         {@const label =
           property.displayName + (property.required ? "" : " (optional)")}

--- a/web-common/src/features/sources/modal/yupSchemas.ts
+++ b/web-common/src/features/sources/modal/yupSchemas.ts
@@ -157,13 +157,13 @@ export const getYupSchema = {
   }),
 
   clickhouse: yup.object().shape({
-    host: yup
-      .string()
-      .required("Host is required")
-      .matches(
-        /^(?!https?:\/\/)[a-zA-Z0-9.-]+$/,
-        "Do not prefix the host with `http(s)://`", // It will be added by the runtime
-      ),
+    managed: yup.boolean().default(false),
+    host: yup.string(),
+    // .required("Host is required")
+    // .matches(
+    //   /^(?!https?:\/\/)[a-zA-Z0-9.-]+$/,
+    //   "Do not prefix the host with `http(s)://`", // It will be added by the runtime
+    // ),
     port: yup
       .string() // Purposefully using a string input, not a numeric input
       .matches(/^\d+$/, "Port must be a number"),

--- a/web-common/src/features/sources/modal/yupSchemas.ts
+++ b/web-common/src/features/sources/modal/yupSchemas.ts
@@ -157,6 +157,7 @@ export const getYupSchema = {
   }),
 
   clickhouse: yup.object().shape({
+    managed: yup.boolean().default(false),
     host: yup.string(),
     // .required("Host is required")
     // .matches(

--- a/web-common/src/features/sources/modal/yupSchemas.ts
+++ b/web-common/src/features/sources/modal/yupSchemas.ts
@@ -157,7 +157,7 @@ export const getYupSchema = {
   }),
 
   clickhouse: yup.object().shape({
-    managed: yup.boolean(),
+    managed: yup.boolean().default(false),
     host: yup.string(),
     // .required("Host is required")
     // .matches(

--- a/web-common/src/features/sources/modal/yupSchemas.ts
+++ b/web-common/src/features/sources/modal/yupSchemas.ts
@@ -157,7 +157,7 @@ export const getYupSchema = {
   }),
 
   clickhouse: yup.object().shape({
-    managed: yup.boolean().default(false),
+    managed: yup.boolean(),
     host: yup.string(),
     // .required("Host is required")
     // .matches(

--- a/web-common/src/features/sources/modal/yupSchemas.ts
+++ b/web-common/src/features/sources/modal/yupSchemas.ts
@@ -157,7 +157,6 @@ export const getYupSchema = {
   }),
 
   clickhouse: yup.object().shape({
-    managed: yup.boolean().default(false),
     host: yup.string(),
     // .required("Host is required")
     // .matches(


### PR DESCRIPTION
This pull request adds a rill-managed and self-managed select option to the ClickHouse form. Created a new `AddClickHouseForm` component to isolate the complexity from the generic form. The duplicative forms are unique to Clickhouse to handle managed toggle, parameters/connection string switch, etc.). Handling all of the logic in the generic form component will dilute the generic logic with special cases.

Looking ahead, there is still work to be done in refactoring yupSchema and [adding parameters to Snowflake](cyrus/snowflake-connector-improvements), it's clear that the data connector flow will have many moving pieces.

Rill managed

https://github.com/user-attachments/assets/17543ac7-272e-40d7-9f09-c056b0fc4711

Self managed

https://github.com/user-attachments/assets/13f940b4-0e29-41bd-9b1b-0caef19abf99




**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
