### PR TITLE
Use different alert check frequencies for external data in OLAPs that may scale to zero

### DIFF
--- a/runtime/drivers/registry.go
+++ b/runtime/drivers/registry.go
@@ -104,9 +104,11 @@ type InstanceConfig struct {
 	// MetricsNullFillingImplementation switches between null-filling implementations for timeseries queries.
 	// Can be "", "none", "new", "pushdown".
 	MetricsNullFillingImplementation string `mapstructure:"rill.metrics.timeseries_null_filling_implementation"`
-	// AlertStreamingRefDefaultRefreshCron sets a default cron expression for refreshing alerts with streaming refs.
+	// AlertsDefaultStreamingRefreshCron sets a default cron expression for refreshing alerts with streaming refs.
 	// Namely, this is used to check alerts against external tables (e.g. in Druid) where new data may be added at any time (i.e. is considered "streaming").
 	AlertsDefaultStreamingRefreshCron string `mapstructure:"rill.alerts.default_streaming_refresh_cron"`
+	// AlertsFastStreamingRefreshCron is similar to AlertsDefaultStreamingRefreshCron but is used for alerts that are based on always-on OLAP connectors (i.e. that have MayScaleToZero == false).
+	AlertsFastStreamingRefreshCron string `mapstructure:"rill.alerts.fast_streaming_refresh_cron"`
 }
 
 // ResolveOLAPConnector resolves the OLAP connector to default to for the instance.
@@ -166,7 +168,8 @@ func (i *Instance) Config() (InstanceConfig, error) {
 		MetricsApproximateComparisonsCTE:     false,
 		MetricsApproxComparisonTwoPhaseLimit: 250,
 		MetricsExactifyDruidTopN:             false,
-		AlertsDefaultStreamingRefreshCron:    "*/10 * * * *", // Every 10 minutes
+		AlertsDefaultStreamingRefreshCron:    "0 0 * * *",    // Every 24 hours
+		AlertsFastStreamingRefreshCron:       "*/10 * * * *", // Every 10 minutes
 	}
 
 	// Resolve variables

--- a/runtime/reconcilers/alert.go
+++ b/runtime/reconcilers/alert.go
@@ -107,16 +107,25 @@ func (r *AlertReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceNa
 	}
 
 	// As a special rule, we set a default refresh schedule if:
-	// ref_update=true and one of the refs is streaming (and an explicit schedule wasn't provided).
-	if hasStreamingRef(ctx, r.C, self.Meta.Refs) {
-		if a.Spec.RefreshSchedule != nil && a.Spec.RefreshSchedule.RefUpdate {
-			if a.Spec.RefreshSchedule.TickerSeconds == 0 && a.Spec.RefreshSchedule.Cron == "" {
-				cfg, err := r.C.Runtime.InstanceConfig(ctx, r.C.InstanceID)
-				if err != nil {
-					return runtime.ReconcileResult{Err: err}
-				}
+	// - ref_update=true, and
+	// - one of the refs is streaming, and
+	// - an explicit schedule wasn't provided.
+	streaming, maybeScaledToZero, err := checkStreamingRef(ctx, r.C, self.Meta.Refs)
+	if err != nil {
+		return runtime.ReconcileResult{Err: err}
+	}
+	if streaming {
+		if a.Spec.RefreshSchedule != nil && a.Spec.RefreshSchedule.RefUpdate && a.Spec.RefreshSchedule.TickerSeconds == 0 && a.Spec.RefreshSchedule.Cron == "" {
+			cfg, err := r.C.Runtime.InstanceConfig(ctx, r.C.InstanceID)
+			if err != nil {
+				return runtime.ReconcileResult{Err: err}
+			}
 
+			// Use a fast refresh schedule only for streaming sources that can't be scaled to zero.
+			if maybeScaledToZero {
 				a.Spec.RefreshSchedule.Cron = cfg.AlertsDefaultStreamingRefreshCron
+			} else {
+				a.Spec.RefreshSchedule.Cron = cfg.AlertsFastStreamingRefreshCron
 			}
 		}
 	}


### PR DESCRIPTION
When an alert references an external table that we don't know the update frequency of, we check it using a default cron tab (which can be overridden with the environment variables shown below).

This PR changes the default cron to adapt to whether the external table is in a connector that may scale to zero. The new defaults are:
- Cron `0 0 * * *` (daily) for databases that may scale to zero
- Cron `*/10 * * * *` (every 10 minutes) for databases that don't scale to zero

The schedules can be overridden with these settings:
```
# Override the alert check frequency for external tables in databases that may scale to zero
rill env set PROJECT rill.alerts.default_streaming_refresh_cron "0 0 * * *"

# Override the alert check frequency for external tables in databases that we know are always-on
rill env set PROJECT rill.alerts.default_streaming_refresh_cron "*/10 * * * *"
```

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
