### PR TITLE
Refactor package `metricssql` to avoid circular dependencies

### DIFF
--- a/runtime/metricsview/metricssql/filter_parser.go
+++ b/runtime/metricsview/metricssql/filter_parser.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rilldata/rill/runtime/metricsview"
 )
 
-func ParseSQLFilter(sql string) (*metricsview.Expression, error) {
+func ParseFilter(sql string) (*metricsview.Expression, error) {
 	p := parser.New()
 	p.SetSQLMode(mysql.ModeANSI | mysql.ModeANSIQuotes)
 	sql = "SELECT * FROM tbl WHERE " + sql

--- a/runtime/metricsview/metricssql/filter_parser_test.go
+++ b/runtime/metricsview/metricssql/filter_parser_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseSQLFilter(t *testing.T) {
+func TestParseFilter(t *testing.T) {
 	tests := []struct {
 		name    string
 		sql     string
@@ -211,7 +211,7 @@ func TestParseSQLFilter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := metricssql.ParseSQLFilter(tt.sql)
+			got, err := metricssql.ParseFilter(tt.sql)
 			if tt.wantErr {
 				require.Equal(t, err, tt.wantErr)
 			} else {

--- a/runtime/metricsview/metricssql/parser.go
+++ b/runtime/metricsview/metricssql/parser.go
@@ -161,7 +161,7 @@ func (q *query) parseFrom(ctx context.Context, node *ast.TableRefsClause) error 
 	q.metricsView = mv
 
 	spec := mv.GetMetricsView().State.ValidSpec
-	if mv.GetMetricsView().State.ValidSpec == nil {
+	if spec == nil {
 		return fmt.Errorf("metrics view %q is not valid", mv.Meta.Name.Name)
 	}
 	q.metricsViewSpec = spec

--- a/runtime/metricsview/metricssql/parser.go
+++ b/runtime/metricsview/metricssql/parser.go
@@ -148,7 +148,7 @@ func (q *query) parseFrom(ctx context.Context, node *ast.TableRefsClause) error 
 		return fmt.Errorf("metrics sql: only FROM `metrics_view` is supported")
 	}
 
-	if q.opts.GetMetricsView == nil {
+	if q.opts == nil || q.opts.GetMetricsView == nil {
 		return fmt.Errorf("metrics sql: must provide the GetMetricsView option to the compiler")
 	}
 	mv, err := q.opts.GetMetricsView(ctx, tblName.Name.String())

--- a/runtime/metricsview/metricssql/parser.go
+++ b/runtime/metricsview/metricssql/parser.go
@@ -13,60 +13,52 @@ import (
 	"github.com/pingcap/tidb/pkg/parser/mysql"
 	"github.com/pingcap/tidb/pkg/parser/opcode"
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
-	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/metricsview"
-	"github.com/rilldata/rill/runtime/metricsview/executor"
 
 	// need to import parser driver as well
 	_ "github.com/pingcap/tidb/pkg/parser/test_driver"
 )
 
+// Compiler is responsible for parsing metrics SQL queries into metricsview.Query objects.
+//
+// Internally, it creates and re-uses a TiDB parser object.
+// It's not lightweight, so re-use the Compiler when possible.
+// However, note that it is not concurrency safe.
 type Compiler struct {
-	p          *parser.Parser
-	controller *runtime.Controller
-	instanceID string
-	claims     *runtime.SecurityClaims
-	priority   int
+	p    *parser.Parser
+	opts *CompilerOptions
 }
 
-// New returns a compiler and created a tidb parser object.
-// The instantiated parser object and thus compiler is not goroutine safe and not lightweight.
-// It is better to keep it in a single goroutine, and reuse it if possible.
-func New(ctrl *runtime.Controller, instanceID string, claims *runtime.SecurityClaims, priority int) *Compiler {
+// CompilerOptions provide options for the Compiler.
+type CompilerOptions struct {
+	// GetMetricsView is a callback to lookup a referenced metrics view.
+	// It is required for parsing full queries, but optional when parsing only filters.
+	GetMetricsView func(ctx context.Context, name string) (*runtimev1.Resource, error)
+	// GetTimestamps is a callback to resolve timestamps for a given time dimension.
+	// It is optional, but if not provided, queries that use rilltime expressions will error.
+	// TODO: Ideally we should replace this with support for rilltime expressions in *metricsview.Expression itself, so evaluation can be delayed until query execution.
+	GetTimestamps func(ctx context.Context, mv *runtimev1.Resource, timeDim string) (metricsview.TimestampsResult, error)
+}
+
+// New creates a new Compiler.
+func New(opts *CompilerOptions) *Compiler {
 	p := parser.New()
 	// Weirdly setting just ModeANSI which is a combination having ModeANSIQuotes doesn't ensure double quotes are used to identify SQL identifiers
 	p.SetSQLMode(mysql.ModeANSI | mysql.ModeANSIQuotes)
+
 	return &Compiler{
-		p:          p,
-		controller: ctrl,
-		instanceID: instanceID,
-		claims:     claims,
-		priority:   priority,
+		p:    p,
+		opts: opts,
 	}
 }
 
-type query struct {
-	q *metricsview.Query
-
-	controller *runtime.Controller
-	claims     *runtime.SecurityClaims
-	instanceID string
-	priority   int
-
-	// fields available after parsing FROM clause
-	metricsViewSpec *runtimev1.MetricsViewSpec
-	executor        *executor.Executor
-	dims            map[string]any
-	measures        map[string]any
-}
-
-// Rewrite parses a metrics SQL query and compiles it to a metricview.Query.
-// It uses tidb parser(which is a MySQL compliant parser) and transforms over the generated AST to generate query.
-// We use MySQL's ANSI sql Mode to conform more closely to standard SQL.
+// Parse parses a metrics SQL query into a metricview.Query.
+// It uses the tidb parser (which is a MySQL compliant parser) and transforms over the generated AST to generate query.
+// We use MySQL's ANSI SQL Mode to conform more closely to standard SQL.
 //
 // Whenever adding transform method over new node type also look at its `Restore` method to get an idea how it can be parsed into a SQL query.
-func (c *Compiler) Rewrite(ctx context.Context, sql string) (*metricsview.Query, error) {
+func (c *Compiler) Parse(ctx context.Context, sql string) (*metricsview.Query, error) {
 	stmtNodes, _, err := c.p.ParseSQL(sql)
 	if err != nil {
 		return nil, err
@@ -82,19 +74,13 @@ func (c *Compiler) Rewrite(ctx context.Context, sql string) (*metricsview.Query,
 	}
 
 	q := &query{
-		q:          &metricsview.Query{},
-		controller: c.controller,
-		claims:     c.claims,
-		instanceID: c.instanceID,
-		priority:   c.priority,
+		q:    &metricsview.Query{},
+		opts: c.opts,
 	}
 
 	// parse from clause
 	if err := q.parseFrom(ctx, stmt.From); err != nil {
 		return nil, err
-	}
-	if q.executor != nil {
-		defer q.executor.Close()
 	}
 
 	// parse select fields
@@ -134,6 +120,17 @@ func (c *Compiler) Rewrite(ctx context.Context, sql string) (*metricsview.Query,
 	return q.q, nil
 }
 
+type query struct {
+	q    *metricsview.Query
+	opts *CompilerOptions
+
+	// fields available after parsing FROM clause
+	metricsView     *runtimev1.Resource
+	metricsViewSpec *runtimev1.MetricsViewSpec
+	dims            map[string]any
+	measures        map[string]any
+}
+
 func (q *query) parseFrom(ctx context.Context, node *ast.TableRefsClause) error {
 	n := node.TableRefs
 	if n == nil || n.Left == nil {
@@ -151,36 +148,29 @@ func (q *query) parseFrom(ctx context.Context, node *ast.TableRefsClause) error 
 		return fmt.Errorf("metrics sql: only FROM `metrics_view` is supported")
 	}
 
-	resource := &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: tblName.Name.String()}
-	mv, err := q.controller.Get(ctx, resource, false)
+	if q.opts.GetMetricsView == nil {
+		return fmt.Errorf("metrics sql: must provide the GetMetricsView option to the compiler")
+	}
+	mv, err := q.opts.GetMetricsView(ctx, tblName.Name.String())
 	if err != nil {
 		if errors.Is(err, drivers.ErrNotFound) {
 			return fmt.Errorf("metrics sql: metrics view `%s` not found", tblName.Name.String())
 		}
 		return err
 	}
+	q.metricsView = mv
 
-	q.q.MetricsView = tblName.Name.String()
 	spec := mv.GetMetricsView().State.ValidSpec
-	if spec == nil {
-		return fmt.Errorf("metrics view %q is not valid: (status: %q, error: %q)", mv.Meta.GetName(), mv.Meta.ReconcileStatus, mv.Meta.ReconcileError)
+	if mv.GetMetricsView().State.ValidSpec == nil {
+		return fmt.Errorf("metrics view %q is not valid", mv.Meta.Name.Name)
 	}
 	q.metricsViewSpec = spec
-	security, err := q.controller.Runtime.ResolveSecurity(q.instanceID, q.claims, mv)
-	if err != nil {
-		return fmt.Errorf("metrics sql: failed to resolve security: %w", err)
-	}
-
-	ex, err := executor.New(ctx, q.controller.Runtime, q.instanceID, q.metricsViewSpec, false, security, q.priority)
-	if err != nil {
-		return fmt.Errorf("metrics sql: failed to create executor: %w", err)
-	}
-	q.executor = ex
 
 	q.measures = make(map[string]any, len(spec.Measures))
 	for _, measure := range spec.Measures {
 		q.measures[measure.Name] = nil
 	}
+
 	q.dims = make(map[string]any, len(spec.Dimensions))
 	for _, dim := range spec.Dimensions {
 		q.dims[dim.Name] = nil

--- a/runtime/metricsview/metricssql/parser.go
+++ b/runtime/metricsview/metricssql/parser.go
@@ -159,6 +159,7 @@ func (q *query) parseFrom(ctx context.Context, node *ast.TableRefsClause) error 
 		return err
 	}
 	q.metricsView = mv
+	q.q.MetricsView = mv.Meta.Name.Name
 
 	spec := mv.GetMetricsView().State.ValidSpec
 	if spec == nil {

--- a/runtime/metricsview/metricssql/parser_test.go
+++ b/runtime/metricsview/metricssql/parser_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/metricsview"
+	"github.com/rilldata/rill/runtime/metricsview/executor"
 	"github.com/rilldata/rill/runtime/metricsview/metricssql"
 	"github.com/rilldata/rill/runtime/testruntime"
 	"github.com/stretchr/testify/require"
@@ -16,22 +17,48 @@ import (
 
 func TestCompile(t *testing.T) {
 	rt, instanceID := testruntime.NewInstanceForProject(t, "ad_bids")
-	ctrl, err := rt.Controller(context.Background(), instanceID)
+	ctrl, err := rt.Controller(t.Context(), instanceID)
 	require.NoError(t, err)
-	olap, release, err := rt.OLAP(context.Background(), instanceID, "")
+	olap, release, err := rt.OLAP(t.Context(), instanceID, "")
 	require.NoError(t, err)
 	defer release()
 
 	resource := &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics"}
-	mv, err := ctrl.Get(context.Background(), resource, false)
+	mv, err := ctrl.Get(t.Context(), resource, false)
 	require.NoError(t, err)
 
 	resource = &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: "ad_bids_metrics_advanced"}
-	advancedMV, err := ctrl.Get(context.Background(), resource, false)
+	advancedMV, err := ctrl.Get(t.Context(), resource, false)
 	require.NoError(t, err)
 
 	claims := &runtime.SecurityClaims{}
-	compiler := metricssql.New(ctrl, instanceID, claims, 1)
+	compiler := metricssql.New(&metricssql.CompilerOptions{
+		GetMetricsView: func(ctx context.Context, name string) (*runtimev1.Resource, error) {
+			mv, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: name}, false)
+			if err != nil {
+				return nil, err
+			}
+			sec, err := rt.ResolveSecurity(ctrl.InstanceID, claims, mv)
+			if err != nil {
+				return nil, err
+			}
+			if !sec.CanAccess() {
+				return nil, runtime.ErrForbidden
+			}
+			return mv, nil
+		},
+		GetTimestamps: func(ctx context.Context, mv *runtimev1.Resource, timeDim string) (metricsview.TimestampsResult, error) {
+			sec, err := rt.ResolveSecurity(ctrl.InstanceID, claims, mv)
+			if err != nil {
+				return metricsview.TimestampsResult{}, err
+			}
+			e, err := executor.New(ctx, rt, instanceID, mv.GetMetricsView().State.ValidSpec, false, sec, 0)
+			if err != nil {
+				return metricsview.TimestampsResult{}, err
+			}
+			return e.Timestamps(ctx, timeDim)
+		},
+	})
 	passTests := []struct {
 		inSQL    string
 		outSQL   string
@@ -159,7 +186,7 @@ func TestCompile(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, test := range passTests {
-		q, err := compiler.Rewrite(context.Background(), test.inSQL)
+		q, err := compiler.Parse(t.Context(), test.inSQL)
 		require.NoError(t, err, "input = %v", test.inSQL)
 		ast, err := metricsview.NewAST(test.resource.GetMetricsView().State.ValidSpec, clm, q, olap.Dialect())
 		require.NoError(t, err)
@@ -169,7 +196,7 @@ func TestCompile(t *testing.T) {
 		require.Equal(t, test.outSQL, sql)
 		require.ElementsMatch(t, test.args, args)
 
-		res, err := olap.Query(context.Background(), &drivers.Statement{Query: sql, Args: args})
+		res, err := olap.Query(t.Context(), &drivers.Statement{Query: sql, Args: args})
 		require.NoError(t, err)
 		require.NoError(t, res.Close())
 	}

--- a/runtime/metricsview/metricssql/time_range_parser.go
+++ b/runtime/metricsview/metricssql/time_range_parser.go
@@ -24,7 +24,7 @@ func (q *query) parseTimeRangeStart(ctx context.Context, node *ast.FuncCallExpr,
 		timeDim = timeDimNode.Name.Name.O
 	}
 
-	if q.opts.GetTimestamps == nil {
+	if q.opts == nil || q.opts.GetTimestamps == nil {
 		return nil, fmt.Errorf("metrics sql: not able to resolve dynamic time expressions in this context")
 	}
 
@@ -58,7 +58,7 @@ func (q *query) parseTimeRangeEnd(ctx context.Context, node *ast.FuncCallExpr, t
 		timeDim = timeDimNode.Name.Name.O
 	}
 
-	if q.opts.GetTimestamps == nil {
+	if q.opts == nil || q.opts.GetTimestamps == nil {
 		return nil, fmt.Errorf("metrics sql: not able to resolve dynamic time expressions in this context")
 	}
 

--- a/runtime/metricsview/metricssql/time_range_parser.go
+++ b/runtime/metricsview/metricssql/time_range_parser.go
@@ -24,7 +24,11 @@ func (q *query) parseTimeRangeStart(ctx context.Context, node *ast.FuncCallExpr,
 		timeDim = timeDimNode.Name.Name.O
 	}
 
-	ts, err := q.executor.Timestamps(ctx, timeDim)
+	if q.opts.GetTimestamps == nil {
+		return nil, fmt.Errorf("metrics sql: not able to resolve dynamic time expressions in this context")
+	}
+
+	ts, err := q.opts.GetTimestamps(ctx, q.metricsView, timeDim)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +58,11 @@ func (q *query) parseTimeRangeEnd(ctx context.Context, node *ast.FuncCallExpr, t
 		timeDim = timeDimNode.Name.Name.O
 	}
 
-	ts, err := q.executor.Timestamps(ctx, timeDim)
+	if q.opts.GetTimestamps == nil {
+		return nil, fmt.Errorf("metrics sql: not able to resolve dynamic time expressions in this context")
+	}
+
+	ts, err := q.opts.GetTimestamps(ctx, q.metricsView, timeDim)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/queries/metricsview_aggregation.go
+++ b/runtime/queries/metricsview_aggregation.go
@@ -528,7 +528,7 @@ func (q *MetricsViewAggregation) getDisplayName(ctx context.Context, rt *runtime
 
 func metricViewExpression(expr *runtimev1.Expression, sql string) (*metricsview.Expression, error) {
 	if expr != nil && sql != "" {
-		sqlExpr, err := metricssql.ParseSQLFilter(sql)
+		sqlExpr, err := metricssql.ParseFilter(sql)
 		if err != nil {
 			return nil, err
 		}
@@ -546,7 +546,7 @@ func metricViewExpression(expr *runtimev1.Expression, sql string) (*metricsview.
 		return metricsview.NewExpressionFromProto(expr), nil
 	}
 	if sql != "" {
-		return metricssql.ParseSQLFilter(sql)
+		return metricssql.ParseFilter(sql)
 	}
 	return nil, nil
 }

--- a/runtime/queries/proto.go
+++ b/runtime/queries/proto.go
@@ -306,7 +306,7 @@ func rowFilterJSON(where *runtimev1.Expression, whereSQL string, filter *runtime
 	}
 	var whereSQLExp *runtimev1.Expression
 	if whereSQL != "" {
-		mvExp, err := metricssql.ParseSQLFilter(whereSQL)
+		mvExp, err := metricssql.ParseFilter(whereSQL)
 		if err != nil {
 			return "", fmt.Errorf("invalid where SQL: %w", err)
 		}

--- a/runtime/resolvers/metrics_sql.go
+++ b/runtime/resolvers/metrics_sql.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 
 	"github.com/mitchellh/mapstructure"
+	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/metricsview"
+	"github.com/rilldata/rill/runtime/metricsview/executor"
 	"github.com/rilldata/rill/runtime/metricsview/metricssql"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -72,8 +74,37 @@ func newMetricsSQL(ctx context.Context, opts *runtime.ResolverOptions) (runtime.
 		return nil, err
 	}
 
-	compiler := metricssql.New(ctrl, opts.InstanceID, opts.Claims, sqlArgs.Priority)
-	query, err := compiler.Rewrite(ctx, props.SQL)
+	// Create a metrics SQL parser
+	compiler := metricssql.New(&metricssql.CompilerOptions{
+		GetMetricsView: func(ctx context.Context, name string) (*runtimev1.Resource, error) {
+			mv, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: name}, false)
+			if err != nil {
+				return nil, err
+			}
+			sec, err := opts.Runtime.ResolveSecurity(ctrl.InstanceID, opts.Claims, mv)
+			if err != nil {
+				return nil, err
+			}
+			if !sec.CanAccess() {
+				return nil, runtime.ErrForbidden
+			}
+			return mv, nil
+		},
+		GetTimestamps: func(ctx context.Context, mv *runtimev1.Resource, timeDim string) (metricsview.TimestampsResult, error) {
+			sec, err := opts.Runtime.ResolveSecurity(ctrl.InstanceID, opts.Claims, mv)
+			if err != nil {
+				return metricsview.TimestampsResult{}, err
+			}
+			e, err := executor.New(ctx, opts.Runtime, opts.InstanceID, mv.GetMetricsView().State.ValidSpec, false, sec, sqlArgs.Priority)
+			if err != nil {
+				return metricsview.TimestampsResult{}, err
+			}
+			return e.Timestamps(ctx, timeDim)
+		},
+	})
+
+	// Parse the metrics SQL query
+	query, err := compiler.Parse(ctx, props.SQL)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/server/canvases.go
+++ b/runtime/server/canvases.go
@@ -121,8 +121,8 @@ func (s *Server) ResolveCanvas(ctx context.Context, req *runtimev1.ResolveCanvas
 	}
 
 	// Extract metrics view names from components
+	var msqlParser *metricssql.Compiler
 	metricsViews := make(map[string]bool)
-
 	for _, cmp := range components {
 		validSpec := cmp.GetComponent().State.ValidSpec
 		if validSpec == nil || validSpec.RendererProperties == nil {
@@ -136,26 +136,43 @@ func (s *Server) ResolveCanvas(ctx context.Context, req *runtimev1.ResolveCanvas
 					metricsViews[name] = true
 				}
 			case "metrics_sql":
-				// Handle single string
-				if sql := v.GetStringValue(); sql != "" {
-					claims := auth.GetClaims(ctx).SecurityClaims()
-					compiler := metricssql.New(ctrl, req.InstanceId, claims, 0)
-					q, err := compiler.Rewrite(ctx, sql)
-					if err == nil && q.MetricsView != "" {
-						metricsViews[q.MetricsView] = true
+				// Instantiate a metrics SQL parser
+				if msqlParser == nil {
+					msqlParser = metricssql.New(&metricssql.CompilerOptions{
+						GetMetricsView: func(ctx context.Context, name string) (*runtimev1.Resource, error) {
+							mv, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: runtime.ResourceKindMetricsView, Name: name}, false)
+							if err != nil {
+								return nil, err
+							}
+							sec, err := s.runtime.ResolveSecurity(ctrl.InstanceID, auth.GetClaims(ctx).SecurityClaims(), mv)
+							if err != nil {
+								return nil, err
+							}
+							if !sec.CanAccess() {
+								return nil, runtime.ErrForbidden
+							}
+							return mv, nil
+						},
+					})
+				}
+
+				// Create list of queries to analyze
+				var queries []string
+				if s := v.GetStringValue(); s != "" {
+					queries = append(queries, s)
+				} else if vals := v.GetListValue(); vals != nil {
+					for _, val := range vals.Values {
+						if s := val.GetStringValue(); s != "" {
+							queries = append(queries, s)
+						}
 					}
 				}
-				// Handle array of strings
-				if listValue := v.GetListValue(); listValue != nil {
-					for _, item := range listValue.Values {
-						if sql := item.GetStringValue(); sql != "" {
-							claims := auth.GetClaims(ctx).SecurityClaims()
-							compiler := metricssql.New(ctrl, req.InstanceId, claims, 0)
-							q, err := compiler.Rewrite(ctx, sql)
-							if err == nil && q.MetricsView != "" {
-								metricsViews[q.MetricsView] = true
-							}
-						}
+
+				// Analyze each query
+				for _, sql := range queries {
+					q, err := msqlParser.Parse(ctx, sql)
+					if err == nil && q.MetricsView != "" {
+						metricsViews[q.MetricsView] = true
 					}
 				}
 			}

--- a/runtime/server/server.go
+++ b/runtime/server/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
+	"github.com/rilldata/rill/runtime/metricsview"
 	"github.com/rilldata/rill/runtime/pkg/activity"
 	"github.com/rilldata/rill/runtime/pkg/graceful"
 	"github.com/rilldata/rill/runtime/pkg/httputil"
@@ -345,6 +346,9 @@ func mapGRPCError(err error) error {
 		return ErrForbidden
 	}
 	if errors.Is(err, runtime.ErrForbidden) {
+		return ErrForbidden
+	}
+	if errors.Is(err, metricsview.ErrForbidden) {
 		return ErrForbidden
 	}
 	return err


### PR DESCRIPTION
This PR refactors the package `runtime/metricsview/metricssql` so it no longer has a dependency on the `runtime` package. This enables it to be imported and used in more places through the codebase.

This change was motivated by the need to parse metrics SQL filters in the `runtime/parser` package. This now becomes possible like this:
```go
expr, err := metricssql.ParseFilter(metricsSQLFilter)
if err != nil { ... }
pb := metricsview.ExpressionToProto(expr)
```

**Checklist:**
- [x] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
