### PR TITLE
fix: initial embed state not applying to dashboard

### DIFF
--- a/web-admin/src/features/embeds/init-embed-public-api.ts
+++ b/web-admin/src/features/embeds/init-embed-public-api.ts
@@ -81,7 +81,7 @@ const EmbedParams = [
   "kind",
   "navigation",
 ];
-function removeEmbedParams(searchParams: URLSearchParams) {
+export function removeEmbedParams(searchParams: URLSearchParams) {
   const cleanedParams = new URLSearchParams(searchParams);
   EmbedParams.forEach((param) => cleanedParams.delete(param));
   const search = cleanedParams.toString();

--- a/web-admin/src/routes/-/embed/+layout.ts
+++ b/web-admin/src/routes/-/embed/+layout.ts
@@ -1,4 +1,5 @@
 import { EmbedStore } from "@rilldata/web-admin/features/embeds/embed-store.ts";
+import { removeEmbedParams } from "@rilldata/web-admin/features/embeds/init-embed-public-api.ts";
 import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors.ts";
 import { redirect } from "@sveltejs/kit";
 
@@ -16,7 +17,12 @@ export const load = ({ url }) => {
       url.searchParams.get("type") === ResourceKind.Canvas
         ? "canvas"
         : "explore";
-    throw redirect(307, `/-/embed/${type}/${resource}`);
+    // Retain non-embed search params
+    const nonEmbedSearchParams = removeEmbedParams(url.searchParams);
+    throw redirect(
+      307,
+      `/-/embed/${type}/${resource}?${nonEmbedSearchParams.toString()}`,
+    );
   }
 
   const {

--- a/web-admin/tests/embeds.spec.ts
+++ b/web-admin/tests/embeds.spec.ts
@@ -119,6 +119,36 @@ test.describe("Embeds", () => {
         logMessages.some((msg) => msg.includes(`{"id":1337,"result":true}`)),
       ).toBeTruthy();
     });
+
+    test.describe("embedded explore with initial state", () => {
+      test.use({
+        embeddedInitialState:
+          "&tr=PT6H&compare_tr=rill-PP&f=advertiser_name+IN+('Instacart')",
+      });
+
+      test("init state is applied to dashboard", async ({ embedPage }) => {
+        const logMessages: string[] = [];
+        await waitForReadyMessage(embedPage, logMessages);
+        const frame = embedPage.frameLocator("iframe");
+
+        await expect(
+          frame.getByRole("button", {
+            name: "Advertising Spend Overall $252.33",
+          }),
+        ).toContainText(
+          /Advertising Spend Overall\s+\$252.33\s+-\$52.08\s+-17%/m,
+        );
+        await embedPage.waitForTimeout(500);
+
+        expect(
+          logMessages.some((msg) =>
+            msg.includes(
+              "tr=PT6H&compare_tr=rill-PP&f=advertiser_name+IN+('Instacart')",
+            ),
+          ),
+        ).toBeTruthy();
+      });
+    });
   });
 
   test.describe("embedded canvas", () => {
@@ -185,7 +215,7 @@ test.describe("Embeds", () => {
       ).toBeTruthy();
     });
 
-    test("setState changes embedded explore", async ({ embedPage }) => {
+    test("setState changes embedded canvas", async ({ embedPage }) => {
       const logMessages: string[] = [];
       await waitForReadyMessage(embedPage, logMessages);
       const frame = embedPage.frameLocator("iframe");
@@ -209,6 +239,32 @@ test.describe("Embeds", () => {
       expect(
         logMessages.some((msg) => msg.includes(`{"id":1337,"result":true}`)),
       ).toBeTruthy();
+    });
+
+    test.describe("embedded canvas with initial state", () => {
+      test.use({
+        embeddedInitialState:
+          "&tr=PT6H&compare_tr=rill-PP&f=advertiser_name+IN+('Instacart')",
+      });
+
+      test("init state is applied to canvas", async ({ embedPage }) => {
+        const logMessages: string[] = [];
+        await waitForReadyMessage(embedPage, logMessages);
+        const frame = embedPage.frameLocator("iframe");
+
+        await expect(frame.getByLabel("overall_spend KPI data")).toContainText(
+          /Advertising Spend Overall\s+\$252.33\s+-\$52.08 -17%\s+vs previous period/m,
+        );
+        await embedPage.waitForTimeout(500);
+
+        expect(
+          logMessages.some((msg) =>
+            msg.includes(
+              "tr=PT6H&compare_tr=rill-PP&f=advertiser_name+IN+('Instacart')",
+            ),
+          ),
+        ).toBeTruthy();
+      });
     });
   });
 

--- a/web-common/tests/fixtures/rill-cloud-fixtures.ts
+++ b/web-common/tests/fixtures/rill-cloud-fixtures.ts
@@ -21,6 +21,7 @@ type MyFixtures = {
   anonPage: Page;
   cli: void;
   embedPage: Page;
+  embeddedInitialState: string | null;
   /**
    * Resource to embed. Should be from the openrtb project.
    * Defaults to "bids_explore"
@@ -30,6 +31,7 @@ type MyFixtures = {
 };
 
 export const rillCloud = base.extend<MyFixtures>({
+  embeddedInitialState: [null, { option: true }],
   embeddedResourceName: ["bids_explore", { option: true }],
   embeddedResourceType: ["rill.runtime.v1.Explore", { option: true }],
 
@@ -69,17 +71,26 @@ export const rillCloud = base.extend<MyFixtures>({
   },
 
   embedPage: [
-    async ({ browser, embeddedResourceName, embeddedResourceType }, use) => {
+    async (
+      {
+        browser,
+        embeddedResourceName,
+        embeddedResourceType,
+        embeddedInitialState,
+      },
+      use,
+    ) => {
       const readPath = path.join(process.cwd(), RILL_EMBED_SERVICE_TOKEN_FILE);
       const rillServiceToken = fs.readFileSync(readPath, "utf-8");
 
-      await generateEmbed(
-        RILL_ORG_NAME,
-        RILL_PROJECT_NAME,
-        embeddedResourceName,
-        embeddedResourceType,
-        rillServiceToken,
-      );
+      await generateEmbed({
+        organization: RILL_ORG_NAME,
+        project: RILL_PROJECT_NAME,
+        resourceName: embeddedResourceName,
+        resourceType: embeddedResourceType,
+        serviceToken: rillServiceToken,
+        initialState: embeddedInitialState,
+      });
       const filePath =
         "file://" + path.resolve(process.cwd(), RILL_EMBED_HTML_FILE);
 

--- a/web-common/tests/utils/generate-embed.ts
+++ b/web-common/tests/utils/generate-embed.ts
@@ -4,13 +4,21 @@ import axios from "axios";
 import fs from "fs";
 import path from "path";
 
-export async function generateEmbed(
-  organization: string,
-  project: string,
-  resourceName: string,
-  resourceType: string,
-  serviceToken: string,
-): Promise<void> {
+export async function generateEmbed({
+  organization,
+  project,
+  resourceName,
+  resourceType,
+  serviceToken,
+  initialState,
+}: {
+  organization: string;
+  project: string;
+  resourceName: string;
+  resourceType: string;
+  serviceToken: string;
+  initialState: string | null;
+}): Promise<void> {
   try {
     const response: AxiosResponse<{ iframeSrc: string }> = await axios.post(
       `http://localhost:8080/v1/orgs/${organization}/projects/${project}/iframe`,
@@ -27,9 +35,12 @@ export async function generateEmbed(
       },
     );
 
-    const iframeSrc = response.data.iframeSrc;
+    let iframeSrc = response.data.iframeSrc;
     if (!iframeSrc) {
       throw new Error("Invalid response: iframeSrc not found");
+    }
+    if (initialState) {
+      iframeSrc += `${initialState}`;
     }
 
     const htmlContent = `<!DOCTYPE html>


### PR DESCRIPTION
After the navigation refactor initial embed state no longer applied to dashboards. This makes sure those are retained after initial redirect.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
