### PR TITLE
fix: project clone downloads variables at root instead of subpath for monorepos

### DIFF
--- a/cli/cmd/project/clone.go
+++ b/cli/cmd/project/clone.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/rilldata/rill/cli/cmd/env"
 	"github.com/rilldata/rill/cli/pkg/cmdutil"
@@ -74,10 +75,17 @@ func CloneCmd(ch *cmdutil.Helper) *cobra.Command {
 				return err
 			}
 
-			ch.Printf("Cloned project %q to %q\n", name, path)
+			var subpath string
+			if res.Project.Subpath != "" {
+				subpath = filepath.Join(path, res.Project.Subpath)
+			} else {
+				subpath = path
+			}
+
+			ch.Printf("Cloned project %q to %q\n", name, subpath)
 
 			// download variables
-			err = env.PullVars(cmd.Context(), ch, path, name, "prod", false)
+			err = env.PullVars(cmd.Context(), ch, subpath, name, "prod", false)
 			if err != nil {
 				return fmt.Errorf("failed to download variables: %w", err)
 			}


### PR DESCRIPTION

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
