### PR TITLE
update connector reconciler state on failures as well

### DIFF
--- a/runtime/reconcilers/connector.go
+++ b/runtime/reconcilers/connector.go
@@ -94,13 +94,10 @@ func (r *ConnectorReconciler) Reconcile(ctx context.Context, n *runtimev1.Resour
 
 	// Test the connector configuration
 	err = r.testConnector(ctx, self.Meta.Name.Name)
-	if err != nil {
-		return runtime.ReconcileResult{Err: fmt.Errorf("validation failed: %w", err)}
-	}
-
+	// update state even if test fails because the instance connectors have already been updated
 	t.State.SpecHash = specHash
 
-	err = r.C.UpdateState(ctx, self.Meta.Name, self)
+	err = errors.Join(err, r.C.UpdateState(ctx, self.Meta.Name, self))
 	if err != nil {
 		return runtime.ReconcileResult{Err: err}
 	}


### PR DESCRIPTION
Since the instance connector list is updated before connectors are tested so we should update the state even if the reconciler fails.
Otherwise it can lead to following situation:
1. Initially the connector is working state as below:
```
type: connector
driver: duckdb
init_sql: |
    SET threads = 2;
```
2. User makes an incorrect change like below. At this point connector definition has been updated in instance but state  still points to definition 1 above.
```
type: connector
driver: duckdb
init_sql: |
    SET threads = 2; SET invalid_prop = 1;
```
3. User reverts to previous working version. The change is ignored because the state is same as current version leading to the connector in incorrect state till a runtime restart.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
