### PR TITLE
design (Rill Developer): When no metrics views in project, show & disable dashboard options

### DIFF
--- a/web-common/src/features/entity-management/AddAssetButton.svelte
+++ b/web-common/src/features/entity-management/AddAssetButton.svelte
@@ -170,7 +170,10 @@
       </div>
     </Button>
   </DropdownMenu.Trigger>
-  <DropdownMenu.Content align="start" class="w-[240px]">
+  <DropdownMenu.Content
+    align="start"
+    class={`w-[${metricsViews.length === 0 ? "280px" : "240px"}]`}
+  >
     <DropdownMenu.Item
       aria-label="Add Data"
       class="flex gap-x-2"
@@ -205,49 +208,61 @@
       />
       Metrics view
     </DropdownMenu.Item>
-    {#if metricsViews.length}
-      <DropdownMenu.Separator />
-      <DropdownMenu.Item
-        aria-label="Add Explore Dashboard"
-        class="flex gap-x-2"
-        on:click={async () => {
-          if (metricsViews.length === 1) {
-            const newFilePath = await createResourceFile(
-              ResourceKind.Explore,
-              metricsViews.pop(),
-            );
-            await wrapNavigation(newFilePath);
-          } else {
-            showExploreDialog = true;
-          }
-        }}
-      >
+    <DropdownMenu.Separator />
+    <DropdownMenu.Item
+      aria-label="Add Explore Dashboard"
+      class="flex gap-x-2"
+      disabled={metricsViews.length === 0}
+      on:click={async () => {
+        if (metricsViews.length === 1) {
+          const newFilePath = await createResourceFile(
+            ResourceKind.Explore,
+            metricsViews.pop(),
+          );
+          await wrapNavigation(newFilePath);
+        } else {
+          showExploreDialog = true;
+        }
+      }}
+    >
+      <div class="flex gap-x-2 items-center">
         <svelte:component
           this={resourceIconMapping[ResourceKind.Explore]}
           color={resourceColorMapping[ResourceKind.Explore]}
           size="16px"
         />
-        Explore dashboard
-      </DropdownMenu.Item>
-
-      <DropdownMenu.Item
-        class="flex items-center justify-between gap-x-2"
-        on:click={async () => {
-          const newFilePath = await createResourceFile(ResourceKind.Canvas);
-          await wrapNavigation(newFilePath);
-        }}
-      >
-        <div class="flex gap-x-2">
-          <svelte:component
-            this={resourceIconMapping[ResourceKind.Canvas]}
-            color={resourceColorMapping[ResourceKind.Canvas]}
-            size="16px"
-          />
-          Canvas dashboard
+        <div class="flex flex-col items-start">
+          Explore dashboard
+          {#if metricsViews.length === 0}
+            <span class="text-gray-500 text-xs"> Requires a metrics view </span>
+          {/if}
         </div>
-        <Tag height={16} color="blue">BETA</Tag>
-      </DropdownMenu.Item>
-    {/if}
+      </div>
+    </DropdownMenu.Item>
+
+    <DropdownMenu.Item
+      class="flex items-center justify-between gap-x-2"
+      on:click={async () => {
+        const newFilePath = await createResourceFile(ResourceKind.Canvas);
+        await wrapNavigation(newFilePath);
+      }}
+      disabled={metricsViews.length === 0}
+    >
+      <div class="flex gap-x-2 items-center">
+        <svelte:component
+          this={resourceIconMapping[ResourceKind.Canvas]}
+          color={resourceColorMapping[ResourceKind.Canvas]}
+          size="16px"
+        />
+        <div class="flex flex-col items-start">
+          Canvas dashboard
+          {#if metricsViews.length === 0}
+            <span class="text-gray-500 text-xs"> Requires a metrics view </span>
+          {/if}
+        </div>
+      </div>
+      <Tag height={16} color="blue">BETA</Tag>
+    </DropdownMenu.Item>
     <DropdownMenu.Separator />
     <DropdownMenu.Sub>
       <DropdownMenu.SubTrigger>More</DropdownMenu.SubTrigger>


### PR DESCRIPTION
When a project does not yet have a metrics view, we should not hide the "Explore dashboard" and "Canvas dashboard" options without explanation. Rather, we should show them and explain why they're not available.

[Conversation in Slack](https://rilldata.slack.com/archives/C02T907FEUB/p1752090206031709)

Before:
<img width="246" height="175" alt="image" src="https://github.com/user-attachments/assets/ef67500c-525c-43fe-aeec-810999ab4ad9" />

After:
<img width="295" height="276" alt="image" src="https://github.com/user-attachments/assets/ca83adff-a364-482c-b232-e3e8582a102f" />

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
