### PR TITLE
fix: time range for canvas for single data point

### DIFF
--- a/web-common/src/features/canvas/stores/time-control.ts
+++ b/web-common/src/features/canvas/stores/time-control.ts
@@ -377,7 +377,7 @@ export class TimeControls {
             end = new Date(Math.max(end.getTime(), metricsEndDate.getTime()));
           }
         });
-        if (start.getTime() >= end.getTime()) {
+        if (start.getTime() > end.getTime()) {
           start = new Date(0);
           end = new Date();
         }


### PR DESCRIPTION
Fixes https://linear.app/rilldata/issue/APP-196/bug-kpi-component-shows-null-value-incorrectly

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
