### PR TITLE
fix(rilltime): ceil legacy iso instead of truncating

### DIFF
--- a/runtime/pkg/rilltime/rilltime.go
+++ b/runtime/pkg/rilltime/rilltime.go
@@ -332,7 +332,11 @@ func (e *Expression) Eval(evalOpts EvalOptions) (time.Time, time.Time, timeutil.
 		tg := timeutil.TimeGrainUnspecified
 		if e.Grain != nil {
 			tg = grainMap[*e.Grain]
+
+			// ISO durations are mapped to `ref-iso to ref as of watermark/grain+1grain`
+			isoStart = timeutil.OffsetTime(isoStart, tg, 1, e.tz)
 			isoStart = timeutil.TruncateTime(isoStart, tg, e.tz, evalOpts.FirstDay, evalOpts.FirstMonth)
+			isoEnd = timeutil.OffsetTime(isoEnd, tg, 1, e.tz)
 			isoEnd = timeutil.TruncateTime(isoEnd, tg, e.tz, evalOpts.FirstDay, evalOpts.FirstMonth)
 		}
 

--- a/runtime/pkg/rilltime/rilltime_test.go
+++ b/runtime/pkg/rilltime/rilltime_test.go
@@ -406,7 +406,7 @@ func TestEval_BackwardsCompatibility(t *testing.T) {
 
 		// `inf` => `earliest to latest+1s`
 		{"inf", "2020-01-01T00:32:36Z", "2025-05-14T06:32:37Z", timeutil.TimeGrainUnspecified, 1, 1},
-		{"P2DT10H", "2025-05-10T20:00:00Z", "2025-05-13T06:00:00Z", timeutil.TimeGrainHour, 1, 1},
+		{"P2DT10H", "2025-05-10T21:00:00Z", "2025-05-13T07:00:00Z", timeutil.TimeGrainHour, 1, 1},
 	}
 
 	runTests(t, testCases, now, minTime, maxTime, watermark, nil)


### PR DESCRIPTION
Legacy iso truncated by the smallest grain in iso only. This is how old ISO resolution worked.

We are changing this behaviour to instead be a add a unit before truncating.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
