### PR TITLE
use limit 1 for ch schema queries

### DIFF
--- a/runtime/drivers/olap.go
+++ b/runtime/drivers/olap.go
@@ -812,6 +812,17 @@ func (d Dialect) SanitizeQueryForLogging(sql string) string {
 	return sql
 }
 
+func (d Dialect) MinRowsForQuerySchema() int {
+	switch d {
+	case DialectDuckDB, DialectDruid, DialectPinot:
+		return 0 // no rows needed
+	case DialectClickHouse:
+		return 1 // Clickhouse requires at least one row to be returned
+	default:
+		panic(fmt.Sprintf("unsupported dialect %q", d))
+	}
+}
+
 func (d Dialect) checkTypeCompatibility(f *runtimev1.StructType_Field) bool {
 	switch f.Type.Code {
 	// types that align with native go types are supported

--- a/runtime/metricsview/executor.go
+++ b/runtime/metricsview/executor.go
@@ -241,9 +241,9 @@ func (e *Executor) Schema(ctx context.Context) (*runtimev1.StructType, error) {
 		}
 	}
 
-	// Importantly, limit to 0 rows
-	zero := int64(0)
-	qry.Limit = &zero
+	// Importantly, limit to min rows required to get the schema. Except for CH it should be zero
+	minRows := int64(e.olap.Dialect().MinRowsForQuerySchema())
+	qry.Limit = &minRows
 
 	// Execute the query to get the schema
 	ast, err := NewAST(e.metricsView, e.security, qry, e.olap.Dialect())

--- a/runtime/metricsview/executor_validate.go
+++ b/runtime/metricsview/executor_validate.go
@@ -287,7 +287,7 @@ func (e *Executor) validateTimeDimension(ctx context.Context, t *drivers.OlapTab
 		}
 		// Validate time dimension type with a query
 		rows, err := e.olap.Query(ctx, &drivers.Statement{
-			Query: fmt.Sprintf("SELECT %s FROM %s LIMIT 0", expr, dialect.EscapeTable(t.Database, t.DatabaseSchema, t.Name)),
+			Query: fmt.Sprintf("SELECT %s FROM %s LIMIT %d", expr, dialect.EscapeTable(t.Database, t.DatabaseSchema, t.Name), dialect.MinRowsForQuerySchema()),
 		})
 		if err != nil {
 			res.TimeDimensionErr = fmt.Errorf("failed to validate time dimension %q: %w", e.metricsView.TimeDimension, err)


### PR DESCRIPTION
Fixes time dimension validation issue with CH which does not return schema with limit 0

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
