### PR TITLE
feat (OLAP connectors): Replace `clickhouseModeling` feature flag with a dynamic check for modeling support

### DIFF
--- a/web-common/src/features/connectors/olap/TableMenuItems.svelte
+++ b/web-common/src/features/connectors/olap/TableMenuItems.svelte
@@ -28,11 +28,11 @@
 
   $: ({ instanceId } = $runtime);
 
-  $: isModelingSupportedForOlapDriver = useIsModelingSupportedForConnector(
+  $: isModelingSupportedForConnector = useIsModelingSupportedForConnector(
     instanceId,
     connector,
   );
-  $: isModelingSupported = $isModelingSupportedForOlapDriver.data;
+  $: isModelingSupported = $isModelingSupportedForConnector.data;
   $: createMetricsViewFromTable = useCreateMetricsViewFromTableUIAction(
     instanceId,
     connector,

--- a/web-common/src/features/connectors/olap/TableMenuItems.svelte
+++ b/web-common/src/features/connectors/olap/TableMenuItems.svelte
@@ -3,6 +3,7 @@
   import Model from "@rilldata/web-common/components/icons/Model.svelte";
   import { getScreenNameFromPage } from "@rilldata/web-common/features/file-explorer/telemetry";
   import NavigationMenuItem from "@rilldata/web-common/layout/navigation/NavigationMenuItem.svelte";
+  import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
   import { behaviourEvent } from "@rilldata/web-common/metrics/initMetrics";
   import { BehaviourEventMedium } from "@rilldata/web-common/metrics/service/BehaviourEventTypes";
   import {
@@ -16,8 +17,7 @@
   import { featureFlags } from "../../feature-flags";
   import { useCreateMetricsViewFromTableUIAction } from "../../metrics-views/ai-generation/generateMetricsView";
   import { createModelFromTable } from "./createModel";
-  import { useIsModelingSupportedForOlapDriver } from "./selectors";
-  import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
+  import { useIsModelingSupportedForConnector } from "./selectors";
 
   const { ai } = featureFlags;
 
@@ -28,10 +28,11 @@
 
   $: ({ instanceId } = $runtime);
 
-  $: isModelingSupportedForOlapDriver = useIsModelingSupportedForOlapDriver(
+  $: isModelingSupportedForOlapDriver = useIsModelingSupportedForConnector(
     instanceId,
     connector,
   );
+  $: isModelingSupported = $isModelingSupportedForOlapDriver.data;
   $: createMetricsViewFromTable = useCreateMetricsViewFromTableUIAction(
     instanceId,
     connector,
@@ -77,7 +78,7 @@
   }
 </script>
 
-{#if $isModelingSupportedForOlapDriver}
+{#if isModelingSupported}
   <NavigationMenuItem on:click={handleCreateModel}>
     <Model slot="icon" />
     Create new model

--- a/web-common/src/features/connectors/olap/selectors.ts
+++ b/web-common/src/features/connectors/olap/selectors.ts
@@ -33,7 +33,7 @@ function createModelingSupportQueryOptions(
     enabled: !!instanceId && !!connectorName,
     select: (data: V1GetResourceResponse) => {
       const spec = data?.resource?.connector?.spec;
-      if (!spec) return false;
+      if (!spec) return connectorName === "duckdb";
 
       // Modeling is supported if:
       // - DuckDB (embedded database with full SQL support)

--- a/web-common/src/features/connectors/olap/selectors.ts
+++ b/web-common/src/features/connectors/olap/selectors.ts
@@ -1,63 +1,85 @@
 import type { CreateQueryResult } from "@tanstack/svelte-query";
+import { createQuery } from "@tanstack/svelte-query";
 import { derived } from "svelte/store";
 import {
-  type V1OlapTableInfo,
   createConnectorServiceOLAPListTables,
-  createRuntimeServiceAnalyzeConnectors,
   createRuntimeServiceGetInstance,
+  getRuntimeServiceGetResourceQueryKey,
+  runtimeServiceGetResource,
+  type RpcStatus,
+  type V1GetResourceResponse,
+  type V1OlapTableInfo,
 } from "../../../runtime-client";
-import { featureFlags } from "../../feature-flags";
-import { OLAP_DRIVERS_WITHOUT_MODELING } from "./olap-config";
+import type { ErrorType } from "../../../runtime-client/http-client";
+import { ResourceKind } from "../../entity-management/resource-selectors";
 
-export function useIsModelingSupportedForOlapDriver(
+/**
+ * Creates query options for checking modeling support of a connector
+ */
+function createModelingSupportQueryOptions(
   instanceId: string,
-  driver: string,
+  connectorName: string,
 ) {
-  const { clickhouseModeling } = featureFlags;
-  return derived(
-    [createRuntimeServiceAnalyzeConnectors(instanceId), clickhouseModeling],
-    ([$connectorsQuery, $clickhouseModeling]) => {
-      const { connectors = [] } = $connectorsQuery.data || {};
-      const olapConnector = connectors.find(
-        (connector) => connector.name === driver,
+  return {
+    queryKey: getRuntimeServiceGetResourceQueryKey(instanceId, {
+      "name.kind": ResourceKind.Connector,
+      "name.name": connectorName,
+    }),
+    queryFn: () =>
+      runtimeServiceGetResource(instanceId, {
+        "name.kind": ResourceKind.Connector,
+        "name.name": connectorName,
+      }),
+    enabled: !!instanceId && !!connectorName,
+    select: (data: V1GetResourceResponse) => {
+      const spec = data?.resource?.connector?.spec;
+      if (!spec) return false;
+
+      // Modeling is supported if:
+      // - DuckDB (embedded database with full SQL support)
+      // - Provisioned (managed) connectors
+      // - Read-write mode connectors
+      return (
+        spec.driver === "duckdb" ||
+        spec.provision === true ||
+        spec.properties?.mode === "readwrite"
       );
-      const olapDriverName = olapConnector?.driver?.name ?? "";
-
-      if (olapDriverName === "clickhouse") {
-        return $clickhouseModeling;
-      }
-
-      return !OLAP_DRIVERS_WITHOUT_MODELING.includes(olapDriverName);
     },
+  };
+}
+
+/**
+ * Check if modeling is supported for a specific connector based on its properties
+ */
+export function useIsModelingSupportedForConnector(
+  instanceId: string,
+  connectorName: string,
+): CreateQueryResult<boolean, ErrorType<RpcStatus>> {
+  return createQuery(
+    createModelingSupportQueryOptions(instanceId, connectorName),
   );
 }
 
-export function useIsModelingSupportedForDefaultOlapDriver(instanceId: string) {
-  const { clickhouseModeling } = featureFlags;
-  return derived(
-    [
-      createRuntimeServiceGetInstance(instanceId, { sensitive: true }),
-      createRuntimeServiceAnalyzeConnectors(instanceId),
-      clickhouseModeling,
-    ],
-    ([$instanceQuery, $connectorsQuery, $clickhouseModeling]) => {
-      const { instance: { olapConnector: olapConnectorName = "" } = {} } =
-        $instanceQuery.data || {};
-      const { connectors = [] } = $connectorsQuery.data || {};
+/**
+ * Check if modeling is supported for the default OLAP connector
+ */
+export function useIsModelingSupportedForDefaultOlapDriver(
+  instanceId: string,
+): CreateQueryResult<boolean, ErrorType<RpcStatus>> {
+  const instanceQuery = createRuntimeServiceGetInstance(instanceId, {
+    sensitive: true,
+  });
 
-      const olapConnector = connectors.find(
-        (connector) => connector.name === olapConnectorName,
-      );
+  // Create queryOptions store that includes the dynamic connector name
+  const queryOptions = derived([instanceQuery], ([$instanceQuery]) => {
+    const olapConnectorName = $instanceQuery.data?.instance?.olapConnector;
+    return createModelingSupportQueryOptions(
+      instanceId,
+      olapConnectorName || "",
+    );
+  });
 
-      const olapDriverName = olapConnector?.driver?.name ?? "";
-
-      if (olapDriverName === "clickhouse") {
-        return $clickhouseModeling;
-      }
-
-      return !OLAP_DRIVERS_WITHOUT_MODELING.includes(olapDriverName);
-    },
-  );
+  return createQuery(queryOptions);
 }
 
 export function useDatabases(instanceId: string, connector: string) {

--- a/web-common/src/features/entity-management/AddAssetButton.svelte
+++ b/web-common/src/features/entity-management/AddAssetButton.svelte
@@ -60,6 +60,7 @@
 
   $: isModelingSupportedForDefaultOlapDriver =
     useIsModelingSupportedForDefaultOlapDriver(instanceId);
+  $: isModelingSupported = $isModelingSupportedForDefaultOlapDriver.data;
 
   $: metricsViewQuery = useFilteredResources(
     instanceId,
@@ -172,7 +173,9 @@
   </DropdownMenu.Trigger>
   <DropdownMenu.Content
     align="start"
-    class={`w-[${metricsViews.length === 0 ? "280px" : "240px"}]`}
+    class={`w-[${
+      !isModelingSupported || metricsViews.length === 0 ? "280px" : "240px"
+    }]`}
   >
     <DropdownMenu.Item
       aria-label="Add Data"
@@ -182,20 +185,26 @@
       <svelte:component this={Database} color="#C026D3" size="16px" />
       Data
     </DropdownMenu.Item>
-    {#if $isModelingSupportedForDefaultOlapDriver}
-      <DropdownMenu.Item
-        aria-label="Add Model"
-        class="flex gap-x-2"
-        on:click={() => handleAddResource(ResourceKind.Model)}
-      >
-        <svelte:component
-          this={resourceIconMapping[ResourceKind.Model]}
-          color={resourceColorMapping[ResourceKind.Model]}
-          size="16px"
-        />
+    <DropdownMenu.Item
+      aria-label="Add Model"
+      class="flex gap-x-2"
+      disabled={!isModelingSupported}
+      on:click={() => handleAddResource(ResourceKind.Model)}
+    >
+      <svelte:component
+        this={resourceIconMapping[ResourceKind.Model]}
+        color={resourceColorMapping[ResourceKind.Model]}
+        size="16px"
+      />
+      <div class="flex flex-col items-start">
         Model
-      </DropdownMenu.Item>
-    {/if}
+        {#if !isModelingSupported}
+          <span class="text-gray-500 text-xs">
+            Requires a supported OLAP driver
+          </span>
+        {/if}
+      </div>
+    </DropdownMenu.Item>
     <DropdownMenu.Item
       aria-label="Add Metrics View"
       class="flex gap-x-2"

--- a/web-common/src/features/feature-flags.ts
+++ b/web-common/src/features/feature-flags.ts
@@ -43,7 +43,6 @@ class FeatureFlags {
   exports = new FeatureFlag("user", true);
   cloudDataViewer = new FeatureFlag("user", false);
   dimensionSearch = new FeatureFlag("user", false);
-  clickhouseModeling = new FeatureFlag("user", false);
   twoTieredNavigation = new FeatureFlag("user", false);
   rillTime = new FeatureFlag("user", false);
   hidePublicUrl = new FeatureFlag("user", false);

--- a/web-common/src/features/metrics-views/editor/Placeholder.svelte
+++ b/web-common/src/features/metrics-views/editor/Placeholder.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { EditorView } from "@codemirror/view";
+  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
   import { initBlankDashboardYAML } from "@rilldata/web-common/features/metrics-views/metrics-internal-store";
   import { useModels } from "@rilldata/web-common/features/models/selectors";
   import {
@@ -9,7 +10,6 @@
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { useIsModelingSupportedForDefaultOlapDriver } from "../../connectors/olap/selectors";
   import { createDashboardFromTableInMetricsEditor } from "../ai-generation/generateMetricsView";
-  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
 
   export let metricsName: string;
   export let filePath: string;
@@ -19,6 +19,7 @@
 
   $: isModelingSupportedForDefaultOlapDriver =
     useIsModelingSupportedForDefaultOlapDriver(instanceId);
+  $: isModelingSupported = $isModelingSupportedForDefaultOlapDriver.data;
   $: models = useModels(instanceId);
 
   const buttonClasses =
@@ -60,7 +61,7 @@
 </script>
 
 <div class="whitespace-normal">
-  {#if $isModelingSupportedForDefaultOlapDriver}
+  {#if isModelingSupported}
     Auto-generate a
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild let:builder>
@@ -94,7 +95,6 @@
     on:click={async () => {
       onCreateSkeletonMetricsConfig();
     }}
-    >{#if $isModelingSupportedForDefaultOlapDriver}s{:else}S{/if}tart with a
-    skeleton</button
+    >{#if isModelingSupported}s{:else}S{/if}tart with a skeleton</button
   >, or just start typing.
 </div>

--- a/web-common/src/features/sources/modal/AddDataModal.svelte
+++ b/web-common/src/features/sources/modal/AddDataModal.svelte
@@ -4,6 +4,7 @@
   import AmazonRedshift from "@rilldata/web-common/components/icons/connectors/AmazonRedshift.svelte";
   import MySQL from "@rilldata/web-common/components/icons/connectors/MySQL.svelte";
   import { getScreenNameFromPage } from "@rilldata/web-common/features/file-explorer/telemetry";
+  import { cn } from "@rilldata/web-common/lib/shadcn";
   import {
     createRuntimeServiceListConnectorDrivers,
     type V1ConnectorDriver,
@@ -31,14 +32,13 @@
   } from "../../../metrics/service/BehaviourEventTypes";
   import { MetricsEventSpace } from "../../../metrics/service/MetricsTypes";
   import { runtime } from "../../../runtime-client/runtime-store";
+  import { connectorIconMapping } from "../../connectors/connector-icon-mapping";
   import { useIsModelingSupportedForDefaultOlapDriver } from "../../connectors/olap/selectors";
   import { duplicateSourceName } from "../sources-store";
   import AddDataForm from "./AddDataForm.svelte";
   import DuplicateSource from "./DuplicateSource.svelte";
   import LocalSourceUpload from "./LocalSourceUpload.svelte";
   import RequestConnectorForm from "./RequestConnectorForm.svelte";
-  import { connectorIconMapping } from "../../connectors/connector-icon-mapping";
-  import { cn } from "@rilldata/web-common/lib/shadcn";
 
   let step = 0;
   let selectedConnector: null | V1ConnectorDriver = null;
@@ -172,6 +172,7 @@
 
   $: isModelingSupportedForDefaultOlapDriver =
     useIsModelingSupportedForDefaultOlapDriver($runtime.instanceId);
+  $: isModelingSupported = $isModelingSupportedForDefaultOlapDriver.data;
 </script>
 
 {#if step >= 1 || $duplicateSourceName}
@@ -193,7 +194,7 @@
       noClose={step === 1}
     >
       {#if step === 1}
-        {#if $isModelingSupportedForDefaultOlapDriver}
+        {#if isModelingSupported}
           <Dialog.Title>Add a source</Dialog.Title>
           <section class="mb-1">
             <div class="connector-grid">

--- a/web-common/src/features/workspaces/MetricsWorkspace.svelte
+++ b/web-common/src/features/workspaces/MetricsWorkspace.svelte
@@ -50,12 +50,12 @@
 
   $: isModelingSupportedForDefaultOlapDriver =
     useIsModelingSupportedForDefaultOlapDriver(instanceId);
-  $: isModelingSupportedForOlapDriver = useIsModelingSupportedForConnector(
+  $: isModelingSupportedForConnector = useIsModelingSupportedForConnector(
     instanceId,
     connector,
   );
   $: isModelingSupported = connector
-    ? $isModelingSupportedForOlapDriver.data
+    ? $isModelingSupportedForConnector.data
     : $isModelingSupportedForDefaultOlapDriver.data;
 
   async function onChangeCallback(newTitle: string) {

--- a/web-common/src/features/workspaces/MetricsWorkspace.svelte
+++ b/web-common/src/features/workspaces/MetricsWorkspace.svelte
@@ -12,8 +12,8 @@
   import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import {
+    useIsModelingSupportedForConnector,
     useIsModelingSupportedForDefaultOlapDriver,
-    useIsModelingSupportedForOlapDriver,
   } from "../connectors/olap/selectors";
   import PreviewButton from "../explores/PreviewButton.svelte";
   import GoToDashboardButton from "../metrics-views/GoToDashboardButton.svelte";
@@ -50,13 +50,13 @@
 
   $: isModelingSupportedForDefaultOlapDriver =
     useIsModelingSupportedForDefaultOlapDriver(instanceId);
-  $: isModelingSupportedForOlapDriver = useIsModelingSupportedForOlapDriver(
+  $: isModelingSupportedForOlapDriver = useIsModelingSupportedForConnector(
     instanceId,
     connector,
   );
   $: isModelingSupported = connector
-    ? $isModelingSupportedForOlapDriver
-    : $isModelingSupportedForDefaultOlapDriver;
+    ? $isModelingSupportedForOlapDriver.data
+    : $isModelingSupportedForDefaultOlapDriver.data;
 
   async function onChangeCallback(newTitle: string) {
     const newRoute = await handleEntityRename(
@@ -73,7 +73,7 @@
   $: errors = mapParseErrorsToLines(allErrors, $remoteContent ?? "");
 </script>
 
-<WorkspaceContainer inspector={isModelingSupported && $selectedView === "code"}>
+<WorkspaceContainer inspector={$selectedView === "code" && isModelingSupported}>
   <WorkspaceHeader
     {filePath}
     {resource}

--- a/web-common/src/features/workspaces/VisualMetrics.svelte
+++ b/web-common/src/features/workspaces/VisualMetrics.svelte
@@ -30,13 +30,12 @@
   import { parseDocument, Scalar, YAMLMap, YAMLSeq } from "yaml";
   import ConnectorExplorer from "../connectors/ConnectorExplorer.svelte";
   import { connectorExplorerStore } from "../connectors/connector-explorer-store";
-  import { OLAP_DRIVERS_WITHOUT_MODELING } from "../connectors/olap/olap-config";
+  import { useIsModelingSupportedForConnector } from "../connectors/olap/selectors";
   import { FileArtifact } from "../entity-management/file-artifact";
   import {
     ResourceKind,
     useResource,
   } from "../entity-management/resource-selectors";
-  import { featureFlags } from "../feature-flags";
   import { useModels } from "../models/selectors";
   import { useSources } from "../sources/selectors";
   import AlertConfirmation from "../visual-metrics-editing/AlertConfirmation.svelte";
@@ -50,7 +49,6 @@
     YAMLMeasure,
   } from "../visual-metrics-editing/lib";
 
-  const { clickhouseModeling } = featureFlags;
   const store = connectorExplorerStore.duplicateStore(
     (connector, database, schema, table) => {
       if (!table || !schema) return;
@@ -105,11 +103,10 @@
     dimensions: parsedDocument.get("dimensions"),
   };
 
-  $: modelingDisabled =
-    olapConnector &&
-    OLAP_DRIVERS_WITHOUT_MODELING.filter(
-      (driver) => driver === "clickhouse" && $clickhouseModeling,
-    ).includes(olapConnector);
+  $: isModelingSupportedForOlapConnector = olapConnector
+    ? useIsModelingSupportedForConnector(instanceId, olapConnector)
+    : null;
+  $: isModelingSupported = $isModelingSupportedForOlapConnector?.data;
 
   $: rawSmallestTimeGrain = parsedDocument.get("smallest_time_grain");
   $: rawTimeDimension = parsedDocument.get("timeseries");
@@ -522,11 +519,11 @@
 <div class="wrapper">
   <div class="main-area">
     <div class="flex gap-x-4 border-b pb-4">
-      {#if tableMode || modelingDisabled}
+      {#if tableMode || !isModelingSupported}
         <div class="flex flex-col gap-y-1 w-full">
           <InputLabel label="Table" id="table">
             <svelte:fragment slot="mode-switch">
-              {#if !modelingDisabled}
+              {#if isModelingSupported}
                 <button
                   on:click={switchTableMode}
                   class="ml-auto text-primary-600 font-medium text-xs"

--- a/web-common/src/features/workspaces/VisualMetrics.svelte
+++ b/web-common/src/features/workspaces/VisualMetrics.svelte
@@ -103,10 +103,10 @@
     dimensions: parsedDocument.get("dimensions"),
   };
 
-  $: isModelingSupportedForOlapConnector = olapConnector
+  $: isModelingSupportedForConnector = olapConnector
     ? useIsModelingSupportedForConnector(instanceId, olapConnector)
     : null;
-  $: isModelingSupported = $isModelingSupportedForOlapConnector?.data;
+  $: isModelingSupported = $isModelingSupportedForConnector?.data;
 
   $: rawSmallestTimeGrain = parsedDocument.get("smallest_time_grain");
   $: rawTimeDimension = parsedDocument.get("timeseries");


### PR DESCRIPTION
This PR removes the `clickhouseModeling` feature flag in favor of the application's own assessment of whether or not the OLAP connector supports modeling. Modeling is currently supported in these cases:
1. The OLAP engine is DuckDB
2. The OLAP engine is Rill-managed (e.g. Rill-managed ClickHouse)
3. The OLAP engine is running in `readwrite` mode
 
Addresses [this Slack request](https://rilldata.slack.com/archives/C02T907FEUB/p1753697369166259)

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
