### PR TITLE
fix: monthly report to always select 1st day

### DIFF
--- a/web-common/src/features/scheduled-reports/time-utils.ts
+++ b/web-common/src/features/scheduled-reports/time-utils.ts
@@ -182,7 +182,7 @@ export function getExistingScheduleFormValues(
   return {
     frequency: getFrequencyFromCronExpression(schedule?.cron),
     dayOfWeek: getDayOfWeekFromCronExpression(schedule?.cron),
-    dayOfMonth: getDayOfMonthFromCronExpression(schedule?.cron),
+    dayOfMonth: 1, // We only support 1st day of month as of now.
     timeOfDay: getTimeOfDayFromCronExpression(schedule?.cron),
     timeZone: schedule?.timeZone ?? getLocalIANA(),
   };


### PR DESCRIPTION
Some customers have gotten into a bad state where reports are run as non-1st day of month. The UI doesnt allow this to be updated. So always set day of month to 1st so an edit will update to be 1st of month.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
