### PR TITLE
feat: Move `Add Option` within component for select input

### DIFF
--- a/web-common/src/components/forms/Input.svelte
+++ b/web-common/src/components/forms/Input.svelte
@@ -46,7 +46,7 @@
     | { value: string; label: string; type?: string }[]
     | undefined = undefined;
   export let optionsLoading: boolean = false;
-  export let onAddOption: () => void | null = null;
+  export let onAddOption: (() => void) | null = null;
   export let addOptionLabel: string | null = null;
   export let additionalClass = "";
   export let onInput: (

--- a/web-common/src/components/forms/Input.svelte
+++ b/web-common/src/components/forms/Input.svelte
@@ -45,6 +45,9 @@
   export let options:
     | { value: string; label: string; type?: string }[]
     | undefined = undefined;
+  export let optionsLoading: boolean = false;
+  export let onAddOption: () => void | null = null;
+  export let addOptionLabel: string | null = null;
   export let additionalClass = "";
   export let onInput: (
     newValue: string,
@@ -234,6 +237,9 @@
       bind:selectElement
       bind:value
       {options}
+      {optionsLoading}
+      {onAddOption}
+      {addOptionLabel}
       {onChange}
       {size}
       fontSize={size === "sm" ? 12 : 14}

--- a/web-common/src/components/forms/Input.svelte
+++ b/web-common/src/components/forms/Input.svelte
@@ -45,9 +45,6 @@
   export let options:
     | { value: string; label: string; type?: string }[]
     | undefined = undefined;
-  export let optionsLoading: boolean = false;
-  export let onAddOption: (() => void) | null = null;
-  export let addOptionLabel: string | null = null;
   export let additionalClass = "";
   export let onInput: (
     newValue: string,
@@ -237,9 +234,6 @@
       bind:selectElement
       bind:value
       {options}
-      {optionsLoading}
-      {onAddOption}
-      {addOptionLabel}
       {onChange}
       {size}
       fontSize={size === "sm" ? 12 : 14}

--- a/web-common/src/components/forms/Select.svelte
+++ b/web-common/src/components/forms/Select.svelte
@@ -26,8 +26,8 @@
     tooltip?: string;
   }[];
   export let optionsLoading: boolean = false;
-  export let onAddOption: (() => void) | null = null;
-  export let addOptionLabel: string | null = null;
+  export let onAddNew: (() => void) | null = null;
+  export let addNewLabel: string | null = null;
   export let placeholder: string = "";
   export let optional: boolean = false;
   export let tooltip: string = "";
@@ -174,7 +174,7 @@
         {:else}
           <div class="px-2.5 py-1.5 text-gray-600">No results found</div>
         {/each}
-        {#if onAddOption}
+        {#if onAddNew}
           <SelectSeparator />
           <Select.Item
             value="__rill_add_option__"
@@ -182,11 +182,11 @@
               e.stopPropagation();
               e.preventDefault();
               open = false;
-              onAddOption();
+              onAddNew();
             }}
             class="text-[{fontSize}px]"
           >
-            {addOptionLabel ?? "+ Add"}
+            {addNewLabel ?? "+ Add"}
           </Select.Item>
         {/if}
       {/if}

--- a/web-common/src/components/forms/Select.svelte
+++ b/web-common/src/components/forms/Select.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
+  import { SelectSeparator } from "@rilldata/web-common/components/select";
   import * as Select from "@rilldata/web-common/components/select";
   import * as Tooltip from "@rilldata/web-common/components/tooltip-v2";
+  import Spinner from "@rilldata/web-common/features/entity-management/Spinner.svelte";
+  import { EntityStatus } from "@rilldata/web-common/features/entity-management/types.ts";
   import { InfoIcon } from "lucide-svelte";
   import { createEventDispatcher } from "svelte";
   import DataTypeIcon from "../data-types/DataTypeIcon.svelte";
@@ -22,6 +25,9 @@
     disabled?: boolean;
     tooltip?: string;
   }[];
+  export let optionsLoading: boolean = false;
+  export let onAddOption: () => void | null = null;
+  export let addOptionLabel: string | null = null;
   export let placeholder: string = "";
   export let optional: boolean = false;
   export let tooltip: string = "";
@@ -54,14 +60,7 @@
       )
     : options;
 
-  // Needed to pass a close method to slots
-  // In certain cases, the "additional-dropdown-content" slot might need to close the dropdown without selecting a value.
-  // So we need an explicit close method and not use Select.Item
   let open = false;
-
-  function close() {
-    open = false;
-  }
 </script>
 
 <div class="flex flex-col gap-y-2 max-w-full" class:w-full={full}>
@@ -138,37 +137,59 @@
           <Search bind:value={searchText} showBorderOnFocus={false} />
         </div>
       {/if}
-      {#each filteredOptions as { type, value, label, description, disabled, tooltip } (value)}
-        <Select.Item
-          {value}
-          {label}
-          {description}
-          {disabled}
-          class="text-[{fontSize}px] gap-x-2 items-start"
-        >
-          {#if tooltip}
-            <Tooltip.Root portal="body">
-              <Tooltip.Trigger class="select-tooltip cursor-default">
-                {#if type}
-                  <DataTypeIcon {type} />
-                {/if}
-                {label ?? value}
-              </Tooltip.Trigger>
-              <Tooltip.Content side="right" sideOffset={8}>
-                {tooltip}
-              </Tooltip.Content>
-            </Tooltip.Root>
-          {:else}
-            {#if type}
-              <DataTypeIcon {type} />
-            {/if}
-            {label ?? value}
-          {/if}
-        </Select.Item>
+      {#if optionsLoading}
+        <div class="flex flex-row items-center ml-5 h-10 w-full">
+          <div class="m-auto w-10">
+            <Spinner size="18px" status={EntityStatus.Running} />
+          </div>
+        </div>
       {:else}
-        <div class="px-2.5 py-1.5 text-gray-600">No results found</div>
-      {/each}
-      <slot name="additional-dropdown-content" {close} />
+        {#each filteredOptions as { type, value, label, description, disabled, tooltip } (value)}
+          <Select.Item
+            {value}
+            {label}
+            {description}
+            {disabled}
+            class="text-[{fontSize}px] gap-x-2 items-start"
+          >
+            {#if tooltip}
+              <Tooltip.Root portal="body">
+                <Tooltip.Trigger class="select-tooltip cursor-default">
+                  {#if type}
+                    <DataTypeIcon {type} />
+                  {/if}
+                  {label ?? value}
+                </Tooltip.Trigger>
+                <Tooltip.Content side="right" sideOffset={8}>
+                  {tooltip}
+                </Tooltip.Content>
+              </Tooltip.Root>
+            {:else}
+              {#if type}
+                <DataTypeIcon {type} />
+              {/if}
+              {label ?? value}
+            {/if}
+          </Select.Item>
+        {:else}
+          <div class="px-2.5 py-1.5 text-gray-600">No results found</div>
+        {/each}
+        {#if onAddOption}
+          <SelectSeparator />
+          <Select.Item
+            value="__rill_add_option__"
+            on:click={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              open = false;
+              onAddOption();
+            }}
+            class="text-[{fontSize}px]"
+          >
+            {addOptionLabel ?? "+ Add"}
+          </Select.Item>
+        {/if}
+      {/if}
     </Select.Content>
   </Select.Root>
 </div>

--- a/web-common/src/components/forms/Select.svelte
+++ b/web-common/src/components/forms/Select.svelte
@@ -26,7 +26,7 @@
     tooltip?: string;
   }[];
   export let optionsLoading: boolean = false;
-  export let onAddOption: () => void | null = null;
+  export let onAddOption: (() => void) | null = null;
   export let addOptionLabel: string | null = null;
   export let placeholder: string = "";
   export let optional: boolean = false;

--- a/web-local/src/routes/(misc)/deploy/organization/select/+page.svelte
+++ b/web-local/src/routes/(misc)/deploy/organization/select/+page.svelte
@@ -2,7 +2,6 @@
   import { Button } from "@rilldata/web-common/components/button";
   import * as Dialog from "@rilldata/web-common/components/dialog";
   import Select from "@rilldata/web-common/components/forms/Select.svelte";
-  import { SelectSeparator } from "@rilldata/web-common/components/select";
   import CreateNewOrgForm from "@rilldata/web-common/features/organization/CreateNewOrgForm.svelte";
   import { CreateNewOrgFormId } from "@rilldata/web-common/features/organization/CreateNewOrgForm.svelte";
   import {

--- a/web-local/src/routes/(misc)/deploy/organization/select/+page.svelte
+++ b/web-local/src/routes/(misc)/deploy/organization/select/+page.svelte
@@ -47,8 +47,8 @@
   ariaLabel="Select organization"
   placeholder="Select organization"
   options={orgOptions}
-  addOptionLabel="+ Create organization"
-  onAddOption={() => (isNewOrgDialogOpen = true)}
+  onAddNew={() => (isNewOrgDialogOpen = true)}
+  addNewLabel="+ Create organization"
   width={400}
   sameWidth
 />

--- a/web-local/src/routes/(misc)/deploy/organization/select/+page.svelte
+++ b/web-local/src/routes/(misc)/deploy/organization/select/+page.svelte
@@ -48,22 +48,11 @@
   ariaLabel="Select organization"
   placeholder="Select organization"
   options={orgOptions}
+  addOptionLabel="+ Create organization"
+  onAddOption={() => (isNewOrgDialogOpen = true)}
   width={400}
   sameWidth
->
-  <div slot="additional-dropdown-content" let:close>
-    <SelectSeparator />
-    <button
-      on:click={() => {
-        isNewOrgDialogOpen = true;
-        close();
-      }}
-      class="w-full cursor-pointer select-none rounded-sm py-1.5 px-2 text-left hover:bg-accent"
-    >
-      + Create organization
-    </button>
-  </div>
-</Select>
+/>
 
 <Button wide type="primary" href={createProjectUrl} disabled={!selectedOrg}>
   Deploy as a new project


### PR DESCRIPTION
To better support https://github.com/rilldata/rill/pull/7778 we need some improvements to the select input.
1. Generalise the `Add Option` section and add support for it in `Input` component as well.
2. Add loading state when options will be loading.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
