### PR TITLE
feat : Allow user to edit git-remote 

### DIFF
--- a/admin/server/projects.go
+++ b/admin/server/projects.go
@@ -793,7 +793,7 @@ func (s *Server) UpdateProject(ctx context.Context, req *adminv1.UpdateProjectRe
 	if req.GitRemote != nil {
 		if safeStr(proj.GitRemote) != *req.GitRemote {
 			if proj.ManagedGitRepoID != nil {
-				return nil, status.Errorf(codes.FailedPrecondition, "cannot edit git remote for a project connected to a managed git repo. Connect project to Github instead")
+				return nil, status.Errorf(codes.FailedPrecondition, "cannot edit git remote for rill managed projects")
 			}
 			// check if another project deploys using the same git remote + subpath
 			projects, err := s.admin.DB.FindProjectsByGitRemote(ctx, *req.GitRemote)

--- a/admin/server/projects.go
+++ b/admin/server/projects.go
@@ -828,6 +828,7 @@ func (s *Server) UpdateProject(ctx context.Context, req *adminv1.UpdateProjectRe
 
 		gitRemote = req.GitRemote
 		managedGitRepoID = nil
+		archiveAssetID = nil
 		if proj.ManagedGitRepoID != nil {
 			transferRepo = true
 			oldRemote = *proj.GitRemote

--- a/admin/server/projects.go
+++ b/admin/server/projects.go
@@ -790,43 +790,48 @@ func (s *Server) UpdateProject(ctx context.Context, req *adminv1.UpdateProjectRe
 	subpath := valOrDefault(req.Subpath, proj.Subpath)
 	prodBranch := valOrDefault(req.ProdBranch, proj.ProdBranch)
 	archiveAssetID := proj.ArchiveAssetID
-	if req.GitRemote != nil {
-		if safeStr(proj.GitRemote) != *req.GitRemote {
-			// check if another project deploys using the same git remote + subpath
-			projects, err := s.admin.DB.FindProjectsByGitRemote(ctx, *req.GitRemote)
-			if err != nil {
-				return nil, err
-			}
-			for _, p := range projects {
-				if p.ID == proj.ID {
-					continue
-				}
-				if p.Subpath == subpath {
-					org, err := s.admin.DB.FindOrganization(ctx, p.OrganizationID)
-					if err != nil {
-						return nil, err
-					}
-					return nil, status.Errorf(codes.FailedPrecondition, "another project %q in org %q is already using the same git remote and subpath", p.Name, org.Name)
-				}
-			}
 
-			// check the Github app is installed and caller has access on the repo
-			var userID *string
-			if claims.OwnerType() == auth.OwnerTypeUser {
-				tmp := claims.OwnerID()
-				userID = &tmp
-			}
-			githubRepoID, githubInstID, managedGitRepoID, prodBranch, err = s.githubOptsForRemote(ctx, proj.OrganizationID, prodBranch, userID, *req.GitRemote)
-			if err != nil {
-				return nil, err
-			}
-			if managedGitRepoID != nil {
-				return nil, status.Error(codes.InvalidArgument, "invalid git remote: cannot switch to a rill managed git repo")
-			}
-			gitRemote = req.GitRemote
-			managedGitRepoID = nil
+	transferRepo := false
+	var oldRemote string
+	if req.GitRemote != nil && safeStr(proj.GitRemote) != *req.GitRemote {
+		// check if another project deploys using the same git remote + subpath
+		projects, err := s.admin.DB.FindProjectsByGitRemote(ctx, *req.GitRemote)
+		if err != nil {
+			return nil, err
 		}
-		archiveAssetID = nil
+		for _, p := range projects {
+			if p.ID == proj.ID {
+				continue
+			}
+			if p.Subpath == subpath {
+				org, err := s.admin.DB.FindOrganization(ctx, p.OrganizationID)
+				if err != nil {
+					return nil, err
+				}
+				return nil, status.Errorf(codes.FailedPrecondition, "another project %q in org %q is already using the same git remote and subpath", p.Name, org.Name)
+			}
+		}
+
+		// check the Github app is installed and caller has access on the repo
+		var userID *string
+		if claims.OwnerType() == auth.OwnerTypeUser {
+			tmp := claims.OwnerID()
+			userID = &tmp
+		}
+		githubRepoID, githubInstID, managedGitRepoID, prodBranch, err = s.githubOptsForRemote(ctx, proj.OrganizationID, prodBranch, userID, *req.GitRemote)
+		if err != nil {
+			return nil, err
+		}
+		if managedGitRepoID != nil {
+			return nil, status.Error(codes.InvalidArgument, "invalid git remote: cannot switch to a rill managed git repo")
+		}
+
+		gitRemote = req.GitRemote
+		managedGitRepoID = nil
+		if proj.ManagedGitRepoID != nil {
+			transferRepo = true
+			oldRemote = *proj.GitRemote
+		}
 	}
 	if req.ArchiveAssetId != nil {
 		archiveAssetID = req.ArchiveAssetId
@@ -876,6 +881,14 @@ func (s *Server) UpdateProject(ctx context.Context, req *adminv1.UpdateProjectRe
 	proj, err = s.admin.UpdateProject(ctx, proj, opts)
 	if err != nil {
 		return nil, err
+	}
+
+	// mark transfer from rill managed git repo if applicable
+	if transferRepo {
+		_, err = s.admin.DB.InsertGitRepoTransfer(ctx, oldRemote, *proj.GitRemote)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &adminv1.UpdateProjectResponse{

--- a/admin/server/projects.go
+++ b/admin/server/projects.go
@@ -792,9 +792,6 @@ func (s *Server) UpdateProject(ctx context.Context, req *adminv1.UpdateProjectRe
 	archiveAssetID := proj.ArchiveAssetID
 	if req.GitRemote != nil {
 		if safeStr(proj.GitRemote) != *req.GitRemote {
-			if proj.ManagedGitRepoID != nil {
-				return nil, status.Errorf(codes.FailedPrecondition, "cannot edit git remote for rill managed projects")
-			}
 			// check if another project deploys using the same git remote + subpath
 			projects, err := s.admin.DB.FindProjectsByGitRemote(ctx, *req.GitRemote)
 			if err != nil {
@@ -823,7 +820,11 @@ func (s *Server) UpdateProject(ctx context.Context, req *adminv1.UpdateProjectRe
 			if err != nil {
 				return nil, err
 			}
+			if managedGitRepoID != nil {
+				return nil, status.Error(codes.InvalidArgument, "invalid git remote: cannot switch to a rill managed git repo")
+			}
 			gitRemote = req.GitRemote
+			managedGitRepoID = nil
 		}
 		archiveAssetID = nil
 	}

--- a/cli/cmd/project/edit.go
+++ b/cli/cmd/project/edit.go
@@ -9,7 +9,7 @@ import (
 )
 
 func EditCmd(ch *cmdutil.Helper) *cobra.Command {
-	var name, description, prodVersion, prodBranch, subpath, path, provisioner string
+	var name, description, prodVersion, prodBranch, subpath, path, provisioner, gitRemote string
 	var public bool
 	var prodTTL int64
 
@@ -66,6 +66,10 @@ func EditCmd(ch *cmdutil.Helper) *cobra.Command {
 				flagSet = true
 				req.ProdTtlSeconds = &prodTTL
 			}
+			if cmd.Flags().Changed("remote-url") {
+				flagSet = true
+				req.GitRemote = &gitRemote
+			}
 
 			if !flagSet {
 				return fmt.Errorf("must specify at least one update flag")
@@ -89,6 +93,7 @@ func EditCmd(ch *cmdutil.Helper) *cobra.Command {
 	editCmd.Flags().StringVar(&prodBranch, "prod-branch", "", "Production branch name")
 	editCmd.Flags().BoolVar(&public, "public", false, "Make dashboards publicly accessible")
 	editCmd.Flags().StringVar(&path, "path", ".", "Project directory")
+	editCmd.Flags().StringVar(&gitRemote, "remote-url", "", "Github remote URL")
 	editCmd.Flags().StringVar(&subpath, "subpath", "", "Relative path to project in the repository (for monorepos)")
 	editCmd.Flags().StringVar(&provisioner, "provisioner", "", "Project provisioner (default: current provisioner)")
 	editCmd.Flags().Int64Var(&prodTTL, "prod-ttl-seconds", 0, "Time-to-live in seconds for production deployment (0 means no expiration)")


### PR DESCRIPTION
`rill project edit --remote-url https://github.com/k-anshul/git-transfer --project git-transfer`

closes https://linear.app/rilldata/issue/PLAT-226/cli-flag-to-allow-user-to-edit-git-remote-url

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
