### PR TITLE
Cyrus/duckdb olap engine

### DIFF
--- a/web-common/src/features/sources/modal/constants.ts
+++ b/web-common/src/features/sources/modal/constants.ts
@@ -22,7 +22,7 @@ export const SOURCES = [
   "athena",
   "azure",
   "bigquery",
-  "duckdb",
+
   "gcs",
   "postgres",
   "mysql",
@@ -36,6 +36,12 @@ export const SOURCES = [
   "local_file",
 ];
 
-export const OLAP_ENGINES = ["clickhouse", "motherduck", "druid", "pinot"];
+export const OLAP_ENGINES = [
+  "clickhouse",
+  "motherduck",
+  "duckdb",
+  "druid",
+  "pinot",
+];
 
 export const ALL_CONNECTORS = [...SOURCES, ...OLAP_ENGINES];

--- a/web-common/src/features/sources/modal/submitAddDataForm.ts
+++ b/web-common/src/features/sources/modal/submitAddDataForm.ts
@@ -300,7 +300,11 @@ export async function submitAddConnectorForm(
   }
 
   if (OLAP_ENGINES.includes(connector.name as string)) {
-    await setOlapConnectorInRillYAML(queryClient, instanceId, newConnectorName);
+    await setOlapConnectorInRillYAML(
+      queryClient,
+      instanceId,
+      connector.name as string,
+    );
   }
 
   // Go to the new connector file


### PR DESCRIPTION
This PR moves DuckDB to the OLAP engines section and updates the `olap_connector` configuration to reference a valid driver name. Closes https://linear.app/rilldata/issue/APP-409/add-support-for-duckdb-as-a-olap-connector

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
