### PR TITLE
chore(docs): Remove unused `sidebar` dependency

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -44,8 +44,5 @@
       "last 1 safari version"
     ]
   },
-  "main": "babel.config.js",
-  "dependencies": {
-    "sidebar": "^1.0.2"
-  }
+  "main": "babel.config.js"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,9 +32,6 @@
     },
     "docs": {
       "version": "0.0.0",
-      "dependencies": {
-        "sidebar": "^1.0.2"
-      },
       "devDependencies": {
         "@docusaurus/core": "^3.1.1",
         "@docusaurus/module-type-aliases": "^3.1.1",
@@ -16312,15 +16309,6 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/bootstrap": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
-      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/boxen": {
       "version": "6.2.1",
@@ -37149,15 +37137,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/sidebar": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/sidebar/-/sidebar-1.0.2.tgz",
-      "integrity": "sha512-JvzZ6OLsvdVK0jo6jTHSfTApuHVHeAm3++UnAoHRpoVeTcW1nC7Xm8LRbRvtGXVSJsdeM6qfv5pgDZUXemgkDw==",
-      "license": "MIT",
-      "dependencies": {
-        "bootstrap": "^3.3.7"
       }
     },
     "node_modules/siginfo": {


### PR DESCRIPTION
Removes the `sidebar` package and its dependency the `bootstrap` package, which [Dependabot called out as having a Moderate vulnerability](https://github.com/rilldata/rill/security/dependabot/187). The `sidebar` package was not actually used anywhere in our docs.
