### PR TITLE
refactor (AI): Migrate `Conversation.conversation.messages` to `Conversation.messages`

### DIFF
--- a/web-common/src/features/chat/core/conversation-manager.ts
+++ b/web-common/src/features/chat/core/conversation-manager.ts
@@ -7,6 +7,7 @@ import {
   type V1Conversation,
   type V1GetConversationResponse,
   type V1ListConversationsResponse,
+  type V1Message,
 } from "@rilldata/web-common/runtime-client";
 import { createQuery, type CreateQueryResult } from "@tanstack/svelte-query";
 import { derived, get, type Readable } from "svelte/store";
@@ -267,19 +268,20 @@ export class ConversationManager {
           this.instanceId,
           conversationId,
         );
-        const cachedConversationData =
+        const cachedGetConversationResponse =
           queryClient.getQueryData<V1GetConversationResponse>(
             conversationCacheKey,
-          );
-        const conversationData = cachedConversationData?.conversation;
+          ) as V1GetConversationResponse | undefined;
+        const conversation = cachedGetConversationResponse?.conversation;
 
         // Create conversation object for the list
         const newConversation: V1Conversation = {
           id: conversationId,
-          title: this.generateConversationTitle(conversationData),
-          createdOn: conversationData?.createdOn || new Date().toISOString(),
-          updatedOn: conversationData?.updatedOn || new Date().toISOString(),
-          messages: [], // Don't include messages in the list view
+          title: this.generateConversationTitle(
+            cachedGetConversationResponse?.messages,
+          ),
+          createdOn: conversation?.createdOn || new Date().toISOString(),
+          updatedOn: conversation?.updatedOn || new Date().toISOString(),
         };
 
         // Add the new conversation to the front of the list
@@ -290,16 +292,16 @@ export class ConversationManager {
   }
 
   /**
-   * Generate a conversation title from the conversation data
+   * Generate a conversation title from messages
    *
    * Note: This replicates the server-side title generation logic client-side
    * to avoid making an additional network request for something we can compute
    * trivially from the conversation data we already have in cache.
    */
-  private generateConversationTitle(conversationData?: V1Conversation): string {
-    // If we have conversation data with messages, generate title from first user message
-    if (conversationData?.messages) {
-      for (const message of conversationData.messages) {
+  private generateConversationTitle(messages?: V1Message[]): string {
+    // If we have messages, generate title from first user message
+    if (messages) {
+      for (const message of messages) {
         if (message.role === "user") {
           let title = extractMessageText(message);
 

--- a/web-common/src/features/chat/core/conversation.ts
+++ b/web-common/src/features/chat/core/conversation.ts
@@ -295,12 +295,13 @@ export class Conversation {
       queryClient.getQueryData<V1GetConversationResponse>(oldCacheKey);
 
     if (existingData?.conversation) {
-      // Transfer the conversation data to the real conversation ID cache
+      // Transfer the conversation data and messages to the real conversation ID cache
       queryClient.setQueryData<V1GetConversationResponse>(newCacheKey, {
         conversation: {
           ...existingData.conversation,
           id: realConversationId,
         },
+        messages: existingData.messages || [],
       });
     }
 
@@ -349,23 +350,23 @@ export class Conversation {
         return {
           conversation: {
             id: this.conversationId,
-            messages: [message],
             createdOn: message.createdOn,
             updatedOn: new Date().toISOString(),
           },
+          messages: [message],
         };
       }
 
-      const existingMessages = old.conversation.messages || [];
+      const existingMessages = old.messages || [];
 
       // Add new message to the end of the list
       return {
         ...old,
         conversation: {
           ...old.conversation,
-          messages: [...existingMessages, message],
           updatedOn: new Date().toISOString(),
         },
+        messages: [...existingMessages, message],
       };
     });
   }
@@ -386,10 +387,9 @@ export class Conversation {
         ...old,
         conversation: {
           ...old.conversation,
-          messages:
-            old.conversation.messages?.filter((m) => m.id !== messageId) || [],
           updatedOn: new Date().toISOString(),
         },
+        messages: old.messages?.filter((m) => m.id !== messageId) || [],
       };
     });
   }

--- a/web-common/src/features/chat/core/messages/Messages.svelte
+++ b/web-common/src/features/chat/core/messages/Messages.svelte
@@ -28,7 +28,7 @@
   $: hasStreamError = !!$streamErrorStore;
 
   // Data
-  $: messages = $getConversationQuery.data?.conversation?.messages ?? [];
+  $: messages = $getConversationQuery.data?.messages ?? [];
 
   // Build a map of result messages by parent ID for correlation with calls (excluding router_agent)
   $: resultMessagesByParentId = new Map(


### PR DESCRIPTION
Closes [APP-498](https://linear.app/rilldata/issue/APP-498/ai-ui-follow-ups-for-new-ai-apis)

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
