### PR TITLE
fix alias conflict for clickhouse schema validation query

### DIFF
--- a/runtime/metricsview/executor.go
+++ b/runtime/metricsview/executor.go
@@ -210,6 +210,10 @@ func (e *Executor) Schema(ctx context.Context) (*runtimev1.StructType, error) {
 
 	for _, d := range e.metricsView.Dimensions {
 		if e.security.CanAccessField(d.Name) {
+			if e.metricsView.TimeDimension == d.Name {
+				// Skip the time dimension if it is already added
+				continue
+			}
 			qry.Dimensions = append(qry.Dimensions, Dimension{Name: d.Name})
 		}
 	}


### PR DESCRIPTION
Only include time dimension in schema query once if its defined in the dimension list. This causes issues with CH as it does not allow duplicate alias.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
