### PR TITLE
Install motherduck extension and set token when connector is motherduck

### DIFF
--- a/runtime/drivers/duckdb/config.go
+++ b/runtime/drivers/duckdb/config.go
@@ -41,6 +41,8 @@ type config struct {
 	// Attach allows user to pass a full ATTACH statement to attach a DuckDB database.
 	// Example YAML syntax : attach: "'ducklake:metadata.ducklake' AS my_ducklake(DATA_PATH 'datafiles1')"
 	Attach string `mapstructure:"attach"`
+	// Token is the authentication token used for MotherDuck.
+	Token string `mapstructure:"token"`
 	// DatabaseName is the name of the attached DuckDB database specified in the Path.
 	// This is usually not required but can be set if our auto detection of name fails.
 	DatabaseName string `mapstructure:"database_name"`

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -465,6 +465,18 @@ func (c *connection) reopenDB(ctx context.Context) error {
 		connInitQueries []string
 	)
 
+	if c.driverName == "motherduck" {
+		dbInitQueries = append(dbInitQueries,
+			"INSTALL 'motherduck'",
+			"LOAD 'motherduck'",
+		)
+		if c.config.Token != "" {
+			dbInitQueries = append(dbInitQueries,
+				fmt.Sprintf("SET motherduck_token = '%s'", c.config.Token),
+			)
+		}
+	}
+
 	// Add custom InitSQL queries before any other (e.g. to override the extensions repository)
 	// BootQueries is deprecated. Use InitSQL instead. Retained for backward compatibility.
 	if c.config.BootQueries != "" {


### PR DESCRIPTION
We should auto install motherduck when connector is motherduck

https://linear.app/rilldata/issue/APP-304/add-schema-name-input-field-to-motherduck#comment-c6cec213

Below format will work now.
```
type: connector

driver: motherduck
token: '{{ .env.connector.motherduck.token }}'
path: "md:sample_data"
schema_name: kaggle
```

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
