### PR TITLE
PLAT-137 Pentest: Change `/auth/with-token` to use short-lived tokens

### DIFF
--- a/admin/server/auth/middleware.go
+++ b/admin/server/auth/middleware.go
@@ -90,8 +90,10 @@ func (a *Authenticator) HTTPMiddlewareLenient(next http.Handler) http.Handler {
 	return a.httpMiddleware(next, true)
 }
 
-// HTTPMiddlewareWithCookieRefresh is a middleware that refreshes the auth cookie
-func (a *Authenticator) HTTPMiddlewareWithCookieRefresh(next http.Handler) http.Handler {
+// CookieRefreshMiddleware is a middleware that refreshes the auth cookie.
+// This enables us to do rolling cookie refreshes so we can have a relatively short cookie max age.
+// Note that it does not update the auth token encrypted inside the cookie.
+func (a *Authenticator) CookieRefreshMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		sess := a.cookies.Get(r, cookieName)
 		if authToken, ok := sess.Values[cookieFieldAccessToken].(string); ok && authToken != "" {

--- a/admin/server/server.go
+++ b/admin/server/server.go
@@ -186,7 +186,8 @@ func (s *Server) HTTPHandler(ctx context.Context) (http.Handler, error) {
 		return nil, fmt.Errorf("failed to create transcoder: %w", err)
 	}
 
-	// Add specific route for GetCurrentUser with cookie refresh
+	// Add auth cookie refresh specifically for the GetCurrentUser RPC.
+	// This is sufficient to refresh the cookie on each page load without unnecessarily refreshing cookies in each API call.
 	mux.Handle("/v1/users/current", s.authenticator.HTTPMiddlewareWithCookieRefresh(transcoder))
 
 	mux.Handle("/v1/", transcoder)

--- a/admin/server/server.go
+++ b/admin/server/server.go
@@ -188,7 +188,7 @@ func (s *Server) HTTPHandler(ctx context.Context) (http.Handler, error) {
 
 	// Add auth cookie refresh specifically for the GetCurrentUser RPC.
 	// This is sufficient to refresh the cookie on each page load without unnecessarily refreshing cookies in each API call.
-	mux.Handle("/v1/users/current", s.authenticator.HTTPMiddlewareWithCookieRefresh(transcoder))
+	mux.Handle("/v1/users/current", s.authenticator.CookieRefreshMiddleware(transcoder))
 
 	mux.Handle("/v1/", transcoder)
 	mux.Handle("/rill.admin.v1.AdminService/", transcoder)

--- a/admin/server/server.go
+++ b/admin/server/server.go
@@ -91,7 +91,7 @@ func New(logger *zap.Logger, adm *admin.Service, issuer *runtimeauth.Issuer, lim
 	cookieStore := cookies.New(logger, opts.SessionKeyPairs...)
 
 	// Auth tokens are validated against the DB on each request, so we can set a long MaxAge.
-	cookieStore.MaxAge(60 * 60 * 24 * 365 * 10) // 10 years
+	cookieStore.MaxAge(60 * 60 * 24 * 14) // 14 days
 
 	// Set Secure if the admin service is served over HTTPS (will resolve to true in production and false in local dev environments).
 	cookieStore.Options.Secure = adm.URLs.IsHTTPS()
@@ -185,6 +185,10 @@ func (s *Server) HTTPHandler(ctx context.Context) (http.Handler, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create transcoder: %w", err)
 	}
+
+	// Add specific route for GetCurrentUser with cookie refresh
+	mux.Handle("/v1/users/current", s.authenticator.HTTPMiddlewareWithCookieRefresh(transcoder))
+
 	mux.Handle("/v1/", transcoder)
 	mux.Handle("/rill.admin.v1.AdminService/", transcoder)
 	mux.Handle("/rill.admin.v1.AIService/", transcoder)

--- a/admin/urls.go
+++ b/admin/urls.go
@@ -156,11 +156,11 @@ func (u *URLs) AuthLogoutCallback() string {
 	return urlutil.MustJoinURL(u.external, "/auth/logout/callback") // NOTE: Always using the primary external URL.
 }
 
-// AuthWithToken returns a URL that sets the auth cookie to the provided token.
+// AuthWithToken returns a URL that sets the auth cookie to the provided nonce token.
 // Providing a redirect URL is optional.
 func (u *URLs) AuthWithToken(tokenStr, redirect string) string {
 	res := urlutil.MustJoinURL(u.External(), "/auth/with-token") // NOTE: Uses custom domain if set.
-	res = urlutil.MustWithQuery(res, map[string]string{"token": tokenStr})
+	res = urlutil.MustWithQuery(res, map[string]string{"nonce_token": tokenStr})
 	if redirect != "" {
 		res = urlutil.MustWithQuery(res, map[string]string{"redirect": redirect})
 	}


### PR DESCRIPTION
[PLAT-137: Pentest: Change `/auth/with-token` to use short-lived tokens](https://linear.app/rilldata/issue/PLAT-137/pentest-change-authwith-token-to-use-short-lived-tokens)

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
