### PR TITLE
fix: chat messae in history is not selectable

### DIFF
--- a/web-common/src/features/chat/core/messages/text/UserMessage.svelte
+++ b/web-common/src/features/chat/core/messages/text/UserMessage.svelte
@@ -26,10 +26,6 @@
         onSubmit: () => {},
       }),
       content,
-      onTransaction: () => {
-        // force re-render so `editor.isActive` works as expected
-        editor = editor;
-      },
     });
 
     return () => {


### PR DESCRIPTION
Chat message in history is not selectable because the selection transaction was getting cleared.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
