### PR TITLE
fix: missing comparison totals for advanced measures

### DIFF
--- a/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
+++ b/web-common/src/features/dashboards/time-series/timeseries-data-store.ts
@@ -184,7 +184,7 @@ export function createTimeSeriesDataStore(
       if (dashboardStore?.selectedComparisonDimension) {
         unfilteredTotals = createUnfilteredTotalsForMeasure(
           ctx,
-          measures,
+          measuresForTotals,
           dashboardStore?.selectedComparisonDimension,
         );
       }
@@ -200,7 +200,7 @@ export function createTimeSeriesDataStore(
           measuresForTimeSeries,
           true,
         );
-        comparisonTotals = createTotalsForMeasure(ctx, measures, true);
+        comparisonTotals = createTotalsForMeasure(ctx, measuresForTotals, true);
       }
 
       let dimensionTimeSeriesCharts:


### PR DESCRIPTION
Comparison totals are missing when there is an advanced measure. We were using the incorrect list of measures for comparison totals.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
