### PR TITLE
Improve show/hide icon clickable area

### DIFF
--- a/web-common/src/components/dropdown-menu/DropdownMenuCheckboxItem.svelte
+++ b/web-common/src/components/dropdown-menu/DropdownMenuCheckboxItem.svelte
@@ -49,13 +49,16 @@
     on:pointerleave
     on:pointermove
   >
-    <span class="flex flex-none h-3.5 w-3.5 items-center justify-center">
+    <span class="flex flex-none h-6 w-6 items-center justify-center rounded-sm hover:bg-gray-100 transition-colors">
       {#if checked}
         <svelte:component
           this={showXForSelected ? X : Check}
           class={checkSize}
           color={iconColor}
         />
+      {:else}
+        <!-- Invisible placeholder to maintain consistent spacing and clickable area -->
+        <span class="h-4 w-4 opacity-0" aria-hidden="true"></span>
       {/if}
     </span>
     <slot />

--- a/web-common/src/features/visual-editing/SelectionDropdown.svelte
+++ b/web-common/src/features/visual-editing/SelectionDropdown.svelte
@@ -72,6 +72,9 @@
             on:click={() => {
               onSelect(item);
             }}
+            on:toggle={() => {
+              onSelect(item);
+            }}
           >
             <slot {item} selected={selectedItems.has(item)}>
               {item}
@@ -89,6 +92,9 @@
           showXForSelected={excludeMode}
           checked={selectedItems.has(item)}
           on:click={() => {
+            onSelect(item);
+          }}
+          on:toggle={() => {
             onSelect(item);
           }}
         >


### PR DESCRIPTION
Resolves APP-305 by improving the clickable area and user experience for show/hide icons in dimension and measure dropdown selectors.

Previously, the visual target for these icons was small (14x14px) and inconsistent between checked (visible icon) and unchecked (no visible icon) states, leading to a frustrating UX.

This change increases the icon container size to 24x24px, adds hover feedback (`hover:bg-gray-100`), and uses an invisible placeholder to ensure consistent spacing and a larger, predictable clickable area regardless of the item's checked state.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-305](https://linear.app/rilldata/issue/APP-305/increase-the-clickable-area-for-the-showhide-icon-in-our-dimension-and)

<a href="https://cursor.com/background-agent?bcId=bc-0f53e23e-9ea7-4323-a626-dd57b550efe0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0f53e23e-9ea7-4323-a626-dd57b550efe0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

