### PR TITLE
Changes to Reference

### DIFF
--- a/docs/docs/home/home.md
+++ b/docs/docs/home/home.md
@@ -3,7 +3,6 @@ title: Ready to embark on your Rill adventure? Let's dive in!
 slug: /
 sidebar_label: Welcome to Rill
 sidebar_position: 00
-hide_table_of_contents: true
 ---
 
 ## Install Rill 

--- a/docs/docs/reference/api/_category_.yml
+++ b/docs/docs/reference/api/_category_.yml
@@ -1,0 +1,5 @@
+position: 4
+label: API Reference
+collapsible: true
+collapsed: false
+className: hidden

--- a/docs/docs/reference/connectors/_category_.yml
+++ b/docs/docs/reference/connectors/_category_.yml
@@ -1,4 +1,5 @@
-position: 1
+position: 3
 label: Connectors
 collapsible: true
 collapsed: false
+description: "This will move to our doc tab soon!"

--- a/docs/docs/reference/project-files/_category_.yml
+++ b/docs/docs/reference/project-files/_category_.yml
@@ -1,4 +1,4 @@
-position: 3
-label: Project Files
+position: 1
+label: Project Specifications
 collapsible: true
 collapsed: false

--- a/docs/docs/reference/project-files/_category_.yml
+++ b/docs/docs/reference/project-files/_category_.yml
@@ -1,4 +1,4 @@
 position: 1
-label: Project Specifications
+label: Project Files
 collapsible: true
 collapsed: false

--- a/docs/docs/reference/project-files/advanced-models.md
+++ b/docs/docs/reference/project-files/advanced-models.md
@@ -7,7 +7,7 @@ hide_table_of_contents: true
 
 :::tip
 
-Both regular models and source models can use the Model YAML specification described on this page. While [SQL models](model) are perfect for simple transformations, Model YAML files provide advanced capabilities for complex data processing scenarios.
+Both regular models and source models can use the Model YAML specification described on this page. While [SQL models](./models) are perfect for simple transformations, Model YAML files provide advanced capabilities for complex data processing scenarios.
 
 **When to use Model YAML:**
 - **Partitions** - Optimize performance with data partitioning strategies

--- a/docs/docs/reference/project-files/advanced-models.md
+++ b/docs/docs/reference/project-files/advanced-models.md
@@ -1,11 +1,24 @@
 ---
-title: Advanced Model YAML
-sidebar_label: Advanced Model YAML
-sidebar_position: 35
+title: Model YAML
+sidebar_label: Model YAML
+sidebar_position: 20
 hide_table_of_contents: true
 ---
 
-In some cases, advanced models will be required when implementing advanced features such as incremental partitioned models or staging models. 
+:::tip
+
+Both regular models and source models can use the Model YAML specification described on this page. While [SQL models](model) are perfect for simple transformations, Model YAML files provide advanced capabilities for complex data processing scenarios.
+
+**When to use Model YAML:**
+- **Partitions** - Optimize performance with data partitioning strategies
+- **Incremental models** - Process only new or changed data efficiently
+- **Pre/post execution hooks** - Run custom logic before or after model execution
+- **Staging** - Create intermediate tables for complex transformations
+- **Output configuration** - Define specific output formats and destinations
+
+Model YAML files give you fine-grained control over how your data is processed and transformed, making them ideal for production workloads and complex analytics pipelines.
+
+:::
 
 
 ## Properties

--- a/docs/docs/reference/project-files/connectors.md
+++ b/docs/docs/reference/project-files/connectors.md
@@ -39,7 +39,7 @@ When connecting to a data source, you can either explicitly define the connectio
 <!-- - **[local_file](#local_file)** - Local files (CSV, Parquet, etc.) -->
 - **[Salesforce](#salesforce)** - Salesforce data
 - **[Slack](#slack)** - Slack data
-- **[Google Sheets](#googlesheets) - Public Google Sheets
+- **[Google Sheets](#google-sheets)** - Public Google Sheets
 
 ### OLAP Engine Drivers
 When connecting to your own OLAP engine (e.g., ClickHouse, Druid, or Pinot), Rill will automatically generate the corresponding connector file and add the `olap_connector` parameter to your `rill.yaml` file. This will change the behavior of your Rill Developer slightly as not all features are supported across engines. Please see our documentation about [olap-engines](/reference/olap-engines/) for more information.
@@ -229,6 +229,13 @@ type: connector                                  # Must be `connector` (required
 driver: sqlite                                   # Must be `sqlite` _(required)_
 
 dsn: "./data/database.db"                        # SQLite connection DSN _(required)_
+```
+
+### Google Sheets
+```yaml
+type: model                                      # Slightly different than the others `model`
+connector: "duckdb"                              # connector will use default DuckDB engine
+sql: "select * from read_csv_auto('https://docs.google.com/spreadsheets/d/<SPREADSHEET_ID>/export?format=csv&gid=<SHEET_ID>', normalize_names=True)"                           # Fill in the parameters with your public Google Sheet.
 ```
 
 ## OLAP Engine Parameters

--- a/docs/docs/reference/project-files/connectors.md
+++ b/docs/docs/reference/project-files/connectors.md
@@ -2,16 +2,13 @@
 title: Connector YAML
 sidebar_label: Connector YAML 
 sidebar_position: 00
-hide_table_of_contents: true
+toc_max_heading_level: 4
+
 ---
 
 Connector YAML files define how Rill connects to external data sources and OLAP engines. Each connector specifies a driver type and its required connection parameters. 
 
 For newly created projects, Rill automatically generates a `/connectors/duckdb.yaml` file. This file allows you to configure custom database connections and SQL initialization commands through the `init_sql` parameter. This approach provides transparency and control over how Rill connects to your data sources, making it easier to understand and customize your setup.
-
-:::warning Security Best Practice
-**Never store plain text credentials in your YAML files!** Instead, use environment variables and reference them with `{{.env.<connector_type>.<parameter_name>}}` syntax. See our [credentials documentation](/build/credentials/) for detailed setup instructions.
-:::
 
 ## Required Properties
 
@@ -19,12 +16,10 @@ For newly created projects, Rill automatically generates a `/connectors/duckdb.y
 
 **`driver`** - The type of connector (required)
 
-## Driver Types
-
 ### Data Source Drivers
 When connecting to a data source, you can either explicitly define the connection in a YAML file or allow Rill to automatically infer this for you based on the file type.
 
-**Data Warehouse**
+#### _Data Warehouse_
 - **[Snowflake](#snowflake)** - Snowflake data warehouse
 - **[BigQuery](#bigquery)** - Google BigQuery
 - **[Redshift](#redshift)** - Amazon Redshift
@@ -34,16 +29,17 @@ When connecting to a data source, you can either explicitly define the connectio
 - **[sqlite](#sqlite)** - SQLite databases
 - **[MotherDuck](#motherduck-source)** - MotherDuck cloud data warehouse
 
-**Cloud Storage**
+#### _Cloud Storage_
 - **[GCS](#gcs)** - Google Cloud Storage
 - **[S3](#s3)** - Amazon S3 storage
 - **[Azure](#azure)** - Azure Blob Storage
 
-**Other**
-<!-- - **[https](#https)** - Public files via HTTP/HTTPS
-- **[local_file](#local_file)** - Local files (CSV, Parquet, etc.) -->
+#### _Other_
+- **[https](#https)** - Public files via HTTP/HTTPS
+<!-- - **[local_file](#local_file)** - Local files (CSV, Parquet, etc.) -->
 - **[Salesforce](#salesforce)** - Salesforce data
-- **[slack](#slack)** - Slack data
+- **[Slack](#slack)** - Slack data
+- **[Google Sheets](#googlesheets) - Public Google Sheets
 
 ### OLAP Engine Drivers
 When connecting to your own OLAP engine (e.g., ClickHouse, Druid, or Pinot), Rill will automatically generate the corresponding connector file and add the `olap_connector` parameter to your `rill.yaml` file. This will change the behavior of your Rill Developer slightly as not all features are supported across engines. Please see our documentation about [olap-engines](/reference/olap-engines/) for more information.
@@ -58,17 +54,14 @@ When connecting to your own OLAP engine (e.g., ClickHouse, Druid, or Pinot), Ril
 [Contact us](/contact) if you need support for a specific data source or OLAP engine!
 :::
 
-## Connection Parameters
 
-Each driver type has specific connection parameters. Click on any driver above to see its detailed configuration options, or refer to the [complete connector reference](/hidden/yaml/connector) for all available parameters.
+## Data Source Parameters
 
-:::tip Security Recommendation
+:::warning Security Recommendation
 For all credential parameters (passwords, tokens, keys), use environment variables with the syntax `{{.env.<connector_type>.<parameter_name>}}`. This keeps sensitive data out of your YAML files and version control. See our [credentials documentation](/build/credentials/) for complete setup instructions.
 :::
 
-### Data Source Parameters
-
-#### Athena
+### Athena
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: athena                                   # Must be `athena` _(required)_
@@ -85,11 +78,7 @@ aws_region: "us-east-1"                          # AWS region (defaults to 'us-e
 allow_host_access: true                          # Allow host environment access _(default: true)_
 ```
 
-:::warning Security Note
-Replace credential values like `aws_access_key_id` and `aws_secret_access_key` with environment variables: `{{.env.athena.aws_access_key_id}}`
-:::
-
-#### Azure
+### Azure
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: azure                                    # Must be `azure` _(required)_
@@ -102,11 +91,7 @@ azure_storage_bucket: "mycontainer"              # Azure Blob Storage container 
 allow_host_access: true                          # Allow host environment access
 ```
 
-:::warning Security Note
-Replace credential values like `azure_storage_key` with environment variables: `{{.env.azure.azure_storage_key}}`
-:::
-
-#### BigQuery
+### BigQuery
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: bigquery                                 # Must be `bigquery` _(required)_
@@ -116,11 +101,7 @@ project_id: "my-project-id"                      # Google Cloud project ID
 allow_host_access: true                          # Allow host environment access _(default: true)_
 ```
 
-:::warning Security Note
-Replace credential values like `google_application_credentials` with environment variables: `{{.env.bigquery.google_application_credentials}}`
-:::
-
-#### GCS
+### GCS
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: gcs                                      # Must be `gcs` _(required)_
@@ -132,11 +113,7 @@ key_id: "myaccesskey"                            # Optional S3-compatible Key ID
 secret: "mysecret"                               # Optional S3-compatible Secret
 ```
 
-:::warning Security Note
-Replace credential values like `google_application_credentials` and `secret` with environment variables: `{{.env.gcs.google_application_credentials}}`
-:::
-
-<!-- #### HTTPS
+### HTTPS
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: https                                    # Must be `https` _(required)_
@@ -145,7 +122,7 @@ path: "https://example.com/data.csv"             # Full HTTPS URI to fetch data 
 headers: "Authorization: Bearer token"           # HTTP headers to include in the request
 ```
 
-#### Local File
+<!-- ### Local File
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: local_file                               # Must be `local_file` _(required)_
@@ -154,7 +131,7 @@ dsn: "./data/file.csv"                           # File path or location _(requi
 allow_host_access: true                          # Allow host-level file path access
 ``` -->
 
-#### MotherDuck Source
+### MotherDuck Source
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: motherduck                               # Must be `motherduck` _(required)_
@@ -163,11 +140,7 @@ dsn: "md:?motherduck_token=mymotherducktoken"    # MotherDuck connection endpoin
 token: "mymotherducktoken"                       # Authentication token _(required)_
 ```
 
-:::warning Security Note
-Replace credential values like `token` with environment variables: `{{.env.motherduck.token}}`
-:::
-
-#### MySQL
+### MySQL
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: mysql                                    # Must be `mysql` _(required)_
@@ -175,11 +148,7 @@ driver: mysql                                    # Must be `mysql` _(required)_
 dsn: "user:password@tcp(localhost:3306)/database" # MySQL connection DSN _(required)_
 ```
 
-:::warning Security Note
-Replace credential values in the DSN with environment variables: `{{.env.mysql.dsn}}`
-:::
-
-#### PostgreSQL
+### PostgreSQL
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: postgres                                 # Must be `postgres` _(required)_
@@ -187,11 +156,7 @@ driver: postgres                                 # Must be `postgres` _(required
 dsn: "postgres://user:password@localhost:5432/database" # PostgreSQL connection DSN _(required)_
 ```
 
-:::warning Security Note
-Replace credential values in the DSN with environment variables: `{{.env.postgres.dsn}}`
-:::
-
-#### Redshift
+### Redshift
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: redshift                                 # Must be `redshift` _(required)_
@@ -205,11 +170,7 @@ workgroup: "my-workgroup"                        # Workgroup name for Redshift S
 cluster_identifier: "my-cluster"                 # Cluster identifier for provisioned clusters
 ```
 
-:::warning Security Note
-Replace credential values like `aws_access_key_id` and `aws_secret_access_key` with environment variables: `{{.env.redshift.aws_access_key_id}}`
-:::
-
-#### S3
+### S3
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: s3                                       # Must be `s3` _(required)_
@@ -224,11 +185,7 @@ allow_host_access: true                          # Allow host environment access
 retain_files: false                              # Retain intermediate files after processing
 ```
 
-:::warning Security Note
-Replace credential values like `aws_access_key_id` and `aws_secret_access_key` with environment variables: `{{.env.s3.aws_access_key_id}}`
-:::
-
-#### Salesforce
+### Salesforce
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: salesforce                               # Must be `salesforce` _(required)_
@@ -240,11 +197,7 @@ endpoint: "https://login.salesforce.com"         # Salesforce API endpoint URL _
 client_id: "myclientid"                          # Client ID for OAuth authentication
 ```
 
-:::warning Security Note
-Replace credential values like `password` and `key` with environment variables: `{{.env.salesforce.password}}`
-:::
-
-#### Slack
+### Slack
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: slack                                    # Must be `slack` _(required)_
@@ -252,11 +205,7 @@ driver: slack                                    # Must be `slack` _(required)_
 bot_token: "xoxb-myslackbottoken"                # Bot token for Slack API authentication _(required)_
 ```
 
-:::warning Security Note
-Replace credential values like `bot_token` with environment variables: `{{.env.slack.bot_token}}`
-:::
-
-#### Snowflake
+### Snowflake
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: snowflake                                # Must be `snowflake` _(required)_
@@ -274,11 +223,7 @@ privateKey: "myprivatekey"                       # RSA private key for JWT authe
 parallel_fetch_limit: 5                          # Maximum concurrent fetches during query execution
 ```
 
-:::warning Security Note
-Replace credential values like `password` and `privateKey` with environment variables: `{{.env.snowflake.password}}`
-:::
-
-#### SQLite
+### SQLite
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: sqlite                                   # Must be `sqlite` _(required)_
@@ -286,9 +231,15 @@ driver: sqlite                                   # Must be `sqlite` _(required)_
 dsn: "./data/database.db"                        # SQLite connection DSN _(required)_
 ```
 
-### OLAP Engine Parameters
+## OLAP Engine Parameters
 
-#### ClickHouse
+:::warning Security Recommendation
+For all credential parameters (passwords, tokens, keys), use environment variables with the syntax `{{.env.<connector_type>.<parameter_name>}}`. This keeps sensitive data out of your YAML files and version control. See our [credentials documentation](/build/credentials/) for complete setup instructions.
+:::
+
+
+
+### ClickHouse
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: clickhouse                               # Must be `clickhouse` _(required)_
@@ -314,11 +265,7 @@ conn_max_lifetime: "1h"                          # Maximum connection reuse time
 read_timeout: "30s"                              # Maximum read timeout
 ```
 
-:::warning Security Note
-Replace credential values like `password` with environment variables: `{{.env.clickhouse.password}}`
-:::
-
-#### Druid
+### Druid
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: druid                                    # Must be `druid` _(required)_
@@ -334,11 +281,7 @@ max_open_conns: 10                               # Maximum open connections (0=d
 skip_version_check: false                        # Skip Druid version compatibility check
 ```
 
-:::warning Security Note
-Replace credential values like `password` with environment variables: `{{.env.druid.password}}`
-:::
-
-#### DuckDB
+### DuckDB
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: duckdb                                   # Must be `duckdb` _(required)_
@@ -354,7 +297,7 @@ secrets: "s3,gcs"                                # Comma-separated list of conne
 log_queries: false                               # Log raw SQL queries through OLAP
 ```
 
-#### Pinot
+### Pinot
 ```yaml
 type: connector                                  # Must be `connector` (required)
 driver: pinot                                    # Must be `pinot` _(required)_
@@ -371,11 +314,7 @@ log_queries: false                               # Log raw SQL queries
 max_open_conns: 10                               # Maximum open connections
 ```
 
-:::warning Security Note
-Replace credential values like `password` with environment variables: `{{.env.pinot.password}}`
-:::
-
-#### Motherduck
+### Motherduck
 
 ```yaml
 ---

--- a/docs/docs/reference/project-files/connectors.md
+++ b/docs/docs/reference/project-files/connectors.md
@@ -8,41 +8,13 @@ toc_max_heading_level: 4
 
 Connector YAML files define how Rill connects to external data sources and OLAP engines. Each connector specifies a driver type and its required connection parameters. 
 
-For newly created projects, Rill automatically generates a `/connectors/duckdb.yaml` file. This file allows you to configure custom database connections and SQL initialization commands through the `init_sql` parameter. This approach provides transparency and control over how Rill connects to your data sources, making it easier to understand and customize your setup.
-
 ## Required Properties
 
 **`type`** - Must be `connector` (required)
 
 **`driver`** - The type of connector (required)
 
-### Connector Drivers
-
-Unless explicitly defined, Rill will [automatically detect connection details](/build/credentials/#setting-credentials-for-rill-developer) from your .env file, credentials passed with the rill start command, or CLI-based configurations.
-
-#### _Data Warehouse_
-- **[Snowflake](#snowflake)** - Snowflake data warehouse
-- **[BigQuery](#bigquery)** - Google BigQuery
-- **[Redshift](#redshift)** - Amazon Redshift
-- **[PostgreSQL](#postgresql)** - PostgreSQL databases
-- **[Athena](#athena)** - Amazon Athena
-- **[mysql](#mysql)** - MySQL databases
-- **[sqlite](#sqlite)** - SQLite databases
-- **[MotherDuck](#motherduck-as-a-source)** - MotherDuck cloud data warehouse
-
-#### _Cloud Storage_
-- **[GCS](#gcs)** - Google Cloud Storage
-- **[S3](#s3)** - Amazon S3 storage
-- **[Azure](#azure)** - Azure Blob Storage
-
-#### _Other_
-- **[https](#https)** - Public files via HTTP/HTTPS
-<!-- - **[local_file](#local_file)** - Local files (CSV, Parquet, etc.) -->
-- **[Salesforce](#salesforce)** - Salesforce data
-- **[Slack](#slack)** - Slack data
-- **[Google Sheets](#google-sheets)** - Public Google Sheets
-
-### OLAP Engine Drivers
+#### _OLAP Engines_
 When connecting to your own OLAP engine using Rill Developer(e.g., ClickHouse, Druid, or Pinot), Rill will automatically generate the corresponding connector file and add the `olap_connector` parameter to your `rill.yaml` file. This will change the behavior of your Rill Developer slightly as not all features are supported across engines. Please see our documentation about [olap-engines](/reference/olap-engines/) for more information.
 
 - **[DuckDB](#duckdb)** - Embedded DuckDB engine (default)
@@ -51,9 +23,29 @@ When connecting to your own OLAP engine using Rill Developer(e.g., ClickHouse, D
 - **[Druid](#druid)** - Apache Druid
 - **[Pinot](#pinot)** - Apache Pinot
 
-:::tip Looking for a different connector?
-[Contact us](/contact) if you need support for a specific data source or OLAP engine!
-:::
+#### _Data Warehouses_
+- **[Snowflake](#snowflake)** - Snowflake data warehouse
+- **[BigQuery](#bigquery)** - Google BigQuery
+- **[Redshift](#redshift)** - Amazon Redshift
+- **[Athena](#athena)** - Amazon Athena
+- **[MotherDuck](#motherduck-as-a-source)** - MotherDuck cloud data warehouse
+
+#### _Databases_
+- **[PostgreSQL](#postgresql)** - PostgreSQL databases
+- **[MySQL](#mysql)** - MySQL databases
+- **[sqlite](#sqlite)** - SQLite databases
+
+#### _Cloud Storage_
+- **[GCS](#gcs)** - Google Cloud Storage
+- **[S3](#s3)** - Amazon S3 storage
+- **[Azure](#azure)** - Azure Blob Storage
+
+#### _Other_
+- **[https](#https)** - Public files via HTTP/HTTPS
+- **[Salesforce](#salesforce)** - Salesforce data
+- **[Slack](#slack)** - Slack data
+- **[Google Sheets](#google-sheets)** - Public Google Sheets
+
 
 
 ## Connector Parameters
@@ -329,9 +321,3 @@ driver: sqlite                                   # Must be `sqlite` _(required)_
 
 dsn: "./data/database.db"                        # SQLite connection DSN _(required)_
 ```
-
-:::warning Security Recommendation
-For all credential parameters (passwords, tokens, keys), use environment variables with the syntax `{{.env.<connector_type>.<parameter_name>}}`. This keeps sensitive data out of your YAML files and version control. See our [credentials documentation](/build/credentials/) for complete setup instructions.
-:::
-
-

--- a/docs/docs/reference/project-files/connectors.md
+++ b/docs/docs/reference/project-files/connectors.md
@@ -24,7 +24,6 @@ When connecting to your own OLAP engine using Rill Developer(e.g., ClickHouse, D
 - **[BigQuery](#bigquery)** - Google BigQuery
 - **[Redshift](#redshift)** - Amazon Redshift
 - **[Athena](#athena)** - Amazon Athena
-- **[MotherDuck](#motherduck-as-a-source)** - MotherDuck cloud data warehouse
 
 #### _Databases_
 - **[PostgreSQL](#postgresql)** - PostgreSQL databases
@@ -190,16 +189,7 @@ dsn: "./data/file.csv"                           # File path or location _(requi
 allow_host_access: true                          # Allow host-level file path access
 ``` -->
 
-### MotherDuck as a source
-```yaml
-type: connector                                  # Must be `connector` (required)
-driver: motherduck                               # Must be `motherduck` _(required)_
-
-dsn: "md:?motherduck_token=mymotherducktoken"    # MotherDuck connection endpoint _(required)_  
-token: "mymotherducktoken"                       # Authentication token _(required)_
-```
-
-### Motherduck
+### MotherDuck
 
 ```yaml
 ---
@@ -212,7 +202,7 @@ path: "md:my_db"                                # Path to your MD database
 init_sql: |                                     # SQL executed during database initialization.
   INSTALL 'motherduck';                         # Install motherduck extension
   LOAD 'motherduck';                            # Load the extensions
-  SET motherduck_token= {{ .env.motherduck_token }} # Define the motherduck token
+  SET motherduck_token= '{{ .env.motherduck_token }}' # Define the motherduck token
 ```
 
 ### MySQL

--- a/docs/docs/reference/project-files/connectors.md
+++ b/docs/docs/reference/project-files/connectors.md
@@ -5,70 +5,389 @@ sidebar_position: 00
 hide_table_of_contents: true
 ---
 
-:::note /connectors/duckdb.yaml
+Connector YAML files define how Rill connects to external data sources and OLAP engines. Each connector specifies a driver type and its required connection parameters. 
 
+For newly created projects, Rill automatically generates a `/connectors/duckdb.yaml` file. This file allows you to configure custom database connections and SQL initialization commands through the `init_sql` parameter. This approach provides transparency and control over how Rill connects to your data sources, making it easier to understand and customize your setup.
 
-
+:::warning Security Best Practice
+**Never store plain text credentials in your YAML files!** Instead, use environment variables and reference them with `{{.env.<connector_type>.<parameter_name>}}` syntax. See our [credentials documentation](/build/credentials/) for detailed setup instructions.
 :::
 
+## Required Properties
 
-When you add olap_connector to your rill.yaml file, you will need to set up a `<connector_name>.yaml` file in the 'connectors' directory. This file requires the following parameters,`type` and `driver` (see below for more parameter options). Rill will automatically test the connectivity to the OLAP engine upon saving the file. This can be viewed in the connectors tab in the UI.
+**`type`** - Must be `connector` (required)
 
-:::tip Did you know?
+**`driver`** - The type of connector (required)
 
-Starting from Rill 0.46, you can directly create OLAP engines from the UI! 
-Select + Add -> Data -> Connect an OLAP engine
+## Driver Types
 
+### Data Source Drivers
+When connecting to a data source, you can either explicitly define the connection in a YAML file or allow Rill to automatically infer this for you based on the file type.
+
+**Data Warehouse**
+- **[Snowflake](#snowflake)** - Snowflake data warehouse
+- **[BigQuery](#bigquery)** - Google BigQuery
+- **[Redshift](#redshift)** - Amazon Redshift
+- **[PostgreSQL](#postgresql)** - PostgreSQL databases
+- **[Athena](#athena)** - Amazon Athena
+- **[mysql](#mysql)** - MySQL databases
+- **[sqlite](#sqlite)** - SQLite databases
+- **[MotherDuck](#motherduck-source)** - MotherDuck cloud data warehouse
+
+**Cloud Storage**
+- **[GCS](#gcs)** - Google Cloud Storage
+- **[S3](#s3)** - Amazon S3 storage
+- **[Azure](#azure)** - Azure Blob Storage
+
+**Other**
+<!-- - **[https](#https)** - Public files via HTTP/HTTPS
+- **[local_file](#local_file)** - Local files (CSV, Parquet, etc.) -->
+- **[Salesforce](#salesforce)** - Salesforce data
+- **[slack](#slack)** - Slack data
+
+### OLAP Engine Drivers
+When connecting to your own OLAP engine (e.g., ClickHouse, Druid, or Pinot), Rill will automatically generate the corresponding connector file and add the `olap_connector` parameter to your `rill.yaml` file. This will change the behavior of your Rill Developer slightly as not all features are supported across engines. Please see our documentation about [olap-engines](/reference/olap-engines/) for more information.
+
+- **[DuckDB](#duckdb)** - Embedded DuckDB engine (default)
+- **[Clickhouse](#clickhouse)** - ClickHouse analytical database
+- **[MotherDuck](#motherduck)** - MotherDuck cloud database
+- **[Druid](#druid)** - Apache Druid
+- **[Pinot](#pinot)** - Apache Pinot
+
+:::tip Looking for a different connector?
+[Contact us](/contact) if you need support for a specific data source or OLAP engine!
 :::
 
+## Connection Parameters
 
-## Properties
+Each driver type has specific connection parameters. Click on any driver above to see its detailed configuration options, or refer to the [complete connector reference](/hidden/yaml/connector) for all available parameters.
 
-**`type`** - refers to the resource type and must be 'connector'
-
-**`driver`** - refers to the [OLAP engine](../olap-engines/multiple-olap.md)
-- _`clickhouse`_ link to[ ClickHouse documentation](https://clickhouse.com/docs/en/intro)
-- _`druid`_ link to[ Druid documentation](https://druid.apache.org/docs/latest/design/)
-- _`pinot`_ link to[ Pinot documentation](https://docs.pinot.apache.org/)
-
-:::tip A note on OLAP engines
-
-By defining the `connector` parameter in a [dashboard's YAML](explore-dashboards.md) file, you can have multiple OLAP engines in a single project.
-
+:::tip Security Recommendation
+For all credential parameters (passwords, tokens, keys), use environment variables with the syntax `{{.env.<connector_type>.<parameter_name>}}`. This keeps sensitive data out of your YAML files and version control. See our [credentials documentation](/build/credentials/) for complete setup instructions.
 :::
 
-**`host`** - refers to the hostname
+### Data Source Parameters
 
-**`port`** - refers to the port 
+#### Athena
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: athena                                   # Must be `athena` _(required)_
 
-**`username`** - the username, in plaintext
+aws_access_key_id: "myawsaccesskey"              # AWS Access Key ID for authentication  
+aws_secret_access_key: "myawssecretkey"          # AWS Secret Access Key for authentication  
+aws_access_token: "mytemporarytoken"             # AWS session token for temporary credentials  
+role_arn: "arn:aws:iam::123456789012:role/MyRole" # ARN of the IAM role to assume  
+role_session_name: "MySession"                   # Session name for STS AssumeRole  
+external_id: "MyExternalID"                      # External ID for cross-account access  
+workgroup: "primary"                             # Athena workgroup (defaults to 'primary')  
+output_location: "s3://my-bucket/athena-output/" # S3 URI for query results  
+aws_region: "us-east-1"                          # AWS region (defaults to 'us-east-1')  
+allow_host_access: true                          # Allow host environment access _(default: true)_
+```
 
-**`password`** - the password, in plaintext
+:::warning Security Note
+Replace credential values like `aws_access_key_id` and `aws_secret_access_key` with environment variables: `{{.env.athena.aws_access_key_id}}`
+:::
 
-**`ssl`** - depending on the engine, this parameter may be required (_pinot_)
+#### Azure
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: azure                                    # Must be `azure` _(required)_
 
+azure_storage_account: "mystorageaccount"        # Azure storage account name  
+azure_storage_key: "credentialjsonstring"        # Azure storage access key  
+azure_storage_sas_token: "optionaltoken"         # Optional SAS token for authentication  
+azure_storage_connection_string: "optionalconnectionstring" # Optional connection string  
+azure_storage_bucket: "mycontainer"              # Azure Blob Storage container name _(required)_  
+allow_host_access: true                          # Allow host environment access
+```
 
-You can also connect using a dsn parameter. You cannot use the above parameters along with the **`dsn`** parameter.
+:::warning Security Note
+Replace credential values like `azure_storage_key` with environment variables: `{{.env.azure.azure_storage_key}}`
+:::
 
-**`dsn`** - connection string containing all the details above, in a single string. Note that each engine's syntax is slightly different. Please refer to [our documentation](https://docs.rilldata.com/reference/olap-engines/) for further details.
+#### BigQuery
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: bigquery                                 # Must be `bigquery` _(required)_
 
+google_application_credentials: "credentialjsonstring"     # Google Cloud service account JSON  
+project_id: "my-project-id"                      # Google Cloud project ID  
+allow_host_access: true                          # Allow host environment access _(default: true)_
+```
+
+:::warning Security Note
+Replace credential values like `google_application_credentials` with environment variables: `{{.env.bigquery.google_application_credentials}}`
+:::
+
+#### GCS
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: gcs                                      # Must be `gcs` _(required)_
+
+google_application_credentials: "credentialjsonstring" # Google Cloud credentials JSON string  
+bucket: "my-bucket"                              # GCS bucket name _(required)_  
+allow_host_access: true                          # Allow host environment access  
+key_id: "myaccesskey"                            # Optional S3-compatible Key ID  
+secret: "mysecret"                               # Optional S3-compatible Secret
+```
+
+:::warning Security Note
+Replace credential values like `google_application_credentials` and `secret` with environment variables: `{{.env.gcs.google_application_credentials}}`
+:::
+
+<!-- #### HTTPS
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: https                                    # Must be `https` _(required)_
+
+path: "https://example.com/data.csv"             # Full HTTPS URI to fetch data from _(required)_  
+headers: "Authorization: Bearer token"           # HTTP headers to include in the request
+```
+
+#### Local File
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: local_file                               # Must be `local_file` _(required)_
+
+dsn: "./data/file.csv"                           # File path or location _(required)_  
+allow_host_access: true                          # Allow host-level file path access
+``` -->
+
+#### MotherDuck Source
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: motherduck                               # Must be `motherduck` _(required)_
+
+dsn: "md:?motherduck_token=mymotherducktoken"    # MotherDuck connection endpoint _(required)_  
+token: "mymotherducktoken"                       # Authentication token _(required)_
+```
+
+:::warning Security Note
+Replace credential values like `token` with environment variables: `{{.env.motherduck.token}}`
+:::
+
+#### MySQL
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: mysql                                    # Must be `mysql` _(required)_
+
+dsn: "user:password@tcp(localhost:3306)/database" # MySQL connection DSN _(required)_
+```
+
+:::warning Security Note
+Replace credential values in the DSN with environment variables: `{{.env.mysql.dsn}}`
+:::
+
+#### PostgreSQL
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: postgres                                 # Must be `postgres` _(required)_
+
+dsn: "postgres://user:password@localhost:5432/database" # PostgreSQL connection DSN _(required)_
+```
+
+:::warning Security Note
+Replace credential values in the DSN with environment variables: `{{.env.postgres.dsn}}`
+:::
+
+#### Redshift
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: redshift                                 # Must be `redshift` _(required)_
+
+aws_access_key_id: "myawsaccesskey"              # AWS Access Key ID _(required)_  
+aws_secret_access_key: "myawssecretkey"          # AWS Secret Access Key _(required)_  
+aws_access_token: "mytemporarytoken"             # AWS Session Token for temporary credentials  
+region: "us-east-1"                              # AWS region  
+database: "my_database"                          # Redshift database name _(required)_  
+workgroup: "my-workgroup"                        # Workgroup name for Redshift Serverless  
+cluster_identifier: "my-cluster"                 # Cluster identifier for provisioned clusters
+```
+
+:::warning Security Note
+Replace credential values like `aws_access_key_id` and `aws_secret_access_key` with environment variables: `{{.env.redshift.aws_access_key_id}}`
+:::
+
+#### S3
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: s3                                       # Must be `s3` _(required)_
+
+aws_access_key_id: "myawsaccesskey"              # AWS Access Key ID  
+aws_secret_access_key: "myawssecretkey"          # AWS Secret Access Key  
+aws_access_token: "mytemporarytoken"             # AWS session token for temporary credentials  
+bucket: "my-bucket"                              # S3 bucket name _(required)_  
+endpoint: "https://s3.amazonaws.com"             # Custom endpoint for S3-compatible storage  
+region: "us-east-1"                              # AWS region of the S3 bucket  
+allow_host_access: true                          # Allow host environment access  
+retain_files: false                              # Retain intermediate files after processing
+```
+
+:::warning Security Note
+Replace credential values like `aws_access_key_id` and `aws_secret_access_key` with environment variables: `{{.env.s3.aws_access_key_id}}`
+:::
+
+#### Salesforce
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: salesforce                               # Must be `salesforce` _(required)_
+
+username: "user@example.com"                     # Salesforce account username _(required)_  
+password: "mypassword"                           # Salesforce account password  
+key: "mysecuritykey"                             # Authentication key  
+endpoint: "https://login.salesforce.com"         # Salesforce API endpoint URL _(required)_  
+client_id: "myclientid"                          # Client ID for OAuth authentication
+```
+
+:::warning Security Note
+Replace credential values like `password` and `key` with environment variables: `{{.env.salesforce.password}}`
+:::
+
+#### Slack
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: slack                                    # Must be `slack` _(required)_
+
+bot_token: "xoxb-myslackbottoken"                # Bot token for Slack API authentication _(required)_
+```
+
+:::warning Security Note
+Replace credential values like `bot_token` with environment variables: `{{.env.slack.bot_token}}`
+:::
+
+#### Snowflake
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: snowflake                                # Must be `snowflake` _(required)_
+
+dsn: "user:password@account/database/schema?warehouse=warehouse&role=role" # Snowflake connection DSN _(required if not using individual parameters)_  
+account: "myaccount"                             # Snowflake account identifier _(required if not using dsn)_  
+user: "myuser"                                   # Snowflake username _(required if not using dsn)_  
+password: "mypassword"                           # Snowflake password _(required if not using dsn and privateKey)_  
+database: "mydatabase"                           # Snowflake database name _(required if not using dsn)_  
+schema: "myschema"                               # Snowflake schema name  
+warehouse: "mywarehouse"                         # Snowflake warehouse name  
+role: "myrole"                                   # Snowflake role name  
+authenticator: "SNOWFLAKE_JWT"                   # Authentication method (e.g., 'SNOWFLAKE_JWT')  
+privateKey: "myprivatekey"                       # RSA private key for JWT authentication _(required if not using password)_  
+parallel_fetch_limit: 5                          # Maximum concurrent fetches during query execution
+```
+
+:::warning Security Note
+Replace credential values like `password` and `privateKey` with environment variables: `{{.env.snowflake.password}}`
+:::
+
+#### SQLite
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: sqlite                                   # Must be `sqlite` _(required)_
+
+dsn: "./data/database.db"                        # SQLite connection DSN _(required)_
+```
+
+### OLAP Engine Parameters
+
+#### ClickHouse
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: clickhouse                               # Must be `clickhouse` _(required)_
+
+managed: false                                   # Enable automatic provisioning _(default: false)_  
+mode: "read"                                     # Operation mode: `read` or `readwrite` _(default: read)_  
+dsn: "clickhouse://user:password@localhost:9000/database" # ClickHouse connection DSN  
+username: "default"                              # Username for authentication  
+password: "mypassword"                           # Password for authentication  
+host: "localhost"                                # ClickHouse instance hostname  
+port: 9000                                       # ClickHouse instance port  
+database: "default"                              # ClickHouse database name  
+ssl: false                                       # Enable SSL connection  
+cluster: "mycluster"                             # Cluster name for distributed queries  
+log_queries: false                               # Log raw SQL queries  
+settings_override: "max_memory_usage=1000000000" # Override default query settings  
+embed_port: 0                                    # Port for local ClickHouse (0 for random)  
+can_scale_to_zero: false                         # Database can scale to zero  
+max_open_conns: 10                               # Maximum open connections  
+max_idle_conns: 5                                # Maximum idle connections  
+dial_timeout: "30s"                              # Connection dial timeout  
+conn_max_lifetime: "1h"                          # Maximum connection reuse time  
+read_timeout: "30s"                              # Maximum read timeout
+```
+
+:::warning Security Note
+Replace credential values like `password` with environment variables: `{{.env.clickhouse.password}}`
+:::
+
+#### Druid
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: druid                                    # Must be `druid` _(required)_
+
+dsn: "http://localhost:8082"                     # Druid connection DSN _(required)_  
+username: "admin"                                # Username for authentication  
+password: "mypassword"                           # Password for authentication  
+host: "localhost"                                # Druid coordinator/broker hostname  
+port: 8082                                       # Druid service port  
+ssl: false                                       # Enable SSL connection  
+log_queries: false                               # Log raw SQL queries  
+max_open_conns: 10                               # Maximum open connections (0=default, -1=unlimited)  
+skip_version_check: false                        # Skip Druid version compatibility check
+```
+
+:::warning Security Note
+Replace credential values like `password` with environment variables: `{{.env.druid.password}}`
+:::
+
+#### DuckDB
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: duckdb                                   # Must be `duckdb` _(required)_
+
+pool_size: 4                                     # Number of concurrent connections and queries  
+allow_host_access: true                          # Allow local environment and file system access  
+cpu: 4                                           # Number of CPU cores available to database  
+memory_limit_gb: 8                               # Memory in GB available to database  
+read_write_ratio: 0.8                            # Resource allocation ratio for read database  
+init_sql: "SET memory_limit='8GB'"               # SQL executed during database initialization  
+conn_init_sql: "SET timezone='UTC'"              # SQL executed when new connection is initialized  
+secrets: "s3,gcs"                                # Comma-separated list of connector names for temporary secrets  
+log_queries: false                               # Log raw SQL queries through OLAP
+```
+
+#### Pinot
+```yaml
+type: connector                                  # Must be `connector` (required)
+driver: pinot                                    # Must be `pinot` _(required)_
+
+dsn: "http://localhost:8099"                     # Pinot connection DSN _(required)_  
+username: "admin"                                # Username for authentication  
+password: "mypassword"                           # Password for authentication  
+broker_host: "localhost"                         # Pinot broker hostname _(required)_  
+broker_port: 8099                                # Pinot broker port  
+controller_host: "localhost"                     # Pinot controller hostname _(required)_  
+controller_port: 9000                            # Pinot controller port  
+ssl: false                                       # Enable SSL connection  
+log_queries: false                               # Log raw SQL queries  
+max_open_conns: 10                               # Maximum open connections
+```
+
+:::warning Security Note
+Replace credential values like `password` with environment variables: `{{.env.pinot.password}}`
+:::
+
+#### Motherduck
+
+```yaml
 ---
- 
-_Example #1: Connecting to a local running ClickHouse server (no security enabled)_
-```yaml
-type: connector
-driver: clickhouse
+type: connector                                  # Must be `connector` (required)
+driver: duckdb                                   # Must be `duckdb` _(required)_
 
-host: "localhost"
-port: "9000"
+
+path: "md:my_db"                                # Path to your MD database
+
+init_sql: |                                     # SQL executed during database initialization.
+  INSTALL 'motherduck';                         # Install motherduck extension
+  LOAD 'motherduck';                            # Load the extensions
+  SET motherduck_token= {{ .env.motherduck_token }} # Define the motherduck token
 ```
 
-_Example #2: Connecting to a ClickHouse Cloud_
-```yaml
-type: connector
-driver: clickhouse
-
-
-dsn: "https://<hostname>:<port>?username=<username>&password=<password>&secure=true&skip_verify=true"
-
-```

--- a/docs/docs/reference/project-files/connectors.md
+++ b/docs/docs/reference/project-files/connectors.md
@@ -1,9 +1,15 @@
 ---
 title: Connector YAML
 sidebar_label: Connector YAML 
-sidebar_position: 70
+sidebar_position: 00
 hide_table_of_contents: true
 ---
+
+:::note /connectors/duckdb.yaml
+
+
+
+:::
 
 
 When you add olap_connector to your rill.yaml file, you will need to set up a `<connector_name>.yaml` file in the 'connectors' directory. This file requires the following parameters,`type` and `driver` (see below for more parameter options). Rill will automatically test the connectivity to the OLAP engine upon saving the file. This can be viewed in the connectors tab in the UI.

--- a/docs/docs/reference/project-files/connectors.md
+++ b/docs/docs/reference/project-files/connectors.md
@@ -8,11 +8,7 @@ toc_max_heading_level: 4
 
 Connector YAML files define how Rill connects to external data sources and OLAP engines. Each connector specifies a driver type and its required connection parameters. 
 
-## Required Properties
-
-**`type`** - Must be `connector` (required)
-
-**`driver`** - The type of connector (required)
+## Connector Types
 
 #### _OLAP Engines_
 When connecting to your own OLAP engine using Rill Developer(e.g., ClickHouse, Druid, or Pinot), Rill will automatically generate the corresponding connector file and add the `olap_connector` parameter to your `rill.yaml` file. This will change the behavior of your Rill Developer slightly as not all features are supported across engines. Please see our documentation about [olap-engines](/reference/olap-engines/) for more information.
@@ -48,7 +44,12 @@ When connecting to your own OLAP engine using Rill Developer(e.g., ClickHouse, D
 
 
 
-## Connector Parameters
+## Required Properties
+
+**`type`** - Must be `connector` (required)
+
+**`driver`** - The type of connector, see [connector types](#connector-types) (required)
+
 
 :::warning Security Recommendation
 For all credential parameters (passwords, tokens, keys), use environment variables with the syntax `{{.env.<connector_type>.<parameter_name>}}`. This keeps sensitive data out of your YAML files and version control. See our [credentials documentation](/build/credentials/) for complete setup instructions.

--- a/docs/docs/reference/project-files/connectors.md
+++ b/docs/docs/reference/project-files/connectors.md
@@ -8,12 +8,11 @@ toc_max_heading_level: 4
 
 Connector YAML files define how Rill connects to external data sources and OLAP engines. Each connector specifies a driver type and its required connection parameters. 
 
-## Connector Types
+## Available Connectors
 
 #### _OLAP Engines_
-When connecting to your own OLAP engine using Rill Developer(e.g., ClickHouse, Druid, or Pinot), Rill will automatically generate the corresponding connector file and add the `olap_connector` parameter to your `rill.yaml` file. This will change the behavior of your Rill Developer slightly as not all features are supported across engines. Please see our documentation about [olap-engines](/reference/olap-engines/) for more information.
 
-- **[DuckDB](#duckdb)** - Embedded DuckDB engine (default)
+- **[DuckDB](#duckdb)** - Embedded DuckDB engine (_default_)
 - **[Clickhouse](#clickhouse)** - ClickHouse analytical database
 - **[MotherDuck](#motherduck)** - MotherDuck cloud database
 - **[Druid](#druid)** - Apache Druid
@@ -47,7 +46,7 @@ When connecting to your own OLAP engine using Rill Developer(e.g., ClickHouse, D
 
 **`type`** - Must be `connector` (required)
 
-**`driver`** - The type of connector, see [connector types](#connector-types) (required)
+**`driver`** - The type of connector, see [available connectors](#available-connectors) (required)
 
 
 :::warning Security Recommendation

--- a/docs/docs/reference/project-files/models.md
+++ b/docs/docs/reference/project-files/models.md
@@ -1,7 +1,7 @@
 ---
 title: Model SQL
 sidebar_label: Model SQL
-sidebar_position: 20
+sidebar_position: 15
 hide_table_of_contents: true
 ---
 

--- a/docs/docs/reference/project-files/sources.md
+++ b/docs/docs/reference/project-files/sources.md
@@ -1,11 +1,21 @@
 ---
 title: Source YAML
 sidebar_label: Source YAML
-sidebar_position: 10
+sidebar_position: 00
 hide_table_of_contents: true
 ---
 
-In your Rill project directory, create a `<source_name>.yaml` file in the `sources` directory containing a `type` and location (`uri` or `path`). Rill will automatically detect and ingest the source next time you run `rill start`.
+:::warning Deprecated Feature
+**Sources have been deprecated** and are now considered "source models." While sources remain backward compatible, we recommend migrating to the new source model format for access to the latest features and improvements.
+
+**Next steps:**
+- Continue using sources if needed (backward compatible)
+- Migrate to source models via the `type:model` parameter for new projects
+- See our [model YAML reference](advanced-models) for current documentation and best practices
+:::
+
+
+
 
 :::tip Did you know?
 

--- a/docs/docs/reference/project-files/sources.md
+++ b/docs/docs/reference/project-files/sources.md
@@ -10,7 +10,7 @@ hide_table_of_contents: true
 
 **Next steps:**
 - Continue using sources if needed (backward compatible)
-- Migrate to source models via the `type:model` parameter for new projects
+- Migrate to source models via the `type:model` parameter for existing projects
 - See our [model YAML reference](advanced-models) for current documentation and best practices
 :::
 

--- a/docs/src/css/_headings.scss
+++ b/docs/src/css/_headings.scss
@@ -20,10 +20,12 @@
 }
 
 .markdown h4 {
-  font-size: 1rem;
   font-weight: 600;
-  margin-top: var(--space-2);
-  margin-bottom: var(--space-1);
+  margin: 0;
+  padding: 0;
+  display: inline;
+  font-size: var(--ifm-h4-font-size);
+  line-height: inherit;
 }
 
 .markdown h1:first-child {

--- a/docs/src/css/_variables.scss
+++ b/docs/src/css/_variables.scss
@@ -64,6 +64,7 @@
   --default-font: 0.875rem; /* 14px */
   --default-line-height: 1.5;
   --ifm-font-family-base: Inter, sans-serif;
+  --ifm-h4-font-size: 0.95rem !important;
   --ifm-h3-font-size: 1rem !important;
   --ifm-h2-font-size: 1.25rem !important;
   --ifm-h1-font-size: 1.75rem !important;


### PR DESCRIPTION
New order of Reference (in prep to move Connectors to Docs)
  - Project FIles
  - OLAP Engines
  - Connectors
  - CLI Usage
Rill Extensions

- Reorderd the Project Files with Connectors First (first item in the experience). 
- Added a deprecated note in source and have them look at model YAML instead
- Model YAML has a snippet on why YAML vs SQL 

Didn't add:
- MotherDuck as an OLAP engine, but it makes sense to and will do it in the future

Notes on PR:
Took the chance to recreate our **connector YAML** in preparation for the new connector experience and the importance to have this clearly defined and allow user to easily copy and paste the sample connector (or use the UI). There's a lot of parameters that we dont have documented anywhere and the **reference** should be the place for it. (not docs or relying on them to read github code)


Driver Types are defined with a in-page link to the corresponding sample YAML. This way a user can just copy and paste then insert their own creds. There is a note on each that references that they should not plain text their creds here and instead use a .env.......

