### PR TITLE
fix : view directory does not gets cleaned during failures

### DIFF
--- a/runtime/pkg/rduckdb/db.go
+++ b/runtime/pkg/rduckdb/db.go
@@ -388,17 +388,17 @@ func (d *db) CreateTableAsSelect(ctx context.Context, name, query string, opts *
 	if err != nil {
 		return nil, fmt.Errorf("create: unable to create dir %q: %w", name, err)
 	}
+	defer func() {
+		if createErr != nil {
+			_ = d.deleteLocalTableFiles(name, newVersion)
+		}
+	}()
 	var dsn string
 	if opts.View {
 		dsn = ""
 		newMeta.SQL = query
 	} else {
 		dsn = d.localDBPath(name, newVersion)
-		defer func() {
-			if createErr != nil {
-				_ = d.deleteLocalTableFiles(name, newVersion)
-			}
-		}()
 	}
 
 	t := time.Now()


### PR DESCRIPTION
Currently it leaves an empty directory on view creation failures

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
