### PR TITLE
chore: send analyst_agent for project/dashboard chat

### DIFF
--- a/web-common/src/features/chat/core/conversation.ts
+++ b/web-common/src/features/chat/core/conversation.ts
@@ -39,11 +39,18 @@ export class Conversation {
   constructor(
     private readonly instanceId: string,
     public conversationId: string,
-    private readonly options?: {
+    private readonly options: {
+      agent?: string;
       onStreamStart?: () => void;
       onConversationCreated?: (conversationId: string) => void;
+    } = {
+      agent: ToolName.ANALYST_AGENT, // Hardcoded default for now
     },
-  ) {}
+  ) {
+    if (this.options) {
+      this.options.agent ??= ToolName.ANALYST_AGENT;
+    }
+  }
 
   // ===== PUBLIC API =====
 
@@ -239,6 +246,7 @@ export class Conversation {
           ? undefined
           : this.conversationId,
       prompt,
+      agent: this.options?.agent,
       ...context,
     };
 


### PR DESCRIPTION
After lifting `developer_agent` feature flag, we need to make sure other chat is forced to use `analyst_agent` to avoid conflicts.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
