### PR TITLE
fix(rill dev): out of view throttle timeout being incorrect

### DIFF
--- a/web-common/src/runtime-client/watch-request-client.ts
+++ b/web-common/src/runtime-client/watch-request-client.ts
@@ -41,8 +41,7 @@ export class WatchRequestClient<Res extends WatchResponse> {
   private stream: AsyncGenerator<StreamingFetchResponse<Res>> | undefined;
   private eventSource: EventSource | undefined;
   private useSSE: boolean = false;
-  // private outOfFocusThrottler = new Throttler(120000, 20000);
-  private outOfFocusThrottler = new Throttler(10000, 1000);
+  private outOfFocusThrottler = new Throttler(120000, 20000);
   public retryAttempts = writable(0);
   private reconnectTimeout: ReturnType<typeof setTimeout> | undefined;
   private retryTimeout: ReturnType<typeof setTimeout> | undefined;


### PR DESCRIPTION
Out of view throttle timeout was incorrectly set in https://github.com/rilldata/rill/pull/7862 for testing. This reverts that and correctly sets a longer timeout.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
