### PR TITLE
Disable outside click for user groups

### DIFF
--- a/web-admin/src/features/organizations/users/CreateUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/users/CreateUserGroupDialog.svelte
@@ -194,7 +194,6 @@
   bind:open
   onOutsideClick={(e) => {
     e.preventDefault();
-    handleClose();
   }}
   onOpenChange={(open) => {
     if (!open) {

--- a/web-admin/src/features/organizations/users/EditUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/users/EditUserGroupDialog.svelte
@@ -228,7 +228,6 @@
   bind:open
   onOutsideClick={(e) => {
     e.preventDefault();
-    handleClose();
   }}
   onOpenChange={(open) => {
     if (!open) {


### PR DESCRIPTION
Closes https://linear.app/rilldata/issue/APP-178/dont-allow-for-user-group-modal-closing-when-you-click-out-of-the

https://github.com/user-attachments/assets/ffef9e16-27f1-43c8-812d-96e7283dd3b3

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
