### PR TITLE
fix: do not keep previous data for topN chart queries

### DIFF
--- a/web-common/src/features/canvas/components/charts/cartesian-charts/CartesianChart.ts
+++ b/web-common/src/features/canvas/components/charts/cartesian-charts/CartesianChart.ts
@@ -147,7 +147,6 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
           {
             query: {
               enabled,
-              placeholderData: keepPreviousData,
             },
           },
         );
@@ -189,7 +188,6 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
           {
             query: {
               enabled,
-              placeholderData: keepPreviousData,
             },
           },
         );
@@ -203,6 +201,7 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
       ([runtime, $timeAndFilterStore, $topNXQuery, $topNColorQuery]) => {
         const { timeRange, where, timeGrain } = $timeAndFilterStore;
         const topNXData = $topNXQuery?.data?.data;
+
         const topNColorData = $topNColorQuery?.data?.data;
         const enabled =
           !!timeRange?.start &&
@@ -222,6 +221,7 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
         // Apply topN filter for x dimension
         if (topNXData?.length && dimensionName) {
           const topXValues = topNXData.map((d) => d[dimensionName] as string);
+
           const filterForTopXValues = createInExpression(
             dimensionName,
             topXValues,

--- a/web-common/src/features/canvas/components/charts/heatmap-charts/HeatmapChart.ts
+++ b/web-common/src/features/canvas/components/charts/heatmap-charts/HeatmapChart.ts
@@ -128,7 +128,6 @@ export class HeatmapChartComponent extends BaseChart<HeatmapChartSpec> {
           {
             query: {
               enabled,
-              placeholderData: keepPreviousData,
             },
           },
         );
@@ -169,7 +168,6 @@ export class HeatmapChartComponent extends BaseChart<HeatmapChartSpec> {
           {
             query: {
               enabled,
-              placeholderData: keepPreviousData,
             },
           },
         );


### PR DESCRIPTION
The main query depends on the topN query results to apply filtering. When topN queries kept previous data, thisdependency chain became stale.
 
Removing `keepPreviousData` ensures that:
  - topN queries immediately show loading/undefined state when parameters change
  - The main chart query is disabled until fresh topN data is available
  - No stale filtering is applied to the chart data

https://rilldata.slack.com/archives/C02T907FEUB/p1752606705698349


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
