### PR TITLE
fix: fill missing implementation

### DIFF
--- a/web-common/src/features/canvas/components/charts/cartesian-charts/CartesianChart.ts
+++ b/web-common/src/features/canvas/components/charts/cartesian-charts/CartesianChart.ts
@@ -286,7 +286,6 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
             where: topNWhere,
             timeRange,
             limit: limit?.toString(),
-            // fillMissing: config.x?.type === "temporal",
           },
           {
             query: {


### PR DESCRIPTION
Setting fillMissing to true triggers a path in the platform code that checks that there is exactly one time dimension being used for the time spine. When creating a chart _without_ a time dimension, this results in a 500 error being returned. This PR only sets fillMissing true when using a time dimension for the x axis.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
