### PR TITLE
Revise leaderboard bar length calculation

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -289,6 +289,26 @@
       measureName === leaderboardSortByMeasureName
     );
   }
+
+  // Calculate maximum values for relative magnitude bar sizing
+  // This includes both above-the-fold and below-the-fold data for accurate scaling
+  $: maxValues = (() => {
+    const allData = [...aboveTheFold, ...belowTheFoldRows];
+    const maxVals: Record<string, number> = {};
+    
+    for (const measureName of leaderboardMeasureNames) {
+      let maxVal = 0;
+      for (const item of allData) {
+        const value = item.values[measureName];
+        if (typeof value === 'number' && isFinite(value)) {
+          maxVal = Math.max(maxVal, Math.abs(value));
+        }
+      }
+      maxVals[measureName] = maxVal;
+    }
+    
+    return maxVals;
+  })();
 </script>
 
 <div
@@ -370,6 +390,7 @@
             {leaderboardSortByMeasureName}
             {formatters}
             {dimensionColumnWidth}
+            {maxValues}
           />
         {/each}
       </DelayedLoadingRows>
@@ -392,6 +413,7 @@
           {leaderboardSortByMeasureName}
           {formatters}
           {dimensionColumnWidth}
+          {maxValues}
         />
       {/each}
     </tbody>

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -33,6 +33,7 @@
   export let leaderboardSortByMeasureName: string | null;
   export let isValidPercentOfTotal: (measureName: string) => boolean;
   export let dimensionColumnWidth: number;
+  export let maxValues: Record<string, number> = {};
   export let toggleDimensionValueSelection: (
     dimensionName: string,
     dimensionValue: string,
@@ -99,11 +100,17 @@
       ? "var(--color-theme-200)"
       : "var(--color-theme-100)";
 
+  // Calculate bar width excluding dimension column
+  $: barWidth = tableWidth - dimensionColumnWidth;
+
+  // Calculate bar lengths based on relative magnitude instead of percent of total
   $: barLengths = Object.fromEntries(
-    Object.entries(pctOfTotals).map(([name, pct]) => [
-      name,
-      pct ? tableWidth * pct : 0,
-    ]),
+    Object.entries(values).map(([name, value]) => {
+      const maxValue = maxValues[name];
+      if (!value || !maxValue || maxValue <= 0) return [name, 0];
+      // Calculate relative magnitude: current value / max value * available bar width
+      return [name, (Math.abs(value) / maxValue) * barWidth];
+    }),
   );
 
   $: totalBarLength = Object.values(barLengths).reduce(
@@ -114,7 +121,7 @@
   $: showZigZags = Object.fromEntries(
     Object.entries(barLengths).map(([name, length]) => [
       name,
-      length > tableWidth,
+      length > barWidth,
     ]),
   );
 


### PR DESCRIPTION
Revise bar lengths on leaderboards to use relative magnitude scaling and correct width calculations.

This PR addresses APP-17 by:
1.  **Switching to Relative Magnitude Scaling**: Bar lengths now represent the relative magnitude of values within each measure. The highest absolute value gets the full bar length, and others are scaled proportionally. This provides a more intuitive and useful visual comparison, especially for percentages, averages, and totals.
2.  **Correcting Bar Width Calculation**: `barWidth` is now explicitly calculated by subtracting the `dimensionColumnWidth` from `tableWidth` in `LeaderboardRow.svelte`, ensuring bars are scaled within their intended display area.
3.  `maxValues` are calculated in `Leaderboard.svelte` (considering all data, visible and hidden) and passed to `LeaderboardRow.svelte` for accurate scaling.
4.  `showZigZags` logic is updated to use the corrected `barWidth`.

**Why these changes?**
The previous bar length logic led to misleading or unreadable visualizations due to incorrect width calculations and a "percent of total" scaling method that was often unhelpful. This update provides a clearer, more accurate, and visually consistent representation of data, aligning with user feedback and the proposed solution in APP-17.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes (APP-17)
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-17](https://linear.app/rilldata/issue/APP-17/revise-bar-lengths-on-leaderboards)

<a href="https://cursor.com/background-agent?bcId=bc-7ff34c0e-d96d-49da-b550-d07b1e1bb381">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ff34c0e-d96d-49da-b550-d07b1e1bb381">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

