### PR TITLE
Show actual exception instead encountered unsupported duckdb type null

### DIFF
--- a/runtime/drivers/duckdb/information_schema.go
+++ b/runtime/drivers/duckdb/information_schema.go
@@ -299,7 +299,7 @@ func scanTables(rows []*rduckdb.Table) ([]*drivers.OlapTable, error) {
 			// For views that depend on secrets, we have an inaccessible schema since
 			// the secret is only set at write time.
 			if strings.HasPrefix(colName.(string), "error(") && databaseType == "\"NULL\"" {
-				return nil, fmt.Errorf("failed to get schema (try setting `materialize: true` — this usually happens for non-materialized views): %s", colName.(string))
+				continue
 			}
 			colType, err := databaseTypeToPB(databaseType, nullable)
 			if err != nil {


### PR DESCRIPTION
When a model view is created without materialize: true on S3 data,
the table listing and preview were previously showing the error: `unsupported duckdb datatype: "NULL"` instead of the actual exception.

- Table listing view: No tables were shown only error `unsupported duckdb datatype: "NULL"`.

This issue will be resolved once we move to the new listTables implementation (base PR).
In that version, errors will no longer occur during listing — they’ll only be raised when fetching table metadata (column name, and data type). As a result, only the affected table will report an error.

- Table preview: Will now display the actual DuckDB error instead of the generic “unsupported datatype” message.


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
