### PR TITLE
Detect github subpath in rill deploy command

### DIFF
--- a/cli/pkg/gitutil/gitcmdwrapper.go
+++ b/cli/pkg/gitutil/gitcmdwrapper.go
@@ -148,6 +148,15 @@ func RunGitPull(ctx context.Context, path string, discardLocal bool, remote, rem
 	return "", nil
 }
 
+func InferGitRepoRoot(path string) (string, error) {
+	cmd := exec.Command("git", "-C", path, "rev-parse", "--show-toplevel")
+	data, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
 // countCommitsAhead counts the number of commits in `from` branch not present in `to` branch.
 func countCommitsAhead(path, to, from string) (int32, error) {
 	cmd := exec.Command("git", "-C", path, "rev-list", "--count", fmt.Sprintf("%s..%s", to, from))

--- a/cli/pkg/gitutil/gitcmdwrapper_test.go
+++ b/cli/pkg/gitutil/gitcmdwrapper_test.go
@@ -101,6 +101,47 @@ func TestGitPull(t *testing.T) {
 	require.Empty(t, output, "unexpected output from GitPull with remote changes")
 }
 
+func TestInferGitRepoRoot_InRepoRoot(t *testing.T) {
+	tempDir, _ := setupTestRepository(t)
+
+	root, err := InferGitRepoRoot(tempDir)
+	require.NoError(t, err, "InferGitRepoRoot failed on repo root")
+	assertPathsEqual(t, root, tempDir)
+}
+
+func TestInferGitRepoRoot_InNestedDir(t *testing.T) {
+	tempDir, _ := setupTestRepository(t)
+
+	nested := filepath.Join(tempDir, "nested", "deep")
+	err := os.MkdirAll(nested, 0o755)
+	require.NoError(t, err, "failed to create nested directories")
+
+	root, err := InferGitRepoRoot(nested)
+	require.NoError(t, err, "InferGitRepoRoot failed on nested path")
+	assertPathsEqual(t, root, tempDir)
+}
+
+func TestInferGitRepoRoot_NotRepo(t *testing.T) {
+	dir := t.TempDir()
+
+	root, err := InferGitRepoRoot(dir)
+	require.Error(t, err, "expected error for non-repo directory")
+	require.Equal(t, "", root, "expected empty root for error case")
+}
+
+// Helper: compare canonicalized paths
+func assertPathsEqual(t *testing.T, p1, p2 string) {
+	t.Helper()
+	p1 = filepath.Clean(p1)
+	p2 = filepath.Clean(p2)
+	if r1, err := filepath.EvalSymlinks(p1); err == nil {
+		p1 = r1
+	}
+	if r2, err := filepath.EvalSymlinks(p2); err == nil {
+		p2 = r2
+	}
+	require.Equal(t, p1, p2)
+}
 func setupTestRepository(t *testing.T) (string, string) {
 	tempDir := t.TempDir()
 


### PR DESCRIPTION
- [ ] Tries to detect subpath if it is not provided by the user
- [ ] Switches the default deploy option to `connect to github` if deploying from a git repository

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
