### PR TITLE
fix: broken citation links, remove them when rewriting

### DIFF
--- a/web-common/src/features/chat/core/messages/TextMessage.svelte
+++ b/web-common/src/features/chat/core/messages/TextMessage.svelte
@@ -29,11 +29,9 @@
     getMetricsResolverQueryToUrlParamsMapperStore(exploreNameStore);
 
   $: renderedInExplore = !!$exploreNameStore;
-  $: hasMapper = !!$mapperStore.data;
-  $: convertCitationUrls =
-    renderedInExplore && hasMapper
-      ? getCitationUrlRewriter($mapperStore.data!)
-      : undefined;
+  $: convertCitationUrls = renderedInExplore
+    ? getCitationUrlRewriter($mapperStore.data)
+    : undefined;
 </script>
 
 <div class="chat-message chat-message--{role}">


### PR DESCRIPTION
Broken citation links break the app in unexpected ways. In embed context the user can get into a scenario where the user's jwt is used instead of embedded jwt.

Closes APP-572

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
