### PR TITLE
Fix: unnecessary annotations API call when metrics view has no annotations defined

### DIFF
--- a/web-common/src/features/dashboards/time-series/annotations-selectors.ts
+++ b/web-common/src/features/dashboards/time-series/annotations-selectors.ts
@@ -39,6 +39,7 @@ export function getAnnotationsForMeasure({
   const annotationsQueryOptions = derived(
     exploreValidSpec,
     (exploreValidSpec) => {
+      const metricsViewSpec = exploreValidSpec.data?.metricsView;
       const exploreSpec = exploreValidSpec.data?.explore;
       const metricsViewName = exploreSpec?.metricsView ?? "";
 
@@ -55,7 +56,10 @@ export function getAnnotationsForMeasure({
         },
         {
           query: {
-            enabled: !!metricsViewName && !!selectedTimeRange,
+            enabled:
+              !!metricsViewSpec?.annotations?.length &&
+              !!metricsViewName &&
+              !!selectedTimeRange,
           },
         },
       );


### PR DESCRIPTION
We are making a call for annotations even when we know for sure the metrics view has no annotations defined.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
