### PR TITLE
Do not hide actions cell for non-reconciling resources

### DIFF
--- a/web-admin/src/features/projects/status/ActionsCell.svelte
+++ b/web-admin/src/features/projects/status/ActionsCell.svelte
@@ -8,7 +8,7 @@
   export let resourceKind: string;
   export let resourceName: string;
   export let canRefresh: boolean;
-  export let onOpenRefreshDialog: (
+  export let onClickRefreshDialog: (
     resourceName: string,
     resourceKind: string,
     refreshType: "full" | "incremental",
@@ -29,7 +29,7 @@
         <DropdownMenu.Item
           class="font-normal flex items-center"
           on:click={() => {
-            onOpenRefreshDialog(resourceName, resourceKind, "full");
+            onClickRefreshDialog(resourceName, resourceKind, "full");
           }}
         >
           <div class="flex items-center">
@@ -40,7 +40,7 @@
         <DropdownMenu.Item
           class="font-normal flex items-center"
           on:click={() => {
-            onOpenRefreshDialog(resourceName, resourceKind, "incremental");
+            onClickRefreshDialog(resourceName, resourceKind, "incremental");
           }}
         >
           <div class="flex items-center">
@@ -52,7 +52,7 @@
         <DropdownMenu.Item
           class="font-normal flex items-center"
           on:click={() => {
-            onOpenRefreshDialog(resourceName, resourceKind, "full");
+            onClickRefreshDialog(resourceName, resourceKind, "full");
           }}
         >
           <div class="flex items-center">

--- a/web-admin/src/features/projects/status/ActionsCell.svelte
+++ b/web-admin/src/features/projects/status/ActionsCell.svelte
@@ -3,59 +3,22 @@
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
   import ThreeDot from "@rilldata/web-common/components/icons/ThreeDot.svelte";
   import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
-  import {
-    createRuntimeServiceCreateTrigger,
-    getRuntimeServiceListResourcesQueryKey,
-  } from "@rilldata/web-common/runtime-client";
-  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
-  import { useQueryClient } from "@tanstack/svelte-query";
   import { RefreshCcwIcon } from "lucide-svelte";
-  import RefreshResourceConfirmDialog from "./RefreshResourceConfirmDialog.svelte";
 
   export let resourceKind: string;
   export let resourceName: string;
   export let canRefresh: boolean;
-
-  let isConfirmDialogOpen = false;
-  let isDropdownOpen = false;
-  let refreshType: "full" | "incremental" = "full";
-
-  const createTrigger = createRuntimeServiceCreateTrigger();
-  const queryClient = useQueryClient();
-
-  async function refresh() {
-    if (resourceKind === ResourceKind.Model) {
-      await $createTrigger.mutateAsync({
-        instanceId: $runtime.instanceId,
-        data: {
-          models: [
-            {
-              model: resourceName,
-              full: refreshType === "full",
-            },
-          ],
-        },
-      });
-    } else {
-      await $createTrigger.mutateAsync({
-        instanceId: $runtime.instanceId,
-        data: {
-          resources: [{ kind: resourceKind, name: resourceName }],
-        },
-      });
-    }
-
-    await queryClient.invalidateQueries({
-      queryKey: getRuntimeServiceListResourcesQueryKey(
-        $runtime.instanceId,
-        undefined,
-      ),
-    });
-  }
+  export let onOpenRefreshDialog: (
+    resourceName: string,
+    resourceKind: string,
+    refreshType: "full" | "incremental",
+  ) => void;
+  export let isDropdownOpen: boolean;
+  export let onDropdownOpenChange: (isOpen: boolean) => void;
 </script>
 
 {#if canRefresh}
-  <DropdownMenu.Root bind:open={isDropdownOpen}>
+  <DropdownMenu.Root open={isDropdownOpen} onOpenChange={onDropdownOpenChange}>
     <DropdownMenu.Trigger class="flex-none">
       <IconButton rounded active={isDropdownOpen} size={20}>
         <ThreeDot size="16px" />
@@ -66,8 +29,7 @@
         <DropdownMenu.Item
           class="font-normal flex items-center"
           on:click={() => {
-            refreshType = "full";
-            isConfirmDialogOpen = true;
+            onOpenRefreshDialog(resourceName, resourceKind, "full");
           }}
         >
           <div class="flex items-center">
@@ -78,8 +40,7 @@
         <DropdownMenu.Item
           class="font-normal flex items-center"
           on:click={() => {
-            refreshType = "incremental";
-            isConfirmDialogOpen = true;
+            onOpenRefreshDialog(resourceName, resourceKind, "incremental");
           }}
         >
           <div class="flex items-center">
@@ -91,8 +52,7 @@
         <DropdownMenu.Item
           class="font-normal flex items-center"
           on:click={() => {
-            refreshType = "full";
-            isConfirmDialogOpen = true;
+            onOpenRefreshDialog(resourceName, resourceKind, "full");
           }}
         >
           <div class="flex items-center">
@@ -104,13 +64,3 @@
     </DropdownMenu.Content>
   </DropdownMenu.Root>
 {/if}
-
-<RefreshResourceConfirmDialog
-  bind:open={isConfirmDialogOpen}
-  name={resourceName}
-  {refreshType}
-  onRefresh={() => {
-    void refresh();
-    isConfirmDialogOpen = false;
-  }}
-/>

--- a/web-admin/src/features/projects/status/ProjectResources.svelte
+++ b/web-admin/src/features/projects/status/ProjectResources.svelte
@@ -20,7 +20,6 @@
   const createTrigger = createRuntimeServiceCreateTrigger();
 
   let isConfirmDialogOpen = false;
-  let isReconciling = false;
 
   const INITIAL_REFETCH_INTERVAL = 200; // Start at 200ms for immediate feedback
   const MAX_REFETCH_INTERVAL = 2_000; // Cap at 2s
@@ -96,13 +95,9 @@
     isResourceReconciling,
   );
 
-  $: isReconciling = Boolean(hasReconcilingResources);
-
   $: isRefreshButtonDisabled = hasReconcilingResources;
 
   function refreshAllSourcesAndModels() {
-    isReconciling = false;
-
     void $createTrigger
       .mutateAsync({
         instanceId,
@@ -141,7 +136,7 @@
       Error loading resources: {$resources.error?.message}
     </div>
   {:else if $resources.data}
-    <ProjectResourcesTable data={$resources?.data?.resources} {isReconciling} />
+    <ProjectResourcesTable data={$resources?.data?.resources} />
   {/if}
 </section>
 

--- a/web-admin/src/features/projects/status/ProjectResourcesTable.svelte
+++ b/web-admin/src/features/projects/status/ProjectResourcesTable.svelte
@@ -96,7 +96,7 @@
       header: "",
       cell: ({ row }) => {
         // Only hide actions for reconciling rows
-        const status = row.original.meta.reconcileStatus;
+        const status = row.original.meta?.reconcileStatus;
         const isRowReconciling =
           status === V1ReconcileStatus.RECONCILE_STATUS_PENDING ||
           status === V1ReconcileStatus.RECONCILE_STATUS_RUNNING;

--- a/web-admin/src/features/projects/status/ProjectResourcesTable.svelte
+++ b/web-admin/src/features/projects/status/ProjectResourcesTable.svelte
@@ -18,7 +18,6 @@
   import ActionsCell from "./ActionsCell.svelte";
 
   export let data: V1Resource[];
-  export let isReconciling: boolean;
 
   const columns: ColumnDef<V1Resource, any>[] = [
     {

--- a/web-admin/src/features/projects/status/ProjectResourcesTable.svelte
+++ b/web-admin/src/features/projects/status/ProjectResourcesTable.svelte
@@ -181,7 +181,7 @@
             canRefresh:
               row.original.meta.name.kind === ResourceKind.Model ||
               row.original.meta.name.kind === ResourceKind.Source,
-            onOpenRefreshDialog: openRefreshDialog,
+            onClickRefreshDialog: openRefreshDialog,
             isDropdownOpen: isDropdownOpen(resourceKey),
             onDropdownOpenChange: (isOpen: boolean) =>
               setDropdownOpen(resourceKey, isOpen),

--- a/web-admin/src/features/projects/status/ProjectResourcesTable.svelte
+++ b/web-admin/src/features/projects/status/ProjectResourcesTable.svelte
@@ -26,19 +26,16 @@
 
   export let data: V1Resource[];
 
-  // Dialog state management to prevent dialogs from closing on table re-renders
   let isConfirmDialogOpen = false;
   let dialogResourceName = "";
   let dialogResourceKind = "";
   let dialogRefreshType: "full" | "incremental" = "full";
 
-  // Dropdown state management to prevent dropdowns from closing on table re-renders
   let openDropdownResourceKey = "";
 
   const createTrigger = createRuntimeServiceCreateTrigger();
   const queryClient = useQueryClient();
 
-  // Make these functions stable by using const declarations
   const openRefreshDialog = (
     resourceName: string,
     resourceKind: string,

--- a/web-admin/src/features/projects/status/ProjectResourcesTable.svelte
+++ b/web-admin/src/features/projects/status/ProjectResourcesTable.svelte
@@ -96,7 +96,12 @@
       accessorKey: "actions",
       header: "",
       cell: ({ row }) => {
-        if (!isReconciling) {
+        // Only hide actions for reconciling rows
+        const status = row.original.meta.reconcileStatus;
+        const isRowReconciling =
+          status === V1ReconcileStatus.RECONCILE_STATUS_PENDING ||
+          status === V1ReconcileStatus.RECONCILE_STATUS_RUNNING;
+        if (!isRowReconciling) {
           return flexRender(ActionsCell, {
             resourceKind: row.original.meta.name.kind,
             resourceName: row.original.meta.name.name,

--- a/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
+++ b/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
@@ -152,7 +152,6 @@
 
   $: ({ length: allErrorsLength } = $allErrors);
 
-  $: includingTomorrowDate = DateTime.now().plus({ days: 1 }).startOf("day");
   $: maxExpirationDate = DateTime.now().plus({ years: 1 }).startOf("day");
 </script>
 

--- a/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
+++ b/web-admin/src/features/public-urls/CreatePublicURLForm.svelte
@@ -197,7 +197,6 @@
                 <Calendar
                   selection={DateTime.fromISO($form.expiresAt)}
                   singleDaySelection
-                  minDate={includingTomorrowDate}
                   maxDate={maxExpirationDate}
                   firstVisibleMonth={DateTime.fromISO($form.expiresAt)}
                   onSelectDay={(date) => {


### PR DESCRIPTION
This PR changes the actions cell visibility logic in the project resources table. Previously, the actions cell was hidden for the entire table when any resource was reconciling. Now, it only hides the actions cell for individual rows where that specific resource is reconciling. In addition to that, when you run an incremental refresh on one resource and open another resource's actions dropdown, both the dropdown and any subsequent dialog will stay open even when the first resource finishes running and updates the table data.

Closes https://linear.app/rilldata/issue/APP-232/project-status-page-dont-hide-model-refresh-button-when-a-different

https://github.com/user-attachments/assets/1bd7ce83-94bb-4c48-9068-28f71f58a3d2

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
