### PR TITLE
refac: donut chart improvements

### DIFF
--- a/web-common/src/features/canvas/components/charts/circular-charts/CircularChart.ts
+++ b/web-common/src/features/canvas/components/charts/circular-charts/CircularChart.ts
@@ -44,6 +44,19 @@ export class CircularChartComponent extends BaseChart<CircularChartSpec> {
   totalsValue: number | undefined = undefined;
 
   static chartInputParams: Record<string, ComponentInputParam> = {
+    measure: {
+      type: "positional",
+      label: "Measure",
+      meta: {
+        chartFieldInput: {
+          type: "measure",
+        },
+      },
+    },
+    innerRadius: {
+      type: "number",
+      label: "Inner Radius (%)",
+    },
     color: {
       type: "positional",
       label: "Color",
@@ -62,19 +75,6 @@ export class CircularChartComponent extends BaseChart<CircularChartSpec> {
           colorMappingSelector: { enable: true },
         },
       },
-    },
-    measure: {
-      type: "positional",
-      label: "Measure",
-      meta: {
-        chartFieldInput: {
-          type: "measure",
-        },
-      },
-    },
-    innerRadius: {
-      type: "number",
-      label: "Inner Radius (%)",
     },
   };
 

--- a/web-common/src/features/canvas/components/charts/circular-charts/CircularChart.ts
+++ b/web-common/src/features/canvas/components/charts/circular-charts/CircularChart.ts
@@ -50,6 +50,7 @@ export class CircularChartComponent extends BaseChart<CircularChartSpec> {
       meta: {
         chartFieldInput: {
           type: "measure",
+          totalSelector: true,
         },
       },
     },
@@ -108,6 +109,7 @@ export class CircularChartComponent extends BaseChart<CircularChartSpec> {
     let colorSort: V1MetricsViewAggregationSort | undefined;
     let limit: number;
     const colorDimensionName = config.color?.field;
+    const showTotal = config.measure?.showTotal;
 
     if (colorDimensionName) {
       limit = config.color?.limit || DEFAULT_COLOR_LIMIT;
@@ -156,7 +158,10 @@ export class CircularChartComponent extends BaseChart<CircularChartSpec> {
       ([runtime, $timeAndFilterStore]) => {
         const { timeRange, where } = $timeAndFilterStore;
         const enabled =
-          !!timeRange?.start && !!timeRange?.end && !!config.measure?.field;
+          !!showTotal &&
+          !!timeRange?.start &&
+          !!timeRange?.end &&
+          !!config.measure?.field;
 
         const totalWhere = getFilterWithNullHandling(where, config.color);
 
@@ -233,7 +238,7 @@ export class CircularChartComponent extends BaseChart<CircularChartSpec> {
           },
         );
 
-        if (config.measure?.field) {
+        if (showTotal && config.measure?.field) {
           this.totalsValue = $totalQuery?.data?.data?.[0]?.[
             config.measure?.field
           ] as number;
@@ -294,7 +299,7 @@ export class CircularChartComponent extends BaseChart<CircularChartSpec> {
           : undefined;
     }
 
-    if (this.totalsValue) {
+    if (config.measure?.showTotal && this.totalsValue) {
       result["total"] = [this.totalsValue];
     }
 
@@ -341,6 +346,7 @@ export class CircularChartComponent extends BaseChart<CircularChartSpec> {
       measure: {
         type: "quantitative",
         field: randomMeasure,
+        showTotal: true,
       },
     };
   }

--- a/web-common/src/features/canvas/components/charts/circular-charts/pie.ts
+++ b/web-common/src/features/canvas/components/charts/circular-charts/pie.ts
@@ -47,8 +47,8 @@ export function generateVLPieChartSpec(
   data: ChartDataResult,
 ): VisualizationSpec {
   const totalValue = data.domainValues?.["total"]?.[0];
-  const hasInnerRadius = config.innerRadius && config.innerRadius > 0;
-  const shouldShowTotal = hasInnerRadius && totalValue !== undefined;
+  const shouldShowTotal =
+    totalValue !== undefined && config.measure?.showTotal === true;
 
   const measureMetaData = config.measure && data.fields[config.measure.field];
 

--- a/web-common/src/features/canvas/components/charts/circular-charts/pie.ts
+++ b/web-common/src/features/canvas/components/charts/circular-charts/pie.ts
@@ -29,6 +29,19 @@ function getInnerRadius(innerRadiusPercentage: number | undefined) {
   return { expr: `${decimal}*min(width,height)/2` };
 }
 
+function getTotalFontSize(innerRadiusPercentage: number | undefined) {
+  if (
+    !innerRadiusPercentage ||
+    innerRadiusPercentage <= 0 ||
+    innerRadiusPercentage >= 100
+  ) {
+    return 16;
+  }
+
+  const decimal = innerRadiusPercentage / 100;
+  return { expr: `max(11, min(32, ${decimal}*min(width,height)/4))` };
+}
+
 export function generateVLPieChartSpec(
   config: CircularChartSpec,
   data: ChartDataResult,
@@ -94,7 +107,7 @@ export function generateVLPieChartSpec(
         align: "center",
         baseline: "middle",
         fontWeight: "normal",
-        fontSize: 16,
+        fontSize: getTotalFontSize(config.innerRadius),
       },
       encoding: {
         text: {

--- a/web-common/src/features/canvas/components/charts/types.ts
+++ b/web-common/src/features/canvas/components/charts/types.ts
@@ -94,6 +94,7 @@ interface QuantitativeFieldConfig {
   zeroBasedOrigin?: boolean; // Default is false
   min?: number;
   max?: number;
+  showTotal?: boolean;
 }
 
 export interface FieldConfig

--- a/web-common/src/features/canvas/inspector/chart/field-config/FieldConfigPopover.svelte
+++ b/web-common/src/features/canvas/inspector/chart/field-config/FieldConfigPopover.svelte
@@ -40,6 +40,7 @@
   $: showOrigin = chartFieldInput?.originSelector ?? false;
   $: sortConfig = chartFieldInput?.sortSelector ?? { enable: false };
   $: showLimit = chartFieldInput?.limitSelector ?? false;
+  $: showTotal = chartFieldInput?.totalSelector ?? false;
   $: showNull = chartFieldInput?.nullSelector ?? false;
   $: showLabelAngle = chartFieldInput?.labelAngleSelector ?? false;
   $: showLegend = chartFieldInput?.defaultLegendOrientation ?? false;
@@ -125,6 +126,18 @@
               checked={fieldConfig?.zeroBasedOrigin}
               on:click={() => {
                 onChange("zeroBasedOrigin", !fieldConfig?.zeroBasedOrigin);
+              }}
+            />
+          </div>
+        {/if}
+        {#if showTotal}
+          <div class="py-1.5 flex items-center justify-between">
+            <span class="text-xs">Show totals value</span>
+            <Switch
+              small
+              checked={fieldConfig?.showTotal}
+              on:click={() => {
+                onChange("showTotal", !fieldConfig?.showTotal);
               }}
             />
           </div>

--- a/web-common/src/features/canvas/inspector/types.ts
+++ b/web-common/src/features/canvas/inspector/types.ts
@@ -50,6 +50,10 @@ export type ChartFieldInput = {
    * If this key is not specified, legend selector will not be shown.
    */
   defaultLegendOrientation?: ChartLegend;
+  /**
+   * For measures toggle for displaying measure total value
+   */
+  totalSelector?: boolean;
 };
 
 export interface ComponentInputParam {


### PR DESCRIPTION
- Add toggle to show and hide totals value in the centre.
- Responsive font size for totals value
- Reorder params to put measure dropdown and inner radius input above color

Addresses some issues from https://linear.app/rilldata/issue/APP-341/improvements-to-donut-chart

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
