### PR TITLE
Increasing grpc received message size

### DIFF
--- a/cli/cmd/project/logs.go
+++ b/cli/cmd/project/logs.go
@@ -11,6 +11,7 @@ import (
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	runtimeclient "github.com/rilldata/rill/runtime/client"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -101,7 +102,9 @@ func LogsCmd(ch *cmdutil.Helper) *cobra.Command {
 				return context.Cause(ctx)
 			}
 
-			res, err := rt.GetLogs(cmd.Context(), &runtimev1.GetLogsRequest{InstanceId: depl.RuntimeInstanceId, Ascending: true, Limit: int32(tail), Level: lvl})
+			res, err := rt.GetLogs(cmd.Context(),
+				&runtimev1.GetLogsRequest{InstanceId: depl.RuntimeInstanceId, Ascending: true, Limit: int32(tail), Level: lvl},
+				grpc.MaxCallRecvMsgSize(17*1024*1024)) // setting grpc received message size to 16MB(default max logbuffer size)+1MB(buffer).
 			if err != nil {
 				return fmt.Errorf("failed to get logs: %w", err)
 			}


### PR DESCRIPTION
Fixes [PLAT-134: Fix `rill project logs` exceeding gRPC message size](https://linear.app/rilldata/issue/PLAT-134/fix-rill-project-logs-exceeding-grpc-message-size)

Tested by pointing rill project log to local runtime.
Before fix failed with
```
Error: failed to get logs: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (15733798 vs. 4194304) (ResourceExhausted)
```
After fix working fine.

No need to change server side send message size as its already int max by default.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
