### PR TITLE
Remove beta flag from canvas dashboard

### DIFF
--- a/web-common/src/features/entity-management/AddAssetButton.svelte
+++ b/web-common/src/features/entity-management/AddAssetButton.svelte
@@ -3,7 +3,6 @@
   import { page } from "$app/stores";
   import Button from "@rilldata/web-common/components/button/Button.svelte";
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
-  import { Tag } from "@rilldata/web-common/components/tag";
   import { getScreenNameFromPage } from "@rilldata/web-common/features/file-explorer/telemetry";
   import { Database, Folder, PlusCircleIcon } from "lucide-svelte";
   import CaretDownIcon from "../../components/icons/CaretDownIcon.svelte";
@@ -270,7 +269,6 @@
           {/if}
         </div>
       </div>
-      <Tag height={16} color="blue">BETA</Tag>
     </DropdownMenu.Item>
     <DropdownMenu.Separator />
     <DropdownMenu.Sub>


### PR DESCRIPTION
Removes the "Beta" flag from the Canvas Dashboard in the "Add Resource" dropdown menu, as it is now a stable feature. This addresses APP-361. The unused `Tag` component import was also removed.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-361](https://linear.app/rilldata/issue/APP-361/lift-beta-flag-from-canvas-dashboard)

<a href="https://cursor.com/background-agent?bcId=bc-c0b22af1-38a3-4312-a15d-3c901e59bbd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0b22af1-38a3-4312-a15d-3c901e59bbd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

