### PR TITLE
Fix feature flags not resetting to defaults when switching projects

### DIFF
--- a/web-common/src/features/feature-flags.ts
+++ b/web-common/src/features/feature-flags.ts
@@ -68,12 +68,12 @@ class FeatureFlags {
       this._resolveReady();
 
       // First, reset all user flags to their defaults
-      const allFlagKeys = Object.keys(this).filter((key) => {
+      const userFlagKeys = Object.keys(this).filter((key) => {
         const flag = this[key];
         return flag instanceof FeatureFlag && !flag.internalOnly;
       });
 
-      for (const key of allFlagKeys) {
+      for (const key of userFlagKeys) {
         const flag = this[key] as FeatureFlag;
         flag.resetToDefault();
       }

--- a/web-common/src/features/feature-flags.ts
+++ b/web-common/src/features/feature-flags.ts
@@ -8,20 +8,27 @@ import { runtime } from "../runtime-client/runtime-store";
 
 class FeatureFlag {
   private _internal = false;
+  private _default: boolean;
   private state = writable(false);
   subscribe = this.state.subscribe;
 
-  constructor(scope: "user" | "rill", initial: boolean) {
+  constructor(scope: "user" | "rill", defaultValue: boolean) {
     this._internal = scope === "rill";
-    this.set(initial);
+    this._default = defaultValue;
+    this.set(defaultValue);
   }
 
   get internalOnly() {
     return this._internal;
   }
 
+  get defaultValue() {
+    return this._default;
+  }
+
   toggle = () => this.state.update((n) => !n);
   set = (n: boolean) => this.state.set(n);
+  resetToDefault = () => this.set(this._default);
 }
 
 type FeatureFlagKey = keyof Omit<FeatureFlags, "set">;
@@ -59,6 +66,19 @@ class FeatureFlags {
 
     const updateFlags = (userFlags: V1InstanceFeatureFlags) => {
       this._resolveReady();
+
+      // First, reset all user flags to their defaults
+      const allFlagKeys = Object.keys(this).filter((key) => {
+        const flag = this[key];
+        return flag instanceof FeatureFlag && !flag.internalOnly;
+      });
+
+      for (const key of allFlagKeys) {
+        const flag = this[key] as FeatureFlag;
+        flag.resetToDefault();
+      }
+
+      // Then apply project-specific overrides
       for (const key in userFlags) {
         const flag = this[key] as FeatureFlag | undefined;
         if (!flag || flag.internalOnly) continue;


### PR DESCRIPTION
When switching between projects, feature flags weren't properly resetting to their default values. If Project A had `chat: true` and Project B had no chat flag set, the chat flag would remain `true` instead of resetting to its default `false` value.

Partly addresses [this Slack report](https://rilldata.slack.com/archives/C08RDR9Q26P/p1753859766565959)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
