### PR TITLE
Add Data Modal Layout

### DIFF
--- a/web-common/src/features/sources/modal/AddDataModal.svelte
+++ b/web-common/src/features/sources/modal/AddDataModal.svelte
@@ -161,9 +161,9 @@
                   <button
                     id={connector.name}
                     on:click={() => goToConnectorForm(connector)}
-                    class="connector-tile-button size-full min-w-24 min-h-16"
+                    class="connector-tile-button size-full min-w-24 min-h-16 h-20"
                   >
-                    <div class="connector-wrapper">
+                    <div class="connector-wrapper px-6 py-4 md:px-4 md:py-2">
                       <svelte:component this={ICONS[connector.name]} />
                     </div>
                   </button>
@@ -185,10 +185,10 @@
               {#if connector.name}
                 <button
                   id={connector.name}
-                  class="connector-tile-button size-full min-w-24 min-h-16"
+                  class="connector-tile-button size-full min-w-24 min-h-16 h-20"
                   on:click={() => goToConnectorForm(connector)}
                 >
-                  <div class="connector-wrapper">
+                  <div class="connector-wrapper px-6 py-4 md:px-4 md:py-2">
                     <svelte:component this={ICONS[connector.name]} />
                   </div>
                 </button>
@@ -265,7 +265,6 @@
   }
 
   .connector-wrapper {
-    @apply px-5 py-2;
     @apply size-full;
     @apply flex items-center justify-center;
   }

--- a/web-common/src/features/sources/modal/AddDataModal.svelte
+++ b/web-common/src/features/sources/modal/AddDataModal.svelte
@@ -256,18 +256,19 @@
   }
 
   .connector-grid {
-    @apply grid grid-cols-3 gap-4;
+    @apply grid grid-cols-4 gap-x-4 gap-y-2;
   }
 
   .connector-tile-button {
-    aspect-ratio: 2/1;
-    @apply basis-40;
+    width: 8rem;
+    height: 4rem;
     @apply border border-gray-300 rounded;
     @apply cursor-pointer overflow-hidden;
   }
 
   .connector-wrapper {
-    @apply py-3 px-7 size-full;
+    @apply px-5 py-2;
+    @apply size-full;
     @apply flex items-center justify-center;
   }
 

--- a/web-common/src/features/sources/modal/AddDataModal.svelte
+++ b/web-common/src/features/sources/modal/AddDataModal.svelte
@@ -153,13 +153,15 @@
         {#if isModelingSupported}
           <Dialog.Title>Add a source</Dialog.Title>
           <section class="mb-1">
-            <div class="connector-grid">
+            <div
+              class="connector-grid grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-x-4 gap-y-2"
+            >
               {#each connectors.filter((c) => c.name && SOURCES.includes(c.name)) as connector (connector.name)}
                 {#if connector.name}
                   <button
                     id={connector.name}
                     on:click={() => goToConnectorForm(connector)}
-                    class="connector-tile-button"
+                    class="connector-tile-button size-full min-w-24 min-h-16"
                   >
                     <div class="connector-wrapper">
                       <svelte:component this={ICONS[connector.name]} />
@@ -176,12 +178,14 @@
         <section>
           <Dialog.Title>Connect an OLAP engine</Dialog.Title>
 
-          <div class="connector-grid">
+          <div
+            class="connector-grid grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-x-4 gap-y-2"
+          >
             {#each connectors?.filter((c) => c.name && OLAP_ENGINES.includes(c.name)) as connector (connector.name)}
               {#if connector.name}
                 <button
                   id={connector.name}
-                  class="connector-tile-button"
+                  class="connector-tile-button size-full min-w-24 min-h-16"
                   on:click={() => goToConnectorForm(connector)}
                 >
                   <div class="connector-wrapper">
@@ -255,13 +259,7 @@
     @apply flex flex-col gap-y-3;
   }
 
-  .connector-grid {
-    @apply grid grid-cols-4 gap-x-4 gap-y-2;
-  }
-
   .connector-tile-button {
-    width: 8rem;
-    height: 4rem;
     @apply border border-gray-300 rounded;
     @apply cursor-pointer overflow-hidden;
   }

--- a/web-common/src/features/sources/modal/RequestConnectorForm.svelte
+++ b/web-common/src/features/sources/modal/RequestConnectorForm.svelte
@@ -57,7 +57,7 @@
 </script>
 
 <form on:submit|preventDefault={submit} id="request-connector-form" use:enhance>
-  <span class="text-slate-500 text-sm">
+  <span class="text-slate-500 text-sm mt-2">
     Don't see the connector you're looking for? Let us know what we're missing!
   </span>
   <Input


### PR DESCRIPTION
This PR tweaks the layout of add data modal from 3 to 4 columns.

Closes https://linear.app/rilldata/issue/APP-381/add-source-modal-is-currently-3-column-grid-layout-needs-4-column-grid

<img width="3456" height="1790" alt="CleanShot 2025-09-17 at 19 17 20@2x" src="https://github.com/user-attachments/assets/8a43bc98-fe0a-4ef8-bd4a-b4530bb85848" />

https://github.com/user-attachments/assets/140eb385-07fd-4541-b9b0-7155a9d206c4

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
