### PR TITLE
fix: markdown llm response sanitisation

### DIFF
--- a/web-common/src/components/markdown/Markdown.svelte
+++ b/web-common/src/components/markdown/Markdown.svelte
@@ -8,7 +8,7 @@
   // Sometimes LLM response adds markdown syntax around the content, so we need to remove it
   $: sanitisedContext = content
     .replace(/^```markdown\n/, "")
-    .replace(/\n```$/, "");
+    .replace(/\n```$/m, "");
 </script>
 
 <div class="chat-markdown">


### PR DESCRIPTION
Sometimes LLM response contains additional markdown syntax. This breaks our rendering which expects it not to present. This PR sanitises the response and always removes the additional syntax.

Pulling out changes from https://github.com/rilldata/rill/pull/8217
Closes APP-595

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
