### PR TITLE
Fix project share popover user count

### DIFF
--- a/web-admin/src/features/organizations/user-management/dialogs/EditUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/user-management/dialogs/EditUserGroupDialog.svelte
@@ -53,6 +53,7 @@
   $: listUsergroupMemberUsers = createAdminServiceListUsergroupMemberUsers(
     organization,
     groupName,
+    { pageSize: 1000 },
   );
 
   $: userGroupMembersUsers = $listUsergroupMemberUsers.data?.members ?? [];

--- a/web-admin/src/features/projects/user-management/GeneralAccessSelectorDropdown.svelte
+++ b/web-admin/src/features/projects/user-management/GeneralAccessSelectorDropdown.svelte
@@ -46,7 +46,7 @@
   $: listUsergroupMemberUsers = createAdminServiceListUsergroupMemberUsers(
     organization,
     "autogroup:members",
-    undefined,
+    { pageSize: 1000 },
     {
       query: {
         enabled: open,

--- a/web-admin/src/features/projects/user-management/ShareProjectForm.svelte
+++ b/web-admin/src/features/projects/user-management/ShareProjectForm.svelte
@@ -122,7 +122,7 @@
   $: listUsergroupMemberUsers = createAdminServiceListUsergroupMemberUsers(
     organization,
     "autogroup:members",
-    undefined,
+    { pageSize: 1000 },
     {
       query: {
         enabled,


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-75dcbf31-9971-48d7-95b8-c6f8f01019bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-75dcbf31-9971-48d7-95b8-c6f8f01019bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase page size to 1000 for user group member queries to ensure complete counts and lists in sharing and edit dialogs.
> 
> - **User management UI**:
>   - Increase page size to `1000` for `createAdminServiceListUsergroupMemberUsers` to load full member lists in:
>     - `web-admin/src/features/projects/user-management/GeneralAccessSelectorDropdown.svelte`
>     - `web-admin/src/features/projects/user-management/ShareProjectForm.svelte`
>     - `web-admin/src/features/organizations/user-management/dialogs/EditUserGroupDialog.svelte`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dcf823cecc03b1c65e1a73518f6b99500a03ad5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->