### PR TITLE
Fixing export failing in readonly mode

### DIFF
--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -388,7 +388,7 @@ func (c *connection) AsObjectStore() (drivers.ObjectStore, bool) {
 
 // AsModelExecutor implements drivers.Handle.
 func (c *connection) AsModelExecutor(instanceID string, opts *drivers.ModelExecutorOptions) (drivers.ModelExecutor, error) {
-	if c.config.Mode != modeReadWrite {
+	if opts.OutputHandle == c && c.config.Mode != modeReadWrite {
 		return nil, fmt.Errorf("model execution is disabled. To enable modeling on this database, set 'mode: readwrite' in your connector configuration. WARNING: This will allow Rill to create and overwrite tables in your database")
 	}
 	if opts.InputHandle == c && opts.OutputHandle == c {


### PR DESCRIPTION
[PLAT-256: Fix pivot exports for external OLAPs with `mode: readonly`](https://linear.app/rilldata/issue/PLAT-256/fix-pivot-exports-for-external-olaps-with-mode-readonly)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
