### PR TITLE
fix: hide canvas explore link from embedded dashboards

### DIFF
--- a/web-common/src/features/canvas/explore-link/ExploreLink.svelte
+++ b/web-common/src/features/canvas/explore-link/ExploreLink.svelte
@@ -15,6 +15,7 @@
     type ExploreLinkError,
   } from "@rilldata/web-common/features/explore-mappers/types";
   import { getErrorMessage } from "@rilldata/web-common/features/explore-mappers/utils";
+  import { isEmbedPage } from "@rilldata/web-common/layout/navigation/navigation-utils";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { derived } from "svelte/store";
   import { useTransformCanvasToExploreState } from "./canvas-explore-transformer";
@@ -31,6 +32,8 @@
 
   $: spec = component.specStore;
   $: metricsViewName = $spec?.metrics_view;
+
+  $: isEmbedded = isEmbedPage($page);
 
   // Check if component can be linked to explore
   $: exploreAvailability = useExploreAvailability(instanceId, metricsViewName);
@@ -84,7 +87,10 @@
   }
 
   $: canNavigate =
-    $exploreAvailability.isAvailable && !isNavigating && !!exploreState;
+    $exploreAvailability.isAvailable &&
+    !isNavigating &&
+    !!exploreState &&
+    !isEmbedded;
 </script>
 
 {#if $exploreAvailability.isAvailable}


### PR DESCRIPTION
Hide the link to explore button from embedded canvas dashboards.


**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
