### PR TITLE
add time dimension to resolver cache key

### DIFF
--- a/runtime/resolvers/metricsview_time_range.go
+++ b/runtime/resolvers/metricsview_time_range.go
@@ -100,7 +100,12 @@ func (r *metricsViewTimeRangeResolver) Close() error {
 }
 
 func (r *metricsViewTimeRangeResolver) CacheKey(ctx context.Context) ([]byte, bool, error) {
-	return cacheKeyForMetricsView(ctx, r.runtime, r.instanceID, r.mvName, r.args.Priority)
+	key, ok, err := cacheKeyForMetricsView(ctx, r.runtime, r.instanceID, r.mvName, r.args.Priority)
+	if err != nil {
+		return nil, false, err
+	}
+	key = append(key, []byte(r.args.TimeDimension)...)
+	return key, ok, nil
 }
 
 func (r *metricsViewTimeRangeResolver) Refs() []*runtimev1.ResourceName {


### PR DESCRIPTION
Add time dimension to `metricsview_time_range` resolver cache key as alternate time dimensions can be used now to query APIs. Mostly affects mcp client doing mv time range query with alternate time dim.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
