### PR TITLE
fix: import issues with vega in CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17961,6 +17961,40 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-geo-projection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-4.0.0.tgz",
+      "integrity": "sha512-p0bK60CEzph1iqmnxut7d/1kyTmm3UWtPlwdkM31AU+LW+BXazd5zJdoCn7VFxNCHXRngPHRnsNn5uGjLRGndg==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "commander": "7",
+        "d3-array": "1 - 3",
+        "d3-geo": "1.12.0 - 3"
+      },
+      "bin": {
+        "geo2svg": "bin/geo2svg.js",
+        "geograticule": "bin/geograticule.js",
+        "geoproject": "bin/geoproject.js",
+        "geoquantize": "bin/geoquantize.js",
+        "geostitch": "bin/geostitch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo-projection/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/d3-hierarchy": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
@@ -20920,6 +20954,14 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -38367,6 +38409,30 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/toposort": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
@@ -40049,6 +40115,131 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vega": {
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.33.0.tgz",
+      "integrity": "sha512-jNAGa7TxLojOpMMMrKMXXBos4K6AaLJbCgGDOw1YEkLRjUkh12pcf65J2lMSdEHjcEK47XXjKiOUVZ8L+MniBA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "vega-crossfilter": "~4.1.3",
+        "vega-dataflow": "~5.7.7",
+        "vega-encode": "~4.10.2",
+        "vega-event-selector": "~3.0.1",
+        "vega-expression": "~5.2.0",
+        "vega-force": "~4.2.2",
+        "vega-format": "~1.1.3",
+        "vega-functions": "~5.18.0",
+        "vega-geo": "~4.4.3",
+        "vega-hierarchy": "~4.1.3",
+        "vega-label": "~1.3.1",
+        "vega-loader": "~4.5.3",
+        "vega-parser": "~6.6.0",
+        "vega-projection": "~1.6.2",
+        "vega-regression": "~1.3.1",
+        "vega-runtime": "~6.2.1",
+        "vega-scale": "~7.4.2",
+        "vega-scenegraph": "~4.13.1",
+        "vega-statistics": "~1.9.0",
+        "vega-time": "~2.1.3",
+        "vega-transforms": "~4.12.1",
+        "vega-typings": "~1.5.0",
+        "vega-util": "~1.17.2",
+        "vega-view": "~5.16.0",
+        "vega-view-transforms": "~4.6.1",
+        "vega-voronoi": "~4.2.4",
+        "vega-wordcloud": "~4.1.6"
+      }
+    },
+    "node_modules/vega-canvas": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
+      "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/vega-crossfilter": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.3.tgz",
+      "integrity": "sha512-nyPJAXAUABc3EocUXvAL1J/IWotZVsApIcvOeZaUdEQEtZ7bt8VtP2nj3CLbHBA8FZZVV+K6SmdwvCOaAD4wFQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.7",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-dataflow": {
+      "version": "5.7.7",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.7.tgz",
+      "integrity": "sha512-R2NX2HvgXL+u4E6u+L5lKvvRiCtnE6N6l+umgojfi53suhhkFP+zB+2UAQo4syxuZ4763H1csfkKc4xpqLzKnw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "vega-format": "^1.1.3",
+        "vega-loader": "^4.5.3",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-embed": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-7.0.2.tgz",
+      "integrity": "sha512-ZHQPWSs9mUTGJPZ5yQVhHV+OLDCoTIjR//De93vG6igZX1MQCVo03ePWlfWCUAnPV1IsKfeJLqA3K/Qd11bAFQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "fast-json-patch": "^3.1.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "semver": "^7.7.1",
+        "tslib": "^2.8.1",
+        "vega-interpreter": "^2.0.0",
+        "vega-schema-url-parser": "^3.0.2",
+        "vega-themes": "3.0.0",
+        "vega-tooltip": "1.0.0"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      },
+      "peerDependencies": {
+        "vega": "*",
+        "vega-lite": "*"
+      }
+    },
+    "node_modules/vega-embed/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vega-encode": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.10.2.tgz",
+      "integrity": "sha512-fsjEY1VaBAmqwt7Jlpz0dpPtfQFiBdP9igEefvumSpy7XUxOJmDQcRDnT3Qh9ctkv3itfPfI9g8FSnGcv2b4jQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-interpolate": "^3.0.1",
+        "vega-dataflow": "^5.7.7",
+        "vega-scale": "^7.4.2",
+        "vega-util": "^1.17.3"
+      }
+    },
     "node_modules/vega-event-selector": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.1.tgz",
@@ -40064,6 +40255,86 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-force": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.2.tgz",
+      "integrity": "sha512-cHZVaY2VNNIG2RyihhSiWniPd2W9R9kJq0znxzV602CgUVgxEfTKtx/lxnVCn8nNrdKAYrGiqIsBzIeKG1GWHw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-force": "^3.0.0",
+        "vega-dataflow": "^5.7.7",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-format": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.3.tgz",
+      "integrity": "sha512-wQhw7KR46wKJAip28FF/CicW+oiJaPAwMKdrxlnTA0Nv8Bf7bloRlc+O3kON4b4H1iALLr9KgRcYTOeXNs2MOA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-format": "^3.1.0",
+        "d3-time-format": "^4.1.0",
+        "vega-time": "^2.1.3",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-functions": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.18.0.tgz",
+      "integrity": "sha512-+D+ey4bDAhZA2CChh7bRZrcqRUDevv05kd2z8xH+il7PbYQLrhi6g1zwvf8z3KpgGInFf5O13WuFK5DQGkz5lQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-dataflow": "^5.7.7",
+        "vega-expression": "^5.2.0",
+        "vega-scale": "^7.4.2",
+        "vega-scenegraph": "^4.13.1",
+        "vega-selections": "^5.6.0",
+        "vega-statistics": "^1.9.0",
+        "vega-time": "^2.1.3",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-geo": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.3.tgz",
+      "integrity": "sha512-+WnnzEPKIU1/xTFUK3EMu2htN35gp9usNZcC0ZFg2up1/Vqu6JyZsX0PIO51oXSIeXn9bwk6VgzlOmJUcx92tA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.7",
+        "vega-projection": "^1.6.2",
+        "vega-statistics": "^1.9.0",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-hierarchy": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.3.tgz",
+      "integrity": "sha512-0Z+TYKRgOEo8XYXnJc2HWg1EGpcbNAhJ9Wpi9ubIbEyEHqIgjCIyFVN8d4nSfsJOcWDzsSmRqohBztxAhOCSaw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-hierarchy": "^3.1.2",
+        "vega-dataflow": "^5.7.7",
         "vega-util": "^1.17.3"
       }
     },
@@ -40083,6 +40354,20 @@
       "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/vega-label": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.3.1.tgz",
+      "integrity": "sha512-Emx4b5s7pvuRj3fBkAJ/E2snCoZACfKAwxVId7f/4kYVlAYLb5Swq6W8KZHrH4M9Qds1XJRUYW9/Y3cceqzEFA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.7",
+        "vega-scenegraph": "^4.13.1",
+        "vega-util": "^1.17.3"
+      }
     },
     "node_modules/vega-lite": {
       "version": "5.23.0",
@@ -40122,6 +40407,204 @@
         "vega-util": "^1.17.3"
       }
     },
+    "node_modules/vega-loader": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.3.tgz",
+      "integrity": "sha512-dUfIpxTLF2magoMaur+jXGvwMxjtdlDZaIS8lFj6N7IhUST6nIvBzuUlRM+zLYepI5GHtCLOnqdKU4XV0NggCA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-dsv": "^3.0.1",
+        "node-fetch": "^2.6.7",
+        "topojson-client": "^3.1.0",
+        "vega-format": "^1.1.3",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-parser": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.6.0.tgz",
+      "integrity": "sha512-jltyrwCTtWeidi/6VotLCybhIl+ehwnzvFWYOdWNUP0z/EskdB64YmawNwjCjzTBMemeiQtY6sJPPbewYqe3Vg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "vega-dataflow": "^5.7.7",
+        "vega-event-selector": "^3.0.1",
+        "vega-functions": "^5.18.0",
+        "vega-scale": "^7.4.2",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-projection": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.6.2.tgz",
+      "integrity": "sha512-3pcVaQL9R3Zfk6PzopLX6awzrQUeYOXJzlfLGP2Xd93mqUepBa6m/reVrTUoSFXA3v9lfK4W/PS2AcVzD/MIcQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-geo": "^3.1.0",
+        "d3-geo-projection": "^4.0.0",
+        "vega-scale": "^7.4.2"
+      }
+    },
+    "node_modules/vega-regression": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.3.1.tgz",
+      "integrity": "sha512-AmccF++Z9uw4HNZC/gmkQGe6JsRxTG/R4QpbcSepyMvQN1Rj5KtVqMcmVFP1r3ivM4dYGFuPlzMWvuqp0iKMkQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.7",
+        "vega-statistics": "^1.9.0",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-runtime": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.2.1.tgz",
+      "integrity": "sha512-b4eot3tWKCk++INWqot+6sLn3wDTj/HE+tRSbiaf8aecuniPMlwJEK7wWuhVGeW2Ae5n8fI/8TeTViaC94bNHA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "vega-dataflow": "^5.7.7",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-scale": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.4.2.tgz",
+      "integrity": "sha512-o6Hl76aU1jlCK7Q8DPYZ8OGsp4PtzLdzI6nGpLt8rxoE78QuB3GBGEwGAQJitp4IF7Lb2rL5oAXEl3ZP6xf9jg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.1.0",
+        "vega-time": "^2.1.3",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-scenegraph": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.13.1.tgz",
+      "integrity": "sha512-LFY9+sLIxRfdDI9ZTKjLoijMkIAzPLBWHpPkwv4NPYgdyx+0qFmv+puBpAUGUY9VZqAZ736Uj5NJY9zw+/M3yQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-path": "^3.1.0",
+        "d3-shape": "^3.2.0",
+        "vega-canvas": "^1.2.7",
+        "vega-loader": "^4.5.3",
+        "vega-scale": "^7.4.2",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-schema-url-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-3.0.2.tgz",
+      "integrity": "sha512-xAnR7KAvNPYewI3O0l5QGdT8Tv0+GCZQjqfP39cW/hbe/b3aYMAQ39vm8O2wfXUHzm04xTe7nolcsx8WQNVLRQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/vega-selections": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.6.0.tgz",
+      "integrity": "sha512-UE2w78rUUbaV3Ph+vQbQDwh8eywIJYRxBiZdxEG/Tr/KtFMLdy2BDgNZuuDO1Nv8jImPJwONmqjNhNDYwM0VJQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "3.2.4",
+        "vega-expression": "^5.2.0",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-statistics": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.9.0.tgz",
+      "integrity": "sha512-GAqS7mkatpXcMCQKWtFu1eMUKLUymjInU0O8kXshWaQrVWjPIO2lllZ1VNhdgE0qGj4oOIRRS11kzuijLshGXQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.2"
+      }
+    },
+    "node_modules/vega-themes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-3.0.0.tgz",
+      "integrity": "sha512-1iFiI3BNmW9FrsLnDLx0ZKEddsCitRY3XmUAwp6qmp+p+IXyJYc9pfjlVj9E6KXBPfm4cQyU++s0smKNiWzO4g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      },
+      "peerDependencies": {
+        "vega": "*",
+        "vega-lite": "*"
+      }
+    },
+    "node_modules/vega-time": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.3.tgz",
+      "integrity": "sha512-hFcWPdTV844IiY0m97+WUoMLADCp+8yUQR1NStWhzBzwDDA7QEGGwYGxALhdMOaDTwkyoNj3V/nox2rQAJD/vQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-time": "^3.1.0",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-tooltip": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-1.0.0.tgz",
+      "integrity": "sha512-P1R0JP29v0qnTuwzCQ0SPJlkjAzr6qeyj+H4VgUFSykHmHc1OBxda//XBaFDl/bZgIscEMvjKSjZpXd84x3aZQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "vega-util": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      }
+    },
+    "node_modules/vega-tooltip/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/vega-transforms": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.12.1.tgz",
+      "integrity": "sha512-Qxo+xeEEftY1jYyKgzOGc9NuW4/MqGm1YPZ5WrL9eXg2G0410Ne+xL/MFIjHF4hRX+3mgFF4Io2hPpfy/thjLg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.7",
+        "vega-statistics": "^1.9.0",
+        "vega-time": "^2.1.3",
+        "vega-util": "^1.17.3"
+      }
+    },
     "node_modules/vega-typings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-1.5.0.tgz",
@@ -40148,6 +40631,65 @@
       "integrity": "sha512-nSNpZLUrRvFo46M5OK4O6x6f08WD1yOcEzHNlqivF+sDLSsVpstaF6fdJYwrbf/debFi2L9Tkp4gZQtssup9iQ==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/vega-view": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.16.0.tgz",
+      "integrity": "sha512-Nxp1MEAY+8bphIm+7BeGFzWPoJnX9+hgvze6wqCAPoM69YiyVR0o0VK8M2EESIL+22+Owr0Fdy94hWHnmon5tQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-timer": "^3.0.1",
+        "vega-dataflow": "^5.7.7",
+        "vega-format": "^1.1.3",
+        "vega-functions": "^5.18.0",
+        "vega-runtime": "^6.2.1",
+        "vega-scenegraph": "^4.13.1",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-view-transforms": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.6.1.tgz",
+      "integrity": "sha512-RYlyMJu5kZV4XXjmyTQKADJWDB25SMHsiF+B1rbE1p+pmdQPlp5tGdPl9r5dUJOp3p8mSt/NGI8GPGucmPMxtw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "vega-dataflow": "^5.7.7",
+        "vega-scenegraph": "^4.13.1",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-voronoi": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.4.tgz",
+      "integrity": "sha512-lWNimgJAXGeRFu2Pz8axOUqVf1moYhD+5yhBzDSmckE9I5jLOyZc/XvgFTXwFnsVkMd1QW1vxJa+y9yfUblzYw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "d3-delaunay": "^6.0.2",
+        "vega-dataflow": "^5.7.7",
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/vega-wordcloud": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.6.tgz",
+      "integrity": "sha512-lFmF3u9/ozU0P+WqPjeThQfZm0PigdbXDwpIUCxczrCXKYJLYFmZuZLZR7cxtmpZ0/yuvRvAJ4g123LXbSZF8A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.7",
+        "vega-scale": "^7.4.2",
+        "vega-statistics": "^1.9.0",
+        "vega-util": "^1.17.3"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",


### PR DESCRIPTION
Fix issues with vega dependancy imports. Regenerating package-lock.json was enough.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
