### PR TITLE
fix: Misc UXQA alert/reprot filter edit issues

### DIFF
--- a/web-common/src/components/searchable-filter-menu/SearchableMenuContent.svelte
+++ b/web-common/src/components/searchable-filter-menu/SearchableMenuContent.svelte
@@ -17,6 +17,7 @@
   export let allowSelectAll = true;
   export let searchText = "";
   export let showHiddenSelectionsCount = false;
+  export let side: "top" | "right" | "bottom" | "left" = "bottom";
   export let onSelect: (name: string) => void;
   export let onToggleSelectAll: () => void = voidFn;
 
@@ -63,6 +64,7 @@
 
 <DropdownMenu.Content
   align="start"
+  {side}
   class="flex flex-col max-h-96 w-72 overflow-hidden p-0"
 >
   <div class="px-3 pt-3 pb-1">

--- a/web-common/src/features/alerts/AlertForm.svelte
+++ b/web-common/src/features/alerts/AlertForm.svelte
@@ -234,6 +234,12 @@
     }
   }
 
+  $: measure = $form.measure;
+  function measureUpdated(mes: string) {
+    $form.criteria.forEach((c) => (c.measure = mes));
+  }
+  $: measureUpdated(measure);
+
   function handleCancel() {
     if ($tainted && isSomeFieldTainted($tainted)) {
       onCancel();

--- a/web-common/src/features/canvas/filters/CanvasComparisonPill.svelte
+++ b/web-common/src/features/canvas/filters/CanvasComparisonPill.svelte
@@ -20,6 +20,7 @@
   export let onDisplayTimeComparison: (show: boolean) => void;
   export let onSetSelectedComparisonRange: (range: TimeRange) => void;
   export let allowCustomTimeRange: boolean = true;
+  export let side: "top" | "right" | "bottom" | "left" = "bottom";
 
   $: interval = selectedTimeRange
     ? Interval.fromDateTimes(
@@ -95,6 +96,7 @@
       {showFullRange}
       disabled={disabled ?? false}
       {allowCustomTimeRange}
+      {side}
     />
   {/if}
 </div>
@@ -130,7 +132,9 @@
     @apply bg-gray-50 cursor-pointer;
   }
 
+  /* Doest apply to all instances except alert/report. So this seems unintentional
   :global(.wrapper > [data-state="open"]) {
     @apply bg-gray-50 border-gray-400 z-50;
   }
+  */
 </style>

--- a/web-common/src/features/dashboards/filters/FilterButton.svelte
+++ b/web-common/src/features/dashboards/filters/FilterButton.svelte
@@ -18,6 +18,7 @@
   export let measureHasFilter: (measureName: string) => boolean;
   export let setTemporaryFilterName: (name: string) => void;
   export let addBorder = true;
+  export let side: "top" | "right" | "bottom" | "left" = "bottom";
 
   let open = false;
 
@@ -68,6 +69,7 @@
     }}
     {selectableGroups}
     selectedItems={[]}
+    {side}
   />
 </DropdownMenu.Root>
 

--- a/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
+++ b/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
@@ -44,6 +44,7 @@
   export let timeControlsReady: boolean | undefined;
   export let smallChip = false;
   export let whereFilter: V1Expression;
+  export let side: "top" | "right" | "bottom" | "left" = "bottom";
   export let onRemove: () => void;
   export let onApplyInList: (values: string[]) => void;
   export let onSelect: (value: string) => void;
@@ -344,6 +345,7 @@
        So we have a custom implementation here to not overload SearchableMenuContent unnecessarily. -->
   <DropdownMenu.Content
     align="start"
+    {side}
     class="flex flex-col max-h-96 w-[400px] overflow-hidden p-0"
   >
     <div class="flex flex-col px-3 pt-3">

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilter.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilter.svelte
@@ -21,6 +21,7 @@
     filter: MeasureFilterEntry;
   }) => void;
   export let allDimensions: MetricsViewSpecDimension[];
+  export let side: "top" | "right" | "bottom" | "left" = "bottom";
 
   let open = !filter;
 </script>
@@ -82,6 +83,7 @@
       {dimensionName}
       {allDimensions}
       {onApply}
+      {side}
     />
   {/if}
 </Popover.Root>

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
@@ -25,6 +25,7 @@
     filter: MeasureFilterEntry;
   }) => void;
   export let allDimensions: MetricsViewSpecDimension[];
+  export let side: "top" | "right" | "bottom" | "left" = "bottom";
 
   const initialValues = {
     dimension: dimensionName,
@@ -114,7 +115,12 @@
   }}
 />
 
-<Popover.Content align="start" class="p-2 px-3 w-[250px]" strategy="fixed">
+<Popover.Content
+  align="start"
+  {side}
+  class="p-2 px-3 w-[250px]"
+  strategy="fixed"
+>
   <form
     use:enhance
     autocomplete="off"

--- a/web-common/src/features/dashboards/time-controls/TimeGrainSelector.svelte
+++ b/web-common/src/features/dashboards/time-controls/TimeGrainSelector.svelte
@@ -16,6 +16,7 @@
   export let minTimeGrain: V1TimeGrain | undefined;
   export let onTimeGrainSelect: (timeGrain: V1TimeGrain) => void;
   export let complete: boolean = false;
+  export let side: "top" | "right" | "bottom" | "left" = "bottom";
 
   let open = false;
 
@@ -75,7 +76,7 @@
         </div>
       </button>
     </DropdownMenu.Trigger>
-    <DropdownMenu.Content class="min-w-52" align="start">
+    <DropdownMenu.Content class="min-w-52" align="start" {side}>
       {#each timeGrains as option (option.key)}
         <DropdownMenu.CheckboxItem
           checkRight

--- a/web-common/src/features/dashboards/time-controls/comparison-pill/ComparisonPill.svelte
+++ b/web-common/src/features/dashboards/time-controls/comparison-pill/ComparisonPill.svelte
@@ -155,7 +155,9 @@
     @apply bg-gray-50 cursor-pointer;
   }
 
+  /* Doest apply to all instances except alert/report. So this seems unintentional
   :global(.wrapper > [data-state="open"]) {
     @apply bg-gray-50 border-gray-400 z-50;
   }
+  */
 </style>

--- a/web-common/src/features/dashboards/time-controls/super-pill/SuperPill.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/SuperPill.svelte
@@ -37,6 +37,7 @@
   export let timeStart: string | undefined;
   export let timeEnd: string | undefined;
   export let context = "dashboard";
+  export let side: "top" | "right" | "bottom" | "left" = "bottom";
   export let onSelectRange: (range: NamedRange | ISODurationString) => void;
   export let onPan: (direction: "left" | "right") => void;
   export let onTimeGrainSelect: (timeGrain: V1TimeGrain) => void;
@@ -73,6 +74,7 @@
           end: interval.end.toJSDate(),
         });
       }}
+      {side}
     />
   {/if}
 
@@ -83,6 +85,7 @@
     {onSelectTimeZone}
     {lockTimeZone}
     {context}
+    {side}
   />
 
   {#if !showPivot && minTimeGrain}
@@ -92,6 +95,7 @@
       {timeStart}
       {timeEnd}
       {complete}
+      {side}
       {onTimeGrainSelect}
     />
   {/if}
@@ -132,7 +136,9 @@
     @apply bg-gray-50 cursor-pointer;
   }
 
+  /* Doest apply to all instances except alert/report. So this seems unintentional
   :global(.wrapper > [data-state="open"]) {
     @apply bg-gray-50 border-gray-400 z-50;
   }
+  */
 </style>

--- a/web-common/src/features/dashboards/time-controls/super-pill/components/Comparison.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/Comparison.svelte
@@ -34,6 +34,7 @@
     end: Date,
   ) => void;
   export let allowCustomTimeRange: boolean = true;
+  export let side: "top" | "right" | "bottom" | "left" = "bottom";
 
   let open = false;
   let showSelector = false;
@@ -127,7 +128,7 @@
     </button>
   </DropdownMenu.Trigger>
 
-  <DropdownMenu.Content align="start" class="p-0 overflow-hidden">
+  <DropdownMenu.Content align="start" {side} class="p-0 overflow-hidden">
     <div class="flex">
       <div class="flex flex-col border-r w-48 p-1">
         {#each timeComparisonOptionsState as option (option.name)}

--- a/web-common/src/features/dashboards/time-controls/super-pill/components/RangePicker.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/RangePicker.svelte
@@ -22,6 +22,7 @@
   export let maxDate: DateTime | undefined = undefined;
   export let showFullRange: boolean;
   export let defaultTimeRange: NamedRange | ISODurationString | undefined;
+  export let side: "top" | "right" | "bottom" | "left" = "bottom";
   export let onSelectRange: (range: NamedRange | ISODurationString) => void;
   export let applyCustomRange: (range: Interval<true>) => void;
   export let allowCustomTimeRange = true;
@@ -59,7 +60,7 @@
       </span>
     </button>
   </DropdownMenu.Trigger>
-  <DropdownMenu.Content align="start" class="p-0 overflow-hidden">
+  <DropdownMenu.Content align="start" {side} class="p-0 overflow-hidden">
     <div class="flex">
       <div class="flex flex-col w-48 p-1">
         <TimeRangeMenu

--- a/web-common/src/features/dashboards/time-controls/super-pill/components/Zone.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/Zone.svelte
@@ -20,6 +20,7 @@
   export let activeTimeZone: string;
   export let context: string;
   export let lockTimeZone = false;
+  export let side: "top" | "right" | "bottom" | "left" = "bottom";
   export let onSelectTimeZone: (timeZone: string) => void;
 
   const recents = localStorageStore<string[]>(`${context}-recent-zones`, []);
@@ -71,7 +72,7 @@
     </button>
   </DropdownMenu.Trigger>
 
-  <DropdownMenu.Content align="start" class="w-80">
+  <DropdownMenu.Content align="start" {side} class="w-80">
     <div class="p-1.5 pb-1 flex items-center gap-x-2">
       <Search bind:value={searchValue} autofocus={false} />
     </div>

--- a/web-common/src/features/scheduled-reports/BaseScheduledReportForm.svelte
+++ b/web-common/src/features/scheduled-reports/BaseScheduledReportForm.svelte
@@ -139,7 +139,7 @@
     </Tooltip>
   </div>
 
-  <FiltersForm {filters} {timeControls} maxWidth={750} />
+  <FiltersForm {filters} {timeControls} maxWidth={750} side="top" />
 
   <MultiInput
     id="emailRecipients"

--- a/web-common/src/features/scheduled-reports/FiltersForm.svelte
+++ b/web-common/src/features/scheduled-reports/FiltersForm.svelte
@@ -33,6 +33,7 @@
   export let timeControls: TimeControls;
   export let readOnly = false;
   export let maxWidth: number;
+  export let side: "top" | "right" | "bottom" | "left" = "bottom";
 
   /** the height of a row of chips */
   const ROW_HEIGHT = "26px";
@@ -245,6 +246,7 @@
         canPanRight={false}
         onPan={() => {}}
         minTimeGrain={undefined}
+        {side}
       />
       <CanvasComparisonPill
         allTimeRange={$allTimeRange}
@@ -256,6 +258,7 @@
         onDisplayTimeComparison={displayTimeComparison}
         onSetSelectedComparisonRange={setSelectedComparisonRange}
         allowCustomTimeRange={false}
+        {side}
       />
     {/if}
   </div>
@@ -293,6 +296,7 @@
                 {inputText}
                 {timeStart}
                 {timeEnd}
+                {side}
                 timeControlsReady
                 excludeMode={$isFilterExcludeMode(name)}
                 whereFilter={$whereFilter}
@@ -316,6 +320,7 @@
               {label}
               {dimensionName}
               {filter}
+              {side}
               onRemove={() => removeMeasureFilter(dimensionName, name)}
               onApply={({ dimension, oldDimension, filter }) =>
                 handleMeasureFilterApply(dimension, name, oldDimension, filter)}
@@ -331,6 +336,7 @@
           dimensionHasFilter={$dimensionHasFilter}
           measureHasFilter={$measureHasFilter}
           {setTemporaryFilterName}
+          {side}
         />
         <!-- if filters are present, place a chip at the end of the flex container
       that enables clearing all filters -->

--- a/web-common/src/features/scheduled-reports/ScheduledReportDialog.svelte
+++ b/web-common/src/features/scheduled-reports/ScheduledReportDialog.svelte
@@ -225,7 +225,7 @@
 </script>
 
 <Dialog.Root bind:open>
-  <Dialog.Content>
+  <Dialog.Content class="min-w-[802px]">
     <Dialog.Title>Schedule report</Dialog.Title>
 
     <BaseScheduledReportForm


### PR DESCRIPTION
1. Time range dropdown border color doesnt match dropdown other places.
2. Changing measure in alert doesnt automatically update the criteria's measure.
3. Pin dropdown in report to top since the controls are below half way mark of screen.
4. Set the dialog width of report to match alert.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
