### PR TITLE
fix: sort order of charts with no color dimension

### DIFF
--- a/web-common/src/features/components/charts/builder.ts
+++ b/web-common/src/features/components/charts/builder.ts
@@ -18,6 +18,7 @@ import {
   isFieldConfig,
   mergedVlConfig,
   resolveColor,
+  sanitizeSortFieldForVega,
 } from "@rilldata/web-common/features/components/charts/util";
 import {
   BarHighlightColorDark,
@@ -73,7 +74,11 @@ export function createPositionEncoding(
     type: field.type,
     ...(metaData && "timeUnit" in metaData && { timeUnit: metaData.timeUnit }),
     ...(field.sort &&
-      field.type !== "temporal" && { sort: data.domainValues?.[field.field] }),
+      field.type !== "temporal" && {
+        sort:
+          data.domainValues?.[field.field] ??
+          sanitizeSortFieldForVega(field.sort),
+      }),
     ...(field.type === "quantitative" && {
       scale: {
         ...(field.zeroBasedOrigin !== true && { zero: false }),

--- a/web-common/src/features/components/charts/cartesian/CartesianChartProvider.ts
+++ b/web-common/src/features/components/charts/cartesian/CartesianChartProvider.ts
@@ -161,7 +161,6 @@ export class CartesianChartProvider {
         const enabled =
           !!timeRange?.start &&
           !!timeRange?.end &&
-          hasColorDimension &&
           config.x?.type === "nominal" &&
           !Array.isArray(config.x?.sort) &&
           !!dimensionName;

--- a/web-common/src/features/components/charts/util.ts
+++ b/web-common/src/features/components/charts/util.ts
@@ -12,6 +12,7 @@ import type { Config } from "vega-lite";
 import type {
   ChartDataResult,
   ChartDomainValues,
+  ChartSortDirection,
   ChartSpec,
   ChartType,
   ColorMapping,
@@ -215,4 +216,11 @@ export function getColorMappingForChart(
   }
 
   return colorMapping;
+}
+
+export function sanitizeSortFieldForVega(sort: ChartSortDirection) {
+  if (sort === "measure" || sort === "-measure") {
+    return undefined;
+  }
+  return sort;
 }


### PR DESCRIPTION
Fix regression where sort order was not applied for cartesian chart types (bar, line, and area).

https://rilldata.slack.com/archives/C06M8V1Q5KK/p1760448013345799

The issue occurred because the charting layer `buildHoverRuleLayer` did not have the correct sort order defined. Adding a sort key directly (e.g., `y` or `-y`) did not work as well.
To resolve this, we now perform a Top N query regardless of whether a color dimension is defined and pass its result to Vega as the sort order.

As a fallback measure for future requirements also added `sanitizeSortFieldForVega` method which adds the sort key when top N data is not available.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
