### PR TITLE
Fix Modal sizing issue with long error message

### DIFF
--- a/web-common/src/components/forms/SubmissionError.svelte
+++ b/web-common/src/components/forms/SubmissionError.svelte
@@ -68,7 +68,7 @@
   .error-container {
     @apply border-red-600 bg-red-50;
     @apply p-2 flex border rounded;
-    @apply max-h-40 overflow-y-auto;
+    @apply max-h-48 overflow-y-auto;
   }
 
   .message {

--- a/web-common/src/features/sources/modal/NeedHelpText.svelte
+++ b/web-common/src/features/sources/modal/NeedHelpText.svelte
@@ -1,42 +1,25 @@
 <script lang="ts">
   import type { V1ConnectorDriver } from "@rilldata/web-common/runtime-client";
   import { ExternalLinkIcon } from "lucide-svelte";
-  import { connectorStepStore } from "./connectorStepStore";
 
   export let connector: V1ConnectorDriver;
-
-  $: stepState = $connectorStepStore;
 </script>
 
 <div>
   <div class="text-sm leading-none font-medium mb-4">Help</div>
-  {#if stepState.step === "connector"}
-    <div class="text-sm leading-normal font-medium text-muted-foreground mb-2">
-      Need help connecting to {connector.displayName}? Check out our
-      documentation for detailed instructions.
-    </div>
-    <span class="flex flex-row items-center gap-2 group mb-4">
-      <a
-        href={connector.docsUrl ||
-          "https://docs.rilldata.com/build/connectors/"}
-        rel="noreferrer noopener"
-        target="_blank"
-        class="text-sm leading-normal text-primary-500 hover:text-primary-600 font-medium group-hover:underline break-all"
-      >
-        How to connect to {connector.displayName}
-      </a>
-      <ExternalLinkIcon size="16px" color="#6366F1" />
-    </span>
-  {:else}
-    <div class="text-sm leading-normal font-medium text-muted-foreground mb-2">
-      Check out our <a
-        href="https://docs.rilldata.com/build/models/source-models/"
-        rel="noreferrer noopener"
-        target="_blank"
-        class="text-sm leading-normal text-primary-500 hover:text-primary-600 font-medium group-hover:underline break-all"
-      >
-        source model documentation
-      </a> for detailed instructions on how to customize up your data source ingestion.
-    </div>
-  {/if}
+  <div class="text-sm leading-normal font-medium text-muted-foreground mb-2">
+    Need help connecting to {connector.displayName}? Check out our documentation
+    for detailed instructions.
+  </div>
+  <span class="flex flex-row items-center gap-2 group mb-4">
+    <a
+      href={connector.docsUrl || "https://docs.rilldata.com/build/connectors/"}
+      rel="noreferrer noopener"
+      target="_blank"
+      class="text-sm leading-normal text-primary-500 hover:text-primary-600 font-medium group-hover:underline break-all"
+    >
+      How to connect to {connector.displayName}
+    </a>
+    <ExternalLinkIcon size="16px" color="#6366F1" />
+  </span>
 </div>

--- a/web-common/src/features/sources/modal/YamlPreview.svelte
+++ b/web-common/src/features/sources/modal/YamlPreview.svelte
@@ -44,7 +44,7 @@
   {#if showAdditionalInfo && connector}
     <div class="mt-4 flex items-center gap-1">
       <span class="text-sm leading-none font-medium"
-        >Additional Information</span
+        >Local Development only</span
       >
       <Tooltip location="right" alignment="middle" distance={8}>
         <div class="text-gray-500">


### PR DESCRIPTION
The additional Information is way to big for sqlite error messages, made it a hoverable message and slightly shrunk error window.

Other option is to make sqlite modals lightly bigger but that looks weird

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
