### PR TITLE
Potential fix for code scanning alert no. 11: Potentially unsafe quoting

### DIFF
--- a/runtime/pkg/duckdbsql/ast_rewrite.go
+++ b/runtime/pkg/duckdbsql/ast_rewrite.go
@@ -186,22 +186,22 @@ func createExpressionStatement(exprNode astNode) (string, error) {
 		return "", err
 	}
 	baseJSON := map[string]interface{}{
-		"error":      false,
+		"error": false,
 		"statements": []map[string]interface{}{
 			{
 				"node": map[string]interface{}{
-					"type":               "SELECT_NODE",
-					"modifiers":          []interface{}{},
-					"cte_map":            map[string]interface{}{"map": []interface{}{}},
-					"select_list":        []json.RawMessage{jsonNode},
-					"from_table":         map[string]interface{}{
-						"type":               "BASE_TABLE",
-						"alias":              "",
-						"sample":             nil,
-						"schema_name":        "",
-						"table_name":         "Dummy",
-						"column_name_alias":  []interface{}{},
-						"catalog_name":       "",
+					"type":        "SELECT_NODE",
+					"modifiers":   []interface{}{},
+					"cte_map":     map[string]interface{}{"map": []interface{}{}},
+					"select_list": []json.RawMessage{jsonNode},
+					"from_table": map[string]interface{}{
+						"type":              "BASE_TABLE",
+						"alias":             "",
+						"sample":            nil,
+						"schema_name":       "",
+						"table_name":        "Dummy",
+						"column_name_alias": []interface{}{},
+						"catalog_name":      "",
 					},
 					"where_clause":       nil,
 					"group_expressions":  []interface{}{},


### PR DESCRIPTION
Potential fix for [https://github.com/rilldata/rill/security/code-scanning/11](https://github.com/rilldata/rill/security/code-scanning/11)

To fix the issue, avoid manually embedding `jsonNode` into the string literal using `fmt.Sprintf`. Instead, construct the JSON object programmatically using a structured approach, ensuring that the serialized JSON is safely integrated without relying on manual quoting. This can be achieved by unmarshaling the base JSON structure into a map or struct, modifying it programmatically, and then re-marshaling it into a string.

Changes required:
1. Replace the manual string construction with programmatic JSON manipulation.
2. Ensure that the resulting JSON structure is correctly serialized and returned.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
