### PR TITLE
fix: missing tooltip values in chart

### DIFF
--- a/web-common/src/features/canvas/components/charts/builder.ts
+++ b/web-common/src/features/canvas/components/charts/builder.ts
@@ -303,9 +303,9 @@ export function createCartesianMultiValueTooltipChannel(
 
   let multiValueTooltipChannel: TooltipValue[] | undefined;
 
-  multiValueTooltipChannel = data.data?.map((value) => ({
-    field: sanitizeValueForVega(value?.[colorField] as string),
-    type: "quantitative",
+  multiValueTooltipChannel = data.domainValues?.[colorField]?.map((value) => ({
+    field: sanitizeValueForVega(value as string),
+    type: "quantitative" as const,
     formatType: sanitizeFieldName(sanitizedYField),
   }));
 


### PR DESCRIPTION
Some tooltip values were being hidden as the channel was being mapped on the whole data. We now instead map on the domain values directly.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
