### PR TITLE
Fix missing variable name on confirmation view

### DIFF
--- a/web-admin/src/features/projects/environment-variables/DeleteDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/DeleteDialog.svelte
@@ -79,7 +79,9 @@
       <AlertDialogTitle>Delete this environment variable?</AlertDialogTitle>
       <AlertDialogDescription>
         <div class="mt-1">
-          The environment variable <span class="source-code text-sm font-medium">{name}</span> will no longer be available for this project.
+          The environment variable <span class="source-code text-sm font-medium"
+            >{name}</span
+          > will no longer be available for this project.
         </div>
       </AlertDialogDescription>
     </AlertDialogHeader>

--- a/web-admin/src/features/projects/environment-variables/DeleteDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/DeleteDialog.svelte
@@ -79,7 +79,7 @@
       <AlertDialogTitle>Delete this environment variable?</AlertDialogTitle>
       <AlertDialogDescription>
         <div class="mt-1">
-          {name} will no longer be available for this project.
+          The environment variable {name} will no longer be available for this project.
         </div>
       </AlertDialogDescription>
     </AlertDialogHeader>

--- a/web-admin/src/features/projects/environment-variables/DeleteDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/DeleteDialog.svelte
@@ -79,7 +79,7 @@
       <AlertDialogTitle>Delete this environment variable?</AlertDialogTitle>
       <AlertDialogDescription>
         <div class="mt-1">
-          The environment variable {name} will no longer be available for this project.
+          The environment variable <span class="source-code text-sm font-medium">{name}</span> will no longer be available for this project.
         </div>
       </AlertDialogDescription>
     </AlertDialogHeader>
@@ -98,3 +98,9 @@
     </AlertDialogFooter>
   </AlertDialogContent>
 </AlertDialog>
+
+<style lang="postcss">
+  .source-code {
+    font-family: "Source Code Variable", monospace;
+  }
+</style>

--- a/web-admin/src/features/projects/environment-variables/DeleteDialog.svelte
+++ b/web-admin/src/features/projects/environment-variables/DeleteDialog.svelte
@@ -79,7 +79,7 @@
       <AlertDialogTitle>Delete this environment variable?</AlertDialogTitle>
       <AlertDialogDescription>
         <div class="mt-1">
-          This environment variable will no longer be available to the project.
+          {name} will no longer be available for this project.
         </div>
       </AlertDialogDescription>
     </AlertDialogHeader>


### PR DESCRIPTION
Fixes ENG-906: Display environment variable name in deletion confirmation dialog.

This change improves user clarity by explicitly stating which variable will be deleted, addressing cases where variable names might be similar or truncated in the list view.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
Linear Issue: [ENG-906](https://linear.app/rilldata/issue/ENG-906/missing-variable-name-on-a-confirmation-view)

<a href="https://cursor.com/background-agent?bcId=bc-b89a403c-aa15-44d8-83cc-2f333e61d345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b89a403c-aa15-44d8-83cc-2f333e61d345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

