### PR TITLE
fix: url initialization flag sequencing

### DIFF
--- a/web-common/src/features/canvas/stores/time-state.ts
+++ b/web-common/src/features/canvas/stores/time-state.ts
@@ -262,8 +262,6 @@ export class TimeState {
   };
 
   onUrlChange = (searchParams: URLSearchParams) => {
-    this.urlInitialized.set(true);
-
     const { range, comparisonRange, zone, grain } =
       parseSearchParams(searchParams);
 
@@ -280,6 +278,8 @@ export class TimeState {
     if (comparisonRange) {
       this.comparisonRangeStore.set(comparisonRange);
     }
+
+    this.urlInitialized.set(true);
   };
 
   set = {


### PR DESCRIPTION
Fixes an issue where the URL initialization flag was set prior to certain stores being initialized. The side effect was that the range store would briefly be set with a default value even when one was present in the URL, though this would only happen on canvases referencing more than one metrics views.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
