### PR TITLE
Fix repo interstitial alignment

### DIFF
--- a/web-common/src/features/project/GithubRepoDetails.svelte
+++ b/web-common/src/features/project/GithubRepoDetails.svelte
@@ -12,8 +12,8 @@
   $: repoName = getRepoNameFromGitRemote(gitRemote);
 </script>
 
-<div class="flex flex-col w-fit mx-auto text-center text-sm">
-  <div class="flex flex-row gap-x-1 items-center">
+<div class="flex flex-col items-center gap-y-1 mx-auto text-center text-sm">
+  <div class="flex flex-row gap-x-1 items-center justify-center w-full">
     <Github className="w-4 h-4" />
     <a
       href={getGitUrlFromRemote(gitRemote)}


### PR DESCRIPTION
Addresses APP-599.
The repo name in the "Detected Repo" interstitial was left-aligned, creating a visual inconsistency with the rest of the center-aligned content. This change centers the repo name to match the page's overall alignment.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-599](https://linear.app/rilldata/issue/APP-599/detected-repo-interstitial-has-repo-left-aligned-while-everything-else)

<a href="https://cursor.com/background-agent?bcId=bc-e1387569-9f12-4318-b08c-72731e90151a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e1387569-9f12-4318-b08c-72731e90151a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

