### PR TITLE
Hotfix for custom tr public url

### DIFF
--- a/web-common/src/features/dashboards/url-state/convertLegacyStateToExplorePreset.ts
+++ b/web-common/src/features/dashboards/url-state/convertLegacyStateToExplorePreset.ts
@@ -44,6 +44,7 @@ import {
   type V1Expression,
   type V1MetricsViewSpec,
 } from "@rilldata/web-common/runtime-client";
+import { TimeRangePreset } from "@rilldata/web-common/lib/time/types";
 
 export function convertLegacyStateToExplorePreset(
   legacyState: DashboardState,
@@ -134,8 +135,15 @@ function fromLegacyTimeRangeFields(
   const errors: Error[] = [];
 
   if (legacyState.timeRange?.name) {
-    preset.timeRange = legacyState.timeRange.name;
-    // TODO: custom time range
+    if (
+      legacyState.timeRange.name === TimeRangePreset.CUSTOM &&
+      legacyState.timeRange.timeStart &&
+      legacyState.timeRange.timeEnd
+    ) {
+      preset.timeRange = `${new Date(Number(legacyState.timeRange.timeStart.seconds)).toISOString()},${new Date(Number(legacyState.timeRange.timeEnd.seconds)).toISOString()}`;
+    } else {
+      preset.timeRange = legacyState.timeRange.name;
+    }
   }
   if (legacyState.timeGrain) {
     preset.timeGrain =


### PR DESCRIPTION
Addressed https://rilldata.slack.com/archives/C02T907FEUB/p1752159312066389

Fixed https://github.com/rilldata/rill/blob/main/web-common/src/features/dashboards/url-state/convertLegacyStateToExplorePreset.ts#L138

This pull request ensures that when a public URL is generated or visited with a custom time range (via the legacy proto state parameter), the custom range is correctly serialized and deserialized. Specifically, if the proto state contains a custom time range, the timeStart and timeEnd fields are now encoded as ISO strings in the URL, allowing the dashboard to restore and display the user's selected custom range accurately.

https://github.com/user-attachments/assets/60302e7a-4f54-44e8-8f8e-5fca60f83d34

Reviewer - create a public URL with custom range, open the public URL. You should be able to view the dashboard now!

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
