### PR TITLE
[PLAT-165] pass query priority to druid

### DIFF
--- a/runtime/drivers/druid/druid.go
+++ b/runtime/drivers/druid/druid.go
@@ -107,6 +107,8 @@ type configProperties struct {
 	MaxOpenConns int `mapstructure:"max_open_conns"`
 	// SkipVersionCheck skips the version check.
 	SkipVersionCheck bool `mapstructure:"skip_version_check"`
+	// SkipQueryPriority indicates whether to skip passing query priority to Druid.
+	SkipQueryPriority bool `mapstructure:"skip_query_priority"`
 }
 
 // Opens a connection to Apache Druid using HTTP API.

--- a/runtime/drivers/druid/druidsqldriver/druid_api_sql_driver.go
+++ b/runtime/drivers/druid/druidsqldriver/druid_api_sql_driver.go
@@ -457,6 +457,7 @@ type DruidQueryContext struct {
 	EnableTimeBoundaryPlanning bool   `json:"enableTimeBoundaryPlanning"`
 	UseCache                   *bool  `json:"useCache,omitempty"`
 	PopulateCache              *bool  `json:"populateCache,omitempty"`
+	Priority                   int    `json:"priority,omitempty"`
 }
 
 type DruidParameter struct {
@@ -482,9 +483,11 @@ func newDruidRequest(query string, args []driver.NamedValue, queryCfg *QueryConf
 		}
 	}
 	var useCache, populateCache *bool
+	priority := 0
 	if queryCfg != nil {
 		useCache = queryCfg.UseCache
 		populateCache = queryCfg.PopulateCache
+		priority = queryCfg.Priority
 	}
 	return &DruidRequest{
 		Query:          query,
@@ -497,6 +500,7 @@ func newDruidRequest(query string, args []driver.NamedValue, queryCfg *QueryConf
 			EnableTimeBoundaryPlanning: true,
 			UseCache:                   useCache,
 			PopulateCache:              populateCache,
+			Priority:                   priority,
 		},
 	}
 }
@@ -512,6 +516,7 @@ func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
 type QueryConfig struct {
 	UseCache      *bool
 	PopulateCache *bool
+	Priority      int
 }
 
 type queryCfgCtxKey struct{}

--- a/runtime/drivers/druid/olap.go
+++ b/runtime/drivers/druid/olap.go
@@ -77,6 +77,12 @@ func (c *connection) Query(ctx context.Context, stmt *drivers.Statement) (*drive
 		}
 		queryCfg.PopulateCache = stmt.PopulateCache
 	}
+	if !c.config.SkipQueryPriority && stmt.Priority != 0 {
+		if queryCfg == nil {
+			queryCfg = &druidsqldriver.QueryConfig{}
+		}
+		queryCfg.Priority = stmt.Priority
+	}
 
 	if queryCfg != nil {
 		ctx = druidsqldriver.WithQueryConfig(ctx, queryCfg)


### PR DESCRIPTION
Pass on query priority to Druid so that watermark queries are not stuck on long running queries which can hang dashboard load. 

This also requires an application change to be effective for `time-range-summary` api should use the highest priority than all other queries, so use 50 for that.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
