### PR TITLE
fix: combo chart data query

### DIFF
--- a/web-common/src/features/canvas/components/charts/combo-charts/ComboChart.ts
+++ b/web-common/src/features/canvas/components/charts/combo-charts/ComboChart.ts
@@ -310,7 +310,15 @@ export class ComboChartComponent extends BaseChart<ComboChartSpec> {
             dimensions,
             where: combinedWhere,
             timeRange,
-            limit: config.x?.limit?.toString(),
+            fillMissing: config.x?.type === "temporal",
+            sort:
+              config.x?.type === "temporal"
+                ? [{ name: config.x?.field, desc: false }]
+                : undefined,
+            limit:
+              config.x?.type === "temporal"
+                ? "5000"
+                : config.x?.limit?.toString(),
           },
           {
             query: {


### PR DESCRIPTION
Fixes the data query to -
- be sorted according to time
- have appropriate limit for temporal data
- enable null filling for missing ts data


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
