### PR TITLE
fix: truncation tooltip behavior

### DIFF
--- a/web-common/src/features/dashboards/time-controls/super-pill/new-time-dropdown/TruncationSelector.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/new-time-dropdown/TruncationSelector.svelte
@@ -25,7 +25,7 @@
   export let watermark: DateTime | undefined;
   export let latest: DateTime | undefined;
   export let zone: string;
-  export let ref: RillTimeLabel | string | undefined;
+  export let ref: RillTimeLabel | undefined;
   export let onSelectAsOfOption: (ref: RillTimeLabel) => void;
   export let onToggleAlignment: (forward: boolean) => void;
   export let onSelectEnding: (
@@ -36,6 +36,7 @@
   let open = false;
   let now = DateTime.now().setZone(zone);
   let interval: ReturnType<typeof setInterval> | undefined = undefined;
+  let disableTooltip = false;
 
   onMount(() => {
     interval = setInterval(() => {
@@ -97,7 +98,7 @@
   }
 
   function humanizeRef(
-    ref: RillTimeLabel | string | undefined,
+    ref: RillTimeLabel | undefined,
     grain: V1TimeGrain | undefined,
   ): string {
     switch (ref) {
@@ -110,12 +111,7 @@
         if (grain) return "current";
         return "now";
       default:
-        try {
-          const dt = DateTime.fromISO(ref as string).setZone(zone);
-          return dt.toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
-        } catch {
-          return ref as string;
-        }
+        return "now";
     }
   }
 
@@ -137,8 +133,6 @@
       }) + (inFuture ? " from now" : " ago")
     );
   }
-
-  let disableTooltip = false;
 </script>
 
 <DropdownMenu.Root bind:open disableFocusFirstItem>


### PR DESCRIPTION
Addresses some limitations with the current version of bits-ui so that the tooltips in the truncation selector only open when intended.

- Fixes an issue where the tooltip for the first anchor option would open with with the dropdown 
- Fixes an issue where the dropdown trigger tooltip would reopen after closing the dropdown (if the cursor remained on the element)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
