### PR TITLE
Remove obsolete River job work wrapper

### DIFF
--- a/admin/jobs/river/biller_event_handlers.go
+++ b/admin/jobs/river/biller_event_handlers.go
@@ -190,10 +190,6 @@ type PaymentFailedGracePeriodCheckWorker struct {
 }
 
 func (w *PaymentFailedGracePeriodCheckWorker) Work(ctx context.Context, job *river.Job[PaymentFailedGracePeriodCheckArgs]) error {
-	return work(ctx, w.admin.Logger, job.Kind, w.paymentFailedGracePeriodCheck)
-}
-
-func (w *PaymentFailedGracePeriodCheckWorker) paymentFailedGracePeriodCheck(ctx context.Context) error {
 	failures, err := w.admin.DB.FindBillingIssueByTypeAndOverdueProcessed(ctx, database.BillingIssueTypePaymentFailed, false)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {

--- a/admin/jobs/river/delete_unused_github_repo.go
+++ b/admin/jobs/river/delete_unused_github_repo.go
@@ -24,13 +24,9 @@ type deleteUnusedGithubReposWorker struct {
 	logger *zap.Logger
 }
 
-func (w *deleteUnusedGithubReposWorker) Work(ctx context.Context, job *river.Job[deleteUnusedGithubReposArgs]) error {
-	return work(ctx, w.admin.Logger, job.Kind, w.deleteUnusedGithubRepos)
-}
-
 // deleteUnusedGithubRepos deletes unused Rill managed Github repositories from the database and Github.
 // An unused repository is one that is not associated with any Rill project since more than 7 days.
-func (w *deleteUnusedGithubReposWorker) deleteUnusedGithubRepos(ctx context.Context) error {
+func (w *deleteUnusedGithubReposWorker) Work(ctx context.Context, job *river.Job[deleteUnusedGithubReposArgs]) error {
 	for {
 		// 1. Fetch repositories that are not associated with any Rill project
 		repos, err := w.admin.DB.FindUnusedManagedGitRepos(ctx, _unusedGithubRepoPageSize)

--- a/admin/jobs/river/subscription_handlers.go
+++ b/admin/jobs/river/subscription_handlers.go
@@ -26,10 +26,6 @@ type SubscriptionCancellationCheckWorker struct {
 
 // Work This worker runs at end of the current subscription term after subscription cancellation
 func (w *SubscriptionCancellationCheckWorker) Work(ctx context.Context, job *river.Job[SubscriptionCancellationCheckArgs]) error {
-	return work(ctx, w.admin.Logger, job.Kind, w.subscriptionCancellationCheck)
-}
-
-func (w *SubscriptionCancellationCheckWorker) subscriptionCancellationCheck(ctx context.Context) error {
 	cancelled, err := w.admin.DB.FindBillingIssueByTypeAndOverdueProcessed(ctx, database.BillingIssueTypeSubscriptionCancelled, false)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {

--- a/admin/jobs/river/trial_checks.go
+++ b/admin/jobs/river/trial_checks.go
@@ -25,10 +25,6 @@ type TrialEndingSoonWorker struct {
 }
 
 func (w *TrialEndingSoonWorker) Work(ctx context.Context, job *river.Job[TrialEndingSoonArgs]) error {
-	return work(ctx, w.admin.Logger, job.Kind, w.trialEndingSoon)
-}
-
-func (w *TrialEndingSoonWorker) trialEndingSoon(ctx context.Context) error {
 	onTrialOrgs, err := w.admin.DB.FindBillingIssueByTypeAndOverdueProcessed(ctx, database.BillingIssueTypeOnTrial, false)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
@@ -104,10 +100,6 @@ type TrialEndCheckWorker struct {
 }
 
 func (w *TrialEndCheckWorker) Work(ctx context.Context, job *river.Job[TrialEndCheckArgs]) error {
-	return work(ctx, w.admin.Logger, job.Kind, w.trialEndCheck)
-}
-
-func (w *TrialEndCheckWorker) trialEndCheck(ctx context.Context) error {
 	onTrialOrgs, err := w.admin.DB.FindBillingIssueByTypeAndOverdueProcessed(ctx, database.BillingIssueTypeOnTrial, true)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
@@ -225,10 +217,6 @@ type TrialGracePeriodCheckWorker struct {
 }
 
 func (w *TrialGracePeriodCheckWorker) Work(ctx context.Context, job *river.Job[TrialGracePeriodCheckArgs]) error {
-	return work(ctx, w.admin.Logger, job.Kind, w.trialGracePeriodCheck)
-}
-
-func (w *TrialGracePeriodCheckWorker) trialGracePeriodCheck(ctx context.Context) error {
 	trailEndedOrgs, err := w.admin.DB.FindBillingIssueByTypeAndOverdueProcessed(ctx, database.BillingIssueTypeTrialEnded, false)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {


### PR DESCRIPTION
Remove obsolete River job work wrapper, since it has been made redundant by our new River observability middleware.