### PR TITLE
Add metrics view used in metrics_sql to canvas resolver

### DIFF
--- a/runtime/server/canvases.go
+++ b/runtime/server/canvases.go
@@ -3,8 +3,6 @@ package server
 import (
 	"context"
 	"errors"
-	"fmt"
-	"strings"
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
@@ -20,25 +18,150 @@ import (
 )
 
 func (s *Server) ResolveCanvas(ctx context.Context, req *runtimev1.ResolveCanvasRequest) (*runtimev1.ResolveCanvasResponse, error) {
-	canvas, ctrl, templateData, err := s.canvasResolution(ctx, req)
-	if err != nil {
-		return nil, err
+	// Add observability attributes
+	s.addInstanceRequestAttributes(ctx, req.InstanceId)
+	observability.AddRequestAttributes(ctx,
+		attribute.String("args.instance_id", req.InstanceId),
+		attribute.String("args.canvas", req.Canvas),
+	)
+
+	// Check if user has access to query for canvas data (we use the ReadAPI permission for this for now)
+	if !auth.GetClaims(ctx).CanInstance(req.InstanceId, auth.ReadAPI) {
+		return nil, status.Errorf(codes.FailedPrecondition, "does not have access to canvas data")
 	}
 
-	components, err := s.resolveCanvasComponents(ctx, ctrl, canvas, templateData)
+	// Find the canvas resource
+	ctrl, err := s.runtime.Controller(ctx, req.InstanceId)
 	if err != nil {
-		return nil, err
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	res, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindCanvas, Name: req.Canvas}, false)
+	if err != nil {
+		if errors.Is(err, drivers.ErrResourceNotFound) {
+			return nil, status.Errorf(codes.NotFound, "canvas with name %q not found", req.Canvas)
+		}
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	spec := res.GetCanvas().State.ValidSpec
+	if spec == nil {
+		return &runtimev1.ResolveCanvasResponse{
+			Canvas: res,
+		}, nil
 	}
 
-	metricsViews, err := s.resolveMetricsViews(ctx, ctrl, req.InstanceId, components)
+	// Setup templating data
+	inst, err := s.runtime.Instance(ctx, req.InstanceId)
 	if err != nil {
-		return nil, err
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	templateData := parser.TemplateData{
+		Environment: inst.Environment,
+		User:        auth.GetClaims(ctx).SecurityClaims().UserAttributes,
+		Variables:   inst.ResolveVariables(false),
+		ExtraProps: map[string]any{
+			"args": req.Args.AsMap(),
+		},
+	}
+
+	components := make(map[string]*runtimev1.Resource)
+
+	for _, row := range spec.Rows {
+		for _, item := range row.Items {
+			// Skip if already resolved.
+			if _, ok := components[item.Component]; ok {
+				continue
+			}
+
+			// Get component resource.
+			// NOTE: By passing true, we get a cloned object that is safe to modify in-place.
+			cmp, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindComponent, Name: item.Component}, true)
+			if err != nil {
+				if errors.Is(err, drivers.ErrResourceNotFound) {
+					return nil, status.Errorf(codes.Internal, "component %q in valid spec not found", item.Component)
+				}
+				return nil, err
+			}
+
+			// Resolve the renderer properties in the valid_spec.
+			validSpec := cmp.GetComponent().State.ValidSpec
+			if validSpec != nil && validSpec.RendererProperties != nil {
+				v, err := parser.ResolveTemplateRecursively(validSpec.RendererProperties.AsMap(), templateData, false)
+				if err != nil {
+					return nil, status.Errorf(codes.InvalidArgument, "component %q: failed to resolve templating: %s", item.Component, err.Error())
+				}
+
+				props, ok := v.(map[string]any)
+				if !ok {
+					return nil, status.Errorf(codes.Internal, "component %q: failed to convert resolved renderer properties to map: %v", item.Component, v)
+				}
+
+				propsPB, err := structpb.NewStruct(props)
+				if err != nil {
+					return nil, status.Errorf(codes.Internal, "component %q: failed to convert renderer properties to struct: %s", item.Component, err.Error())
+				}
+
+				validSpec.RendererProperties = propsPB
+			}
+
+			// Add to map.
+			components[item.Component] = cmp
+		}
+	}
+
+	// Extract metrics view names from components
+	metricsViews := make(map[string]bool)
+
+	for _, cmp := range components {
+		var mvNames []string
+		validSpec := cmp.GetComponent().State.ValidSpec
+		if validSpec == nil || validSpec.RendererProperties == nil {
+			continue
+		}
+
+		for k, v := range validSpec.RendererProperties.Fields {
+			switch k {
+			case "metrics_view":
+				if name := v.GetStringValue(); name != "" {
+					mvNames = append(mvNames, name)
+				}
+			case "metrics_sql":
+				if sql := v.GetStringValue(); sql != "" {
+					claims := auth.GetClaims(ctx).SecurityClaims()
+					compiler := metricssqlparser.New(ctrl, req.InstanceId, claims, 0)
+					q, err := compiler.Rewrite(ctx, sql)
+					if err == nil {
+						mvNames = append(mvNames, q.MetricsView)
+					}
+				}
+			}
+		}
+
+		for _, mvName := range mvNames {
+			if mvName != "" {
+				metricsViews[mvName] = true
+			}
+		}
+	}
+
+	// Lookup metrics view resources
+	referencedMetricsViews := make(map[string]*runtimev1.Resource)
+	for mvName := range metricsViews {
+		mv, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: mvName}, false)
+		if err != nil {
+			if errors.Is(err, drivers.ErrResourceNotFound) {
+				return nil, status.Errorf(codes.Internal, "metrics view %q in valid spec not found", mvName)
+			}
+			return nil, err
+		}
+
+		// Add to map.
+		referencedMetricsViews[mvName] = mv
 	}
 
 	return &runtimev1.ResolveCanvasResponse{
-		Canvas:                 canvas,
+		Canvas:                 res,
 		ResolvedComponents:     components,
-		ReferencedMetricsViews: metricsViews,
+		ReferencedMetricsViews: referencedMetricsViews,
 	}, nil
 }
 
@@ -114,202 +237,4 @@ func (s *Server) ResolveComponent(ctx context.Context, req *runtimev1.ResolveCom
 	return &runtimev1.ResolveComponentResponse{
 		RendererProperties: rendererProps,
 	}, nil
-}
-
-func (s *Server) canvasResolution(ctx context.Context, req *runtimev1.ResolveCanvasRequest) (*runtimev1.Resource, *runtime.Controller, parser.TemplateData, error) {
-	// Add observability attributes
-	s.addInstanceRequestAttributes(ctx, req.InstanceId)
-	observability.AddRequestAttributes(ctx,
-		attribute.String("args.instance_id", req.InstanceId),
-		attribute.String("args.canvas", req.Canvas),
-	)
-
-	// Check if user has access to query for canvas data (we use the ReadAPI permission for this for now)
-	if !auth.GetClaims(ctx).CanInstance(req.InstanceId, auth.ReadAPI) {
-		return nil, nil, parser.TemplateData{}, status.Errorf(codes.FailedPrecondition, "does not have access to canvas data")
-	}
-
-	// Find the canvas resource
-	ctrl, err := s.runtime.Controller(ctx, req.InstanceId)
-	if err != nil {
-		return nil, nil, parser.TemplateData{}, status.Error(codes.Internal, err.Error())
-	}
-	canvas, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindCanvas, Name: req.Canvas}, false)
-	if err != nil {
-		if errors.Is(err, drivers.ErrResourceNotFound) {
-			return nil, nil, parser.TemplateData{}, status.Errorf(codes.NotFound, "canvas with name %q not found", req.Canvas)
-		}
-		return nil, nil, parser.TemplateData{}, status.Error(codes.Internal, err.Error())
-	}
-	spec := canvas.GetCanvas().State.ValidSpec
-	if spec == nil {
-		return canvas, ctrl, parser.TemplateData{}, nil
-	}
-
-	// Setup templating data
-	inst, err := s.runtime.Instance(ctx, req.InstanceId)
-	if err != nil {
-		return nil, nil, parser.TemplateData{}, status.Error(codes.Internal, err.Error())
-	}
-	td := parser.TemplateData{
-		Environment: inst.Environment,
-		User:        auth.GetClaims(ctx).SecurityClaims().UserAttributes,
-		Variables:   inst.ResolveVariables(false),
-		ExtraProps: map[string]any{
-			"args": req.Args.AsMap(),
-		},
-	}
-
-	return canvas, ctrl, td, nil
-}
-
-func (s *Server) resolveCanvasComponents(ctx context.Context, ctrl *runtime.Controller, canvas *runtimev1.Resource, td parser.TemplateData) (map[string]*runtimev1.Resource, error) {
-	components := make(map[string]*runtimev1.Resource)
-	spec := canvas.GetCanvas().State.ValidSpec
-
-	for _, row := range spec.Rows {
-		for _, item := range row.Items {
-			// Skip if already resolved.
-			if _, ok := components[item.Component]; ok {
-				continue
-			}
-
-			// Get component resource.
-			// NOTE: By passing true, we get a cloned object that is safe to modify in-place.
-			cmp, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindComponent, Name: item.Component}, true)
-			if err != nil {
-				if errors.Is(err, drivers.ErrResourceNotFound) {
-					return nil, status.Errorf(codes.Internal, "component %q in valid spec not found", item.Component)
-				}
-				return nil, err
-			}
-
-			// Resolve the renderer properties in the valid_spec.
-			validSpec := cmp.GetComponent().State.ValidSpec
-			if validSpec != nil && validSpec.RendererProperties != nil {
-				v, err := parser.ResolveTemplateRecursively(validSpec.RendererProperties.AsMap(), td, false)
-				if err != nil {
-					return nil, status.Errorf(codes.InvalidArgument, "component %q: failed to resolve templating: %s", item.Component, err.Error())
-				}
-
-				props, ok := v.(map[string]any)
-				if !ok {
-					return nil, status.Errorf(codes.Internal, "component %q: failed to convert resolved renderer properties to map: %v", item.Component, v)
-				}
-
-				propsPB, err := structpb.NewStruct(props)
-				if err != nil {
-					return nil, status.Errorf(codes.Internal, "component %q: failed to convert renderer properties to struct: %s", item.Component, err.Error())
-				}
-
-				validSpec.RendererProperties = propsPB
-			}
-
-			// Add to map.
-			components[item.Component] = cmp
-		}
-	}
-
-	return components, nil
-}
-
-func (s *Server) resolveMetricsViews(ctx context.Context, ctrl *runtime.Controller, instanceID string, components map[string]*runtimev1.Resource) (map[string]*runtimev1.Resource, error) {
-	// Extract metrics view names from components
-	allMVNames := s.extractMetricsViewNames(ctx, ctrl, instanceID, components)
-
-	// Lookup metrics view resources
-	metricsViews := make(map[string]*runtimev1.Resource)
-	for _, mvName := range allMVNames {
-		mv, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: mvName}, false)
-		if err != nil {
-			if errors.Is(err, drivers.ErrResourceNotFound) {
-				return nil, status.Errorf(codes.Internal, "metrics view %q in valid spec not found", mvName)
-			}
-			return nil, err
-		}
-
-		// Add to map.
-		metricsViews[mvName] = mv
-	}
-
-	return metricsViews, nil
-}
-
-func (s *Server) extractMetricsViewNames(ctx context.Context, ctrl *runtime.Controller, instanceID string, components map[string]*runtimev1.Resource) []string {
-	allMVNames := make(map[string]bool)
-
-	for cmpName, cmp := range components {
-		mvNames := s.getMetricsViewNamesFromComponent(ctx, ctrl, instanceID, cmpName, cmp)
-
-		for _, mvName := range mvNames {
-			if mvName != "" {
-				allMVNames[mvName] = true
-			}
-		}
-	}
-
-	result := make([]string, 0, len(allMVNames))
-	for mvName := range allMVNames {
-		result = append(result, mvName)
-	}
-
-	return result
-}
-
-func (s *Server) getMetricsViewNamesFromComponent(ctx context.Context, ctrl *runtime.Controller, instanceID, cmpName string, cmp *runtimev1.Resource) []string {
-	var mvNames []string
-	validSpec := cmp.GetComponent().State.ValidSpec
-	if validSpec == nil || validSpec.RendererProperties == nil {
-		return mvNames
-	}
-
-	for k, v := range validSpec.RendererProperties.Fields {
-		switch k {
-		case "metrics_view":
-			if name := v.GetStringValue(); name != "" {
-				mvNames = append(mvNames, name)
-			}
-		case "metrics_sql":
-			mvName, err := parseMetricsViewsFromSQL(ctx, ctrl, instanceID, v.GetStringValue())
-			if err != nil {
-				observability.AddRequestAttributes(ctx,
-					attribute.String("sql_parse_error.component", cmpName),
-					attribute.String("sql_parse_error.message", err.Error()),
-				)
-				// Don't fail the entire canvas resolution if one component has an invalid SQL
-				continue
-			}
-			if mvName != "" {
-				mvNames = append(mvNames, mvName)
-			}
-		}
-	}
-
-	return mvNames
-}
-
-func parseMetricsViewsFromSQL(ctx context.Context, ctrl *runtime.Controller, instanceID, sql string) (string, error) {
-	// basic validations
-	sql = strings.TrimSpace(sql)
-	if sql == "" {
-		return "", fmt.Errorf("SQL query cannot be empty")
-	}
-
-	if len(sql) > 10000 {
-		return "", fmt.Errorf("SQL query too large")
-	}
-
-	if !strings.HasPrefix(strings.ToUpper(sql), "SELECT") {
-		return "", fmt.Errorf("only SELECT statements are allowed")
-	}
-
-	// Parse the SQL to extract metrics view
-	claims := auth.GetClaims(ctx).SecurityClaims()
-	compiler := metricssqlparser.New(ctrl, instanceID, claims, 0)
-	q, err := compiler.Rewrite(ctx, sql)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse metrics SQL: %w", err)
-	}
-
-	return q.MetricsView, nil
 }

--- a/runtime/server/canvases.go
+++ b/runtime/server/canvases.go
@@ -3,11 +3,14 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/parser"
+	metricssqlparser "github.com/rilldata/rill/runtime/pkg/metricssql"
 	"github.com/rilldata/rill/runtime/pkg/observability"
 	"github.com/rilldata/rill/runtime/server/auth"
 	"go.opentelemetry.io/otel/attribute"
@@ -17,135 +20,23 @@ import (
 )
 
 func (s *Server) ResolveCanvas(ctx context.Context, req *runtimev1.ResolveCanvasRequest) (*runtimev1.ResolveCanvasResponse, error) {
-	// Add observability attributes
-	s.addInstanceRequestAttributes(ctx, req.InstanceId)
-	observability.AddRequestAttributes(ctx,
-		attribute.String("args.instance_id", req.InstanceId),
-		attribute.String("args.canvas", req.Canvas),
-	)
-
-	// Check if user has access to query for canvas data (we use the ReadAPI permission for this for now)
-	if !auth.GetClaims(ctx).CanInstance(req.InstanceId, auth.ReadAPI) {
-		return nil, status.Errorf(codes.FailedPrecondition, "does not have access to canvas data")
-	}
-
-	// Find the canvas resource
-	ctrl, err := s.runtime.Controller(ctx, req.InstanceId)
+	canvas, ctrl, templateData, err := s.canvasResolution(ctx, req)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, err
 	}
-	res, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindCanvas, Name: req.Canvas}, false)
+
+	components, err := s.resolveCanvasComponents(ctx, ctrl, canvas, templateData)
 	if err != nil {
-		if errors.Is(err, drivers.ErrResourceNotFound) {
-			return nil, status.Errorf(codes.NotFound, "canvas with name %q not found", req.Canvas)
-		}
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	spec := res.GetCanvas().State.ValidSpec
-	if spec == nil {
-		return &runtimev1.ResolveCanvasResponse{
-			Canvas: res,
-		}, nil
+		return nil, err
 	}
 
-	// Setup templating data
-	inst, err := s.runtime.Instance(ctx, req.InstanceId)
+	metricsViews, err := s.resolveMetricsViews(ctx, ctrl, req.InstanceId, components)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	td := parser.TemplateData{
-		Environment: inst.Environment,
-		User:        auth.GetClaims(ctx).SecurityClaims().UserAttributes,
-		Variables:   inst.ResolveVariables(false),
-		ExtraProps: map[string]any{
-			"args": req.Args.AsMap(),
-		},
+		return nil, err
 	}
 
-	// Build map of referenced components.
-	components := make(map[string]*runtimev1.Resource)
-	for _, row := range spec.Rows {
-		for _, item := range row.Items {
-			// Skip if already resolved.
-			if _, ok := components[item.Component]; ok {
-				continue
-			}
-
-			// Get component resource.
-			// NOTE: By passing true, we get a cloned object that is safe to modify in-place.
-			cmp, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindComponent, Name: item.Component}, true)
-			if err != nil {
-				if errors.Is(err, drivers.ErrResourceNotFound) {
-					return nil, status.Errorf(codes.Internal, "component %q in valid spec not found", item.Component)
-				}
-				return nil, err
-			}
-
-			// Resolve the renderer properties in the valid_spec.
-			validSpec := cmp.GetComponent().State.ValidSpec
-			if validSpec != nil && validSpec.RendererProperties != nil {
-				v, err := parser.ResolveTemplateRecursively(validSpec.RendererProperties.AsMap(), td, false)
-				if err != nil {
-					return nil, status.Errorf(codes.InvalidArgument, "component %q: failed to resolve templating: %s", item.Component, err.Error())
-				}
-
-				props, ok := v.(map[string]any)
-				if !ok {
-					return nil, status.Errorf(codes.Internal, "component %q: failed to convert resolved renderer properties to map: %v", item.Component, v)
-				}
-
-				propsPB, err := structpb.NewStruct(props)
-				if err != nil {
-					return nil, status.Errorf(codes.Internal, "component %q: failed to convert renderer properties to struct: %s", item.Component, err.Error())
-				}
-
-				validSpec.RendererProperties = propsPB
-			}
-
-			// Add to map.
-			components[item.Component] = cmp
-		}
-	}
-
-	// Build map of referenced metrics views.
-	metricsViews := make(map[string]*runtimev1.Resource)
-	for cmpName, cmp := range components {
-		// Look for a metrics view reference in the renderer properties.
-		var mvName string
-		validSpec := cmp.GetComponent().State.ValidSpec
-		if validSpec != nil && validSpec.RendererProperties != nil {
-			for k, v := range validSpec.RendererProperties.Fields {
-				if k == "metrics_view" {
-					mvName = v.GetStringValue()
-					break
-				}
-			}
-		}
-		if mvName == "" {
-			continue
-		}
-
-		// Skip if already resolved.
-		if _, ok := metricsViews[mvName]; ok {
-			continue
-		}
-
-		// Get metrics view resource.
-		mv, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: mvName}, false)
-		if err != nil {
-			if errors.Is(err, drivers.ErrResourceNotFound) {
-				return nil, status.Errorf(codes.Internal, "component %q: metrics view %q in valid spec not found", cmpName, mvName)
-			}
-			return nil, err
-		}
-
-		// Add to map.
-		metricsViews[mvName] = mv
-	}
-
-	// Return the response
 	return &runtimev1.ResolveCanvasResponse{
-		Canvas:                 res,
+		Canvas:                 canvas,
 		ResolvedComponents:     components,
 		ReferencedMetricsViews: metricsViews,
 	}, nil
@@ -223,4 +114,202 @@ func (s *Server) ResolveComponent(ctx context.Context, req *runtimev1.ResolveCom
 	return &runtimev1.ResolveComponentResponse{
 		RendererProperties: rendererProps,
 	}, nil
+}
+
+func (s *Server) canvasResolution(ctx context.Context, req *runtimev1.ResolveCanvasRequest) (*runtimev1.Resource, *runtime.Controller, parser.TemplateData, error) {
+	// Add observability attributes
+	s.addInstanceRequestAttributes(ctx, req.InstanceId)
+	observability.AddRequestAttributes(ctx,
+		attribute.String("args.instance_id", req.InstanceId),
+		attribute.String("args.canvas", req.Canvas),
+	)
+
+	// Check if user has access to query for canvas data (we use the ReadAPI permission for this for now)
+	if !auth.GetClaims(ctx).CanInstance(req.InstanceId, auth.ReadAPI) {
+		return nil, nil, parser.TemplateData{}, status.Errorf(codes.FailedPrecondition, "does not have access to canvas data")
+	}
+
+	// Find the canvas resource
+	ctrl, err := s.runtime.Controller(ctx, req.InstanceId)
+	if err != nil {
+		return nil, nil, parser.TemplateData{}, status.Error(codes.Internal, err.Error())
+	}
+	canvas, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindCanvas, Name: req.Canvas}, false)
+	if err != nil {
+		if errors.Is(err, drivers.ErrResourceNotFound) {
+			return nil, nil, parser.TemplateData{}, status.Errorf(codes.NotFound, "canvas with name %q not found", req.Canvas)
+		}
+		return nil, nil, parser.TemplateData{}, status.Error(codes.Internal, err.Error())
+	}
+	spec := canvas.GetCanvas().State.ValidSpec
+	if spec == nil {
+		return canvas, ctrl, parser.TemplateData{}, nil
+	}
+
+	// Setup templating data
+	inst, err := s.runtime.Instance(ctx, req.InstanceId)
+	if err != nil {
+		return nil, nil, parser.TemplateData{}, status.Error(codes.Internal, err.Error())
+	}
+	td := parser.TemplateData{
+		Environment: inst.Environment,
+		User:        auth.GetClaims(ctx).SecurityClaims().UserAttributes,
+		Variables:   inst.ResolveVariables(false),
+		ExtraProps: map[string]any{
+			"args": req.Args.AsMap(),
+		},
+	}
+
+	return canvas, ctrl, td, nil
+}
+
+func (s *Server) resolveCanvasComponents(ctx context.Context, ctrl *runtime.Controller, canvas *runtimev1.Resource, td parser.TemplateData) (map[string]*runtimev1.Resource, error) {
+	components := make(map[string]*runtimev1.Resource)
+	spec := canvas.GetCanvas().State.ValidSpec
+
+	for _, row := range spec.Rows {
+		for _, item := range row.Items {
+			// Skip if already resolved.
+			if _, ok := components[item.Component]; ok {
+				continue
+			}
+
+			// Get component resource.
+			// NOTE: By passing true, we get a cloned object that is safe to modify in-place.
+			cmp, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindComponent, Name: item.Component}, true)
+			if err != nil {
+				if errors.Is(err, drivers.ErrResourceNotFound) {
+					return nil, status.Errorf(codes.Internal, "component %q in valid spec not found", item.Component)
+				}
+				return nil, err
+			}
+
+			// Resolve the renderer properties in the valid_spec.
+			validSpec := cmp.GetComponent().State.ValidSpec
+			if validSpec != nil && validSpec.RendererProperties != nil {
+				v, err := parser.ResolveTemplateRecursively(validSpec.RendererProperties.AsMap(), td, false)
+				if err != nil {
+					return nil, status.Errorf(codes.InvalidArgument, "component %q: failed to resolve templating: %s", item.Component, err.Error())
+				}
+
+				props, ok := v.(map[string]any)
+				if !ok {
+					return nil, status.Errorf(codes.Internal, "component %q: failed to convert resolved renderer properties to map: %v", item.Component, v)
+				}
+
+				propsPB, err := structpb.NewStruct(props)
+				if err != nil {
+					return nil, status.Errorf(codes.Internal, "component %q: failed to convert renderer properties to struct: %s", item.Component, err.Error())
+				}
+
+				validSpec.RendererProperties = propsPB
+			}
+
+			// Add to map.
+			components[item.Component] = cmp
+		}
+	}
+
+	return components, nil
+}
+
+func (s *Server) resolveMetricsViews(ctx context.Context, ctrl *runtime.Controller, instanceID string, components map[string]*runtimev1.Resource) (map[string]*runtimev1.Resource, error) {
+	// Extract metrics view names from components
+	allMVNames := s.extractMetricsViewNames(ctx, ctrl, instanceID, components)
+
+	// Lookup metrics view resources
+	metricsViews := make(map[string]*runtimev1.Resource)
+	for _, mvName := range allMVNames {
+		mv, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: mvName}, false)
+		if err != nil {
+			if errors.Is(err, drivers.ErrResourceNotFound) {
+				return nil, status.Errorf(codes.Internal, "metrics view %q in valid spec not found", mvName)
+			}
+			return nil, err
+		}
+
+		// Add to map.
+		metricsViews[mvName] = mv
+	}
+
+	return metricsViews, nil
+}
+
+func (s *Server) extractMetricsViewNames(ctx context.Context, ctrl *runtime.Controller, instanceID string, components map[string]*runtimev1.Resource) []string {
+	allMVNames := make(map[string]bool)
+
+	for cmpName, cmp := range components {
+		mvNames := s.getMetricsViewNamesFromComponent(ctx, ctrl, instanceID, cmpName, cmp)
+
+		for _, mvName := range mvNames {
+			if mvName != "" {
+				allMVNames[mvName] = true
+			}
+		}
+	}
+
+	result := make([]string, 0, len(allMVNames))
+	for mvName := range allMVNames {
+		result = append(result, mvName)
+	}
+
+	return result
+}
+
+func (s *Server) getMetricsViewNamesFromComponent(ctx context.Context, ctrl *runtime.Controller, instanceID, cmpName string, cmp *runtimev1.Resource) []string {
+	var mvNames []string
+	validSpec := cmp.GetComponent().State.ValidSpec
+	if validSpec == nil || validSpec.RendererProperties == nil {
+		return mvNames
+	}
+
+	for k, v := range validSpec.RendererProperties.Fields {
+		switch k {
+		case "metrics_view":
+			if name := v.GetStringValue(); name != "" {
+				mvNames = append(mvNames, name)
+			}
+		case "metrics_sql":
+			mvName, err := parseMetricsViewsFromSQL(ctx, ctrl, instanceID, v.GetStringValue())
+			if err != nil {
+				observability.AddRequestAttributes(ctx,
+					attribute.String("sql_parse_error.component", cmpName),
+					attribute.String("sql_parse_error.message", err.Error()),
+				)
+				// Don't fail the entire canvas resolution if one component has an invalid SQL
+				continue
+			}
+			if mvName != "" {
+				mvNames = append(mvNames, mvName)
+			}
+		}
+	}
+
+	return mvNames
+}
+
+func parseMetricsViewsFromSQL(ctx context.Context, ctrl *runtime.Controller, instanceID, sql string) (string, error) {
+	// basic validations
+	sql = strings.TrimSpace(sql)
+	if sql == "" {
+		return "", fmt.Errorf("SQL query cannot be empty")
+	}
+
+	if len(sql) > 10000 {
+		return "", fmt.Errorf("SQL query too large")
+	}
+
+	if !strings.HasPrefix(strings.ToUpper(sql), "SELECT") {
+		return "", fmt.Errorf("only SELECT statements are allowed")
+	}
+
+	// Parse the SQL to extract metrics view
+	claims := auth.GetClaims(ctx).SecurityClaims()
+	compiler := metricssqlparser.New(ctrl, instanceID, claims, 0)
+	q, err := compiler.Rewrite(ctx, sql)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse metrics SQL: %w", err)
+	}
+
+	return q.MetricsView, nil
 }

--- a/runtime/server/canvases_test.go
+++ b/runtime/server/canvases_test.go
@@ -22,6 +22,9 @@ func TestResolveCanvas(t *testing.T) {
 			"m1.sql": `
 SELECT 'US' AS country
 `,
+			"m2.sql": `
+SELECT 'PA' AS state
+`,
 			// Metrics view
 			"mv1.yaml": `
 type: metrics_view
@@ -29,6 +32,16 @@ version: 1
 model: m1
 dimensions:
 - column: country
+measures:
+- expression: COUNT(*)
+`,
+			// Metrics view
+			"mv2.yaml": `
+type: metrics_view
+version: 1
+model: m2
+dimensions:
+- column: state
 measures:
 - expression: COUNT(*)
 `,
@@ -43,13 +56,15 @@ rows:
       metrics_view: mv1
       foo: "{{ .args.foo }}"
       bar: "{{ .env.bar }}"
+  - kpi:
+      metrics_sql: "SELECT state FROM mv2 WHERE state = 'PA'"
 `,
 		},
 		Variables: map[string]string{
 			"bar": "bar",
 		},
 	})
-	testruntime.RequireReconcileState(t, rt, instanceID, 6, 0, 0)
+	testruntime.RequireReconcileState(t, rt, instanceID, 9, 0, 0)
 
 	server, err := server.NewServer(context.Background(), &server.Options{}, rt, zap.NewNop(), ratelimit.NewNoop(), activity.NewNoopClient())
 	require.NoError(t, err)
@@ -67,8 +82,7 @@ rows:
 	require.Equal(t, "c1", res.Canvas.Meta.Name.Name)
 	require.NotNil(t, res.Canvas.GetCanvas().State.ValidSpec)
 
-	// Check components resolved correctly
-	require.Len(t, res.ResolvedComponents, 2)
+	require.Len(t, res.ResolvedComponents, 3)
 	comp0Props := res.ResolvedComponents["c1--component-0-0"].GetComponent().State.ValidSpec.RendererProperties.AsMap()
 	require.Len(t, comp0Props, 1)
 	require.Equal(t, "mv1", comp0Props["metrics_view"])
@@ -79,8 +93,233 @@ rows:
 	require.Equal(t, "bar", comp1Props["bar"])
 
 	// Check referenced metrics views
-	require.Len(t, res.ReferencedMetricsViews, 1)
+	require.Len(t, res.ReferencedMetricsViews, 2)
 	require.Equal(t, "m1", res.ReferencedMetricsViews["mv1"].GetMetricsView().State.ValidSpec.Model)
+	require.Equal(t, "m2", res.ReferencedMetricsViews["mv2"].GetMetricsView().State.ValidSpec.Model)
+}
+
+func TestResolveCanvasWithInvalidSQL(t *testing.T) {
+	rt, instanceID := testruntime.NewInstanceWithOptions(t, testruntime.InstanceOptions{
+		Files: map[string]string{
+			"rill.yaml": "",
+			"m1.sql":    `SELECT 'US' AS country`,
+			"mv1.yaml": `
+type: metrics_view
+version: 1
+model: m1
+dimensions:
+- column: country
+measures:
+- expression: COUNT(*)
+`,
+			"c_invalid.yaml": `
+type: canvas
+rows:
+- items:
+  - kpi:
+      metrics_view: mv1
+  - kpi:
+      metrics_sql: "INVALID SQL SYNTAX HERE"
+  - kpi:
+      metrics_sql: "SELECT * FROM nonexistent_mv"
+`,
+		},
+	})
+	testruntime.RequireReconcileState(t, rt, instanceID, 7, 0, 0)
+
+	server, err := server.NewServer(context.Background(), &server.Options{}, rt, zap.NewNop(), ratelimit.NewNoop(), activity.NewNoopClient())
+	require.NoError(t, err)
+
+	res, err := server.ResolveCanvas(testCtx(), &runtimev1.ResolveCanvasRequest{
+		InstanceId: instanceID,
+		Canvas:     "c_invalid",
+	})
+
+	// Should still resolve components and their metrics views
+	require.Len(t, res.ResolvedComponents, 3, "All components should be resolved even with invalid SQL")
+	require.Len(t, res.ReferencedMetricsViews, 1, "Should only include mv1 from valid component")
+	require.Contains(t, res.ReferencedMetricsViews, "mv1")
+}
+
+func TestResolveCanvasWithTemplatedSQL(t *testing.T) {
+	rt, instanceID := testruntime.NewInstanceWithOptions(t, testruntime.InstanceOptions{
+		Files: map[string]string{
+			"rill.yaml": "",
+			"m1.sql":    `SELECT 'US' AS country`,
+			"m2.sql":    `SELECT 'CA' AS country`,
+			"mv1.yaml": `
+type: metrics_view
+version: 1
+model: m1
+dimensions:
+- column: country
+measures:
+- expression: COUNT(*)
+`,
+			"mv2.yaml": `
+type: metrics_view
+version: 1
+model: m2
+dimensions:
+- column: country
+measures:
+- expression: COUNT(*)
+`,
+			"c_templated.yaml": `
+type: canvas
+rows:
+- items:
+  - kpi:
+      metrics_sql: "SELECT country FROM {{ .args.metrics_view_name }}"
+  - kpi:
+      metrics_sql: "SELECT country FROM {{ .env.default_mv }}"
+`,
+		},
+		Variables: map[string]string{
+			"default_mv": "mv2",
+		},
+	})
+	testruntime.RequireReconcileState(t, rt, instanceID, 8, 0, 0)
+
+	server, err := server.NewServer(context.Background(), &server.Options{}, rt, zap.NewNop(), ratelimit.NewNoop(), activity.NewNoopClient())
+	require.NoError(t, err)
+
+	res, err := server.ResolveCanvas(testCtx(), &runtimev1.ResolveCanvasRequest{
+		InstanceId: instanceID,
+		Canvas:     "c_templated",
+		Args: must(structpb.NewStruct(map[string]any{
+			"metrics_view_name": "mv1",
+		})),
+	})
+	require.NoError(t, err)
+
+	// Check that both mv1 and mv2 are referenced through templated SQL
+	require.Len(t, res.ReferencedMetricsViews, 2)
+	require.Contains(t, res.ReferencedMetricsViews, "mv1")
+	require.Contains(t, res.ReferencedMetricsViews, "mv2")
+
+	// Check that templates were resolved in the components
+	require.Len(t, res.ResolvedComponents, 2)
+	comp0Props := res.ResolvedComponents["c_templated--component-0-0"].GetComponent().State.ValidSpec.RendererProperties.AsMap()
+	require.Equal(t, "SELECT country FROM mv1", comp0Props["metrics_sql"])
+	comp1Props := res.ResolvedComponents["c_templated--component-0-1"].GetComponent().State.ValidSpec.RendererProperties.AsMap()
+	require.Equal(t, "SELECT country FROM mv2", comp1Props["metrics_sql"])
+}
+
+func TestResolveCanvasWithEmptyCanvas(t *testing.T) {
+	rt, instanceID := testruntime.NewInstanceWithOptions(t, testruntime.InstanceOptions{
+		Files: map[string]string{
+			"rill.yaml": "",
+			"c_empty.yaml": `
+type: canvas
+rows: []
+`,
+		},
+	})
+	testruntime.RequireReconcileState(t, rt, instanceID, 2, 0, 0)
+
+	server, err := server.NewServer(context.Background(), &server.Options{}, rt, zap.NewNop(), ratelimit.NewNoop(), activity.NewNoopClient())
+	require.NoError(t, err)
+
+	res, err := server.ResolveCanvas(testCtx(), &runtimev1.ResolveCanvasRequest{
+		InstanceId: instanceID,
+		Canvas:     "c_empty",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "c_empty", res.Canvas.Meta.Name.Name)
+	require.Len(t, res.ResolvedComponents, 0)
+	require.Len(t, res.ReferencedMetricsViews, 0)
+}
+
+func TestResolveCanvasWithMultipleMetricsViewsReferences(t *testing.T) {
+	rt, instanceID := testruntime.NewInstanceWithOptions(t, testruntime.InstanceOptions{
+		Files: map[string]string{
+			"rill.yaml": "",
+			"m1.sql":    `SELECT 'US' AS country`,
+			"mv1.yaml": `
+type: metrics_view
+version: 1
+model: m1
+dimensions:
+- column: country
+measures:
+- expression: COUNT(*)
+`,
+			"c_duplicate.yaml": `
+type: canvas
+rows:
+- items:
+  - kpi:
+      metrics_view: mv1
+  - kpi:
+      metrics_view: mv1
+  - kpi:
+      metrics_sql: "SELECT country FROM mv1"
+`,
+		},
+	})
+	testruntime.RequireReconcileState(t, rt, instanceID, 7, 0, 0)
+
+	server, err := server.NewServer(context.Background(), &server.Options{}, rt, zap.NewNop(), ratelimit.NewNoop(), activity.NewNoopClient())
+	require.NoError(t, err)
+
+	res, err := server.ResolveCanvas(testCtx(), &runtimev1.ResolveCanvasRequest{
+		InstanceId: instanceID,
+		Canvas:     "c_duplicate",
+	})
+	require.NoError(t, err)
+
+	require.Len(t, res.ReferencedMetricsViews, 1)
+	require.Contains(t, res.ReferencedMetricsViews, "mv1")
+	require.Len(t, res.ResolvedComponents, 3)
+}
+
+func TestResolveCanvasWithMetricsSQL(t *testing.T) {
+	rt, instanceID := testruntime.NewInstanceWithOptions(t, testruntime.InstanceOptions{
+		Files: map[string]string{
+			"rill.yaml": "",
+			"m1.sql":    `SELECT 'US' AS country, 100 AS revenue`,
+			"mv1.yaml": `
+type: metrics_view
+version: 1
+model: m1
+dimensions:
+- column: country
+measures:
+- expression: COUNT(*)
+  name: total_records
+- expression: SUM(revenue)
+  name: total_revenue
+`,
+			"c_complex.yaml": `
+type: canvas
+rows:
+- items:
+  - kpi:
+      metrics_sql: "SELECT country, total_revenue FROM mv1 WHERE country = 'US'"
+  - kpi:
+      metrics_sql: "SELECT COUNT(*) as count FROM mv1 GROUP BY country HAVING count > 5"
+  - kpi:
+      metrics_sql: "SELECT country FROM mv1 ORDER BY total_revenue DESC LIMIT 10"
+`,
+		},
+	})
+	testruntime.RequireReconcileState(t, rt, instanceID, 7, 0, 0)
+
+	server, err := server.NewServer(context.Background(), &server.Options{}, rt, zap.NewNop(), ratelimit.NewNoop(), activity.NewNoopClient())
+	require.NoError(t, err)
+
+	res, err := server.ResolveCanvas(testCtx(), &runtimev1.ResolveCanvasRequest{
+		InstanceId: instanceID,
+		Canvas:     "c_complex",
+	})
+	require.NoError(t, err)
+
+	// All complex SQL queries should parse mv1 correctly
+	require.Len(t, res.ReferencedMetricsViews, 1)
+	require.Contains(t, res.ReferencedMetricsViews, "mv1")
+	require.Len(t, res.ResolvedComponents, 3)
 }
 
 func must[T any](v T, err error) T {


### PR DESCRIPTION
Extract metrics views from components metrics sql. This will enable the canvas resolver to return a full list of metrics view referenced by all the components

Using the `Open RTB Ads` sample

```yaml
type: canvas
display_name: Test
defaults:
  time_range: PT24H
  comparison_mode: time
rows:
  - items:
      - kpi:
          metrics_sql: SELECT app_site_name FROM auction_metrics
        width: 12
    height: 40px
  - items:
      - bar_chart:
          metrics_view: bids_metrics
          color: hsl(246, 66%, 50%)
          x:
            type: temporal
            field: __time
            sort: -y
            limit: 20
          y:
            type: quantitative
            field: video_completion_rate
            zeroBasedOrigin: true
        width: 12

```

Sample canvas resolver 

```json
{
    "canvas": {},
    "resolvedComponents": {},
    "referencedMetricsViews": {
        "auction_metrics": {},
        "bids_metrics": {}
    }
}
```


**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] [Linked](https://linear.app/rilldata/issue/PLAT-126/add-metrics-view-used-in-metrics-sql-to-canvas-resolver) the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
