### PR TITLE
use creator as default at backend as well

### DIFF
--- a/runtime/reconcilers/report.go
+++ b/runtime/reconcilers/report.go
@@ -516,7 +516,7 @@ func (r *ReportReconciler) sendReport(ctx context.Context, self *runtimev1.Resou
 	if w, ok := rep.Spec.Annotations["web_open_mode"]; ok {
 		webOpenMode = w
 		if webOpenMode == "" { // backwards compatibility
-			webOpenMode = "recipient"
+			webOpenMode = "creator"
 		}
 	}
 


### PR DESCRIPTION
At application level its already set, platform side PR was merged before change was decided. This is for extra safety against reports that did not had web open mode set at all (which I checked no customer reports had but some old internal reports).

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
