### PR TITLE
installing motherduck based on path

### DIFF
--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -476,7 +476,13 @@ func (c *connection) reopenDB(ctx context.Context) error {
 		connInitQueries []string
 	)
 
-	if strings.HasPrefix(strings.TrimSpace(c.config.Path), "md:") {
+	normalize := func(s string) string {
+		s = strings.TrimSpace(s)
+		s = strings.Trim(s, `"'`)
+		return s
+	}
+
+	if strings.HasPrefix(normalize(c.config.Path), "md:") || strings.HasPrefix(normalize(c.config.Attach), "md:") {
 		dbInitQueries = append(dbInitQueries,
 			"INSTALL 'motherduck'",
 			"LOAD 'motherduck'",

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -476,7 +476,7 @@ func (c *connection) reopenDB(ctx context.Context) error {
 		connInitQueries []string
 	)
 
-	if c.driverName == "motherduck" {
+	if strings.HasPrefix(strings.TrimSpace(c.config.Path), "md:") {
 		dbInitQueries = append(dbInitQueries,
 			"INSTALL 'motherduck'",
 			"LOAD 'motherduck'",


### PR DESCRIPTION
>2. Using driver: duckdb instead of driver: motherduck to be consistent with what we do with ClickHouse

based on this we need to install motherduck based on path

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
