### PR TITLE
fix: contains filter not applying to dimension table

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
@@ -10,13 +10,9 @@ import {
   createInExpression,
   createLikeExpression,
   createOrExpression,
-  filterExpressions,
   matchExpressionByName,
 } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
-import {
-  type V1MetricsViewAggregationResponseDataItem,
-  V1Operation,
-} from "../../../runtime-client";
+import { type V1MetricsViewAggregationResponseDataItem } from "../../../runtime-client";
 import PercentOfTotal from "./PercentOfTotal.svelte";
 
 import { PERC_DIFF } from "../../../components/data-types/type-utils";


### PR DESCRIPTION
We were removing any like/ilike filter when there was no search in dimension table. This is probably some legacy code that is not relevant anymore.

Removing this since we have ilike filters now with `contains`

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
