### PR TITLE
fix: highlight filename without extension

### DIFF
--- a/web-common/src/components/forms/InputWithConfirm.svelte
+++ b/web-common/src/components/forms/InputWithConfirm.svelte
@@ -16,21 +16,10 @@
   export let size: "sm" | "md" | "lg" = "lg";
   export let showIndicator = false;
   export let editing = false;
+  export let selectionStart: number | undefined = undefined;
+  export let selectionEnd: number | undefined = undefined;
 
   $: editedValue = value;
-
-  let selectionStart: number | undefined = undefined;
-  let selectionEnd: number | undefined = undefined;
-  $: if (type === "File" && value) {
-    const lastDotIndex = value.lastIndexOf(".");
-    if (lastDotIndex > 0) {
-      selectionStart = 0;
-      selectionEnd = lastDotIndex;
-    } else {
-      selectionStart = undefined;
-      selectionEnd = undefined;
-    }
-  }
 
   async function triggerConfirm() {
     if (!editedValue) return;

--- a/web-common/src/features/entity-management/RenameAssetModal.svelte
+++ b/web-common/src/features/entity-management/RenameAssetModal.svelte
@@ -10,6 +10,7 @@
     useDirectoryNamesInDirectory,
     useFileNamesInDirectory,
   } from "@rilldata/web-common/features/entity-management/file-selectors";
+  import { getFilenameSelectionRange } from "@rilldata/web-common/features/entity-management/filename-selection-utils";
   import { defaults, setError, superForm } from "sveltekit-superforms";
   import { yup } from "sveltekit-superforms/adapters";
   import { object, string } from "yup";
@@ -32,16 +33,12 @@
 
   const [folderName, fileName] = splitFolderAndFileName(filePath);
 
-  let selectionStart: number | undefined;
-  let selectionEnd: number | undefined;
-
-  if (!isDir && fileName) {
-    const lastDotIndex = fileName.lastIndexOf(".");
-    if (lastDotIndex > 0) {
-      selectionStart = 0;
-      selectionEnd = lastDotIndex;
-    }
-  }
+  // Calculate selection range for files (exclude extension)
+  const selectionRange = !isDir
+    ? getFilenameSelectionRange(fileName)
+    : undefined;
+  const selectionStart = selectionRange?.selectionStart;
+  const selectionEnd = selectionRange?.selectionEnd;
 
   const validationSchema = object({
     newName: string()

--- a/web-common/src/features/entity-management/filename-selection-utils.ts
+++ b/web-common/src/features/entity-management/filename-selection-utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Calculates the selection range for a filename, excluding the extension.
+ * This allows users to edit just the filename without having to adjust the selection.
+ *
+ * @param fileName - The full filename including extension
+ * @returns An object with selectionStart and selectionEnd, or undefined if no selection should be made
+ */
+export function getFilenameSelectionRange(
+  fileName: string | undefined,
+): { selectionStart: number; selectionEnd: number } | undefined {
+  if (!fileName) return undefined;
+
+  const lastDotIndex = fileName.lastIndexOf(".");
+  
+  // Only create a selection if there's an extension (dot not at the start)
+  if (lastDotIndex > 0) {
+    return {
+      selectionStart: 0,
+      selectionEnd: lastDotIndex,
+    };
+  }
+
+  return undefined;
+}
+

--- a/web-common/src/layout/workspace/WorkspaceHeader.svelte
+++ b/web-common/src/layout/workspace/WorkspaceHeader.svelte
@@ -12,6 +12,7 @@
     resourceIconMapping,
   } from "@rilldata/web-common/features/entity-management/resource-icon-mapping";
   import type { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
+  import { getFilenameSelectionRange } from "@rilldata/web-common/features/entity-management/filename-selection-utils";
   import CodeToggle from "@rilldata/web-common/features/visual-editing/CodeToggle.svelte";
   import WorkspaceBreadcrumbs from "@rilldata/web-common/features/workspaces/WorkspaceBreadcrumbs.svelte";
   import type { V1Resource } from "@rilldata/web-common/runtime-client";
@@ -39,6 +40,11 @@
   $: tableVisible = workspaceLayout.table.visible;
 
   $: view = workspaceLayout.view;
+
+  // Calculate selection range for file titles (exclude extension)
+  $: selectionRange = getFilenameSelectionRange(value);
+  $: selectionStart = selectionRange?.selectionStart;
+  $: selectionEnd = selectionRange?.selectionEnd;
 </script>
 
 <header bind:clientWidth={width}>
@@ -76,6 +82,8 @@
         id="model-title-input"
         textClass="text-xl font-semibold"
         {value}
+        {selectionStart}
+        {selectionEnd}
         onConfirm={onTitleChange}
         showIndicator={hasUnsavedChanges}
       />


### PR DESCRIPTION
Opinionated nit: when editing a file name this will highlight just filename without extension so you can just type the new name without having to touch the mouse.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
