### PR TITLE
chore: Provide cancellation reasons to `controller.abort()`

### DIFF
--- a/web-common/src/features/dashboards/pivot/DragList.svelte
+++ b/web-common/src/features/dashboards/pivot/DragList.svelte
@@ -146,7 +146,8 @@
   }
 
   function handleDrop() {
-    if (zoneStartedDrag) $controllerStore?.abort();
+    if (zoneStartedDrag)
+      $controllerStore?.abort("Drag cancelled - item dropped");
 
     if (isValidDropZone) {
       if (dragChip && ghostIndex !== null) {

--- a/web-common/src/features/metrics-views/ai-generation/generateMetricsView.ts
+++ b/web-common/src/features/metrics-views/ai-generation/generateMetricsView.ts
@@ -20,11 +20,11 @@ import {
   runtimeServiceGetFile,
 } from "../../../runtime-client";
 import httpClient from "../../../runtime-client/http-client";
+import { createYamlModelFromTable } from "../../connectors/code-utils";
 import { getName } from "../../entity-management/name-utils";
 import { featureFlags } from "../../feature-flags";
 import { createAndPreviewExplore } from "../create-and-preview-explore";
 import OptionToCancelAIGeneration from "./OptionToCancelAIGeneration.svelte";
-import { createYamlModelFromTable } from "../../connectors/code-utils";
 
 /**
  * TanStack Query does not support mutation cancellation (at least as of v4).
@@ -73,7 +73,7 @@ export function useCreateMetricsViewFromTableUIAction(
         component: OptionToCancelAIGeneration,
         props: {
           onCancel: () => {
-            abortController.abort();
+            abortController.abort("AI generation cancelled by user");
             isAICancelled = true;
           },
         },
@@ -198,7 +198,7 @@ export async function createDashboardFromTableInMetricsEditor(
       component: OptionToCancelAIGeneration,
       props: {
         onCancel: () => {
-          abortController.abort();
+          abortController.abort("Dashboard generation cancelled by user");
           isAICancelled = true;
         },
       },
@@ -319,7 +319,7 @@ export async function createModelAndMetricsAndExplore(
       component: OptionToCancelAIGeneration,
       props: {
         onCancel: () => {
-          abortController.abort();
+          abortController.abort("Metrics creation cancelled by user");
           isAICancelled = true;
         },
       },
@@ -334,7 +334,7 @@ export async function createModelAndMetricsAndExplore(
         component: OptionToCancelAIGeneration,
         props: {
           onCancel: () => {
-            abortController.abort();
+            abortController.abort("Model creation cancelled by user");
             isAICancelled = true;
           },
         },
@@ -373,7 +373,7 @@ export async function createModelAndMetricsAndExplore(
         component: OptionToCancelAIGeneration,
         props: {
           onCancel: () => {
-            abortController.abort();
+            abortController.abort("Metrics view creation cancelled by user");
             isAICancelled = true;
           },
         },
@@ -451,7 +451,9 @@ export async function createModelAndMetricsAndExplore(
         component: OptionToCancelAIGeneration,
         props: {
           onCancel: () => {
-            abortController.abort();
+            abortController.abort(
+              "Explore dashboard creation cancelled by user",
+            );
             isAICancelled = true;
           },
         },

--- a/web-common/src/runtime-client/StreamingQueryBatch.ts
+++ b/web-common/src/runtime-client/StreamingQueryBatch.ts
@@ -72,7 +72,7 @@ export class StreamingQueryBatch {
     queries.forEach(({ query, signal }) => {
       body.queries?.push(query);
       signal?.addEventListener("abort", () => {
-        controller.abort();
+        controller.abort(signal.reason || "Query cancelled");
       });
     });
 

--- a/web-common/src/runtime-client/sse-fetch-client.ts
+++ b/web-common/src/runtime-client/sse-fetch-client.ts
@@ -175,7 +175,7 @@ export class SSEFetchClient {
    */
   public stop(): void {
     if (this.abortController) {
-      this.abortController.abort();
+      this.abortController.abort("SSE stream stopped by client");
       this.abortController = undefined;
     }
   }

--- a/web-common/src/runtime-client/watch-request-client.ts
+++ b/web-common/src/runtime-client/watch-request-client.ts
@@ -134,7 +134,7 @@ export class WatchRequestClient<Res extends WatchResponse> {
 
   private cancel() {
     // Clean up fetch stream
-    this.controller?.abort();
+    this.controller?.abort("Watch request cancelled");
     this.stream = this.controller = undefined;
 
     // Clean up SSE connection


### PR DESCRIPTION
Our error telemetry has been picking up many instances of "signal is aborted without reason". This PR will hopefully eliminate those errors.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended – no, I haven't reproduced these "signal is aborted without reason" errors
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
