### PR TITLE
chore: keep only relevant examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,20 @@ cli-only:
 cli: cli.prepare
 	go build -o rill cli/main.go 
 
+KEEP_DIRS := rill-openrtb-prog-ads rill-github-analytics rill-cost-monitoring
+
 .PHONY: cli.prepare
 cli.prepare:
-	rm -rf runtime/pkg/examples/embed/dist || true
-	mkdir -p runtime/pkg/examples/embed/dist
-	git clone --quiet https://github.com/rilldata/rill-examples.git runtime/pkg/examples/embed/dist
-	find runtime/pkg/examples/embed/dist -mindepth 1 -maxdepth 1 -type d \
-	! -name 'rill-openrtb-prog-ads' \
-	! -name 'rill-github-analytics' \
-	! -name 'rill-cost-monitoring' \
-	-exec rm -rf {} +
+	@set -e; \
+	rm -rf runtime/pkg/examples/embed/dist || true; \
+	mkdir -p runtime/pkg/examples/embed/dist; \
+	# Create a temp dir (GNU mktemp first, then BSD/macOS fallback)
+	TMP_CLONE_DIR=$$(mktemp -d 2>/dev/null || mktemp -d -t rill-examples); \
+	trap 'rm -rf "$$TMP_CLONE_DIR"' EXIT; \
+	git clone --quiet --depth=1 https://github.com/rilldata/rill-examples.git "$$TMP_CLONE_DIR"; \
+	for d in $(KEEP_DIRS); do \
+		cp -R "$$TMP_CLONE_DIR/$$d" runtime/pkg/examples/embed/dist/; \
+	done
 	npm install
 	npm run build
 	rm -rf cli/pkg/web/embed/dist || true

--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,19 @@ cli: cli.prepare
 
 .PHONY: cli.prepare
 cli.prepare:
+	rm -rf runtime/pkg/examples/embed/dist || true
+	mkdir -p runtime/pkg/examples/embed/dist
+	git clone --quiet https://github.com/rilldata/rill-examples.git runtime/pkg/examples/embed/dist
+	find runtime/pkg/examples/embed/dist -mindepth 1 -maxdepth 1 -type d \
+	! -name 'rill-openrtb-prog-ads' \
+	! -name 'rill-github-analytics' \
+	! -name 'rill-cost-monitoring' \
+	-exec rm -rf {} +
 	npm install
 	npm run build
 	rm -rf cli/pkg/web/embed/dist || true
 	mkdir -p cli/pkg/web/embed/dist
 	cp -r web-local/build/* cli/pkg/web/embed/dist
-	rm -rf runtime/pkg/examples/embed/dist || true
-	mkdir -p runtime/pkg/examples/embed/dist
-	git clone --quiet https://github.com/rilldata/rill-examples.git runtime/pkg/examples/embed/dist
-	rm -rf runtime/pkg/examples/embed/dist/.git
 	go run scripts/embed_duckdb_ext/main.go
 
 .PHONY: coverage.go


### PR DESCRIPTION
Only keeps the example projects that are actually used in the UI to reduce file size.