### PR TITLE
fix: alert crtieria broken in edit when changing measure

### DIFF
--- a/web-common/src/features/alerts/AlertForm.svelte
+++ b/web-common/src/features/alerts/AlertForm.svelte
@@ -237,6 +237,7 @@
   $: measure = $form.measure;
   function measureUpdated(mes: string) {
     $form.criteria.forEach((c) => (c.measure = mes));
+    $form.criteria = [...$form.criteria];
   }
   $: measureUpdated(measure);
 


### PR DESCRIPTION
Changing measure broken criteria while editing alerts. We need to update the criteria array to be a new object for it to take effect.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
