### PR TITLE
Support `rill sudo user open <email>` + handle repeated assumes gracefully

### DIFF
--- a/admin/server/auth/middleware.go
+++ b/admin/server/auth/middleware.go
@@ -136,7 +136,13 @@ func (a *Authenticator) httpMiddleware(next http.Handler, lenient bool) http.Han
 		if ok && authToken != "" {
 			newCtx, err := a.parseClaimsFromToken(r.Context(), authToken)
 			if err != nil {
-				// NOTE: No lenient mode for cookies. It doesn't make sense at the moment.
+				// In lenient mode, we set anonClaims.
+				if lenient {
+					newCtx := context.WithValue(r.Context(), claimsContextKey{}, anonClaims{})
+					next.ServeHTTP(w, r.WithContext(newCtx))
+					return
+				}
+
 				http.Error(w, err.Error(), http.StatusUnauthorized)
 				return
 			}

--- a/cli/cmd/sudo/user/open.go
+++ b/cli/cmd/sudo/user/open.go
@@ -12,37 +12,53 @@ import (
 )
 
 func OpenCmd(ch *cmdutil.Helper) *cobra.Command {
+	var noOpen bool
 	var ttlMinutes int
 	openCmd := &cobra.Command{
-		Use:   "open",
-		Args:  cobra.NoArgs,
-		Short: "Open browser as the assume user",
+		Use:   "open [<email>]",
+		Args:  cobra.MaximumNArgs(1),
+		Short: "Open browser as an assumed user",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			authURL := ch.AdminURL()
 			assumeOpenURI, err := url.JoinPath(authURL, "auth", "assume-open")
 			if err != nil {
 				return err
 			}
-			representingUser, err := ch.DotRill.GetRepresentingUser()
-			if err != nil {
-				return err
+
+			var email string
+			if len(args) == 1 {
+				email = args[0]
 			}
-			if representingUser == "" {
-				return errors.New("please assume a user first")
+			if email == "" {
+				email, err = ch.DotRill.GetRepresentingUser()
+				if err != nil {
+					return err
+				}
 			}
+			if email == "" {
+				return errors.New("no user specified; you must specify a user's email or separately assume a user with `rill sudo user assume`")
+			}
+
 			qry := map[string]string{
-				"representing_user": representingUser,
+				"representing_user": email,
 				"ttl_minutes":       strconv.Itoa(ttlMinutes),
 			}
 			assumeOpenURI, err = urlutil.WithQuery(assumeOpenURI, qry)
 			if err != nil {
 				return err
 			}
-			_ = browser.Open(assumeOpenURI)
+
+			if !noOpen {
+				ch.Printf("Opening browser at: %s\n", assumeOpenURI)
+				_ = browser.Open(assumeOpenURI)
+			} else {
+				ch.Printf("Open browser at: %s\n", assumeOpenURI)
+			}
 
 			return nil
 		},
 	}
+	openCmd.Flags().BoolVar(&noOpen, "no-open", false, "Do not open the browser automatically")
 	openCmd.Flags().IntVar(&ttlMinutes, "ttl-minutes", 60, "Minutes until the token should expire")
 	return openCmd
 }


### PR DESCRIPTION
Changes:

- Adds optional support for passing an email directly to `rill sudo user open` so you don't have to run `rill sudo user assume` separately
- Prints the open link when running `rill sudo user open` in case you want to open in a non-standard browser
- Adds automatic handling for when assuming a user while already assumed as another user

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
