### PR TITLE
fix: Query is already running error for clickhouse

### DIFF
--- a/runtime/drivers/clickhouse/context.go
+++ b/runtime/drivers/clickhouse/context.go
@@ -54,6 +54,6 @@ func contextWithQueryID(ctx context.Context) context.Context {
 
 	// clickhouse complains if the query ID of two concurrent queries are the same
 	// we append a random suffix to ensure uniqueness but users can still correlate queries by trace ID
-	queryID := traceID + uuid.New().String()[0:8]
+	queryID := traceID + "_" + uuid.New().String()[0:8]
 	return clickhouse.Context(ctx, clickhouse.WithQueryID(queryID))
 }


### PR DESCRIPTION
closes https://linear.app/rilldata/issue/PLAT-125/debug-query-is-already-running-in-clickhouse

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
