### PR TITLE
fix: editing report/alert for broken dashboards

### DIFF
--- a/web-admin/src/features/alerts/EditAlert.svelte
+++ b/web-admin/src/features/alerts/EditAlert.svelte
@@ -9,6 +9,7 @@
   import Button from "web-common/src/components/button/Button.svelte";
 
   export let alertSpec: V1AlertSpec;
+  export let disabled: boolean;
 </script>
 
 <GuardedDialog
@@ -20,7 +21,7 @@
   let:onClose
 >
   <DialogTrigger asChild let:builder>
-    <Button type="secondary" builders={[builder]}>Edit</Button>
+    <Button type="secondary" builders={[builder]} {disabled}>Edit</Button>
   </DialogTrigger>
   <DialogContent class="p-0 m-0 w-[802px] max-w-fit" noClose>
     <AlertForm props={{ mode: "edit", alertSpec }} {onCancel} {onClose} />

--- a/web-admin/src/features/alerts/metadata/AlertMetadata.svelte
+++ b/web-admin/src/features/alerts/metadata/AlertMetadata.svelte
@@ -111,9 +111,7 @@
         </h1>
         <div class="grow" />
         {#if !$isAlertCreatedByCode.data}
-          {#if $exploreIsValid}
-            <EditAlert {alertSpec} />
-          {/if}
+          <EditAlert {alertSpec} disabled={!$exploreIsValid} />
           <DropdownMenu.Root>
             <DropdownMenu.Trigger>
               <IconButton ariaLabel="Alert context menu">

--- a/web-admin/src/features/scheduled-reports/metadata/ReportMetadata.svelte
+++ b/web-admin/src/features/scheduled-reports/metadata/ReportMetadata.svelte
@@ -124,11 +124,12 @@
               </IconButton>
             </DropdownMenu.Trigger>
             <DropdownMenu.Content align="start">
-              {#if $exploreIsValid}
-                <DropdownMenu.Item on:click={handleEditReport}>
-                  Edit report
-                </DropdownMenu.Item>
-              {/if}
+              <DropdownMenu.Item
+                on:click={handleEditReport}
+                disabled={!$exploreIsValid}
+              >
+                Edit report
+              </DropdownMenu.Item>
               <DropdownMenu.Item on:click={handleDeleteReport}>
                 Delete report
               </DropdownMenu.Item>

--- a/web-common/src/features/dashboards/selectors.ts
+++ b/web-common/src/features/dashboards/selectors.ts
@@ -8,7 +8,9 @@ import {
   useFilteredResources,
   useResource,
 } from "@rilldata/web-common/features/entity-management/resource-selectors";
+import { useExploreValidSpec } from "@rilldata/web-common/features/explores/selectors.ts";
 import {
+  getQueryServiceMetricsViewTimeRangeQueryOptions,
   type RpcStatus,
   type V1Expression,
   type V1GetResourceResponse,
@@ -21,6 +23,7 @@ import {
   createRuntimeServiceListResources,
 } from "@rilldata/web-common/runtime-client";
 import {
+  createQuery,
   type CreateQueryOptions,
   type CreateQueryResult,
   type QueryClient,
@@ -28,6 +31,7 @@ import {
 import { derived } from "svelte/store";
 import type { ErrorType } from "../../runtime-client/http-client";
 import type { DimensionThresholdFilter } from "web-common/src/features/dashboards/stores/explore-state";
+import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
 
 export function useMetricsView(
   instanceId: string,
@@ -120,6 +124,37 @@ export function useMetricsViewTimeRange(
         queryClient,
       ).subscribe(set),
   );
+}
+
+export function hasValidMetricsViewTimeRange(
+  instanceId: string,
+  exploreName: string,
+) {
+  const fullTimeRangeQueryOptionsStore = derived(
+    useExploreValidSpec(instanceId, exploreName),
+    (validSpecResp) => {
+      const metricsViewSpec = validSpecResp.data?.metricsView ?? {};
+      const exploreSpec = validSpecResp.data?.explore ?? {};
+      const metricsViewName = exploreSpec.metricsView ?? "";
+
+      return getQueryServiceMetricsViewTimeRangeQueryOptions(
+        instanceId,
+        metricsViewName,
+        {},
+        {
+          query: {
+            enabled: Boolean(metricsViewSpec.timeDimension),
+          },
+        },
+      );
+    },
+  );
+  const fullTimeRangeQuery = createQuery(
+    fullTimeRangeQueryOptionsStore,
+    queryClient,
+  );
+
+  return derived(fullTimeRangeQuery, (fullTimeRange) => !fullTimeRange.isError);
 }
 
 export function getFiltersForOtherDimensions(

--- a/web-common/src/features/scheduled-reports/BaseScheduledReportForm.svelte
+++ b/web-common/src/features/scheduled-reports/BaseScheduledReportForm.svelte
@@ -139,7 +139,9 @@
     </Tooltip>
   </div>
 
-  <FiltersForm {filters} {timeControls} maxWidth={750} side="top" />
+  <FormSection title="Filters">
+    <FiltersForm {filters} {timeControls} maxWidth={750} side="top" />
+  </FormSection>
 
   <MultiInput
     id="emailRecipients"

--- a/web-common/src/features/scheduled-reports/BaseScheduledReportForm.svelte
+++ b/web-common/src/features/scheduled-reports/BaseScheduledReportForm.svelte
@@ -139,7 +139,7 @@
     </Tooltip>
   </div>
 
-  <FormSection title="Filters">
+  <FormSection title="Filters" padding="">
     <FiltersForm {filters} {timeControls} maxWidth={750} side="top" />
   </FormSection>
 


### PR DESCRIPTION
We need a lot of info from dashboard when editing report or alert. So if the dashboard is broken then we need to disable editing.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
