### PR TITLE
Remove conditional connector file creation for DuckDB OLAP engine

### DIFF
--- a/runtime/parser/init.go
+++ b/runtime/parser/init.go
@@ -57,19 +57,6 @@ mock_users:
 		return err
 	}
 
-	// Only create connector files for non-DuckDB OLAP engines or when explicitly requested
-	// This allows DuckDB-based projects to go through the welcome page for user-guided initialization
-	if olap != "duckdb" {
-		connector := "type: connector\ndriver: duckdb"
-		if olap == "clickhouse" {
-			connector = "type: connector\ndriver: clickhouse\nmanaged: true"
-		}
-
-		err = repo.Put(ctx, fmt.Sprintf("connectors/%s.yaml", olap), strings.NewReader(connector))
-		if err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/runtime/parser/init_test.go
+++ b/runtime/parser/init_test.go
@@ -60,7 +60,7 @@ func TestInitEmptyDuckDB(t *testing.T) {
 	require.Error(err) // Should error because file doesn't exist
 }
 
-func TestInitEmptyCH(t *testing.T) {
+func TestInitEmpty(t *testing.T) {
 	require := require.New(t)
 
 	repo := makeRepo(t, map[string]string{})
@@ -81,14 +81,4 @@ func TestInitEmptyCH(t *testing.T) {
 	require.Contains(gitignore, "# Rill")
 	require.Contains(gitignore, ".env")
 	require.Contains(gitignore, "tmp")
-
-	// Verify the contents of the connector file
-	connector, err := repo.Get(t.Context(), "connectors/clickhouse.yaml")
-	require.NoError(err)
-	require.Contains(connector, "type: connector")
-	require.Contains(connector, "driver: clickhouse")
-	require.Contains(connector, "managed: true")
-
-	// Verify duckdb is not present
-	require.NotContains(connector, "driver: duckdb")
 }


### PR DESCRIPTION
The `InitEmpty` function will no longer create any connector files during project initialization, preventing the generation of duckdb.yaml or other connector YAML files. This allows the UI to handle connector creation through user-guided initialization.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
