### PR TITLE
Update InitEmpty to always create an OLAP connector file

### DIFF
--- a/runtime/parser/init.go
+++ b/runtime/parser/init.go
@@ -58,6 +58,12 @@ driver: duckdb
 driver: clickhouse
 managed: true
 `
+	default:
+		connectorYAML = fmt.Sprintf(`type: connector
+driver: %s
+
+# TODO: Configure the connection.
+`, olap)
 	}
 
 	err = repo.Put(ctx, fmt.Sprintf("connectors/%s.yaml", olap), strings.NewReader(connectorYAML))


### PR DESCRIPTION
Update InitEmpty and remove default OLAP connector assignment

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
