### PR TITLE
fix (AI chatbot): Handle errors for new conversations

### DIFF
--- a/web-common/src/features/chat/core/messages/ChatMessages.svelte
+++ b/web-common/src/features/chat/core/messages/ChatMessages.svelte
@@ -14,11 +14,19 @@
   $: currentConversationStore = chat.getCurrentConversation();
   $: currentConversation = $currentConversationStore;
   $: getConversationQuery = currentConversation.getConversationQuery();
+
+  // Loading states
   $: isSendingMessageStore = currentConversation.isSendingMessage;
   $: isConversationLoading =
     !!$getConversationQuery.isLoading && !$isSendingMessageStore;
-  $: conversationQueryError = currentConversation.getConversationQueryError();
   $: isResponseLoading = $isSendingMessageStore;
+
+  // Error handling
+  $: sendMessageErrorStore = currentConversation.errorMessage;
+  $: conversationQueryError = currentConversation.getConversationQueryError();
+  $: hasError = $conversationQueryError || $sendMessageErrorStore;
+
+  // Data
   $: messages = $getConversationQuery.data?.conversation?.messages ?? [];
 
   // Auto-scroll to bottom when messages change or loading state changes
@@ -46,10 +54,14 @@
     <div class="chat-loading">
       <DelayedSpinner isLoading={isConversationLoading} size="24px" />
     </div>
-  {:else if $conversationQueryError}
+  {:else if hasError}
     <div class="chat-error">
       <AlertCircle size="1.2em" />
-      Unable to load conversation: {$conversationQueryError}
+      {#if $conversationQueryError}
+        Unable to load conversation: {$conversationQueryError}
+      {:else if $sendMessageErrorStore}
+        {$sendMessageErrorStore}
+      {/if}
     </div>
   {:else if messages.length === 0}
     <div class="chat-empty">


### PR DESCRIPTION
Previously, we handled errors for messages sent to existing conversations, but neglected to handle errors for messages that initiated new conversations. 

[Reported in Slack](https://rilldata.slack.com/archives/C08RDR9Q26P/p1757531312070319?thread_ts=1757456778.550229&cid=C08RDR9Q26P)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
