### PR TITLE
Create a connector file for DuckDB connector

### DIFF
--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -65,8 +65,11 @@
           (property) => property.key !== "dsn",
         )) ?? [];
 
-  // FIXME: APP-209
-  const filteredParamsProperties = properties;
+  // Filter properties based on connector type
+  const filteredParamsProperties = (() => {
+    // For other connectors, filter out noPrompt properties
+    return properties.filter((property) => !property.noPrompt);
+  })();
   const schema = yup(getYupSchema[connector.name as keyof typeof getYupSchema]);
   const initialFormValues = getInitialFormValuesFromProperties(properties);
   const {

--- a/web-common/src/features/sources/modal/AddDataModal.svelte
+++ b/web-common/src/features/sources/modal/AddDataModal.svelte
@@ -122,10 +122,8 @@
   $: isModelingSupported = $isModelingSupportedForDefaultOlapDriver.data;
 
   // FIXME: excluding salesforce until we implement the table discovery APIs
-  // NOTE: DuckDB should not create connector files, only sources
   $: isConnectorType =
-    (selectedConnector?.implementsOlap &&
-      selectedConnector?.name !== "duckdb") ||
+    selectedConnector?.implementsOlap ||
     selectedConnector?.implementsSqlStore ||
     (selectedConnector?.implementsWarehouse &&
       selectedConnector?.name !== "salesforce");
@@ -144,8 +142,8 @@
   >
     <Dialog.Content
       class={cn(
-        "overflow-hidden",
-        step === 2 ? "max-w-4xl p-0 gap-0" : "p-6 gap-4",
+        "overflow-hidden max-w-4xl",
+        step === 2 ? "p-0 gap-0" : "p-6 gap-4",
       )}
       noClose={step === 1}
     >
@@ -163,7 +161,7 @@
                     on:click={() => goToConnectorForm(connector)}
                     class="connector-tile-button size-full min-w-24 min-h-16 h-20"
                   >
-                    <div class="connector-wrapper px-6 py-4 md:px-4 md:py-2">
+                    <div class="connector-wrapper px-6 py-4">
                       <svelte:component this={ICONS[connector.name]} />
                     </div>
                   </button>
@@ -188,7 +186,7 @@
                   class="connector-tile-button size-full min-w-24 min-h-16 h-20"
                   on:click={() => goToConnectorForm(connector)}
                 >
-                  <div class="connector-wrapper px-6 py-4 md:px-4 md:py-2">
+                  <div class="connector-wrapper px-6 py-4">
                     <svelte:component this={ICONS[connector.name]} />
                   </div>
                 </button>

--- a/web-common/src/features/sources/modal/yupSchemas.ts
+++ b/web-common/src/features/sources/modal/yupSchemas.ts
@@ -36,12 +36,8 @@ export const getYupSchema = {
   }),
 
   duckdb: yup.object().shape({
-    db: yup.string().required("db is required"),
-    sql: yup.string().required("sql is required"),
-    name: yup
-      .string()
-      .matches(VALID_NAME_PATTERN, INVALID_NAME_MESSAGE)
-      .required("Source name is required"),
+    path: yup.string().required("path is required"),
+    attach: yup.string().optional(),
   }),
 
   motherduck: yup.object().shape({


### PR DESCRIPTION
This PR tweaks [the max w and padding of AddDataForm](https://github.com/rilldata/rill/pull/7979#issuecomment-3312209622) and enforces the duckdb form to create a `type: connector` file. The DuckDB form will now have a required `path` and an optional `attach`.

https://linear.app/rilldata/issue/APP-403/add-path-to-duckdb-form

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
