### PR TITLE
Fix combo chart y-axis ceiling bug

### DIFF
--- a/web-common/src/features/canvas/components/charts/combo-charts/spec.ts
+++ b/web-common/src/features/canvas/components/charts/combo-charts/spec.ts
@@ -160,6 +160,10 @@ export function generateVLComboChartSpec(
         y: {
           ...createPositionEncoding(config.y1, data),
           field: valueField,
+          scale: {
+            ...createPositionEncoding(config.y1, data).scale,
+            nice: true,
+          },
           axis: {
             ...createPositionEncoding(config.y1, data).axis,
             orient: "left",
@@ -199,6 +203,10 @@ export function generateVLComboChartSpec(
         y: {
           ...createPositionEncoding(config.y2, data),
           field: valueField,
+          scale: {
+            ...createPositionEncoding(config.y2, data).scale,
+            nice: true,
+          },
           axis: {
             ...createPositionEncoding(config.y2, data).axis,
             orient: "right",


### PR DESCRIPTION
Fixes APP-342: Combo charts no longer hit the ceiling of the y-axis.

This issue occurred because Vega-Lite does not automatically apply "nice" scaling to independent y-axes in multi-layer charts (like combo charts). This caused the y-axis domain to exactly match the maximum data value, making data points touch the top of the chart.

The fix adds `nice: true` to the `scale` configuration for both y1 and y2 axes in the combo chart specification. This ensures the y-axis extends to visually appealing, rounded values, preventing data points from hitting the ceiling.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-342](https://linear.app/rilldata/issue/APP-342/combo-charts-hit-ceiling-of-y-axis-while-other-chart-types-do-not)

<a href="https://cursor.com/background-agent?bcId=bc-9e2014e4-e3b1-4056-bd52-daf401d7ffa1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9e2014e4-e3b1-4056-bd52-daf401d7ffa1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

