### PR TITLE
Skip e2e canvas global filters test (#7660)"

### DIFF
--- a/web-local/tests/canvas/global-dimension-filters.spec.ts
+++ b/web-local/tests/canvas/global-dimension-filters.spec.ts
@@ -1,0 +1,36 @@
+import { expect } from "@playwright/test";
+import { gotoNavEntry } from "web-local/tests/utils/waitHelpers";
+import { test } from "../setup/base";
+
+test.describe("canvas global dimension filters", () => {
+  test.use({ project: "AdBids" });
+
+  // TODO: Fix test with latest filter related changes
+  test.skip("global dimension filters run through", async ({ page }) => {
+    await page.getByLabel("/dashboards").click();
+    await gotoNavEntry(page, "/dashboards/AdBids_metrics_canvas.yaml");
+
+    await page.getByRole("button", { name: "Preview" }).click();
+
+    await page.waitForTimeout(1000);
+
+    await expect(page.getByText("Total records 1,122")).toBeVisible();
+
+    await page.getByRole("button", { name: "Add filter button" }).click();
+    await page.getByRole("menuitem", { name: "Publisher" }).click();
+
+    await page.getByLabel("publisher results").getByText("Facebook").click();
+
+    await expect(page.getByText("Total records 283")).toBeVisible();
+
+    // Change filter to excluded
+    await page.getByLabel("Include exclude toggle").click();
+    await page.getByText("Exclude Publisher Facebook").click();
+
+    await expect(page.getByText("Total records 839")).toBeVisible();
+
+    await page.getByRole("button", { name: "Clear filters" }).click();
+
+    await expect(page.getByText("Total records 1,122")).toBeVisible();
+  });
+});

--- a/web-local/tests/canvas/global-time-filters.spec.ts
+++ b/web-local/tests/canvas/global-time-filters.spec.ts
@@ -1,0 +1,61 @@
+import { expect } from "@playwright/test";
+import { interactWithTimeRangeMenu } from "@rilldata/web-common/tests/utils/explore-interactions";
+import { gotoNavEntry } from "web-local/tests/utils/waitHelpers";
+import { test } from "../setup/base";
+
+test.describe("canvas global time filters", () => {
+  test.use({ project: "AdBids" });
+
+  // TODO: Fix test with latest time related changes
+  test.skip("global time filters run through", async ({ page }) => {
+    await page.getByLabel("/dashboards").click();
+    await gotoNavEntry(page, "/dashboards/AdBids_metrics_canvas.yaml");
+
+    await page.getByRole("button", { name: "Preview" }).click();
+
+    await page.waitForTimeout(1000);
+
+    // Change global time range
+    await interactWithTimeRangeMenu(page, async () => {
+      await page.getByRole("menuitem", { name: "Last 6 Hours" }).click();
+    });
+
+    await expect(page.getByText("Total records 272")).toBeVisible();
+
+    await interactWithTimeRangeMenu(page, async () => {
+      await page.getByRole("menuitem", { name: "Week to date" }).click();
+    });
+
+    await expect(page.getByText("Total records 3,435")).toBeVisible();
+
+    const timeGrainSelector = page.getByRole("button", {
+      name: "Select a time grain",
+    });
+    await timeGrainSelector.click();
+    await page.getByRole("menuitem", { name: "day" }).click();
+
+    await page.getByLabel("Toggle time comparison").click();
+
+    await expect(page.getByText("Total records 3,435 +52 +2%")).toBeVisible();
+
+    await interactWithTimeRangeMenu(page, async () => {
+      await page.getByRole("menuitem", { name: "Today" }).click();
+    });
+
+    await timeGrainSelector.click();
+    await page.getByRole("menuitem", { name: "hour" }).click();
+
+    await expect(page.getByText("Total records 1,122")).toBeVisible();
+
+    const timeZoneSelector = page.getByRole("button", {
+      name: "Timezone selector",
+    });
+    await timeZoneSelector.click();
+
+    await page.getByRole("textbox", { name: "Search" }).click();
+    await page.getByRole("textbox", { name: "Search" }).fill("IST");
+    await page.getByText("Asia/Calcutta").click();
+
+    await expect(page.getByText("Total records 251")).toBeVisible();
+  });
+});


### PR DESCRIPTION
Skips tests from https://github.com/rilldata/rill/pull/7660

The tests worked at the time the PR was created but since then there have been changes in how filters work leading the tests to fail.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
