### PR TITLE
Fix "Log-in / Sign Up" button click handler

### DIFF
--- a/web-admin/src/client/redirect-utils.ts
+++ b/web-admin/src/client/redirect-utils.ts
@@ -4,8 +4,20 @@ import {
 } from "@rilldata/web-admin/client/http-client";
 import { redirect } from "@sveltejs/kit";
 
+/**
+ * Redirects to the login page by throwing a SvelteKit redirect.
+ * Use this in SvelteKit load functions (+page.ts, +layout.ts, etc.)
+ */
 export function redirectToLogin() {
   throw redirect(307, buildLoginUrl());
+}
+
+/**
+ * Redirects to the login page using window.location.href.
+ * Use this in Svelte component event handlers (onClick, etc.)
+ */
+export function redirectToLoginFromComponent() {
+  window.location.href = buildLoginUrl();
 }
 
 export function redirectToLogout() {

--- a/web-admin/src/features/authentication/SignIn.svelte
+++ b/web-admin/src/features/authentication/SignIn.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import { redirectToLogin } from "@rilldata/web-admin/client/redirect-utils";
+  import { redirectToLoginFromComponent } from "@rilldata/web-admin/client/redirect-utils";
   import { Button } from "@rilldata/web-common/components/button";
 </script>
 
-<Button type="primary" onClick={redirectToLogin}>Log In / Sign Up</Button>
+<Button type="primary" onClick={redirectToLoginFromComponent}
+  >Log In / Sign Up</Button
+>


### PR DESCRIPTION
The login button in `SignIn.svelte` was using `redirectToLogin()` which throws a SvelteKit redirect. This works in load functions but fails when called from component event handlers, causing the login button to not work properly.

Closes [PLAT-141](https://linear.app/rilldata/issue/PLAT-141/log-in-sign-up-button-does-not-work-when-in-a-logged-out-state)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
