### PR TITLE
Revert "Fix nav tab indicator alignment (#7939)"

### DIFF
--- a/web-admin/src/components/nav/Tab.svelte
+++ b/web-admin/src/components/nav/Tab.svelte
@@ -23,19 +23,7 @@
   const observer = new ResizeObserver((entries) => {
     for (const entry of entries) {
       if (entry.target instanceof HTMLElement) {
-        // Get position relative to the nav container's parent (the div with border-b)
-        const navElement = entry.target.parentElement;
-        const containerElement = navElement?.parentElement;
-
-        if (containerElement) {
-          const containerRect = containerElement.getBoundingClientRect();
-          const targetRect = entry.target.getBoundingClientRect();
-          left = targetRect.left - containerRect.left;
-        } else {
-          // Fallback to original calculation
-          left = entry.target.offsetLeft;
-        }
-
+        left = entry.target.offsetLeft;
         size = entry.target.clientWidth;
       }
     }

--- a/web-admin/src/features/organizations/OrganizationTabs.svelte
+++ b/web-admin/src/features/organizations/OrganizationTabs.svelte
@@ -53,7 +53,7 @@
     {#if $width && $position}
       <span
         style:width="{$width}px"
-        style:transform="translateX({$position}px)"
+        style:transform="translateX({$position}px) "
       />
     {/if}
   {/if}

--- a/web-admin/src/features/projects/ProjectTabs.svelte
+++ b/web-admin/src/features/projects/ProjectTabs.svelte
@@ -82,7 +82,7 @@
   {#if $width && $position}
     <span
       style:width="{$width}px"
-      style:transform="translateX({$position}px)"
+      style:transform="translateX({$position}px) "
     />
   {/if}
 </div>


### PR DESCRIPTION
This reverts commit 54553f1b7fa61092247774a195d5ee34f4def42d from [PR 7939](https://github.com/rilldata/rill/pull/7939). The PR did not fix what it attempted to fix, and it added complexity to the `Tab` component.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
