### PR TITLE
fix (Explore Chat): hide chat sidebar when navigating to projects with chat disabled

### DIFF
--- a/web-common/src/features/chat/Chat.svelte
+++ b/web-common/src/features/chat/Chat.svelte
@@ -8,6 +8,7 @@
     type V1Conversation,
   } from "../../runtime-client";
   import { runtime } from "../../runtime-client/runtime-store";
+  import { featureFlags } from "../feature-flags";
   import {
     chatActions,
     chatOpen,
@@ -21,6 +22,8 @@
   import ChatFooter from "./input/ChatFooter.svelte";
   import ChatInput from "./input/ChatInput.svelte";
   import ChatMessages from "./messages/ChatMessages.svelte";
+
+  const { chat: chatFlag } = featureFlags;
 
   // Local UI state
   let input = "";
@@ -109,7 +112,7 @@
   }
 </script>
 
-{#if $chatOpen}
+{#if $chatOpen && $chatFlag}
   <div class="chat-sidebar" style="--sidebar-width: {$sidebarWidth}px;">
     <Resizer
       min={DEFAULTS.MIN_SIDEBAR_WIDTH}


### PR DESCRIPTION
When navigating from a project with chat enabled (where the chat sidebar was open) to a project with chat disabled, the chat sidebar would remain visible even though the chat feature flag was off for the destination project.

In conjunction with https://github.com/rilldata/rill/pull/7696, addresses [this Slack report](https://rilldata.slack.com/archives/C08RDR9Q26P/p1753859766565959).

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
