### PR TITLE
fix: error detecting resource: conflicting Schema URL

### DIFF
--- a/runtime/pkg/observability/observability.go
+++ b/runtime/pkg/observability/observability.go
@@ -64,10 +64,10 @@ func Start(ctx context.Context, logger *zap.Logger, opts *Options) (ShutdownFunc
 		resource.WithFromEnv(),
 	)
 	if err != nil {
-		if errors.Is(err, resource.ErrPartialResource) || errors.Is(err, resource.ErrSchemaURLConflict) {
-			logger.Info("otel resource only partially detected", zap.Error(err))
+		if !errors.Is(err, resource.ErrPartialResource) && !errors.Is(err, resource.ErrSchemaURLConflict) {
+			return nil, err
 		}
-		return nil, err
+		logger.Info("otel resource only partially detected", zap.Error(err))
 	}
 
 	// Create global metrics exporter


### PR DESCRIPTION
closes https://github.com/rilldata/rill/issues/8381

Looking at the fix here : https://github.com/open-telemetry/opentelemetry-go/pull/4876
It seems other language SDKs just logs the errors and returns the merged resource. Go SDK requires user to take explicit action.
Usage in go code indicates that other libraries using the SDK implement the same behaviour.
Tested the fix on linux machine.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
