### PR TITLE
fix: enable text selection in markdown

### DIFF
--- a/web-common/src/features/canvas/components/markdown/Markdown.svelte
+++ b/web-common/src/features/canvas/components/markdown/Markdown.svelte
@@ -12,7 +12,7 @@
   $: positionClasses = getPositionClasses(markdownProperties.alignment);
 </script>
 
-<div class="size-full px-2 bg-surface overflow-y-auto">
+<div class="size-full px-2 bg-surface overflow-y-auto select-text cursor-text">
   <div class="canvas-markdown {positionClasses} h-full flex flex-col min-h-min">
     {#await marked(markdownProperties.content) then content}
       {@html DOMPurify.sanitize(content)}


### PR DESCRIPTION
https://linear.app/rilldata/issue/APP-38/text-within-markdown-components-is-not-selectable

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
