### PR TITLE
fix: add sveltekit-sync step to orval client scripts

### DIFF
--- a/web-admin/package.json
+++ b/web-admin/package.json
@@ -14,7 +14,7 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --check . && eslint .",
     "format": "prettier --write .",
-    "generate:client": "orval"
+    "generate:client": "svelte-kit sync && orval"
   },
   "devDependencies": {
     "@fontsource/fira-mono": "^4.5.0",

--- a/web-common/package.json
+++ b/web-common/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "prettier --check . && eslint .",
     "format": "prettier --write .",
-    "generate:runtime-client": "orval --config ./orval.config.ts",
+    "generate:runtime-client": "svelte-kit sync && orval --config ./orval.config.ts",
     "generate:sveltekit": "svelte-kit sync",
     "generate:template-schema": "ts-json-schema-generator --path 'src/features/canvas/components/types.ts' --type TemplateSpec -o ../runtime/parser/data/component-template-v1.json",
     "test": "vitest run",


### PR DESCRIPTION
Allows `make proto.generate` to be run without additional steps (other than package installation) from a newly cloned repo.

