### PR TITLE
Handle error when converting meta field to struct in query resolver

### DIFF
--- a/runtime/server/query_resolver.go
+++ b/runtime/server/query_resolver.go
@@ -82,9 +82,9 @@ func (s *Server) QueryResolver(ctx context.Context, req *runtimev1.QueryResolver
 	}
 
 	// Return the response
-	metaPB, err := structpb.NewStruct(res.Meta())
+	metaPB, err := pbutil.ToStruct(res.Meta(), nil)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to convert meta to struct: %v", err)
+		metaPB = &structpb.Struct{Fields: make(map[string]*structpb.Value)}
 	}
 	return &runtimev1.QueryResolverResponse{
 		Meta:   metaPB,


### PR DESCRIPTION
Handle error when converting meta field to struct in query resolver

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
