### PR TITLE
fix: switching dimension tables crashing the app

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/DimensionTable.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionTable.svelte
@@ -235,22 +235,24 @@ TableCells – the cell contents.
             {toggleComparisonDimension}
             on:select-item={(event) => onSelectItem(event)}
           />
-          <DimensionValueHeader
-            on:resize-column={handleResizeDimensionColumn}
-            virtualRowItems={virtualRows}
-            totalHeight={virtualHeight}
-            width={estimateColumnSize[0]}
-            column={dimensionColumn}
-            {rows}
-            {activeIndex}
-            {selectedIndex}
-            {excludeMode}
-            {scrolling}
-            {horizontalScrolling}
-            on:dimension-sort
-            on:select-item={(event) => onSelectItem(event)}
-            on:inspect={setActiveIndex}
-          />
+          {#if dimensionColumn}
+            <DimensionValueHeader
+              on:resize-column={handleResizeDimensionColumn}
+              virtualRowItems={virtualRows}
+              totalHeight={virtualHeight}
+              width={estimateColumnSize[0]}
+              column={dimensionColumn}
+              {rows}
+              {activeIndex}
+              {selectedIndex}
+              {excludeMode}
+              {scrolling}
+              {horizontalScrolling}
+              on:dimension-sort
+              on:select-item={(event) => onSelectItem(event)}
+              on:inspect={setActiveIndex}
+            />
+          {/if}
         </div>
         {#if rows.length}
           <!-- VirtualTableBody -->


### PR DESCRIPTION
Switching between dimension tables of different dimensions breaks the app. This can be reproduced by creating bookmarks of 2 dimension tables or using dashboard chat that links to different dimension tables.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
