### PR TITLE
Ability to select text Leaderboard cell value

### DIFF
--- a/web-common/src/components/data-types/Base.svelte
+++ b/web-common/src/components/data-types/Base.svelte
@@ -5,7 +5,7 @@
   export let color = "text-gray-900";
 </script>
 
-<span class:truncate class="{classes} {color}">
+<span class:truncate class="{classes} {color} select-text">
   {#if isNull}
     <span class="text-gray-400">-</span>
   {:else}

--- a/web-common/src/components/virtualized-table/core/Cell.svelte
+++ b/web-common/src/components/virtualized-table/core/Cell.svelte
@@ -53,6 +53,14 @@
 
   function onSelectItem(e: MouseEvent) {
     if (e.shiftKey) return;
+
+    // Check if user has selected text
+    const selection = window.getSelection();
+    if (selection && selection.toString().length > 0) {
+      // User has selected text, don't trigger row selection
+      return;
+    }
+
     dispatch("select-item", { index: row.index, meta: e.ctrlKey || e.metaKey });
   }
 

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -160,6 +160,23 @@
       `copied dimension value "${truncatedLabel}" to clipboard`,
     );
   }
+
+  function onDimensionCellClick(e: MouseEvent) {
+    // Check if user has selected text
+    const selection = window.getSelection();
+    if (selection && selection.toString().length > 0) {
+      // User has selected text, don't trigger row selection
+      return;
+    }
+
+    // If no text is selected, proceed with normal click behavior
+    toggleDimensionValueSelection(
+      dimensionName,
+      dimensionValue,
+      false,
+      e.ctrlKey || e.metaKey,
+    );
+  }
 </script>
 
 <tr
@@ -174,12 +191,7 @@
   on:pointerout={() => (hovered = false)}
   on:click={(e) => {
     if (e.shiftKey) return;
-    toggleDimensionValueSelection(
-      dimensionName,
-      dimensionValue,
-      false,
-      e.ctrlKey || e.metaKey,
-    );
+    onDimensionCellClick(e);
   }}
 >
   <td data-comparison-cell>
@@ -214,7 +226,7 @@
     class="relative size-full flex flex-none justify-between items-center leaderboard-label"
     style:background={dimensionGradients}
   >
-    <span class="truncate">
+    <span class="truncate select-text">
       <FormattedDataType value={dimensionValue} truncate />
     </span>
 


### PR DESCRIPTION
This PR adds the ability to select text in unexpanded/expanded table cells. Fixes https://linear.app/rilldata/issue/APP-300/ability-to-copy-leaderboard-value

https://github.com/user-attachments/assets/28b61692-4b58-4b0e-91df-015609d443fd

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
