### PR TITLE
don't include compare time measure in base query for 2 phase comparisons

### DIFF
--- a/runtime/metricsview/executor_rewrite_two_phase_comparisons.go
+++ b/runtime/metricsview/executor_rewrite_two_phase_comparisons.go
@@ -26,7 +26,7 @@ func (e *Executor) rewriteTwoPhaseComparisons(ctx context.Context, qry *Query, a
 
 	var bm []Measure
 	for _, qm := range qry.Measures {
-		if qm.Compute == nil || (qm.Compute.ComparisonValue == nil && qm.Compute.ComparisonDelta == nil && qm.Compute.ComparisonRatio == nil && qm.Compute.PercentOfTotal == nil) {
+		if qm.Compute == nil || (qm.Compute.ComparisonValue == nil && qm.Compute.ComparisonDelta == nil && qm.Compute.ComparisonRatio == nil && qm.Compute.PercentOfTotal == nil && qm.Compute.ComparisonTime == nil) {
 			bm = append(bm, qm)
 			continue
 		}


### PR DESCRIPTION

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
