### PR TITLE
Use infinite query when listing org users

### DIFF
--- a/web-admin/src/routes/[organization]/-/users/groups/+page.svelte
+++ b/web-admin/src/routes/[organization]/-/users/groups/+page.svelte
@@ -3,7 +3,7 @@
   import {
     createAdminServiceGetCurrentUser,
     createAdminServiceListOrganizationMemberUsergroups,
-    createAdminServiceListOrganizationMemberUsers,
+    createAdminServiceListOrganizationMemberUsersInfinite,
   } from "@rilldata/web-admin/client";
   import CreateUserGroupDialog from "@rilldata/web-admin/features/organizations/users/CreateUserGroupDialog.svelte";
   import EditUserGroupDialog from "@rilldata/web-admin/features/organizations/users/EditUserGroupDialog.svelte";
@@ -28,8 +28,23 @@
       pageToken,
       includeCounts: true,
     });
-  $: listOrganizationMemberUsers =
-    createAdminServiceListOrganizationMemberUsers(organization);
+  $: listOrganizationMemberUsersInfinite =
+    createAdminServiceListOrganizationMemberUsersInfinite(
+      organization,
+      {
+        pageSize: PAGE_SIZE,
+      },
+      {
+        query: {
+          getNextPageParam: (lastPage) => {
+            if (lastPage.nextPageToken !== "") {
+              return lastPage.nextPageToken;
+            }
+            return undefined;
+          },
+        },
+      },
+    );
 
   const currentUser = createAdminServiceGetCurrentUser();
 
@@ -45,6 +60,12 @@
   );
 
   $: isFetchingNextPage = $listOrganizationMemberUsergroups.isFetching;
+
+  // Flatten all pages of organization users
+  $: allOrganizationUsers =
+    $listOrganizationMemberUsersInfinite.data?.pages.flatMap(
+      (page) => page.members ?? [],
+    ) ?? [];
 
   function handleLoadMore() {
     if (hasNextPage) {
@@ -77,7 +98,7 @@
     <div class="text-red-500">
       Error loading organization user groups: {$listOrganizationMemberUsergroups.error}
     </div>
-  {:else if $listOrganizationMemberUsergroups.isSuccess && $listOrganizationMemberUsers.isSuccess}
+  {:else if $listOrganizationMemberUsergroups.isSuccess && $listOrganizationMemberUsersInfinite.isSuccess}
     <div class="flex flex-col">
       <div class="flex flex-row gap-x-4">
         <Search
@@ -100,7 +121,7 @@
         <OrgGroupsTable
           data={filteredGroups}
           currentUserEmail={$currentUser.data?.user.email}
-          searchUsersList={$listOrganizationMemberUsers.data?.members ?? []}
+          searchUsersList={allOrganizationUsers}
           {hasNextPage}
           {isFetchingNextPage}
           onLoadMore={handleLoadMore}
@@ -122,13 +143,13 @@
 <CreateUserGroupDialog
   bind:open={isCreateUserGroupDialogOpen}
   groupName={userGroupName}
-  organizationUsers={$listOrganizationMemberUsers.data?.members ?? []}
+  organizationUsers={allOrganizationUsers}
   currentUserEmail={$currentUser.data?.user.email}
 />
 
 <EditUserGroupDialog
   bind:open={isEditUserGroupDialogOpen}
   groupName={userGroupName}
-  organizationUsers={$listOrganizationMemberUsers.data?.members ?? []}
+  organizationUsers={allOrganizationUsers}
   currentUserEmail={$currentUser.data?.user.email}
 />


### PR DESCRIPTION
This PR resolves the pagination issue where user search bars in group management dialogs only showed the first 20 users, preventing users from finding and adding users beyond that limit in their organization.

Closes https://linear.app/rilldata/issue/APP-252/user-search-bar-does-not-paginate-beyond-first-20-users

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
