### PR TITLE
feat: enable instance health check caching for motherduck

### DIFF
--- a/runtime/drivers/duckdb/config.go
+++ b/runtime/drivers/duckdb/config.go
@@ -40,6 +40,9 @@ type config struct {
 	Secrets string `mapstructure:"secrets"`
 	// Mode specifies the mode in which to open the database.
 	Mode string `mapstructure:"mode"`
+	// CanScaleToZero indicates if the underlying duckdb service may scale to zero when idle.
+	// When set to true, we try to avoid too frequent non-user queries to the database (such as alert checks and fetching metrics).
+	CanScaleToZero bool `mapstructure:"can_scale_to_zero"`
 
 	// Path switches the implementation to use a generic rduckdb implementation backed by the db used in the Path
 	Path string `mapstructure:"path"`
@@ -89,6 +92,11 @@ func newConfig(cfgMap map[string]any) (*config, error) {
 	}
 	poolSize = max(poolSizeMin, poolSize) // Always enforce min pool size
 	cfg.PoolSize = poolSize
+
+	// set can_scale_to_zero for motherduck by default
+	if _, ok := cfgMap["can_scale_to_zero"]; !ok && cfg.isMotherduck() {
+		cfg.CanScaleToZero = true
+	}
 
 	return cfg, nil
 }

--- a/runtime/drivers/duckdb/olap.go
+++ b/runtime/drivers/duckdb/olap.go
@@ -31,7 +31,7 @@ func (c *connection) Dialect() drivers.Dialect {
 }
 
 func (c *connection) MayBeScaledToZero(ctx context.Context) bool {
-	return false
+	return c.config.CanScaleToZero
 }
 
 func (c *connection) WithConnection(ctx context.Context, priority int, fn drivers.WithConnectionFunc) error {


### PR DESCRIPTION
Instance health check caching will be enabled by default for motherduck

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
