### PR TITLE
Fix DimensionTable virtualized jankiness

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/DimensionTable.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionTable.svelte
@@ -102,6 +102,9 @@ TableCells – the cell contents.
     getScrollElement: () => container,
     count: rows.length,
     estimateSize: () => config.rowHeight,
+    // Provides a stable identity for each virtualized row so the virtualizer can reuse DOM nodes
+    // instead of remounting them during fast scrolls or data updates. This reduces blank frames,
+    // preserves focus/hover state, and avoids unnecessary re-renders.
     getItemKey: (index) => String(rows?.[index]?.[dimensionName] ?? index),
     overscan: rowOverscanAmount,
     paddingStart: config.columnHeaderHeight,


### PR DESCRIPTION
This PR tweaks the row and col overscan values to address the flick-scrolling blank rows. Fixes https://linear.app/rilldata/issue/APP-282/issue-with-loading-leaderboard-table-rows

https://github.com/user-attachments/assets/6f2e9b5c-ffb4-4402-9160-df9a4841795c

https://github.com/user-attachments/assets/946c309c-c924-43e6-8127-22b97341bac7

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
