### PR TITLE
[APP-120] fix: fill missing values on cartesian charts

### DIFF
--- a/web-common/src/features/canvas/components/charts/cartesian-charts/CartesianChart.ts
+++ b/web-common/src/features/canvas/components/charts/cartesian-charts/CartesianChart.ts
@@ -164,6 +164,7 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
             where: topNWhere,
             timeRange,
             limit: limit?.toString(),
+            fillMissing: true,
           },
           {
             query: {
@@ -205,6 +206,7 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
             where: topNWhere,
             timeRange,
             limit: colorLimit?.toString(),
+            fillMissing: true,
           },
           {
             query: {
@@ -291,6 +293,7 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
             sort: xAxisSort ? [xAxisSort] : undefined,
             where: combinedWhere,
             timeRange,
+            fillMissing: true,
             limit: hasColorDimension || !limit ? "5000" : limit?.toString(),
           },
           {


### PR DESCRIPTION
Sets the `fillMissing` property to `true` on the aggregation queries used for Canvas charts.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
