### PR TITLE
Add CLUSTER privilege to user grants in Clickhouse provisioner

### DIFF
--- a/admin/provisioner/clickhousestatic/provisioner.go
+++ b/admin/provisioner/clickhousestatic/provisioner.go
@@ -201,13 +201,12 @@ func (p *Provisioner) Provision(ctx context.Context, r *provisioner.Resource, op
 		"POSTGRES",
 		"S3",
 		"AZURE",
+		"CLUSTER", // Always grant CLUSTER privilege for DDL operations
 	}
 
-	// If cluster is configured, grant specific cluster privileges instead of global CLUSTER
+	// If cluster is configured, also grant specific cluster privileges
 	if p.spec.Cluster != "" {
 		globalPrivileges = append(globalPrivileges, fmt.Sprintf("SHOW TABLES ON CLUSTER %s", escapeSQLIdentifier(p.spec.Cluster)), fmt.Sprintf("SHOW DATABASES ON CLUSTER %s", escapeSQLIdentifier(p.spec.Cluster)))
-	} else {
-		globalPrivileges = append(globalPrivileges, "CLUSTER")
 	}
 
 	_, err = p.ch.ExecContext(ctx, fmt.Sprintf(`GRANT %s %s ON *.* TO %s`, p.onCluster(), strings.Join(globalPrivileges, ", "), user))

--- a/admin/provisioner/clickhousestatic/provisioner.go
+++ b/admin/provisioner/clickhousestatic/provisioner.go
@@ -195,6 +195,7 @@ func (p *Provisioner) Provision(ctx context.Context, r *provisioner.Resource, op
 	// Grant some additional global privileges to the user
 	_, err = p.ch.ExecContext(ctx, fmt.Sprintf(`
 		GRANT %s
+			CLUSTER,
 			URL,
 			REMOTE,
 			MONGO,

--- a/admin/provisioner/clickhousestatic/provisioner.go
+++ b/admin/provisioner/clickhousestatic/provisioner.go
@@ -210,7 +210,7 @@ func (p *Provisioner) Provision(ctx context.Context, r *provisioner.Resource, op
 		globalPrivileges = append(globalPrivileges, "CLUSTER")
 	}
 
-	_, err = p.ch.ExecContext(ctx, fmt.Sprintf(`GRANT %s %s ON *.* TO %s`, p.onCluster(), strings.Join(globalPrivileges, ",\n\t\t\t"), user))
+	_, err = p.ch.ExecContext(ctx, fmt.Sprintf(`GRANT %s %s ON *.* TO %s`, p.onCluster(), strings.Join(globalPrivileges, ", "), user))
 	if err != nil {
 		return nil, fmt.Errorf("failed to grant global privileges to clickhouse user: %w", err)
 	}


### PR DESCRIPTION
Resolves:

```
failed to create model: code: 497, message: rill_574191b053eb4848a89e554da14c2eeb: Not enough privileges. To execute this query, it's necessary to have the grant CLUSTER ON *.*
```

Added `CLUSTER` privilege grant. `CLUSTER` allows a user to execute queries and DDL operations like `CREATE TABLE` on a distributed cluster.

**Checklist:**
- [x] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
