### PR TITLE
fix: alert execution when rill time syntax is used

### DIFF
--- a/runtime/queries/proto.go
+++ b/runtime/queries/proto.go
@@ -177,7 +177,13 @@ func overrideTimeRange(tr *runtimev1.TimeRange, t time.Time) *runtimev1.TimeRang
 		tr = &runtimev1.TimeRange{}
 	}
 
-	tr.End = timestamppb.New(t)
+	if tr.Expression != "" {
+		// Do not override the `end` when we are using expression.
+		// Instead, add `as of <time>`
+		tr.Expression = fmt.Sprintf("%s as of %s", tr.Expression, t.UTC().Format(time.RFC3339Nano))
+		return tr
+	}
 
+	tr.End = timestamppb.New(t)
 	return tr
 }


### PR DESCRIPTION
We set `end` to `executionTime` while running an alert. But with rill time we need to update the time range to use `as of <execution_time>`

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
