### PR TITLE
refac: pull out metric view selectors from canvas spec

### DIFF
--- a/web-common/src/features/canvas/LocalFiltersHeader.svelte
+++ b/web-common/src/features/canvas/LocalFiltersHeader.svelte
@@ -16,7 +16,7 @@
   $: ({
     specStore,
     parent: {
-      spec: { getDimensionsForMetricView, getMeasuresForMetricView },
+      metricsView: { getDimensionsForMetricView, getMeasuresForMetricView },
     },
     timeAndFilterStore,
     localFilters,

--- a/web-common/src/features/canvas/components/BaseCanvasComponent.ts
+++ b/web-common/src/features/canvas/components/BaseCanvasComponent.ts
@@ -165,7 +165,7 @@ export abstract class BaseCanvasComponent<T = ComponentSpec> {
     );
 
     this.localFilters = new Filters(
-      this.parent.spec,
+      this.parent.metricsView,
       yamlDimensionFilterStore,
       this.id,
     );

--- a/web-common/src/features/canvas/components/charts/Chart.svelte
+++ b/web-common/src/features/canvas/components/charts/Chart.svelte
@@ -39,7 +39,7 @@
   $: store = getCanvasStore(canvasName, instanceId);
   $: ({
     canvasEntity: {
-      spec: { getMeasuresForMetricView },
+      metricsView: { getMeasuresForMetricView },
     },
   } = store);
 

--- a/web-common/src/features/canvas/components/charts/cartesian-charts/CartesianChart.ts
+++ b/web-common/src/features/canvas/components/charts/cartesian-charts/CartesianChart.ts
@@ -104,7 +104,7 @@ export class CartesianChartComponent extends BaseChart<CartesianChartSpec> {
     const config = get(this.specStore);
     const metricsViewName = config.metrics_view;
     const measuresStore =
-      this.parent.spec.getMeasuresForMetricView(metricsViewName);
+      this.parent.metricsView.getMeasuresForMetricView(metricsViewName);
     const measures = get(measuresStore);
 
     let measureDisplayNames: string[] | undefined;

--- a/web-common/src/features/canvas/components/charts/combo-charts/ComboChart.ts
+++ b/web-common/src/features/canvas/components/charts/combo-charts/ComboChart.ts
@@ -143,7 +143,7 @@ export class ComboChartComponent extends BaseChart<ComboChartSpec> {
     const config = get(this.specStore);
     const metricsViewName = config.metrics_view;
     const measuresStore =
-      this.parent.spec.getMeasuresForMetricView(metricsViewName);
+      this.parent.metricsView.getMeasuresForMetricView(metricsViewName);
     const measures = get(measuresStore);
 
     let measureDisplayNames: string[] | undefined;

--- a/web-common/src/features/canvas/components/charts/funnel-charts/FunnelChart.ts
+++ b/web-common/src/features/canvas/components/charts/funnel-charts/FunnelChart.ts
@@ -196,9 +196,10 @@ export class FunnelChartComponent extends BaseChart<FunnelChartSpec> {
           newSpec.color = "stage";
         }
 
-        const dimensionsStore = this.parent.spec.getDimensionsForMetricView(
-          currentSpec.metrics_view,
-        );
+        const dimensionsStore =
+          this.parent.metricsView.getDimensionsForMetricView(
+            currentSpec.metrics_view,
+          );
         const dimensions = get(dimensionsStore);
         if (dimensions?.length) {
           newSpec.stage = {

--- a/web-common/src/features/canvas/components/charts/selector.ts
+++ b/web-common/src/features/canvas/components/charts/selector.ts
@@ -27,7 +27,6 @@ export function getChartData(
     ctx,
     timeAndFilterStore,
   );
-  const { spec } = ctx.canvasEntity;
 
   const themeStore = ctx.canvasEntity.theme;
 

--- a/web-common/src/features/canvas/components/charts/selector.ts
+++ b/web-common/src/features/canvas/components/charts/selector.ts
@@ -41,11 +41,19 @@ export function getChartData(
   ];
 
   // Match each field to its corresponding measure or dimension spec.
+  const metricsView = ctx.canvasEntity.metricsView;
+
   const fieldReadableMap = allFields.map((field) => {
     if (field.type === "measure") {
-      return spec.getMeasureForMetricView(field.field, config.metrics_view);
+      return metricsView.getMeasureForMetricView(
+        field.field,
+        config.metrics_view,
+      );
     } else if (field.type === "dimension") {
-      return spec.getDimensionForMetricView(field.field, config.metrics_view);
+      return metricsView.getDimensionForMetricView(
+        field.field,
+        config.metrics_view,
+      );
     } else {
       return getTimeDimensionDefinition(field.field, timeAndFilterStore);
     }

--- a/web-common/src/features/canvas/components/charts/types.ts
+++ b/web-common/src/features/canvas/components/charts/types.ts
@@ -118,15 +118,6 @@ export interface CommonChartProperties {
   vl_config?: string;
 }
 
-// TODO: Remove this once we have a better way to handle chart config
-export interface ChartConfig extends CommonChartProperties {
-  x?: FieldConfig;
-  y?: FieldConfig;
-  color?: FieldConfig | string;
-  tooltip?: FieldConfig;
-  vl_config?: string;
-}
-
 /** Temporary solution for the lack of vega lite type exports */
 export interface TooltipValue {
   title?: string;

--- a/web-common/src/features/canvas/components/charts/validate.ts
+++ b/web-common/src/features/canvas/components/charts/validate.ts
@@ -20,7 +20,7 @@ export function validateChartSchema(
   const { measures, dimensions, timeDimensions } = getFieldsByType(chartSpec);
 
   return derived(
-    ctx.canvasEntity.spec.getMetricsViewFromName(metrics_view),
+    ctx.canvasEntity.metricsView.getMetricsViewFromName(metrics_view),
     (metricsViewQuery) => {
       if (metricsViewQuery.isLoading) {
         return {

--- a/web-common/src/features/canvas/components/kpi/KPIProvider.svelte
+++ b/web-common/src/features/canvas/components/kpi/KPIProvider.svelte
@@ -20,7 +20,7 @@
 
   $: ctx = getCanvasStore(canvasName, instanceId);
   $: ({
-    spec: { getMeasureForMetricView },
+    metricsView: { getMeasureForMetricView },
   } = ctx.canvasEntity);
 
   $: ({ instanceId } = $runtime);

--- a/web-common/src/features/canvas/components/kpi/selector.ts
+++ b/web-common/src/features/canvas/components/kpi/selector.ts
@@ -13,7 +13,7 @@ export function validateKPISchema(
 }> {
   const { metrics_view } = kpiSpec;
   return derived(
-    ctx.canvasEntity.spec.getMetricsViewFromName(metrics_view),
+    ctx.canvasEntity.metricsView.getMetricsViewFromName(metrics_view),
     (metricsViewQuery) => {
       const measure = kpiSpec.measure;
       if (metricsViewQuery.isLoading) {

--- a/web-common/src/features/canvas/components/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/canvas/components/leaderboard/LeaderboardDisplay.svelte
@@ -43,7 +43,7 @@
   $: store = getCanvasStore(canvasName, instanceId);
   $: ({
     canvasEntity: {
-      spec: {
+      metricsView: {
         getMetricsViewFromName,
         getDimensionsForMetricView,
         getMeasuresForMetricView,

--- a/web-common/src/features/canvas/components/pivot/CanvasPivotDisplay.svelte
+++ b/web-common/src/features/canvas/components/pivot/CanvasPivotDisplay.svelte
@@ -9,7 +9,7 @@
 
   $: ({
     parent: {
-      spec: { getMetricsViewFromName },
+      metricsView: { getMetricsViewFromName },
     },
     specStore,
     config,

--- a/web-common/src/features/canvas/components/pivot/index.ts
+++ b/web-common/src/features/canvas/components/pivot/index.ts
@@ -199,7 +199,7 @@ export class PivotCanvasComponent extends BaseCanvasComponent<
 
     const currentSpec = get(this.specStore);
 
-    const metricsViewSpecQuery = this.parent.spec.getMetricsViewFromName(
+    const metricsViewSpecQuery = this.parent.metricsView.getMetricsViewFromName(
       currentSpec.metrics_view,
     );
 

--- a/web-common/src/features/canvas/components/pivot/util.ts
+++ b/web-common/src/features/canvas/components/pivot/util.ts
@@ -17,15 +17,15 @@ import {
   type PivotTimeConfig,
 } from "@rilldata/web-common/features/dashboards/pivot/types";
 import { createAndExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
+import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
 import type {
   V1Expression,
   V1MetricsViewSpec,
   V1TimeRange,
 } from "@rilldata/web-common/runtime-client";
 import { type Readable, type Writable, derived, writable } from "svelte/store";
-import type { PivotSpec, TableSpec } from "./";
 import type { CanvasEntity } from "../../stores/canvas-entity";
-import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
+import type { PivotSpec, TableSpec } from "./";
 
 type CacheEntry = {
   store: ReturnType<typeof createPivotDataStore>;
@@ -270,7 +270,7 @@ export const usePivotForCanvas = (
   const pivotDashboardContext: PivotDashboardContext = {
     metricsViewName: metricsViewStore,
     queryClient: queryClient,
-    enabled: !!canvas.spec.canvasSpec,
+    enabled: !!canvas.spec,
   };
 
   const pivotDataStore = createPivotDataStore(

--- a/web-common/src/features/canvas/filters/CanvasFilters.svelte
+++ b/web-common/src/features/canvas/filters/CanvasFilters.svelte
@@ -12,11 +12,11 @@
   import { isExpressionUnsupported } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
   import SuperPill from "@rilldata/web-common/features/dashboards/time-controls/super-pill/SuperPill.svelte";
   import { TimeComparisonOption } from "@rilldata/web-common/lib/time/types";
+  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { DateTime, Interval } from "luxon";
   import { flip } from "svelte/animate";
   import { fly } from "svelte/transition";
   import CanvasComparisonPill from "./CanvasComparisonPill.svelte";
-  import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
 
   export let readOnly = false;
   export let maxWidth: number;
@@ -48,7 +48,8 @@
         allMeasureFilterItems,
         measureHasFilter,
       },
-      spec: { canvasSpec, allDimensions, allSimpleMeasures },
+      spec,
+      metricsView: { allDimensions, allSimpleMeasures },
       timeControls: {
         allTimeRange,
         timeRangeStateStore,
@@ -69,9 +70,9 @@
 
   $: selectedRangeAlias = selectedTimeRange?.name;
   $: activeTimeGrain = selectedTimeRange?.interval;
-  $: defaultTimeRange = $canvasSpec?.defaultPreset?.timeRange;
-  $: availableTimeZones = $canvasSpec?.timeZones ?? [];
-  $: timeRanges = $canvasSpec?.timeRanges ?? [];
+  $: defaultTimeRange = $spec?.defaultPreset?.timeRange;
+  $: availableTimeZones = $spec?.timeZones ?? [];
+  $: timeRanges = $spec?.timeRanges ?? [];
 
   $: interval = selectedTimeRange
     ? Interval.fromDateTimes(
@@ -143,7 +144,7 @@
       {activeTimeGrain}
       {activeTimeZone}
       watermark={undefined}
-      allowCustomTimeRange={$canvasSpec?.allowCustomTimeRange}
+      allowCustomTimeRange={$spec?.allowCustomTimeRange}
       canPanLeft
       canPanRight
       showPan

--- a/web-common/src/features/canvas/inspector/PageEditor.svelte
+++ b/web-common/src/features/canvas/inspector/PageEditor.svelte
@@ -24,10 +24,10 @@
     DEFAULT_TIME_RANGES,
     DEFAULT_TIMEZONES,
   } from "@rilldata/web-common/lib/time/config";
+  import { allTimeZones } from "@rilldata/web-common/lib/time/timezone";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import { YAMLMap, YAMLSeq } from "yaml";
   import { DEFAULT_DASHBOARD_WIDTH } from "../layout-util";
-  import { allTimeZones } from "@rilldata/web-common/lib/time/timezone";
 
   export let updateProperties: (
     newRecord: Record<string, unknown>,
@@ -38,7 +38,7 @@
 
   $: ({
     canvasEntity: {
-      spec: { canvasSpec },
+      spec,
       filters: { setFilters },
     },
   } = getCanvasStore(canvasName, instanceId));
@@ -91,13 +91,13 @@
     .map((theme) => theme.meta?.name?.name ?? "")
     .filter((string) => !string.endsWith("--theme"));
 
-  $: showFilterBar = $canvasSpec?.filtersEnabled ?? true;
+  $: showFilterBar = $spec?.filtersEnabled ?? true;
   $: theme = !rawTheme
     ? undefined
     : typeof rawTheme === "string"
       ? rawTheme
       : rawTheme instanceof YAMLMap
-        ? $canvasSpec?.embeddedTheme
+        ? $spec?.embeddedTheme
         : undefined;
 
   async function toggleFilterBar() {

--- a/web-common/src/features/canvas/inspector/chart/ChartTypeSelector.svelte
+++ b/web-common/src/features/canvas/inspector/chart/ChartTypeSelector.svelte
@@ -15,7 +15,7 @@
 
   $: ({
     parent: {
-      spec: { getMetricsViewFromName },
+      metricsView: { getMetricsViewFromName },
     },
     chartType,
     specStore,

--- a/web-common/src/features/canvas/inspector/chart/PositionalFieldConfig.svelte
+++ b/web-common/src/features/canvas/inspector/chart/PositionalFieldConfig.svelte
@@ -25,7 +25,7 @@
   $: ({
     canvasEntity: {
       selectedComponent,
-      spec: { getTimeDimensionForMetricView },
+      metricsView: { getTimeDimensionForMetricView },
     },
   } = getCanvasStore(canvasName, instanceId));
 

--- a/web-common/src/features/canvas/inspector/fields/SingleFieldInput.svelte
+++ b/web-common/src/features/canvas/inspector/fields/SingleFieldInput.svelte
@@ -24,7 +24,7 @@
   $: ({ instanceId } = $runtime);
 
   $: ctx = getCanvasStore(canvasName, instanceId);
-  $: ({ getTimeDimensionForMetricView } = ctx.canvasEntity.spec);
+  $: ({ getTimeDimensionForMetricView } = ctx.canvasEntity.metricsView);
 
   $: timeDimension = getTimeDimensionForMetricView(metricName);
 

--- a/web-common/src/features/canvas/inspector/filters/DimensionFiltersInput.svelte
+++ b/web-common/src/features/canvas/inspector/filters/DimensionFiltersInput.svelte
@@ -9,10 +9,10 @@
   import MeasureFilter from "@rilldata/web-common/features/dashboards/filters/measure-filters/MeasureFilter.svelte";
   import type { MeasureFilterEntry } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry";
   import { isExpressionUnsupported } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
-  import { flip } from "svelte/animate";
-  import type { Filters } from "../../stores/filters";
   import { ExploreStateURLParams } from "@rilldata/web-common/features/dashboards/url-state/url-params";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
+  import { flip } from "svelte/animate";
+  import type { Filters } from "../../stores/filters";
 
   export let id: string;
   export let canvasName: string;
@@ -26,7 +26,10 @@
 
   $: ({
     canvasEntity: {
-      spec: { getDimensionsForMetricView, getSimpleMeasuresForMetricView },
+      metricsView: {
+        getDimensionsForMetricView,
+        getSimpleMeasuresForMetricView,
+      },
     },
   } = getCanvasStore(canvasName, instanceId));
 

--- a/web-common/src/features/canvas/inspector/filters/TimeFiltersInput.svelte
+++ b/web-common/src/features/canvas/inspector/filters/TimeFiltersInput.svelte
@@ -4,8 +4,8 @@
   import CanvasComparisonPill from "@rilldata/web-common/features/canvas/filters/CanvasComparisonPill.svelte";
   import { getCanvasStore } from "@rilldata/web-common/features/canvas/state-managers/state-managers";
   import SuperPill from "@rilldata/web-common/features/dashboards/time-controls/super-pill/SuperPill.svelte";
-  import { DateTime, Interval } from "luxon";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
+  import { DateTime, Interval } from "luxon";
   import type { TimeControls } from "../../stores/time-control";
 
   export let id: string;
@@ -17,9 +17,7 @@
   $: ({ instanceId } = $runtime);
 
   $: ({
-    canvasEntity: {
-      spec: { canvasSpec },
-    },
+    canvasEntity: { spec },
   } = getCanvasStore(canvasName, instanceId));
 
   $: ({
@@ -42,8 +40,8 @@
 
   $: selectedRangeAlias = selectedTimeRange?.name;
   $: activeTimeGrain = selectedTimeRange?.interval;
-  $: defaultTimeRange = $canvasSpec?.defaultPreset?.timeRange;
-  $: timeRanges = $canvasSpec?.timeRanges ?? [];
+  $: defaultTimeRange = $spec?.defaultPreset?.timeRange;
+  $: timeRanges = $spec?.timeRanges ?? [];
 
   $: activeTimeZone = $selectedTimezone;
 

--- a/web-common/src/features/canvas/inspector/selectors.ts
+++ b/web-common/src/features/canvas/inspector/selectors.ts
@@ -26,9 +26,9 @@ export function useMetricFieldData(
   searchValue = "",
   excludedValues: string[] | undefined = undefined,
 ) {
-  const { spec, timeControls } = ctx.canvasEntity;
+  const { metricsView, timeControls } = ctx.canvasEntity;
 
-  const metricsViewQuery = spec.getMetricsViewFromName(metricViewName);
+  const metricsViewQuery = metricsView.getMetricsViewFromName(metricViewName);
 
   return derived(
     [metricsViewQuery, timeControls.minTimeGrain],

--- a/web-common/src/features/canvas/stores/canvas-entity.ts
+++ b/web-common/src/features/canvas/stores/canvas-entity.ts
@@ -32,6 +32,7 @@ import { parseDocument } from "yaml";
 import type { FileArtifact } from "../../entity-management/file-artifact";
 import { fileArtifacts } from "../../entity-management/file-artifacts";
 import { ResourceKind } from "../../entity-management/resource-selectors";
+import { MetricsViewSelectors } from "../../metrics-views/metrics-view-selectors";
 import type { BaseCanvasComponent } from "../components/BaseCanvasComponent";
 import type { CanvasComponentType, ComponentSpec } from "../components/types";
 import {
@@ -42,7 +43,6 @@ import {
 } from "../components/util";
 import { Filters } from "./filters";
 import { Grid } from "./grid";
-import { MetricsViewSelectors } from "./metrics-view-selectors";
 import { TimeControls } from "./time-control";
 
 // Store for managing URL search parameters

--- a/web-common/src/features/canvas/stores/canvas-entity.ts
+++ b/web-common/src/features/canvas/stores/canvas-entity.ts
@@ -13,6 +13,7 @@ import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryCl
 import {
   getRuntimeServiceGetResourceQueryKey,
   runtimeServiceGetResource,
+  type V1CanvasSpec,
   type V1ComponentSpecRendererProperties,
   type V1MetricsViewSpec,
   type V1Resource,
@@ -41,7 +42,7 @@ import {
 } from "../components/util";
 import { Filters } from "./filters";
 import { Grid } from "./grid";
-import { CanvasResolvedSpec } from "./spec";
+import { MetricsViewSelectors } from "./metrics-view-selectors";
 import { TimeControls } from "./time-control";
 
 // Store for managing URL search parameters
@@ -65,10 +66,11 @@ export class CanvasEntity {
   // Dimension and measure filter state
   filters: Filters;
 
-  /**
-   * Spec store containing selectors derived from ResolveCanvas query
-   */
-  spec: CanvasResolvedSpec;
+  // Metrics view selectors
+  metricsView: MetricsViewSelectors;
+
+  // Canvas resource infered from YAML spec
+  spec: Readable<V1CanvasSpec | undefined>;
   selectedComponent = writable<string | null>(null);
   fileArtifact: FileArtifact | undefined;
   parsedContent: Readable<ReturnType<typeof parseDocument>>;
@@ -125,14 +127,24 @@ export class CanvasEntity {
       };
     })();
 
-    this.spec = new CanvasResolvedSpec(this.specStore);
+    this.spec = derived(this.specStore, ($specStore) => {
+      return $specStore.data?.canvas;
+    });
+
+    this.metricsView = new MetricsViewSelectors(
+      instanceId,
+      derived(this.specStore, ($specStore) => {
+        return $specStore.data?.metricsViews || {};
+      }),
+    );
+
     this.timeControls = new TimeControls(
       this.specStore,
       searchParamsStore,
       undefined,
       this.name,
     );
-    this.filters = new Filters(this.spec, searchParamsStore);
+    this.filters = new Filters(this.metricsView, searchParamsStore);
 
     searchParamsStore.subscribe((searchParams) => {
       const themeFromUrl = searchParams.get("theme");
@@ -214,7 +226,7 @@ export class CanvasEntity {
     }
 
     const metricsViewSpec = get(
-      this.spec.getMetricsViewFromName(metricsViewName),
+      this.metricsView.getMetricsViewFromName(metricsViewName),
     ).metricsView;
 
     if (!metricsViewSpec) {

--- a/web-common/src/features/canvas/stores/filters.ts
+++ b/web-common/src/features/canvas/stores/filters.ts
@@ -1,4 +1,3 @@
-import type { MetricsViewSelectors } from "@rilldata/web-common/features/canvas/stores/metrics-view-selectors";
 import { DimensionFilterMode } from "@rilldata/web-common/features/dashboards/filters/dimension-filters/constants";
 import { getFiltersFromText } from "@rilldata/web-common/features/dashboards/filters/dimension-filters/dimension-search-text-utils";
 import {
@@ -28,6 +27,8 @@ import {
   sanitiseExpression,
 } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
 import { convertExpressionToFilterParam } from "@rilldata/web-common/features/dashboards/url-state/filters/converters";
+import type { MetricsViewSelectors } from "@rilldata/web-common/features/metrics-views/metrics-view-selectors";
+import { getMapFromArray } from "@rilldata/web-common/lib/arrayUtils";
 import type {
   MetricsViewSpecDimension,
   V1Expression,
@@ -45,7 +46,6 @@ import {
 } from "svelte/store";
 import { ExploreStateURLParams } from "../../dashboards/url-state/url-params";
 import type { SearchParamsStore } from "./canvas-entity";
-import { getMapFromArray } from "@rilldata/web-common/lib/arrayUtils";
 
 export class Filters {
   private metricsView: MetricsViewSelectors;

--- a/web-common/src/features/canvas/stores/filters.ts
+++ b/web-common/src/features/canvas/stores/filters.ts
@@ -1,4 +1,4 @@
-import type { CanvasResolvedSpec } from "@rilldata/web-common/features/canvas/stores/spec";
+import type { MetricsViewSelectors } from "@rilldata/web-common/features/canvas/stores/metrics-view-selectors";
 import { DimensionFilterMode } from "@rilldata/web-common/features/dashboards/filters/dimension-filters/constants";
 import { getFiltersFromText } from "@rilldata/web-common/features/dashboards/filters/dimension-filters/dimension-search-text-utils";
 import {
@@ -48,7 +48,7 @@ import type { SearchParamsStore } from "./canvas-entity";
 import { getMapFromArray } from "@rilldata/web-common/lib/arrayUtils";
 
 export class Filters {
-  private spec: CanvasResolvedSpec;
+  private metricsView: MetricsViewSelectors;
   // -------------------
   // STORES (writable)
   // -------------------
@@ -85,14 +85,14 @@ export class Filters {
   temporaryFilters = writable<Set<string>>(new Set());
 
   constructor(
-    spec: CanvasResolvedSpec,
+    metricsView: MetricsViewSelectors,
     public searchParamsStore: SearchParamsStore,
     public componentName?: string,
   ) {
     // -----------------------------
     // Initialize writable stores
     // -----------------------------
-    this.spec = spec;
+    this.metricsView = metricsView;
     this.dimensionFilterExcludeMode = writable(new Map<string, boolean>());
 
     this.whereFilter = writable({
@@ -109,7 +109,7 @@ export class Filters {
     // -------------------------------
 
     this.allMeasures = derived(
-      [this.spec.allSimpleMeasures],
+      [this.metricsView.allSimpleMeasures],
       ([$allSimpleMeasures]) =>
         getMapFromArray($allSimpleMeasures, (m) => m.name as string),
     );
@@ -142,7 +142,7 @@ export class Filters {
             measureIdMap.has(tempFilter) &&
             !itemsCopy.some((i) => i.name === tempFilter)
           ) {
-            const dimensions = spec.getDimensionsFromMeasure(tempFilter);
+            const dimensions = metricsView.getDimensionsFromMeasure(tempFilter);
             itemsCopy.push({
               dimensionName: "",
               name: tempFilter,
@@ -160,7 +160,7 @@ export class Filters {
     // DIMENSION SELECTORS
     // -------------------------------
     this.allDimensions = derived(
-      [this.spec.allDimensions],
+      [this.metricsView.allDimensions],
       ([$allDimensions]) =>
         getMapFromArray(
           $allDimensions,
@@ -178,7 +178,7 @@ export class Filters {
         );
         dimensionFilters.forEach((dimensionFilter) => {
           dimensionFilter.metricsViewNames =
-            spec.getMetricsViewNamesForDimension(dimensionFilter.name);
+            metricsView.getMetricsViewNamesForDimension(dimensionFilter.name);
         });
         return dimensionFilters;
       },
@@ -199,7 +199,7 @@ export class Filters {
 
           if (tempFilter && $allDimensions.has(tempFilter) && !hasFilter) {
             const metricsViewNames =
-              spec.getMetricsViewNamesForDimension(tempFilter);
+              metricsView.getMetricsViewNamesForDimension(tempFilter);
             merged.set(tempFilter, {
               mode: DimensionFilterMode.Select,
               name: tempFilter,
@@ -359,7 +359,9 @@ export class Filters {
       if (addedMeasure.has(filter.measure)) return;
       const measure = measureIdMap.get(filter.measure);
       if (!measure) return;
-      const dimensions = this.spec.getDimensionsFromMeasure(filter.measure);
+      const dimensions = this.metricsView.getDimensionsFromMeasure(
+        filter.measure,
+      );
       addedMeasure.add(filter.measure);
       filteredMeasures.push({
         dimensionName: name,

--- a/web-common/src/features/metrics-views/metrics-view-selectors.ts
+++ b/web-common/src/features/metrics-views/metrics-view-selectors.ts
@@ -10,7 +10,7 @@ import { derived, get, type Readable } from "svelte/store";
 import {
   ResourceKind,
   useFilteredResources,
-} from "../../entity-management/resource-selectors";
+} from "../entity-management/resource-selectors";
 
 type MetricsViewsData = Readable<Record<string, V1MetricsView | undefined>>;
 


### PR DESCRIPTION
Converts the `spec` store to a simple readable of the canvas resource. Created a new metrics selector store which is agnostic of canvas.


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
