### PR TITLE
Updated Search bar to prioritize 

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -79,7 +79,12 @@ const config = {
         appId: "4U01DM4NS4",
         apiKey: "c0399915ae21a35c6d34a473d017c15b",
         indexName: "rilldata",
-        debug: false // Set debug to true if you want to inspect the modal        
+        debug: false, // Set debug to true if you want to inspect the modal      
+        contextualSearch: true,
+        searchParameters: {
+          optionalFilters: ['type:doc', 'type:guide', 'type:reference'],
+          hitsPerPage: 10,
+        },
       },
       metadata: [
         {

--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -179,11 +179,10 @@ li.theme-doc-sidebar-item-category-level-2 .menu__list-item-collapsible {
 }
 
 .menu__link {
-  padding-top: 4px;
-  padding-bottom: 4px;
+  padding-top: 5px;
+  padding-bottom: 5px;
   padding-left: 8px;
   font-size: 14px !important;
-
   &--active {
     font-weight: 600;
   }
@@ -199,8 +198,7 @@ li.theme-doc-sidebar-item-category-level-2 .menu__list-item-collapsible {
 
 .menu__caret {
   padding-top: 0px !important;
-  padding-bottom: 0px !important;
-
+  padding-bottom: 1px !important;
 }
 
 .theme-doc-sidebar-item-link-level-3,
@@ -246,6 +244,7 @@ li.theme-doc-sidebar-item-category-level-2 .menu__list-item-collapsible {
 
 .sub-menu-link .menu__link--sublist {
   font-weight: 700;
+
 }
 
 .center-content {
@@ -279,8 +278,6 @@ li.theme-doc-sidebar-item-category-level-2 .menu__list-item-collapsible {
   margin-right: auto;
   width: 100%;
   box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.2); 
-
-
 }
 
 .centered {
@@ -334,6 +331,7 @@ li.theme-doc-sidebar-item-category-level-2 .menu__list-item-collapsible {
   min-height: 0; /* This is important for flexbox scrolling */
   padding-bottom: 72px; /* Add some bottom padding for better scroll experience */
 }
+
 
 // Dark mode override
 [data-theme='dark'] .sidebar-release-notes-section {

--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -179,10 +179,11 @@ li.theme-doc-sidebar-item-category-level-2 .menu__list-item-collapsible {
 }
 
 .menu__link {
-  padding-top: 5px;
-  padding-bottom: 5px;
+  padding-top: 4px;
+  padding-bottom: 4px;
   padding-left: 8px;
   font-size: 14px !important;
+
   &--active {
     font-weight: 600;
   }
@@ -198,7 +199,8 @@ li.theme-doc-sidebar-item-category-level-2 .menu__list-item-collapsible {
 
 .menu__caret {
   padding-top: 0px !important;
-  padding-bottom: 1px !important;
+  padding-bottom: 0px !important;
+
 }
 
 .theme-doc-sidebar-item-link-level-3,


### PR DESCRIPTION
Looking into the blank algolia search, but it at least prioritizes the docs before release notes now. 

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
