### PR TITLE
Fix user group dropdown user list

### DIFF
--- a/web-admin/src/features/organizations/users/OrgGroupsTable.svelte
+++ b/web-admin/src/features/organizations/users/OrgGroupsTable.svelte
@@ -15,6 +15,7 @@
   export let hasNextPage: boolean;
   export let isFetchingNextPage: boolean;
   export let onLoadMore: () => void;
+  export let ensureAllUsersLoaded: (() => Promise<void>) | undefined = undefined;
 
   function transformGroupName(groupName: string) {
     return groupName
@@ -63,6 +64,7 @@
           groupName: row.original.groupName,
           currentUserEmail: currentUserEmail,
           searchUsersList: searchUsersList,
+          ensureAllUsersLoaded: ensureAllUsersLoaded,
         }),
       meta: {
         widthPercent: 5,

--- a/web-admin/src/features/organizations/users/OrgGroupsTableActionsCell.svelte
+++ b/web-admin/src/features/organizations/users/OrgGroupsTableActionsCell.svelte
@@ -10,10 +10,16 @@
   export let groupName: string;
   export let currentUserEmail: string;
   export let searchUsersList: V1OrganizationMemberUser[];
+  export let ensureAllUsersLoaded: (() => Promise<void>) | undefined = undefined;
 
   let isDropdownOpen = false;
   let isDeleteConfirmOpen = false;
   let isEditDialogOpen = false;
+
+  // Ensure all users are loaded when edit dialog opens
+  $: if (isEditDialogOpen && ensureAllUsersLoaded) {
+    ensureAllUsersLoaded();
+  }
 </script>
 
 <!-- Managed groups cannot be deleted or edited -->

--- a/web-admin/src/routes/[organization]/-/users/groups/+page.svelte
+++ b/web-admin/src/routes/[organization]/-/users/groups/+page.svelte
@@ -145,6 +145,7 @@
           {hasNextPage}
           {isFetchingNextPage}
           onLoadMore={handleLoadMore}
+          {ensureAllUsersLoaded}
         />
       </div>
       {#if filteredGroups.length > 0}


### PR DESCRIPTION
Fixes APP-393: User Group dropdown not displaying full list of users

The "Edit User Group" dialog's user search was incomplete because the `ensureAllUsersLoaded` function, which fetches all paginated users, was not being triggered when the dialog was opened from the `OrgGroupsTableActionsCell`.

This PR passes the `ensureAllUsersLoaded` function down from `+page.svelte` to `OrgGroupsTable.svelte` and then to `OrgGroupsTableActionsCell.svelte`. The `OrgGroupsTableActionsCell.svelte` now calls this function reactively when the `isEditDialogOpen` state becomes true, ensuring all users are loaded for the search dropdown.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-393](https://linear.app/rilldata/issue/APP-393/user-group-is-still-not-displaying-the-full-list-of-users-in-the)

<a href="https://cursor.com/background-agent?bcId=bc-1143a8a3-8bdc-4054-a0fa-d6f7312f014b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1143a8a3-8bdc-4054-a0fa-d6f7312f014b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

