### PR TITLE
fix: rill time v1 for daylight savings

### DIFF
--- a/runtime/drivers/olap.go
+++ b/runtime/drivers/olap.go
@@ -9,14 +9,13 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	// Load IANA time zone data
+	_ "time/tzdata"
 
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime/pkg/timeutil"
-
-	// Load IANA time zone data
-	_ "time/tzdata"
 )
 
 var (
@@ -553,7 +552,7 @@ func (d Dialect) SelectTimeRangeBins(start, end time.Time, grain runtimev1.TimeG
 		// format - SELECT c1 AS "alias" FROM VALUES(toDateTime('2021-01-01 00:00:00'), toDateTime('2021-01-01 00:00:00'),...)
 		var sb strings.Builder
 		sb.WriteString(fmt.Sprintf("SELECT c1 AS %s FROM VALUES(", d.EscapeIdentifier(alias)))
-		for t := start; t.Before(end); t = timeutil.OffsetTime(t, timeutil.TimeGrainFromAPI(grain), 1) {
+		for t := start; t.Before(end); t = timeutil.OffsetTime(t, timeutil.TimeGrainFromAPI(grain), 1, time.UTC) {
 			if t != start {
 				sb.WriteString(", ")
 			}
@@ -570,7 +569,7 @@ func (d Dialect) SelectTimeRangeBins(start, end time.Time, grain runtimev1.TimeG
 		// ) t (time)
 		var sb strings.Builder
 		sb.WriteString("SELECT * FROM (VALUES ")
-		for t := start; t.Before(end); t = timeutil.OffsetTime(t, timeutil.TimeGrainFromAPI(grain), 1) {
+		for t := start; t.Before(end); t = timeutil.OffsetTime(t, timeutil.TimeGrainFromAPI(grain), 1, time.UTC) {
 			if t != start {
 				sb.WriteString(", ")
 			}

--- a/runtime/pkg/rilltime/rilltime.go
+++ b/runtime/pkg/rilltime/rilltime.go
@@ -342,10 +342,10 @@ func (e *Expression) Eval(evalOpts EvalOptions) (time.Time, time.Time, timeutil.
 	if e.Grain != nil {
 		tg = grainMap[*e.Grain]
 	} else {
-		tg = getLowerOrderGrain(start, end, tg)
+		tg = getLowerOrderGrain(start, end, tg, e.tz)
 	}
 
-	return start, end, tg
+	return start.In(time.UTC), end.In(time.UTC), tg
 }
 
 /* Intervals */
@@ -522,7 +522,7 @@ func (p *PointInTimeWithSnap) parse() error {
 func (p *PointInTimeWithSnap) eval(evalOpts EvalOptions, tm time.Time, tz *time.Location) (time.Time, timeutil.TimeGrain) {
 	tg := timeutil.TimeGrainUnspecified
 	if p.Grain != nil {
-		tm, tg = p.Grain.eval(tm)
+		tm, tg = p.Grain.eval(tm, tz)
 	} else if p.Labeled != nil {
 		tm = p.Labeled.eval(evalOpts)
 	} else if p.ISO != nil {
@@ -551,21 +551,21 @@ func (p *PointInTimeWithSnap) eval(evalOpts EvalOptions, tm time.Time, tz *time.
 	return tm, tg
 }
 
-func (g *GrainPointInTime) eval(tm time.Time) (time.Time, timeutil.TimeGrain) {
+func (g *GrainPointInTime) eval(tm time.Time, tz *time.Location) (time.Time, timeutil.TimeGrain) {
 	tg := timeutil.TimeGrainUnspecified
 	for _, part := range g.Parts {
-		tm, tg = part.eval(tm)
+		tm, tg = part.eval(tm, tz)
 	}
 	return tm, tg
 }
 
-func (g *GrainPointInTimePart) eval(tm time.Time) (time.Time, timeutil.TimeGrain) {
+func (g *GrainPointInTimePart) eval(tm time.Time, tz *time.Location) (time.Time, timeutil.TimeGrain) {
 	dir := -1
 	if g.Prefix == "+" {
 		dir = 1
 	}
 	// Offset the time based on duration. Direction is specified here rather in Duration.
-	return g.Duration.offset(tm, dir)
+	return g.Duration.offset(tm, dir, tz)
 }
 
 func (l *LabeledPointInTime) eval(evalOpts EvalOptions) time.Time {
@@ -639,7 +639,7 @@ func (a *ISOPointInTime) parse() error {
 func (a *ISOPointInTime) eval(tz *time.Location) (time.Time, time.Time, timeutil.TimeGrain) {
 	// Since we use this to build a time, month and day cannot be zero, hence the max(1, xx)
 	absStart := time.Date(a.year, time.Month(max(1, a.month)), max(1, a.day), a.hour, a.minute, a.second, a.nano, tz)
-	absEnd := timeutil.OffsetTime(absStart, a.tg, 1)
+	absEnd := timeutil.OffsetTime(absStart, a.tg, 1, tz)
 
 	return absStart, absEnd, a.tg
 }
@@ -650,30 +650,30 @@ func (o *Ordinal) eval(evalOpts EvalOptions, start time.Time, tz *time.Location)
 	tg := grainMap[o.Grain]
 	offset := o.Num - 1
 
-	start = timeutil.OffsetTime(start, tg, offset)
+	start = timeutil.OffsetTime(start, tg, offset, tz)
 	start = truncateWithCorrection(start, tg, tz, evalOpts.FirstDay, evalOpts.FirstMonth)
 
-	end := timeutil.OffsetTime(start, tg, 1)
+	end := timeutil.OffsetTime(start, tg, 1, tz)
 
 	return start, end, tg
 }
 
-func (g *GrainDuration) offset(tm time.Time, dir int) (time.Time, timeutil.TimeGrain) {
+func (g *GrainDuration) offset(tm time.Time, dir int, tz *time.Location) (time.Time, timeutil.TimeGrain) {
 	tg := timeutil.TimeGrainUnspecified
 	i := len(g.Parts) - 1
 	for i >= 0 {
-		tm, tg = g.Parts[i].offset(tm, dir)
+		tm, tg = g.Parts[i].offset(tm, dir, tz)
 		i--
 	}
 	return tm, tg
 }
 
-func (g *GrainDurationPart) offset(tm time.Time, dir int) (time.Time, timeutil.TimeGrain) {
+func (g *GrainDurationPart) offset(tm time.Time, dir int, tz *time.Location) (time.Time, timeutil.TimeGrain) {
 	tg := grainMap[g.Grain]
 	offset := g.Num
 	offset *= dir
 
-	return timeutil.OffsetTime(tm, tg, offset), tg
+	return timeutil.OffsetTime(tm, tg, offset, tz), tg
 }
 
 func parseISO(from string, parseOpts ParseOptions) (*Expression, error) {
@@ -781,7 +781,7 @@ func truncateWithCorrection(tm time.Time, tg timeutil.TimeGrain, tz *time.Locati
 			weekday = 7
 		}
 		if weekday >= 5 {
-			newTm = timeutil.OffsetTime(newTm, tg, 1)
+			newTm = timeutil.OffsetTime(newTm, tg, 1, tz)
 		}
 	}
 
@@ -789,9 +789,9 @@ func truncateWithCorrection(tm time.Time, tg timeutil.TimeGrain, tz *time.Locati
 }
 
 // getLowerOrderGrain returns the lowest grain where 2 periods can fit between start and end. Uses lowerOrderMap to get the lower grain.
-func getLowerOrderGrain(start, end time.Time, tg timeutil.TimeGrain) timeutil.TimeGrain {
+func getLowerOrderGrain(start, end time.Time, tg timeutil.TimeGrain, tz *time.Location) timeutil.TimeGrain {
 	for tg > timeutil.TimeGrainMillisecond {
-		twoLower := timeutil.OffsetTime(end, tg, -2)
+		twoLower := timeutil.OffsetTime(end, tg, -2, tz)
 		// if start < end - 2*grain, then we can return the grain.
 		if start.Before(twoLower) || start.Equal(twoLower) {
 			return tg

--- a/runtime/pkg/rilltime/rilltime_test.go
+++ b/runtime/pkg/rilltime/rilltime_test.go
@@ -370,6 +370,25 @@ func Test_KatmanduTimezone(t *testing.T) {
 	runTests(t, testCases, now, minTime, maxTime, watermark, tz)
 }
 
+func Test_TimeNewYorkTimezone(t *testing.T) {
+	tz, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	testCases := []testCase{
+		// Cases of time moving forward due to daylight savings
+		{"D3 of M11 as of 2024", "2024-11-03T04:00:00Z", "2024-11-04T05:00:00Z", timeutil.TimeGrainHour, 1, 1},
+		{"3D as of 2024-11-04", "2024-11-01T04:00:00Z", "2024-11-04T05:00:00Z", timeutil.TimeGrainDay, 1, 1},
+		{"2M as of 2024-12", "2024-10-01T04:00:00Z", "2024-12-01T05:00:00Z", timeutil.TimeGrainMonth, 1, 1},
+
+		// Cases of time moving backwards due to daylight savings
+		{"D10 of M3 as of 2024", "2024-03-10T05:00:00Z", "2024-03-11T04:00:00Z", timeutil.TimeGrainHour, 1, 1},
+		{"3D as of 2024-03-11", "2024-03-08T05:00:00Z", "2024-03-11T04:00:00Z", timeutil.TimeGrainDay, 1, 1},
+		{"2M as of 2024-04", "2024-02-01T05:00:00Z", "2024-04-01T04:00:00Z", timeutil.TimeGrainMonth, 1, 1},
+	}
+
+	runTests(t, testCases, now, minTime, maxTime, watermark, tz)
+}
+
 func TestEval_BackwardsCompatibility(t *testing.T) {
 	testCases := []testCase{
 		{"rill-TD", "2025-05-13T00:00:00Z", "2025-05-13T06:32:36Z", timeutil.TimeGrainHour, 1, 1},

--- a/runtime/pkg/timeutil/timeutil.go
+++ b/runtime/pkg/timeutil/timeutil.go
@@ -2,11 +2,10 @@ package timeutil
 
 import (
 	"time"
-
-	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
-
 	// Load IANA time zone data
 	_ "time/tzdata"
+
+	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 )
 
 // TimeGrain is extension of std time package with Week and Quarter added
@@ -73,16 +72,6 @@ func TimeGrainToAPI(tg TimeGrain) runtimev1.TimeGrain {
 		return runtimev1.TimeGrain_TIME_GRAIN_YEAR
 	}
 	return runtimev1.TimeGrain_TIME_GRAIN_UNSPECIFIED
-}
-
-func MinGrain(grain1, grain2 TimeGrain) TimeGrain {
-	if grain1 == TimeGrainUnspecified {
-		return grain2
-	}
-	if grain2 == TimeGrainUnspecified {
-		return grain1
-	}
-	return min(grain1, grain2)
 }
 
 func TruncateTime(tm time.Time, tg TimeGrain, tz *time.Location, firstDay, firstMonth int) time.Time {
@@ -161,15 +150,6 @@ func TruncateTime(tm time.Time, tg TimeGrain, tz *time.Location, firstDay, first
 	return tm
 }
 
-func CeilTime(start time.Time, tg TimeGrain, tz *time.Location, firstDay, firstMonth int) time.Time {
-	truncated := TruncateTime(start, tg, tz, firstDay, firstMonth)
-	if start.Equal(truncated) {
-		return start
-	}
-
-	return OffsetTime(truncated, tg, 1)
-}
-
 func ApproximateBins(start, end time.Time, tg TimeGrain) int {
 	switch tg {
 	case TimeGrainUnspecified:
@@ -197,22 +177,23 @@ func ApproximateBins(start, end time.Time, tg TimeGrain) int {
 	return -1
 }
 
-func OffsetTime(tm time.Time, tg TimeGrain, n int) time.Time {
+func OffsetTime(tm time.Time, tg TimeGrain, n int, tz *time.Location) time.Time {
+	tm = tm.In(tz)
+
 	switch tg {
 	case TimeGrainUnspecified:
-		return tm
 	case TimeGrainMillisecond:
-		return tm.Add(time.Duration(n) * time.Millisecond)
+		tm = tm.Add(time.Duration(n) * time.Millisecond)
 	case TimeGrainSecond:
-		return tm.Add(time.Duration(n) * time.Second)
+		tm = tm.Add(time.Duration(n) * time.Second)
 	case TimeGrainMinute:
-		return tm.Add(time.Duration(n) * time.Minute)
+		tm = tm.Add(time.Duration(n) * time.Minute)
 	case TimeGrainHour:
-		return tm.Add(time.Duration(n) * time.Hour)
+		tm = tm.Add(time.Duration(n) * time.Hour)
 	case TimeGrainDay:
-		return tm.AddDate(0, 0, n)
+		tm = tm.AddDate(0, 0, n)
 	case TimeGrainWeek:
-		return tm.AddDate(0, 0, n*7)
+		tm = tm.AddDate(0, 0, n*7)
 	case TimeGrainMonth, TimeGrainQuarter, TimeGrainYear:
 		// Offset with correction for different days in months
 
@@ -235,10 +216,10 @@ func OffsetTime(tm time.Time, tg TimeGrain, n int) time.Time {
 		// Get the max days possible for the month in the year.
 		maxDays := daysInMonth(offsetFirstDay.Year(), int(offsetFirstDay.Month()))
 		// Take the min of max-days or day from `tm`
-		return offsetFirstDay.AddDate(0, 0, min(maxDays-1, tm.Day()-1))
+		tm = offsetFirstDay.AddDate(0, 0, min(maxDays-1, tm.Day()-1))
 	}
 
-	return tm
+	return tm.In(time.UTC)
 }
 
 var daysForMonths = []int{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}

--- a/runtime/pkg/timeutil/timeutil_test.go
+++ b/runtime/pkg/timeutil/timeutil_test.go
@@ -108,32 +108,38 @@ func TestTruncateTime_Kathmandu_first_month(t *testing.T) {
 
 func TestOffsetTime(t *testing.T) {
 	// Offset to February in a non-leap year
-	require.Equal(t, parseTestTime(t, "2025-02-28T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-03-31T10:10:00Z"), TimeGrainMonth, -1))
-	require.Equal(t, parseTestTime(t, "2025-02-28T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-05-31T10:10:00Z"), TimeGrainQuarter, -1))
-	require.Equal(t, parseTestTime(t, "2025-02-28T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-01-31T10:10:00Z"), TimeGrainMonth, 1))
-	require.Equal(t, parseTestTime(t, "2025-02-28T10:10:00Z"), OffsetTime(parseTestTime(t, "2024-11-30T10:10:00Z"), TimeGrainQuarter, 1))
+	require.Equal(t, parseTestTime(t, "2025-02-28T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-03-31T10:10:00Z"), TimeGrainMonth, -1, time.UTC))
+	require.Equal(t, parseTestTime(t, "2025-02-28T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-05-31T10:10:00Z"), TimeGrainQuarter, -1, time.UTC))
+	require.Equal(t, parseTestTime(t, "2025-02-28T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-01-31T10:10:00Z"), TimeGrainMonth, 1, time.UTC))
+	require.Equal(t, parseTestTime(t, "2025-02-28T10:10:00Z"), OffsetTime(parseTestTime(t, "2024-11-30T10:10:00Z"), TimeGrainQuarter, 1, time.UTC))
 
 	// Offset to February in a leap year
-	require.Equal(t, parseTestTime(t, "2024-02-29T10:10:00Z"), OffsetTime(parseTestTime(t, "2024-03-31T10:10:00Z"), TimeGrainMonth, -1))
-	require.Equal(t, parseTestTime(t, "2024-02-29T10:10:00Z"), OffsetTime(parseTestTime(t, "2024-05-31T10:10:00Z"), TimeGrainQuarter, -1))
-	require.Equal(t, parseTestTime(t, "2024-02-29T10:10:00Z"), OffsetTime(parseTestTime(t, "2024-01-31T10:10:00Z"), TimeGrainMonth, 1))
-	require.Equal(t, parseTestTime(t, "2024-02-29T10:10:00Z"), OffsetTime(parseTestTime(t, "2023-11-30T10:10:00Z"), TimeGrainQuarter, 1))
+	require.Equal(t, parseTestTime(t, "2024-02-29T10:10:00Z"), OffsetTime(parseTestTime(t, "2024-03-31T10:10:00Z"), TimeGrainMonth, -1, time.UTC))
+	require.Equal(t, parseTestTime(t, "2024-02-29T10:10:00Z"), OffsetTime(parseTestTime(t, "2024-05-31T10:10:00Z"), TimeGrainQuarter, -1, time.UTC))
+	require.Equal(t, parseTestTime(t, "2024-02-29T10:10:00Z"), OffsetTime(parseTestTime(t, "2024-01-31T10:10:00Z"), TimeGrainMonth, 1, time.UTC))
+	require.Equal(t, parseTestTime(t, "2024-02-29T10:10:00Z"), OffsetTime(parseTestTime(t, "2023-11-30T10:10:00Z"), TimeGrainQuarter, 1, time.UTC))
 
 	// Offset to April (30 days)
-	require.Equal(t, parseTestTime(t, "2025-04-30T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-05-31T10:10:00Z"), TimeGrainMonth, -1))
-	require.Equal(t, parseTestTime(t, "2025-04-30T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-07-31T10:10:00Z"), TimeGrainQuarter, -1))
-	require.Equal(t, parseTestTime(t, "2025-04-30T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-03-31T10:10:00Z"), TimeGrainMonth, 1))
-	require.Equal(t, parseTestTime(t, "2025-04-30T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-01-31T10:10:00Z"), TimeGrainQuarter, 1))
+	require.Equal(t, parseTestTime(t, "2025-04-30T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-05-31T10:10:00Z"), TimeGrainMonth, -1, time.UTC))
+	require.Equal(t, parseTestTime(t, "2025-04-30T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-07-31T10:10:00Z"), TimeGrainQuarter, -1, time.UTC))
+	require.Equal(t, parseTestTime(t, "2025-04-30T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-03-31T10:10:00Z"), TimeGrainMonth, 1, time.UTC))
+	require.Equal(t, parseTestTime(t, "2025-04-30T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-01-31T10:10:00Z"), TimeGrainQuarter, 1, time.UTC))
 
 	// Offset by a year from feb in leap year to non-leap year
-	require.Equal(t, parseTestTime(t, "2023-02-28T10:10:00Z"), OffsetTime(parseTestTime(t, "2024-02-29T10:10:00Z"), TimeGrainYear, -1))
-	require.Equal(t, parseTestTime(t, "2025-02-28T10:10:00Z"), OffsetTime(parseTestTime(t, "2024-02-29T10:10:00Z"), TimeGrainYear, 1))
+	require.Equal(t, parseTestTime(t, "2023-02-28T10:10:00Z"), OffsetTime(parseTestTime(t, "2024-02-29T10:10:00Z"), TimeGrainYear, -1, time.UTC))
+	require.Equal(t, parseTestTime(t, "2025-02-28T10:10:00Z"), OffsetTime(parseTestTime(t, "2024-02-29T10:10:00Z"), TimeGrainYear, 1, time.UTC))
 
 	// Offset within max days
-	require.Equal(t, parseTestTime(t, "2025-02-20T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-03-20T10:10:00Z"), TimeGrainMonth, -1))
-	require.Equal(t, parseTestTime(t, "2025-02-20T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-05-20T10:10:00Z"), TimeGrainQuarter, -1))
-	require.Equal(t, parseTestTime(t, "2025-02-20T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-01-20T10:10:00Z"), TimeGrainMonth, 1))
-	require.Equal(t, parseTestTime(t, "2025-02-20T10:10:00Z"), OffsetTime(parseTestTime(t, "2024-11-20T10:10:00Z"), TimeGrainQuarter, 1))
+	require.Equal(t, parseTestTime(t, "2025-02-20T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-03-20T10:10:00Z"), TimeGrainMonth, -1, time.UTC))
+	require.Equal(t, parseTestTime(t, "2025-02-20T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-05-20T10:10:00Z"), TimeGrainQuarter, -1, time.UTC))
+	require.Equal(t, parseTestTime(t, "2025-02-20T10:10:00Z"), OffsetTime(parseTestTime(t, "2025-01-20T10:10:00Z"), TimeGrainMonth, 1, time.UTC))
+	require.Equal(t, parseTestTime(t, "2025-02-20T10:10:00Z"), OffsetTime(parseTestTime(t, "2024-11-20T10:10:00Z"), TimeGrainQuarter, 1, time.UTC))
+
+	tz, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	// Offset through daylight savings
+	require.Equal(t, parseTestTime(t, "2024-11-02T04:00:00Z"), OffsetTime(parseTestTime(t, "2024-11-04T05:00:00Z"), TimeGrainDay, -2, tz))
+	require.Equal(t, parseTestTime(t, "2024-03-11T04:00:00Z"), OffsetTime(parseTestTime(t, "2024-03-09T05:00:00Z"), TimeGrainDay, 2, tz))
 }
 
 func parseTestTime(tst *testing.T, t string) time.Time {


### PR DESCRIPTION
Ordinals and ranges were returning incorrect start/end dates when going through daylight savings.

Fixing by running the offset math in specified time zone.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
