### PR TITLE
[DOCS] Add navigational side bar

### DIFF
--- a/docs/src/css/_sidebar.scss
+++ b/docs/src/css/_sidebar.scss
@@ -26,7 +26,7 @@ li.theme-doc-sidebar-item-category-level-1 {
   }
   ul.menu__list {
     margin-left: 0.8rem;
-    border-left: 1px solid #ccc;
+    border-left: 1px solid  var(--ifm-menu-sidebar-color);
   }
   .menu__list-item:hover {
       border-left: 1px solid var(--ifm-color-primary);
@@ -60,6 +60,11 @@ li.theme-doc-sidebar-item-category-level-2 .menu__list-item-collapsible {
   &--active {
     font-weight: 600;
   }
+  &:hover {
+    color: var(--ifm-color-primary);
+    font-weight: 600;
+  }
+
 }
 
 .menu__caret:before,

--- a/docs/src/css/_sidebar.scss
+++ b/docs/src/css/_sidebar.scss
@@ -28,10 +28,6 @@ li.theme-doc-sidebar-item-category-level-1 {
     margin-left: 0.8rem;
     border-left: 1px solid  var(--ifm-menu-sidebar-color);
   }
-  .menu__list-item:hover {
-      border-left: 1px solid var(--ifm-color-primary);
-      margin-left: -1px;
-    }
 }
 
 li.theme-doc-sidebar-item-category-level-2 {
@@ -40,11 +36,6 @@ li.theme-doc-sidebar-item-category-level-2 {
     margin-top: 0 !important;
     font-size: var(--default-font) !important;
   }
-
-  .menu__list-item:hover {
-      border-left: 1px solid var(--ifm-color-primary) !important;
-      margin-left: -1px !important;
-    }
 }
 li.theme-doc-sidebar-item-category-level-2 .menu__list-item-collapsible {
   font-weight: 400 !important;
@@ -64,8 +55,8 @@ li.theme-doc-sidebar-item-category-level-2 .menu__list-item-collapsible {
     color: var(--ifm-color-primary);
     font-weight: 600;
   }
-
 }
+
 
 .menu__caret:before,
 .menu__link--sublist-caret:after {
@@ -77,10 +68,25 @@ li.theme-doc-sidebar-item-category-level-2 .menu__list-item-collapsible {
   padding-bottom: 0 !important;
 }
 
+.theme-doc-sidebar-item-link-level-1,
+.theme-doc-sidebar-item-category-level-1 {
+  padding-left: 0.5rem;
+  // .menu__list-item:hover {
+  //   border-left: 1px solid var(--ifm-color-primary);
+  //   margin-left: -1px;
+  // }
+}
+
 .theme-doc-sidebar-item-link-level-2,
 .theme-doc-sidebar-item-category-level-2 {
   padding-left: 0.5rem;
+  // .menu__list-item:hover {
+  //   border-left: 1px solid var(--ifm-color-primary);
+  //   margin-left: -1px;
+  // }
 }
+
+
 .theme-doc-sidebar-item-link-level-3,
 .theme-doc-sidebar-item-category-level-3,
 .theme-doc-sidebar-item-link-level-4,

--- a/docs/src/css/_sidebar.scss
+++ b/docs/src/css/_sidebar.scss
@@ -22,13 +22,30 @@ li.theme-doc-sidebar-item-category-level-1 {
     }
   }
   &:not(:first-of-type) .menu__list-item-collapsible {
-    margin-top: var(--space-3); /* Standardized spacing */
+    margin-top: var(--space-3);
   }
-  &:last-of-type {
-    display: block;
+  ul.menu__list {
+    margin-left: 0.8rem;
+    border-left: 1px solid #ccc;
   }
+  .menu__list-item:hover {
+      border-left: 1px solid var(--ifm-color-primary);
+      margin-left: -1px;
+    }
 }
 
+li.theme-doc-sidebar-item-category-level-2 {
+  .menu__list-item-collapsible {
+    font-weight: 400 !important;
+    margin-top: 0 !important;
+    font-size: var(--default-font) !important;
+  }
+
+  .menu__list-item:hover {
+      border-left: 1px solid var(--ifm-color-primary) !important;
+      margin-left: -1px !important;
+    }
+}
 li.theme-doc-sidebar-item-category-level-2 .menu__list-item-collapsible {
   font-weight: 400 !important;
   margin-top: 0 !important;
@@ -55,24 +72,23 @@ li.theme-doc-sidebar-item-category-level-2 .menu__list-item-collapsible {
   padding-bottom: 0 !important;
 }
 
-
 .theme-doc-sidebar-item-link-level-2,
 .theme-doc-sidebar-item-category-level-2 {
-  padding-left: 1rem;
+  padding-left: 0.5rem;
 }
 .theme-doc-sidebar-item-link-level-3,
 .theme-doc-sidebar-item-category-level-3,
 .theme-doc-sidebar-item-link-level-4,
 .theme-doc-sidebar-item-category-level-4 {
-  padding-left: 1.5rem;
+  padding-left: 1rem;
 }
 .theme-doc-sidebar-item-link-level-5,
 .theme-doc-sidebar-item-category-level-5 {
-  padding-left: 2.5rem;
+  padding-left: 1.5rem;
 }
 .theme-doc-sidebar-item-link-level-6,
 .theme-doc-sidebar-item-category-level-6 {
-  padding-left: 3rem;
+  padding-left: 2rem; 
 }
 li.theme-doc-sidebar-item-category-level-2 > .menu__list {
   border-left: 1px solid var(--click-color-stroke);

--- a/docs/src/css/_variables.scss
+++ b/docs/src/css/_variables.scss
@@ -56,6 +56,7 @@
   --color-stroke: var(--palette_slate_100);
   --doc-menu-caret-right-padding: 1.25rem; /* Standardized to rem */
   --sidebar-scroll-padding: 4.5rem; /* For sticky release notes */
+  --ifm-menu-sidebar-color: #ccc;
 
   /* Footer */
   --ifm-footer-padding-vertical: 1rem;


### PR DESCRIPTION
onhover: when hovering the side bar illuminates

<img width="289" height="128" alt="Screenshot 2025-08-12 at 11 21 06" src="https://github.com/user-attachments/assets/b87c0732-47ca-4b5a-b091-5288f8db2233" />



onClick: on select the text bolds, and illuminates disappears
<img width="297" height="222" alt="Screenshot 2025-08-12 at 11 20 59" src="https://github.com/user-attachments/assets/80694b40-d7e6-4c62-a95a-8a9a4ae8c3b6" />



This way is a bit less noisy on the side bar. 

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
