### PR TITLE
Grant full access to the underlying metrics views when you have transitive access on a canvas

### DIFF
--- a/runtime/reconcilers/canvas.go
+++ b/runtime/reconcilers/canvas.go
@@ -316,7 +316,7 @@ func (r *CanvasReconciler) validateMetricsViewTimeConsistency(ctx context.Contex
 
 // rendererRefs tracks all metrics views found in canvas component renderer properties.
 // It currently only tracks metrics views, but in the future we may want to add an option to also track metrics view fields and filters.
-// We did that previously, but removed it since such granular security was considered too strict (it also impacts ability to filter by fields no present on the canvas).
+// We did that previously, but removed it since such granular security was considered too strict (it also impacts ability to filter by fields not present on the canvas).
 // See this PR for details in case we want to reintroduce it: https://github.com/rilldata/rill/pull/8370
 type rendererRefs struct {
 	metricsViews map[string]bool


### PR DESCRIPTION
Our initial support for transitive access on canvases only granted access to those metrics view fields and filters that were used in the canvas components. This has turned out to be too restrictive for users who expect to be able to add filters on metrics view fields that are not directly referenced in the canvas.

**Checklist:**
- [x] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
