### PR TITLE
feat: link canvas temporal charts to TDD

### DIFF
--- a/web-common/src/features/canvas/components/charts/BaseChart.ts
+++ b/web-common/src/features/canvas/components/charts/BaseChart.ts
@@ -1,6 +1,10 @@
 import { BaseCanvasComponent } from "@rilldata/web-common/features/canvas/components/BaseCanvasComponent";
 import { CHART_CONFIG } from "@rilldata/web-common/features/canvas/components/charts";
 import {
+  canLinkTimeDimensionDetail,
+  CanvasChartTypeToTDDChartType,
+} from "@rilldata/web-common/features/canvas/components/charts/util";
+import {
   commonOptions,
   createComponent,
   getFilterOptions,
@@ -108,13 +112,27 @@ export abstract class BaseChart<
     );
 
     const timeGrain = get(this.timeAndFilterStore)?.timeGrain;
+    const showTDD = canLinkTimeDimensionDetail(spec, this.type);
 
     return {
       whereFilter: dimensionFilters,
       dimensionThresholdFilters,
       showTimeComparison: false,
-      activePage: DashboardState_ActivePage.PIVOT,
+      activePage: showTDD.canLink
+        ? DashboardState_ActivePage.TIME_DIMENSIONAL_DETAIL
+        : DashboardState_ActivePage.PIVOT,
       pivot: getPivotStateFromChartSpec(spec, timeGrain),
+      ...(showTDD.canLink &&
+        showTDD.measureName && {
+          tdd: {
+            expandedMeasureName: showTDD.measureName,
+            pinIndex: 0,
+            chartType: CanvasChartTypeToTDDChartType[this.type],
+          },
+        }),
+      ...(showTDD.dimensionName && {
+        selectedComparisonDimension: showTDD.dimensionName,
+      }),
     };
   }
 

--- a/web-common/src/features/canvas/components/charts/BaseChart.ts
+++ b/web-common/src/features/canvas/components/charts/BaseChart.ts
@@ -1,8 +1,8 @@
 import { BaseCanvasComponent } from "@rilldata/web-common/features/canvas/components/BaseCanvasComponent";
 import { CHART_CONFIG } from "@rilldata/web-common/features/canvas/components/charts";
 import {
-  canLinkTimeDimensionDetail,
   CanvasChartTypeToTDDChartType,
+  getLinkStateForTimeDimensionDetail,
 } from "@rilldata/web-common/features/canvas/components/charts/util";
 import {
   commonOptions,
@@ -112,26 +112,26 @@ export abstract class BaseChart<
     );
 
     const timeGrain = get(this.timeAndFilterStore)?.timeGrain;
-    const showTDD = canLinkTimeDimensionDetail(spec, this.type);
+    const tddLink = getLinkStateForTimeDimensionDetail(spec, this.type);
 
     return {
       whereFilter: dimensionFilters,
       dimensionThresholdFilters,
       showTimeComparison: false,
-      activePage: showTDD.canLink
+      activePage: tddLink.canLink
         ? DashboardState_ActivePage.TIME_DIMENSIONAL_DETAIL
         : DashboardState_ActivePage.PIVOT,
       pivot: getPivotStateFromChartSpec(spec, timeGrain),
-      ...(showTDD.canLink &&
-        showTDD.measureName && {
+      ...(tddLink.canLink &&
+        tddLink.measureName && {
           tdd: {
-            expandedMeasureName: showTDD.measureName,
+            expandedMeasureName: tddLink.measureName,
             pinIndex: 0,
             chartType: CanvasChartTypeToTDDChartType[this.type],
           },
         }),
-      ...(showTDD.dimensionName && {
-        selectedComparisonDimension: showTDD.dimensionName,
+      ...(tddLink.dimensionName && {
+        selectedComparisonDimension: tddLink.dimensionName,
       }),
     };
   }

--- a/web-common/src/features/canvas/components/charts/util.ts
+++ b/web-common/src/features/canvas/components/charts/util.ts
@@ -144,7 +144,7 @@ export const CanvasChartTypeToTDDChartType = {
   bar_chart: TDDChart.GROUPED_BAR,
 };
 
-export function canLinkTimeDimensionDetail(
+export function getLinkStateForTimeDimensionDetail(
   spec: ChartSpec,
   type: ChartType,
 ): {

--- a/web-common/src/features/canvas/explore-link/canvas-explore-transformer.ts
+++ b/web-common/src/features/canvas/explore-link/canvas-explore-transformer.ts
@@ -1,6 +1,6 @@
 import type { BaseCanvasComponent } from "@rilldata/web-common/features/canvas/components/BaseCanvasComponent";
 import type { ChartSpec } from "@rilldata/web-common/features/canvas/components/charts";
-import type { FieldConfig } from "@rilldata/web-common/features/canvas/components/charts/types";
+import { isFieldConfig } from "@rilldata/web-common/features/canvas/components/charts/util";
 import type { ComponentWithMetricsView } from "@rilldata/web-common/features/canvas/components/types";
 import type { TimeAndFilterStore } from "@rilldata/web-common/features/canvas/stores/types";
 import { splitWhereFilter } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
@@ -86,13 +86,8 @@ export function getPivotStateFromChartSpec(
     }
 
     // Check if this property is a field config object
-    if (
-      typeof value === "object" &&
-      value !== null &&
-      "field" in value &&
-      "type" in value
-    ) {
-      const fieldConfig = value as FieldConfig;
+    if (isFieldConfig(value)) {
+      const fieldConfig = value;
 
       let chipType: PivotChipType;
       let id: string;


### PR DESCRIPTION
Instead of linking all canvas charts to pivot, we now check for certain chart types if they can be mapped to time dimension detail table. On a match we redirect to TDD instead.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
