### PR TITLE
Fix missing totals row label in flat tables

### DIFF
--- a/web-common/src/features/dashboards/pivot/FlatTable.svelte
+++ b/web-common/src/features/dashboards/pivot/FlatTable.svelte
@@ -198,6 +198,7 @@
               cell.getValue() !== undefined}
             class:text-right={getMeasureColumn(cell.column)}
             class:border-r={hasBorderRight(cell.column.id)}
+            class:totals-label={cell.getValue() === "Totals"}
             data-value={cell.getValue()}
             data-rowid={cell.row.id}
             data-columnid={cell.column.id}
@@ -300,6 +301,11 @@
   .with-measure tbody > tr:nth-of-type(2) {
     @apply bg-surface sticky z-20;
     top: var(--total-header-height);
+  }
+
+  /* The totals row label - make it bold for flat tables */
+  .totals-label {
+    @apply font-semibold;
   }
 
   tr:hover,

--- a/web-common/src/features/dashboards/pivot/FlatTable.svelte
+++ b/web-common/src/features/dashboards/pivot/FlatTable.svelte
@@ -198,7 +198,7 @@
               cell.getValue() !== undefined}
             class:text-right={getMeasureColumn(cell.column)}
             class:border-r={hasBorderRight(cell.column.id)}
-            class:totals-label={cell.getValue() === "Totals"}
+            class:total-label={cell.getValue() === "Total"}
             data-value={cell.getValue()}
             data-rowid={cell.row.id}
             data-columnid={cell.column.id}
@@ -304,7 +304,7 @@
   }
 
   /* The totals row label - make it bold for flat tables */
-  .totals-label {
+  .total-label {
     @apply font-semibold;
   }
 

--- a/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
@@ -210,7 +210,7 @@ export function getTotalsRow(
       // For flat tables, find the first dimension column to place the Totals label
       const firstDimensionName = getFirstDimensionForFlat(config);
       if (firstDimensionName) {
-        totalsRow[firstDimensionName] = "Totals";
+        totalsRow[firstDimensionName] = "Total";
       }
     }
   }

--- a/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
@@ -2,6 +2,7 @@ import { NUM_ROWS_PER_PAGE } from "@rilldata/web-common/features/dashboards/pivo
 import type { V1MetricsViewAggregationResponseDataItem } from "@rilldata/web-common/runtime-client";
 import { createIndexMap, getAccessorForCell } from "./pivot-utils";
 import type { PivotDataRow, PivotDataStoreConfig } from "./types";
+import { PivotChipType } from "./types";
 
 /**
  * During the phase when queries are still being resolved, we don't have enough
@@ -127,12 +128,51 @@ export function getTotalsRowSkeleton(
 
     totalsRow = totalsRowTable[0] || {};
 
-    if (anchorDimensionName) {
+    if (anchorDimensionName && !config.isFlat) {
       totalsRow[anchorDimensionName] = "Total";
+    } else if (config.isFlat && anchorDimensionName) {
+      // For flat tables, find the first dimension column to place the Totals label
+      const firstDimensionName = getFirstDimensionForFlat(config);
+      if (firstDimensionName) {
+        totalsRow[firstDimensionName] = "Totals";
+      }
     }
   }
 
   return totalsRow;
+}
+
+/**
+ * For flat tables, find the first dimension column to place the Totals label.
+ * This handles the case where measures might come before dimensions in the column order.
+ */
+function getFirstDimensionForFlat(config: PivotDataStoreConfig): string | null {
+  const { rowDimensionNames, pivot } = config;
+  
+  // Go through the columns in order and find the first dimension
+  for (const column of pivot.columns) {
+    if (column.type === PivotChipType.Dimension || column.type === PivotChipType.Time) {
+      // For time dimensions, we need to construct the actual dimension name
+      if (column.type === PivotChipType.Time) {
+        const timeDimension = config.time?.timeDimension;
+        if (timeDimension) {
+          const timeDimensionName = `${timeDimension}_rill_${column.id}`;
+          // Check if this time dimension is in our row dimensions
+          if (rowDimensionNames.includes(timeDimensionName)) {
+            return timeDimensionName;
+          }
+        }
+      } else {
+        // Regular dimension
+        if (rowDimensionNames.includes(column.id)) {
+          return column.id;
+        }
+      }
+    }
+  }
+  
+  // Fallback to the first row dimension if we can't find one in the column order
+  return rowDimensionNames[0] || null;
 }
 
 export function getTotalsRow(
@@ -163,6 +203,12 @@ export function getTotalsRow(
 
     if (anchorDimensionName && !config.isFlat) {
       totalsRow[anchorDimensionName] = "Total";
+    } else if (config.isFlat && anchorDimensionName) {
+      // For flat tables, find the first dimension column to place the Totals label
+      const firstDimensionName = getFirstDimensionForFlat(config);
+      if (firstDimensionName) {
+        totalsRow[firstDimensionName] = "Totals";
+      }
     }
   }
 

--- a/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
@@ -134,7 +134,7 @@ export function getTotalsRowSkeleton(
       // For flat tables, find the first dimension column to place the Totals label
       const firstDimensionName = getFirstDimensionForFlat(config);
       if (firstDimensionName) {
-        totalsRow[firstDimensionName] = "Totals";
+        totalsRow[firstDimensionName] = "Total";
       }
     }
   }

--- a/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-table-transformations.ts
@@ -148,10 +148,13 @@ export function getTotalsRowSkeleton(
  */
 function getFirstDimensionForFlat(config: PivotDataStoreConfig): string | null {
   const { rowDimensionNames, pivot } = config;
-  
+
   // Go through the columns in order and find the first dimension
   for (const column of pivot.columns) {
-    if (column.type === PivotChipType.Dimension || column.type === PivotChipType.Time) {
+    if (
+      column.type === PivotChipType.Dimension ||
+      column.type === PivotChipType.Time
+    ) {
       // For time dimensions, we need to construct the actual dimension name
       if (column.type === PivotChipType.Time) {
         const timeDimension = config.time?.timeDimension;
@@ -170,7 +173,7 @@ function getFirstDimensionForFlat(config: PivotDataStoreConfig): string | null {
       }
     }
   }
-  
+
   // Fallback to the first row dimension if we can't find one in the column order
   return rowDimensionNames[0] || null;
 }

--- a/web-local/tests/explores/pivot.spec.ts
+++ b/web-local/tests/explores/pivot.spec.ts
@@ -524,7 +524,7 @@ const expectSortedDeltaCol = [
 
 const expectedFlatTable = [
   [],
-  ["Totals", "", "100.0k", "300.6k"],
+  ["Total", "", "100.0k", "300.6k"],
   ["facebook.com", "Facebook", "10.5k", "32.9k"],
   ["msn.com", "Microsoft", "10.4k", "32.5k"],
   ["google.com", "Google", "10.1k", "31.3k"],

--- a/web-local/tests/explores/pivot.spec.ts
+++ b/web-local/tests/explores/pivot.spec.ts
@@ -524,7 +524,7 @@ const expectSortedDeltaCol = [
 
 const expectedFlatTable = [
   [],
-  ["", "", "100.0k", "300.6k"],
+  ["Totals", "", "100.0k", "300.6k"],
   ["facebook.com", "Facebook", "10.5k", "32.9k"],
   ["msn.com", "Microsoft", "10.4k", "32.5k"],
   ["google.com", "Google", "10.1k", "31.3k"],


### PR DESCRIPTION
This PR resolves APP-246 by introducing a bolded "Totals" label in the leftmost dimension cell of flat tables.

Previously, flat tables were explicitly excluded from receiving the "Total" label. This change implements the following rules:
*   The "Totals" label is now displayed in the first dimensional cell of the totals row.
*   This correctly handles cases where measures might precede dimensions in the column order.
*   The label is bolded as per the issue requirements.

**Technical details:**
*   Modified `getTotalsRow` and `getTotalsRowSkeleton` in `pivot-table-transformations.ts` to include flat tables.
*   Added `getFirstDimensionForFlat` helper to determine the correct dimension column for the label.
*   Updated `FlatTable.svelte` to apply `font-semibold` styling to the "Totals" label.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes (APP-246)
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
Linear Issue: [APP-246](https://linear.app/rilldata/issue/APP-246/totals-row-label-is-missing-in-flat-tables)

<a href="https://cursor.com/background-agent?bcId=bc-49cb583f-6e4f-4173-9e13-e9edd9661dc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-49cb583f-6e4f-4173-9e13-e9edd9661dc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

