### PR TITLE
fix: time range switching not cancelling old queries

### DIFF
--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -10,6 +10,7 @@
   import { isExpressionUnsupported } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
   import { isUrlTooLong } from "@rilldata/web-common/features/dashboards/url-state/url-length-limits";
   import { getMapFromArray } from "@rilldata/web-common/lib/arrayUtils";
+  import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient.ts";
   import type { TimeRange } from "@rilldata/web-common/lib/time/types";
   import {
     TimeComparisonOption,
@@ -20,6 +21,7 @@
     V1ExploreTimeRange,
     V1TimeGrain,
   } from "@rilldata/web-common/runtime-client";
+  import { isMetricsViewQuery } from "@rilldata/web-common/runtime-client/invalidation.ts";
   import { DateTime, Interval } from "luxon";
   import { flip } from "svelte/animate";
   import { fly } from "svelte/transition";
@@ -229,6 +231,11 @@
 
       if (timeZone) metricsExplorerStore.setTimeZone($exploreName, timeZone);
     }
+
+    await queryClient.cancelQueries({
+      predicate: (query) =>
+        isMetricsViewQuery(query.queryHash, metricsViewName),
+    });
 
     const { interval, grain } = await deriveInterval(
       alias,

--- a/web-common/src/features/dashboards/time-controls/new-time-controls.ts
+++ b/web-common/src/features/dashboards/time-controls/new-time-controls.ts
@@ -4,16 +4,14 @@
 // IntervalStore and MetricsTimeControls are WIP references, but are not currently being used
 // The functions below UTILS are being used
 
+import { fetchTimeRanges } from "@rilldata/web-common/features/dashboards/time-controls/rill-time-ranges.ts";
 import {
   overrideRillTimeRef,
   parseRillTime,
 } from "@rilldata/web-common/features/dashboards/url-state/time-ranges/parser";
 import { humaniseISODuration } from "@rilldata/web-common/lib/time/ranges/iso-ranges";
 import type { V1ExploreTimeRange } from "@rilldata/web-common/runtime-client";
-import {
-  getQueryServiceMetricsViewTimeRangesQueryKey,
-  V1TimeGrain,
-} from "@rilldata/web-common/runtime-client";
+import { V1TimeGrain } from "@rilldata/web-common/runtime-client";
 import {
   DateTime,
   type DateTimeUnit,
@@ -23,7 +21,6 @@ import {
   Interval,
   type WeekdayNumbers,
 } from "luxon";
-import { queryServiceMetricsViewTimeRanges } from "@rilldata/web-common/runtime-client";
 import { get, writable, type Writable } from "svelte/store";
 
 // CONSTANTS -> time-control-constants.ts
@@ -318,7 +315,6 @@ import {
   GrainAliasToV1TimeGrain,
   V1TimeGrainToAlias,
 } from "@rilldata/web-common/lib/time/new-grains";
-import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
 import {
   RillLegacyDaxInterval,
   RillLegacyIsoInterval,
@@ -355,26 +351,12 @@ export async function deriveInterval(
     const instanceId = get(runtime).instanceId;
     const cacheBust = name.includes("now");
 
-    const queryKey = getQueryServiceMetricsViewTimeRangesQueryKey(
+    const response = await fetchTimeRanges({
       instanceId,
       metricsViewName,
-      { expressions: [name], timeZone: activeTimeZone, priority: 100 },
-    );
-
-    if (cacheBust) {
-      await queryClient.invalidateQueries({
-        queryKey: queryKey,
-      });
-    }
-
-    const response = await queryClient.fetchQuery({
-      queryKey: queryKey,
-      queryFn: () =>
-        queryServiceMetricsViewTimeRanges(instanceId, metricsViewName, {
-          expressions: [name],
-          timeZone: activeTimeZone,
-        }),
-      staleTime: Infinity,
+      rillTimes: [name],
+      timeZone: activeTimeZone,
+      cacheBust,
     });
 
     const timeRange = response.resolvedTimeRanges?.[0];

--- a/web-common/src/features/scheduled-reports/FiltersForm.svelte
+++ b/web-common/src/features/scheduled-reports/FiltersForm.svelte
@@ -13,6 +13,7 @@
   import SuperPill from "@rilldata/web-common/features/dashboards/time-controls/super-pill/SuperPill.svelte";
   import type { Filters } from "@rilldata/web-common/features/dashboards/stores/Filters.ts";
   import type { TimeControls } from "@rilldata/web-common/features/dashboards/stores/TimeControls.ts";
+  import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient.ts";
   import { DEFAULT_TIME_RANGES } from "@rilldata/web-common/lib/time/config.ts";
   import { getDefaultTimeGrain } from "@rilldata/web-common/lib/time/grains";
   import {
@@ -22,6 +23,7 @@
     TimeRangePreset,
   } from "@rilldata/web-common/lib/time/types.ts";
   import { V1TimeGrain } from "@rilldata/web-common/runtime-client";
+  import { isMetricsViewQuery } from "@rilldata/web-common/runtime-client/invalidation.ts";
   import { DateTime, Interval } from "luxon";
   import { onMount } from "svelte";
   import { flip } from "svelte/animate";
@@ -167,6 +169,11 @@
 
       if (timeZone) setTimeZone(timeZone);
     }
+
+    await queryClient.cancelQueries({
+      predicate: (query) =>
+        isMetricsViewQuery(query.queryHash, metricsViewName),
+    });
 
     const { interval, grain } = await deriveInterval(
       name,


### PR DESCRIPTION
Switching time range in rill-dev can be blocked until queued previous queries are finished. So switching time range quickly can make the UI feel unresponsive.

Cancelling old metrics view queries when time range switch is triggered.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
