### PR TITLE
fix: Disable Go-To-Explore in embedded canvas when navigation is disabled

### DIFF
--- a/web-admin/src/features/embeds/CanvasEmbed.svelte
+++ b/web-admin/src/features/embeds/CanvasEmbed.svelte
@@ -8,6 +8,7 @@
 
   export let instanceId: string;
   export let canvasName: string;
+  export let navigationEnabled: boolean = true;
 
   $: canvasQuery = useResource(instanceId, canvasName, ResourceKind.Canvas);
 
@@ -35,6 +36,6 @@
   {#if isCanvasErrored}
     <br /> Canvas Error <br />
   {:else if data}
-    <CanvasDashboardEmbed {resource} />
+    <CanvasDashboardEmbed {resource} {navigationEnabled} />
   {/if}
 {/if}

--- a/web-admin/src/routes/-/embed/+page.svelte
+++ b/web-admin/src/routes/-/embed/+page.svelte
@@ -23,6 +23,7 @@
   $: resourceType =
     $page.url.searchParams.get("type") ?? $page.url.searchParams.get("kind"); // "kind" is for backwards compatibility
   const navigation = $page.url.searchParams.get("navigation");
+  const navigationEnabled = navigation === "true";
   // Ignoring state and theme params for now
   // const state = $page.url.searchParams.get("state");
   // const theme = $page.url.searchParams.get("theme");
@@ -78,7 +79,7 @@
   {/if}
 </svelte:head>
 
-{#if navigation}
+{#if navigationEnabled}
   <TopNavigationBarEmbed
     {instanceId}
     {activeResource}
@@ -99,7 +100,11 @@
   {#if activeResource?.kind === ResourceKind.Explore.toString()}
     <ExploreEmbed {instanceId} exploreName={activeResource.name} />
   {:else if activeResource?.kind === ResourceKind.Canvas.toString()}
-    <CanvasEmbed {instanceId} canvasName={activeResource.name} />
+    <CanvasEmbed
+      {instanceId}
+      canvasName={activeResource.name}
+      {navigationEnabled}
+    />
   {:else}
     <UnsupportedKind />
   {/if}

--- a/web-common/src/features/canvas/CanvasComponent.svelte
+++ b/web-common/src/features/canvas/CanvasComponent.svelte
@@ -11,6 +11,7 @@
   export let ghost = false;
   export let allowPointerEvents = true;
   export let editable = false;
+  export let navigationEnabled: boolean = true;
   export let onMouseDown: (e: MouseEvent) => void = () => {};
   export let onDuplicate: () => void = () => {};
   export let onDelete: () => void = () => {};
@@ -39,6 +40,7 @@
     {onDuplicate}
     {editable}
     bind:dropdownOpen={open}
+    {navigationEnabled}
   />
 
   <div

--- a/web-common/src/features/canvas/CanvasDashboardEmbed.svelte
+++ b/web-common/src/features/canvas/CanvasDashboardEmbed.svelte
@@ -7,6 +7,7 @@
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
 
   export let resource: V1Resource;
+  export let navigationEnabled: boolean = true;
 
   $: ({ instanceId } = $runtime);
 
@@ -30,7 +31,13 @@
     filtersEnabled={canvas?.spec?.filtersEnabled}
   >
     {#each rows as row, rowIndex (rowIndex)}
-      <StaticCanvasRow {row} {rowIndex} {components} {maxWidth} />
+      <StaticCanvasRow
+        {row}
+        {rowIndex}
+        {components}
+        {maxWidth}
+        {navigationEnabled}
+      />
     {:else}
       <div class="size-full flex items-center justify-center">
         <p class="text-lg text-gray-500">No components added</p>

--- a/web-common/src/features/canvas/StaticCanvasRow.svelte
+++ b/web-common/src/features/canvas/StaticCanvasRow.svelte
@@ -13,6 +13,7 @@
   export let rowIndex: number;
   export let components: CanvasEntity["components"];
   export let heightUnit: string = "px";
+  export let navigationEnabled: boolean = true;
 
   $: ({ height, items: _itemIds, widths: itemWidths } = row);
 
@@ -35,7 +36,7 @@
     {@const component = components.get(id)}
     <ItemWrapper type={component?.type} zIndex={4 - columnIndex}>
       {#if component}
-        <CanvasComponent {component} />
+        <CanvasComponent {component} {navigationEnabled} />
       {:else}
         <ComponentError error="No valid component {id} in project" />
       {/if}

--- a/web-common/src/features/canvas/Toolbar.svelte
+++ b/web-common/src/features/canvas/Toolbar.svelte
@@ -12,6 +12,7 @@
   export let onDuplicate: () => void;
   export let editable = false;
   export let component: BaseCanvasComponent;
+  export let navigationEnabled: boolean = true;
 
   // Component types that support link to explore functionality
   const EXPLORE_SUPPORTED_TYPES = [
@@ -29,7 +30,9 @@
     "heatmap",
   ] as const;
 
-  $: showExplore = EXPLORE_SUPPORTED_TYPES.includes(component.type as any);
+  $: showExplore =
+    navigationEnabled &&
+    EXPLORE_SUPPORTED_TYPES.includes(component.type as any);
   $: exploreComponent = showExplore
     ? (component as BaseCanvasComponent<ComponentWithMetricsView>)
     : null;


### PR DESCRIPTION
Disables "Go-To-Explore" action in embedded canvas when navigation is disabled.

Use this to test embed scenario: https://github.com/AdityaHegde/rill-embed-sample

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
