### PR TITLE
Fix GCS google_application_credentials raw value in model regression

### DIFF
--- a/web-common/src/features/sources/sourceUtils.ts
+++ b/web-common/src/features/sources/sourceUtils.ts
@@ -19,7 +19,7 @@ export function compileSourceYAML(
   connector: V1ConnectorDriver,
   formValues: Record<string, unknown>,
 ) {
-  // Get the secret property keys.
+  // Get the secret property keys
   const secretPropertyKeys =
     connector.sourceProperties
       ?.filter((property) => property.secret)


### PR DESCRIPTION
This PR strips the connector config from model YAML in multi-step flow (prevent GCS creds leak). 

Root cause: Connector step values (e.g., google_application_credentials) were carried into the model step and used for model YAML generation; preview filtered them, but submission did not.

Closes https://linear.app/rilldata/issue/APP-587/regression-model-includes-plaintext-credentials-introduced-in-8142

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
