### PR TITLE
Fix `olap_connector` for various project init flows

### DIFF
--- a/web-common/src/features/sources/modal/FileDrop.svelte
+++ b/web-common/src/features/sources/modal/FileDrop.svelte
@@ -36,6 +36,7 @@
             instanceId,
             data: {
               displayName: EMPTY_PROJECT_TITLE,
+              olap: "duckdb", // Explicitly set DuckDB as OLAP for local file uploads
             },
           });
 

--- a/web-common/src/features/sources/modal/LocalSourceUpload.svelte
+++ b/web-common/src/features/sources/modal/LocalSourceUpload.svelte
@@ -37,6 +37,7 @@
             instanceId,
             data: {
               displayName: EMPTY_PROJECT_TITLE,
+              olap: "duckdb", // Explicitly set DuckDB as OLAP for local file uploads
             },
           });
 

--- a/web-common/src/features/sources/modal/submitAddDataForm.ts
+++ b/web-common/src/features/sources/modal/submitAddDataForm.ts
@@ -41,7 +41,10 @@ interface AddDataFormValues {
   [key: string]: unknown;
 }
 
-async function beforeSubmitForm(instanceId: string) {
+async function beforeSubmitForm(
+  instanceId: string,
+  connector?: V1ConnectorDriver,
+) {
   // Emit telemetry
   behaviourEvent?.fireSourceTriggerEvent(
     BehaviourEventAction.SourceAdd,
@@ -53,8 +56,17 @@ async function beforeSubmitForm(instanceId: string) {
   // If project is uninitialized, initialize an empty project
   const projectInitialized = await isProjectInitialized(instanceId);
   if (!projectInitialized) {
+    // Determine the OLAP engine based on the connector being added
+    let olapEngine = "duckdb"; // Default for data sources
+
+    if (connector && OLAP_ENGINES.includes(connector.name as string)) {
+      // For OLAP engines, use the connector name as the OLAP engine
+      olapEngine = connector.name as string;
+    }
+
     await runtimeServiceUnpackEmpty(instanceId, {
       displayName: EMPTY_PROJECT_TITLE,
+      olap: olapEngine, // Explicitly set OLAP based on connector type
     });
 
     // Race condition: invalidate("init") must be called before we navigate to
@@ -135,7 +147,7 @@ export async function submitAddSourceForm(
   formValues: AddDataFormValues,
 ): Promise<void> {
   const instanceId = get(runtime).instanceId;
-  await beforeSubmitForm(instanceId);
+  await beforeSubmitForm(instanceId, connector);
 
   const newSourceName = formValues.name as string;
 
@@ -218,7 +230,7 @@ export async function submitAddConnectorForm(
   formValues: AddDataFormValues,
 ): Promise<void> {
   const instanceId = get(runtime).instanceId;
-  await beforeSubmitForm(instanceId);
+  await beforeSubmitForm(instanceId, connector);
 
   const newConnectorName = getName(
     connector.name as string,

--- a/web-common/src/features/welcome/is-project-initialized.ts
+++ b/web-common/src/features/welcome/is-project-initialized.ts
@@ -40,6 +40,7 @@ export async function handleUninitializedProject(instanceId: string) {
     // Clickhouse and Druid-backed projects should be initialized immediately
     await runtimeServiceUnpackEmpty(instanceId, {
       displayName: EMPTY_PROJECT_TITLE,
+      olap: olapConnector, // Use the instance's configured OLAP connector
       force: true,
     });
 

--- a/web-local/tests/init.spec.ts
+++ b/web-local/tests/init.spec.ts
@@ -30,4 +30,28 @@ test.describe("Example project initialization", () => {
       ).toBeVisible();
     });
   });
+
+  // Different behaviors
+  // @source: https://www.notion.so/rilldata/Project-init-olap_connector-Behaviors-278ba33c8f5780a5bda1d44314bc306f
+  test.describe("Default olap_connector behavior", () => {
+    // Empty project
+    test("should set default OLAP connector to duckdb for empty project", async ({
+      page,
+    }) => {
+      await page.getByRole("link", { name: "Empty Project" }).click();
+      await expect(page.getByText("Getting started")).toBeVisible();
+
+      // Navigate to rill.yaml to verify default OLAP connector
+      await page.getByRole("link", { name: "rill.yaml" }).click();
+      const rillYamlEditor = page
+        .getByLabel("codemirror editor")
+        .getByRole("textbox");
+
+      // Verify that the OLAP connector is set to duckdb by default
+      await expect(rillYamlEditor).toContainText("olap_connector: duckdb");
+    });
+
+    // TODO: local file using csv
+    // TODO: clickhouse managed
+  });
 });

--- a/web-local/tests/init.spec.ts
+++ b/web-local/tests/init.spec.ts
@@ -30,28 +30,4 @@ test.describe("Example project initialization", () => {
       ).toBeVisible();
     });
   });
-
-  // Different behaviors
-  // @source: https://www.notion.so/rilldata/Project-init-olap_connector-Behaviors-278ba33c8f5780a5bda1d44314bc306f
-  test.describe("Default olap_connector behavior", () => {
-    // Empty project
-    test("should set default OLAP connector to duckdb for empty project", async ({
-      page,
-    }) => {
-      await page.getByRole("link", { name: "Empty Project" }).click();
-      await expect(page.getByText("Getting started")).toBeVisible();
-
-      // Navigate to rill.yaml to verify default OLAP connector
-      await page.getByRole("link", { name: "rill.yaml" }).click();
-      const rillYamlEditor = page
-        .getByLabel("codemirror editor")
-        .getByRole("textbox");
-
-      // Verify that the OLAP connector is set to duckdb by default
-      await expect(rillYamlEditor).toContainText("olap_connector: duckdb");
-    });
-
-    // TODO: local file using csv
-    // TODO: clickhouse managed
-  });
 });

--- a/web-local/tests/rill-yaml.spec.ts
+++ b/web-local/tests/rill-yaml.spec.ts
@@ -1,0 +1,33 @@
+import { expect } from "@playwright/test";
+import { uploadFile } from "./utils/sourceHelpers";
+import { test } from "./setup/base";
+
+test.describe("Default olap_connector behavior", () => {
+  test("Start with an empty project", async ({ page }) => {
+    await page.getByRole("link", { name: "Empty Project" }).click();
+    await expect(page.getByText("Getting started")).toBeVisible();
+
+    await page.getByRole("link", { name: "rill.yaml" }).click();
+    const rillYamlEditor = page
+      .getByLabel("codemirror editor")
+      .getByRole("textbox");
+
+    await expect(rillYamlEditor).toContainText("olap_connector: duckdb");
+  });
+
+  test("Start with a new project with a local file", async ({ page }) => {
+    await page.getByRole("link", { name: "Empty Project" }).click();
+    await expect(page.getByText("Getting started")).toBeVisible();
+
+    await uploadFile(page, "AdBids.csv");
+
+    await page.getByText("View this source").click();
+
+    await page.getByRole("link", { name: "rill.yaml" }).click();
+    const rillYamlEditor = page
+      .getByLabel("codemirror editor")
+      .getByRole("textbox");
+
+    await expect(rillYamlEditor).toContainText("olap_connector: duckdb");
+  });
+});

--- a/web-local/tests/rill-yaml.spec.ts
+++ b/web-local/tests/rill-yaml.spec.ts
@@ -2,7 +2,7 @@ import { expect, type Page } from "@playwright/test";
 import { uploadFile } from "./utils/sourceHelpers";
 import { test } from "./setup/base";
 
-async function expectRillYAMLToContain(page: Page, text: string) {
+async function expectRillYAMLToContainOlapConnector(page: Page, text: string) {
   const rillYamlEditor = page
     .getByLabel("codemirror editor")
     .getByRole("textbox");
@@ -17,7 +17,7 @@ test.describe("Default olap_connector behavior", () => {
     await expect(page.getByText("Getting started")).toBeVisible();
 
     await page.getByRole("link", { name: "rill.yaml" }).click();
-    await expectRillYAMLToContain(page, "duckdb");
+    await expectRillYAMLToContainOlapConnector(page, "duckdb");
   });
 
   test("Should set default olap_connector to duckdb for local file upload", async ({
@@ -31,7 +31,7 @@ test.describe("Default olap_connector behavior", () => {
     await page.getByText("View this source").click();
 
     await page.getByRole("link", { name: "rill.yaml" }).click();
-    await expectRillYAMLToContain(page, "duckdb");
+    await expectRillYAMLToContainOlapConnector(page, "duckdb");
   });
 
   test("Should set default olap_connector to clickhouse for Rill-managed ClickHouse", async ({
@@ -55,6 +55,6 @@ test.describe("Default olap_connector behavior", () => {
     await page.waitForURL(`**/files/connectors/clickhouse.yaml`);
 
     await page.getByRole("link", { name: "rill.yaml" }).click();
-    await expectRillYAMLToContain(page, "clickhouse");
+    await expectRillYAMLToContainOlapConnector(page, "clickhouse");
   });
 });

--- a/web-local/tests/rill-yaml.spec.ts
+++ b/web-local/tests/rill-yaml.spec.ts
@@ -1,21 +1,28 @@
-import { expect } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import { uploadFile } from "./utils/sourceHelpers";
 import { test } from "./setup/base";
 
+async function expectRillYAMLToContain(page: Page, text: string) {
+  const rillYamlEditor = page
+    .getByLabel("codemirror editor")
+    .getByRole("textbox");
+  await expect(rillYamlEditor).toContainText(`olap_connector: ${text}`);
+}
+
 test.describe("Default olap_connector behavior", () => {
-  test("Start with an empty project", async ({ page }) => {
+  test("Should set default olap_connector to duckdb for empty project", async ({
+    page,
+  }) => {
     await page.getByRole("link", { name: "Empty Project" }).click();
     await expect(page.getByText("Getting started")).toBeVisible();
 
     await page.getByRole("link", { name: "rill.yaml" }).click();
-    const rillYamlEditor = page
-      .getByLabel("codemirror editor")
-      .getByRole("textbox");
-
-    await expect(rillYamlEditor).toContainText("olap_connector: duckdb");
+    await expectRillYAMLToContain(page, "duckdb");
   });
 
-  test("Start with a new project with a local file", async ({ page }) => {
+  test("Should set default olap_connector to duckdb for local file upload", async ({
+    page,
+  }) => {
     await page.getByRole("link", { name: "Empty Project" }).click();
     await expect(page.getByText("Getting started")).toBeVisible();
 
@@ -24,10 +31,30 @@ test.describe("Default olap_connector behavior", () => {
     await page.getByText("View this source").click();
 
     await page.getByRole("link", { name: "rill.yaml" }).click();
-    const rillYamlEditor = page
-      .getByLabel("codemirror editor")
-      .getByRole("textbox");
+    await expectRillYAMLToContain(page, "duckdb");
+  });
 
-    await expect(rillYamlEditor).toContainText("olap_connector: duckdb");
+  test("Should set default olap_connector to clickhouse for Rill-managed ClickHouse", async ({
+    page,
+  }) => {
+    await page.getByRole("link", { name: "Empty Project" }).click();
+    await expect(page.getByText("Getting started")).toBeVisible();
+
+    await page.getByRole("button", { name: "Add Data" }).click();
+    await page.locator("#clickhouse").click();
+    await page.locator("#managed").selectOption("rill-managed");
+    await page
+      .getByRole("dialog", { name: "ClickHouse" })
+      .getByRole("button", {
+        name: "Connect",
+        exact: true,
+      })
+      .click();
+
+    // Wait for navigation to the connector file
+    await page.waitForURL(`**/files/connectors/clickhouse.yaml`);
+
+    await page.getByRole("link", { name: "rill.yaml" }).click();
+    await expectRillYAMLToContain(page, "clickhouse");
   });
 });


### PR DESCRIPTION
This PR adds explicit olap configuration when using unpack empty services. The handled cases can be found in https://www.notion.so/rilldata/Project-init-olap_connector-Behaviors-278ba33c8f5780a5bda1d44314bc306f

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
