### PR TITLE
Add managed to default duckdb.yaml on project init

### DIFF
--- a/runtime/parser/init.go
+++ b/runtime/parser/init.go
@@ -51,10 +51,13 @@ mock_users:
 	switch olap {
 	case "duckdb":
 		connectorYAML = `type: connector
+
 driver: duckdb
+managed: true
 `
 	case "clickhouse":
 		connectorYAML = `type: connector
+
 driver: clickhouse
 managed: true
 `

--- a/runtime/parser/init_test.go
+++ b/runtime/parser/init_test.go
@@ -61,6 +61,7 @@ func TestInitWithDuckDB(t *testing.T) {
 	require.NoError(err)
 	require.Contains(duckdbYAML, "type: connector")
 	require.Contains(duckdbYAML, "driver: duckdb")
+	require.Contains(duckdbYAML, "managed: true")
 }
 
 func TestInitWithClickHouse(t *testing.T) {
@@ -90,6 +91,7 @@ func TestInitWithClickHouse(t *testing.T) {
 	require.NoError(err)
 	require.Contains(clickhouseYAML, "type: connector")
 	require.Contains(clickhouseYAML, "driver: clickhouse")
+	require.Contains(clickhouseYAML, "managed: true")
 
 	// Verify that duckdb.yaml is NOT created for ClickHouse projects
 	_, err = repo.Get(t.Context(), "connectors/duckdb.yaml")


### PR DESCRIPTION
Add managed to default duckdb.yaml on project init

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] [Linked the issues it closes](https://linear.app/rilldata/issue/PLAT-239/add-managed-true-to-default-duckdbyaml-on-project-init)
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
