### PR TITLE
chore: rilltime tweaks

### DIFF
--- a/web-common/src/features/dashboards/time-controls/new-time-controls.ts
+++ b/web-common/src/features/dashboards/time-controls/new-time-controls.ts
@@ -9,7 +9,10 @@ import {
   parseRillTime,
 } from "@rilldata/web-common/features/dashboards/url-state/time-ranges/parser";
 import { humaniseISODuration } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
-import type { V1ExploreTimeRange } from "@rilldata/web-common/runtime-client";
+import type {
+  V1ExploreTimeRange,
+  V1TimeRange,
+} from "@rilldata/web-common/runtime-client";
 import {
   getQueryServiceMetricsViewTimeRangesQueryKey,
   V1TimeGrain,
@@ -328,6 +331,7 @@ import {
   type RillTime,
 } from "../url-state/time-ranges/RillTime";
 import { getDefaultRangeBuckets } from "@rilldata/web-common/lib/time/defaults";
+import type { DashboardTimeControls } from "@rilldata/web-common/lib/time/types";
 
 export async function deriveInterval(
   name: RillPeriodToDate | RillPreviousPeriod | ISODurationString,

--- a/web-common/src/features/dashboards/time-controls/new-time-controls.ts
+++ b/web-common/src/features/dashboards/time-controls/new-time-controls.ts
@@ -9,10 +9,7 @@ import {
   parseRillTime,
 } from "@rilldata/web-common/features/dashboards/url-state/time-ranges/parser";
 import { humaniseISODuration } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
-import type {
-  V1ExploreTimeRange,
-  V1TimeRange,
-} from "@rilldata/web-common/runtime-client";
+import type { V1ExploreTimeRange } from "@rilldata/web-common/runtime-client";
 import {
   getQueryServiceMetricsViewTimeRangesQueryKey,
   V1TimeGrain,
@@ -331,7 +328,6 @@ import {
   type RillTime,
 } from "../url-state/time-ranges/RillTime";
 import { getDefaultRangeBuckets } from "@rilldata/web-common/lib/time/defaults";
-import type { DashboardTimeControls } from "@rilldata/web-common/lib/time/types";
 
 export async function deriveInterval(
   name: RillPeriodToDate | RillPreviousPeriod | ISODurationString,

--- a/web-common/src/features/dashboards/time-controls/super-pill/components/RangeDisplay.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/RangeDisplay.svelte
@@ -3,7 +3,7 @@
   import { V1TimeGrain } from "@rilldata/web-common/runtime-client";
   import { Interval } from "luxon";
 
-  export let interval: Interval;
+  export let interval: Interval | undefined;
   export let timeGrain: V1TimeGrain = V1TimeGrain.TIME_GRAIN_UNSPECIFIED;
   export let abbreviation: string | undefined = undefined;
 
@@ -12,7 +12,7 @@
 
 <div class="flex gap-x-1 whitespace-nowrap truncate">
   <span class="line-clamp-1 text-left">
-    {#if interval.isValid}
+    {#if interval?.isValid}
       {formattedInterval}
       {#if abbreviation}
         {abbreviation}

--- a/web-common/src/features/dashboards/time-controls/super-pill/new-time-dropdown/RangePickerV2.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/new-time-dropdown/RangePickerV2.svelte
@@ -47,7 +47,7 @@
   import PrimaryRangeTooltip from "./PrimaryRangeTooltip.svelte";
 
   export let timeString: string | undefined;
-  export let interval: Interval<true> | undefined;
+  export let interval: Interval<true>;
   export let timeGrain: V1TimeGrain | undefined;
   export let zone: string;
   export let showDefaultItem: boolean;
@@ -267,7 +267,6 @@
       {timeString}
       onSelectRange={(range) => {
         open = false;
-        console.log({ range });
         handleRangeSelect(range);
       }}
     />

--- a/web-common/src/lib/time/ranges/formatter.ts
+++ b/web-common/src/lib/time/ranges/formatter.ts
@@ -3,7 +3,10 @@ import { V1TimeGrain } from "@rilldata/web-common/runtime-client";
 import { DateTime, type DateTimeFormatOptions, Interval } from "luxon";
 
 // Formats a Luxon interval for human readable display throughout the application.
-export function prettyFormatTimeRange(interval: Interval, grain: V1TimeGrain) {
+export function prettyFormatTimeRange(
+  interval: Interval | undefined,
+  grain: V1TimeGrain,
+) {
   if (!interval?.isValid || !interval.start || !interval.end)
     return "Invalid interval";
 


### PR DESCRIPTION
- Hides `as of` dropdown when viewing an All Time range
- Fixes an issue where going from All time to another range would set the reference point to `now`
- Applies `as of` clause when submitting a time string via the text input i.e. `-4d to -3d as of watermark/d` now sets the as of dropdown to `watermark` and `day`
- Maintains properties of existing `as of` selector when submitting via text input i.e. `-4d to -3d` (Previously, these were all interpreted as `as of now`)


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
