### PR TITLE
feat: Automatically configure duckdb secrets for object stores

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	github.com/fatih/color v1.16.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/getkin/kin-openapi v0.132.0
-	github.com/go-git/go-billy/v5 v5.6.2
 	github.com/go-git/go-git/v5 v5.13.2
 	github.com/go-jose/go-jose/v3 v3.0.4
 	github.com/go-logr/zapr v1.2.4
@@ -162,6 +161,7 @@ require (
 require (
 	github.com/ForceCLI/inflect v0.0.0-20130829110746-cc00b5ad7a6a // indirect
 	github.com/ViViDboarder/gotifier v0.0.0-20140619195515-0f19f3d7c54c // indirect
+	github.com/go-git/go-billy/v5 v5.6.2 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect

--- a/runtime/drivers/models.go
+++ b/runtime/drivers/models.go
@@ -3,6 +3,8 @@ package drivers
 import (
 	"context"
 	"time"
+
+	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 )
 
 // ModelExecutor executes models.
@@ -88,6 +90,7 @@ type ModelEnv struct {
 	RepoRoot           string
 	StageChanges       bool
 	DefaultMaterialize bool
+	Connectors         []*runtimev1.Connector
 	AcquireConnector   func(ctx context.Context, name string) (Handle, func(), error)
 }
 

--- a/runtime/drivers/registry.go
+++ b/runtime/drivers/registry.go
@@ -184,3 +184,38 @@ func (i *Instance) Config() (InstanceConfig, error) {
 
 	return res, nil
 }
+
+func (i *Instance) ResolveConnectors() []*runtimev1.Connector {
+	var res []*runtimev1.Connector
+	res = append(res, i.Connectors...)
+	res = append(res, i.ProjectConnectors...)
+	// implicit connectors
+	vars := i.ResolveVariables(true)
+	for k := range vars {
+		if !strings.HasPrefix(k, "connector.") {
+			continue
+		}
+
+		parts := strings.Split(k, ".")
+		if len(parts) <= 2 {
+			continue
+		}
+
+		// Implicitly defined connectors always have the same name as the driver
+		name := parts[1]
+		found := false
+		for _, c := range res {
+			if c.Name == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			res = append(res, &runtimev1.Connector{
+				Type: name,
+				Name: name,
+			})
+		}
+	}
+	return res
+}

--- a/runtime/reconcilers/model.go
+++ b/runtime/reconcilers/model.go
@@ -1562,7 +1562,12 @@ func (r *ModelReconciler) acquireExecutorInner(ctx context.Context, opts *driver
 
 // newModelEnv makes a ModelEnv configured using the current instance.
 func (r *ModelReconciler) newModelEnv(ctx context.Context) (*drivers.ModelEnv, error) {
-	cfg, err := r.C.Runtime.InstanceConfig(ctx, r.C.InstanceID)
+	inst, err := r.C.Runtime.Instance(ctx, r.C.InstanceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to access instance: %w", err)
+	}
+
+	cfg, err := inst.Config()
 	if err != nil {
 		return nil, fmt.Errorf("failed to access instance config: %w", err)
 	}
@@ -1583,6 +1588,7 @@ func (r *ModelReconciler) newModelEnv(ctx context.Context) (*drivers.ModelEnv, e
 		RepoRoot:           repoRoot,
 		StageChanges:       cfg.StageChanges,
 		DefaultMaterialize: cfg.ModelDefaultMaterialize,
+		Connectors:         inst.ResolveConnectors(),
 		AcquireConnector:   r.C.AcquireConn,
 	}, nil
 }

--- a/runtime/resolvers/testdata/s3_connector.yaml
+++ b/runtime/resolvers/testdata/s3_connector.yaml
@@ -36,7 +36,8 @@ project_files:
     type: model
     connector: duckdb
     materialize: true
-    pre_exec: "CREATE SECRET secret1 (TYPE s3, KEY_ID '{{.env.connector.s3.aws_access_key_id}}', SECRET '{{.env.connector.s3.aws_secret_access_key}}', REGION 'us-east-1')"
+    # commenting the `pre_exec` below to test that automatic s3 secret creation in duckdb works 
+    # pre_exec: "CREATE SECRET secret1 (TYPE s3, KEY_ID '{{.env.connector.s3.aws_access_key_id}}', SECRET '{{.env.connector.s3.aws_secret_access_key}}', REGION 'us-east-1')"
     partitions:
       glob:
         path: s3://integration-test.rilldata.com/glob_test/y=202*/a*.csv


### PR DESCRIPTION
https://linear.app/rilldata/issue/PLAT-217/automatically-create-duckdb-secrets-for-compatible-connectors

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
