### PR TITLE
Update user group modal placeholder text

### DIFF
--- a/web-admin/src/features/organizations/users/CreateUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/users/CreateUserGroupDialog.svelte
@@ -241,7 +241,7 @@
           <Combobox
             searchValue={searchText}
             options={coercedUsersToOptions}
-            placeholder="Search for users"
+            placeholder="Search to add/remove users"
             {getMetadata}
             selectedValues={[
               ...new Set(

--- a/web-admin/src/features/organizations/users/EditUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/users/EditUserGroupDialog.svelte
@@ -275,7 +275,7 @@
           <Combobox
             searchValue={searchText}
             options={coercedUsersToOptions}
-            placeholder="Search for users"
+            placeholder="Search to add/remove users"
             {getMetadata}
             selectedValues={[
               ...new Set(


### PR DESCRIPTION
Updated placeholder text in the User Group modals (`CreateUserGroupDialog.svelte` and `EditUserGroupDialog.svelte`) from "Search for users" to "Search to add/remove users".

This change addresses Linear issue APP-311 and improves clarity for users by indicating the dual functionality of the search field for managing users within a group.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes (Closes APP-311)
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-311](https://linear.app/rilldata/issue/APP-311/update-copy-of-user-group-modal)

<a href="https://cursor.com/background-agent?bcId=bc-c9f67676-1668-4f62-9ad3-e6c57c78d425">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c9f67676-1668-4f62-9ad3-e6c57c78d425">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

