### PR TITLE
fix: remote changes check not showing up during update flow

### DIFF
--- a/web-common/src/features/dashboards/workspace/DeployProjectCTA.svelte
+++ b/web-common/src/features/dashboards/workspace/DeployProjectCTA.svelte
@@ -68,14 +68,14 @@
   });
 
   async function onDeploy(resumingDeploy = false) {
-    if (hasRemoteChanges) {
+    await waitUntil(() => !get(deploymentState).loading);
+    if (get(deploymentState).hasRemoteChanges) {
       remoteChangeDialog = true;
       return;
     }
 
     // Check user login
 
-    await waitUntil(() => !get(userQuery).isLoading);
     const userResp = get(userQuery).data;
     if (!userResp?.user) {
       if (resumingDeploy) {
@@ -146,7 +146,7 @@
   });
 </script>
 
-{#if isDeployed}
+{#if isDeployed && !hasRemoteChanges}
   <UpdateProjectPopup
     bind:open={updateProjectDropdownOpen}
     matchingProjects={$matchingProjectsQuery.data?.projects ?? []}
@@ -155,7 +155,8 @@
   <Tooltip distance={8}>
     <Button
       {loading}
-      onClick={() => onDeploy()}
+      onClick={() =>
+        hasRemoteChanges ? (remoteChangeDialog = true) : onDeploy()}
       type={hasValidDashboard ? "primary" : "secondary"}
     >
       <Rocket size="16px" />

--- a/web-common/src/features/project/RemoteProjectManager.svelte
+++ b/web-common/src/features/project/RemoteProjectManager.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { page } from "$app/stores";
   import type { ConnectError } from "@connectrpc/connect";
   import { isMergeConflictError } from "@rilldata/web-common/features/project/deploy/github-utils.ts";
   import MergeConflictResolutionDialog from "@rilldata/web-common/features/project/MergeConflictResolutionDialog.svelte";
@@ -17,6 +18,7 @@
 
   let remoteChangeDialog = false;
   let mergeConflictResolutionDialog = false;
+  $: inDeployPage = $page.route.id?.startsWith("/(misc)/deploy") ? true : false;
 
   $: if ($gitStatusQuery.data) {
     processGithubStatus($gitStatusQuery.data);
@@ -32,6 +34,8 @@
   }
 
   async function handleFetchRemoteCommits() {
+    if (inDeployPage) return; // Do not show the modal in deploy pages
+
     if ($gitStatusQuery.data!.localCommits > 0) {
       // Since we can't really merge remote commits with local commits,
       // we just show the user the merge conflicts dialog for confirmation to clear it.


### PR DESCRIPTION
There was a regression during update flow changes where remote git change dialog was not triggered. Updating the flow to show the dialog when user hits deploy in both create/update project cases.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
