### PR TITLE
Update label of Self-hosted ClickHouse

### DIFF
--- a/web-common/src/features/sources/modal/constants.ts
+++ b/web-common/src/features/sources/modal/constants.ts
@@ -3,7 +3,7 @@ export const CONNECTOR_TYPE_OPTIONS: {
   label: string;
 }[] = [
   { value: true, label: "Rill-managed ClickHouse" },
-  { value: false, label: "Self-managed ClickHouse" },
+  { value: false, label: "Self-hosted ClickHouse" },
 ];
 
 export const CONNECTION_TAB_OPTIONS: { value: string; label: string }[] = [


### PR DESCRIPTION
This PR updates the label of Self-hosted ClickHouse. Closes https://linear.app/rilldata/issue/APP-271/update-label-self-managed-clickhouse-to-self-hosted-clickhouse

<img width="1924" height="1454" alt="CleanShot 2025-08-26 at 14 34 29@2x" src="https://github.com/user-attachments/assets/c2ca55e2-e7d1-42bc-bf54-92a1588d2fe7" />

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
