### PR TITLE
fix: legacy iso time range comparisions in reports

### DIFF
--- a/web-common/src/features/alerts/alert-preview-data.ts
+++ b/web-common/src/features/alerts/alert-preview-data.ts
@@ -87,6 +87,7 @@ function getAlertPreviewQueryRequest(
     timeControlArgs,
     exploreSpec,
   );
+
   req.limit = "50"; // arbitrary limit to make sure we do not pull too much of data
   if (!timeControlArgs.selectedTimeRange?.end) return req;
 

--- a/web-common/src/features/dashboards/time-controls/time-range-mappers.ts
+++ b/web-common/src/features/dashboards/time-controls/time-range-mappers.ts
@@ -105,28 +105,36 @@ export function mapSelectedComparisonTimeRangeToV1TimeRange(
     return undefined;
   }
 
+  let isoDuration = timeRange.isoDuration;
+  const name = selectedComparisonTimeRange.name;
+
   if (
     timeRange.expression &&
     TIME_COMPARISON[selectedComparisonTimeRange.name]?.rillTimeOffset
   ) {
     const rt = parseRillTime(timeRange.expression);
-    return {
-      expression:
-        rt.toString() +
-        " offset " +
-        TIME_COMPARISON[selectedComparisonTimeRange.name]?.rillTimeOffset,
-    };
+    if (!rt.isOldFormat) {
+      return {
+        expression:
+          rt.toString() +
+          " offset " +
+          TIME_COMPARISON[selectedComparisonTimeRange.name]?.rillTimeOffset,
+      };
+    } else {
+      // Handle old syntax differently until we have the backend parser updated.
+      isoDuration = timeRange.expression;
+    }
   }
 
   const comparisonTimeRange: V1TimeRange = {};
-  switch (selectedComparisonTimeRange.name) {
+  switch (name) {
     default:
       comparisonTimeRange.isoOffset = selectedComparisonTimeRange.name;
-      comparisonTimeRange.isoDuration = timeRange.isoDuration;
+      comparisonTimeRange.isoDuration = isoDuration;
       break;
     case TimeComparisonOption.CONTIGUOUS:
       comparisonTimeRange.isoOffset = comparisonTimeRange.isoDuration =
-        timeRange.isoDuration;
+        isoDuration;
       break;
 
     case TimeComparisonOption.CUSTOM:


### PR DESCRIPTION
Until we have https://github.com/rilldata/rill/pull/8032 in, we need to use old iso ranges for comparisons.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
