### PR TITLE
fix: Add backwards compatibility for credentials endpoint

### DIFF
--- a/admin/server/server.go
+++ b/admin/server/server.go
@@ -210,6 +210,12 @@ func (s *Server) HTTPHandler(ctx context.Context) (http.Handler, error) {
 		transcoder.ServeHTTP(w, r)
 	}))
 
+	// Add backwards compatibility alias for credentials endpoint
+	observability.MuxHandle(mux, "/v1/organizations/{org}/projects/{project}/credentials", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.URL.Path = strings.Replace(r.URL.Path, "/v1/organizations/", "/v1/orgs/", 1)
+		transcoder.ServeHTTP(w, r)
+	}))
+
 	// Add Prometheus
 	if s.opts.ServePrometheus {
 		mux.Handle("/metrics", promhttp.Handler())

--- a/docs/docs/integrate/custom-api.md
+++ b/docs/docs/integrate/custom-api.md
@@ -63,9 +63,9 @@ You can use a service token to issue a short-lived, ephemeral access token with 
 
 The primary use case for these tokens is to have your backend issue a short-lived token that represents your current user, which your frontend can use to make direct calls to APIs in Rill. This is the same feature that powers Rill's embedded dashboards.
 
-To get an ephemeral user token, you need to use a service token to perform a handshake with Rill's credentials API at `https://api.rilldata.com/v1/organizations/<org-name>/projects/<project-name>/credentials`. For example:
+To get an ephemeral user token, you need to use a service token to perform a handshake with Rill's credentials API at `https://api.rilldata.com/v1/orgs/<org-name>/projects/<project-name>/credentials`. For example:
 ```bash
-curl -X POST https://api.rilldata.com/v1/organizations/<org-name>/projects/<project-name>/credentials \
+curl -X POST https://api.rilldata.com/v1/orgs/<org-name>/projects/<project-name>/credentials \
   -H "Authorization: Bearer <service-account-token>" \
   --data-raw '{ "user_email":"<user-email>" }'
 ``` 


### PR DESCRIPTION
Add backwards compatibility for credentials endpoint and updates the docs

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
