### PR TITLE
Fix "show context for all measures" toggle bug

### DIFF
--- a/web-common/src/components/menu/LeaderboardAdvancedActions.svelte
+++ b/web-common/src/components/menu/LeaderboardAdvancedActions.svelte
@@ -12,7 +12,12 @@
   import { useTimeControlStore } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
 
   const ctx = getStateManagers();
-  const { exploreName } = ctx;
+  const {
+    exploreName,
+    selectors: {
+      leaderboard: { leaderboardShowContextForAllMeasures },
+    },
+  } = ctx;
 
   const timeControlsStore = useTimeControlStore(ctx);
   $: ({ showTimeComparison } = $timeControlsStore);
@@ -42,6 +47,7 @@
     <span>Show context for all measures</span>
     <Switch
       theme
+      checked={$leaderboardShowContextForAllMeasures}
       onCheckedChange={() => {
         ensureTimeComparisonEnabled();
 


### PR DESCRIPTION
Fixes APP-447.

The "Show context for all measures" toggle in the leaderboard's advanced actions menu was not reflecting its actual state, preventing users from turning it off. This PR wires the toggle's `checked` prop to the `leaderboardShowContextForAllMeasures` store value, ensuring the UI accurately represents the feature's status and allows for proper toggling.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-447](https://linear.app/rilldata/issue/APP-447/show-context-for-all-measures-once-turned-on-cannot-be-turned-off)

<a href="https://cursor.com/background-agent?bcId=bc-298690b1-6815-4abd-a349-903a88efb2c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-298690b1-6815-4abd-a349-903a88efb2c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

