### PR TITLE
Add icons and group breadcrumb navigation

### DIFF
--- a/web-common/src/components/navigation/breadcrumbs/types.ts
+++ b/web-common/src/components/navigation/breadcrumbs/types.ts
@@ -16,3 +16,15 @@ export type PathOption = {
 };
 
 export type PathOptions = Map<Param, PathOption>;
+
+export type PathOptionEntry = [Param, PathOption];
+
+export type PathOptionGroup = {
+  id: string;
+  label: string;
+  options: PathOptionEntry[];
+};
+
+export type PathOptionsWithGroups = PathOptions & {
+  groups?: PathOptionGroup[];
+};


### PR DESCRIPTION
This PR enhances the breadcrumb navigation menu to improve user clarity and organization, addressing DES-79.

It introduces:
*   **Type-specific icons:** Distinct icons are now displayed next to Explore and Canvas dashboard names in the breadcrumb and dropdown, making their type immediately obvious.
*   **Grouped navigation:** Dashboard options in the dropdown are now grouped by type (Explores first, then Canvases), providing a clearer mental model for projects with numerous dashboards. The active dashboard's group is prioritized in the dropdown.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [DES-79](https://linear.app/rilldata/issue/DES-79/add-icons-to-the-breadcrumb-navigation-menu-to-indicate-explore-vs)

<a href="https://cursor.com/background-agent?bcId=bc-cff0600f-f5e4-4bc5-94be-fb87ee67eaac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cff0600f-f5e4-4bc5-94be-fb87ee67eaac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

