### PR TITLE
Increase test connection timeout

### DIFF
--- a/web-common/src/features/entity-management/actions.ts
+++ b/web-common/src/features/entity-management/actions.ts
@@ -78,7 +78,7 @@ export async function waitForResourceReconciliation(
 
       // Last attempt and still not idle
       throw new Error(
-        `Resource reconciliation timeout. Current status: ${reconcileStatus || "unknown"}`,
+        `Resource reconciliation timeout after ${(maxAttempts * pollInterval) / 1000} seconds. Large datasets may take longer to process.`,
       );
     } catch (error) {
       // Resource not found could mean it was deleted due to reconcile failure

--- a/web-common/src/features/entity-management/actions.ts
+++ b/web-common/src/features/entity-management/actions.ts
@@ -46,13 +46,8 @@ export async function waitForResourceReconciliation(
   instanceId: string,
   resourceName: string,
   resourceKind: ResourceKind,
-  connectorType?: string,
 ) {
-  // Use longer timeout for OLAP connectors since they take longer to establish connections
-  const isOLAP =
-    connectorType &&
-    ["clickhouse", "motherduck", "druid", "pinot"].includes(connectorType);
-  const maxAttempts = isOLAP ? 30 : 10; // 60 seconds for OLAP, 20 seconds for others
+  const maxAttempts = 30; // 60 seconds
   const pollInterval = 2000; // 2 seconds
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {

--- a/web-common/src/features/sources/modal/submitAddDataForm.ts
+++ b/web-common/src/features/sources/modal/submitAddDataForm.ts
@@ -181,7 +181,6 @@ export async function submitAddSourceForm(
       instanceId,
       newSourceName,
       ResourceKind.Model,
-      connector.name as string,
     );
   } catch (error) {
     // The source file was already created, so we need to delete it
@@ -271,7 +270,6 @@ export async function submitAddConnectorForm(
       instanceId,
       newConnectorName,
       ResourceKind.Connector,
-      connector.name as string,
     );
   } catch (error) {
     // The connector file was already created, so we need to delete it


### PR DESCRIPTION
This PR adjusts the maximum timeout for resource-level reconciliation to 60 seconds, allowing additional buffer time for processing larger datasets. Closes https://linear.app/rilldata/issue/APP-430/tweak-test-connection-timeout

https://github.com/user-attachments/assets/052d4d07-92be-4981-9eb7-be6f2c564780

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
