### PR TITLE
Preserve DSN when in managed mode

### DIFF
--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -196,8 +196,7 @@ type configProperties struct {
 
 func (c *configProperties) validate() error {
 	if c.Managed {
-		// In managed mode, clear all connection-related properties
-		c.DSN = ""
+		// In managed mode, clear connection properties but preserve provisioner DSN
 		c.Username = ""
 		c.Password = ""
 		c.Host = ""


### PR DESCRIPTION
This change allows managed ClickHouse instances to connect properly using the DSN provided by the provisioner, fixing the connection issue that was preventing managed ClickHouse support from working. I Adjusted `validate()` to preserve the DSN when it's provided (likely by the provisioner) while still clearing conflicting individual connection properties.

- Provisioner-provided DSNs are preserved in managed mode
- Conflicting individual connection properties are still cleared to prevent configuration conflicts

Relates to: https://github.com/rilldata/rill/pull/7811#pullrequestreview-3196209491

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
