### PR TITLE
Pull project environment variables for authenticated users on start

### DIFF
--- a/cli/cmd/start/start.go
+++ b/cli/cmd/start/start.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/joho/godotenv"
+	"github.com/rilldata/rill/cli/cmd/env"
 	"github.com/rilldata/rill/cli/pkg/cmdutil"
 	"github.com/rilldata/rill/cli/pkg/gitutil"
 	"github.com/rilldata/rill/cli/pkg/local"
@@ -47,6 +48,15 @@ func StartCmd(ch *cmdutil.Helper) *cobra.Command {
 					}
 
 					projectPath = repoName
+
+					if ch.IsAuthenticated() {
+						if _, err := os.Stat(filepath.Join(projectPath, "rill.yaml")); err == nil {
+							err := env.PullVars(cmd.Context(), ch, projectPath, "", environment, true)
+							if err != nil {
+								ch.PrintfWarn("Warning: failed to pull environment credentials: %v\n", err)
+							}
+						}
+					}
 				}
 			} else if !cmdutil.HasRillProject(".") {
 				if !ch.Interactive {


### PR DESCRIPTION
The `rill start` will automatically pull the env after the repository has been cloned. Assuming the use has the proper privileges (e.g. admin rights to the project)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] [Linked](https://linear.app/rilldata/issue/PLAT-173/rill-start-github-repo-should-also-execute-a-rill-env-pull) the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
