### PR TITLE
fix: Disable comparison with rill time in alerts and reports

### DIFF
--- a/web-common/src/features/dashboards/aggregation-request-builder.ts
+++ b/web-common/src/features/dashboards/aggregation-request-builder.ts
@@ -1,9 +1,6 @@
 import { getAggregationDimensionFromFieldName } from "@rilldata/web-common/features/dashboards/aggregation-request/dimension-utils.ts";
+import { getComparisonRequestMeasures } from "@rilldata/web-common/features/dashboards/dashboard-utils.ts";
 import { mergeDimensionAndMeasureFilters } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils.ts";
-import {
-  COMPARISON_DELTA,
-  COMPARISON_PERCENT,
-} from "@rilldata/web-common/features/dashboards/pivot/types.ts";
 import { sanitiseExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils.ts";
 import type { FiltersState } from "@rilldata/web-common/features/dashboards/stores/Filters.ts";
 import type { TimeControlState } from "@rilldata/web-common/features/dashboards/stores/TimeControls.ts";
@@ -94,13 +91,12 @@ export const aggregationRequestWithRowsAndColumns = ({
     const measures = columns
       .filter((col) => exploreSpec.measures?.includes(col))
       .flatMap((measureName) => {
-        const group = [{ name: measureName }];
+        const group: V1MetricsViewAggregationMeasure[] = [
+          { name: measureName },
+        ];
 
-        if (showTimeComparison) {
-          group.push(
-            { name: `${measureName}${COMPARISON_DELTA}` },
-            { name: `${measureName}${COMPARISON_PERCENT}` },
-          );
+        if (showTimeComparison && aggregationRequest.comparisonTimeRange) {
+          group.push(...getComparisonRequestMeasures(measureName));
         }
 
         return group;

--- a/web-common/src/features/dashboards/filters/measure-filters/measure-filter-entry.ts
+++ b/web-common/src/features/dashboards/filters/measure-filters/measure-filter-entry.ts
@@ -36,7 +36,8 @@ export const ComparisonDeltaPreviousSuffix = "_prev";
 export const ComparisonDeltaAbsoluteSuffix = "_delta";
 export const ComparisonDeltaRelativeSuffix = "_delta_perc";
 export const ComparisonPercentOfTotal = "_percent_of_total";
-export const MeasureModifierSuffixRegex = /_delta(?:_perc)?|_percent_of_total/;
+export const MeasureModifierSuffixRegex =
+  /_prev|_delta(?:_perc)?|_percent_of_total/;
 
 export function mapExprToMeasureFilter(
   expr: V1Expression | undefined,

--- a/web-common/src/features/dashboards/time-controls/time-range-mappers.ts
+++ b/web-common/src/features/dashboards/time-controls/time-range-mappers.ts
@@ -1,4 +1,8 @@
-import { validateRillTime } from "@rilldata/web-common/features/dashboards/url-state/time-ranges/parser.ts";
+import {
+  overrideRillTimeRef,
+  parseRillTime,
+  validateRillTime,
+} from "@rilldata/web-common/features/dashboards/url-state/time-ranges/parser.ts";
 import { TIME_COMPARISON } from "@rilldata/web-common/lib/time/config.ts";
 import { isoDurationToFullTimeRange } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
 import {
@@ -98,7 +102,12 @@ export function mapSelectedComparisonTimeRangeToV1TimeRange(
   showTimeComparison: boolean,
   timeRange: V1TimeRange | undefined,
 ) {
-  if (!timeRange || !showTimeComparison || !selectedComparisonTimeRange?.name) {
+  if (
+    !timeRange ||
+    !showTimeComparison ||
+    !selectedComparisonTimeRange?.name ||
+    timeRange.expression
+  ) {
     return undefined;
   }
 
@@ -141,6 +150,16 @@ export function mapV1TimeRangeToSelectedTimeRange(
       start: new Date(timeRange.start),
       end: new Date(timeRange.end),
     };
+  } else if (timeRange.expression) {
+    try {
+      const rt = parseRillTime(timeRange.expression);
+      overrideRillTimeRef(rt, end);
+      selectedTimeRange = {
+        name: rt.toString(),
+      } as DashboardTimeControls;
+    } catch {
+      return undefined;
+    }
   } else if (duration && timeRangeSummary.min) {
     selectedTimeRange = isoDurationToFullTimeRange(
       duration,

--- a/web-common/src/features/explore-mappers/utils.ts
+++ b/web-common/src/features/explore-mappers/utils.ts
@@ -55,7 +55,10 @@ export function fillTimeRange(
       timeRangeSummary,
       executionTime,
     );
-    if (exploreState.selectedTimeRange) {
+    if (
+      exploreState.selectedTimeRange?.start &&
+      exploreState.selectedTimeRange?.end
+    ) {
       exploreState.selectedTimeRange.name = TimeRangePreset.CUSTOM;
     }
   }

--- a/web-common/src/features/scheduled-reports/FiltersForm.svelte
+++ b/web-common/src/features/scheduled-reports/FiltersForm.svelte
@@ -250,11 +250,13 @@
 >
   {#if $newPicker}
     {#if v1TimeRange}
-      <!-- We dont support the new dropdown in alert creation -->
-      <TimeRangeReadOnly
-        timeRange={v1TimeRange}
-        comparisonTimeRange={v1ComparisonTimeRange}
-      />
+      <div class="flex flex-wrap gap-2">
+        <!-- We dont support the new dropdown in alert creation -->
+        <TimeRangeReadOnly
+          timeRange={v1TimeRange}
+          comparisonTimeRange={v1ComparisonTimeRange}
+        />
+      </div>
     {/if}
   {:else}
     <div


### PR DESCRIPTION
We cant really do correct comparison without some additional rill time syntax support. So temporarily disabling comparisons in alerts an reports.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
