### PR TITLE
Fix: Large value formatting in cli commands

### DIFF
--- a/cli/cmd/project/tables.go
+++ b/cli/cmd/project/tables.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/rilldata/rill/cli/pkg/cmdutil"
-	"github.com/rilldata/rill/cli/pkg/printer"
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/spf13/cobra"
@@ -95,7 +94,7 @@ func TablesCmd(ch *cmdutil.Helper) *cobra.Command {
 				queryRes, err := rt.RuntimeServiceClient.QueryResolver(cmd.Context(), &runtimev1.QueryResolverRequest{
 					InstanceId:         instanceID,
 					Resolver:           "sql",
-					ResolverProperties: &structpb.Struct{Fields: map[string]*structpb.Value{"sql": {Kind: &structpb.Value_StringValue{StringValue: countQuery}}}},
+					ResolverProperties: must(structpb.NewStruct(map[string]any{"sql": countQuery})),
 				})
 				if err != nil {
 					rowCount = "error"
@@ -103,7 +102,7 @@ func TablesCmd(ch *cmdutil.Helper) *cobra.Command {
 					// Extract the count value from the first row, first column (should be only one column from COUNT(*))
 					for _, countValue := range queryRes.Data[0].Fields {
 						if countValue != nil {
-							rowCount = printer.FormatValue(countValue.AsInterface())
+							rowCount = fmt.Sprint(countValue.AsInterface())
 						} else {
 							rowCount = "unknown"
 						}
@@ -132,4 +131,11 @@ func TablesCmd(ch *cmdutil.Helper) *cobra.Command {
 	tablesCmd.Flags().BoolVar(&local, "local", false, "Target local runtime instead of Rill Cloud")
 
 	return tablesCmd
+}
+
+func must[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
 }

--- a/cli/pkg/printer/printer.go
+++ b/cli/pkg/printer/printer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/fatih/color"
@@ -194,4 +195,28 @@ func (p *Printer) FormatNumber(num int64) string {
 		return fmt.Sprintf("%.1fM", float64(num)/1000000)
 	}
 	return fmt.Sprintf("%.1fB", float64(num)/1000000000)
+}
+
+// FormatValue formats a value for display, avoiding scientific notation for numbers
+func (p *Printer) FormatValue(val interface{}) string {
+	if val == nil {
+		return "null"
+	}
+
+	switch v := val.(type) {
+	case float64:
+		if v == float64(int64(v)) {
+			return strconv.FormatInt(int64(v), 10)
+		}
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case float32:
+		if v == float32(int32(v)) {
+			return strconv.FormatInt(int64(v), 10)
+		}
+		return strconv.FormatFloat(float64(v), 'f', -1, 32)
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return fmt.Sprintf("%d", v)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
 }

--- a/cli/pkg/printer/resources.go
+++ b/cli/pkg/printer/resources.go
@@ -667,30 +667,6 @@ type billingIssue struct {
 	EventTime    string `header:"event_time,timestamp(ms|utc|human)" json:"event_time"`
 }
 
-// FormatValue formats a value for display, avoiding scientific notation for numbers
-func FormatValue(val interface{}) string {
-	if val == nil {
-		return "null"
-	}
-
-	switch v := val.(type) {
-	case float64:
-		if v == float64(int64(v)) {
-			return strconv.FormatInt(int64(v), 10)
-		}
-		return strconv.FormatFloat(v, 'f', -1, 64)
-	case float32:
-		if v == float32(int32(v)) {
-			return strconv.FormatInt(int64(v), 10)
-		}
-		return strconv.FormatFloat(float64(v), 'f', -1, 32)
-	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		return fmt.Sprintf("%d", v)
-	default:
-		return fmt.Sprintf("%v", v)
-	}
-}
-
 // PrintQueryResponse prints the query response in the desired format (human, json, csv)
 func (p *Printer) PrintQueryResponse(res *runtimev1.QueryResolverResponse) {
 	if len(res.Data) == 0 {
@@ -708,7 +684,7 @@ func (p *Printer) PrintQueryResponse(res *runtimev1.QueryResolverResponse) {
 			rows[i] = make([]string, len(headers))
 			for j, field := range headers {
 				if val, ok := row.GetFields()[field]; ok {
-					rows[i][j] = FormatValue(val.AsInterface())
+					rows[i][j] = p.FormatValue(val.AsInterface())
 				} else {
 					rows[i][j] = "null"
 				}
@@ -731,7 +707,7 @@ func (p *Printer) PrintQueryResponse(res *runtimev1.QueryResolverResponse) {
 			record := make([]string, len(headers))
 			for i, field := range headers {
 				if val, ok := row.GetFields()[field]; ok {
-					record[i] = FormatValue(val.AsInterface())
+					record[i] = p.FormatValue(val.AsInterface())
 				} else {
 					record[i] = ""
 				}


### PR DESCRIPTION
Removing the use of scientific notation in query results for `table` and `query` commands

```sh
rill query --sql "SELECT 1000000000000 as big_number, 1.23456789 as decimal_number" --project demo
  BIG NUMBER      DECIMAL NUMBER  
 --------------- ---------------- 
  1000000000000   1.23456789      
  ```
  
  ```sh
./rill project tables rill-bluesky | head -15
  NAME                       ROW COUNT   COLUMN COUNT   DATABASE SIZE
 -------------------------- ----------- -------------- ---------------
  jetstream_clean            42058892    9              3.7 GiB
  jetstream_parquet          44500000    10             11.1 GiB
  jetstream_parquet (copy)   44500000    1              7.1 GiB
```
