### PR TITLE
feat: measure anomaly quick explanation

### DIFF
--- a/runtime/server/mcp_server.go
+++ b/runtime/server/mcp_server.go
@@ -29,9 +29,9 @@ const mcpInstructions = `
 # Rill MCP Server
 This server exposes APIs for querying **metrics views**, which represent Rill's metrics layer.
 ## Workflow Overview
-1. **List metrics views:** Use "list_metrics_views" to discover available metrics views in the project.
+1. **List metrics views:** Use "list_metrics_views" to discover available metrics views in the project. Skip this if dashboard is already provided in the prompt.
 2. **Get metrics view spec:** Use "get_metrics_view" to fetch a metrics view's specification. This is important to understand all the dimensions and measures in a metrics view.
-3. **Query the summary:** Use "query_metrics_view_summary" to obtain the available time range for a metrics view and sample values with their data types for each dimension. This provides a richer context for understanding the data.
+3. **Query the summary:** Use "query_metrics_view_summary" to obtain the available time range for a metrics view and sample values with their data types for each dimension. This provides a richer context for understanding the data. Skip this if time range is already provided in the prompt.
 4. **Query the metrics:** Use "query_metrics_view" to run queries to get aggregated results.
 In the workflow, do not proceed with the next step until the previous step has been completed. If the information from the previous step is already known (let's say for subsequent queries), you can skip it.
 If a response contains an "ai_instructions" field, you should interpret it as additional instructions for how to behave in subsequent responses that relate to that tool call.

--- a/web-common/src/features/chat/core/context.ts
+++ b/web-common/src/features/chat/core/context.ts
@@ -1,0 +1,61 @@
+import {
+  type ConversationContextEntry,
+  ConversationContextType,
+} from "@rilldata/web-common/features/chat/core/types.ts";
+import { get, type Writable, writable } from "svelte/store";
+
+const ContextTypeData: Record<ConversationContextType, { label: string }> = {
+  [ConversationContextType.MetricsView]: {
+    label: "Metrics View",
+  },
+  [ConversationContextType.TimeRange]: {
+    label: "Time Range",
+  },
+  [ConversationContextType.Measures]: {
+    label: "Measures",
+  },
+};
+
+export class ConversationContext {
+  public context: Writable<ConversationContextEntry[]> = writable([]);
+
+  public set(type: ConversationContextType, value: string) {
+    this.context.update((c) => {
+      let idx = -1;
+      let exists = false;
+      for (idx = 0; idx < c.length && c[idx].type <= type; idx++) {
+        exists = c[idx].type === type;
+      }
+
+      const deleteCount = exists ? 1 : 0;
+      c.splice(idx, deleteCount, { type, value });
+      return c;
+    });
+  }
+
+  public delete(type: ConversationContextType) {
+    this.context.update((c) => {
+      return c.filter((e) => e.type !== type);
+    });
+  }
+
+  public clear() {
+    this.context.set([]);
+  }
+
+  public override(context: ConversationContextEntry[]) {
+    this.context.set(context);
+  }
+
+  public toString() {
+    const c = get(this.context);
+
+    if (c.length === 0) return "";
+
+    const contextPart = get(this.context)
+      .map((e) => `${ContextTypeData[e.type].label}: ${e.value}`)
+      .join("\n");
+
+    return `\n\n${contextPart}`;
+  }
+}

--- a/web-common/src/features/chat/core/presets/anomaly-explanation.ts
+++ b/web-common/src/features/chat/core/presets/anomaly-explanation.ts
@@ -1,0 +1,28 @@
+import { ConversationContextType } from "@rilldata/web-common/features/chat/core/types.ts";
+import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus.ts";
+
+export function anomalyExplanation(
+  metricsViewName: string,
+  timestamp: string,
+  measure: string,
+) {
+  const prompt = `Please explain what drives this data point. What dimensions have noticeably changed, as compared to other time windows?`;
+
+  eventBus.emit("chat-intent", {
+    prompt,
+    context: [
+      {
+        type: ConversationContextType.MetricsView,
+        value: metricsViewName,
+      },
+      {
+        type: ConversationContextType.TimeRange,
+        value: timestamp,
+      },
+      {
+        type: ConversationContextType.Measures,
+        value: measure,
+      },
+    ],
+  });
+}

--- a/web-common/src/features/chat/core/types.ts
+++ b/web-common/src/features/chat/core/types.ts
@@ -1,0 +1,10 @@
+export enum ConversationContextType {
+  MetricsView,
+  TimeRange,
+  Measures,
+}
+
+export type ConversationContextEntry = {
+  type: ConversationContextType;
+  value: string;
+};

--- a/web-common/src/features/chat/layouts/sidebar/SidebarChat.svelte
+++ b/web-common/src/features/chat/layouts/sidebar/SidebarChat.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { beforeNavigate } from "$app/navigation";
+  import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus.ts";
+  import { get } from "svelte/store";
   import Resizer from "../../../../layout/Resizer.svelte";
   import { runtime } from "../../../../runtime-client/runtime-store";
   import { cleanupChatInstance, getChatInstance } from "../../core/chat";
@@ -29,6 +31,13 @@
   function onNewConversation() {
     chatInputComponent?.focusInput();
   }
+
+  eventBus.on("chat-intent", (intent) => {
+    chat.enterNewConversationMode();
+    get(chat.getCurrentConversation()).context.override(intent.context);
+    get(chat.getCurrentConversation()).draftMessage.set(intent.prompt);
+    chatInputComponent?.focusInput();
+  });
 
   // Clean up chat resources when switching projects
   beforeNavigate(({ from, to }) => {

--- a/web-common/src/features/dashboards/time-series/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/MeasureChart.svelte
@@ -20,6 +20,7 @@
     ScaleStore,
     SimpleConfigurationStore,
   } from "@rilldata/web-common/components/data-graphic/state/types";
+  import { anomalyExplanation } from "@rilldata/web-common/features/chat/core/presets/anomaly-explanation.ts";
   import { getStateManagers } from "@rilldata/web-common/features/dashboards/state-managers/state-managers";
   import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
   import { tableInteractionStore } from "@rilldata/web-common/features/dashboards/time-dimension-details/time-dimension-data-store";
@@ -54,6 +55,7 @@
   } from "./utils";
 
   export let measure: MetricsViewSpecMeasure;
+  export let metricsViewName: string;
   export let exploreName: string;
   export let width: number | undefined = undefined;
   export let height: number | undefined = undefined;
@@ -242,9 +244,19 @@
     );
   }
 
-  function onMouseClick() {
+  function onMouseClick(e: PointerEvent) {
     // skip if still scrubbing
     if (preventScrubReset) return;
+
+    if ((e.ctrlKey || e.metaKey) && hoveredTime && measure.name) {
+      anomalyExplanation(
+        metricsViewName,
+        hoveredTime.toISOString(),
+        measure.name,
+      );
+      return;
+    }
+
     // skip if no scrub range selected
     if (!hasSubrangeSelected) return;
 
@@ -268,7 +280,7 @@
     left={0}
     let:config
     let:yScale
-    on:click={() => onMouseClick()}
+    on:click={onMouseClick}
     on:scrub-end={() => scrub?.endScrub()}
     on:scrub-move={(e) => scrub?.moveScrub(e)}
     on:scrub-start={(e) => scrub?.startScrub(e)}

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -82,6 +82,7 @@
     },
     validSpecStore,
     dashboardStore,
+    metricsViewName,
   } = getStateManagers();
 
   const timeControlsStore = useTimeControlStore(getStateManagers());
@@ -537,6 +538,7 @@
               {isScrubbing}
               {scrubStart}
               {scrubEnd}
+              metricsViewName={$metricsViewName}
               {exploreName}
               data={formattedData}
               {dimensionData}

--- a/web-common/src/lib/event-bus/event-bus.ts
+++ b/web-common/src/lib/event-bus/event-bus.ts
@@ -1,4 +1,4 @@
-import type { BannerEvent, NotificationMessage } from "./events";
+import type { BannerEvent, ChatIntent, NotificationMessage } from "./events";
 
 class EventBus {
   private listeners: EventMap = new Map();
@@ -58,6 +58,7 @@ export interface Events {
   "command-click": null;
   click: null;
   "shift-command-click": null;
+  "chat-intent": ChatIntent;
 }
 
 type T = keyof Events;

--- a/web-common/src/lib/event-bus/events.ts
+++ b/web-common/src/lib/event-bus/events.ts
@@ -44,3 +44,8 @@ export interface BannerMessage {
     onClick?: () => void | Promise<void>;
   };
 }
+
+export interface ChatIntent {
+  prompt: string;
+  context: { type: number; value: string }[];
+}


### PR DESCRIPTION
Adds a quick way to get info about a particular timestamp. `Cmd/Ctrl + click` on a measure chart will auto fill the chat window with a prompt.

Adds some very basic WIP context framework. This is subject to change based on the backend refactor PR.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
