### PR TITLE
fix: github connection always throwing a popup

### DIFF
--- a/web-admin/src/features/projects/github/ProjectGithubConnection.svelte
+++ b/web-admin/src/features/projects/github/ProjectGithubConnection.svelte
@@ -58,7 +58,7 @@
   function confirmConnectToGithub() {
     // prompt reselection repos since a new repo might be created here.
     repoSelectionOpen.set(true);
-    void githubData.reselectRepos();
+    void githubData.startRepoSelection();
     behaviourEvent?.fireGithubIntentEvent(
       BehaviourEventAction.GithubConnectStart,
       {


### PR DESCRIPTION
We were throwing the github auth popup even if user already had access.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
