### PR TITLE
Restore "Test and Connect"

### DIFF
--- a/web-common/src/features/sources/modal/AddDataForm.svelte
+++ b/web-common/src/features/sources/modal/AddDataForm.svelte
@@ -284,6 +284,9 @@
       dsnError = message;
       dsnErrorDetails = details;
     },
+    setShowSaveAnyway: (value: boolean) => {
+      showSaveAnyway = value;
+    },
   });
 
   async function handleFileUpload(file: File): Promise<string> {

--- a/web-common/src/features/sources/modal/AddDataFormManager.ts
+++ b/web-common/src/features/sources/modal/AddDataFormManager.ts
@@ -34,6 +34,7 @@ import { compileSourceYAML, prepareSourceFormData } from "../sourceUtils";
 import type { ConnectorDriverProperty } from "@rilldata/web-common/runtime-client";
 import type { ClickHouseConnectorType } from "./constants";
 import { applyClickHouseCloudRequirements } from "./utils";
+import type { ActionResult } from "@sveltejs/kit";
 
 // Minimal onUpdate event type carrying Superforms's validated form
 type SuperFormUpdateEvent = {
@@ -238,6 +239,7 @@ export class AddDataFormManager {
     getConnectionTab: () => "parameters" | "dsn";
     setParamsError: (message: string | null, details?: string) => void;
     setDsnError: (message: string | null, details?: string) => void;
+    setShowSaveAnyway?: (value: boolean) => void;
   }) {
     const {
       onClose,
@@ -245,6 +247,7 @@ export class AddDataFormManager {
       getConnectionTab,
       setParamsError,
       setDsnError,
+      setShowSaveAnyway,
     } = args;
     const connector = this.connector;
     const isMultiStepConnector = MULTI_STEP_CONNECTORS.includes(
@@ -258,7 +261,18 @@ export class AddDataFormManager {
         any,
         Record<string, unknown>
       >;
+      result?: Extract<ActionResult, { type: "success" | "failure" }>;
     }) => {
+      // For non-ClickHouse connectors, expose Save Anyway when a submission starts
+      if (
+        isConnectorForm &&
+        connector.name !== "clickhouse" &&
+        typeof setShowSaveAnyway === "function" &&
+        event?.result
+      ) {
+        setShowSaveAnyway(true);
+      }
+
       if (!event.form.valid) return;
 
       const values = event.form.data;


### PR DESCRIPTION
This fixes `AddDataFormManager` to use the correct path for “Test and Connect,” restoring immediate error display in the AddDataForm sidebar and avoiding premature file creation. The regression stems from a bad rebase.

https://github.com/user-attachments/assets/d7d1cf4a-061e-405b-8ad4-9e210719441c

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
