### PR TITLE
Bump long reconciliation message

### DIFF
--- a/web-common/src/features/entity-management/actions.ts
+++ b/web-common/src/features/entity-management/actions.ts
@@ -82,9 +82,7 @@ export async function waitForResourceReconciliation(
       }
 
       // Last attempt and still not idle
-      throw new Error(
-        `Resource reconciliation timeout. Current status: ${reconcileStatus || "unknown"}`,
-      );
+      throw new Error(`Resource reconciliation timeout. Please try again.`);
     } catch (error) {
       // Resource not found could mean it was deleted due to reconcile failure
       if (error?.status === 404 || error?.response?.status === 404) {


### PR DESCRIPTION
This PR simplifies the timeout message when it takes too long to reconcile a resource. Closes https://linear.app/rilldata/issue/APP-456/fix-long-resource-reconciliation-message

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
