### PR TITLE
no default limit for timeseries request

### DIFF
--- a/runtime/queries/metricsview_aggregation.go
+++ b/runtime/queries/metricsview_aggregation.go
@@ -412,10 +412,6 @@ func (q *MetricsViewAggregation) rewriteToMetricsViewQuery(export bool) (*metric
 
 	if q.Limit != nil {
 		if *q.Limit == 0 {
-			if q.shouldAddLimit() {
-				tmp := int64(100)
-				q.Limit = &tmp
-			}
 			q.Limit = nil
 		}
 		qry.Limit = q.Limit
@@ -526,14 +522,6 @@ func (q *MetricsViewAggregation) getDisplayName(ctx context.Context, rt *runtime
 		}
 	}
 	return resourceName.Name, nil
-}
-
-// timeseries request will not have any limit set, so we should not set any default limit if time range is specified otherwise timeseries graph will be partial
-func (q *MetricsViewAggregation) shouldAddLimit() bool {
-	if q.TimeRange == nil || (q.TimeRange.Start == nil && q.TimeRange.End == nil && q.TimeRange.IsoDuration == "") {
-		return true
-	}
-	return false
 }
 
 func metricViewExpression(expr *runtimev1.Expression, sql string) (*metricsview.Expression, error) {

--- a/runtime/queries/metricsview_aggregation.go
+++ b/runtime/queries/metricsview_aggregation.go
@@ -412,8 +412,11 @@ func (q *MetricsViewAggregation) rewriteToMetricsViewQuery(export bool) (*metric
 
 	if q.Limit != nil {
 		if *q.Limit == 0 {
-			tmp := int64(100)
-			q.Limit = &tmp
+			if q.shouldAddLimit() {
+				tmp := int64(100)
+				q.Limit = &tmp
+			}
+			q.Limit = nil
 		}
 		qry.Limit = q.Limit
 	}
@@ -523,6 +526,14 @@ func (q *MetricsViewAggregation) getDisplayName(ctx context.Context, rt *runtime
 		}
 	}
 	return resourceName.Name, nil
+}
+
+// timeseries request will not have any limit set, so we should not set any default limit if time range is specified otherwise timeseries graph will be partial
+func (q *MetricsViewAggregation) shouldAddLimit() bool {
+	if q.TimeRange == nil || (q.TimeRange.Start == nil && q.TimeRange.End == nil && q.TimeRange.IsoDuration == "") {
+		return true
+	}
+	return false
 }
 
 func metricViewExpression(expr *runtimev1.Expression, sql string) (*metricsview.Expression, error) {


### PR DESCRIPTION
Fixes partial results for timeseries request because of default limit 

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
