### PR TITLE
fix: hide doc link in embed

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotDisplay.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotDisplay.svelte
@@ -16,6 +16,8 @@
   import PivotTable from "./PivotTable.svelte";
   import PivotToolbar from "./PivotToolbar.svelte";
 
+  export let isEmbedded: boolean = false;
+
   const stateManagers = getStateManagers();
   const {
     exploreName,
@@ -121,7 +123,12 @@
       {#if $pivotDataStore?.error?.length}
         <PivotError errors={$pivotDataStore.error} />
       {:else if !$pivotDataStore?.data || $pivotDataStore?.data?.length === 0}
-        <PivotEmpty {assembled} {isFetching} {hasColumnAndNoMeasure} />
+        <PivotEmpty
+          {assembled}
+          {isFetching}
+          {hasColumnAndNoMeasure}
+          {isEmbedded}
+        />
       {:else}
         <PivotTable
           {pivotDataStore}

--- a/web-common/src/features/dashboards/pivot/PivotEmpty.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotEmpty.svelte
@@ -7,6 +7,7 @@
   export let isFetching = false;
   export let assembled = false;
   export let hasColumnAndNoMeasure = false;
+  export let isEmbedded = false;
 </script>
 
 <div class="flex flex-col items-center w-full h-full justify-center gap-y-6">
@@ -30,13 +31,15 @@
         Add a measure to complete your table.
       </div>
     </div>
-    <div class="text-gray-600">
-      Learn more about tables in our <a
-        target="_blank"
-        rel="noopener"
-        href="https://docs.rilldata.com/explore/filters/pivot">docs</a
-      >.
-    </div>
+    {#if !isEmbedded}
+      <div class="text-gray-600">
+        Learn more about tables in our <a
+          target="_blank"
+          rel="noopener"
+          href="https://docs.rilldata.com/explore/filters/pivot">docs</a
+        >.
+      </div>
+    {/if}
   {:else if assembled}
     <EmptyTableIcon />
     <div class="text-gray-600 text-base">
@@ -52,11 +55,13 @@
         Give it some data to keep it company.
       </div>
     </div>
-    <div class="text-gray-600">
-      Learn more about tables in our <a
-        target="_blank"
-        href="https://docs.rilldata.com/explore/filters/pivot">docs</a
-      >.
-    </div>
+    {#if !isEmbedded}
+      <div class="text-gray-600">
+        Learn more about tables in our <a
+          target="_blank"
+          href="https://docs.rilldata.com/explore/filters/pivot">docs</a
+        >.
+      </div>
+    {/if}
   {/if}
 </div>

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -152,7 +152,7 @@
         body="The security policy for this dashboard may make contents invisible to you. If you deploy this dashboard, {$selectedMockUserStore?.email} will see a 404."
       />
     {:else if $showPivot}
-      <PivotDisplay />
+      <PivotDisplay {isEmbedded} />
     {:else}
       <div
         class="flex gap-x-1 gap-y-2 overflow-hidden pl-4 slide bg-surface"


### PR DESCRIPTION
It does not handle if you for some reason would publish a Canvas dashboard with a empty pivot table but at that point a doc link is the least of your concerns.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
