### PR TITLE
fix: undefined measure values not showing as n/a

### DIFF
--- a/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
@@ -154,7 +154,7 @@
       on:focus={handleFocus}
       tabindex="0"
     >
-      {#if value !== null && status === EntityStatus.Idle}
+      {#if value !== null && value !== undefined && status === EntityStatus.Idle}
         <WithTween {value} tweenProps={{ duration: 500 }} let:output>
           {measureValueFormatter(output)}
         </WithTween>
@@ -233,6 +233,8 @@
         </div>
       {:else if value === null}
         <span class="ui-copy-disabled-faint italic text-sm">no data</span>
+      {:else if value === undefined}
+        <span class="ui-copy-disabled-faint italic text-sm">n/a</span>
       {/if}
     </div>
   </svelte:element>

--- a/web-common/src/features/dashboards/stores/AdvancedMeasureCorrector.ts
+++ b/web-common/src/features/dashboards/stores/AdvancedMeasureCorrector.ts
@@ -94,7 +94,7 @@ export class AdvancedMeasureCorrector {
       !this.measureIsValidForComponent(
         this.exploreState.tdd.expandedMeasureName ?? "",
         true,
-        false,
+        true,
       )
     ) {
       return;

--- a/web-common/src/lib/number-formatting/format-measure-value.ts
+++ b/web-common/src/lib/number-formatting/format-measure-value.ts
@@ -238,9 +238,7 @@ export function createMeasureValueFormatter<T extends null | undefined = never>(
       const hasCurrencySymbol = includesCurrencySymbol(measureSpec.formatD3);
       const hasPercentSymbol = measureSpec.formatD3.includes("%");
       return (value: number | string | T) => {
-        if (typeof value !== "number") {
-          return maybeFormatUndefined(value);
-        }
+        if (typeof value !== "number") return value;
 
         // For the Big Number, Axis and Tooltips, override the d3formatter
         // with humanized values that respect the locale configuration
@@ -284,11 +282,5 @@ export function createMeasureValueFormatter<T extends null | undefined = never>(
   }
 
   return (value: number | T) =>
-    typeof value === "number"
-      ? humanizer(value, formatPreset)
-      : maybeFormatUndefined(value);
-}
-
-function maybeFormatUndefined(val) {
-  return val === undefined ? "n/a" : val;
+    typeof value === "number" ? humanizer(value, formatPreset) : value;
 }


### PR DESCRIPTION
In certain cases we get `undefined` as measure value. Especially in advanced measures where we do not query for the measure.

There is also an edge case where navigating to time dimension detail for these measures didnt work. URL state is updated by not reflected in UI.

Use an advanced measure to reliably test,
```
  - name: total_records
    label: Total records
    expression: COUNT(*)
  - name: total_records_avg
    label: Total records avg
    expression: AVG(total_records)
    window:
      order: timestamp
      frame: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
    requires: [ total_records ]
```

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
