### PR TITLE
fix: time syntax beta issues

### DIFF
--- a/web-common/src/features/canvas/LocalFiltersHeader.svelte
+++ b/web-common/src/features/canvas/LocalFiltersHeader.svelte
@@ -31,15 +31,18 @@
     dimensions = getDimensionsForMetricView(metricsViewName);
   }
 
-  $: whereFilters = localFilters.whereFilter;
-  $: dimensionThresholdFilters = localFilters.dimensionThresholdFilters;
-  $: dimensionsWithInlistFilter = localFilters.dimensionsWithInlistFilter;
-  $: selectedTimeRange = localTimeControls.selectedTimeRange;
-  $: showTimeComparison = localTimeControls.showTimeComparison;
+  $: ({ showTimeComparison, timeRangeStateStore } = localTimeControls);
+
+  $: selectedTimeRange = $timeRangeStateStore?.selectedTimeRange;
+
+  $: ({ whereFilter, dimensionThresholdFilters, dimensionsWithInlistFilter } =
+    localFilters);
+
   $: displayTimeRange = {
     ...$timeAndFilterStore.timeRange,
-    isoDuration: $selectedTimeRange?.name,
+    isoDuration: selectedTimeRange?.name,
   };
+
   $: displayComparisonTimeRange = $timeAndFilterStore.comparisonTimeRange;
 
   $: hasTimeFilters = "time_filters" in $specStore && $specStore.time_filters;
@@ -56,13 +59,13 @@
       measures={$measures}
       dimensionThresholdFilters={$dimensionThresholdFilters}
       dimensionsWithInlistFilter={$dimensionsWithInlistFilter}
-      filters={$whereFilters}
+      filters={$whereFilter}
       displayComparisonTimeRange={$showTimeComparison
         ? displayComparisonTimeRange
         : undefined}
       displayTimeRange={hasTimeFilters ? displayTimeRange : undefined}
-      queryTimeStart={$selectedTimeRange?.start?.toISOString()}
-      queryTimeEnd={$selectedTimeRange?.end?.toISOString()}
+      queryTimeStart={selectedTimeRange?.start?.toISOString()}
+      queryTimeEnd={selectedTimeRange?.end?.toISOString()}
       hasBoldTimeRange={false}
       chipLayout="scroll"
     />

--- a/web-common/src/features/canvas/LocalFiltersHeader.svelte
+++ b/web-common/src/features/canvas/LocalFiltersHeader.svelte
@@ -46,6 +46,8 @@
   $: displayComparisonTimeRange = $timeAndFilterStore.comparisonTimeRange;
 
   $: hasTimeFilters = "time_filters" in $specStore && $specStore.time_filters;
+
+  $: $timeAndFilterStore);
 </script>
 
 {#if "metrics_view" in $specStore}

--- a/web-common/src/features/canvas/LocalFiltersHeader.svelte
+++ b/web-common/src/features/canvas/LocalFiltersHeader.svelte
@@ -46,8 +46,6 @@
   $: displayComparisonTimeRange = $timeAndFilterStore.comparisonTimeRange;
 
   $: hasTimeFilters = "time_filters" in $specStore && $specStore.time_filters;
-
-  $: $timeAndFilterStore);
 </script>
 
 {#if "metrics_view" in $specStore}

--- a/web-common/src/features/canvas/inspector/filters/TimeFiltersInput.svelte
+++ b/web-common/src/features/canvas/inspector/filters/TimeFiltersInput.svelte
@@ -89,6 +89,7 @@
   {#if localFiltersEnabled}
     <div class="flex flex-row flex-wrap pt-2 gap-y-1.5 items-center">
       <SuperPill
+        context="filters-input"
         allTimeRange={$allTimeRange}
         {selectedRangeAlias}
         showPivot={!showGrain}

--- a/web-common/src/features/canvas/stores/time-control.ts
+++ b/web-common/src/features/canvas/stores/time-control.ts
@@ -55,7 +55,6 @@ export class TimeControls {
   /**
    * Writables which can be updated by the user
    */
-  // selectedTimeRange: Writable<DashboardTimeControls | undefined>;
   selectedComparisonTimeRange: Writable<DashboardTimeControls | undefined>;
   showTimeComparison: Writable<boolean>;
   selectedTimezone: Writable<string>;

--- a/web-common/src/features/canvas/stores/time-control.ts
+++ b/web-common/src/features/canvas/stores/time-control.ts
@@ -55,7 +55,7 @@ export class TimeControls {
   /**
    * Writables which can be updated by the user
    */
-  selectedTimeRange: Writable<DashboardTimeControls | undefined>;
+  // selectedTimeRange: Writable<DashboardTimeControls | undefined>;
   selectedComparisonTimeRange: Writable<DashboardTimeControls | undefined>;
   showTimeComparison: Writable<boolean>;
   selectedTimezone: Writable<string>;

--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -128,7 +128,11 @@
   $: exploreState = useExploreState($exploreName);
   $: activeTimeZone = $exploreState?.selectedTimezone;
 
-  $: selectedRangeAlias = selectedTimeRange?.name;
+  $: selectedRangeAlias =
+    selectedTimeRange?.name === TimeRangePreset.CUSTOM
+      ? `${selectedTimeRange.start.toISOString()},${selectedTimeRange.end.toISOString()}`
+      : selectedTimeRange?.name;
+
   $: activeTimeGrain = selectedTimeRange?.interval;
   $: defaultTimeRange = exploreSpec.defaultPreset?.timeRange;
 

--- a/web-common/src/features/dashboards/filters/TimeRangeReadOnly.svelte
+++ b/web-common/src/features/dashboards/filters/TimeRangeReadOnly.svelte
@@ -1,44 +1,40 @@
 <script lang="ts">
   import { Chip } from "@rilldata/web-common/components/chip";
-  import { getRillTimeLabel } from "@rilldata/web-common/features/dashboards/url-state/time-ranges/parser.ts";
   import { getComparisonLabel } from "@rilldata/web-common/lib/time/comparisons";
-  import { DEFAULT_TIME_RANGES } from "@rilldata/web-common/lib/time/config";
-  import { prettyFormatTimeRange } from "@rilldata/web-common/lib/time/ranges";
-  import { humaniseISODuration } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
-  import { TimeRangePreset } from "@rilldata/web-common/lib/time/types";
   import type { V1TimeRange } from "@rilldata/web-common/runtime-client";
+  import { getRangeLabel } from "../time-controls/new-time-controls";
+  import RangeDisplay from "../time-controls/super-pill/components/RangeDisplay.svelte";
+  import { DateTime, Interval } from "luxon";
 
   export let timeRange: V1TimeRange;
   export let comparisonTimeRange: V1TimeRange | undefined;
   export let hasBoldTimeRange: boolean = true;
+
+  $: selectedLabel = getRangeLabel(timeRange.isoDuration);
+
+  $: showRange =
+    selectedLabel === "Custom" ||
+    selectedLabel?.startsWith("-") ||
+    !isNaN(Number(selectedLabel?.[0]));
 </script>
 
 <Chip type="time" readOnly>
   <svelte:fragment slot="body">
-    <div class="text-xs text-slate-800 px-2">
-      {#if timeRange.isoDuration && timeRange.isoDuration !== TimeRangePreset.CUSTOM}
-        <div class="font-bold">
-          {#if timeRange.isoDuration === TimeRangePreset.ALL_TIME}
-            All Time
-          {:else if timeRange.isoDuration in DEFAULT_TIME_RANGES}
-            {DEFAULT_TIME_RANGES[timeRange.isoDuration].label}
-          {:else}
-            Last {humaniseISODuration(timeRange.isoDuration)}
-          {/if}
-        </div>
-      {:else if timeRange.start && timeRange.end}
-        <div class:font-bold={hasBoldTimeRange}>
-          {prettyFormatTimeRange(
-            new Date(timeRange.start),
-            new Date(timeRange.end),
-            TimeRangePreset.CUSTOM,
-            "UTC", // TODO
+    <div class="text-xs text-slate-800 flex gap-x-1.5">
+      <div class="font-bold">
+        {#if showRange}
+          Custom
+        {:else}
+          {selectedLabel}
+        {/if}
+      </div>
+      {#if showRange && timeRange.start && timeRange.end}
+        <RangeDisplay
+          interval={Interval.fromDateTimes(
+            DateTime.fromISO(timeRange.start).setZone(timeRange.timeZone),
+            DateTime.fromISO(timeRange.end).setZone(timeRange.timeZone),
           )}
-        </div>
-      {:else if timeRange.expression}
-        <div class:font-bold={hasBoldTimeRange}>
-          {getRillTimeLabel(timeRange.expression)}
-        </div>
+        />
       {/if}
     </div>
   </svelte:fragment>

--- a/web-common/src/features/dashboards/time-controls/super-pill/SuperPill.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/SuperPill.svelte
@@ -17,8 +17,6 @@
   import * as Elements from "./components";
   import RangePickerV2 from "./new-time-dropdown/RangePickerV2.svelte";
   import { featureFlags } from "@rilldata/web-common/features/feature-flags";
-  import { page } from "$app/stores";
-  import { ExploreStateURLParams } from "../../url-state/url-params";
 
   export let allTimeRange: TimeRange;
   export let selectedRangeAlias: string | undefined;
@@ -53,15 +51,11 @@
 
   $: rangeBuckets = bucketYamlRanges(timeRanges);
 
-  $: ({
-    url: { searchParams },
-  } = $page);
+  $: v2TimeString = normalizeRangeString(selectedRangeAlias);
 
-  $: rawTimeString = searchParams.get(ExploreStateURLParams.TimeRange);
-
-  $: v2TimeString = normalizeRangeString(rawTimeString);
-
-  function normalizeRangeString(alias: string | null): string | undefined {
+  function normalizeRangeString(
+    alias: string | null | undefined,
+  ): string | undefined {
     return alias?.replace(",", " to ");
   }
 </script>
@@ -86,6 +80,7 @@
       zone={activeTimeZone}
       {lockTimeZone}
       {availableTimeZones}
+      {showFullRange}
       {onSelectTimeZone}
       {onSelectRange}
       {onTimeGrainSelect}
@@ -100,7 +95,7 @@
       {defaultTimeRange}
       {allowCustomTimeRange}
       selected={selectedRangeAlias ?? ""}
-      {onSelectRange}
+      {side}
       {interval}
       zone={activeTimeZone}
       applyCustomRange={(interval) => {
@@ -110,7 +105,7 @@
           end: interval.end.toJSDate(),
         });
       }}
-      {side}
+      {onSelectRange}
     />
   {/if}
 

--- a/web-common/src/features/dashboards/time-controls/super-pill/components/RangePicker.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/RangePicker.svelte
@@ -20,11 +20,11 @@
   export let minDate: DateTime | undefined = undefined;
   export let maxDate: DateTime | undefined = undefined;
   export let showFullRange: boolean;
+  export let allowCustomTimeRange = true;
   export let defaultTimeRange: NamedRange | ISODurationString | undefined;
   export let side: "top" | "right" | "bottom" | "left" = "bottom";
   export let onSelectRange: (range: NamedRange | ISODurationString) => void;
   export let applyCustomRange: (range: Interval<true>) => void;
-  export let allowCustomTimeRange = true;
 
   let firstVisibleMonth: DateTime<true> = interval.start;
   let open = false;
@@ -51,6 +51,7 @@
       type="button"
     >
       <b class="mr-1 line-clamp-1 flex-none">{getRangeLabel(selected)}</b>
+
       {#if interval.isValid && showFullRange}
         <RangeDisplay {interval} />
       {/if}

--- a/web-common/src/features/dashboards/time-controls/super-pill/new-time-dropdown/RangePickerV2.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/new-time-dropdown/RangePickerV2.svelte
@@ -58,6 +58,7 @@
   export let allowCustomTimeRange = true;
   export let availableTimeZones: string[];
   export let lockTimeZone = false;
+  export let showFullRange = true;
   export let onSelectTimeZone: (timeZone: string) => void;
   export let onSelectRange: (range: string) => void;
   export let onTimeGrainSelect: (grain: V1TimeGrain) => void;
@@ -224,12 +225,12 @@
     }
   }}
 >
-  <Popover.Trigger asChild let:builder id="super-pill-trigger">
+  <Popover.Trigger asChild let:builder id="super-pill-trigger-{context}">
     <Tooltip.Root openDelay={800}>
       <Tooltip.Trigger
         asChild
         let:builder={tooltipBuilder}
-        id="super-pill-trigger"
+        id="super-pill-trigger-{context}"
       >
         <button
           use:builderActions={{ builders: [builder, tooltipBuilder] }}
@@ -247,13 +248,15 @@
             </b>
           {/if}
 
-          <RangeDisplay {interval} />
+          {#if showFullRange}
+            <RangeDisplay {interval} />
 
-          <div
-            class="font-bold bg-gray-100 rounded-[2px] p-1 py-0 text-gray-600 text-[11px]"
-          >
-            {zoneAbbreviation}
-          </div>
+            <div
+              class="font-bold bg-gray-100 rounded-[2px] p-1 py-0 text-gray-600 text-[11px]"
+            >
+              {zoneAbbreviation}
+            </div>
+          {/if}
 
           <span class="flex-none transition-transform" class:-rotate-180={open}>
             <CaretDownIcon />

--- a/web-common/src/features/dashboards/time-controls/time-control-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.ts
@@ -54,6 +54,7 @@ export type TimeRangeState = {
   adjustedStart?: string;
   adjustedEnd?: string;
 };
+
 export type ComparisonTimeRangeState = {
   showTimeComparison?: boolean;
   selectedComparisonTimeRange?: DashboardTimeControls;
@@ -62,6 +63,7 @@ export type ComparisonTimeRangeState = {
   comparisonTimeEnd?: string;
   comparisonAdjustedEnd?: string;
 };
+
 export type TimeControlState = {
   isFetching: boolean;
 

--- a/web-common/src/features/scheduled-reports/FiltersForm.svelte
+++ b/web-common/src/features/scheduled-reports/FiltersForm.svelte
@@ -45,28 +45,21 @@
   const ROW_HEIGHT = "26px";
   $: ({
     whereFilter,
-
     allDimensionFilterItems,
     isFilterExcludeMode,
     dimensionHasFilter,
-
     allMeasureFilterItems,
     measureHasFilter,
-
     hasFilters,
-
     removeDimensionFilter,
     toggleDimensionFilterMode,
     toggleMultipleDimensionValueSelections,
     applyDimensionInListMode,
     applyDimensionContainsMode,
-
     removeMeasureFilter,
     setMeasureFilter,
-
     setTemporaryFilterName,
     clearAllFilters,
-
     metricsViewMetadata: {
       metricsViewName,
       allDimensions,
@@ -74,13 +67,12 @@
       validSpecQuery,
     },
   } = filters);
+
   $: ({
     selectedTimezone,
     allTimeRange,
-
     timeRangeStateStore,
     comparisonRangeStateStore,
-
     setTimeZone,
     selectTimeRange,
     setSelectedComparisonRange,
@@ -243,6 +235,7 @@
   }
 </script>
 
+showFullRange
 <div
   class="flex flex-col gap-y-2 size-full pointer-events-none"
   style:max-width="{maxWidth}px"

--- a/web-common/src/features/scheduled-reports/FiltersForm.svelte
+++ b/web-common/src/features/scheduled-reports/FiltersForm.svelte
@@ -235,7 +235,6 @@
   }
 </script>
 
-showFullRange
 <div
   class="flex flex-col gap-y-2 size-full pointer-events-none"
   style:max-width="{maxWidth}px"

--- a/web-common/src/lib/time/new-grains.ts
+++ b/web-common/src/lib/time/new-grains.ts
@@ -107,8 +107,7 @@ export function grainAliasToDateTimeUnit(alias: TimeGrainAlias): DateTimeUnit {
 }
 
 const allowedGrains = [
-  // V1TimeGrain.TIME_GRAIN_MILLISECOND,
-  // V1TimeGrain.TIME_GRAIN_SECOND,
+  V1TimeGrain.TIME_GRAIN_SECOND,
   V1TimeGrain.TIME_GRAIN_MINUTE,
   V1TimeGrain.TIME_GRAIN_HOUR,
   V1TimeGrain.TIME_GRAIN_DAY,


### PR DESCRIPTION
- Fixes an issue where local time filters on Canvas would not display their human readable label
- Fixes an issue where the `smallest_time_grain` value could not be selected as the aggregation grain on Explore
- Fixes an issue where range tooltips would not render properly on the Canvas editing surface

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
