### PR TITLE
Making connector service timeout same as query service

### DIFF
--- a/runtime/server/server.go
+++ b/runtime/server/server.go
@@ -291,7 +291,8 @@ func timeoutSelector(fullMethodName string) time.Duration {
 		return time.Minute * 59 // Not 60 to avoid forced timeout on ingress
 	}
 
-	if strings.HasPrefix(fullMethodName, "/rill.runtime.v1.QueryService") {
+	if strings.HasPrefix(fullMethodName, "/rill.runtime.v1.QueryService") ||
+		strings.HasPrefix(fullMethodName, "/rill.runtime.v1.ConnectorService") {
 		return time.Minute * 5
 	}
 


### PR DESCRIPTION
In [PLAT-177: Clickhouse connector testing hangs when it is unavailable](https://linear.app/rilldata/issue/PLAT-177/clickhouse-connector-testing-hangs-when-it-is-unavailable), , the issue was caused by using the wrong TCP port (9000). While 9000 is the ClickHouse default, play.clickhouse.com requires port 9440.

A second issue we identified is that the connector was returning context deadline exceeded instead of the actual underlying error. This happened because the connector service timeout was set to 30s, which expired before the driver surfaced the real error. We have now increased the connector service timeout to 5 minutes, matching the query service.

Currently, the ClickHouse driver Open uses a default DialTimeout of 1 minute. As part of initialization, it attempts two pings (one over TCP and one over HTTP). With this setup, the effective timeout should be at least 2 minutes.

The original reasoning for the 1-minute DialTimeout was documented as:

> Apply an increased default to reduce the chance of dropped connections with scaled-to-zero ClickHouse.

In other words, the longer timeout was intended to handle cases where ClickHouse instances take extra time to start up.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
