### PR TITLE
fix: alert metadata page for non query based alerts

### DIFF
--- a/web-admin/src/features/alerts/metadata/AlertMetadata.svelte
+++ b/web-admin/src/features/alerts/metadata/AlertMetadata.svelte
@@ -65,7 +65,8 @@
 
   $: queryArgsJson =
     (alertSpec?.resolverProperties?.query_args_json as string) ||
-    alertSpec?.queryArgsJson;
+    alertSpec?.queryArgsJson ||
+    "{}";
   $: queryName =
     alertSpec?.queryName ||
     (alertSpec?.resolverProperties?.query_name as string);


### PR DESCRIPTION
We do not handle non-query based alerts. These would have a resolver and resolver properties instead of `queryArgsJson`. Make sure the UI doesnt break. But we still do not support editing it from cloud UI. Execution history will still be available.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
