### PR TITLE
Align pivot table text left

### DIFF
--- a/web-common/src/components/chip/core/Chip.svelte
+++ b/web-common/src/components/chip/core/Chip.svelte
@@ -220,6 +220,10 @@
   }
 
   .fullWidth {
-    @apply w-full;
+    @apply w-full justify-start;
+  }
+
+  .fullWidth button {
+    @apply text-left;
   }
 </style>

--- a/web-common/src/features/dashboards/pivot/DragList.svelte
+++ b/web-common/src/features/dashboards/pivot/DragList.svelte
@@ -48,6 +48,8 @@
   import { timePillSelectors } from "./time-pill-store";
 
   const isDropLocation = zone === "columns" || zone === "rows";
+  $: shouldFillWidth =
+    zone === "Time" || zone === "Measures" || zone === "Dimensions";
 
   const _ghostIndex = writable<number | null>(null);
 
@@ -271,6 +273,7 @@
             grab
             removable
             availableGrains={availableTimeGrains}
+            fullWidth={shouldFillWidth}
             onTimeGrainSelect={(timeGrain) =>
               handleTimeGrainSelect(item, timeGrain)}
             on:mousedown={(e) => handleMouseDown(e, item)}
@@ -283,6 +286,7 @@
           <PivotChip
             {item}
             grab
+            fullWidth={shouldFillWidth}
             removable={isDropLocation}
             on:mousedown={(e) => handleMouseDown(e, item)}
             onRemove={() => {

--- a/web-common/src/features/dashboards/pivot/DragList.svelte
+++ b/web-common/src/features/dashboards/pivot/DragList.svelte
@@ -404,7 +404,7 @@
   }
 
   .item-wrapper.aligned {
-    @apply justify-between w-full;
+    @apply justify-start w-full gap-x-2;
   }
 
   .icons {


### PR DESCRIPTION
Fixes APP-575

Ensures that wrapped text for Measures, Dimensions, and Time chips in the pivot table sidebar is left-aligned. Previously, these chips were center-aligned, leading to an awkward appearance when text wrapped.

This is achieved by:
1.  Setting `fullWidth` to `true` for chips in the "Time", "Measures", and "Dimensions" zones within the `DragList.svelte`.
2.  Updating the `Chip.svelte` styles to apply `justify-start` and `text-left` for any chip with the `fullWidth` class.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-575](https://linear.app/rilldata/issue/APP-575/make-sure-that-measures-and-dimensions-in-the-pivot-table-are-wrapped)

<a href="https://cursor.com/background-agent?bcId=bc-99110f62-eb5e-4ff4-9e21-c47c04ae1ef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-99110f62-eb5e-4ff4-9e21-c47c04ae1ef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

