### PR TITLE
Support Motherduck paths when using `driver: duckdb`

### DIFF
--- a/runtime/drivers/duckdb/config.go
+++ b/runtime/drivers/duckdb/config.go
@@ -1,6 +1,7 @@
 package duckdb
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -82,6 +83,11 @@ func newConfig(cfgMap map[string]any) (*config, error) {
 		}
 	}
 
+	// Validate Motherduck token
+	if cfg.isMotherduck() && cfg.Token == "" {
+		return nil, errors.New("you must configure the 'token' connector property when using Motherduck")
+	}
+
 	// Set pool size
 	poolSize := cfg.PoolSize
 	if poolSize == 0 && cfg.CPU != 0 {
@@ -114,4 +120,15 @@ func (c *config) secretConnectors() []string {
 		res[i] = strings.TrimSpace(s)
 	}
 	return res
+}
+
+// isMotherduck returns true if the Path or Attach config options reference a Motherduck database.
+func (c *config) isMotherduck() bool {
+	if c.Path != "" && strings.HasPrefix(c.Path, "md:") {
+		return true
+	}
+	if c.Attach != "" && strings.HasPrefix(c.Attach, "'md:") {
+		return true
+	}
+	return false
 }

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -476,7 +476,7 @@ func (c *connection) reopenDB(ctx context.Context) error {
 		connInitQueries []string
 	)
 
-	if c.driverName == "motherduck" {
+	if c.driverName == "motherduck" || c.config.isMotherduck() {
 		dbInitQueries = append(dbInitQueries,
 			"INSTALL 'motherduck'",
 			"LOAD 'motherduck'",

--- a/runtime/reconcilers/model.go
+++ b/runtime/reconcilers/model.go
@@ -1528,31 +1528,34 @@ func (r *ModelReconciler) acquireExecutorInner(ctx context.Context, opts *driver
 
 	opts.InputHandle = ic
 	opts.OutputHandle = oc
+	release := func() {
+		ir()
+		or()
+	}
 
 	executorName := opts.InputConnector
 	e, err := ic.AsModelExecutor(r.C.InstanceID, opts)
 	if err != nil {
-		if !errors.Is(err, drivers.ErrNotImplemented) {
-			// found another error, return it
-			ir()
-			or()
-			return "", nil, nil, err
-		}
+		// Try the other connector
 		executorName = opts.OutputConnector
-		e, err = oc.AsModelExecutor(r.C.InstanceID, opts)
-		if err != nil {
-			ir()
-			or()
-			if errors.Is(err, drivers.ErrNotImplemented) {
-				return "", nil, nil, fmt.Errorf("cannot execute model: input connector %q and output connector %q are not compatible", opts.InputConnector, opts.OutputConnector)
-			}
-			return "", nil, nil, err
-		}
-	}
+		inputErr := err
+		var outputErr error
+		e, outputErr = oc.AsModelExecutor(r.C.InstanceID, opts)
+		if outputErr != nil {
+			// Both connectors are not model executors.
+			release()
 
-	release := func() {
-		ir()
-		or()
+			// If one of them returned a unique error, return it
+			if !errors.Is(inputErr, drivers.ErrNotImplemented) {
+				return "", nil, nil, inputErr
+			}
+			if !errors.Is(outputErr, drivers.ErrNotImplemented) {
+				return "", nil, nil, outputErr
+			}
+
+			// Both returned not implemented errors
+			return "", nil, nil, fmt.Errorf("cannot execute model: input connector %q and output connector %q are not compatible", opts.InputConnector, opts.OutputConnector)
+		}
 	}
 
 	return executorName, e, release, nil

--- a/runtime/resolvers/testdata/motherduck_connector.yaml
+++ b/runtime/resolvers/testdata/motherduck_connector.yaml
@@ -1,27 +1,93 @@
 connectors:
   - motherduck
 project_files:
-  all_datatypes_duckdb.yaml:
+  # Model that extracts data from Motherduck to the local DuckDB.
+  all_datatypes.yaml:
     type: model
     connector: motherduck
-    dsn: "md:_share/rilldata/25169ce8-45af-4ac5-9174-00c859d5aa77"
     sql: "select * from rilldata.integration_test.all_datatypes"
     output:
       connector: duckdb
 tests:
-  - name: query_all_results_duckdb
+  # Note: Test queries Motherduck directly as an OLAP engine.
+  - name: query_data_motherduck
     resolver: sql
     properties:
-      sql: "select * from all_datatypes_duckdb order by tinyint_col"
+      connector: motherduck
+      sql: "select * from rilldata.integration_test.all_datatypes order by tinyint_col"
     result_csv: |
       tinyint_col,smallint_col,integer_col,bigint_col,hugeint_col,utinyint_col,usmallint_col,uinteger_col,ubigint_col,float_col,double_col,decimal_col,boolean_col,varchar_col,blob_col,date_col,time_col,timestamp_col,timestamp_s_col,timestamp_ms_col,timestamp_ns_col,timestamptz_col,interval_col,uuid_col,list_int_col,list_float_col,list_varchar_col,list_boolean_col,list_timestamp_col,list_date_col,array_int_col,array_float_col,array_varchar_col,array_boolean_col,array_date_col,array_timestamp_col,map_int_col,map_float_col,map_varchar_col,map_boolean_col,map_date_col,map_timestamp_col,struct_col
       0,0,0,0,0,0,0,0,0,0,0,0,false,,,1970-01-01,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0,00000000-0000-0000-0000-000000000000,"[0,0]","[0,0]","["""",""""]","[false,false]","[""1970-01-01T00:00:00Z"",""1970-01-01T00:00:00Z""]","[""1970-01-01"",""1970-01-01""]","[0,0,0]","[0,0,0]","["""","""",""""]","[false,false,false]","[""1970-01-01"",""1970-01-01"",""1970-01-01""]","[""1970-01-01T00:00:00Z"",""1970-01-01T00:00:00Z"",""1970-01-01T00:00:00Z""]","{"""":0}","{"""":0}","{"""":""""}","{"""":false}","{"""":""1970-01-01""}","{"""":""1970-01-01T00:00:00Z""}","{""field_bool"":false,""field_date"":""1970-01-01"",""field_float"":0,""field_int"":0,""field_str"":"""",""field_timestamp"":""1970-01-01T00:00:00Z""}"
       127,32767,2147483647,9223372036854776000,1234567890123456800,255,65535,4294967295,18446744073709552000,3.141590118408203,2.71828,1234.567,true,Hello,SGVsbG8gQmxvYg==,2025-04-29,0001-01-01T12:34:56Z,2025-04-29T12:34:56Z,2025-04-29T12:34:56Z,2025-04-29T12:34:56.123Z,2025-04-29T12:34:56.123456789Z,2025-04-29T12:34:56Z,31104000000,550e8400-e29b-41d4-a716-446655440000,"[1,2]","[1.100000023841858,2.200000047683716]","[""A"",""B""]","[true,false]","[""2025-04-29T12:34:56Z"",""2025-05-01T12:34:56Z""]","[""2025-04-29"",""2025-05-01""]","[1,2,3]","[1.100000023841858,2.200000047683716,3.299999952316284]","[""A"",""B"",""C""]","[true,false,true]","[""2025-04-29"",""2025-05-01"",""2025-05-02""]","[""2025-04-29T12:34:56Z"",""2025-05-01T12:34:56Z"",""2025-05-02T12:34:56Z""]","{""key1"":1,""key2"":2}","{""key1"":1.100000023841858,""key2"":2.200000047683716}","{""key1"":""A"",""key2"":""B""}","{""key1"":true,""key2"":false}","{""key1"":""2025-04-29"",""key2"":""2025-05-01""}","{""key1"":""2025-04-29T12:34:56Z"",""key2"":""2025-05-01T12:34:56Z""}","{""field_bool"":true,""field_date"":""2025-04-29"",""field_float"":1.2300000190734863,""field_int"":123,""field_str"":""Struct Field"",""field_timestamp"":""2025-04-29T12:34:56Z""}"
       ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-  - name: query_all_datatypes_duckdb
+  # Note: Test queries Motherduck directly as an OLAP engine.
+  - name: query_datatypes_motherduck
     resolver: sql
     properties:
-      sql: "describe all_datatypes_duckdb"
+      connector: motherduck
+      sql: "describe rilldata.integration_test.all_datatypes"
+    result_csv: |
+      column_name,column_type,null,key,default,extra
+      tinyint_col,TINYINT,YES,,,
+      smallint_col,SMALLINT,YES,,,
+      integer_col,INTEGER,YES,,,
+      bigint_col,BIGINT,YES,,,
+      hugeint_col,HUGEINT,YES,,,
+      utinyint_col,UTINYINT,YES,,,
+      usmallint_col,USMALLINT,YES,,,
+      uinteger_col,UINTEGER,YES,,,
+      ubigint_col,UBIGINT,YES,,,
+      float_col,FLOAT,YES,,,
+      double_col,DOUBLE,YES,,,
+      decimal_col,"DECIMAL(18,3)",YES,,,
+      boolean_col,BOOLEAN,YES,,,
+      varchar_col,VARCHAR,YES,,,
+      blob_col,BLOB,YES,,,
+      date_col,DATE,YES,,,
+      time_col,TIME,YES,,,
+      timestamp_col,TIMESTAMP,YES,,,
+      timestamp_s_col,TIMESTAMP_S,YES,,,
+      timestamp_ms_col,TIMESTAMP_MS,YES,,,
+      timestamp_ns_col,TIMESTAMP_NS,YES,,,
+      timestamptz_col,TIMESTAMP WITH TIME ZONE,YES,,,
+      interval_col,INTERVAL,YES,,,
+      uuid_col,UUID,YES,,,
+      list_int_col,INTEGER[],YES,,,
+      list_float_col,FLOAT[],YES,,,
+      list_varchar_col,VARCHAR[],YES,,,
+      list_boolean_col,BOOLEAN[],YES,,,
+      list_timestamp_col,TIMESTAMP[],YES,,,
+      list_date_col,DATE[],YES,,,
+      array_int_col,INTEGER[3],YES,,,
+      array_float_col,FLOAT[3],YES,,,
+      array_varchar_col,VARCHAR[3],YES,,,
+      array_boolean_col,BOOLEAN[3],YES,,,
+      array_date_col,DATE[3],YES,,,
+      array_timestamp_col,TIMESTAMP[3],YES,,,
+      map_int_col,"MAP(VARCHAR, INTEGER)",YES,,,
+      map_float_col,"MAP(VARCHAR, FLOAT)",YES,,,
+      map_varchar_col,"MAP(VARCHAR, VARCHAR)",YES,,,
+      map_boolean_col,"MAP(VARCHAR, BOOLEAN)",YES,,,
+      map_date_col,"MAP(VARCHAR, DATE)",YES,,,
+      map_timestamp_col,"MAP(VARCHAR, TIMESTAMP)",YES,,,
+      struct_col,"STRUCT(field_int INTEGER, field_float FLOAT, field_str VARCHAR, field_bool BOOLEAN, field_date DATE, field_timestamp TIMESTAMP)",YES,,,
+  # Note: Test queries local DuckDB for data extracted from Motherduck. This support is deprecated.
+  - name: query_data_duckdb
+    resolver: sql
+    properties:
+      connector: duckdb
+      sql: "select * from all_datatypes order by tinyint_col"
+    result_csv: |
+      tinyint_col,smallint_col,integer_col,bigint_col,hugeint_col,utinyint_col,usmallint_col,uinteger_col,ubigint_col,float_col,double_col,decimal_col,boolean_col,varchar_col,blob_col,date_col,time_col,timestamp_col,timestamp_s_col,timestamp_ms_col,timestamp_ns_col,timestamptz_col,interval_col,uuid_col,list_int_col,list_float_col,list_varchar_col,list_boolean_col,list_timestamp_col,list_date_col,array_int_col,array_float_col,array_varchar_col,array_boolean_col,array_date_col,array_timestamp_col,map_int_col,map_float_col,map_varchar_col,map_boolean_col,map_date_col,map_timestamp_col,struct_col
+      0,0,0,0,0,0,0,0,0,0,0,0,false,,,1970-01-01,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0,00000000-0000-0000-0000-000000000000,"[0,0]","[0,0]","["""",""""]","[false,false]","[""1970-01-01T00:00:00Z"",""1970-01-01T00:00:00Z""]","[""1970-01-01"",""1970-01-01""]","[0,0,0]","[0,0,0]","["""","""",""""]","[false,false,false]","[""1970-01-01"",""1970-01-01"",""1970-01-01""]","[""1970-01-01T00:00:00Z"",""1970-01-01T00:00:00Z"",""1970-01-01T00:00:00Z""]","{"""":0}","{"""":0}","{"""":""""}","{"""":false}","{"""":""1970-01-01""}","{"""":""1970-01-01T00:00:00Z""}","{""field_bool"":false,""field_date"":""1970-01-01"",""field_float"":0,""field_int"":0,""field_str"":"""",""field_timestamp"":""1970-01-01T00:00:00Z""}"
+      127,32767,2147483647,9223372036854776000,1234567890123456800,255,65535,4294967295,18446744073709552000,3.141590118408203,2.71828,1234.567,true,Hello,SGVsbG8gQmxvYg==,2025-04-29,0001-01-01T12:34:56Z,2025-04-29T12:34:56Z,2025-04-29T12:34:56Z,2025-04-29T12:34:56.123Z,2025-04-29T12:34:56.123456789Z,2025-04-29T12:34:56Z,31104000000,550e8400-e29b-41d4-a716-446655440000,"[1,2]","[1.100000023841858,2.200000047683716]","[""A"",""B""]","[true,false]","[""2025-04-29T12:34:56Z"",""2025-05-01T12:34:56Z""]","[""2025-04-29"",""2025-05-01""]","[1,2,3]","[1.100000023841858,2.200000047683716,3.299999952316284]","[""A"",""B"",""C""]","[true,false,true]","[""2025-04-29"",""2025-05-01"",""2025-05-02""]","[""2025-04-29T12:34:56Z"",""2025-05-01T12:34:56Z"",""2025-05-02T12:34:56Z""]","{""key1"":1,""key2"":2}","{""key1"":1.100000023841858,""key2"":2.200000047683716}","{""key1"":""A"",""key2"":""B""}","{""key1"":true,""key2"":false}","{""key1"":""2025-04-29"",""key2"":""2025-05-01""}","{""key1"":""2025-04-29T12:34:56Z"",""key2"":""2025-05-01T12:34:56Z""}","{""field_bool"":true,""field_date"":""2025-04-29"",""field_float"":1.2300000190734863,""field_int"":123,""field_str"":""Struct Field"",""field_timestamp"":""2025-04-29T12:34:56Z""}"
+      ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+  # Note: Test queries local DuckDB for data extracted from Motherduck. This support is deprecated.
+  - name: query_datatypes_motherduck
+    resolver: sql
+    properties:
+      connector: duckdb
+      sql: "describe all_datatypes"
     result_csv: |
       column_name,column_type,null,key,default,extra
       tinyint_col,TINYINT,YES,,,

--- a/runtime/testruntime/connectors.go
+++ b/runtime/testruntime/connectors.go
@@ -100,9 +100,12 @@ var Connectors = map[string]ConnectorAcquireFunc{
 			require.NoError(t, godotenv.Load(envPath))
 		}
 
+		path := os.Getenv("RILL_RUNTIME_MOTHERDUCK_TEST_PATH")
+		require.NotEmpty(t, path)
 		token := os.Getenv("RILL_RUNTIME_MOTHERDUCK_TEST_TOKEN")
-		require.NotEmpty(t, token, "RILL_RUNTIME_MOTHERDUCK_TEST_TOKEN not configured")
-		return map[string]string{"token": token}
+		require.NotEmpty(t, token)
+
+		return map[string]string{"path": path, "token": token}
 	},
 	// gcs connector uses an actual gcs bucket with data populated from testdata/init_data/azure.
 	"gcs": func(t TestingT) map[string]string {


### PR DESCRIPTION
- Loads the Motherduck extension and validates that `token` is set when the DuckDB path starts with `md:`
- Updates the deprecated Motherduck-to-DuckDB executor to use the `token` and `path` from `motherduck.yaml`
- Updates the integration test to test Motherduck both as an OLAP and as a source

**Checklist:**
- [x] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
