### PR TITLE
Fix json display in leaderboards

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
@@ -38,6 +38,7 @@ import { getFiltersForOtherDimensions } from "../selectors";
 import type { ExploreState } from "web-common/src/features/dashboards/stores/explore-state";
 import type { DimensionTableRow } from "./dimension-table-types";
 import type { DimensionTableConfig } from "./DimensionTableConfig";
+import { formatDimensionValue } from "../leaderboard/leaderboard-utils";
 
 /** Returns an updated filter set for a given dimension on search */
 export function updateFilterOnSearch(
@@ -450,6 +451,7 @@ export function prepareDimensionTableRows(
   addDeltas: boolean,
   addPercentOfTotal: boolean,
   unfilteredTotal: number | { [key: string]: number },
+  dimensionDataType?: { code?: string },
 ): DimensionTableRow[] {
   if (!queryRows || !queryRows.length) return [];
 
@@ -475,7 +477,7 @@ export function prepareDimensionTableRows(
         ]);
 
       const rowOut: DimensionTableRow = Object.fromEntries([
-        [dimensionColumn, row[dimensionColumn] as string],
+        [dimensionColumn, formatDimensionValue(row[dimensionColumn], dimensionDataType)],
         ...rawVals,
         ...formattedVals,
       ]);

--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -33,6 +33,7 @@
   import {
     cleanUpComparisonValue,
     compareLeaderboardValues,
+    formatDimensionValue,
     getSort,
     prepareLeaderboardItemData,
   } from "./leaderboard-utils";
@@ -209,6 +210,7 @@
       slice,
       $selectedValues?.data ?? [],
       leaderboardTotals,
+      dimension?.dataType,
     ));
 
   $: belowTheFoldDataLimit = maxValuesToShow - aboveTheFold.length;
@@ -267,8 +269,9 @@
       leaderboardMeasureNames,
       leaderboardTotals,
       $selectedValues?.data?.findIndex((value) =>
-        compareLeaderboardValues(value, item[dimensionName]),
+        compareLeaderboardValues(value, formatDimensionValue(item[dimensionName], dimension?.dataType)),
       ) ?? -1,
+      dimension?.dataType,
     ),
   );
 

--- a/web-common/src/features/dashboards/state-managers/selectors/dimension-table.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/dimension-table.ts
@@ -96,6 +96,7 @@ export const prepareDimTableRows =
       isTimeComparisonActive(dashData),
       isValidPercentOfTotal(dashData),
       unfilteredTotal,
+      dimension?.dataType,
     );
   };
 


### PR DESCRIPTION
Fixes APP-308: Display JSON in leaderboards and dimension tables, and enable filtering.

Previously, JSON dimension values were displayed as `[object Object]` and caused SQL errors (`unsupported type map[string]interface {}`) when filtered. This PR introduces a `formatDimensionValue` helper to properly stringify JSON, STRUCT, MAP, and ARRAY types. This ensures correct display in leaderboards and dimension tables, and allows filtering on these values without errors by passing stringified JSON to the backend.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes (APP-308)
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-308](https://linear.app/rilldata/issue/APP-308/display-json-in-leaderboards)

<a href="https://cursor.com/background-agent?bcId=bc-a31e572e-107a-4a22-b067-382b7e573e5c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a31e572e-107a-4a22-b067-382b7e573e5c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

