### PR TITLE
Fix project home page name display

### DIFF
--- a/web-admin/src/routes/[organization]/[project]/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/+page.svelte
@@ -5,7 +5,7 @@
   import InlineChat from "@rilldata/web-common/features/chat/layouts/inline/InlineChat.svelte";
   import DelayedContent from "@rilldata/web-common/features/entity-management/DelayedContent.svelte";
   import { featureFlags } from "@rilldata/web-common/features/feature-flags";
-  import { createRuntimeServiceGetInstance } from "@rilldata/web-common/runtime-client";
+  import { useProjectTitle } from "@rilldata/web-common/features/project/selectors";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
 
   const { chat } = featureFlags;
@@ -16,12 +16,11 @@
 
   $: ({ instanceId } = $runtime);
 
-  // Query the instance to get the project display name
-  $: instanceQuery = createRuntimeServiceGetInstance(instanceId);
-  $: projectDisplayName =
-    $instanceQuery.data?.instance?.projectDisplayName || project;
-  $: isLoadingDisplayName = $instanceQuery.isLoading;
-  $: isErrorDisplayName = $instanceQuery.isError;
+  // Query the project metadata to get the display name from rill.yaml
+  $: projectTitleQuery = useProjectTitle(instanceId);
+  $: projectDisplayName = $projectTitleQuery?.data || project;
+  $: isLoadingDisplayName = $projectTitleQuery?.isLoading;
+  $: isErrorDisplayName = $projectTitleQuery?.isError;
 </script>
 
 <svelte:head>


### PR DESCRIPTION
Fixes APP-604

The project home page incorrectly displayed "Untitled Rill Project" instead of the actual project display name. This change updates the home page to reuse the `useProjectTitle` selector, ensuring the project's `displayName` from `rill.yaml` (or the project slug as a fallback) is consistently displayed, aligning it with the header.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-604](https://linear.app/rilldata/issue/APP-604/project-home-page-isnt-displaying-the-correct-project-name)

<a href="https://cursor.com/background-agent?bcId=bc-697c1668-7942-46db-b4ef-9a4253dd5a90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-697c1668-7942-46db-b4ef-9a4253dd5a90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

