### PR TITLE
fix: metrics view selector dropdown

### DIFF
--- a/web-common/src/components/forms/Select.svelte
+++ b/web-common/src/components/forms/Select.svelte
@@ -66,7 +66,10 @@
 
 <div class="flex flex-col gap-y-2 max-w-full" class:w-full={full}>
   {#if label?.length}
-    <label for={id} class="text-sm flex items-center gap-x-1">
+    <label
+      for={id}
+      class="{size === 'sm' ? 'text-xs' : 'text-sm'} flex items-center gap-x-1"
+    >
       <span class="text-gray-800 font-medium">
         {label}
       </span>

--- a/web-common/src/features/canvas/inspector/MetricSelectorDropdown.svelte
+++ b/web-common/src/features/canvas/inspector/MetricSelectorDropdown.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
-  import Input from "@rilldata/web-common/components/forms/Input.svelte";
-  import type { ComponentInputParam } from "@rilldata/web-common/features/canvas/inspector/types";
+  import Select from "@rilldata/web-common/components/forms/Select.svelte";
+  import type {
+    AllKeys,
+    ComponentInputParam,
+  } from "@rilldata/web-common/features/canvas/inspector/types";
   import {
     ResourceKind,
     useFilteredResources,
   } from "@rilldata/web-common/features/entity-management/resource-selectors";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { isString } from "../../workspaces/visual-util";
-  import type { AllKeys } from "@rilldata/web-common/features/canvas/inspector/types";
-  import type { ComponentSpec } from "../components/types";
   import type { BaseCanvasComponent } from "../components/BaseCanvasComponent";
+  import type { ComponentSpec } from "../components/types";
 
   export let component: BaseCanvasComponent;
   export let key: AllKeys<ComponentSpec>;
@@ -33,23 +35,19 @@
     "metrics_view" in $spec ? $spec.metrics_view : metricsViewNames[0];
 </script>
 
-<Input
-  hint="View documentation"
-  link="https://docs.rilldata.com/reference/project-files/metrics-views"
+<Select
+  id="metrics-view-selector"
   label={inputParam.label}
-  capitalizeLabel={false}
   bind:value={metricsView}
-  sameWidth
+  full
   size="sm"
-  labelGap={2}
+  sameWidth
   options={metricsViewNames.map((name) => ({
     label: name,
     value: name,
   }))}
-  onBlur={() => {
-    component.updateProperty(key, metricsView);
+  onChange={(value) => {
+    component.updateProperty(key, value);
   }}
-  onChange={() => {
-    component.updateProperty(key, metricsView);
-  }}
+  tooltip="View documentation: https://docs.rilldata.com/reference/project-files/metrics-views"
 />


### PR DESCRIPTION
There seems to be a regression with metrics view selector where the width of the dropdown is not taking the full width of the container.

This PR removes the usage of `Input` component in favor of `Select` component for Metrics selector dropdown.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
