### PR TITLE
add utc tz to date_trunc func in ch

### DIFF
--- a/runtime/drivers/olap.go
+++ b/runtime/drivers/olap.go
@@ -564,9 +564,9 @@ func (d Dialect) DateTruncExpr(dim *runtimev1.MetricsViewSpec_Dimension, grain r
 
 		if tz == "" {
 			if shift == "" {
-				return fmt.Sprintf("date_trunc('%s', %s)::DateTime64", specifier, expr), nil
+				return fmt.Sprintf("date_trunc('%s', %s, 'UTC')::DateTime64", specifier, expr), nil
 			}
-			return fmt.Sprintf("date_trunc('%s', %s + INTERVAL %s)::DateTime64 - INTERVAL %s", specifier, expr, shift, shift), nil
+			return fmt.Sprintf("date_trunc('%s', %s + INTERVAL %s, 'UTC')::DateTime64 - INTERVAL %s", specifier, expr, shift, shift), nil
 		}
 
 		if shift == "" {


### PR DESCRIPTION
Resolves https://linear.app/rilldata/issue/APP-562/growthcode-canvas-in-rd-shows-only-data-at-hour-level

Its an issue in Rill developer where `date_trunc` function somehow returns results in local timezone instead of UTC, thus causing issues with spine join as time values won't match

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
