### PR TITLE
Exclude myemail from top 5 in the default share project

### DIFF
--- a/web-admin/src/features/projects/user-management/UserAndGroupInviteForm.svelte
+++ b/web-admin/src/features/projects/user-management/UserAndGroupInviteForm.svelte
@@ -146,7 +146,8 @@
     const options = getAdminServiceListOrganizationMemberUsersQueryOptions(
       organization,
       {
-        pageSize: 5,
+        // Request one extra to keep a consistent 5 after filtering out self
+        pageSize: 6,
         ...(query ? { searchPattern: `${query}%` } : {}),
       },
     );
@@ -165,8 +166,10 @@
       ? users.filter((u) => u.userEmail?.toLowerCase() !== myEmail)
       : users;
 
+    const trimmed = filtered.length > 5 ? filtered.slice(0, 5) : filtered;
+
     // Return only remote user results; SearchAndInviteInput merges with local searchList
-    return filtered.map((u) => ({
+    return trimmed.map((u) => ({
       identifier: u.userEmail,
       type: "user" as const,
       name: u.userName,


### PR DESCRIPTION
This PR filters out myemail when requesting top 5 members in the ShareProjectPopover.

<img width="3456" height="1860" alt="CleanShot 2025-10-29 at 19 03 54@2x" src="https://github.com/user-attachments/assets/ca473547-90bf-4d97-8d11-cdd55ca260d3" />


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
