### PR TITLE
fix: persist viz in ai chart

### DIFF
--- a/web-common/src/features/chat/core/messages/ToolMessage.svelte
+++ b/web-common/src/features/chat/core/messages/ToolMessage.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import ChartBlock from "@rilldata/web-common/features/chat/core/messages/ChartBlock.svelte";
-  import { isChartToolResult } from "@rilldata/web-common/features/chat/core/utils";
+  import {
+    isChartToolResult,
+    parseChartData,
+  } from "@rilldata/web-common/features/chat/core/utils";
   import type { V1Message } from "../../../../runtime-client";
   import TextMessage from "./TextMessage.svelte";
   import ToolCallBlock from "./ToolCallBlock.svelte";
@@ -18,20 +21,6 @@
   // Currently we have split responsibility: Conversation handles streaming correlation,
   // but UI handles initial fetch correlation. This creates inconsistent architecture.
   // All correlation should happen in the business layer, with UI just displaying pre-correlated data.
-
-  // Helper to parse chart data from tool result
-  function parseChartData(toolResult: any) {
-    try {
-      const parsed = JSON.parse(toolResult.content);
-      return {
-        chartType: parsed.chart_type,
-        chartSpec: parsed.spec,
-      };
-    } catch (error) {
-      console.error("Failed to parse chart data:", error);
-      return null;
-    }
-  }
 
   // Helper to create a tool block
   function createToolBlock(toolCall: any, toolResult: any, index: number) {
@@ -70,7 +59,7 @@
     }
 
     // Try to parse chart data
-    const chartData = parseChartData(toolResult);
+    const chartData = parseChartData(block.toolCall);
     if (!chartData) {
       // Parsing failed, fallback to regular tool block
       return [createToolBlock(block.toolCall, toolResult, index)];

--- a/web-common/src/features/chat/core/utils.ts
+++ b/web-common/src/features/chat/core/utils.ts
@@ -87,12 +87,34 @@ export function detectAppContext(page: Page): V1AppContext | null {
 
 // Helper to check if a tool result contains chart data
 export function isChartToolResult(toolResult: any, toolCall: any): boolean {
-  if (!toolResult || !toolResult?.content || toolResult?.isError) return false;
-  if (toolCall?.name !== "create_chart") return false;
+  if (toolResult?.isError || toolCall?.name !== "create_chart") return false;
   try {
-    const parsed = JSON.parse(toolResult.content);
-    return !!(parsed.chart_type && parsed.spec);
+    // Check if input is already an object or needs parsing
+    const parsed =
+      typeof toolCall?.input === "string"
+        ? JSON.parse(toolCall.input)
+        : toolCall?.input;
+    return !!(parsed?.chart_type && parsed?.spec);
   } catch {
     return false;
+  }
+}
+
+// Helper to parse chart data from tool result
+export function parseChartData(toolCall: any) {
+  try {
+    // Check if input is already an object or needs parsing
+    const parsed =
+      typeof toolCall?.input === "string"
+        ? JSON.parse(toolCall.input)
+        : toolCall?.input;
+
+    return {
+      chartType: parsed.chart_type,
+      chartSpec: parsed.spec,
+    };
+  } catch (error) {
+    console.error("Failed to parse chart data:", error);
+    return null;
   }
 }


### PR DESCRIPTION
There seems to be regression where if you refresh the chat page, the visualization block is not shown. 

`toolResult.content` is valid when text was being generated but on refresh it was `undefined`. Instead of using `toolResult.content`, switching to `toolCall.input`.

This PR fixes it.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
