### PR TITLE
Apply security policies in `ResolveCanvas`

### DIFF
--- a/runtime/server/auth/claims.go
+++ b/runtime/server/auth/claims.go
@@ -93,6 +93,10 @@ type openClaims struct{}
 
 var _ Claims = (*openClaims)(nil)
 
+func NewOpenClaims() Claims {
+	return openClaims{}
+}
+
 func (c openClaims) Subject() string {
 	return ""
 }
@@ -154,6 +158,10 @@ type devJWTClaims struct {
 }
 
 var _ Claims = (*devJWTClaims)(nil)
+
+func NewDevClaims(attrs map[string]any) Claims {
+	return &devJWTClaims{Attrs: attrs}
+}
 
 func (c devJWTClaims) Subject() string {
 	return ""

--- a/runtime/server/auth/interceptors.go
+++ b/runtime/server/auth/interceptors.go
@@ -31,6 +31,13 @@ func GetClaims(ctx context.Context) Claims {
 	return claims
 }
 
+// WithClaims wraps a context with the given claims.
+// It mimics the result of parsing a JWT using a middleware. It should only be used in tests.
+// NOTE: We should remove this when the server tests support interceptors.
+func WithClaims(ctx context.Context, claims Claims) context.Context {
+	return context.WithValue(ctx, claimsContextKey{}, claims)
+}
+
 // UnaryServerInterceptor is a middleware for setting claims on runtime server requests.
 // The assigned claims can be retrieved using GetClaims. If the interceptor succeeds, a Claims value is guaranteed to be set on the ctx.
 // The claim parsing logic is as follows
@@ -154,10 +161,4 @@ func parseClaims(ctx context.Context, aud *Audience, authorizationHeader string)
 
 	ctx = context.WithValue(ctx, claimsContextKey{}, claims)
 	return ctx, nil
-}
-
-// WithOpen wraps a context with open claims. It's used for testing.
-// NOTE: We should remove this when the server tests support interceptors.
-func WithOpen(ctx context.Context) context.Context {
-	return context.WithValue(ctx, claimsContextKey{}, openClaims{})
 }

--- a/runtime/server/canvases.go
+++ b/runtime/server/canvases.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
@@ -42,6 +43,17 @@ func (s *Server) ResolveCanvas(ctx context.Context, req *runtimev1.ResolveCanvas
 		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}
+
+	// Check if the user has access to the canvas
+	res, access, err := s.applySecurityPolicy(ctx, req.InstanceId, res)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply security policy: %w", err)
+	}
+	if !access {
+		return nil, status.Errorf(codes.PermissionDenied, "user does not have access to canvas %q", req.Canvas)
+	}
+
+	// Exit early if the canvas is not valid
 	spec := res.GetCanvas().State.ValidSpec
 	if spec == nil {
 		return &runtimev1.ResolveCanvasResponse{
@@ -165,6 +177,20 @@ func (s *Server) ResolveCanvas(ctx context.Context, req *runtimev1.ResolveCanvas
 		referencedMetricsViews[mvName] = mv
 	}
 
+	// Apply security policies to the metrics views.
+	for name, mv := range referencedMetricsViews {
+		mv, access, err := s.applySecurityPolicy(ctx, req.InstanceId, mv)
+		if err != nil {
+			return nil, fmt.Errorf("failed to apply security policy: %w", err)
+		}
+		if !access {
+			delete(referencedMetricsViews, name)
+			continue
+		}
+		referencedMetricsViews[name] = mv
+	}
+
+	// Return the response
 	return &runtimev1.ResolveCanvasResponse{
 		Canvas:                 res,
 		ResolvedComponents:     components,

--- a/runtime/server/mcp_test.go
+++ b/runtime/server/mcp_test.go
@@ -15,7 +15,7 @@ import (
 
 // testCtx provides authentication context for testing
 func testCtx() context.Context {
-	return auth.WithOpen(context.Background())
+	return auth.WithClaims(context.Background(), auth.NewOpenClaims())
 }
 
 func newMCPTestServer(t *testing.T) (*Server, string) {

--- a/runtime/server/server_test.go
+++ b/runtime/server/server_test.go
@@ -22,5 +22,5 @@ func getTestServer(t *testing.T) (*server.Server, string) {
 }
 
 func testCtx() context.Context {
-	return auth.WithOpen(context.Background())
+	return auth.WithClaims(context.Background(), auth.NewOpenClaims())
 }


### PR DESCRIPTION
Apply the same security policy checks in `ResolveCanvas` as we do in `GetResource`. Without this, the `ResolveCanvas` returns metadata about metrics views and dimensions/measures that will fail when queried for the current user.

Closes https://linear.app/rilldata/issue/PLAT-164/sec-policy-exclude-not-working-on-canvas

**Checklist:**
- [x] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
