### PR TITLE
Move `applySecurityPolicy` to package `runtime`

### DIFF
--- a/runtime/resources.go
+++ b/runtime/resources.go
@@ -6,6 +6,7 @@ import (
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime/parser"
+	"google.golang.org/protobuf/proto"
 )
 
 // Built-in resource kinds
@@ -159,5 +160,166 @@ func PrettifyReconcileStatus(s runtimev1.ReconcileStatus) string {
 		return "Running"
 	default:
 		panic(fmt.Errorf("unknown reconcile status: %s", s.String()))
+	}
+}
+
+// ApplySecurityPolicy applies relevant security policies to the resource.
+// The input resource will not be modified in-place (so no need to set clone=true when obtaining it from the catalog).
+func (r *Runtime) ApplySecurityPolicy(instID string, claims *SecurityClaims, res *runtimev1.Resource) (*runtimev1.Resource, bool, error) {
+	security, err := r.ResolveSecurity(instID, claims, res)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if security == nil {
+		return res, true, nil
+	}
+
+	if !security.CanAccess() {
+		return nil, false, nil
+	}
+
+	// Some resources may need deeper checks than just access.
+	switch res.Resource.(type) {
+	case *runtimev1.Resource_MetricsView:
+		// For metrics views, we need to remove fields excluded by the field access rules.
+		return r.applyMetricsViewSecurity(res, security), true, nil
+	case *runtimev1.Resource_Explore:
+		// For explores, we need to remove fields excluded by the field access rules.
+		return r.applyExploreSecurity(res, security), true, nil
+	default:
+		// The resource can be returned as is.
+		return res, true, nil
+	}
+}
+
+// applyMetricsViewSecurity rewrites a metrics view based on the field access conditions of a security policy.
+func (r *Runtime) applyMetricsViewSecurity(res *runtimev1.Resource, security *ResolvedSecurity) *runtimev1.Resource {
+	if security.CanAccessAllFields() {
+		return res
+	}
+
+	mv := res.GetMetricsView()
+	specDims, specMeasures, specChanged := r.applyMetricsViewSpecSecurity(mv.Spec, security)
+	validSpecDims, validSpecMeasures, validSpecChanged := r.applyMetricsViewSpecSecurity(mv.State.ValidSpec, security)
+
+	if !specChanged && !validSpecChanged {
+		return res
+	}
+
+	mv = proto.Clone(mv).(*runtimev1.MetricsView)
+
+	if specChanged {
+		mv.Spec.Dimensions = specDims
+		mv.Spec.Measures = specMeasures
+	}
+
+	if validSpecChanged {
+		mv.State.ValidSpec.Dimensions = validSpecDims
+		mv.State.ValidSpec.Measures = validSpecMeasures
+	}
+
+	// We mustn't modify the resource in-place
+	return &runtimev1.Resource{
+		Meta:     res.Meta,
+		Resource: &runtimev1.Resource_MetricsView{MetricsView: mv},
+	}
+}
+
+// applyMetricsViewSpecSecurity rewrites a metrics view spec based on the field access conditions of a security policy.
+func (r *Runtime) applyMetricsViewSpecSecurity(spec *runtimev1.MetricsViewSpec, security *ResolvedSecurity) ([]*runtimev1.MetricsViewSpec_Dimension, []*runtimev1.MetricsViewSpec_Measure, bool) {
+	if spec == nil {
+		return nil, nil, false
+	}
+
+	var dims []*runtimev1.MetricsViewSpec_Dimension
+	for _, dim := range spec.Dimensions {
+		if security.CanAccessField(dim.Name) {
+			dims = append(dims, dim)
+		}
+	}
+
+	var ms []*runtimev1.MetricsViewSpec_Measure
+	for _, m := range spec.Measures {
+		if security.CanAccessField(m.Name) {
+			ms = append(ms, m)
+		}
+	}
+
+	if len(dims) == len(spec.Dimensions) && len(ms) == len(spec.Measures) {
+		return nil, nil, false
+	}
+
+	return dims, ms, true
+}
+
+// applyExploreSecurity rewrites an explore based on the field access conditions of a security policy.
+func (r *Runtime) applyExploreSecurity(res *runtimev1.Resource, security *ResolvedSecurity) *runtimev1.Resource {
+	if security.CanAccessAllFields() {
+		return res
+	}
+
+	// We only rewrite the ValidSpec at the moment.
+	// In the future, to avoid leaking field names in the main spec (which is not really used outside of the reconciler),
+	// we might consider not returning the spec at all for non-admins.
+	spec := res.GetExplore().State.ValidSpec
+	if spec == nil {
+		return res
+	}
+	if spec.DimensionsSelector != nil || spec.MeasuresSelector != nil {
+		// If the ValidSpec has dynamic selectors, we don't know what the available fields, so we can't filter it correctly.
+		// This should never happen because the Explore reconciler should have resolved the fields and removed the exclude flags.
+		panic(fmt.Errorf("the ValidSpec for an explore should not have exclude flags set"))
+	}
+
+	// Clone the spec so we can edit it in-place
+	spec = proto.Clone(spec).(*runtimev1.ExploreSpec)
+
+	// Filter the dimensions
+	var dims []string
+	for _, dim := range spec.Dimensions {
+		if security.CanAccessField(dim) {
+			dims = append(dims, dim)
+		}
+	}
+	spec.Dimensions = dims
+
+	// Filter the measures
+	var ms []string
+	for _, m := range spec.Measures {
+		if security.CanAccessField(m) {
+			ms = append(ms, m)
+		}
+	}
+	spec.Measures = ms
+
+	// Filter the dimensions and measures in the presets
+	if spec.DefaultPreset != nil {
+		p := spec.DefaultPreset
+
+		var dims []string
+		for _, dim := range p.Dimensions {
+			if security.CanAccessField(dim) {
+				dims = append(dims, dim)
+			}
+		}
+		p.Dimensions = dims
+
+		var ms []string
+		for _, m := range p.Measures {
+			if security.CanAccessField(m) {
+				ms = append(ms, m)
+			}
+		}
+		p.Measures = ms
+	}
+
+	// We mustn't modify the resource in-place
+	return &runtimev1.Resource{
+		Meta: res.Meta,
+		Resource: &runtimev1.Resource_Explore{Explore: &runtimev1.Explore{
+			Spec:  res.GetExplore().Spec,
+			State: &runtimev1.ExploreState{ValidSpec: spec},
+		}},
 	}
 }

--- a/runtime/server/canvases.go
+++ b/runtime/server/canvases.go
@@ -45,7 +45,7 @@ func (s *Server) ResolveCanvas(ctx context.Context, req *runtimev1.ResolveCanvas
 	}
 
 	// Check if the user has access to the canvas
-	res, access, err := s.applySecurityPolicy(ctx, req.InstanceId, res)
+	res, access, err := s.runtime.ApplySecurityPolicy(req.InstanceId, auth.GetClaims(ctx).SecurityClaims(), res)
 	if err != nil {
 		return nil, fmt.Errorf("failed to apply security policy: %w", err)
 	}
@@ -179,7 +179,7 @@ func (s *Server) ResolveCanvas(ctx context.Context, req *runtimev1.ResolveCanvas
 
 	// Apply security policies to the metrics views.
 	for name, mv := range referencedMetricsViews {
-		mv, access, err := s.applySecurityPolicy(ctx, req.InstanceId, mv)
+		mv, access, err := s.runtime.ApplySecurityPolicy(req.InstanceId, auth.GetClaims(ctx).SecurityClaims(), mv)
 		if err != nil {
 			return nil, fmt.Errorf("failed to apply security policy: %w", err)
 		}

--- a/runtime/server/controller.go
+++ b/runtime/server/controller.go
@@ -24,7 +24,6 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -74,7 +73,7 @@ func (s *Server) ListResources(ctx context.Context, req *runtimev1.ListResources
 	i := 0
 	for i < len(rs) {
 		r := rs[i]
-		r, access, err := s.applySecurityPolicy(ctx, req.InstanceId, r)
+		r, access, err := s.runtime.ApplySecurityPolicy(req.InstanceId, auth.GetClaims(ctx).SecurityClaims(), r)
 		if err != nil {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
@@ -115,7 +114,7 @@ func (s *Server) WatchResources(req *runtimev1.WatchResourcesRequest, ss runtime
 		}
 
 		for _, r := range rs {
-			r, access, err := s.applySecurityPolicy(ss.Context(), req.InstanceId, r)
+			r, access, err := s.runtime.ApplySecurityPolicy(req.InstanceId, auth.GetClaims(ss.Context()).SecurityClaims(), r)
 			if err != nil {
 				return status.Error(codes.InvalidArgument, err.Error())
 			}
@@ -137,7 +136,7 @@ func (s *Server) WatchResources(req *runtimev1.WatchResourcesRequest, ss runtime
 		if r != nil { // r is nil for deletion events
 			var access bool
 			var err error
-			r, access, err = s.applySecurityPolicy(ss.Context(), req.InstanceId, r)
+			r, access, err = s.runtime.ApplySecurityPolicy(req.InstanceId, auth.GetClaims(ss.Context()).SecurityClaims(), r)
 			if err != nil {
 				s.logger.Info("failed to apply security policy", zap.String("name", n.Name), zap.Error(err))
 				return
@@ -192,7 +191,7 @@ func (s *Server) GetResource(ctx context.Context, req *runtimev1.GetResourceRequ
 		return &runtimev1.GetResourceResponse{Resource: r}, nil
 	}
 
-	r, access, err := s.applySecurityPolicy(ctx, req.InstanceId, r)
+	r, access, err := s.runtime.ApplySecurityPolicy(req.InstanceId, auth.GetClaims(ctx).SecurityClaims(), r)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -229,7 +228,7 @@ func (s *Server) GetExplore(ctx context.Context, req *runtimev1.GetExploreReques
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	e, access, err := s.applySecurityPolicy(ctx, req.InstanceId, e)
+	e, access, err := s.runtime.ApplySecurityPolicy(req.InstanceId, auth.GetClaims(ctx).SecurityClaims(), e)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -253,7 +252,7 @@ func (s *Server) GetExplore(ctx context.Context, req *runtimev1.GetExploreReques
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	m, access, err = s.applySecurityPolicy(ctx, req.InstanceId, m)
+	m, access, err = s.runtime.ApplySecurityPolicy(req.InstanceId, auth.GetClaims(ctx).SecurityClaims(), m)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -293,7 +292,7 @@ func (s *Server) GetModelPartitions(ctx context.Context, req *runtimev1.GetModel
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	r, access, err := s.applySecurityPolicy(ctx, req.InstanceId, r)
+	r, access, err := s.runtime.ApplySecurityPolicy(req.InstanceId, auth.GetClaims(ctx).SecurityClaims(), r)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
@@ -466,167 +465,6 @@ func (s *Server) WatchResourcesHandler(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	eventServer.ServeHTTP(w, r)
-}
-
-// applySecurityPolicy applies relevant security policies to the resource.
-// The input resource will not be modified in-place (so no need to set clone=true when obtaining it from the catalog).
-func (s *Server) applySecurityPolicy(ctx context.Context, instID string, r *runtimev1.Resource) (*runtimev1.Resource, bool, error) {
-	security, err := s.runtime.ResolveSecurity(instID, auth.GetClaims(ctx).SecurityClaims(), r)
-	if err != nil {
-		return nil, false, err
-	}
-
-	if security == nil {
-		return r, true, nil
-	}
-
-	if !security.CanAccess() {
-		return nil, false, nil
-	}
-
-	// Some resources may need deeper checks than just access.
-	switch r.Resource.(type) {
-	case *runtimev1.Resource_MetricsView:
-		// For metrics views, we need to remove fields excluded by the field access rules.
-		return s.applyMetricsViewSecurity(r, security), true, nil
-	case *runtimev1.Resource_Explore:
-		// For explores, we need to remove fields excluded by the field access rules.
-		return s.applyExploreSecurity(r, security), true, nil
-	default:
-		// The resource can be returned as is.
-		return r, true, nil
-	}
-}
-
-// applyMetricsViewSecurity rewrites a metrics view based on the field access conditions of a security policy.
-func (s *Server) applyMetricsViewSecurity(r *runtimev1.Resource, security *runtime.ResolvedSecurity) *runtimev1.Resource {
-	if security.CanAccessAllFields() {
-		return r
-	}
-
-	mv := r.GetMetricsView()
-	specDims, specMeasures, specChanged := s.applyMetricsViewSpecSecurity(mv.Spec, security)
-	validSpecDims, validSpecMeasures, validSpecChanged := s.applyMetricsViewSpecSecurity(mv.State.ValidSpec, security)
-
-	if !specChanged && !validSpecChanged {
-		return r
-	}
-
-	mv = proto.Clone(mv).(*runtimev1.MetricsView)
-
-	if specChanged {
-		mv.Spec.Dimensions = specDims
-		mv.Spec.Measures = specMeasures
-	}
-
-	if validSpecChanged {
-		mv.State.ValidSpec.Dimensions = validSpecDims
-		mv.State.ValidSpec.Measures = validSpecMeasures
-	}
-
-	// We mustn't modify the resource in-place
-	return &runtimev1.Resource{
-		Meta:     r.Meta,
-		Resource: &runtimev1.Resource_MetricsView{MetricsView: mv},
-	}
-}
-
-// applyMetricsViewSpecSecurity rewrites a metrics view spec based on the field access conditions of a security policy.
-func (s *Server) applyMetricsViewSpecSecurity(spec *runtimev1.MetricsViewSpec, policy *runtime.ResolvedSecurity) ([]*runtimev1.MetricsViewSpec_Dimension, []*runtimev1.MetricsViewSpec_Measure, bool) {
-	if spec == nil {
-		return nil, nil, false
-	}
-
-	var dims []*runtimev1.MetricsViewSpec_Dimension
-	for _, dim := range spec.Dimensions {
-		if policy.CanAccessField(dim.Name) {
-			dims = append(dims, dim)
-		}
-	}
-
-	var ms []*runtimev1.MetricsViewSpec_Measure
-	for _, m := range spec.Measures {
-		if policy.CanAccessField(m.Name) {
-			ms = append(ms, m)
-		}
-	}
-
-	if len(dims) == len(spec.Dimensions) && len(ms) == len(spec.Measures) {
-		return nil, nil, false
-	}
-
-	return dims, ms, true
-}
-
-// applyExploreSecurity rewrites an explore based on the field access conditions of a security policy.
-func (s *Server) applyExploreSecurity(r *runtimev1.Resource, security *runtime.ResolvedSecurity) *runtimev1.Resource {
-	if security.CanAccessAllFields() {
-		return r
-	}
-
-	// We only rewrite the ValidSpec at the moment.
-	// In the future, to avoid leaking field names in the main spec (which is not really used outside of the reconciler),
-	// we might consider not returning the spec at all for non-admins.
-	spec := r.GetExplore().State.ValidSpec
-	if spec == nil {
-		return r
-	}
-	if spec.DimensionsSelector != nil || spec.MeasuresSelector != nil {
-		// If the ValidSpec has dynamic selectors, we don't know what the available fields, so we can't filter it correctly.
-		// This should never happen because the Explore reconciler should have resolved the fields and removed the exclude flags.
-		panic(fmt.Errorf("the ValidSpec for an explore should not have exclude flags set"))
-	}
-
-	// Clone the spec so we can edit it in-place
-	spec = proto.Clone(spec).(*runtimev1.ExploreSpec)
-
-	// Filter the dimensions
-	var dims []string
-	for _, dim := range spec.Dimensions {
-		if security.CanAccessField(dim) {
-			dims = append(dims, dim)
-		}
-	}
-	spec.Dimensions = dims
-
-	// Filter the measures
-	var ms []string
-	for _, m := range spec.Measures {
-		if security.CanAccessField(m) {
-			ms = append(ms, m)
-		}
-	}
-	spec.Measures = ms
-
-	// Filter the dimensions and measures in the presets
-	if spec.DefaultPreset != nil {
-		p := spec.DefaultPreset
-
-		var dims []string
-		for _, dim := range p.Dimensions {
-			if security.CanAccessField(dim) {
-				dims = append(dims, dim)
-			}
-		}
-		p.Dimensions = dims
-
-		var ms []string
-		for _, m := range p.Measures {
-			if security.CanAccessField(m) {
-				ms = append(ms, m)
-			}
-		}
-		p.Measures = ms
-	}
-
-	// We mustn't modify the resource in-place
-	return &runtimev1.Resource{
-		Meta: r.Meta,
-		Resource: &runtimev1.Resource_Explore{Explore: &runtimev1.Explore{
-			Spec:  r.GetExplore().Spec,
-			State: &runtimev1.ExploreState{ValidSpec: spec},
-		}},
-	}
 }
 
 // modelPartitionsToPB converts a slice of drivers.ModelPartition to a slice of runtimev1.ModelPartition.

--- a/runtime/server/downloads.go
+++ b/runtime/server/downloads.go
@@ -53,7 +53,7 @@ func (s *Server) ExportReport(ctx context.Context, req *runtimev1.ExportReportRe
 		return nil, status.Errorf(codes.Internal, "failed to get report: %s", err.Error())
 	}
 
-	r, access, err := s.applySecurityPolicy(ctx, req.InstanceId, res)
+	r, access, err := s.runtime.ApplySecurityPolicy(req.InstanceId, auth.GetClaims(ctx).SecurityClaims(), res)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}


### PR DESCRIPTION
This PR moves the `applySecurityPolicy` function to the `runtime` package. This is in preparation for another PR that needs to use this functionality from outside the `server` package. 