### PR TITLE
Support additional time range with metrics sql

### DIFF
--- a/runtime/resolvers/metrics_sql.go
+++ b/runtime/resolvers/metrics_sql.go
@@ -19,12 +19,12 @@ func init() {
 type metricsSQLProps struct {
 	// SQL is the metrics SQL to evaluate.
 	SQL string `mapstructure:"sql"`
+	// TimeZone is a timezone to apply to the metrics SQL.
+	TimeZone string `mapstructure:"time_zone"`
 	// AdditionalWhere is a filter to apply to the metrics SQL. (additional WHERE clause)
 	AdditionalWhere *metricsview.Expression `mapstructure:"additional_where"`
 	// AdditionalTimeRange is a time range filter to apply to the metrics SQL.
 	AdditionalTimeRange *metricsview.TimeRange `mapstructure:"additional_time_range"`
-	// AdditionalTimeZone is a timezone to apply to the metrics SQL.
-	AdditionalTimeZone string `mapstructure:"additional_time_zone"`
 }
 
 type metricsSQLArgs struct {
@@ -49,7 +49,7 @@ func newMetricsSQL(ctx context.Context, opts *runtime.ResolverOptions) (runtime.
 		span.SetAttributes(attribute.String("metrics_sql", props.SQL))
 		span.SetAttributes(attribute.Bool("has_additional_where", props.AdditionalWhere != nil))
 		span.SetAttributes(attribute.Bool("has_additional_time_range", props.AdditionalTimeRange != nil))
-		span.SetAttributes(attribute.Bool("has_additional_time_zone", props.AdditionalTimeZone != ""))
+		span.SetAttributes(attribute.Bool("has_additional_time_zone", props.TimeZone != ""))
 	}
 
 	instance, err := opts.Runtime.Instance(ctx, opts.InstanceID)
@@ -85,8 +85,8 @@ func newMetricsSQL(ctx context.Context, opts *runtime.ResolverOptions) (runtime.
 	query.TimeRange = applyAdditionalTimeRange(query.TimeRange, props.AdditionalTimeRange)
 
 	// Set the additional timezone if provided
-	if props.AdditionalTimeZone != "" {
-		query.TimeZone = props.AdditionalTimeZone
+	if props.TimeZone != "" {
+		query.TimeZone = props.TimeZone
 	}
 
 	// Build the options for the metrics resolver

--- a/runtime/resolvers/metrics_sql_test.go
+++ b/runtime/resolvers/metrics_sql_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/testruntime"
@@ -188,6 +189,61 @@ func TestMetricsSQLWithAdditionalWhere(t *testing.T) {
 		}
 	}
 	require.Greater(t, len(domains), 1, "Unfiltered results should include multiple domains")
+}
+
+func TestMetricsSQLWithAdditionalTimeRange(t *testing.T) {
+	rt, instanceID := testruntime.NewInstanceForProject(t, "ad_bids")
+
+	additionalTimeRange := map[string]any{
+		"start": time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+		"end":   time.Date(2022, 12, 31, 23, 59, 59, 0, time.UTC),
+	}
+
+	testruntime.RequireParseErrors(t, rt, instanceID, nil)
+	res, err := rt.Resolve(context.Background(), &runtime.ResolveOptions{
+		InstanceID: instanceID,
+		Resolver:   "metrics_sql",
+		ResolverProperties: map[string]any{
+			"sql":                   "SELECT dom, pub FROM ad_bids_metrics",
+			"additional_time_range": additionalTimeRange,
+		},
+		Args:   nil,
+		Claims: &runtime.SecurityClaims{},
+	})
+	require.NoError(t, err)
+	defer res.Close()
+
+	require.NotNil(t, res)
+	var rows []map[string]interface{}
+	require.NoError(t, json.Unmarshal(must(res.MarshalJSON()), &rows))
+	require.Greater(t, len(rows), 0, "Should return filtered results for the additional time range")
+
+	// Use additional_time_range and additional_where to filter results
+	resWithFilter, err := rt.Resolve(context.Background(), &runtime.ResolveOptions{
+		InstanceID: instanceID,
+		Resolver:   "metrics_sql",
+		ResolverProperties: map[string]any{
+			"sql":                   "SELECT dom, pub FROM ad_bids_metrics",
+			"additional_time_range": additionalTimeRange,
+			"additional_where": map[string]any{
+				"cond": map[string]any{
+					"op":    "eq",
+					"exprs": []map[string]any{{"name": "dom"}, {"val": "msn.com"}},
+				},
+			},
+		},
+		Args:   nil,
+		Claims: &runtime.SecurityClaims{},
+	})
+	require.NoError(t, err)
+	defer resWithFilter.Close()
+
+	var rowsWithFilter []map[string]interface{}
+	require.NoError(t, json.Unmarshal(must(resWithFilter.MarshalJSON()), &rowsWithFilter))
+
+	t.Logf("Rows with filter: %v", rowsWithFilter)
+
+	require.Greater(t, len(rowsWithFilter), 0, "Should return filtered results for the additional time range and where clause")
 }
 
 func TestMetricsSQLWithAdditionalTimeZone(t *testing.T) {

--- a/runtime/resolvers/metrics_sql_test.go
+++ b/runtime/resolvers/metrics_sql_test.go
@@ -254,8 +254,8 @@ func TestMetricsSQLWithAdditionalTimeZone(t *testing.T) {
 		InstanceID: instanceID,
 		Resolver:   "metrics_sql",
 		ResolverProperties: map[string]any{
-			"sql":                  "SELECT dom, pub FROM ad_bids_metrics",
-			"additional_time_zone": "America/New_York",
+			"sql":       "SELECT dom, pub FROM ad_bids_metrics",
+			"time_zone": "America/New_York",
 		},
 		Args:   nil,
 		Claims: &runtime.SecurityClaims{},
@@ -272,8 +272,8 @@ func TestMetricsSQLWithAdditionalTimeZone(t *testing.T) {
 		InstanceID: instanceID,
 		Resolver:   "metrics_sql",
 		ResolverProperties: map[string]any{
-			"sql":                  "SELECT dom, pub FROM ad_bids_metrics",
-			"additional_time_zone": "Invalid/Timezone",
+			"sql":       "SELECT dom, pub FROM ad_bids_metrics",
+			"time_zone": "Invalid/Timezone",
 		},
 		Args:   nil,
 		Claims: &runtime.SecurityClaims{},


### PR DESCRIPTION
Similar to the `additional_where` field this PR enables a way to merge the time range and timezone state to a metrics_sql query.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] [Linked the issues it closes](https://linear.app/rilldata/issue/PLAT-127/support-merging-of-time-range-state-with-metrics-sql)
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
