### PR TITLE
refac: pivot measure column widths

### DIFF
--- a/web-common/src/features/dashboards/pivot/NestedTable.svelte
+++ b/web-common/src/features/dashboards/pivot/NestedTable.svelte
@@ -68,19 +68,10 @@
 
   $: {
     // Get the longest column dimension header to ensure proper width calculation
-    let maxColumnDimensionHeader = "";
-    if (hasColumnDimension && headerGroups.length > 0) {
-      // Get the second-to-last header group which contains column dimension values
-      const colDimensionHeaderGroup = headerGroups[headerGroups.length - 2];
-      if (colDimensionHeaderGroup?.headers) {
-        colDimensionHeaderGroup.headers.forEach((header) => {
-          const headerText = String(header.column?.columnDef?.header ?? "");
-          if (headerText.length > maxColumnDimensionHeader.length) {
-            maxColumnDimensionHeader = headerText;
-          }
-        });
-      }
-    }
+    const maxColumnDimensionHeader = getMaxColumnDimensionHeader(
+      hasColumnDimension,
+      headerGroups,
+    );
 
     measures.forEach(({ name, label, formatter }) => {
       if (!$measureLengths.has(name)) {
@@ -175,6 +166,25 @@
     let offset = 0;
     if (!hasRowDimension) offset = 1;
     return (index + offset) % measureCount === 0 && index > 0;
+  }
+
+  function getMaxColumnDimensionHeader(
+    hasColumnDimension: boolean,
+    headerGroups: HeaderGroup<PivotDataRow>[],
+  ): string {
+    if (!hasColumnDimension || headerGroups.length === 0) return "";
+
+    // Get the second-to-last header group which contains column dimension values
+    const colDimensionHeaderGroup =
+      headerGroups.length >= 2
+        ? headerGroups[headerGroups.length - 2]
+        : undefined;
+    if (!colDimensionHeaderGroup?.headers) return "";
+
+    return colDimensionHeaderGroup.headers.reduce((longest, header) => {
+      const headerText = String(header.column?.columnDef?.header ?? "");
+      return headerText.length > longest.length ? headerText : longest;
+    }, "");
   }
 
   function shouldShowRightBorder(index: number): boolean {

--- a/web-common/src/features/dashboards/pivot/pivot-column-width-utils.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-column-width-utils.ts
@@ -15,6 +15,7 @@ export const COLUMN_WIDTH_CONSTANTS = {
   INIT_MEASURE_WIDTH: 100,
   MEASURE_PADDING: 24,
   ROW_DIMENSION_MIN_WIDTH: 160,
+  MAX_COL_DIMENSION_HEADER_LENGTH: 18,
 };
 
 export function calculateColumnWidth(
@@ -91,7 +92,7 @@ export function calculateMeasureWidth(
   // When there's a column dimension, also consider its header length
   const columnDimensionLength = Math.min(
     columnDimensionHeader?.length ?? 0,
-    18,
+    COLUMN_WIDTH_CONSTANTS.MAX_COL_DIMENSION_HEADER_LENGTH,
   );
 
   const finalBasis = Math.max(


### PR DESCRIPTION
- Increase the min width of a measure column to accommodate various humanized numeric values
- Take account of column dimension value string in determining the column width 

Fixes https://linear.app/rilldata/issue/APP-509/ensure-pivot-tables-use-the-full-width-of-the-screen-when-navigating

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
