### PR TITLE
fix: alert open throwing a proto parse error

### DIFF
--- a/web-admin/src/routes/[organization]/[project]/-/alerts/[alert]/open/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/alerts/[alert]/open/+page.svelte
@@ -48,7 +48,7 @@
     },
     {
       exploreProtoState:
-        $alert.data?.resource?.alert?.spec?.annotations?.web_open_path,
+        $alert.data?.resource?.alert?.spec?.annotations?.web_open_state,
     },
   );
 

--- a/web-admin/src/routes/[organization]/[project]/-/reports/[report]/open/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/reports/[report]/open/+page.svelte
@@ -33,7 +33,7 @@
     },
     {
       exploreProtoState:
-        reportResource?.report?.spec?.annotations?.web_open_path,
+        reportResource?.report?.spec?.annotations?.web_open_state,
       forceOpenPivot: true,
     },
   );


### PR DESCRIPTION
We were using the incorrect param to convert report/alert to a dashboard.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
