### PR TITLE
fix: zone reactivity in new rill time picker

### DIFF
--- a/web-common/src/features/dashboards/time-controls/super-pill/new-time-dropdown/RangePickerV2.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/new-time-dropdown/RangePickerV2.svelte
@@ -96,7 +96,7 @@
       ? GrainAliasToV1TimeGrain[parsedTime.asOfLabel?.snap]
       : undefined;
 
-  $: dateTimeAnchor = returnAnchor(ref);
+  $: dateTimeAnchor = returnAnchor(ref, zone);
 
   $: selectedLabel = getRangeLabel(timeString);
 
@@ -192,7 +192,8 @@
     onSelectRange(newString);
   }
 
-  function returnAnchor(asOf: string): DateTime | undefined {
+  // Zone is taken as a param to make it reactive
+  function returnAnchor(asOf: string, zone: string): DateTime | undefined {
     if (asOf === "latest") {
       return maxDate.setZone(zone);
     } else if (asOf === "watermark" && watermark) {


### PR DESCRIPTION
In certain components selected time zone was not propagated because it was not reactive.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
