### PR TITLE
fix: dashboard timezone not applying to reports and alerts

### DIFF
--- a/runtime/metricsview/executor/executor_rewrite_time.go
+++ b/runtime/metricsview/executor/executor_rewrite_time.go
@@ -85,7 +85,8 @@ func (e *Executor) resolveTimeRange(ctx context.Context, tr *metricsview.TimeRan
 	}
 
 	rillTime, err := rilltime.Parse(tr.Expression, rilltime.ParseOptions{
-		SmallestGrain: timeutil.TimeGrainFromAPI(e.metricsView.SmallestTimeGrain),
+		SmallestGrain:   timeutil.TimeGrainFromAPI(e.metricsView.SmallestTimeGrain),
+		DefaultTimeZone: tz,
 	})
 	if err != nil {
 		return err

--- a/web-common/src/features/dashboards/time-controls/time-range-mappers.ts
+++ b/web-common/src/features/dashboards/time-controls/time-range-mappers.ts
@@ -62,6 +62,7 @@ export function mapSelectedTimeRangeToV1TimeRange(
   if (!validateRillTime(selectedTimeRange.name)) {
     return {
       expression: selectedTimeRange.name,
+      timeZone,
     };
   }
 


### PR DESCRIPTION
With rill time we were no longer applying timezone from dashboard to reports and alerts.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
