### PR TITLE
Invalid group name fixes

### DIFF
--- a/web-admin/src/features/organizations/users/CreateUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/users/CreateUserGroupDialog.svelte
@@ -181,12 +181,19 @@
       : undefined;
   }
 
+  // Check if form has been modified
+  $: hasFormChanges = $form.name !== initialValues.name;
+
   function handleClose() {
     open = false;
     searchText = "";
     selectedUsers = [];
     pendingAdditions = [];
     pendingRemovals = [];
+    // Only reset the form if it has been modified
+    if (hasFormChanges) {
+      $form.name = initialValues.name;
+    }
   }
 </script>
 

--- a/web-admin/src/features/organizations/users/CreateUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/users/CreateUserGroupDialog.svelte
@@ -318,7 +318,7 @@
       <Button type="plain" onClick={handleClose}>Cancel</Button>
       <Button
         type="primary"
-        disabled={$submitting || $form.name.trim() === ""}
+        disabled={$submitting || $form.name.trim() === "" || !!$errors.name}
         form={formId}
         submitForm
       >

--- a/web-admin/src/features/organizations/users/CreateUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/users/CreateUserGroupDialog.svelte
@@ -222,6 +222,7 @@
           label="Name"
           placeholder="Untitled"
           errors={$errors.name}
+          alwaysShowError={true}
         />
 
         <div class="flex flex-col gap-y-1">

--- a/web-admin/src/features/organizations/users/EditUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/users/EditUserGroupDialog.svelte
@@ -352,7 +352,9 @@
       <Button type="plain" onClick={handleClose}>Cancel</Button>
       <Button
         type="primary"
-        disabled={$submitting || $form.newName.trim() === ""}
+        disabled={$submitting ||
+          $form.newName.trim() === "" ||
+          !!$errors.newName}
         form={formId}
         submitForm
       >

--- a/web-admin/src/features/organizations/users/EditUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/users/EditUserGroupDialog.svelte
@@ -214,6 +214,9 @@
       : undefined;
   }
 
+  // Check if form has been modified
+  $: hasFormChanges = $form.newName !== initialValues.newName;
+
   function handleClose() {
     open = false;
     searchText = "";
@@ -221,6 +224,10 @@
     pendingAdditions = [];
     pendingRemovals = [];
     initialized = false;
+    // Only reset the form if it has been modified
+    if (hasFormChanges) {
+      $form.newName = initialValues.newName;
+    }
   }
 </script>
 

--- a/web-admin/src/features/organizations/users/EditUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/users/EditUserGroupDialog.svelte
@@ -256,6 +256,7 @@
           label="Name"
           placeholder="Untitled"
           errors={$errors.newName}
+          alwaysShowError={true}
         />
 
         <div class="flex flex-col gap-y-1">


### PR DESCRIPTION
Closes https://linear.app/rilldata/issue/APP-139/user-group-name-invalid-error-message-only-appears-when-field-is-not

- Shows errors on input rather than on blur
- Reset tainted form on close
- Disable submission button on group name error

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
