### PR TITLE
fix: add tooltip to pivot hide panels

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotToolbar.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotToolbar.svelte
@@ -101,18 +101,23 @@
 </script>
 
 <div class="flex items-center gap-x-4 select-none pointer-events-none">
-  <Button
-    square
-    type="secondary"
-    theme
-    selected={showPanels}
-    onClick={(e) => {
-      showPanels = !showPanels;
-      blurCurrentTarget(e);
-    }}
-  >
-    <PivotPanel size="18px" open={showPanels} colorClass="fill-theme-800" />
-  </Button>
+  <Tooltip location="bottom" alignment="start" distance={8}>
+    <Button
+      square
+      type="secondary"
+      theme
+      selected={showPanels}
+      onClick={(e) => {
+        showPanels = !showPanels;
+        blurCurrentTarget(e);
+      }}
+    >
+      <PivotPanel size="18px" open={showPanels} colorClass="fill-theme-800" />
+    </Button>
+    <TooltipContent slot="tooltip-content">
+      {showPanels ? "Hide panels" : "Show panels"}
+    </TooltipContent>
+  </Tooltip>
 
   <div class="flex items-center gap-x-1">
     <Tooltip location="bottom" alignment="start" distance={8}>


### PR DESCRIPTION
Adds a tooltip to the hide/show panel button for pivot

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
