### PR TITLE
fix: ghost tooltips from time dimension detail charts

### DIFF
--- a/web-common/src/components/vega/VegaLiteRenderer.svelte
+++ b/web-common/src/components/vega/VegaLiteRenderer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import CancelCircle from "@rilldata/web-common/components/icons/CancelCircle.svelte";
+  import { onDestroy } from "svelte";
   import {
     type SignalListeners,
     VegaLite,
@@ -24,13 +25,19 @@
   export let viewVL: View;
 
   let contentRect = new DOMRect(0, 0, 0, 0);
+  let tooltipHandler: VegaLiteTooltipHandler | null = null;
 
   $: width = contentRect.width;
   $: height = contentRect.height - 10;
 
   $: if (viewVL && tooltipFormatter) {
-    const handler = new VegaLiteTooltipHandler(tooltipFormatter);
-    viewVL.tooltip(handler.handleTooltip);
+    // Clean up previous handler if it exists
+    if (tooltipHandler) {
+      tooltipHandler.destroy();
+    }
+
+    tooltipHandler = new VegaLiteTooltipHandler(tooltipFormatter);
+    viewVL.tooltip(tooltipHandler.handleTooltip);
     void viewVL.runAsync();
   }
 
@@ -46,13 +53,28 @@
   const onError = (e: CustomEvent<{ error: Error }>) => {
     error = e.detail.error.message;
   };
+
+  const handleMouseLeave = () => {
+    if (tooltipHandler) {
+      tooltipHandler.removeTooltip();
+    }
+  };
+
+  onDestroy(() => {
+    if (tooltipHandler) {
+      tooltipHandler.destroy();
+      tooltipHandler = null;
+    }
+  });
 </script>
 
 <div
   bind:contentRect
+  role="presentation"
   class:bg-surface={canvasDashboard}
   class:px-2={canvasDashboard}
-  class="overflow-y-auto overflow-x-hidden size-full flex flex-col items-center"
+  class="rill-vega-container overflow-y-auto overflow-x-hidden size-full flex flex-col items-center"
+  on:mouseleave={handleMouseLeave}
 >
   {#if error}
     <div

--- a/web-common/src/components/vega/VegaRenderer.svelte
+++ b/web-common/src/components/vega/VegaRenderer.svelte
@@ -24,6 +24,7 @@
   export let isScrubbing: boolean;
 
   let contentRect = new DOMRect(0, 0, 0, 0);
+  let tooltipHandler: VegaLiteTooltipHandler | null = null;
 
   $: width = contentRect.width;
   $: height = contentRect.height * 0.95 - 80;
@@ -54,8 +55,12 @@
   }
 
   $: if (view && tooltipFormatter) {
-    const handler = new VegaLiteTooltipHandler(tooltipFormatter);
-    view.tooltip(createHoverIntentTooltipHandler(handler.handleTooltip));
+    if (tooltipHandler) {
+      tooltipHandler.destroy();
+    }
+
+    tooltipHandler = new VegaLiteTooltipHandler(tooltipFormatter);
+    view.tooltip(createHoverIntentTooltipHandler(tooltipHandler.handleTooltip));
     void view.runAsync();
   }
 
@@ -72,19 +77,35 @@
     error = e.detail.error.message;
   };
 
+  const handleMouseLeave = () => {
+    if (tooltipTimer !== null) {
+      clearTimeout(tooltipTimer);
+      tooltipTimer = null;
+    }
+    if (tooltipHandler) {
+      tooltipHandler.removeTooltip();
+    }
+  };
+
   onDestroy(() => {
     if (tooltipTimer !== null) {
       clearTimeout(tooltipTimer);
+    }
+    if (tooltipHandler) {
+      tooltipHandler.destroy();
+      tooltipHandler = null;
     }
   });
 </script>
 
 <div
   bind:contentRect
+  role="presentation"
   class:bg-surface={canvasDashboard}
   class:px-4={canvasDashboard}
   class:pb-2={canvasDashboard}
-  class="overflow-hidden size-full flex flex-col items-center justify-center"
+  class="rill-vega-container overflow-hidden size-full flex flex-col items-center justify-center"
+  on:mouseleave={handleMouseLeave}
 >
   {#if error}
     <div

--- a/web-common/src/components/vega/vega-tooltip.ts
+++ b/web-common/src/components/vega/vega-tooltip.ts
@@ -17,10 +17,18 @@ export class VegaLiteTooltipHandler {
   distance = 0;
   pad = 8;
   public valueFormatter: VLTooltipFormatter;
+  private mouseLeaveHandler: ((event: Event) => void) | null = null;
 
   constructor(valueFormatter: VLTooltipFormatter) {
     this.valueFormatter = valueFormatter;
   }
+
+  removeTooltip = () => {
+    const existingEl = document.getElementById(TOOLTIP_ID);
+    if (existingEl) {
+      existingEl.remove();
+    }
+  };
 
   handleTooltip = (
     _view: View,
@@ -28,10 +36,8 @@ export class VegaLiteTooltipHandler {
     _item: unknown,
     value: unknown,
   ) => {
-    const existingEl = document.getElementById(TOOLTIP_ID);
-    if (existingEl) {
-      existingEl.remove();
-    }
+    this.removeTooltip();
+
     if (value == null || value === "") {
       return;
     }
@@ -60,4 +66,19 @@ export class VegaLiteTooltipHandler {
 
     el.setAttribute("style", `top: ${topPos}px; left: ${leftPos}px`);
   };
+
+  removeMouseLeaveHandler() {
+    if (this.mouseLeaveHandler) {
+      // Find all potential containers and remove listener
+      document.querySelectorAll(".vega-embed").forEach((container) => {
+        container.removeEventListener("mouseleave", this.mouseLeaveHandler!);
+      });
+      this.mouseLeaveHandler = null;
+    }
+  }
+
+  destroy() {
+    this.removeTooltip();
+    this.removeMouseLeaveHandler();
+  }
 }


### PR DESCRIPTION
Fixes https://linear.app/rilldata/issue/PLAT-145/ghost-tool-tips-persist-when-navigating-between-tdd-and-explore

Adds checks for previous tooltip element before mounting new tooltips. Adds additional check on container for `mouseleave` event


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
