### PR TITLE
Motherduck/Externalduck should be attached in read only mode and mode…

### DIFF
--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -541,6 +541,7 @@ func (c *connection) reopenDB(ctx context.Context) error {
 			Attach:             c.config.Attach,
 			DBName:             c.config.DatabaseName,
 			SchemaName:         c.config.SchemaName,
+			ReadOnlyMode:       c.config.Mode == modeReadOnly,
 			LocalDataDir:       dataDir,
 			LocalCPU:           c.config.CPU,
 			LocalMemoryLimitGB: c.config.MemoryLimitGB,

--- a/runtime/pkg/rduckdb/generic.go
+++ b/runtime/pkg/rduckdb/generic.go
@@ -45,6 +45,8 @@ type GenericOptions struct {
 	DBName string
 	// SchemaName switches the default schema.
 	SchemaName string
+	// ReadOnlyMode is set to true if the connection is read-only.
+	ReadOnlyMode bool
 
 	// LocalDataDir is the path to the local DuckDB database file.
 	LocalDataDir string
@@ -137,7 +139,11 @@ func NewGeneric(ctx context.Context, opts *GenericOptions) (res DB, dbErr error)
 
 	// attach the passed external db
 	if opts.Path != "" {
-		_, err = db.ExecContext(ctx, fmt.Sprintf("ATTACH %s", safeSQLString(opts.Path)))
+		if opts.ReadOnlyMode {
+			_, err = db.ExecContext(ctx, fmt.Sprintf("ATTACH %s (READ_ONLY)", safeSQLString(opts.Path)))
+		} else {
+			_, err = db.ExecContext(ctx, fmt.Sprintf("ATTACH %s", safeSQLString(opts.Path)))
+		}
 		if err != nil {
 			return nil, fmt.Errorf("error attaching external db: %w", err)
 		}


### PR DESCRIPTION
[PLAT-260: Motherduck/Externalduck should be attached in read only mode and mode is read](https://linear.app/rilldata/issue/PLAT-260/motherduckexternalduck-should-be-attached-in-read-only-mode-and-mode)



**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
