### PR TITLE
Adjust ClickHouse static provisioner naming `rill_org_project_uuid`

### DIFF
--- a/admin/provisioner/clickhousestatic/provisioner.go
+++ b/admin/provisioner/clickhousestatic/provisioner.go
@@ -110,8 +110,16 @@ func (p *Provisioner) Provision(ctx context.Context, r *provisioner.Resource, op
 
 	// Prepare for creating the schema and user.
 	id := strings.ReplaceAll(r.ID, "-", "")
-	dbName := fmt.Sprintf("rill_%s", id)
 	user := fmt.Sprintf("rill_%s", id)
+	dbName := fmt.Sprintf("rill_%s", id)
+
+	// Use org and project names to create a more human-readable database name.
+	orgName := sanitizeName(getAnnotationValue(opts.Annotations, "org"))
+	projectName := sanitizeName(getAnnotationValue(opts.Annotations, "project"))
+	if orgName != "" && projectName != "" {
+		dbName = fmt.Sprintf("rill_%s_%s_%s", orgName, projectName, id)
+	}
+
 	password := newPassword()
 	annotationsJSON, err := json.Marshal(opts.Annotations)
 	if err != nil {
@@ -276,4 +284,34 @@ func newPassword() string {
 	}
 	// Ensure all of digits/letters/uppercase/lowercase/special characters
 	return fmt.Sprintf("1Rr!%x", b[:])
+}
+
+// Helper function to get annotation value
+func getAnnotationValue(annotations map[string]string, key string) string {
+	if annotations == nil {
+		return ""
+	}
+	return annotations[key]
+}
+
+// Helper function to sanitize names for ClickHouse identifiers
+func sanitizeName(name string) string {
+	if name == "" {
+		return ""
+	}
+
+	// Replace invalid characters with underscores and convert to lowercase
+	sanitized := strings.ToLower(name)
+	sanitized = strings.ReplaceAll(sanitized, "-", "_")
+	sanitized = strings.ReplaceAll(sanitized, " ", "_")
+
+	// Remove any characters that aren't alphanumeric or underscore
+	var result strings.Builder
+	for _, r := range sanitized {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
+			result.WriteRune(r)
+		}
+	}
+
+	return result.String()
 }

--- a/admin/provisioner/clickhousestatic/provisioner_test.go
+++ b/admin/provisioner/clickhousestatic/provisioner_test.go
@@ -233,3 +233,197 @@ func TestClickHouseStaticEnvVarEmpty(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "environment variable EMPTY_CLICKHOUSE_DSN is not set or empty")
 }
+
+func TestClickHouseStaticHumanReadableNaming(t *testing.T) {
+	// Create a test ClickHouse cluster
+	container, err := testcontainersclickhouse.Run(
+		context.Background(),
+		"clickhouse/clickhouse-server:24.11.1.2557",
+		// Add a user config file that enables access management for the "default" user
+		testcontainers.CustomizeRequestOption(func(req *testcontainers.GenericContainerRequest) error {
+			req.Files = append(req.Files, testcontainers.ContainerFile{
+				Reader:            strings.NewReader(`<clickhouse><users><default><access_management>1</access_management></default></users></clickhouse>`),
+				ContainerFilePath: "/etc/clickhouse-server/users.d/default.xml",
+				FileMode:          0o755,
+			})
+			return nil
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := container.Terminate(context.Background())
+		require.NoError(t, err)
+	})
+	host, err := container.Host(context.Background())
+	require.NoError(t, err)
+	port, err := container.MappedPort(context.Background(), "9000/tcp")
+	require.NoError(t, err)
+	dsn := fmt.Sprintf("clickhouse://default:default@%v:%v", host, port.Port())
+
+	// Create the provisioner
+	specJSON, err := json.Marshal(&Spec{
+		DSN: dsn,
+	})
+	require.NoError(t, err)
+	p, err := New(specJSON, nil, zap.NewNop())
+	require.NoError(t, err)
+
+	// Test with org and project annotations
+	resourceID := uuid.New().String()
+	in := &provisioner.Resource{
+		ID:     resourceID,
+		Type:   provisioner.ResourceTypeClickHouse,
+		State:  nil,
+		Config: nil,
+	}
+	opts := &provisioner.ResourceOptions{
+		Args: nil,
+		Annotations: map[string]string{
+			"org":     "Acme-Corp",
+			"project": "My-Project",
+		},
+		RillVersion: "dev",
+	}
+
+	out, err := p.Provision(context.Background(), in, opts)
+	require.NoError(t, err)
+
+	// Parse the DSN to get the database name and user
+	cfg, err := provisioner.NewClickhouseConfig(out.Config)
+	require.NoError(t, err)
+	opts2, err := clickhouse.ParseDSN(cfg.DSN)
+	require.NoError(t, err)
+	// Check that the database name follows the expected format
+	expectedID := strings.ReplaceAll(resourceID, "-", "")
+	expectedDBName := fmt.Sprintf("rill_acme_corp_my_project_%s", expectedID)
+	expectedUser := fmt.Sprintf("rill_%s", expectedID) // User name remains UUID format
+
+	require.Equal(t, expectedDBName, opts2.Auth.Database)
+	require.Equal(t, expectedUser, opts2.Auth.Username)
+
+	// Test the connection works
+	db, err := sql.Open("clickhouse", cfg.DSN)
+	require.NoError(t, err)
+	defer db.Close()
+
+	err = db.Ping()
+	require.NoError(t, err)
+
+	// Create a table to ensure permissions work
+	_, err = db.Exec("CREATE TABLE test (id UInt64) ENGINE = Memory")
+	require.NoError(t, err)
+	_, err = db.Exec("INSERT INTO test VALUES (1)")
+	require.NoError(t, err)
+
+	// Clean up
+	err = p.Deprovision(context.Background(), out)
+	require.NoError(t, err)
+}
+
+func TestClickHouseStaticFallbackNaming(t *testing.T) {
+	// Create a test ClickHouse cluster
+	container, err := testcontainersclickhouse.Run(
+		context.Background(),
+		"clickhouse/clickhouse-server:24.11.1.2557",
+		// Add a user config file that enables access management for the "default" user
+		testcontainers.CustomizeRequestOption(func(req *testcontainers.GenericContainerRequest) error {
+			req.Files = append(req.Files, testcontainers.ContainerFile{
+				Reader:            strings.NewReader(`<clickhouse><users><default><access_management>1</access_management></default></users></clickhouse>`),
+				ContainerFilePath: "/etc/clickhouse-server/users.d/default.xml",
+				FileMode:          0o755,
+			})
+			return nil
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := container.Terminate(context.Background())
+		require.NoError(t, err)
+	})
+	host, err := container.Host(context.Background())
+	require.NoError(t, err)
+	port, err := container.MappedPort(context.Background(), "9000/tcp")
+	require.NoError(t, err)
+	dsn := fmt.Sprintf("clickhouse://default:default@%v:%v", host, port.Port())
+
+	// Create the provisioner
+	specJSON, err := json.Marshal(&Spec{
+		DSN: dsn,
+	})
+	require.NoError(t, err)
+	p, err := New(specJSON, nil, zap.NewNop())
+	require.NoError(t, err)
+
+	// Test without org/project annotations (should fall back to old format)
+	resourceID := uuid.New().String()
+	in := &provisioner.Resource{
+		ID:     resourceID,
+		Type:   provisioner.ResourceTypeClickHouse,
+		State:  nil,
+		Config: nil,
+	}
+	opts := &provisioner.ResourceOptions{
+		Args:        nil,
+		Annotations: map[string]string{}, // Empty annotations
+		RillVersion: "dev",
+	}
+
+	out, err := p.Provision(context.Background(), in, opts)
+	require.NoError(t, err)
+
+	// Parse the DSN to get the database name and user
+	cfg, err := provisioner.NewClickhouseConfig(out.Config)
+	require.NoError(t, err)
+	opts2, err := clickhouse.ParseDSN(cfg.DSN)
+	require.NoError(t, err)
+	// Check that the database name follows the fallback format
+	expectedID := strings.ReplaceAll(resourceID, "-", "")
+	expectedDBName := fmt.Sprintf("rill_%s", expectedID)
+	expectedUser := fmt.Sprintf("rill_%s", expectedID) // User name always uses UUID format
+
+	require.Equal(t, expectedDBName, opts2.Auth.Database)
+	require.Equal(t, expectedUser, opts2.Auth.Username)
+
+	// Log the database name for debugging
+	t.Logf("Provisioned database name: %s", opts2.Auth.Database)
+	t.Logf("Provisioned user name: %s", opts2.Auth.Username)
+
+	// Test the connection works
+	db, err := sql.Open("clickhouse", cfg.DSN)
+	require.NoError(t, err)
+	defer db.Close()
+
+	err = db.Ping()
+	require.NoError(t, err)
+
+	// Clean up
+	err = p.Deprovision(context.Background(), out)
+	require.NoError(t, err)
+}
+
+func TestSanitizeName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"simple", "simple"},
+		{"Simple", "simple"},
+		{"UPPERCASE", "uppercase"},
+		{"with-dashes", "with_dashes"},
+		{"with spaces", "with_spaces"},
+		{"with@special!chars", "withspecialchars"},
+		{"mixed-Case_Name", "mixed_case_name"},
+		{"123numbers", "123numbers"},
+		{"_underscore_", "_underscore_"},
+		{"Acme-Corp", "acme_corp"},
+		{"My-Project", "my_project"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := sanitizeName(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Currently we use a uuid as the table name `rill_uuid` this PR changes that to a more human readable string `rill_org_project_uuid`

```
new: rill_acme_corp_my_project_9b32f48044d142a18e4634367e13a277
old: rill_9b32f48044d142a18e4634367e13a277
```

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it [closes](https://linear.app/rilldata/issue/PLAT-113/managed-ch-databases-should-be-human-readable) 
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
