### PR TITLE
Adding additional notes to warn against DuckDB/SQLite files in the connector UI

### DIFF
--- a/web-common/src/features/sources/modal/NeedHelpText.svelte
+++ b/web-common/src/features/sources/modal/NeedHelpText.svelte
@@ -24,11 +24,17 @@
   </span>
   {#if connector.displayName === "DuckDB" || connector.displayName === "SQLite"}
     <div class="mt-8">
-      <div class="text-sm leading-none font-medium mb-4">Additional Information</div>
+      <div class="text-sm leading-none font-medium mb-4">
+        Additional Information
+      </div>
 
-      <div class="text-sm leading-normal font-medium text-muted-foreground mb-2">
-          External {connector.displayName} files are meant for local development only. They may run fine on your machine, but aren’t reliably supported in production deployments—especially if the file is large (100MB) or outside the data directory.
-      </div> 
+      <div
+        class="text-sm leading-normal font-medium text-muted-foreground mb-2"
+      >
+        External {connector.displayName} files are meant for local development only.
+        They may run fine on your machine, but aren’t reliably supported in production
+        deployments—especially if the file is large (100MB) or outside the data directory.
+      </div>
     </div>
   {/if}
 </div>


### PR DESCRIPTION
https://linear.app/rilldata/issue/APP-411/add-messagingwarning-on-the-new-duckdbsqlite-modal-about-location-of

Not sure if an if connectorName='xxx' /if is okay in the NeedHelp.svelte or should add a extra parameter in the V1ConnectorDriver?


/
<img width="894" height="688" alt="Screenshot 2025-12-02 at 11 55 43" src="https://github.com/user-attachments/assets/0711441c-77a5-4abf-ab1e-8579ce091eb9" />
<img width="893" height="682" alt="Screenshot 2025-12-02 at 11 55 48" src="https://github.com/user-attachments/assets/527b07bd-7ca2-4546-8416-5be8586d575e" />


**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
