### PR TITLE
fix (Column profiles): Show timestamp profiles for certain DuckDB types

### DIFF
--- a/web-common/src/lib/duckdb-data-types.ts
+++ b/web-common/src/lib/duckdb-data-types.ts
@@ -58,6 +58,9 @@ export const TIMESTAMPS = new Set([
   "DATETIME",
   "TIMESTAMPTZ",
   "TIMESTAMP WITH TIME ZONE",
+  "TIMESTAMP_S",
+  "TIMESTAMP_MS",
+  "TIMESTAMP_NS",
 
   ...DATES,
 ]);

--- a/web-common/src/lib/duckdb-data-types.ts
+++ b/web-common/src/lib/duckdb-data-types.ts
@@ -4,7 +4,7 @@
  */
 
 export const INTEGERS = new Set([
-  // Go Types
+  // Rill runtime types
   "CODE_INT8",
   "CODE_INT16",
   "CODE_INT32",
@@ -16,7 +16,7 @@ export const INTEGERS = new Set([
   "CODE_UINT64",
   "CODE_UINT128",
 
-  // Node Types
+  // DuckDB native types
   "BIGINT",
   "HUGEINT",
   "SMALLINT",
@@ -33,11 +33,11 @@ export const INTEGERS = new Set([
 ]);
 
 export const FLOATS = new Set([
-  // Go Types
+  // Rill runtime types
   "CODE_FLOAT32",
   "CODE_FLOAT64",
 
-  // Node Types
+  // DuckDB native types
   "DOUBLE",
   "DECIMAL",
   "FLOAT8",
@@ -48,11 +48,11 @@ export const DATES = new Set(["CODE_DATE", "DATE"]);
 export const NUMERICS = new Set([...INTEGERS, ...FLOATS]);
 export const BOOLEANS = new Set(["CODE_BOOL", "BOOLEAN", "BOOL", "LOGICAL"]);
 export const TIMESTAMPS = new Set([
-  // Go Types
+  // Rill runtime types
   "CODE_TIMESTAMP",
   "CODE_TIME",
 
-  // Node Types
+  // DuckDB native types
   "TIMESTAMP",
   "TIME",
   "DATETIME",
@@ -88,12 +88,12 @@ export function isNested(type: string) {
 }
 
 export const STRING_LIKES = new Set([
-  // Go Types
+  // Rill runtime types
   "CODE_STRING",
   "CODE_BYTES",
   "CODE_UUID",
 
-  // Node Types
+  // DuckDB native types
   "UUID",
   "BYTE_ARRAY",
   "VARCHAR",


### PR DESCRIPTION
Addresses [this Slack report](https://rilldata.slack.com/archives/C02T907FEUB/p1754381965384539?thread_ts=1754323698.573649&cid=C02T907FEUB)

Before, the DuckDB `TIMESTAMP_S`, `TIMESTAMP_MS`, and `TIMESTAMP_NS` types did not show up in the column profiler:
<img width="987" height="224" alt="image" src="https://github.com/user-attachments/assets/7530b84e-1dd2-4600-8fe9-f7260467937c" />

Now they do:
<img width="991" height="233" alt="image" src="https://github.com/user-attachments/assets/58bf3493-161a-4255-a393-9f23b59ff89a" />

... and here's the output of a more complex model that shows more clearly that the data viz is working correctly:
<img width="262" height="305" alt="image" src="https://github.com/user-attachments/assets/3017440a-2c3d-4548-a8b3-aa0f886f9bb5" />


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
