### PR TITLE
Fix filters being applied twice in report downloads that use creator mode

### DIFF
--- a/runtime/server/downloads.go
+++ b/runtime/server/downloads.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strings"
 	"time"
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
@@ -92,6 +93,31 @@ func (s *Server) ExportReport(ctx context.Context, req *runtimev1.ExportReportRe
 		}
 	}
 
+	// Reports delivered in "creator mode" are accessed using claims that contain AdditionalRules that grant transitive access to the report.
+	// The transitive rule resolves into a RowFilter rule for the underlying metrics view that contains the filters in the query above.
+	// This means that the filters will be applied twice, which can impact the accuracy of subquery filters.
+	// On the frontend, this is handled by not adding the report's filters to the dashboard when it's opened.
+	// On the backend however, since we know the download token is scoped to a specific query, it is easier to just create a download token that doesn't have the transitive access rule.
+	// This ensures the report's filters don't get applied twice in the query.
+	claims := auth.GetClaims(ctx, req.InstanceId)
+	downloadClaims := &runtime.SecurityClaims{
+		UserID:          claims.UserID,
+		UserAttributes:  claims.UserAttributes,
+		Permissions:     claims.Permissions,
+		AdditionalRules: nil, // Will be populated below
+		SkipChecks:      claims.SkipChecks,
+	}
+	for _, r := range claims.AdditionalRules {
+		ta := r.GetTransitiveAccess()
+		if ta == nil {
+			continue
+		}
+		if ta.Resource.Kind == runtime.ResourceKindReport && strings.EqualFold(ta.Resource.Name, req.Report) {
+			continue
+		}
+		downloadClaims.AdditionalRules = append(downloadClaims.AdditionalRules, r)
+	}
+
 	// Note - We are passing caller's user attributes to generateDownloadToken which may not always be the creator's attributes in case of external user's magic token. This is different from the alerts use case.
 	tkn, err := s.generateDownloadToken(&runtimev1.ExportRequest{
 		InstanceId:      req.InstanceId,
@@ -102,7 +128,7 @@ func (s *Server) ExportReport(ctx context.Context, req *runtimev1.ExportReportRe
 		OriginDashboard: originDashboard,
 		OriginUrl:       originURL,
 		ExecutionTime:   valOrNullTime(t),
-	}, auth.GetClaims(ctx, req.InstanceId))
+	}, downloadClaims)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to generate download token: %s", err.Error())
 	}


### PR DESCRIPTION
**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
