### PR TITLE
Update validate deployment orphaned clean up criteria

### DIFF
--- a/admin/jobs/river/validate_deployments.go
+++ b/admin/jobs/river/validate_deployments.go
@@ -21,13 +21,9 @@ type ValidateDeploymentsWorker struct {
 	admin *admin.Service
 }
 
-func (w *ValidateDeploymentsWorker) Work(ctx context.Context, job *river.Job[ValidateDeploymentsArgs]) error {
-	return work(ctx, w.admin.Logger, job.Kind, w.validateDeployments)
-}
-
 const validateDeploymentsForProjectTimeout = 5 * time.Minute
 
-func (w *ValidateDeploymentsWorker) validateDeployments(ctx context.Context) error {
+func (w *ValidateDeploymentsWorker) Work(ctx context.Context, job *river.Job[ValidateDeploymentsArgs]) error {
 	var wg sync.WaitGroup
 	ch := make(chan *database.Project)
 


### PR DESCRIPTION
This PR updates the criteria we use to determine if a prod deployment is orphaned and should be cleaned up by the `ValidateDeployments` job.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
