### PR TITLE
fix: adds back the caret for pivot

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotExpandableCell.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotExpandableCell.svelte
@@ -23,7 +23,7 @@
   {#if value === "LOADING_CELL"}
     <span class="loading-cell" />
   {:else if assembledAndCanExpand}
-    <div class="caret opacity-0 group-hover/cell:opacity-100" class:expanded>
+    <div class="caret opacity-100" class:expanded>
       <ChevronRight size="16px" color="#9CA3AF" />
     </div>
   {:else if row.depth >= 1}


### PR DESCRIPTION
Adds back the caret for sub-levels to always be visible for Pivot. Users weren't finding it when we only displayed it on hover

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
