### PR TITLE
fix: misaligned pivot cell text

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotExpandableCell.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotExpandableCell.svelte
@@ -23,14 +23,14 @@
   {#if value === "LOADING_CELL"}
     <span class="loading-cell" />
   {:else if assembledAndCanExpand}
-    <div class="caret opacity-100" class:expanded>
+    <div class="caret opacity-100 shrink-0" class:expanded>
       <ChevronRight size="16px" color="#9CA3AF" />
     </div>
   {:else if row.depth >= 1}
-    <Spacer size="16px" />
+    <span class="shrink-0"><Spacer size="16px" /></span>
   {/if}
 
-  <span class="truncate">
+  <span class="truncate min-w-0">
     {#if value === "LOADING_CELL"}
       {""}
     {:else if value === ""}


### PR DESCRIPTION
Fixes misalignment in pivot dimension cell component

<img width="986" height="1136" alt="image" src="https://github.com/user-attachments/assets/961c106b-1afd-4531-816a-97998493ec55" />


This was caused by the truncated text overlapping over the spacer.


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
