### PR TITLE
fix: aggregation dropdown rendering

### DIFF
--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -437,7 +437,6 @@
       <!-- FIXME: this is pending the remaining state work for show/hide measures and dimensions -->
       {#each renderedMeasures as measure, i (measure.name)}
         <!-- FIXME: I can't select the big number by the measure id. -->
-
         {@const bigNum = measure.name ? totals?.[measure.name] : null}
         {@const comparisonValue = measure.name
           ? totalsComparisons?.[measure.name]

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -375,12 +375,12 @@
                 checkRight
                 role="menuitem"
                 checked={option === activeTimeGrain}
-                class="text-xs cursor-pointer capitalize"
+                class="text-xs cursor-pointer"
                 on:click={() => {
                   metricsExplorerStore.setTimeGrain(exploreName, option);
                 }}
               >
-                {TIME_GRAIN[option].label}
+                {V1TimeGrainToDateTimeUnit[option]}
               </DropdownMenu.CheckboxItem>
             {/each}
           </DropdownMenu.Content>

--- a/web-common/src/lib/time/new-grains.ts
+++ b/web-common/src/lib/time/new-grains.ts
@@ -57,19 +57,19 @@ export function getAllowedEndingGrains(
   return getSmallerGrainsFromOrders(order, getGrainOrder(smallestTimeGrain));
 }
 
-type Order = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | typeof Infinity;
+type Order = 0 | 1 | 2 | 3 | 4 | 5 | 6 | typeof Infinity;
 
 export const V1TimeGrainToOrder: Record<V1TimeGrain, Order> = {
   [V1TimeGrain.TIME_GRAIN_UNSPECIFIED]: 0,
   [V1TimeGrain.TIME_GRAIN_MILLISECOND]: 0,
   [V1TimeGrain.TIME_GRAIN_SECOND]: 0,
-  [V1TimeGrain.TIME_GRAIN_MINUTE]: 1,
-  [V1TimeGrain.TIME_GRAIN_HOUR]: 2,
-  [V1TimeGrain.TIME_GRAIN_DAY]: 3,
-  [V1TimeGrain.TIME_GRAIN_WEEK]: 4,
-  [V1TimeGrain.TIME_GRAIN_MONTH]: 5,
-  [V1TimeGrain.TIME_GRAIN_QUARTER]: 6,
-  [V1TimeGrain.TIME_GRAIN_YEAR]: 7,
+  [V1TimeGrain.TIME_GRAIN_MINUTE]: 0,
+  [V1TimeGrain.TIME_GRAIN_HOUR]: 1,
+  [V1TimeGrain.TIME_GRAIN_DAY]: 2,
+  [V1TimeGrain.TIME_GRAIN_WEEK]: 3,
+  [V1TimeGrain.TIME_GRAIN_MONTH]: 4,
+  [V1TimeGrain.TIME_GRAIN_QUARTER]: 5,
+  [V1TimeGrain.TIME_GRAIN_YEAR]: 6,
 };
 
 export const V1TimeGrainToAlias: Record<V1TimeGrain, TimeGrainAlias> = {
@@ -107,7 +107,7 @@ export function grainAliasToDateTimeUnit(alias: TimeGrainAlias): DateTimeUnit {
 }
 
 const allowedGrains = [
-  V1TimeGrain.TIME_GRAIN_SECOND,
+  // V1TimeGrain.TIME_GRAIN_SECOND,
   V1TimeGrain.TIME_GRAIN_MINUTE,
   V1TimeGrain.TIME_GRAIN_HOUR,
   V1TimeGrain.TIME_GRAIN_DAY,


### PR DESCRIPTION
- Changes aggregation grain label rendering to lowercase
- Fixes a bug where metrics views without a `smallest_time_grain` (or one set to a value smaller than `minute`) would crash when opening the menu

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
