### PR TITLE
Safeguard valid datetime

### DIFF
--- a/web-common/src/features/dashboards/filters/TimeRangeReadOnly.svelte
+++ b/web-common/src/features/dashboards/filters/TimeRangeReadOnly.svelte
@@ -6,6 +6,7 @@
   import { humaniseISODuration } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
   import { TimeRangePreset } from "@rilldata/web-common/lib/time/types";
   import type { V1TimeRange } from "@rilldata/web-common/runtime-client";
+  import { isValidDateTime } from "@rilldata/web-common/lib/time/is-valid-datetime";
 
   export let timeRange: V1TimeRange;
   export let comparisonTimeRange: V1TimeRange | undefined;
@@ -27,12 +28,16 @@
         </div>
       {:else if timeRange.start && timeRange.end}
         <div class:font-bold={hasBoldTimeRange}>
-          {prettyFormatTimeRange(
-            new Date(timeRange.start),
-            new Date(timeRange.end),
-            TimeRangePreset.CUSTOM,
-            "UTC", // TODO
-          )}
+          {#if isValidDateTime(timeRange.start) && isValidDateTime(timeRange.end)}
+            {prettyFormatTimeRange(
+              new Date(timeRange.start),
+              new Date(timeRange.end),
+              TimeRangePreset.CUSTOM,
+              "UTC", // TODO
+            )}
+          {:else}
+            -
+          {/if}
         </div>
       {/if}
     </div>

--- a/web-common/src/features/dashboards/time-controls/super-pill/components/RangeDisplay.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/RangeDisplay.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { DateTime, Interval } from "luxon";
-  import { isValidDateTime } from "@rilldata/web-common/lib/time/is-valid-datetime";
 
   export let interval: Interval<true>;
   export let grain: string;

--- a/web-common/src/features/dashboards/time-controls/super-pill/components/RangeDisplay.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/RangeDisplay.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { DateTime, Interval } from "luxon";
+  import { isValidDateTime } from "@rilldata/web-common/lib/time/is-valid-datetime";
 
   export let interval: Interval<true>;
   export let grain: string;
@@ -14,15 +15,19 @@
 
   $: displayedInterval = showTime ? interval : inclusiveInterval;
 
-  $: date = displayedInterval.toLocaleString(DateTime.DATE_MED);
-
-  $: time = displayedInterval.toFormat(timeFormat, { separator: "-" });
+  $: isValidInterval = displayedInterval?.isValid;
+  $: date = isValidInterval
+    ? displayedInterval.toLocaleString(DateTime.DATE_MED)
+    : "-";
+  $: time = isValidInterval
+    ? displayedInterval.toFormat(timeFormat, { separator: "-" })
+    : "-";
 </script>
 
 <div class="flex gap-x-1 whitespace-nowrap truncate" title="{date} {time}">
   <span class="line-clamp-1 text-left">
     {date}
-    {#if showTime}
+    {#if showTime && isValidInterval}
       ({time})
     {/if}
     {#if abbreviation}

--- a/web-common/src/features/dashboards/time-controls/super-pill/components/Timestamp.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/Timestamp.svelte
@@ -3,6 +3,7 @@
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { copyToClipboard } from "@rilldata/web-common/lib/actions/copy-to-clipboard";
   import { DateTime, Duration } from "luxon";
+  import { isValidDateTime } from "@rilldata/web-common/lib/time/is-valid-datetime";
 
   export let date: DateTime = DateTime.now();
   export let zone: string;
@@ -10,23 +11,26 @@
   export let suppress = false;
   export let italic = false;
 
-  $: zonedDate = date.setZone(zone);
-  $: isoString = zonedDate.toISO();
+  $: isValid = isValidDateTime(date);
+  $: zonedDate = isValid ? date.setZone(zone) : null;
+  $: isoString = isValid && zonedDate ? zonedDate.toISO() : "";
+  $: formattedString =
+    isValid && zonedDate
+      ? zonedDate.toLocaleString(DateTime.DATETIME_MED_WITH_WEEKDAY)
+      : "-";
 
-  $: formattedString = zonedDate.toLocaleString(
-    DateTime.DATETIME_MED_WITH_WEEKDAY,
-  );
-
-  $: humanReadableTimeOffset = Duration.fromObject(
-    Object.fromEntries(
-      Object.entries(DateTime.now().diff(date).rescale().toObject())
-        .filter(([, value]) => value !== 0)
-        .slice(0, 2),
-    ),
-  ).toHuman({
-    listStyle: "narrow",
-    maximumFractionDigits: 0,
-  });
+  $: humanReadableTimeOffset = isValid
+    ? Duration.fromObject(
+        Object.fromEntries(
+          Object.entries(DateTime.now().diff(date).rescale().toObject())
+            .filter(([, value]) => value !== 0)
+            .slice(0, 2),
+        ),
+      ).toHuman({
+        listStyle: "narrow",
+        maximumFractionDigits: 0,
+      })
+    : "";
 </script>
 
 <Tooltip {suppress}>
@@ -36,28 +40,41 @@
     on:click={() => {
       if (isoString) copyToClipboard(isoString);
     }}
+    disabled={!isValid}
   >
-    {#if showDate}
-      {formattedString}
+    {#if isValid}
+      {#if showDate}
+        {formattedString}
+      {:else}
+        ({humanReadableTimeOffset} ago)
+      {/if}
     {:else}
-      ({humanReadableTimeOffset} ago)
+      -
     {/if}
   </button>
 
   <TooltipContent slot="tooltip-content">
     <div class="flex flex-col gap-y-1 items-center">
       <span>
-        {#if showDate}
-          {#if humanReadableTimeOffset.length}
-            {humanReadableTimeOffset} ago
+        {#if isValid}
+          {#if showDate}
+            {#if humanReadableTimeOffset.length}
+              {humanReadableTimeOffset} ago
+            {/if}
+          {:else}
+            {formattedString}
           {/if}
         {:else}
-          {formattedString}
+          -
         {/if}
       </span>
 
       <span>
-        {isoString}
+        {#if isValid}
+          {isoString}
+        {:else}
+          -
+        {/if}
       </span>
     </div>
   </TooltipContent>

--- a/web-common/src/lib/time/is-valid-datetime.ts
+++ b/web-common/src/lib/time/is-valid-datetime.ts
@@ -1,0 +1,13 @@
+import { DateTime } from "luxon";
+
+/**
+ * Checks if a value is a valid Luxon DateTime or can be parsed into one.
+ * Accepts ISO strings, JS Date, or Luxon DateTime.
+ */
+export function isValidDateTime(value: unknown): boolean {
+  if (!value) return false;
+  if (value instanceof DateTime) return value.isValid;
+  if (value instanceof Date) return DateTime.fromJSDate(value).isValid;
+  if (typeof value === "string") return DateTime.fromISO(value).isValid;
+  return false;
+}


### PR DESCRIPTION
This pull request resolves `RangeError: Invalid time value` found in https://rilldata.slack.com/archives/C02T907FEUB/p1752163567950159?thread_ts=1752159312.066389&cid=C02T907FEUB. This happens when we try to parse an invalid datetime.

These are the downstream components from `/share/[token]/explore/[dashboard]/+page.svelte`.

- Timestamp.svelte
- RangeDisplay.svelte
- TimeRangeReadOnly.svelte

These components will now safely check for valid date/time values before formatting or displaying them, and will show a dash (-) as a fallback if the value is invalid. This will prevent the RangeError: Invalid time value bug from occurring in these UI areas.

- [ ] to create a public URL with old dates

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
