### PR TITLE
Fix panic in cleanup when query failed on redshift

### DIFF
--- a/runtime/drivers/redshift/warehouse.go
+++ b/runtime/drivers/redshift/warehouse.go
@@ -182,7 +182,7 @@ func deleteObjectsInPrefix(ctx context.Context, cfg aws.Config, bucketName, pref
 			}
 		}
 
-		if *out.IsTruncated && out.NextContinuationToken != nil {
+		if out.IsTruncated != nil && *out.IsTruncated && out.NextContinuationToken != nil {
 			continuationToken = out.NextContinuationToken
 		} else {
 			break


### PR DESCRIPTION
[ENG-858: Unable to view redshift table model properly](https://linear.app/rilldata/issue/ENG-858/unable-to-view-redshift-table-model-properly)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
