### PR TITLE
feat: add flag to disable deploy actions

### DIFF
--- a/runtime/drivers/registry.go
+++ b/runtime/drivers/registry.go
@@ -246,4 +246,6 @@ var DefaultFeatureFlags = map[string]string{
 	"chat": "true",
 	// Controls visibility of dashboard-level chat functionality
 	"dashboard_chat": "false",
+	// Controls whether to show/hide deploy related actions.
+	"deploy": "true",
 }

--- a/runtime/registry_test.go
+++ b/runtime/registry_test.go
@@ -523,6 +523,7 @@ func Test_ResolveFeatureFlags(t *testing.T) {
 				"darkMode":            false,
 				"chat":                true,
 				"dashboardChat":       false,
+				"deploy":              true,
 			},
 		},
 		{
@@ -543,6 +544,7 @@ func Test_ResolveFeatureFlags(t *testing.T) {
 				"darkMode":            false,
 				"chat":                true,
 				"dashboardChat":       false,
+				"deploy":              true,
 			},
 		},
 		{
@@ -563,6 +565,7 @@ func Test_ResolveFeatureFlags(t *testing.T) {
 				"darkMode":            false,
 				"chat":                true,
 				"dashboardChat":       false,
+				"deploy":              true,
 			},
 		},
 		{
@@ -583,6 +586,7 @@ func Test_ResolveFeatureFlags(t *testing.T) {
 				"darkMode":            false,
 				"chat":                false,
 				"dashboardChat":       true,
+				"deploy":              true,
 			},
 		},
 	}

--- a/web-common/src/features/feature-flags.ts
+++ b/web-common/src/features/feature-flags.ts
@@ -61,6 +61,7 @@ class FeatureFlags {
   darkMode = new FeatureFlag("user", false);
   chat = new FeatureFlag("user", true);
   dashboardChat = new FeatureFlag("user", false);
+  deploy = new FeatureFlag("user", true);
 
   constructor() {
     this.ready = new Promise<void>((resolve) => {

--- a/web-common/src/layout/ApplicationHeader.svelte
+++ b/web-common/src/layout/ApplicationHeader.svelte
@@ -21,7 +21,7 @@
   import InputWithConfirm from "../components/forms/InputWithConfirm.svelte";
   import { fileArtifacts } from "../features/entity-management/file-artifacts";
 
-  const { darkMode } = featureFlags;
+  const { darkMode, deploy } = featureFlags;
 
   export let mode: string;
 
@@ -35,6 +35,7 @@
   $: ({ unsavedFiles } = fileArtifacts);
   $: ({ size: unsavedFileCount } = $unsavedFiles);
   $: onDeployPage = isDeployPage($page);
+  $: showDeployCTA = $deploy && !onDeployPage;
 
   $: exploresQuery = useValidExplores(instanceId);
   $: canvasQuery = useValidCanvases(instanceId);
@@ -121,7 +122,7 @@
         <CanvasPreviewCTAs canvasName={dashboardName} />
       {/if}
     {/if}
-    {#if !onDeployPage}
+    {#if showDeployCTA}
       <DeployProjectCTA {hasValidDashboard} />
     {/if}
     <LocalAvatarButton darkMode={$darkMode} />

--- a/web-local/src/routes/+layout.svelte
+++ b/web-local/src/routes/+layout.svelte
@@ -31,6 +31,8 @@
 
   export let data: LayoutData;
 
+  const { deploy } = featureFlags;
+
   queryClient.getQueryCache().config.onError = (
     error: AxiosError,
     query: Query,
@@ -81,7 +83,9 @@
         <BannerCenter />
         <RepresentingUserBanner />
         <ApplicationHeader {mode} />
-        <RemoteProjectManager />
+        {#if $deploy}
+          <RemoteProjectManager />
+        {/if}
       {/if}
 
       <slot />


### PR DESCRIPTION
For self managed git it can be confusing sometimes when the remote changes popup shows up. As a temporary fix for non-github integrations we are adding a `deploy` flag to disable all deploy related actions in rill cloud.

We need a follow to only show the remote changes popup when the local folder has just a rill managed remote.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
