### PR TITLE
Update source modal to 4 column grid

### DIFF
--- a/web-common/src/features/sources/modal/AddDataModal.svelte
+++ b/web-common/src/features/sources/modal/AddDataModal.svelte
@@ -288,7 +288,7 @@
   }
 
   .connector-grid {
-    @apply grid grid-cols-3 gap-4;
+    @apply grid grid-cols-4 gap-4;
   }
 
   .connector-tile-button {


### PR DESCRIPTION
Updates the "Add source" modal to use a 4-column grid layout instead of 3 columns, improving the visual organization and use of horizontal space for connector tiles.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes (Closes APP-381)
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
Linear Issue: [APP-381](https://linear.app/rilldata/issue/APP-381/add-source-modal-is-currently-3-column-grid-layout-needs-4-column-grid)

<a href="https://cursor.com/background-agent?bcId=bc-2f498a58-7062-4d64-8b09-753455f4f833">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f498a58-7062-4d64-8b09-753455f4f833">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

