### PR TITLE
fix: bookmarks backwards compatibility broken

### DIFF
--- a/web-admin/src/features/bookmarks/utils.ts
+++ b/web-admin/src/features/bookmarks/utils.ts
@@ -133,7 +133,7 @@ export function parseBookmarks(
 ) {
   return bookmarkResp.map((bookmarkResource) => {
     const bookmarkUrlSearch =
-      bookmarkResource.urlSearch ??
+      bookmarkResource.urlSearch ||
       dataTransformer(bookmarkResource.data ?? "");
 
     const bookmarkUrlParams = new URLSearchParams(bookmarkUrlSearch);


### PR DESCRIPTION
Moving from `data` to `url_search` broke backwards compatibility for bookmarks.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
