### PR TITLE
Display selected results on search in dimension filter

### DIFF
--- a/web-common/src/features/dashboards/filters/dimension-filters/helpers.ts
+++ b/web-common/src/features/dashboards/filters/dimension-filters/helpers.ts
@@ -52,14 +52,18 @@ export function getItemLists(
   curSearchText: string,
 ): { checkedItems: string[]; uncheckedItems: string[] } {
   if (mode === DimensionFilterMode.Select && correctedSearchResults) {
+    // While searching in Select mode, include selected items in the unified list
+    // so that matching selections are visible. When not searching, keep the
+    // split view: checked items first, then unchecked.
+    const isSearching = Boolean(curSearchText);
     return {
-      checkedItems: curSearchText
+      checkedItems: isSearching
         ? []
         : correctedSearchResults.filter((item) =>
             selectedValues.includes(item),
           ),
-      uncheckedItems: correctedSearchResults.filter(
-        (item) => !selectedValues.includes(item),
+      uncheckedItems: correctedSearchResults.filter((item) =>
+        isSearching ? true : !selectedValues.includes(item),
       ),
     };
   }


### PR DESCRIPTION
This PR displays the selected results on search in the DimensionFilter. Closes https://linear.app/rilldata/issue/APP-366/dimension-filter-dropdown-search-not-showing-selected-values

https://github.com/user-attachments/assets/57a432aa-8eea-44e7-9ccf-66aa56c95402

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
