### PR TITLE
feat: Easy way to add extra query settings for clickhouse

### DIFF
--- a/docs/docs/reference/project-files/connectors.md
+++ b/docs/docs/reference/project-files/connectors.md
@@ -257,8 +257,11 @@ _[boolean]_ - Controls whether to log raw SQL queries
 
 ### `query_settings_override`
 
-_[string]_ - override the default settings used in queries. Changing the default settings can lead to incorrect query results and is generally not recommended. If you need to add settings, append them to the defaults:  
-`cast_keep_nullable = 1, join_use_nulls = 1, session_timezone = 'UTC', prefer_global_in_and_join = 1, insert_distributed_sync = 1, <your additional settings>`
+_[string]_ - override the default settings used in queries. Changing the default settings can lead to incorrect query results and is generally not recommended. If you need to add additional settings use query_settings.
+
+### `query_settings`
+
+_[string]_ - query settings to be set on dashboard queries. `query_settings_override` takes precedence over these settings and if set these are ignored. Each setting must be separated by a comma. Example `max_threads = 8, max_memory_usage = 10000000000`"
 
 ### `embed_port`
 

--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -176,6 +176,9 @@ type configProperties struct {
 	// QuerySettingsOverride overrides the default query settings used for OLAP SELECT queries.
 	// Use cases include disabling settings or setting `readonly = 1` when using read-only user.
 	QuerySettingsOverride string `mapstructure:"query_settings_override"`
+	// QuerySettings are set on each read query. QuerySettingsOverride takes precedence over these settings and if set these are ignored./
+	// Each setting must be separated by a comma. Example `max_threads = 8, max_memory_usage = 10000000000`
+	QuerySettings string `mapstructure:"query_settings"`
 	// EmbedPort is the port to run Clickhouse locally (0 is random port).
 	EmbedPort int `mapstructure:"embed_port"`
 	// CanScaleToZero indicates if the underlying Clickhouse service may scale to zero when idle.

--- a/runtime/drivers/clickhouse/olap.go
+++ b/runtime/drivers/clickhouse/olap.go
@@ -130,6 +130,9 @@ func (c *Connection) Query(ctx context.Context, stmt *drivers.Statement) (res *d
 		stmt.Query += "\n SETTINGS " + c.config.QuerySettingsOverride
 	} else {
 		stmt.Query += "\n SETTINGS cast_keep_nullable = 1, join_use_nulls = 1, session_timezone = 'UTC', prefer_global_in_and_join = 1, insert_distributed_sync = 1"
+		if c.config.QuerySettings != "" {
+			stmt.Query += ", " + c.config.QuerySettings
+		}
 	}
 
 	// Gather metrics only for actual queries

--- a/runtime/parser/schema/project.schema.yaml
+++ b/runtime/parser/schema/project.schema.yaml
@@ -259,7 +259,10 @@ definitions:
               description: Controls whether to log raw SQL queries
             query_settings_override:
               type: string
-              description: "override the default settings used in queries. Changing the default settings can lead to incorrect query results and is generally not recommended. If you need to add settings, append them to the defaults - `cast_keep_nullable = 1, join_use_nulls = 1, session_timezone = 'UTC', prefer_global_in_and_join = 1, insert_distributed_sync = 1, <your additional settings>`"
+              description: "override the default settings used in queries. Changing the default settings can lead to incorrect query results and is generally not recommended. If you need to add settings, use `query_settings`"
+            query_settings:
+              type: string
+              description: "query settings to be set on dashboard queries. `query_settings_override` takes precedence over these settings and if set these are ignored. Each setting must be separated by a comma. Example `max_threads = 8, max_memory_usage = 10000000000`"
             embed_port:
               type: integer
               description: Port to run ClickHouse locally (0 for random port)


### PR DESCRIPTION
```

type: connector

driver: clickhouse
managed: false
host: "localhost"
port: 9000
query_settings: "log_comment = 'rilldata'"
```

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
