### PR TITLE
Druid time range where clause fix

### DIFF
--- a/runtime/metricsview/executor_timestamps.go
+++ b/runtime/metricsview/executor_timestamps.go
@@ -233,7 +233,7 @@ func (e *Executor) resolveDruid(ctx context.Context, timeExpr string) (Timestamp
 			if err != nil {
 				return err
 			}
-			return errors.New("no rows returned for min time")
+			// don't return error if there are no rows as druid does not return any rows when where clause does not match
 		}
 
 		return nil
@@ -269,7 +269,7 @@ func (e *Executor) resolveDruid(ctx context.Context, timeExpr string) (Timestamp
 			if err != nil {
 				return err
 			}
-			return errors.New("no rows returned for max time")
+			// don't return error if there are no rows as druid does not return any rows when where clause does not match
 		}
 		return nil
 	})
@@ -305,7 +305,7 @@ func (e *Executor) resolveDruid(ctx context.Context, timeExpr string) (Timestamp
 				if err != nil {
 					return err
 				}
-				return errors.New("no rows returned for max time")
+				// don't return error if there are no rows as druid does not return any rows when where clause does not match
 			}
 			return nil
 		})


### PR DESCRIPTION
don't return error if there are no rows as druid does not return any rows when where clause does not match

INSERT DESCRIPTION HERE

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
