### PR TITLE
Fix pagination token parsing error

### DIFF
--- a/runtime/server/controller.go
+++ b/runtime/server/controller.go
@@ -327,13 +327,14 @@ func (s *Server) GetModelPartitions(ctx context.Context, req *runtimev1.GetModel
 	defer release()
 
 	defaultPageSize := 100
+	pageLimit := pagination.ValidPageSize(req.PageSize, defaultPageSize)
 	opts := &drivers.FindModelPartitionsOptions{
 		ModelID:          partitionsModelID,
 		WherePending:     req.Pending,
 		WhereErrored:     req.Errored,
 		BeforeExecutedOn: beforeExecutedOn,
 		AfterKey:         afterKey,
-		Limit:            pagination.ValidPageSize(req.PageSize, defaultPageSize),
+		Limit:            pageLimit,
 	}
 
 	partitions, err := catalog.FindModelPartitions(ctx, opts)
@@ -342,15 +343,23 @@ func (s *Server) GetModelPartitions(ctx context.Context, req *runtimev1.GetModel
 	}
 
 	var nextPageToken string
-	if len(partitions) == pagination.ValidPageSize(req.PageSize, defaultPageSize) {
+	if len(partitions) == pageLimit && len(partitions) > 0 {
 		last := partitions[len(partitions)-1]
-		nextPageToken = pagination.MarshalPageToken(last.Index, last.Key)
+		nextPageToken = modelPartitionPageToken(last)
 	}
 
 	return &runtimev1.GetModelPartitionsResponse{
 		Partitions:    modelPartitionsToPB(partitions),
 		NextPageToken: nextPageToken,
 	}, nil
+}
+
+func modelPartitionPageToken(partition drivers.ModelPartition) string {
+	var executedOn time.Time
+	if partition.ExecutedOn != nil {
+		executedOn = *partition.ExecutedOn
+	}
+	return pagination.MarshalPageToken(executedOn, partition.Key)
 }
 
 // CreateTrigger implements runtimev1.RuntimeServiceServer

--- a/runtime/server/controller_pagination_test.go
+++ b/runtime/server/controller_pagination_test.go
@@ -1,0 +1,44 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rilldata/rill/runtime/drivers"
+	"github.com/rilldata/rill/runtime/pkg/pagination"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelPartitionPageToken_ExecutedOn(t *testing.T) {
+	ts := time.Date(2024, time.March, 5, 12, 0, 0, 0, time.UTC)
+	partition := drivers.ModelPartition{
+		Key:        "abc123",
+		ExecutedOn: &ts,
+	}
+
+	token := modelPartitionPageToken(partition)
+	require.NotEmpty(t, token)
+
+	var decoded time.Time
+	var decodedKey string
+	err := pagination.UnmarshalPageToken(token, &decoded, &decodedKey)
+	require.NoError(t, err)
+	require.True(t, ts.Equal(decoded))
+	require.Equal(t, partition.Key, decodedKey)
+}
+
+func TestModelPartitionPageToken_NilExecutedOn(t *testing.T) {
+	partition := drivers.ModelPartition{
+		Key: "pending",
+	}
+
+	token := modelPartitionPageToken(partition)
+	require.NotEmpty(t, token)
+
+	var decoded time.Time
+	var decodedKey string
+	err := pagination.UnmarshalPageToken(token, &decoded, &decodedKey)
+	require.NoError(t, err)
+	require.True(t, decoded.IsZero())
+	require.Equal(t, partition.Key, decodedKey)
+}


### PR DESCRIPTION
Fixes APP-613

The `rill project partitions` command's `--page-token` failed because the `ExecutedOn` timestamp was not correctly marshaled into the pagination token, leading to a `Time.UnmarshalJSON` error.

This PR updates the pagination token generation to correctly encode the `ExecutedOn` timestamp (with a zero-time fallback for nil values) alongside the partition key. A new helper function `modelPartitionPageToken` encapsulates this logic, and dedicated unit tests ensure proper token creation and decoding for both present and nil `ExecutedOn` values.

**Checklist:**
- [x] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-613](https://linear.app/rilldata/issue/APP-613/pagination-command-is-not-accepting-the-next-page-token)

<a href="https://cursor.com/background-agent?bcId=bc-a1844248-1d0d-4ebb-8375-e902ce2c48cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a1844248-1d0d-4ebb-8375-e902ce2c48cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes page token generation for model partitions by encoding ExecutedOn with key, refines pagination limit usage, and adds unit tests.
> 
> - **Runtime server**:
>   - **Pagination**:
>     - Generate `NextPageToken` using new `modelPartitionPageToken`, encoding `ExecutedOn` (with zero-time fallback) and partition `Key` via `pagination.MarshalPageToken`.
>     - Refactor page size handling to use `pageLimit` and update next-page condition to `len(partitions) == pageLimit && > 0`.
>   - **Tests**:
>     - Add `controller_pagination_test.go` with cases for present and nil `ExecutedOn`, verifying token marshal/unmarshal of time and key.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1b581d67b8ad68958da5475a7ea10a811d458ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->