### PR TITLE
chore: add e2e canvas global filters test

### DIFF
--- a/web-local/tests/canvas/global-dimension-filters.spec.ts
+++ b/web-local/tests/canvas/global-dimension-filters.spec.ts
@@ -2,10 +2,10 @@ import { expect } from "@playwright/test";
 import { gotoNavEntry } from "web-local/tests/utils/waitHelpers";
 import { test } from "../setup/base";
 
-test.describe("canvas global time filters", () => {
+test.describe("canvas global dimension filters", () => {
   test.use({ project: "AdBids" });
 
-  test("global time filters run through", async ({ page }) => {
+  test("global dimension filters run through", async ({ page }) => {
     await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_canvas.yaml");
 

--- a/web-local/tests/canvas/global-dimension-filters.spec.ts
+++ b/web-local/tests/canvas/global-dimension-filters.spec.ts
@@ -1,0 +1,35 @@
+import { expect } from "@playwright/test";
+import { gotoNavEntry } from "web-local/tests/utils/waitHelpers";
+import { test } from "../setup/base";
+
+test.describe("canvas global time filters", () => {
+  test.use({ project: "AdBids" });
+
+  test("global time filters run through", async ({ page }) => {
+    await page.getByLabel("/dashboards").click();
+    await gotoNavEntry(page, "/dashboards/AdBids_metrics_canvas.yaml");
+
+    await page.getByRole("button", { name: "Preview" }).click();
+
+    await page.waitForTimeout(1000);
+
+    await expect(page.getByText("Total records 1,122")).toBeVisible();
+
+    await page.getByRole("button", { name: "Add filter button" }).click();
+    await page.getByRole("menuitem", { name: "Publisher" }).click();
+
+    await page.getByLabel("publisher results").getByText("Facebook").click();
+
+    await expect(page.getByText("Total records 283")).toBeVisible();
+
+    // Change filter to excluded
+    await page.getByLabel("Include exclude toggle").click();
+    await page.getByText("Exclude Publisher Facebook").click();
+
+    await expect(page.getByText("Total records 839")).toBeVisible();
+
+    await page.getByRole("button", { name: "Clear filters" }).click();
+
+    await expect(page.getByText("Total records 1,122")).toBeVisible();
+  });
+});

--- a/web-local/tests/canvas/global-time-filters.spec.ts
+++ b/web-local/tests/canvas/global-time-filters.spec.ts
@@ -1,0 +1,60 @@
+import { expect } from "@playwright/test";
+import { interactWithTimeRangeMenu } from "@rilldata/web-common/tests/utils/explore-interactions";
+import { gotoNavEntry } from "web-local/tests/utils/waitHelpers";
+import { test } from "../setup/base";
+
+test.describe("canvas global time filters", () => {
+  test.use({ project: "AdBids" });
+
+  test("global time filters run through", async ({ page }) => {
+    await page.getByLabel("/dashboards").click();
+    await gotoNavEntry(page, "/dashboards/AdBids_metrics_canvas.yaml");
+
+    await page.getByRole("button", { name: "Preview" }).click();
+
+    await page.waitForTimeout(1000);
+
+    // Change global time range
+    await interactWithTimeRangeMenu(page, async () => {
+      await page.getByRole("menuitem", { name: "Last 6 Hours" }).click();
+    });
+
+    await expect(page.getByText("Total records 272")).toBeVisible();
+
+    await interactWithTimeRangeMenu(page, async () => {
+      await page.getByRole("menuitem", { name: "Week to date" }).click();
+    });
+
+    await expect(page.getByText("Total records 3,435")).toBeVisible();
+
+    const timeGrainSelector = page.getByRole("button", {
+      name: "Select a time grain",
+    });
+    await timeGrainSelector.click();
+    await page.getByRole("menuitem", { name: "day" }).click();
+
+    await page.getByLabel("Toggle time comparison").click();
+
+    await expect(page.getByText("Total records 3,435 +52 +2%")).toBeVisible();
+
+    await interactWithTimeRangeMenu(page, async () => {
+      await page.getByRole("menuitem", { name: "Today" }).click();
+    });
+
+    await timeGrainSelector.click();
+    await page.getByRole("menuitem", { name: "hour" }).click();
+
+    await expect(page.getByText("Total records 1,122")).toBeVisible();
+
+    const timeZoneSelector = page.getByRole("button", {
+      name: "Timezone selector",
+    });
+    await timeZoneSelector.click();
+
+    await page.getByRole("textbox", { name: "Search" }).click();
+    await page.getByRole("textbox", { name: "Search" }).fill("IST");
+    await page.getByText("Asia/Calcutta").click();
+
+    await expect(page.getByText("Total records 251")).toBeVisible();
+  });
+});


### PR DESCRIPTION
Add global filters run through for canvas

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
