### PR TITLE
fix: race condition during dashboard init causing additional url history entries

### DIFF
--- a/web-common/src/features/dashboards/state-managers/loaders/DashboardStateSync.ts
+++ b/web-common/src/features/dashboards/state-managers/loaders/DashboardStateSync.ts
@@ -120,7 +120,7 @@ export class DashboardStateSync {
    * Initializes the dashboard store.
    * If the url needs to change to match the init then we replace the current url with the new url.
    */
-  private handleExploreInit(initExploreState: ExploreState) {
+  private async handleExploreInit(initExploreState: ExploreState) {
     // If this is re-triggered any of the dependant query was refetched, then we need to make sure this is not run again.
     if (this.initialized) return;
 
@@ -164,14 +164,14 @@ export class DashboardStateSync {
       return;
     }
 
-    this.initialized = true;
     // Else navigate to the new url.
     // using `replaceState` directly messes up the navigation entries,
     // `from` and `to` have the old url before being replaced in `afterNavigate` calls leading to incorrect handling.
-    return goto(redirectUrl, {
+    await goto(redirectUrl, {
       replaceState: true,
       state: pageState.state,
     });
+    this.initialized = true;
   }
 
   /**


### PR DESCRIPTION
There is a race condition during dashboard init where both `replaceState` and `goto` get called. This adds 2 history events.

Moving the mutex update after goto happens to avoid this.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
