### PR TITLE
fix: disable adminServer flag

### DIFF
--- a/web-admin/src/routes/-/embed/+layout.svelte
+++ b/web-admin/src/routes/-/embed/+layout.svelte
@@ -22,6 +22,10 @@
 
   const { dashboardChat } = featureFlags;
 
+  // Embedded dashboards communicate directly with the project runtime and do not communicate with the admin server.
+  // One by-product of this is that they have no access to control plane features like alerts, bookmarks, and scheduled reports.
+  featureFlags.set(false, "adminServer");
+
   $: activeResource = {
     kind: $page.route.id?.includes("explore")
       ? ResourceKind.Explore


### PR DESCRIPTION
disable adminserver to hide reports in embeds

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
