### PR TITLE
fix: report recipient valdiation to match backend parser validation

### DIFF
--- a/web-common/src/features/scheduled-reports/ScheduledReportDialog.svelte
+++ b/web-common/src/features/scheduled-reports/ScheduledReportDialog.svelte
@@ -40,7 +40,7 @@
   import { get } from "svelte/store";
   import { defaults, superForm } from "sveltekit-superforms";
   import { yup, type ValidationAdapter } from "sveltekit-superforms/adapters";
-  import { array, object, string } from "yup";
+  import { array, object, string, boolean } from "yup";
   import { Button } from "../../components/button";
   import {
     getRuntimeServiceGetResourceQueryKey,
@@ -116,6 +116,7 @@
     object({
       title: string().required("Required"),
       emailRecipients: array().of(string().email("Invalid email")),
+      enableSlackNotification: boolean(), // Needed to get the type for validation
       slackChannels: array().of(string()),
       slackUsers: array().of(string().email("Invalid email")),
       columns: array().of(string()).min(1),
@@ -124,14 +125,17 @@
       "At least one email recipient, slack user, or slack channel is required",
       function (value) {
         // Check if at least one array has non-empty values
-        const hasEmailRecipients =
-          value.emailRecipients?.filter(Boolean)?.length > 0;
-        const hasSlackUsers =
-          value.slackUsers?.filter(Boolean).length > 0 &&
-          value.enableSlackNotification;
-        const hasSlackChannels =
-          value.slackChannels?.filter(Boolean).length > 0 &&
-          value.enableSlackNotification;
+        const hasEmailRecipients = value.emailRecipients
+          ? value.emailRecipients.filter(Boolean).length > 0
+          : false;
+        if (!value.enableSlackNotification) return hasEmailRecipients;
+
+        const hasSlackUsers = value.slackUsers
+          ? value.slackUsers.filter(Boolean).length > 0
+          : false;
+        const hasSlackChannels = value.slackChannels
+          ? value.slackChannels.filter(Boolean).length > 0
+          : false;
 
         return hasEmailRecipients || hasSlackUsers || hasSlackChannels;
       },


### PR DESCRIPTION
Backend checks if atleast one of email recipient or slack user or slack channel is provided in reports. Matching UI validation to be this way.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
