### PR TITLE
fix (AI): Don't render agent tool calls

### DIFF
--- a/web-common/src/features/chat/core/messages/ToolMessage.svelte
+++ b/web-common/src/features/chat/core/messages/ToolMessage.svelte
@@ -2,6 +2,7 @@
   import ChartBlock from "@rilldata/web-common/features/chat/core/messages/ChartBlock.svelte";
   import {
     isChartToolResult,
+    isHiddenAgentTool,
     parseChartData,
   } from "@rilldata/web-common/features/chat/core/utils";
   import type { V1Message } from "../../../../runtime-client";
@@ -50,6 +51,11 @@
     index: number,
     toolResults: Map<string, any>,
   ): any[] {
+    // Filter out high-level agent invocations
+    if (isHiddenAgentTool(block.toolCall?.name)) {
+      return [];
+    }
+
     // Streaming merges tool results into toolCall blocks.
     // For initial fetch (GetConversation), calls/results are separate, so we attach via fallback.
     const toolResult = block.toolResult || toolResults.get(block.toolCall.id);

--- a/web-common/src/features/chat/core/utils.ts
+++ b/web-common/src/features/chat/core/utils.ts
@@ -85,6 +85,15 @@ export function detectAppContext(page: Page): V1AppContext | null {
 }
 */
 
+// High-level agent tools that should not be rendered in the UI (for now)
+// These are internal orchestration agents, not user-facing tools
+const HIDDEN_AGENT_TOOLS = ["router_agent", "analyst_agent", "developer_agent"];
+
+// Helper to check if a tool call should be hidden from the UI
+export function isHiddenAgentTool(toolName: string | undefined): boolean {
+  return !!toolName && HIDDEN_AGENT_TOOLS.includes(toolName);
+}
+
 // Helper to check if a tool result contains chart data
 export function isChartToolResult(toolResult: any, toolCall: any): boolean {
   if (toolResult?.isError || toolCall?.name !== "create_chart") return false;


### PR DESCRIPTION
In the short-term, we do not want to show the high-level agent invocations; we only want to render the granular tool calls. In the future, we would like to communicate the agent invocations– it just requires a little design work.

Before:
<img width="764" height="322" alt="image" src="https://github.com/user-attachments/assets/ac2c6749-4c32-4843-9e16-c93bbfffbbf4" />

After:
<img width="804" height="300" alt="image" src="https://github.com/user-attachments/assets/db824383-2c81-4f07-b19b-b21cf2288bd8" />

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
