### PR TITLE
fix: default explore sort by not honouring default measures

### DIFF
--- a/web-common/src/features/dashboards/stores/get-explore-state-from-yaml-config.ts
+++ b/web-common/src/features/dashboards/stores/get-explore-state-from-yaml-config.ts
@@ -149,14 +149,14 @@ function getDefaultComparisonTimeRangeName(
     timezone,
   );
 
-  const comparisonTimeRangeNmae = getValidComparisonOption(
+  const comparisonTimeRangeName = getValidComparisonOption(
     exploreSpec.timeRanges,
     timeRange,
     undefined,
     allTimeRange,
   );
 
-  return comparisonTimeRangeNmae;
+  return comparisonTimeRangeName;
 }
 
 function getExploreViewStateFromYAMLConfig(
@@ -184,6 +184,9 @@ function getExploreViewStateFromYAMLConfig(
 
   if (defaultPreset.exploreSortBy) {
     exploreViewState.leaderboardSortByMeasureName = defaultPreset.exploreSortBy;
+  } else if (exploreViewState.visibleMeasures?.length) {
+    exploreViewState.leaderboardSortByMeasureName =
+      exploreViewState.visibleMeasures[0];
   }
 
   if ("exploreSortAsc" in defaultPreset) {
@@ -201,6 +204,10 @@ function getExploreViewStateFromYAMLConfig(
   if (defaultPreset.exploreLeaderboardMeasures?.length) {
     exploreViewState.leaderboardMeasureNames =
       defaultPreset.exploreLeaderboardMeasures;
+  } else if (exploreViewState.leaderboardSortByMeasureName) {
+    exploreViewState.leaderboardMeasureNames = [
+      exploreViewState.leaderboardSortByMeasureName,
+    ];
   }
 
   if (defaultPreset.exploreLeaderboardShowContextForAllMeasures !== undefined) {


### PR DESCRIPTION
Default explore sort by was taking the 1st measure from all measures instead from the default visible measures if present.

Closes APP-327

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
