### PR TITLE
fix: folder rename keeps the old file path

### DIFF
--- a/web-common/src/features/entity-management/RenameAssetModal.svelte
+++ b/web-common/src/features/entity-management/RenameAssetModal.svelte
@@ -95,7 +95,7 @@
             )
           ) {
             // if the file focused has the dir then replace the dir path to the new one
-            void goto(
+            await goto(
               $page.url.pathname.replace(
                 `/files/${removeLeadingSlash(filePath)}`,
                 `/files/${removeLeadingSlash(newPath)}`,


### PR DESCRIPTION
Renaming a folder when a file within the folder is active would keep the old path. Any changes to the file after the rename would save it in the old path.

Closes APP-360

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
