### PR TITLE
fix: missing grain for time pivot chips

### DIFF
--- a/web-common/src/features/dashboards/pivot/time-pill-store.ts
+++ b/web-common/src/features/dashboards/pivot/time-pill-store.ts
@@ -57,7 +57,7 @@ export const timePills = derived(
         ) {
           return true;
         }
-        return isGrainBigger(grain, timeControls.minTimeGrain);
+        return !isGrainBigger(timeControls.minTimeGrain, grain);
       });
 
       const availableGrains = validGrains.filter(


### PR DESCRIPTION
When the the min time grain is same as the grain being check, it was not being added to `validGrains`

- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
