### PR TITLE
fix: github connect adding transfer twice leading to an apparent failure

### DIFF
--- a/admin/server/github.go
+++ b/admin/server/github.go
@@ -324,14 +324,6 @@ func (s *Server) ConnectProjectToGithub(ctx context.Context, req *adminv1.Connec
 		return nil, err
 	}
 
-	// Mark the project as transferred so that the local project folder can detect the correct remote project
-	if proj.ManagedGitRepoID != nil && proj.GitRemote != nil {
-		_, err = s.admin.DB.InsertGitRepoTransfer(ctx, *proj.GitRemote, req.Remote)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return &adminv1.ConnectProjectToGithubResponse{}, nil
 }
 

--- a/web-admin/src/features/projects/github/GithubConnectionDialog.svelte
+++ b/web-admin/src/features/projects/github/GithubConnectionDialog.svelte
@@ -102,6 +102,7 @@
       SPA: true,
       validators: schema,
       onUpdate: async ({ form }) => {
+        console.log(form.valid);
         if (!form.valid) return;
         const values = form.data;
 
@@ -142,12 +143,20 @@
 
     $form.branch = repo.defaultBranch;
   }
+
+  function resetMutations() {
+    $connectProjectToGithub.reset();
+    $updateProject.reset();
+  }
 </script>
 
 <Dialog.Root
   bind:open
   onOpenChange={(o) => {
-    if (!o) reset();
+    if (!o) {
+      resetMutations();
+      reset();
+    }
   }}
 >
   <Dialog.Trigger asChild let:builder>
@@ -167,7 +176,7 @@
       <div class="flex flex-row gap-x-2 items-center">
         <Github size="40px" />
         <div class="flex flex-col gap-y-1">
-          <Dialog.Title>Connect to github</Dialog.Title>
+          <Dialog.Title>Connect to GitHub</Dialog.Title>
           <Dialog.Description>
             Connect this project to a new repo.
           </Dialog.Description>
@@ -187,6 +196,7 @@
         label="Connection type"
         sameWidth
         options={GithubSelectionTypeOptions}
+        onChange={resetMutations}
       />
 
       {#if isNewRepoType}


### PR DESCRIPTION
Because of some merge issue `InsertGitRepoTransfer` was called twice during github connect API call. This lead to an error message shown to user even though the connect actually succeeded.

Also contains a small change to make sure errors are cleared from the dialog.

Closes APP-523

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
