### PR TITLE
fix: Add support for comma in custom time for backwards compatibility

### DIFF
--- a/runtime/pkg/rilltime/rilltime.go
+++ b/runtime/pkg/rilltime/rilltime.go
@@ -39,8 +39,10 @@ var (
 		{"Of", `(?i)of`},
 		{"As", `(?i)as`},
 		{"Tz", `(?i)tz`},
+		// Separate entry is needed outside of Punct
+		{"RangeSeparator", `[,]`},
 		// needed for misc. direct character references used
-		{"Punct", `[-[!@#$%^&*()+_={}\|:;"'<,>.?/]]`},
+		{"Punct", `[-[!@#$%^&*()+_={}\|:;"'<>.?/]]`},
 		{"Whitespace", `[ \t]+`},
 	})
 	rillTimeParser = participle.MustBuild[Expression](
@@ -149,7 +151,7 @@ type StartEndInterval struct {
 // IsoInterval is an interval formed by ISO timestamps. Allows for partial timestamps in ISOPointInTime.
 type IsoInterval struct {
 	Start *ISOPointInTime `parser:"@@"`
-	End   *ISOPointInTime `parser:"((To | '/') @@)?"`
+	End   *ISOPointInTime `parser:"((To | '/' | RangeSeparator) @@)?"`
 }
 
 type PointInTime struct {

--- a/runtime/pkg/rilltime/rilltime_test.go
+++ b/runtime/pkg/rilltime/rilltime_test.go
@@ -301,6 +301,7 @@ func TestEval_IsoTimeRanges(t *testing.T) {
 	testCases := []testCase{
 		{"2025-02-20T01:23:45Z to 2025-07-15T02:34:50Z", "2025-02-20T01:23:45Z", "2025-07-15T02:34:50Z", timeutil.TimeGrainSecond, 1, 1},
 		{"2025-02-20T01:23:45Z / 2025-07-15T02:34:50Z", "2025-02-20T01:23:45Z", "2025-07-15T02:34:50Z", timeutil.TimeGrainSecond, 1, 1},
+		{"2025-02-20T01:23:45Z,2025-07-15T02:34:50Z", "2025-02-20T01:23:45Z", "2025-07-15T02:34:50Z", timeutil.TimeGrainSecond, 1, 1},
 
 		{"2025-02-20T01:23", "2025-02-20T01:23:00Z", "2025-02-20T01:24:00Z", timeutil.TimeGrainSecond, 1, 1},
 		{"2025-02-20T01", "2025-02-20T01:00:00Z", "2025-02-20T02:00:00Z", timeutil.TimeGrainMinute, 1, 1},

--- a/web-common/src/features/dashboards/url-state/time-ranges/RillTime.ts
+++ b/web-common/src/features/dashboards/url-state/time-ranges/RillTime.ts
@@ -372,7 +372,7 @@ export class RillIsoInterval implements RillTimeInterval {
   }
 
   public getLabel(): [label: string, supported: boolean] {
-    return ["", false];
+    return ["Custom", true];
   }
 
   public getGrain() {

--- a/web-common/src/features/dashboards/url-state/time-ranges/rill-time.cjs
+++ b/web-common/src/features/dashboards/url-state/time-ranges/rill-time.cjs
@@ -308,6 +308,11 @@ let ParserRules = [
   },
   {
     name: "iso_interval",
+    symbols: ["abs_time", "_", { literal: "," }, "_", "abs_time"],
+    postprocess: ([start, , , , end]) => new RillIsoInterval(start, end),
+  },
+  {
+    name: "iso_interval",
     symbols: ["abs_time"],
     postprocess: ([start]) => new RillIsoInterval(start, undefined),
   },

--- a/web-common/src/features/dashboards/url-state/time-ranges/rill-time.ne
+++ b/web-common/src/features/dashboards/url-state/time-ranges/rill-time.ne
@@ -46,6 +46,7 @@ start_end_interval => point_in_time _ "to"i _ point_in_time {% ([start, , , , en
 
 iso_interval => abs_time _ "to"i _ abs_time {% ([start, , , , end]) => new RillIsoInterval(start, end) %}
               | abs_time _ "/" _ abs_time   {% ([start, , , , end]) => new RillIsoInterval(start, end) %}
+              | abs_time _ "," _ abs_time   {% ([start, , , , end]) => new RillIsoInterval(start, end) %}
               | abs_time                    {% ([start]) => new RillIsoInterval(start, undefined) %}
 
 point_in_time              => point_in_time_with_snap:* point_in_time_without_snap {% ([points, last]) => new RillPointInTime([...points, last]) %}

--- a/web-common/src/features/dashboards/url-state/time-ranges/rill-time.spec.ts
+++ b/web-common/src/features/dashboards/url-state/time-ranges/rill-time.spec.ts
@@ -143,6 +143,14 @@ describe("rill time", () => {
         V1TimeGrain.TIME_GRAIN_DAY,
         undefined,
       ],
+
+      [
+        `2025-02-20T01:23:45Z,2025-07-15T02:34:50Z`,
+        `Custom`,
+        false,
+        undefined,
+        undefined,
+      ],
     ];
 
     const compiledGrammar = nearley.Grammar.fromCompiled(grammar);


### PR DESCRIPTION
In old time picker, custom time is separated by a comma. This leads to some edge cases where it is parsed as new rill time and errror is thrown instead of resolving time. In canvas it happens all the time when custom range is selected. 

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
