### PR TITLE
Display "show context for all measures" toggle when multiple measures are selected in Leaderboard

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
@@ -53,6 +53,8 @@
     .map(({ name }) => name)
     .filter(isDefined);
 
+  $: isMultiSelectEnabled = $leaderboardMeasureNames.length > 1;
+
   // if the percent of total is currently being shown,
   // but it is not valid for this measure, then turn it off
   $: if (
@@ -85,8 +87,10 @@
     {setLeaderboardMeasureNames}
     {setLeaderboardSortByMeasureName}
   />
-  <LeaderboardAdvancedActions
-    isOpen={isLeaderboardActionsOpen}
-    toggle={toggleLeaderboardShowContextForAllMeasures}
-  />
+  {#if isMultiSelectEnabled}
+    <LeaderboardAdvancedActions
+      isOpen={isLeaderboardActionsOpen}
+      toggle={toggleLeaderboardShowContextForAllMeasures}
+    />
+  {/if}
 </div>


### PR DESCRIPTION
This PR only displays "Show context for all measures" toggle when multiple measures are selected. The toggle is still intact in the Dimension Table. Closes https://linear.app/rilldata/issue/APP-448/fix-show-context-for-all-measures-customer-bug

https://github.com/user-attachments/assets/049bc79c-39ff-4d09-b9ef-d0fa027b50a0

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
