### PR TITLE
[APP-427] fix: pan behavior

### DIFF
--- a/web-common/src/features/canvas/filters/CanvasFilters.svelte
+++ b/web-common/src/features/canvas/filters/CanvasFilters.svelte
@@ -51,6 +51,7 @@
       spec,
       metricsView: { allDimensions, allSimpleMeasures },
       timeControls: {
+        _canPan,
         allTimeRange,
         timeRangeStateStore,
         comparisonRangeStateStore,
@@ -84,6 +85,8 @@
   $: allDimensionFilters = $allDimensionFilterItems;
 
   $: allMeasureFilters = $allMeasureFilterItems;
+
+  $: canPan = $_canPan;
 
   // hasFilter only checks for complete filters and excludes temporary ones
   $: hasFilters =
@@ -143,11 +146,10 @@
       {timeEnd}
       {activeTimeGrain}
       {activeTimeZone}
+      canPanLeft={canPan.left}
+      canPanRight={canPan.right}
       watermark={undefined}
       allowCustomTimeRange={$spec?.allowCustomTimeRange}
-      canPanLeft
-      canPanRight
-      showPan
       {showDefaultItem}
       applyRange={(timeRange) => {
         const string = `${timeRange.start.toISOString()},${timeRange.end.toISOString()}`;

--- a/web-common/src/features/canvas/inspector/filters/TimeFiltersInput.svelte
+++ b/web-common/src/features/canvas/inspector/filters/TimeFiltersInput.svelte
@@ -102,8 +102,7 @@
         {timeEnd}
         {activeTimeGrain}
         {activeTimeZone}
-        canPanLeft={false}
-        canPanRight={false}
+        hidePan
         showFullRange={false}
         showDefaultItem={false}
         applyRange={(timeRange) => {

--- a/web-common/src/features/canvas/stores/time-control.ts
+++ b/web-common/src/features/canvas/stores/time-control.ts
@@ -71,6 +71,7 @@ export class TimeControls {
   timeRangeStateStore: Writable<TimeRangeState | undefined> =
     writable(undefined);
   comparisonRangeStateStore: Readable<ComparisonTimeRangeState | undefined>;
+  _canPan: Readable<{ left: boolean; right: boolean }>;
 
   constructor(
     private specStore: CanvasSpecResponseStore,
@@ -234,6 +235,21 @@ export class TimeControls {
         this.processSpec(spec.data);
       });
     }
+
+    this._canPan = derived(
+      [this.interval, this.allTimeRange],
+      ([interval, allTimeRange]) => {
+        if (!interval || !interval.start || !interval.end)
+          return { left: false, right: false };
+
+        const canPanLeft =
+          interval?.start > DateTime.fromJSDate(allTimeRange.start);
+        const canPanRight =
+          interval?.end < DateTime.fromJSDate(allTimeRange.end);
+
+        return { left: canPanLeft, right: canPanRight };
+      },
+    );
   }
 
   processSpec = (spec: CanvasResponse) => {

--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -381,7 +381,6 @@
           {activeTimeZone}
           canPanLeft={$canPanLeft}
           canPanRight={$canPanRight}
-          showPan
           {showDefaultItem}
           watermark={watermark ? DateTime.fromISO(watermark) : undefined}
           applyRange={selectRange}

--- a/web-common/src/features/dashboards/state-managers/selectors/charts.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/charts.ts
@@ -15,8 +15,9 @@ export const chartSelectors = {
     const timeControls = timeControlsState(dashData);
     const startRange = timeControls.allTimeRange?.start;
     const selectedStart = timeControls.selectedTimeRange?.start;
+
     return (
-      (selectedStart?.getTime() || Infinity) >=
+      (selectedStart?.getTime() || Infinity) >
       (startRange?.getTime() || -Infinity)
     );
   },
@@ -25,7 +26,7 @@ export const chartSelectors = {
     const endRange = timeControls?.allTimeRange?.end;
     const selectedEnd = timeControls.selectedTimeRange?.end;
     return (
-      (selectedEnd?.getTime() || -Infinity) <= (endRange?.getTime() || Infinity)
+      (selectedEnd?.getTime() || -Infinity) < (endRange?.getTime() || Infinity)
     );
   },
   getNewPanRange: (dashData: DashboardDataSources) => {

--- a/web-common/src/features/dashboards/time-controls/super-pill/SuperPill.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/SuperPill.svelte
@@ -27,10 +27,10 @@
   export let timeRanges: V1ExploreTimeRange[];
   export let showDefaultItem: boolean;
   export let activeTimeGrain: V1TimeGrain | undefined;
-  export let canPanLeft: boolean;
-  export let canPanRight: boolean;
   export let interval: Interval;
-  export let showPan = false;
+  export let hidePan = false;
+  export let canPanLeft: boolean = !hidePan;
+  export let canPanRight: boolean = !hidePan;
   export let lockTimeZone = false;
   export let allowCustomTimeRange = true;
   export let showFullRange = true;
@@ -61,7 +61,7 @@
 </script>
 
 <div class="wrapper">
-  {#if showPan}
+  {#if !hidePan}
     <Elements.Nudge {canPanLeft} {canPanRight} {onPan} direction="left" />
     <Elements.Nudge {canPanLeft} {canPanRight} {onPan} direction="right" />
   {/if}

--- a/web-common/src/features/scheduled-reports/FiltersForm.svelte
+++ b/web-common/src/features/scheduled-reports/FiltersForm.svelte
@@ -256,8 +256,7 @@
         {onSelectRange}
         {onTimeGrainSelect}
         {onSelectTimeZone}
-        canPanLeft={false}
-        canPanRight={false}
+        hidePan
         onPan={() => {}}
         {minTimeGrain}
         {side}


### PR DESCRIPTION
Changes boolean for pan behavior so that panning is not allowed when the currently selected range falls on the edge of the dataset boundaries.

Also brings pan enable/disable logic to Canvas.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
