### PR TITLE
fix: selecting all on a high cardinality dimension in dimension filter drop down crashes the app

### DIFF
--- a/web-common/src/features/canvas/filters/CanvasFilters.svelte
+++ b/web-common/src/features/canvas/filters/CanvasFilters.svelte
@@ -33,7 +33,7 @@
     canvasEntity: {
       filters: {
         whereFilter,
-        toggleDimensionValueSelection,
+        toggleMultipleDimensionValueSelections,
         applyDimensionInListMode,
         applyDimensionContainsMode,
         removeDimensionFilter,
@@ -217,7 +217,9 @@
                 onRemove={() => removeDimensionFilter(name)}
                 onToggleFilterMode={() => toggleDimensionFilterMode(name)}
                 onSelect={(value) =>
-                  toggleDimensionValueSelection(name, value, true)}
+                  toggleMultipleDimensionValueSelections(name, [value], true)}
+                onMultiSelect={(values) =>
+                  toggleMultipleDimensionValueSelections(name, values, true)}
                 onApplyInList={(values) =>
                   applyDimensionInListMode(name, values)}
                 onApplyContainsMode={(searchText) =>

--- a/web-common/src/features/canvas/inspector/filters/DimensionFiltersInput.svelte
+++ b/web-common/src/features/canvas/inspector/filters/DimensionFiltersInput.svelte
@@ -32,7 +32,7 @@
 
   $: ({
     whereFilter,
-    toggleDimensionValueSelection,
+    toggleMultipleDimensionValueSelections,
     applyDimensionInListMode,
     applyDimensionContainsMode,
     removeDimensionFilter,
@@ -154,7 +154,9 @@
                   onRemove={() => removeDimensionFilter(name)}
                   onToggleFilterMode={() => toggleDimensionFilterMode(name)}
                   onSelect={(value) =>
-                    toggleDimensionValueSelection(name, value, true)}
+                    toggleMultipleDimensionValueSelections(name, [value], true)}
+                  onMultiSelect={(values) =>
+                    toggleMultipleDimensionValueSelections(name, values, true)}
                   onApplyInList={(values) =>
                     applyDimensionInListMode(name, values)}
                   onApplyContainsMode={(searchText) =>

--- a/web-common/src/features/canvas/stores/filters.ts
+++ b/web-common/src/features/canvas/stores/filters.ts
@@ -10,6 +10,7 @@ import {
   mergeDimensionAndMeasureFilters,
   splitWhereFilter,
 } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-utils";
+import { toggleDimensionFilterValue } from "@rilldata/web-common/features/dashboards/state-managers/actions/dimension-filters.ts";
 import {
   type DimensionFilterItem,
   getDimensionFiltersMap,
@@ -20,7 +21,6 @@ import {
   createAndExpression,
   createInExpression,
   createLikeExpression,
-  getValueIndexInExpression,
   getValuesInExpression,
   isExpressionUnsupported,
   matchExpressionByName,
@@ -443,6 +443,20 @@ export class Filters {
     keepPillVisible?: boolean,
     isExclusiveFilter?: boolean,
   ) => {
+    this.toggleMultipleDimensionValueSelections(
+      dimensionName,
+      [dimensionValue],
+      keepPillVisible,
+      isExclusiveFilter,
+    );
+  };
+
+  toggleMultipleDimensionValueSelections = (
+    dimensionName: string,
+    dimensionValues: string[],
+    keepPillVisible?: boolean,
+    isExclusiveFilter?: boolean,
+  ) => {
     this.checkTemporaryFilter(dimensionName);
 
     const excludeMode = get(this.dimensionFilterExcludeMode);
@@ -450,45 +464,37 @@ export class Filters {
     const wf = get(this.whereFilter);
 
     // Use the derived selector:
-    const exprIndex =
+    let exprIndex =
       get(this.getWhereFilterExpressionIndex)(dimensionName) ?? -1;
-    const expr = wf.cond?.exprs?.[exprIndex];
+    let expr = wf.cond?.exprs?.[exprIndex];
 
-    const inIdx = getValueIndexInExpression(expr, dimensionValue);
+    const wasLikeFilter =
+      expr?.cond?.op === V1Operation.OPERATION_LIKE ||
+      expr?.cond?.op === V1Operation.OPERATION_NLIKE;
+    if (!expr?.cond?.exprs || wasLikeFilter) {
+      expr = createInExpression(dimensionName, [], isExclude);
+      wf.cond?.exprs?.push(expr);
+      exprIndex = wf.cond!.exprs!.length - 1;
+    }
 
-    if (exprIndex === -1 || !expr?.cond?.exprs) {
-      wf.cond?.exprs?.push(
-        createInExpression(dimensionName, [dimensionValue], isExclude),
-      );
-    } else if (
-      expr.cond?.op === V1Operation.OPERATION_LIKE ||
-      expr.cond?.op === V1Operation.OPERATION_NLIKE
-    ) {
-      wf.cond?.exprs?.push(
-        createInExpression(dimensionName, [dimensionValue], isExclude),
-      );
-    } else {
+    const wasInListFilter = get(this.dimensionsWithInlistFilter).includes(
+      dimensionName,
+    );
+    if (wasInListFilter) {
       this.dimensionsWithInlistFilter.update((dimensionsWithInlistFilter) =>
         dimensionsWithInlistFilter.filter((d) => d !== dimensionName),
       );
+    }
 
-      if (inIdx === -1) {
-        if (isExclusiveFilter) {
-          expr.cond.exprs.splice(1, expr.cond.exprs.length - 1, {
-            val: dimensionValue,
-          });
-        } else {
-          expr.cond.exprs.push({ val: dimensionValue });
-        }
-      } else {
-        expr.cond.exprs.splice(inIdx, 1);
-        if (expr.cond.exprs.length === 1) {
-          wf.cond?.exprs?.splice(exprIndex, 1);
+    dimensionValues.forEach((dimensionValue) => {
+      toggleDimensionFilterValue(expr, dimensionValue, !!isExclusiveFilter);
+    });
 
-          if (keepPillVisible) {
-            this.setTemporaryFilterName(dimensionName);
-          }
-        }
+    if (expr?.cond?.exprs?.length === 1) {
+      wf.cond?.exprs?.splice(exprIndex, 1);
+
+      if (keepPillVisible) {
+        this.setTemporaryFilterName(dimensionName);
       }
     }
 

--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -64,7 +64,7 @@
     validSpecStore,
     actions: {
       dimensionsFilter: {
-        toggleDimensionValueSelection,
+        toggleMultipleDimensionValueSelections,
         applyDimensionInListMode,
         applyDimensionContainsMode,
         removeDimensionFilter,
@@ -456,7 +456,9 @@
                 onRemove={() => removeDimensionFilter(name)}
                 onToggleFilterMode={() => toggleDimensionFilterMode(name)}
                 onSelect={(value) =>
-                  toggleDimensionValueSelection(name, value, true)}
+                  toggleMultipleDimensionValueSelections(name, [value], true)}
+                onMultiSelect={(values) =>
+                  toggleMultipleDimensionValueSelections(name, values, true)}
                 onApplyInList={(values) =>
                   applyDimensionInListMode(name, values)}
                 onApplyContainsMode={(searchText) =>

--- a/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
+++ b/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
@@ -50,6 +50,7 @@
   export let onRemove: () => void;
   export let onApplyInList: (values: string[]) => void;
   export let onSelect: (value: string) => void;
+  export let onMultiSelect: (values: string[]) => void;
   export let onApplyContainsMode: (inputText: string) => void = () => {};
   export let onToggleFilterMode: () => void;
   export let isUrlTooLongAfterInListFilter: (
@@ -325,14 +326,14 @@
     const proxyValues = new Set(selectedValuesProxy);
 
     // Apply all changes
-    [...currentValues, ...proxyValues].forEach((value) => {
-      const wasSelected = currentValues.has(value);
-      const isSelected = proxyValues.has(value);
+    onMultiSelect(
+      [...currentValues, ...proxyValues].filter((value) => {
+        const wasSelected = currentValues.has(value);
+        const isSelected = proxyValues.has(value);
 
-      if (wasSelected !== isSelected) {
-        onSelect(value);
-      }
-    });
+        return wasSelected !== isSelected;
+      }),
+    );
 
     // Handle exclude mode toggle
     if (curExcludeMode !== excludeMode) {

--- a/web-common/src/features/dashboards/stores/Filters.ts
+++ b/web-common/src/features/dashboards/stores/Filters.ts
@@ -4,6 +4,7 @@ import {
   getMeasureDisplayName,
 } from "@rilldata/web-common/features/dashboards/filters/getDisplayName.ts";
 import type { MeasureFilterEntry } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry.ts";
+import { toggleDimensionFilterValue } from "@rilldata/web-common/features/dashboards/state-managers/actions/dimension-filters.ts";
 import {
   type DimensionFilterItem,
   getDimensionFilters,
@@ -19,7 +20,6 @@ import {
   createAndExpression,
   createInExpression,
   createLikeExpression,
-  getValueIndexInExpression,
   matchExpressionByName,
   negateExpression,
 } from "@rilldata/web-common/features/dashboards/stores/filter-utils.ts";
@@ -265,9 +265,23 @@ export class Filters {
     this.dimensionThresholdFilters.set(dtfs);
   };
 
-  public toggleDimensionValueSelection = (
+  toggleDimensionValueSelection = (
     dimensionName: string,
     dimensionValue: string,
+    keepPillVisible?: boolean,
+    isExclusiveFilter?: boolean,
+  ) => {
+    this.toggleMultipleDimensionValueSelections(
+      dimensionName,
+      [dimensionValue],
+      keepPillVisible,
+      isExclusiveFilter,
+    );
+  };
+
+  toggleMultipleDimensionValueSelections = (
+    dimensionName: string,
+    dimensionValues: string[],
     keepPillVisible?: boolean,
     isExclusiveFilter?: boolean,
   ) => {
@@ -275,55 +289,45 @@ export class Filters {
     if (tempFilter !== null) {
       this.temporaryFilterName.set(null);
     }
+
     const excludeMode = get(this.dimensionFilterExcludeMode);
     const isExclude = !!excludeMode.get(dimensionName);
     const wf = get(this.whereFilter);
 
     // Use the derived selector:
-    const exprIndex = this.getWhereFilterExpressionIndex(dimensionName);
+    let exprIndex = this.getWhereFilterExpressionIndex(dimensionName) ?? -1;
+    let expr = wf.cond?.exprs?.[exprIndex];
 
-    if (exprIndex === undefined || exprIndex === -1) {
-      wf.cond?.exprs?.push(
-        createInExpression(dimensionName, [dimensionValue], isExclude),
-      );
-      this.whereFilter.set(wf);
-      return;
+    const wasLikeFilter =
+      expr?.cond?.op === V1Operation.OPERATION_LIKE ||
+      expr?.cond?.op === V1Operation.OPERATION_NLIKE;
+    if (!expr?.cond?.exprs || wasLikeFilter) {
+      expr = createInExpression(dimensionName, [], isExclude);
+      wf.cond?.exprs?.push(expr);
+      exprIndex = wf.cond!.exprs!.length - 1;
     }
 
-    const expr = wf.cond?.exprs?.[exprIndex];
-    if (!expr?.cond?.exprs) return;
-    this.dimensionsWithInlistFilter.update((dimensionsWithInlistFilter) =>
-      dimensionsWithInlistFilter.filter((d) => d !== dimensionName),
+    const wasInListFilter = get(this.dimensionsWithInlistFilter).includes(
+      dimensionName,
     );
-    if (
-      expr.cond?.op === V1Operation.OPERATION_LIKE ||
-      expr.cond?.op === V1Operation.OPERATION_NLIKE
-    ) {
-      wf.cond?.exprs?.push(
-        createInExpression(dimensionName, [dimensionValue], isExclude),
+    if (wasInListFilter) {
+      this.dimensionsWithInlistFilter.update((dimensionsWithInlistFilter) =>
+        dimensionsWithInlistFilter.filter((d) => d !== dimensionName),
       );
-      this.whereFilter.set(wf);
-      return;
     }
 
-    const inIdx = getValueIndexInExpression(expr, dimensionValue) as number;
-    if (inIdx === -1) {
-      if (isExclusiveFilter) {
-        expr.cond.exprs.splice(1, expr.cond.exprs.length - 1, {
-          val: dimensionValue,
-        });
-      } else {
-        expr.cond.exprs.push({ val: dimensionValue });
-      }
-    } else {
-      expr.cond.exprs.splice(inIdx, 1);
-      if (expr.cond.exprs.length === 1) {
-        wf.cond?.exprs?.splice(exprIndex, 1);
-        if (keepPillVisible) {
-          this.temporaryFilterName.set(dimensionName);
-        }
+    dimensionValues.forEach((dimensionValue) => {
+      toggleDimensionFilterValue(expr, dimensionValue, !!isExclusiveFilter);
+    });
+
+    if (expr?.cond?.exprs?.length === 1) {
+      wf.cond?.exprs?.splice(exprIndex, 1);
+
+      if (keepPillVisible) {
+        this.setTemporaryFilterName(dimensionName);
       }
     }
+
     this.whereFilter.set(wf);
   };
 

--- a/web-common/src/features/dashboards/stores/filter-utils.ts
+++ b/web-common/src/features/dashboards/stores/filter-utils.ts
@@ -299,8 +299,7 @@ export function getValueIndexInExpression(
   expr: V1Expression | undefined,
   value: string,
 ) {
-  if (!expr || !expr.cond?.exprs?.length) return -1;
-  return expr.cond?.exprs?.findIndex((e, i) => i > 0 && e.val === value);
+  return expr?.cond?.exprs?.findIndex((e, i) => i > 0 && e.val === value) ?? -1;
 }
 
 export function getValuesInExpression(expr?: V1Expression): any[] {

--- a/web-common/src/features/scheduled-reports/FiltersForm.svelte
+++ b/web-common/src/features/scheduled-reports/FiltersForm.svelte
@@ -57,7 +57,7 @@
 
     removeDimensionFilter,
     toggleDimensionFilterMode,
-    toggleDimensionValueSelection,
+    toggleMultipleDimensionValueSelections,
     applyDimensionInListMode,
     applyDimensionContainsMode,
 
@@ -343,7 +343,9 @@
                 onRemove={() => removeDimensionFilter(name)}
                 onToggleFilterMode={() => toggleDimensionFilterMode(name)}
                 onSelect={(value) =>
-                  toggleDimensionValueSelection(name, value, true)}
+                  toggleMultipleDimensionValueSelections(name, [value], true)}
+                onMultiSelect={(values) =>
+                  toggleMultipleDimensionValueSelections(name, values, true)}
                 onApplyInList={(values) =>
                   applyDimensionInListMode(name, values)}
                 onApplyContainsMode={(searchText) =>


### PR DESCRIPTION
In dimension filter dropdown, select all does it one at a time. This leads to gzip calculation to happen one at a time. With a large set of values this slows down and crashes the app.

Moveing to using a multi select method so that all the values are toggled at once.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
