### PR TITLE
Extend `CompleteStreaming` timeout from 30s to 2min

### DIFF
--- a/runtime/server/chat.go
+++ b/runtime/server/chat.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/r3labs/sse/v2"
 	aiv1 "github.com/rilldata/rill/proto/gen/rill/ai/v1"
@@ -220,6 +221,13 @@ func (s *Server) CompleteStreaming(req *runtimev1.CompleteStreamingRequest, stre
 func (s *Server) CompleteStreamingHandler(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	instanceID := req.PathValue("instance_id")
+
+	// Add timeout matching the completionTimeout from runtime/completion.go
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*2)
+	defer cancel()
+
+	// Replace request context with the timed context
+	req = req.WithContext(ctx)
 
 	observability.AddRequestAttributes(ctx,
 		attribute.String("args.instance_id", instanceID),

--- a/runtime/server/server.go
+++ b/runtime/server/server.go
@@ -312,6 +312,10 @@ func timeoutSelector(fullMethodName string) time.Duration {
 		return time.Minute * 2 // Match the completionTimeout from runtime/completion.go
 	}
 
+	if fullMethodName == runtimev1.RuntimeService_CompleteStreaming_FullMethodName {
+		return time.Minute * 2 // Match the completionTimeout from runtime/completion.go
+	}
+
 	return time.Second * 30
 }
 


### PR DESCRIPTION
Our current 30s context timeout is too short, as AI responses can easily take >30 seconds to finish.

Closes [APP-454](https://linear.app/rilldata/issue/APP-454/extend-completestreaming-timeout-from-30s-to-2-minutes)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
