### PR TITLE
Update canvas configuration title

### DIFF
--- a/web-common/src/features/canvas/inspector/PageEditor.svelte
+++ b/web-common/src/features/canvas/inspector/PageEditor.svelte
@@ -113,7 +113,7 @@
   }
 </script>
 
-<SidebarWrapper type="secondary" disableHorizontalPadding title="Canvas">
+<SidebarWrapper type="secondary" disableHorizontalPadding title="General canvas configurations">
   <div class="page-param">
     <Input
       hint="Shown in global header and when deployed to Rill Cloud"


### PR DESCRIPTION
Updates the title of the Canvas configuration panel from "Canvas" to "General canvas configurations" for improved clarity, addressing Linear issue APP-484.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-484](https://linear.app/rilldata/issue/APP-484/change-canvas-configuration-title)

<a href="https://cursor.com/background-agent?bcId=bc-0246a108-fd3f-4e51-810a-f774b7ff8d46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0246a108-fd3f-4e51-810a-f774b7ff8d46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

