### PR TITLE
Fix for array of struct containing array

### DIFF
--- a/runtime/drivers/duckdb/information_schema.go
+++ b/runtime/drivers/duckdb/information_schema.go
@@ -174,7 +174,7 @@ func databaseTypeToPB(dbt string, nullable bool) (*runtimev1.Type, error) {
 	// Handle complex types
 
 	// Handle arrays. They can have the format "type[]" or "type[N]"
-	openBracket := strings.Index(dbt, "[")
+	openBracket := strings.LastIndex(dbt, "[")
 	if openBracket != -1 && strings.HasSuffix(dbt, "]") {
 		at, err := databaseTypeToPB(dbt[:openBracket], true)
 		if err != nil {

--- a/runtime/drivers/duckdb/information_schema_test.go
+++ b/runtime/drivers/duckdb/information_schema_test.go
@@ -240,6 +240,42 @@ func TestDatabaseTypeToPB(t *testing.T) {
 				}}}},
 			}}},
 		},
+		// Array having struct
+		{
+			input: `STRUCT(id BIGINT, name VARCHAR)[]`,
+			output: &runtimev1.Type{
+				Code:     runtimev1.Type_CODE_ARRAY,
+				Nullable: true,
+				ArrayElementType: &runtimev1.Type{
+					Code:     runtimev1.Type_CODE_STRUCT,
+					Nullable: true,
+					StructType: &runtimev1.StructType{Fields: []*runtimev1.StructType_Field{
+						{Name: "id", Type: &runtimev1.Type{Code: runtimev1.Type_CODE_INT64, Nullable: true}},
+						{Name: "name", Type: &runtimev1.Type{Code: runtimev1.Type_CODE_STRING, Nullable: true}},
+					}},
+				},
+			},
+		},
+		// Array of struct having array
+		{
+			input: `STRUCT(id BIGINT, tags VARCHAR[])[]`,
+			output: &runtimev1.Type{
+				Code:     runtimev1.Type_CODE_ARRAY,
+				Nullable: true,
+				ArrayElementType: &runtimev1.Type{
+					Code:     runtimev1.Type_CODE_STRUCT,
+					Nullable: true,
+					StructType: &runtimev1.StructType{Fields: []*runtimev1.StructType_Field{
+						{Name: "id", Type: &runtimev1.Type{Code: runtimev1.Type_CODE_INT64, Nullable: true}},
+						{Name: "tags", Type: &runtimev1.Type{
+							Code:             runtimev1.Type_CODE_ARRAY,
+							Nullable:         true,
+							ArrayElementType: &runtimev1.Type{Code: runtimev1.Type_CODE_STRING, Nullable: true},
+						}},
+					}},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
[PLAT-247: Issues with Duckdb driver in dev: Loads data in inspector but not in results preview](https://linear.app/rilldata/issue/PLAT-247/issues-with-duckdb-driver-in-dev-loads-data-in-inspector-but-not-in)

It was failing for Array of Struct having Array in it.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
