### PR TITLE
Rename connectors to `data explorer`

### DIFF
--- a/web-common/src/features/connectors/explorer/ConnectorExplorer.svelte
+++ b/web-common/src/features/connectors/explorer/ConnectorExplorer.svelte
@@ -33,7 +33,7 @@
     </span>
   {:else if data?.connectors}
     {#if data.connectors.length === 0}
-      <span class="message"> No tables found. Add data to get started! </span>
+      <span class="message"> No data found. Add data to get started! </span>
     {:else}
       <ol transition:slide={{ duration }}>
         {#each data.connectors as connector (connector.name)}

--- a/web-common/src/layout/navigation/Navigation.svelte
+++ b/web-common/src/layout/navigation/Navigation.svelte
@@ -144,13 +144,13 @@
                 className="text-gray-400 transition-transform {!showConnectors &&
                   '-rotate-90'}"
               />
-              <h3>Table Explorer</h3>
+              <h3>Data Explorer</h3>
             </button>
 
             <div
               class="connector-wrapper"
               role="region"
-              aria-label="Table explorer"
+              aria-label="Data explorer"
               bind:this={connectorWrapper}
               style:height="{showConnectors ? connectorSectionHeight : 0}px"
             >

--- a/web-local/tests/olap-connectors.spec.ts
+++ b/web-local/tests/olap-connectors.spec.ts
@@ -96,7 +96,7 @@ test.describe("ClickHouse connector", () => {
 
     // Assert that the connector explorer now has a ClickHouse connector
     await expect(
-      page.getByRole("region", { name: "Table explorer" }).getByRole("button", {
+      page.getByRole("region", { name: "Data explorer" }).getByRole("button", {
         name: "clickhouse",
         exact: true,
       }),
@@ -157,7 +157,7 @@ test.describe("ClickHouse connector", () => {
 
     // Assert that the connector explorer now has a ClickHouse connector
     await expect(
-      page.getByRole("region", { name: "Table explorer" }).getByRole("button", {
+      page.getByRole("region", { name: "Data explorer" }).getByRole("button", {
         name: "clickhouse",
         exact: true,
       }),


### PR DESCRIPTION
Renames "Connectors" to "Data Explorer" across the Rill Developer UI, including navigation, empty states, and accessibility labels. This change improves user experience by aligning the UI terminology with the section's primary function of exploring available tables, as per APP-382.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
Linear Issue: [APP-382](https://linear.app/rilldata/issue/APP-382/rename-connectors-to-table-explorer-in-rill-developer)

<a href="https://cursor.com/background-agent?bcId=bc-c74af604-a1ed-470e-94bf-4e2afdc2546a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c74af604-a1ed-470e-94bf-4e2afdc2546a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

