### PR TITLE
Fix pivot table first dimensional value bolding

### DIFF
--- a/web-common/src/features/dashboards/pivot/NestedTable.svelte
+++ b/web-common/src/features/dashboards/pivot/NestedTable.svelte
@@ -452,11 +452,17 @@
   }
 
   /* The totals row header - only apply when there are actual measures and totals */
-  .with-row-dimension.with-totals-row.with-measures tbody > tr:nth-of-type(2) > td:first-of-type {
+  .with-row-dimension.with-totals-row.with-measures
+    tbody
+    > tr:nth-of-type(2)
+    > td:first-of-type {
     @apply font-semibold;
   }
 
-  .with-expandable-rows.with-totals-row tbody > tr:nth-of-type(2) > td:first-of-type {
+  .with-expandable-rows.with-totals-row
+    tbody
+    > tr:nth-of-type(2)
+    > td:first-of-type {
     @apply pl-5;
   }
 

--- a/web-common/src/features/dashboards/pivot/NestedTable.svelte
+++ b/web-common/src/features/dashboards/pivot/NestedTable.svelte
@@ -57,6 +57,7 @@
 
   $: hasRowDimension = rowDimensions.length > 0;
   $: hasExpandableRows = rowDimensions.length > 1;
+  $: hasMeasures = measures.length > 0;
   $: rowDimensionLabel = getRowNestedLabel(rowDimensions);
   $: rowDimensionName = rowDimensionLabel ? rowDimensionLabel : null;
 
@@ -232,6 +233,8 @@
   class:with-row-dimension={hasRowDimension}
   class:with-col-dimension={hasColumnDimension}
   class:with-expandable-rows={hasExpandableRows}
+  class:with-totals-row={!!totalsRow}
+  class:with-measures={hasMeasures}
   role="presentation"
   style:width="{totalLength + rowDimensionWidth}px"
   on:click={modified({ shift: onCellCopy, click: onCellClick })}
@@ -442,18 +445,18 @@
   }
 
   /* The totals row */
-  tbody > tr:nth-of-type(2) {
+  .with-totals-row tbody > tr:nth-of-type(2) {
     @apply bg-surface sticky z-20;
     top: var(--total-header-height);
     height: calc(var(--row-height) + 2px);
   }
 
-  /* The totals row header */
-  .with-row-dimension tbody > tr:nth-of-type(2) > td:first-of-type {
+  /* The totals row header - only apply when there are actual measures and totals */
+  .with-row-dimension.with-totals-row.with-measures tbody > tr:nth-of-type(2) > td:first-of-type {
     @apply font-semibold;
   }
 
-  .with-expandable-rows tbody > tr:nth-of-type(2) > td:first-of-type {
+  .with-expandable-rows.with-totals-row tbody > tr:nth-of-type(2) > td:first-of-type {
     @apply pl-5;
   }
 


### PR DESCRIPTION
Fixes APP-123

This PR resolves an issue where a pivot table with only row dimensions (no measures) would incorrectly bold the first dimensional value, making it appear as a total.

The problem was that a CSS rule in `NestedTable.svelte` applied `font-semibold` to the second row's first cell if the table had `with-row-dimension`, without checking for the actual presence of measures or a totals row.

The fix introduces a `with-measures` class to the table and updates the CSS selector for the totals row header. The bold styling is now applied only when `with-row-dimension`, `with-totals-row`, AND `with-measures` classes are all present. This ensures correct visual display for dimensions-only pivot tables.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
Linear Issue: [APP-123](https://linear.app/rilldata/issue/APP-123/pivot-showing-first-dimensional-value-as-total)

<a href="https://cursor.com/background-agent?bcId=bc-3ef0c1fd-44f8-4e6c-b3b2-0d94c7040ff4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ef0c1fd-44f8-4e6c-b3b2-0d94c7040ff4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

