### PR TITLE
fix: explain range selection clearing unnecessarily

### DIFF
--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -278,6 +278,8 @@
     }),
   );
 
+  let grainDropdownOpen = false;
+
   let showReplacePivotModal = false;
   function startPivotForTimeseries() {
     const pivot = $exploreState?.pivot;
@@ -322,10 +324,15 @@
     );
   }
 
-  let open = false;
+  function maybeClearMeasureSelection() {
+    // Range selection should only clear when scrub range is cleared.
+    if (!measureSelection.isRangeSelection()) {
+      measureSelection.clear();
+    }
+  }
 </script>
 
-<svelte:window on:click={() => measureSelection.clear()} />
+<svelte:window on:click={maybeClearMeasureSelection} />
 
 <TimeSeriesChartContainer
   enableFullWidth={showTimeDimensionDetail}
@@ -355,7 +362,7 @@
       />
 
       {#if $rillTime && activeTimeGrain}
-        <DropdownMenu.Root bind:open>
+        <DropdownMenu.Root bind:open={grainDropdownOpen}>
           <DropdownMenu.Trigger asChild let:builder>
             <button
               {...builder}
@@ -365,7 +372,10 @@
               by <b>
                 {V1TimeGrainToDateTimeUnit[activeTimeGrain]}
               </b>
-              <span class:-rotate-90={open} class="transition-transform">
+              <span
+                class:-rotate-90={grainDropdownOpen}
+                class="transition-transform"
+              >
                 <CaretDownIcon />
               </span>
             </button>

--- a/web-common/src/features/dashboards/time-series/measure-selection/measure-selection.ts
+++ b/web-common/src/features/dashboards/time-series/measure-selection/measure-selection.ts
@@ -70,6 +70,10 @@ export class MeasureSelection {
     return Boolean(get(this.measure));
   }
 
+  public isRangeSelection() {
+    return Boolean(get(this.end));
+  }
+
   public startAnomalyExplanationChat(metricsView: string) {
     if (!this.hasSelection()) return;
     const measure = get(this.measure)!;


### PR DESCRIPTION
Explain range selection is cleared when clicking outside the chart. But it should only clear when the scrub range is cleared. But the explain point selection should still be cleared when clicking outside the chart.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
