### PR TITLE
Motherduck to duck failed with new connector mother connector format

### DIFF
--- a/runtime/resolvers/testdata/motherduck_connector.yaml
+++ b/runtime/resolvers/testdata/motherduck_connector.yaml
@@ -4,7 +4,7 @@ project_files:
   all_datatypes_duckdb.yaml:
     type: model
     connector: motherduck
-    dsn: "md:_share/rilldata/25169ce8-45af-4ac5-9174-00c859d5aa77"
+    path: "md:_share/rilldata/25169ce8-45af-4ac5-9174-00c859d5aa77"
     sql: "select * from rilldata.integration_test.all_datatypes"
     output:
       connector: duckdb


### PR DESCRIPTION
Fixes: https://linear.app/rilldata/issue/PLAT-166/duckdb-connector-create-model-error

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
