### PR TITLE
docs: Tweak sidebar spacing between sections

### DIFF
--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -160,7 +160,7 @@ li.theme-doc-sidebar-item-category-level-1 {
   }
 
   &:not(:first-of-type) .menu__list-item-collapsible {
-    margin-top: 24px;
+    margin-top: 12px;
   }
 
   /* This is a very hacky way to hide references from the main sidebar */


### PR DESCRIPTION
24px -> 12px

Before:
<img width="903" height="968" alt="image" src="https://github.com/user-attachments/assets/018eefb0-66e4-4d09-9a64-2ab31e7afcd4" />


After:
<img width="758" height="958" alt="image" src="https://github.com/user-attachments/assets/417e2d44-f401-483a-bfa9-12c504d45a56" />
