### PR TITLE
tweak: update dark mode colors for canvas charts

### DIFF
--- a/web-common/src/features/canvas/components/charts/Chart.svelte
+++ b/web-common/src/features/canvas/components/charts/Chart.svelte
@@ -24,6 +24,7 @@
   export let component: BaseChart<ChartSpec>;
 
   $: themePreference = $themeControl;
+  $: isDarkMode = themePreference === "dark";
 
   $: ({ instanceId } = $runtime);
 
@@ -54,7 +55,13 @@
 
   $: schema = $schemaStore;
 
-  $: chartQuery = getChartData(store, component, chartSpec, timeAndFilterStore);
+  $: chartQuery = getChartData(
+    store,
+    component,
+    chartSpec,
+    timeAndFilterStore,
+    isDarkMode,
+  );
 
   $: ({ isFetching, data, error } = $chartQuery);
   $: hasNoData = !isFetching && data.length === 0;
@@ -127,12 +134,12 @@
           bind:viewVL
           canvasDashboard
           data={{ "metrics-view": data }}
-          theme={themePreference === "dark" ? "dark" : "light"}
+          theme={isDarkMode ? "dark" : "light"}
           {spec}
           {colorMapping}
           renderer="canvas"
           {expressionFunctions}
-          config={getRillTheme(true, themePreference === "dark")}
+          config={getRillTheme(true, isDarkMode)}
         />
       {/if}
     {/if}

--- a/web-common/src/features/canvas/components/charts/builder.ts
+++ b/web-common/src/features/canvas/components/charts/builder.ts
@@ -18,6 +18,10 @@ import {
   mergedVlConfig,
   resolveColor,
 } from "@rilldata/web-common/features/canvas/components/charts/util";
+import {
+  BarHighlightColorDark,
+  BarHighlightColorLight,
+} from "@rilldata/web-common/features/dashboards/time-series/chart-colors";
 import type { Color } from "chroma-js";
 import merge from "deepmerge";
 import type { VisualizationSpec } from "svelte-vega";
@@ -349,6 +353,7 @@ export function buildHoverRuleLayer(args: {
   primaryColor: Color;
   xBand?: number;
   isBarMark?: boolean;
+  isDarkMode?: boolean;
 }): UnitSpec<Field> {
   const {
     xField,
@@ -360,6 +365,7 @@ export function buildHoverRuleLayer(args: {
     primaryColor,
     xBand,
     isBarMark = false,
+    isDarkMode = false,
   } = args;
 
   return {
@@ -390,7 +396,11 @@ export function buildHoverRuleLayer(args: {
           {
             param: "hover",
             empty: false,
-            value: isBarMark ? "#eee" : primaryColor.brighten().css(),
+            value: isBarMark
+              ? isDarkMode
+                ? BarHighlightColorDark
+                : BarHighlightColorLight
+              : primaryColor.brighten().css(),
           },
         ],
         value: "transparent",

--- a/web-common/src/features/canvas/components/charts/cartesian-charts/area/spec.ts
+++ b/web-common/src/features/canvas/components/charts/cartesian-charts/area/spec.ts
@@ -59,6 +59,7 @@ export function generateVLAreaChartSpec(
       multiValueTooltipChannel,
       xSort: config.x?.sort,
       primaryColor: data.theme.primary,
+      isDarkMode: data.isDarkMode,
       pivot:
         xField && yField && colorField && multiValueTooltipChannel?.length
           ? { field: colorField, value: yField, groupby: [xField] }

--- a/web-common/src/features/canvas/components/charts/cartesian-charts/bar-chart/spec.ts
+++ b/web-common/src/features/canvas/components/charts/cartesian-charts/bar-chart/spec.ts
@@ -47,6 +47,7 @@ export function generateVLBarChartSpec(
       multiValueTooltipChannel,
       xSort: config.x?.sort,
       primaryColor: data.theme.primary,
+      isDarkMode: data.isDarkMode,
       xBand: config.x?.type === "temporal" ? 0.5 : undefined,
       pivot:
         xField && yField && colorField && multiValueTooltipChannel?.length

--- a/web-common/src/features/canvas/components/charts/cartesian-charts/line-chart/spec.ts
+++ b/web-common/src/features/canvas/components/charts/cartesian-charts/line-chart/spec.ts
@@ -54,6 +54,7 @@ export function generateVLLineChartSpec(
       multiValueTooltipChannel,
       xSort: config.x?.sort,
       primaryColor: data.theme.primary,
+      isDarkMode: data.isDarkMode,
       pivot:
         xField && yField && colorField && multiValueTooltipChannel?.length
           ? { field: colorField, value: yField, groupby: [xField] }

--- a/web-common/src/features/canvas/components/charts/cartesian-charts/multi-metric-chart.ts
+++ b/web-common/src/features/canvas/components/charts/cartesian-charts/multi-metric-chart.ts
@@ -149,6 +149,7 @@ export function generateVLMultiMetricChartSpec(
     multiValueTooltipChannel,
     primaryColor: data.theme.primary,
     xBand: xBand,
+    isDarkMode: data.isDarkMode,
     pivot:
       xField && measures.length && multiValueTooltipChannel?.length
         ? { field: measureField, value: valueField, groupby: [xField] }

--- a/web-common/src/features/canvas/components/charts/cartesian-charts/stacked-bar/default.ts
+++ b/web-common/src/features/canvas/components/charts/cartesian-charts/stacked-bar/default.ts
@@ -47,6 +47,7 @@ export function generateVLStackedBarChartSpec(
       multiValueTooltipChannel,
       xSort: config.x?.sort,
       primaryColor: data.theme.primary,
+      isDarkMode: data.isDarkMode,
       xBand: config.x?.type === "temporal" ? 0.5 : undefined,
       pivot:
         xField && yField && colorField && multiValueTooltipChannel?.length

--- a/web-common/src/features/canvas/components/charts/cartesian-charts/stacked-bar/normalized.ts
+++ b/web-common/src/features/canvas/components/charts/cartesian-charts/stacked-bar/normalized.ts
@@ -106,6 +106,7 @@ export function generateVLStackedBarNormalizedSpec(
       multiValueTooltipChannel,
       xSort: config.x?.sort,
       primaryColor: data.theme.primary,
+      isDarkMode: data.isDarkMode,
       xBand: config.x?.type === "temporal" ? 0.5 : undefined,
       pivot:
         xField && yField && colorField && multiValueTooltipChannel?.length

--- a/web-common/src/features/canvas/components/charts/circular-charts/pie.ts
+++ b/web-common/src/features/canvas/components/charts/circular-charts/pie.ts
@@ -105,6 +105,7 @@ export function generateVLPieChartSpec(
       mark: {
         type: "text",
         align: "center",
+        color: data.isDarkMode ? "#eeeeee" : "#353535",
         baseline: "middle",
         fontWeight: "normal",
         fontSize: getTotalFontSize(config.innerRadius),

--- a/web-common/src/features/canvas/components/charts/combo-charts/spec.ts
+++ b/web-common/src/features/canvas/components/charts/combo-charts/spec.ts
@@ -107,6 +107,7 @@ export function generateVLComboChartSpec(
       defaultTooltip: defaultTooltipChannel,
       xSort: config.x?.sort,
       primaryColor: data.theme.primary,
+      isDarkMode: data.isDarkMode,
       xBand: config.x?.type === "temporal" ? 0.5 : undefined,
     }),
   );

--- a/web-common/src/features/canvas/components/charts/selector.ts
+++ b/web-common/src/features/canvas/components/charts/selector.ts
@@ -22,6 +22,7 @@ export function getChartData(
   component: BaseChart<ChartSpec>,
   config: ChartSpec,
   timeAndFilterStore: Readable<TimeAndFilterStore>,
+  isDarkMode: boolean,
 ): Readable<ChartDataResult> {
   const chartDataQuery = component.createChartDataQuery(
     ctx,
@@ -87,6 +88,7 @@ export function getChartData(
         error: chartData?.error,
         fields: fieldSpecMap,
         domainValues,
+        isDarkMode,
         theme: {
           primary: theme.primary || chroma(`hsl(${defaultPrimaryColors[500]})`),
           secondary:

--- a/web-common/src/features/canvas/components/charts/types.ts
+++ b/web-common/src/features/canvas/components/charts/types.ts
@@ -50,6 +50,7 @@ export type ChartDataResult = {
   error?: HTTPError | null;
   theme: { primary: Color; secondary: Color };
   domainValues?: ChartDomainValues;
+  isDarkMode: boolean;
 };
 
 export interface ChartDomainValues {

--- a/web-common/src/features/dashboards/time-series/chart-colors.ts
+++ b/web-common/src/features/dashboards/time-series/chart-colors.ts
@@ -43,3 +43,6 @@ export const BarColor = "var(--color-theme-400)";
 export const AnnotationDiamondColor = "var(--color-theme-800)";
 export const AnnotationHighlightColor = "var(--color-theme-500)";
 export const AnnotationHighlightBottomColor = "var(--color-theme-800)";
+
+export const BarHighlightColorLight = "#eeeeee";
+export const BarHighlightColorDark = "#353535";


### PR DESCRIPTION
For dark mode update colors for highlight bar and donut total

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
