### PR TITLE
Implement user column sorting before data passing

### DIFF
--- a/web-admin/src/features/organizations/user-management/table/users/OrgUsersTable.svelte
+++ b/web-admin/src/features/organizations/user-management/table/users/OrgUsersTable.svelte
@@ -39,6 +39,10 @@
   export let billingContact: string | undefined;
   export let scrollToTopTrigger: any = null;
   export let guestOnly: boolean;
+  export let userSortDirection: "asc" | "desc" | null = "asc";
+  export let onUserSortChange: (
+    direction: "asc" | "desc" | null,
+  ) => void = () => {};
 
   export let onAttemptRemoveBillingContactUser: () => void;
   export let onAttemptChangeBillingContactUserRole: () => void;
@@ -50,7 +54,7 @@
   const UserCell = <ColumnDef<OrgUser, any>>{
     accessorKey: "user",
     header: "User",
-    enableSorting: false,
+    enableSorting: true,
     cell: ({ row }) =>
       flexRender(UserCompositeCell, {
         name: row.original.userName ?? row.original.email,
@@ -161,4 +165,9 @@
   emptyStateMessage="No users found"
   {headerIcons}
   {scrollToTopTrigger}
+  externalSorting={{
+    columnId: "user",
+    direction: userSortDirection,
+    onSortChange: onUserSortChange,
+  }}
 />

--- a/web-admin/src/routes/[organization]/-/users/+page.svelte
+++ b/web-admin/src/routes/[organization]/-/users/+page.svelte
@@ -38,6 +38,9 @@
   let searchText = "";
   let filterSelection: "all" | "members" | "guests" | "pending" = "all";
 
+  // Sorting state for User column
+  let userSortDirection: "asc" | "desc" | null = "asc";
+
   let scrollToTopTrigger = null;
   $: {
     // Update trigger when filter selection changes to scroll to top
@@ -106,9 +109,23 @@
       return matchesSearch && matchesRole;
     })
     .sort((a, b) => {
-      // Sort by current user first
+      // Sort by current user first (always on top)
       if (a.userEmail === $currentUser.data?.user.email) return -1;
       if (b.userEmail === $currentUser.data?.user.email) return 1;
+
+      // If user column sorting is enabled, apply it
+      if (userSortDirection) {
+        const aName =
+          ("userName" in a ? a.userName : null) ?? a.userEmail ?? "";
+        const bName =
+          ("userName" in b ? b.userName : null) ?? b.userEmail ?? "";
+
+        const comparison = aName
+          .toLowerCase()
+          .localeCompare(bName.toLowerCase());
+        return userSortDirection === "asc" ? comparison : -comparison;
+      }
+
       return 0;
     });
 
@@ -158,6 +175,10 @@
           {organizationPermissions}
           billingContact={$billingContactUser?.email}
           {scrollToTopTrigger}
+          {userSortDirection}
+          onUserSortChange={(direction) => {
+            userSortDirection = direction;
+          }}
           guestOnly={false}
           onAttemptRemoveBillingContactUser={() =>
             (isRemovingBillingContactDialogOpen = true)}


### PR DESCRIPTION
Adds sorting capabilities to the "User" column in the organization-level user management table (APP-404).

**Why:**
The primary goal is to ensure sorting applies to the *complete dataset*, not just the currently visible data due to infinite scroll. This PR implements sorting logic *before* data is passed to the `InfiniteScrollTable`, addressing previous feedback that `sortingFn` only sorts loaded data.

**What:**
-   **`+page.svelte`**: Manages the `userSortDirection` state and applies sorting to the `filteredUsers` array, including keeping the current user on top and using locale-aware comparison for names/emails.
-   **`OrgUsersTable.svelte`**: Enables sorting for the "User" column and passes the `userSortDirection` and a callback `onUserSortChange` to the `InfiniteScrollTable` via a new `externalSorting` prop.
-   **`InfiniteScrollTable.svelte`**: Updated to accept an `externalSorting` prop. When this prop is provided, the table's internal sorting is disabled (`manualSorting: true`), and its visual sort state is driven by the external prop. It also handles the ASC → DESC → ASC cycle via the `onSortChange` callback.

This ensures the user column defaults to ascending order, toggles to descending on click, and cycles back to ascending, all while sorting the entire dataset.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-404](https://linear.app/rilldata/issue/APP-404/add-sorting-capabilities-to-the-user-column-in-the-user-management)

<a href="https://cursor.com/background-agent?bcId=bc-82de0f79-7262-441e-8656-e716210e8ed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-82de0f79-7262-441e-8656-e716210e8ed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

