### PR TITLE
fix: chart query enable condition

### DIFF
--- a/web-common/src/features/canvas/components/charts/cartesian-charts/CartesianChart.ts
+++ b/web-common/src/features/canvas/components/charts/cartesian-charts/CartesianChart.ts
@@ -225,10 +225,10 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
           (hasColorDimension &&
           config.x?.type === "nominal" &&
           !Array.isArray(config.x?.sort)
-            ? !!topNXData?.length
+            ? topNXData !== undefined
             : true) &&
           (hasColorDimension && colorDimensionName && colorLimit
-            ? !!topNColorData?.length
+            ? topNColorData !== undefined
             : true);
 
         let combinedWhere: V1Expression | undefined = getFilterWithNullHandling(

--- a/web-common/src/features/canvas/components/charts/heatmap-charts/HeatmapChart.ts
+++ b/web-common/src/features/canvas/components/charts/heatmap-charts/HeatmapChart.ts
@@ -215,10 +215,10 @@ export class HeatmapChartComponent extends BaseChart<HeatmapChartSpec> {
           !!timeRange?.start &&
           !!timeRange?.end &&
           (config.x?.type === "nominal" && !Array.isArray(config.x?.sort)
-            ? !!xTopNData?.length
+            ? xTopNData !== undefined
             : true) &&
           (config.y?.type === "nominal" && !Array.isArray(config.y?.sort)
-            ? !!yTopNData?.length
+            ? yTopNData !== undefined
             : true);
 
         let combinedWhere: V1Expression | undefined = where;


### PR DESCRIPTION
Fixes https://rilldata.slack.com/archives/C06M8V1Q5KK/p1753702788347949

The issue was that the the chart's query was disabled when all dimension values were excluded because it was checking for non-empty arrays `(!!xTopNData?.length)` instead of just checking if the data was defined. By changing the condition to `xTopNData !== undefined`, the chart now properly updates even when all values are excluded from a dimension filter

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
