### PR TITLE
fix: empty existing directories return EOF error on project clone

### DIFF
--- a/cli/cmd/project/clone.go
+++ b/cli/cmd/project/clone.go
@@ -1,7 +1,9 @@
 package project
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/rilldata/rill/cli/cmd/env"
@@ -103,6 +105,9 @@ func isDirAbsentOrEmpty(path string) (bool, error) {
 	// Read the directory entries
 	entries, err := f.Readdirnames(1)
 	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return len(entries) == 0, nil
+		}
 		return false, err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	github.com/fatih/color v1.16.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/getkin/kin-openapi v0.132.0
-	github.com/go-git/go-billy/v5 v5.6.2
 	github.com/go-git/go-git/v5 v5.13.2
 	github.com/go-jose/go-jose/v3 v3.0.4
 	github.com/go-logr/zapr v1.2.4
@@ -162,6 +161,7 @@ require (
 require (
 	github.com/ForceCLI/inflect v0.0.0-20130829110746-cc00b5ad7a6a // indirect
 	github.com/ViViDboarder/gotifier v0.0.0-20140619195515-0f19f3d7c54c // indirect
+	github.com/go-git/go-billy/v5 v5.6.2 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect


### PR DESCRIPTION
closes https://linear.app/rilldata/issue/PLAT-244/project-clone-fails-with-eof-when-directory-already-exists

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
