### PR TITLE
feat: Cancel TanStack Query requests when document is hidden

### DIFF
--- a/web-admin/src/routes/+layout.svelte
+++ b/web-admin/src/routes/+layout.svelte
@@ -3,7 +3,6 @@
   import { isAdminServerQuery } from "@rilldata/web-admin/client/utils";
   import { errorStore } from "@rilldata/web-admin/components/errors/error-store";
   import { createUserFacingError } from "@rilldata/web-admin/components/errors/user-facing-errors";
-  import { dynamicHeight } from "@rilldata/web-common/layout/layout-settings.ts";
   import BillingBannerManager from "@rilldata/web-admin/features/billing/banner/BillingBannerManager.svelte";
   import {
     isBillingUpgradePage,
@@ -14,12 +13,15 @@
   } from "@rilldata/web-admin/features/navigation/nav-utils";
   import OrganizationTabs from "@rilldata/web-admin/features/organizations/OrganizationTabs.svelte";
   import { initCloudMetrics } from "@rilldata/web-admin/features/telemetry/initCloudMetrics";
+  import "@rilldata/web-common/app.css";
   import BannerCenter from "@rilldata/web-common/components/banner/BannerCenter.svelte";
   import NotificationCenter from "@rilldata/web-common/components/notifications/NotificationCenter.svelte";
   import { featureFlags } from "@rilldata/web-common/features/feature-flags";
   import { initPylonWidget } from "@rilldata/web-common/features/help/initPylonWidget";
+  import { dynamicHeight } from "@rilldata/web-common/layout/layout-settings.ts";
   import { isEmbedPage } from "@rilldata/web-common/layout/navigation/navigation-utils.ts";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus.ts";
+  import { cancelQueriesOnHidden } from "@rilldata/web-common/lib/svelte-query/cancel-queries-on-hidden";
   import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
   import { errorEventHandler } from "@rilldata/web-common/metrics/initMetrics";
   import { type Query, QueryClientProvider } from "@tanstack/svelte-query";
@@ -27,7 +29,6 @@
   import { onMount } from "svelte";
   import ErrorBoundary from "../components/errors/ErrorBoundary.svelte";
   import TopNavigationBar from "../features/navigation/TopNavigationBar.svelte";
-  import "@rilldata/web-common/app.css";
 
   export let data;
 
@@ -60,6 +61,7 @@
       errorStore.set(createUserFacingError(null, error.message));
     }
   };
+  cancelQueriesOnHidden();
 
   // The admin server enables some dashboard features like scheduled reports and alerts
   // Set read-only mode so that the user can't edit the dashboard

--- a/web-common/src/lib/svelte-query/cancel-queries-on-hidden.ts
+++ b/web-common/src/lib/svelte-query/cancel-queries-on-hidden.ts
@@ -1,0 +1,22 @@
+import { onMount } from "svelte";
+import { queryClient } from "./globalQueryClient";
+
+/**
+ * Cancels all in-flight queries when the browser tab becomes hidden.
+ * This prevents expensive server-side queries from continuing when users switch tabs.
+ *
+ * Call this function from the root layout component.
+ */
+export function cancelQueriesOnHidden() {
+  onMount(() => {
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        queryClient.cancelQueries();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () =>
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+  });
+}

--- a/web-local/src/routes/+layout.svelte
+++ b/web-local/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { dev } from "$app/environment";
   import { page } from "$app/stores";
+  import "@rilldata/web-common/app.css";
   import BannerCenter from "@rilldata/web-common/components/banner/BannerCenter.svelte";
   import NotificationCenter from "@rilldata/web-common/components/notifications/NotificationCenter.svelte";
   import RepresentingUserBanner from "@rilldata/web-common/features/authentication/RepresentingUserBanner.svelte";
@@ -15,6 +16,7 @@
     initPosthog,
     posthogIdentify,
   } from "@rilldata/web-common/lib/analytics/posthog";
+  import { cancelQueriesOnHidden } from "@rilldata/web-common/lib/svelte-query/cancel-queries-on-hidden";
   import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
   import {
     errorEventHandler,
@@ -27,7 +29,6 @@
   import type { AxiosError } from "axios";
   import { onMount } from "svelte";
   import type { LayoutData } from "./$types";
-  import "@rilldata/web-common/app.css";
 
   export let data: LayoutData;
 
@@ -37,6 +38,8 @@
     error: AxiosError,
     query: Query,
   ) => errorEventHandler?.requestErrorEventHandler(error, query);
+  cancelQueriesOnHidden();
+
   initPylonWidget();
 
   let removeJavascriptListeners: () => void;


### PR DESCRIPTION
Prevents expensive server-side analytical queries from continuing when users switch away from the Rill tab.

Closes [APP-602](https://linear.app/rilldata/issue/APP-602/investigate-query-cancellation-when-switching-tabs-on-loading)

TODO: test this & double-check `refetchOnWindowFocus: false`.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
