### PR TITLE
fix: double scrollbars in canvas

### DIFF
--- a/web-common/src/features/dashboards/ThemeProvider.svelte
+++ b/web-common/src/features/dashboards/ThemeProvider.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { dynamicHeight } from "@rilldata/web-common/layout/layout-settings.ts";
   import { Theme } from "../themes/theme";
 
   export let theme: Theme | undefined;
@@ -16,8 +17,10 @@
 </script>
 
 <div
-  class="dashboard-theme-boundary flex flex-col size-full"
+  class="dashboard-theme-boundary flex flex-col overflow-hidden"
   bind:this={themeBoundary}
+  class:w-full={$dynamicHeight}
+  class:size-full={!$dynamicHeight}
 >
   <style bind:this={styleEl}></style>
   <slot />


### PR DESCRIPTION
Double scrollbars appear in canvas if the height is greater than the screen.

Closes APP-546

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
