### PR TITLE
feat:add color range config to heatmap

### DIFF
--- a/web-common/src/features/canvas/components/charts/builder.ts
+++ b/web-common/src/features/canvas/components/charts/builder.ts
@@ -16,6 +16,7 @@ import {
   isDomainStringArray,
   isFieldConfig,
   mergedVlConfig,
+  resolveColor,
 } from "@rilldata/web-common/features/canvas/components/charts/util";
 import type { Color } from "chroma-js";
 import merge from "deepmerge";
@@ -126,15 +127,30 @@ export function createColorEncoding(
       };
     }
 
+    if (colorField.type === "quantitative" && colorField.colorRange) {
+      const colorRange = colorField.colorRange;
+
+      if (colorRange.mode === "scheme") {
+        baseEncoding.scale = {
+          scheme: colorRange.scheme,
+        };
+      } else if (colorRange.mode === "range") {
+        baseEncoding.scale = {
+          range: [
+            resolveColor(data.theme, colorRange.start),
+            resolveColor(data.theme, colorRange.end),
+          ],
+          type: "linear",
+        };
+      }
+    }
+
     return baseEncoding;
   }
+
   if (typeof colorField === "string") {
-    if (colorField === "primary") {
-      return { value: data.theme.primary.css("hsl") };
-    } else if (colorField === "secondary") {
-      return { value: data.theme.secondary.css("hsl") };
-    }
-    return { value: colorField };
+    const color = resolveColor(data.theme, colorField);
+    return { value: color };
   }
   return {};
 }

--- a/web-common/src/features/canvas/components/charts/builder.ts
+++ b/web-common/src/features/canvas/components/charts/builder.ts
@@ -134,7 +134,7 @@ export function createColorEncoding(
         baseEncoding.scale = {
           scheme: colorRange.scheme,
         };
-      } else if (colorRange.mode === "range") {
+      } else if (colorRange.mode === "gradient") {
         baseEncoding.scale = {
           range: [
             resolveColor(data.theme, colorRange.start),

--- a/web-common/src/features/canvas/components/charts/heatmap-charts/HeatmapChart.ts
+++ b/web-common/src/features/canvas/components/charts/heatmap-charts/HeatmapChart.ts
@@ -81,6 +81,9 @@ export class HeatmapChartComponent extends BaseChart<HeatmapChartSpec> {
         chartFieldInput: {
           type: "measure",
           defaultLegendOrientation: "right",
+          colorRangeSelector: {
+            enable: true,
+          },
         },
       },
     },
@@ -347,6 +350,10 @@ export class HeatmapChartComponent extends BaseChart<HeatmapChartSpec> {
       color: {
         type: "quantitative",
         field: randomMeasure,
+        colorRange: {
+          mode: "scheme",
+          scheme: "tealblues",
+        },
       },
     };
   }

--- a/web-common/src/features/canvas/components/charts/types.ts
+++ b/web-common/src/features/canvas/components/charts/types.ts
@@ -1,4 +1,7 @@
-import type { ColorMapping } from "@rilldata/web-common/features/canvas/inspector/types";
+import type {
+  ColorMapping,
+  ColorRangeMapping,
+} from "@rilldata/web-common/features/canvas/inspector/types";
 import type {
   V1Expression,
   V1MetricsViewAggregationDimension,
@@ -95,6 +98,7 @@ interface QuantitativeFieldConfig {
   min?: number;
   max?: number;
   showTotal?: boolean;
+  colorRange?: ColorRangeMapping;
 }
 
 export interface FieldConfig

--- a/web-common/src/features/canvas/components/charts/util.ts
+++ b/web-common/src/features/canvas/components/charts/util.ts
@@ -11,6 +11,7 @@ import {
   type V1MetricsViewAggregationResponseDataItem,
   type V1MetricsViewAggregationSort,
 } from "@rilldata/web-common/runtime-client";
+import type { Color } from "chroma-js";
 import merge from "deepmerge";
 import type { Config } from "vega-lite";
 import { CHART_CONFIG, type ChartSpec } from "./";
@@ -316,4 +317,21 @@ export function getColorMappingForChart(
   }
 
   return colorMapping;
+}
+
+export function resolveColor(
+  theme: { primary: Color; secondary: Color },
+  color: string,
+): string {
+  if (color === "primary") {
+    // Vega lite requires scale hsl colors to be comma separated
+    const hslColor = theme.primary
+      .css("hsl")
+      .replace("deg", "")
+      .replaceAll(" ", ", ");
+    return hslColor;
+  } else if (color === "secondary") {
+    return theme.secondary.css("hsl").replace("deg", "").replaceAll(" ", ", ");
+  }
+  return color;
 }

--- a/web-common/src/features/canvas/inspector/chart/PositionalFieldConfig.svelte
+++ b/web-common/src/features/canvas/inspector/chart/PositionalFieldConfig.svelte
@@ -3,6 +3,7 @@
   import type { FieldConfig } from "@rilldata/web-common/features/canvas/components/charts/types";
   import { isFieldConfig } from "@rilldata/web-common/features/canvas/components/charts/util";
   import ColorPaletteSelector from "@rilldata/web-common/features/canvas/inspector/chart/field-config/ColorPaletteSelector.svelte";
+  import ColorRangeSelector from "@rilldata/web-common/features/canvas/inspector/chart/field-config/ColorRangeSelector.svelte";
   import MultiPositionalFieldsInput from "@rilldata/web-common/features/canvas/inspector/fields/MultiPositionalFieldsInput.svelte";
   import SingleFieldInput from "@rilldata/web-common/features/canvas/inspector/fields/SingleFieldInput.svelte";
   import type { ComponentInputParam } from "@rilldata/web-common/features/canvas/inspector/types";
@@ -30,6 +31,7 @@
   $: chartFieldInput = config.meta?.chartFieldInput;
   $: multiMetricSelector = chartFieldInput?.multiFieldSelector;
   $: colorMapConfig = chartFieldInput?.colorMappingSelector;
+  $: colorRangeConfig = chartFieldInput?.colorRangeSelector;
 
   $: isDimension = chartFieldInput?.type === "dimension";
   $: hasMultipleMeasures = fieldConfig.fields && fieldConfig.fields.length > 1;
@@ -159,6 +161,16 @@
             colorMapping={fieldConfig.colorMapping}
             onChange={updateFieldProperty}
             {colorMapConfig}
+          />
+        </div>
+      {/if}
+      {#if isFieldConfig(fieldConfig) && colorRangeConfig?.enable}
+        <div class="pt-2">
+          <ColorRangeSelector
+            colorRange={fieldConfig.colorRange}
+            onChange={updateFieldProperty}
+            {colorRangeConfig}
+            {canvasName}
           />
         </div>
       {/if}

--- a/web-common/src/features/canvas/inspector/chart/field-config/ColorRangeSelector.svelte
+++ b/web-common/src/features/canvas/inspector/chart/field-config/ColorRangeSelector.svelte
@@ -78,17 +78,6 @@
     return color;
   };
 
-  const getColorLabel = (color: string): string => {
-    switch (color) {
-      case "primary":
-        return "Primary";
-      case "secondary":
-        return "Secondary";
-      default:
-        return "";
-    }
-  };
-
   function handleModeSwitch(mode: "scheme" | "range") {
     let updatedRange: ColorRangeMapping;
 

--- a/web-common/src/features/canvas/inspector/chart/field-config/ColorRangeSelector.svelte
+++ b/web-common/src/features/canvas/inspector/chart/field-config/ColorRangeSelector.svelte
@@ -1,0 +1,215 @@
+<!--
+  ColorRangeSelector - Component for configuring continuous color ranges in charts like heatmaps.
+  Supports both predefined color schemes (tealblues, magma, etc.) and custom color ranges.
+  Defaults to tealblues scheme but allows switching to custom range mode.
+-->
+<script lang="ts">
+  import Button from "@rilldata/web-common/components/button/Button.svelte";
+  import ColorInput from "@rilldata/web-common/components/color-picker/ColorInput.svelte";
+  import FieldSwitcher from "@rilldata/web-common/components/forms/FieldSwitcher.svelte";
+  import Select from "@rilldata/web-common/components/forms/Select.svelte";
+  import type { FieldConfig } from "@rilldata/web-common/features/canvas/components/charts/types";
+  import type {
+    ChartFieldInput,
+    ColorRangeMapping,
+  } from "@rilldata/web-common/features/canvas/inspector/types";
+  import { getCanvasStore } from "@rilldata/web-common/features/canvas/state-managers/state-managers";
+  import {
+    defaultPrimaryColors,
+    defaultSecondaryColors,
+  } from "@rilldata/web-common/features/themes/color-config";
+  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
+  import { slide } from "svelte/transition";
+  import type { ColorScheme } from "vega-typings";
+
+  export let colorRange: ColorRangeMapping | undefined;
+  export let onChange: (property: keyof FieldConfig, value: any) => void;
+  export let colorRangeConfig: ChartFieldInput["colorRangeSelector"];
+  export let canvasName: string;
+
+  // Available Vega-Lite color schemes
+  // https://vega.github.io/vega/docs/schemes/
+  const colorSchemes: { label: string; value: ColorScheme }[] = [
+    { label: "Teal blues", value: "tealblues" },
+    { label: "Viridis", value: "viridis" },
+    { label: "Magma", value: "magma" },
+    { label: "Inferno", value: "inferno" },
+    { label: "Plasma", value: "plasma" },
+    { label: "Cividis", value: "cividis" },
+    { label: "Blues", value: "blues" },
+    { label: "Teals", value: "teals" },
+    { label: "Greens", value: "greens" },
+    { label: "Greys", value: "greys" },
+    { label: "Oranges", value: "oranges" },
+    { label: "Purples", value: "purples" },
+    { label: "Reds", value: "reds" },
+    { label: "Turbo", value: "turbo" },
+    { label: "Spectral", value: "spectral" },
+  ];
+
+  $: ({ instanceId } = $runtime);
+  $: ({
+    canvasEntity: { theme },
+  } = getCanvasStore(canvasName, instanceId));
+
+  $: currentColorRange =
+    colorRange ||
+    ({
+      mode: "scheme",
+      scheme: "tealblues",
+    } as ColorRangeMapping);
+
+  $: currentMode = currentColorRange.mode || "scheme";
+
+  function isRangeMode(
+    colorRange: ColorRangeMapping,
+  ): colorRange is { mode: "range"; start: string; end: string } {
+    return colorRange.mode === "range";
+  }
+
+  const resolveColor = (color: string): string => {
+    if (color === "primary") {
+      return $theme.primary?.css("hsl") || `hsl(${defaultPrimaryColors[500]})`;
+    } else if (color === "secondary") {
+      return (
+        $theme.secondary?.css("hsl") || `hsl(${defaultSecondaryColors[500]})`
+      );
+    }
+    return color;
+  };
+
+  const getColorLabel = (color: string): string => {
+    switch (color) {
+      case "primary":
+        return "Primary";
+      case "secondary":
+        return "Secondary";
+      default:
+        return "";
+    }
+  };
+
+  function handleModeSwitch(mode: "scheme" | "range") {
+    let updatedRange: ColorRangeMapping;
+
+    if (mode === "scheme") {
+      updatedRange = {
+        mode: "scheme",
+        scheme: "tealblues",
+      };
+    } else {
+      updatedRange = {
+        mode: "range",
+        start: "primary",
+        end: "secondary",
+      };
+    }
+
+    onChange("colorRange", updatedRange);
+  }
+
+  function handleSchemeChange(scheme: ColorScheme) {
+    const updatedRange: ColorRangeMapping = {
+      mode: "scheme",
+      scheme,
+    };
+    onChange("colorRange", updatedRange);
+  }
+
+  function handleStartColorChange(newColor: string) {
+    let currentEnd = "secondary";
+
+    if (isRangeMode(currentColorRange)) {
+      currentEnd = currentColorRange.end;
+    }
+
+    const updatedRange: ColorRangeMapping = {
+      mode: "range",
+      start: newColor,
+      end: currentEnd,
+    };
+    onChange("colorRange", updatedRange);
+  }
+
+  function handleEndColorChange(newColor: string) {
+    let currentStart = "primary";
+
+    if (isRangeMode(currentColorRange)) {
+      currentStart = currentColorRange.start;
+    }
+
+    const updatedRange: ColorRangeMapping = {
+      mode: "range",
+      start: currentStart,
+      end: newColor,
+    };
+    onChange("colorRange", updatedRange);
+  }
+
+  function resetToDefault() {
+    onChange("colorRange", {
+      mode: "scheme",
+      scheme: "tealblues",
+    });
+  }
+</script>
+
+{#if colorRangeConfig?.enable}
+  <div>
+    <div class="space-y-2" transition:slide={{ duration: 200 }}>
+      <!-- Mode Switcher -->
+      <FieldSwitcher
+        small
+        fields={["Scheme", "Range"]}
+        selected={currentMode === "scheme" ? 0 : 1}
+        onClick={(i, value) =>
+          handleModeSwitch(value === "Scheme" ? "scheme" : "range")}
+      />
+
+      {#if currentMode === "scheme"}
+        <!-- Color Scheme Selector -->
+        <Select
+          size="sm"
+          sameWidth
+          id="color-scheme-select"
+          options={colorSchemes}
+          value={currentColorRange.mode === "scheme"
+            ? currentColorRange.scheme
+            : "tealblues"}
+          onChange={handleSchemeChange}
+        />
+      {:else}
+        <!-- Custom Range Selectors -->
+        <ColorInput
+          small
+          stringColor={resolveColor(
+            isRangeMode(currentColorRange)
+              ? currentColorRange.start
+              : "primary",
+          )}
+          labelFirst
+          allowLightnessControl
+          label="Start color"
+          onChange={handleStartColorChange}
+        />
+
+        <ColorInput
+          small
+          stringColor={resolveColor(
+            isRangeMode(currentColorRange)
+              ? currentColorRange.end
+              : "secondary",
+          )}
+          labelFirst
+          allowLightnessControl
+          label="End color"
+          onChange={handleEndColorChange}
+        />
+      {/if}
+
+      <div class="px-1 flex items-center justify-end">
+        <Button type="text" onClick={resetToDefault}>Reset to default</Button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/web-common/src/features/canvas/inspector/chart/field-config/ColorRangeSelector.svelte
+++ b/web-common/src/features/canvas/inspector/chart/field-config/ColorRangeSelector.svelte
@@ -1,7 +1,7 @@
 <!--
   ColorRangeSelector - Component for configuring continuous color ranges in charts like heatmaps.
-  Supports both predefined color schemes (tealblues, magma, etc.) and custom color ranges.
-  Defaults to tealblues scheme but allows switching to custom range mode.
+  Supports both predefined color schemes (tealblues, magma, etc.) and custom color gradients.
+  Defaults to tealblues scheme but allows switching to custom gradient mode.
 -->
 <script lang="ts">
   import Button from "@rilldata/web-common/components/button/Button.svelte";
@@ -61,10 +61,10 @@
 
   $: currentMode = currentColorRange.mode || "scheme";
 
-  function isRangeMode(
+  function isGradientMode(
     colorRange: ColorRangeMapping,
-  ): colorRange is { mode: "range"; start: string; end: string } {
-    return colorRange.mode === "range";
+  ): colorRange is { mode: "gradient"; start: string; end: string } {
+    return colorRange.mode === "gradient";
   }
 
   const resolveColor = (color: string): string => {
@@ -78,7 +78,7 @@
     return color;
   };
 
-  function handleModeSwitch(mode: "scheme" | "range") {
+  function handleModeSwitch(mode: "scheme" | "gradient") {
     let updatedRange: ColorRangeMapping;
 
     if (mode === "scheme") {
@@ -88,7 +88,7 @@
       };
     } else {
       updatedRange = {
-        mode: "range",
+        mode: "gradient",
         start: "primary",
         end: "secondary",
       };
@@ -108,12 +108,12 @@
   function handleStartColorChange(newColor: string) {
     let currentEnd = "secondary";
 
-    if (isRangeMode(currentColorRange)) {
+    if (isGradientMode(currentColorRange)) {
       currentEnd = currentColorRange.end;
     }
 
     const updatedRange: ColorRangeMapping = {
-      mode: "range",
+      mode: "gradient",
       start: newColor,
       end: currentEnd,
     };
@@ -123,12 +123,12 @@
   function handleEndColorChange(newColor: string) {
     let currentStart = "primary";
 
-    if (isRangeMode(currentColorRange)) {
+    if (isGradientMode(currentColorRange)) {
       currentStart = currentColorRange.start;
     }
 
     const updatedRange: ColorRangeMapping = {
-      mode: "range",
+      mode: "gradient",
       start: currentStart,
       end: newColor,
     };
@@ -149,10 +149,10 @@
       <!-- Mode Switcher -->
       <FieldSwitcher
         small
-        fields={["Scheme", "Range"]}
+        fields={["Scheme", "Graident"]}
         selected={currentMode === "scheme" ? 0 : 1}
         onClick={(i, value) =>
-          handleModeSwitch(value === "Scheme" ? "scheme" : "range")}
+          handleModeSwitch(value === "Scheme" ? "scheme" : "gradient")}
       />
 
       {#if currentMode === "scheme"}
@@ -168,11 +168,11 @@
           onChange={handleSchemeChange}
         />
       {:else}
-        <!-- Custom Range Selectors -->
+        <!-- Custom Graident Selectors -->
         <ColorInput
           small
           stringColor={resolveColor(
-            isRangeMode(currentColorRange)
+            isGradientMode(currentColorRange)
               ? currentColorRange.start
               : "primary",
           )}
@@ -185,7 +185,7 @@
         <ColorInput
           small
           stringColor={resolveColor(
-            isRangeMode(currentColorRange)
+            isGradientMode(currentColorRange)
               ? currentColorRange.end
               : "secondary",
           )}

--- a/web-common/src/features/canvas/inspector/types.ts
+++ b/web-common/src/features/canvas/inspector/types.ts
@@ -3,6 +3,7 @@ import type {
   ChartSortDirectionOptions,
 } from "@rilldata/web-common/features/canvas/components/charts/types";
 import type { ComponentAlignment } from "@rilldata/web-common/features/canvas/components/types";
+import type { ColorScheme } from "vega-typings";
 
 type NativeInputTypes = "text" | "number" | "boolean" | "textArea" | "select";
 type SemanticInputTypes = "metrics" | "measure" | "dimension" | "multi_fields";
@@ -36,7 +37,14 @@ export type ChartFieldInput = {
   originSelector?: boolean;
   sortSelector?: SortSelectorConfig;
   limitSelector?: { defaultLimit: number };
-  colorMappingSelector?: { enable: boolean; values?: string[] };
+  colorMappingSelector?: {
+    enable: boolean;
+    values?: string[];
+    isContinuous?: boolean;
+  };
+  colorRangeSelector?: {
+    enable: boolean;
+  };
   nullSelector?: boolean;
   labelAngleSelector?: boolean;
   axisRangeSelector?: boolean;
@@ -71,6 +79,17 @@ export interface ComponentInputParam {
 }
 
 export type ColorMapping = { value: string; color: string }[];
+
+export type ColorRangeMapping =
+  | {
+      mode: "scheme";
+      scheme: ColorScheme;
+    }
+  | {
+      mode: "range";
+      start: string;
+      end: string;
+    };
 
 export interface FilterInputParam {
   type: FilterInputTypes;

--- a/web-common/src/features/canvas/inspector/types.ts
+++ b/web-common/src/features/canvas/inspector/types.ts
@@ -86,7 +86,7 @@ export type ColorRangeMapping =
       scheme: ColorScheme;
     }
   | {
-      mode: "range";
+      mode: "gradient";
       start: string;
       end: string;
     };


### PR DESCRIPTION
Add a scheme and range toggle under Color selector for heatmap charts.

The scheme tab has a list of preset color schemes. The range tab has a start and end color value which the user can tweak.

https://linear.app/rilldata/issue/APP-295/support-custom-chart-colors-for-heatmaps-and-pie-charts

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
