### PR TITLE
[APP-33] fix: add delete confirmation dialog to canvas

### DIFF
--- a/web-common/src/features/canvas/CanvasBuilder.svelte
+++ b/web-common/src/features/canvas/CanvasBuilder.svelte
@@ -422,7 +422,6 @@
         e.target.tagName !== "TEXTAREA" &&
         !e.target.isContentEditable)
     ) {
-      console.log("what");
       pendingComponentDelete = selected;
     }
   }}


### PR DESCRIPTION
The original issue is not practical to fully solve in the short term as it is an issue with an older version of a library we are using that can't be updated until we migrate to Svelte 5. This PR puts in a tangential fix by displaying a confirmation dialog when trying to delete a component/widget with the backspace/delete key.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
