### PR TITLE
Add option to run OPTIMIZE on the temporary table 

### DIFF
--- a/docs/docs/connect/olap/clickhouse.md
+++ b/docs/docs/connect/olap/clickhouse.md
@@ -143,6 +143,16 @@ You can configure your ClickHouse connector to operate in read-only mode by addi
 mode: read # readwrite
 ```
 
+## Advanced Configuration Options
+
+### Optimize Temporary Tables Before Partition Replace
+
+When using incremental models with partition overwrite strategies, you can enable automatic optimization of temporary tables before partition replacement operations. This can improve query performance by reducing the number of parts in each partition, but may increase processing time during model refreshes.
+
+```yaml
+optimize_temporary_tables_before_partition_replace: true # default: false
+```
+
 ## Configuring Rill Cloud
 
 When deploying a ClickHouse-backed project to Rill Cloud, you have the following options to pass the appropriate connection string to Rill Cloud:

--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -167,6 +167,8 @@ type configProperties struct {
 	// This is just a *quick hack* to avoid fetching all databases in the table list till we have a better solution.
 	// This does not list queries to other databases.
 	DatabaseWhitelist string `mapstructure:"database_whitelist"`
+	// OptimizeTemporaryTablesBeforePartitionReplace determines whether to optimize temporary tables before partition replacement.
+	OptimizeTemporaryTablesBeforePartitionReplace bool `mapstructure:"optimize_temporary_tables_before_partition_replace"`
 	// SSL determines whether secured connection need to be established. Should not be set if DSN is set.
 	SSL bool `mapstructure:"ssl"`
 	// Cluster name. If a cluster is configured, Rill will create all models in the cluster as distributed tables.

--- a/runtime/drivers/clickhouse/olap_test.go
+++ b/runtime/drivers/clickhouse/olap_test.go
@@ -37,6 +37,7 @@ func TestClickhouseSingle(t *testing.T) {
 	t.Run("InsertTableAsSelect_WithPartitionOverwrite_DatePartition", func(t *testing.T) { testInsertTableAsSelect_WithPartitionOverwrite_DatePartition(t, c, olap) })
 	t.Run("TestDictionary", func(t *testing.T) { testDictionary(t, c, olap) })
 	t.Run("TestIntervalType", func(t *testing.T) { testIntervalType(t, olap) })
+	t.Run("TestOptimizeTable", func(t *testing.T) { testOptimizeTable(t, c, olap) })
 }
 
 func TestClickhouseCluster(t *testing.T) {
@@ -65,6 +66,7 @@ func TestClickhouseCluster(t *testing.T) {
 	t.Run("InsertTableAsSelect_WithPartitionOverwrite", func(t *testing.T) { testInsertTableAsSelect_WithPartitionOverwrite(t, c, olap) })
 	t.Run("InsertTableAsSelect_WithPartitionOverwrite_DatePartition", func(t *testing.T) { testInsertTableAsSelect_WithPartitionOverwrite_DatePartition(t, c, olap) })
 	t.Run("TestDictionary", func(t *testing.T) { testDictionary(t, c, olap) })
+	t.Run("TestOptimizeTable", func(t *testing.T) { testOptimizeTable(t, c, olap) })
 }
 
 func testWithConnection(t *testing.T, olap drivers.OLAPStore) {
@@ -454,6 +456,64 @@ func testIntervalType(t *testing.T, olap drivers.OLAPStore) {
 		require.Equal(t, c.ms, ms)
 		require.NoError(t, rows.Close())
 	}
+}
+
+func testOptimizeTable(t *testing.T, c *Connection, olap drivers.OLAPStore) {
+	ctx := context.Background()
+	tempTableName := "optimize_basic_test"
+
+	// Create table with MergeTree engine - handle cluster mode
+	var err error
+	if c.config.Cluster != "" {
+		localTableName := tempTableName + "_local"
+		localCreateQuery := fmt.Sprintf("CREATE TABLE %s ON CLUSTER %s (id INT, value VARCHAR) ENGINE=MergeTree ORDER BY id", localTableName, c.config.Cluster)
+		err = olap.Exec(ctx, &drivers.Statement{Query: localCreateQuery})
+		require.NoError(t, err)
+	} else {
+		createQuery := fmt.Sprintf("CREATE TABLE %s (id INT, value VARCHAR) ENGINE=MergeTree ORDER BY id", tempTableName)
+		err = olap.Exec(ctx, &drivers.Statement{Query: createQuery})
+		require.NoError(t, err)
+	}
+
+	// Insert test data
+	err = olap.Exec(ctx, &drivers.Statement{
+		Query: fmt.Sprintf("INSERT INTO %s VALUES (1, 'test1'), (2, 'test2'), (3, 'test3')", tempTableName),
+	})
+	require.NoError(t, err)
+
+	// Run OPTIMIZE
+	err = c.optimizeTable(ctx, tempTableName)
+	require.NoError(t, err)
+
+	// Verify data integrity after optimization
+	res, err := olap.Query(ctx, &drivers.Statement{
+		Query: fmt.Sprintf("SELECT id, value FROM %s ORDER BY id", tempTableName),
+	})
+	require.NoError(t, err)
+
+	var results []struct {
+		ID    int
+		Value string
+	}
+	for res.Next() {
+		var r struct {
+			ID    int
+			Value string
+		}
+		require.NoError(t, res.Scan(&r.ID, &r.Value))
+		results = append(results, r)
+	}
+	require.NoError(t, res.Close())
+
+	expected := []struct {
+		ID    int
+		Value string
+	}{
+		{1, "test1"},
+		{2, "test2"},
+		{3, "test3"},
+	}
+	require.Equal(t, expected, results)
 }
 
 func prepareClusterConn(t *testing.T, olap drivers.OLAPStore, cluster string) {


### PR DESCRIPTION
Adds option to run `OPTIMIZE` on ClickHouse temporary tables. This PR enables '[optimization](https://clickhouse.com/docs/sql-reference/statements/optimize)' of temporary tables before partition replacement operations. 


```yaml
# connectors/clickhouse.yaml
type: connector
driver: clickhouse
managed: true
optimize_temporary_tables_before_partition_replace: true # default: false
```


**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] [Linked](https://linear.app/rilldata/issue/PLAT-180/add-option-to-run-optimize-on-the-temporary-table-before-doing-a) the issues it closes
- [x] Checked if the docs need to be updated. DOCS attached*
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
