### PR TITLE
Stop session replay obfuscation for non-EU/CA users

### DIFF
--- a/web-common/src/lib/analytics/posthog.ts
+++ b/web-common/src/lib/analytics/posthog.ts
@@ -109,12 +109,14 @@ export function initPosthog(rillVersion: string, sessionId?: string | null) {
     persistRegulatedStatus(computed);
   };
 
-  const geoMaskInputFn = (
-    text: string,
-    element?: HTMLInputElement | HTMLTextAreaElement | null,
-  ) => {
+  const geoMaskInputFn = (text: string, element?: HTMLElement | null) => {
     if (!text) return text;
-    const inputType = element?.getAttribute?.("type")?.toLowerCase();
+    const inputType =
+      element instanceof HTMLInputElement
+        ? element.type?.toLowerCase()
+        : element instanceof HTMLTextAreaElement
+          ? element.getAttribute("type")?.toLowerCase()
+          : element?.getAttribute?.("type")?.toLowerCase();
     if (inputType === "password") {
       return maskValue(text);
     }
@@ -126,7 +128,6 @@ export function initPosthog(rillVersion: string, sessionId?: string | null) {
     api_host: "https://us.i.posthog.com", // TODO: use a reverse proxy https://posthog.com/docs/advanced/proxy
     session_recording: {
       maskAllInputs: false,
-      maskAllText: false,
       maskInputFn: geoMaskInputFn,
       maskInputOptions: {
         password: true,


### PR DESCRIPTION
**WHY:** To enable unredacted session replays for non-EU/CA users while maintaining privacy compliance for regulated regions. This change implements capture-time masking based on user's GeoIP location, as recommended by PostHog (APP-582).

**WHAT:** Configured PostHog `session_recording` to dynamically apply masking:
- Utilizes GeoIP data to identify EU/CA users and sets an `is_regulated_region` person property.
- Applies a custom `maskInputFn` that masks inputs only for regulated users (passwords are always masked).
- Integrated into `posthog.init` `loaded` and `onFeatureFlags` callbacks for timely GeoIP evaluation.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-582](https://linear.app/rilldata/issue/APP-582/remove-session-replay-data-obfuscation-for-non-euca-users)

<a href="https://cursor.com/background-agent?bcId=bc-4bbf9ba3-3517-4919-b930-383803bda31d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4bbf9ba3-3517-4919-b930-383803bda31d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

