### PR TITLE
PLAT-28 : Disable enable_external_access for duckdb for finer controls

### DIFF
--- a/runtime/drivers/duckdb/duckdb_test.go
+++ b/runtime/drivers/duckdb/duckdb_test.go
@@ -3,6 +3,9 @@ package duckdb
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -175,6 +178,47 @@ func TestNoFatalErrConcurrent(t *testing.T) {
 
 	err = olap.Exec(context.Background(), &drivers.Statement{Query: "SELECT * FROM a"})
 	require.NoError(t, err)
+
+	err = handle.Close()
+	require.NoError(t, err)
+}
+
+func TestDirectoryAccess(t *testing.T) {
+	tempDir := t.TempDir()
+	st := storage.MustNew(tempDir, nil).WithPrefix("default")
+
+	handle, err := Driver{}.Open("default", map[string]any{"allow_host_access": false}, st, activity.NewNoopClient(), zap.NewNop())
+	require.NoError(t, err)
+
+	olap, ok := handle.AsOLAP("")
+	require.True(t, ok)
+
+	// Create a file in the temp directory to test directory access
+	subTemp, err := st.RandomTempDir("test*")
+	require.NoError(t, err)
+	// write a CSV file to the subTemp directory
+	path := filepath.Join(subTemp, "test.csv")
+	csvFile, err := os.Create(path)
+	require.NoError(t, err)
+	_, err = csvFile.WriteString("id,country\n1,IND\n2,USA\n")
+	require.NoError(t, err)
+	require.NoError(t, csvFile.Close())
+
+	err = olap.Exec(context.Background(), &drivers.Statement{Query: fmt.Sprintf("CREATE OR REPLACE TABLE test AS SELECT * FROM read_csv_auto(%s)", safeSQLString(path))})
+	require.NoError(t, err)
+
+	// Create a file in another directory to test no directory access
+	otherTemp := t.TempDir()
+	otherPath := filepath.Join(otherTemp, "test.csv")
+	otherCSVFile, err := os.Create(otherPath)
+	require.NoError(t, err)
+	_, err = otherCSVFile.WriteString("id,country\n1,IND\n2,USA\n")
+	require.NoError(t, err)
+	require.NoError(t, otherCSVFile.Close())
+
+	err = olap.Exec(context.Background(), &drivers.Statement{Query: fmt.Sprintf("CREATE OR REPLACE TABLE other_test AS SELECT * FROM read_csv_auto(%s)", safeSQLString(otherPath))})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ile system operations are disabled by configuration")
 
 	err = handle.Close()
 	require.NoError(t, err)


### PR DESCRIPTION
INSERT DESCRIPTION HERE

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
