### PR TITLE
Display loading icons for upstream model ingestion

### DIFF
--- a/web-admin/src/features/projects/status/ResourceErrorMessage.svelte
+++ b/web-admin/src/features/projects/status/ResourceErrorMessage.svelte
@@ -10,11 +10,26 @@
 
   export let message: string;
   export let status: V1ReconcileStatus;
+
+  // Check if the error message indicates waiting for an upstream dependency
+  $: isWaitingForUpstreamDependency = message && (
+    message.includes("is not idle") || 
+    message.startsWith("dependency error:")
+  );
 </script>
 
 <div class="container">
-  {#if status === V1ReconcileStatus.RECONCILE_STATUS_PENDING || status === V1ReconcileStatus.RECONCILE_STATUS_RUNNING}
-    <LoadingSpinner size="18px" />
+  {#if status === V1ReconcileStatus.RECONCILE_STATUS_PENDING || status === V1ReconcileStatus.RECONCILE_STATUS_RUNNING || isWaitingForUpstreamDependency}
+    {#if isWaitingForUpstreamDependency}
+      <Tooltip distance={8}>
+        <LoadingSpinner size="18px" />
+        <TooltipContent slot="tooltip-content" maxWidth="300px">
+          <p>Waiting for upstream dependencies to finish processing</p>
+        </TooltipContent>
+      </Tooltip>
+    {:else}
+      <LoadingSpinner size="18px" />
+    {/if}
   {:else if message}
     <Tooltip distance={8}>
       <button


### PR DESCRIPTION
Resolves APP-259. Previously, the Project Status page displayed an error icon for resources waiting on upstream dependencies to finish processing (e.g., "resource is not idle"). This was confusing as it's a temporary waiting state, not an actual error.

This PR updates `ResourceErrorMessage.svelte` to:
- Detect specific messages indicating a resource is waiting for upstream dependencies.
- Display a loading spinner with a "Waiting for upstream dependencies to finish processing" tooltip in these cases, instead of an error icon.

This improves user clarity by differentiating between true errors and temporary processing states.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-259](https://linear.app/rilldata/issue/APP-259/we-should-be-displaying-a-loading-icon-for-each-resource-in-the)

<a href="https://cursor.com/background-agent?bcId=bc-c36b5595-ac3f-432e-9418-05bb407064df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c36b5595-ac3f-432e-9418-05bb407064df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

