### PR TITLE
Fix user count display on management page

### DIFF
--- a/web-admin/src/routes/[organization]/-/users/+page.svelte
+++ b/web-admin/src/routes/[organization]/-/users/+page.svelte
@@ -46,6 +46,7 @@
       organization,
       {
         pageSize: PAGE_SIZE,
+        includeCounts: true,
       },
       {
         query: {
@@ -97,6 +98,11 @@
     ...allOrgMemberUsersRows,
     ...coerceInvitesToUsers(allOrgInvitesRows),
   ];
+
+  // Calculate total counts from API responses
+  $: totalMemberCount = $orgMemberUsersInfiniteQuery.data?.pages?.[0]?.totalCount ?? 0;
+  $: totalInviteCount = $orgInvitesInfiniteQuery.data?.pages?.[0]?.totalCount ?? 0;
+  $: totalUserCount = totalMemberCount + totalInviteCount;
 
   $: currentUserRole = allOrgMemberUsersRows.find(
     (member) => member.userEmail === $currentUser.data?.user.email,
@@ -192,15 +198,16 @@
             (isChangingBillingContactRoleDialogOpen = true)}
         />
       </div>
-      {#if filteredUsers.length > 0}
-        <div class="px-2 py-3">
-          <span class="font-medium text-sm text-gray-500">
-            {filteredUsers.length} total user{filteredUsers.length === 1
-              ? ""
-              : "s"}
-          </span>
-        </div>
-      {/if}
+      <div class="px-2 py-3">
+        <span class="font-medium text-sm text-gray-500">
+          {totalUserCount} total user{totalUserCount === 1 ? "" : "s"}
+          {#if totalMemberCount > 0 && totalInviteCount > 0}
+            ({totalMemberCount} member{totalMemberCount === 1 ? "" : "s"}, {totalInviteCount} pending invitation{totalInviteCount === 1 ? "" : "s"})
+          {:else if totalInviteCount > 0}
+            ({totalInviteCount} pending invitation{totalInviteCount === 1 ? "" : "s"})
+          {/if}
+        </span>
+      </div>
     </div>
   {/if}
 </div>


### PR DESCRIPTION
This PR resolves [APP-392](https://linear.app/rilldata/issue/APP-392) by ensuring the user management page consistently displays the total count of all organization users (members + pending invitations).

Previously, the displayed user count would change as users scrolled through the infinite list, reflecting only the loaded items. This change leverages the `totalCount` provided by the backend API (introduced in rilldata/rill#7504) to show a static, accurate total.

The implementation fetches the total member and invite counts and presents a combined total, with an optional breakdown, providing a stable and clear overview of the organization's user base.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-392](https://linear.app/rilldata/issue/APP-392/always-display-total-user-count-on-user-management-page)

<a href="https://cursor.com/background-agent?bcId=bc-6c8060b2-1bcd-4eab-8df5-96f7688bbab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6c8060b2-1bcd-4eab-8df5-96f7688bbab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

