### PR TITLE
Fix panic when parsing a YAML file with an empty environment override

### DIFF
--- a/runtime/parser/parse_node.go
+++ b/runtime/parser/parse_node.go
@@ -150,7 +150,7 @@ func (p *Parser) parseStem(paths []string, ymlPath, yml, sqlPath, sql string) (*
 			res.YAMLOverride = &envOverride
 
 			// Apply the override immediately in case it changes any of the commonYAML fields
-			err := res.YAMLOverride.Decode(&cfg)
+			err := res.YAMLOverride.Decode(cfg)
 			if err != nil {
 				return nil, pathError{path: ymlPath, err: newYAMLError(err)}
 			}


### PR DESCRIPTION
Fixes a bug that arises when an environment override is empty, e.g.:
```
type: model
sql: SELECT 1
dev:
```

**Checklist:**
- [x] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
