### PR TITLE
fix: canvas workspace sequencing

### DIFF
--- a/web-common/src/features/canvas/CanvasInitialization.svelte
+++ b/web-common/src/features/canvas/CanvasInitialization.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+  import {
+    getCanvasStoreUnguarded,
+    setCanvasStore,
+    type CanvasStore,
+  } from "./state-managers/state-managers";
+  import { page } from "$app/stores";
+  import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
+  import {
+    DashboardBannerID,
+    DashboardBannerPriority,
+  } from "@rilldata/web-common/components/banner/constants";
+  import { onNavigate } from "$app/navigation";
+  import { writable } from "svelte/store";
+  import {
+    createQueryServiceResolveCanvas,
+    type V1MetricsView,
+    type V1ResolveCanvasResponse,
+  } from "@rilldata/web-common/runtime-client";
+  import {
+    ResourceKind,
+    useResource,
+  } from "../entity-management/resource-selectors";
+
+  const PollIntervalWhenDashboardFirstReconciling = 1000;
+  const PollIntervalWhenDashboardErrored = 5000;
+
+  export let canvasName: string;
+  export let instanceId: string;
+  export let showBanner = false;
+  export let projectId: string | undefined = undefined;
+
+  let resolvedStore: CanvasStore | undefined = undefined;
+
+  $: ({ url } = $page);
+
+  $: existingStore = getCanvasStoreUnguarded(canvasName, instanceId);
+
+  $: resourceQuery = useResource(
+    instanceId,
+    canvasName,
+    ResourceKind.Canvas,
+    {},
+  );
+
+  $: fetchedCanvasQuery = !existingStore
+    ? createQueryServiceResolveCanvas(
+        instanceId,
+        canvasName,
+        {},
+        {
+          query: {
+            retry: 5,
+            refetchInterval: (query) => {
+              const resource = query?.state?.data;
+              if (!resource) return false;
+              if (isCanvasReconcilingForFirstTime(resource))
+                return PollIntervalWhenDashboardFirstReconciling;
+              if (isCanvasErrored(resource))
+                return PollIntervalWhenDashboardErrored;
+              return false;
+            },
+          },
+        },
+      )
+    : undefined;
+
+  $: isLoading = fetchedCanvasQuery ? $fetchedCanvasQuery?.isLoading : false;
+
+  $: fetchedCanvas = fetchedCanvasQuery ? $fetchedCanvasQuery?.data : undefined;
+
+  $: validSpec = fetchedCanvas?.canvas?.canvas?.state?.validSpec;
+  $: reconcileError = fetchedCanvas?.canvas?.meta?.reconcileError;
+
+  $: isReconciling =
+    !existingStore && !validSpec && !reconcileError && !isLoading;
+
+  $: resource = resourceQuery ? $resourceQuery?.data : undefined;
+
+  $: errorMessage = !validSpec
+    ? reconcileError || resource?.meta?.reconcileError
+    : undefined;
+
+  $: resolvedStore = getResolvedStore(
+    fetchedCanvas,
+    isReconciling,
+    existingStore,
+  );
+
+  $: ready = !!resolvedStore;
+
+  $: if (resolvedStore) {
+    resolvedStore.canvasEntity
+      .onUrlChange({ url, projectId })
+      .catch(console.error);
+  }
+
+  $: title = resolvedStore?.canvasEntity.titleStore || writable("");
+  $: canvasTitle = $title;
+
+  $: bannerStore = resolvedStore?.canvasEntity.bannerStore || writable("");
+  $: banner = $bannerStore;
+
+  $: hasBanner = !!banner;
+
+  $: if (hasBanner && showBanner) {
+    eventBus.emit("add-banner", {
+      id: DashboardBannerID,
+      priority: DashboardBannerPriority,
+      message: {
+        type: "default",
+        message: banner ?? "",
+        iconType: "alert",
+      },
+    });
+  }
+
+  onNavigate(() => {
+    if (hasBanner) {
+      eventBus.emit("remove-banner", DashboardBannerID);
+    }
+  });
+
+  function isCanvasReconcilingForFirstTime(
+    canvasResource: V1ResolveCanvasResponse,
+  ) {
+    if (!canvasResource) return undefined;
+    const isCanvasReconcilingForFirstTime =
+      !canvasResource.canvas?.canvas?.state?.validSpec &&
+      !canvasResource?.canvas?.meta?.reconcileError;
+    return isCanvasReconcilingForFirstTime;
+  }
+
+  function isCanvasErrored(canvasResource: V1ResolveCanvasResponse) {
+    if (!canvasResource) return undefined;
+    // We only consider a dashboard errored (from the end-user perspective) when BOTH a reconcile error exists AND a validSpec does not exist.
+    // If there's any validSpec (which can persist from a previous, non-current spec), then we serve that version of the dashboard to the user,
+    // so the user does not see an error state.
+    const isCanvasErrored =
+      !canvasResource.canvas?.canvas?.state?.validSpec &&
+      !!canvasResource?.canvas?.meta?.reconcileError;
+    return isCanvasErrored;
+  }
+
+  function getResolvedStore(
+    fetchedCanvas: V1ResolveCanvasResponse | undefined,
+    isReconciling: boolean,
+    existingStore: CanvasStore | undefined,
+  ) {
+    if (fetchedCanvas && !isReconciling) {
+      const metricsViews: Record<string, V1MetricsView | undefined> = {};
+      const refMetricsViews = fetchedCanvas?.referencedMetricsViews;
+      if (refMetricsViews) {
+        Object.keys(refMetricsViews).forEach((key) => {
+          metricsViews[key] = refMetricsViews?.[key]?.metricsView;
+        });
+      }
+
+      const validSpec = fetchedCanvas?.canvas?.canvas?.state?.validSpec;
+
+      if (validSpec) {
+        const processed = {
+          canvas: fetchedCanvas?.canvas?.canvas?.state?.validSpec,
+          components: fetchedCanvas?.resolvedComponents,
+          metricsViews,
+          filePath: fetchedCanvas?.canvas?.meta?.filePaths?.[0],
+        };
+
+        return setCanvasStore(canvasName, instanceId, processed);
+      }
+    }
+
+    return existingStore;
+  }
+</script>
+
+<svelte:head>
+  <title>{canvasTitle || `${canvasName} - Rill`}</title>
+</svelte:head>
+
+<slot {ready} {errorMessage} {isLoading} {isReconciling} />

--- a/web-common/src/features/canvas/CanvasLoadingState.svelte
+++ b/web-common/src/features/canvas/CanvasLoadingState.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import ErrorPage from "@rilldata/web-common/components/ErrorPage.svelte";
+  import DashboardBuilding from "../dashboards/DashboardBuilding.svelte";
+  import DelayedSpinner from "../entity-management/DelayedSpinner.svelte";
+
+  export let ready: boolean;
+  export let errorMessage: string | undefined;
+  export let isReconciling: boolean | undefined;
+  export let isLoading: boolean | undefined;
+</script>
+
+<div class="size-full justify-center items-center flex flex-col">
+  {#if ready}
+    <slot />
+  {:else if errorMessage}
+    <ErrorPage
+      statusCode={404}
+      header="Canvas not found"
+      body={errorMessage || "An unknown error occurred."}
+    />
+  {:else if isReconciling}
+    <DashboardBuilding />
+  {:else if isLoading}
+    <DelayedSpinner isLoading={true} size="48px" />
+  {:else}
+    <header
+      role="presentation"
+      class="bg-background border-b py-4 px-2 w-full h-[100px] select-none z-50 flex items-center justify-center"
+    ></header>
+    <div class="size-full flex justify-center items-center">
+      <DelayedSpinner isLoading={true} size="48px" />
+    </div>
+  {/if}
+</div>

--- a/web-common/src/features/canvas/CanvasProvider.svelte
+++ b/web-common/src/features/canvas/CanvasProvider.svelte
@@ -1,206 +1,24 @@
 <script lang="ts">
-  import {
-    getCanvasStoreUnguarded,
-    setCanvasStore,
-    type CanvasStore,
-  } from "./state-managers/state-managers";
-  import { page } from "$app/stores";
-  import DashboardBuilding from "@rilldata/web-common/features/dashboards/DashboardBuilding.svelte";
-  import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
-  import {
-    DashboardBannerID,
-    DashboardBannerPriority,
-  } from "@rilldata/web-common/components/banner/constants";
-  import { onNavigate } from "$app/navigation";
-  import { writable } from "svelte/store";
-  import DelayedSpinner from "../entity-management/DelayedSpinner.svelte";
-  import ErrorPage from "@rilldata/web-common/components/ErrorPage.svelte";
-  import {
-    createQueryServiceResolveCanvas,
-    type V1MetricsView,
-    type V1ResolveCanvasResponse,
-  } from "@rilldata/web-common/runtime-client";
-  import {
-    ResourceKind,
-    useResource,
-  } from "../entity-management/resource-selectors";
-
-  const PollIntervalWhenDashboardFirstReconciling = 1000;
-  const PollIntervalWhenDashboardErrored = 5000;
+  import CanvasLoadingState from "@rilldata/web-common/features/canvas/CanvasLoadingState.svelte";
+  import CanvasInitialization from "./CanvasInitialization.svelte";
 
   export let canvasName: string;
   export let instanceId: string;
-  export let ready = false;
   export let showBanner = false;
   export let projectId: string | undefined = undefined;
-
-  let resolvedStore: CanvasStore | undefined = undefined;
-
-  $: ({ url } = $page);
-
-  $: existingStore = getCanvasStoreUnguarded(canvasName, instanceId);
-
-  $: resourceQuery = useResource(
-    instanceId,
-    canvasName,
-    ResourceKind.Canvas,
-    {},
-  );
-
-  $: fetchedCanvasQuery = !existingStore
-    ? createQueryServiceResolveCanvas(
-        instanceId,
-        canvasName,
-        {},
-        {
-          query: {
-            retry: 5,
-            refetchInterval: (query) => {
-              const resource = query?.state?.data;
-              if (!resource) return false;
-              if (isCanvasReconcilingForFirstTime(resource))
-                return PollIntervalWhenDashboardFirstReconciling;
-              if (isCanvasErrored(resource))
-                return PollIntervalWhenDashboardErrored;
-              return false;
-            },
-          },
-        },
-      )
-    : undefined;
-
-  $: isLoading = fetchedCanvasQuery ? $fetchedCanvasQuery?.isLoading : false;
-
-  $: fetchedCanvas = fetchedCanvasQuery ? $fetchedCanvasQuery?.data : undefined;
-
-  $: validSpec = fetchedCanvas?.canvas?.canvas?.state?.validSpec;
-  $: reconcileError = fetchedCanvas?.canvas?.meta?.reconcileError;
-
-  $: isReconciling =
-    !existingStore && !validSpec && !reconcileError && !isLoading;
-
-  $: resource = resourceQuery ? $resourceQuery?.data : undefined;
-
-  $: errorMessage =
-    !validSpec && (reconcileError || resource?.meta?.reconcileError);
-
-  $: resolvedStore = getResolvedStore(
-    fetchedCanvas,
-    isReconciling,
-    existingStore,
-  );
-
-  $: ready = !!resolvedStore;
-
-  $: if (resolvedStore) {
-    resolvedStore.canvasEntity
-      .onUrlChange({ url, projectId })
-      .catch(console.error);
-  }
-
-  $: title = resolvedStore?.canvasEntity.titleStore || writable("");
-  $: canvasTitle = $title;
-
-  $: bannerStore = resolvedStore?.canvasEntity.bannerStore || writable("");
-  $: banner = $bannerStore;
-
-  $: hasBanner = !!banner;
-
-  $: if (hasBanner && showBanner) {
-    eventBus.emit("add-banner", {
-      id: DashboardBannerID,
-      priority: DashboardBannerPriority,
-      message: {
-        type: "default",
-        message: banner ?? "",
-        iconType: "alert",
-      },
-    });
-  }
-
-  onNavigate(() => {
-    if (hasBanner) {
-      eventBus.emit("remove-banner", DashboardBannerID);
-    }
-  });
-
-  function isCanvasReconcilingForFirstTime(
-    canvasResource: V1ResolveCanvasResponse,
-  ) {
-    if (!canvasResource) return undefined;
-    const isCanvasReconcilingForFirstTime =
-      !canvasResource.canvas?.canvas?.state?.validSpec &&
-      !canvasResource?.canvas?.meta?.reconcileError;
-    return isCanvasReconcilingForFirstTime;
-  }
-
-  function isCanvasErrored(canvasResource: V1ResolveCanvasResponse) {
-    if (!canvasResource) return undefined;
-    // We only consider a dashboard errored (from the end-user perspective) when BOTH a reconcile error exists AND a validSpec does not exist.
-    // If there's any validSpec (which can persist from a previous, non-current spec), then we serve that version of the dashboard to the user,
-    // so the user does not see an error state.
-    const isCanvasErrored =
-      !canvasResource.canvas?.canvas?.state?.validSpec &&
-      !!canvasResource?.canvas?.meta?.reconcileError;
-    return isCanvasErrored;
-  }
-
-  function getResolvedStore(
-    fetchedCanvas: V1ResolveCanvasResponse | undefined,
-    isReconciling: boolean,
-    existingStore: CanvasStore | undefined,
-  ) {
-    if (fetchedCanvas && !isReconciling) {
-      const metricsViews: Record<string, V1MetricsView | undefined> = {};
-      const refMetricsViews = fetchedCanvas?.referencedMetricsViews;
-      if (refMetricsViews) {
-        Object.keys(refMetricsViews).forEach((key) => {
-          metricsViews[key] = refMetricsViews?.[key]?.metricsView;
-        });
-      }
-
-      const validSpec = fetchedCanvas?.canvas?.canvas?.state?.validSpec;
-
-      if (validSpec) {
-        const processed = {
-          canvas: fetchedCanvas?.canvas?.canvas?.state?.validSpec,
-          components: fetchedCanvas?.resolvedComponents,
-          metricsViews,
-          filePath: fetchedCanvas?.canvas?.meta?.filePaths?.[0],
-        };
-
-        return setCanvasStore(canvasName, instanceId, processed);
-      }
-    }
-
-    return existingStore;
-  }
 </script>
 
-<svelte:head>
-  <title>{canvasTitle || `${canvasName} - Rill`}</title>
-</svelte:head>
-
-<div class="size-full justify-center items-center flex flex-col">
-  {#if resolvedStore}
+<CanvasInitialization
+  {canvasName}
+  {instanceId}
+  {projectId}
+  {showBanner}
+  let:ready
+  let:errorMessage
+  let:isLoading
+  let:isReconciling
+>
+  <CanvasLoadingState {ready} {errorMessage} {isLoading} {isReconciling}>
     <slot />
-  {:else if errorMessage}
-    <ErrorPage
-      statusCode={404}
-      header="Canvas not found"
-      body={errorMessage || "An unknown error occurred."}
-    />
-  {:else if isReconciling}
-    <DashboardBuilding />
-  {:else if isLoading}
-    <DelayedSpinner isLoading={true} size="48px" />
-  {:else}
-    <header
-      role="presentation"
-      class="bg-background border-b py-4 px-2 w-full h-[100px] select-none z-50 flex items-center justify-center"
-    ></header>
-    <div class="size-full flex justify-center items-center">
-      <DelayedSpinner isLoading={true} size="48px" />
-    </div>
-  {/if}
-</div>
+  </CanvasLoadingState>
+</CanvasInitialization>

--- a/web-common/src/features/workspaces/CanvasWorkspace.svelte
+++ b/web-common/src/features/workspaces/CanvasWorkspace.svelte
@@ -21,13 +21,13 @@
   import PreviewButton from "../explores/PreviewButton.svelte";
   import CanvasBuilder from "../canvas/CanvasBuilder.svelte";
   import SaveDefaultsButton from "../canvas/components/SaveDefaultsButton.svelte";
-  import CanvasProvider from "../canvas/CanvasProvider.svelte";
+  import CanvasLoadingState from "../canvas/CanvasLoadingState.svelte";
+  import CanvasInitialization from "../canvas/CanvasInitialization.svelte";
 
   export let fileArtifact: FileArtifact;
 
   let canvasName: string;
   let selectedView: "split" | "code" | "viz";
-  let ready = false;
 
   $: ({ instanceId } = $runtime);
 
@@ -41,9 +41,6 @@
     hasUnsavedChanges,
     saveState: { saving },
   } = fileArtifact);
-
-  // Reset ready when canvasName changes
-  $: if (canvasName) ready = false;
 
   $: resourceQuery = getResource(queryClient, instanceId);
 
@@ -79,60 +76,76 @@
 </script>
 
 {#key canvasName}
-  <WorkspaceContainer>
-    <WorkspaceHeader
-      slot="header"
-      {filePath}
-      resource={data}
-      hasUnsavedChanges={$hasUnsavedChanges}
-      titleInput={fileName}
-      codeToggle
-      onTitleChange={onChangeCallback}
-      resourceKind={ResourceKind.Canvas}
-    >
-      <div class="flex gap-x-2" slot="cta">
-        {#if ready}
-          <SaveDefaultsButton {canvasName} {instanceId} saving={$saving} />
-        {/if}
+  <CanvasInitialization
+    {canvasName}
+    {instanceId}
+    let:ready
+    let:isReconciling
+    let:isLoading
+    let:errorMessage
+  >
+    <WorkspaceContainer>
+      <WorkspaceHeader
+        slot="header"
+        {filePath}
+        resource={data}
+        hasUnsavedChanges={$hasUnsavedChanges}
+        titleInput={fileName}
+        codeToggle
+        onTitleChange={onChangeCallback}
+        resourceKind={ResourceKind.Canvas}
+      >
+        <div class="flex gap-x-2" slot="cta">
+          {#if ready}
+            <SaveDefaultsButton {canvasName} {instanceId} saving={$saving} />
+          {/if}
 
-        <PreviewButton
-          href="/canvas/{canvasName}"
-          disabled={allErrors.length > 0 || resourceIsReconciling}
-          reconciling={resourceIsReconciling}
-        />
-      </div>
-    </WorkspaceHeader>
-
-    <WorkspaceEditorContainer
-      slot="body"
-      error={mainError}
-      showError={!!$remoteContent && selectedView === "code"}
-    >
-      {#if selectedView === "code"}
-        <CanvasEditor
-          bind:autoSave={$autoSave}
-          {canvasName}
-          {fileArtifact}
-          {lineBasedRuntimeErrors}
-        />
-      {:else if selectedView === "viz"}
-        <CanvasProvider {canvasName} {instanceId} bind:ready>
-          <CanvasBuilder
-            {canvasName}
-            openSidebar={workspace.inspector.open}
-            {fileArtifact}
+          <PreviewButton
+            href="/canvas/{canvasName}"
+            disabled={allErrors.length > 0 || resourceIsReconciling}
+            reconciling={resourceIsReconciling}
           />
-        </CanvasProvider>
-      {/if}
-    </WorkspaceEditorContainer>
-    <svelte:fragment slot="inspector">
-      {#if ready}
-        <VisualCanvasEditing
-          {canvasName}
-          {fileArtifact}
-          autoSave={selectedView === "viz" || $autoSave}
-        />
-      {/if}
-    </svelte:fragment>
-  </WorkspaceContainer>
+        </div>
+      </WorkspaceHeader>
+
+      <WorkspaceEditorContainer
+        slot="body"
+        error={mainError}
+        showError={!!$remoteContent && selectedView === "code"}
+      >
+        {#if selectedView === "code"}
+          <CanvasEditor
+            bind:autoSave={$autoSave}
+            {canvasName}
+            {fileArtifact}
+            {lineBasedRuntimeErrors}
+          />
+        {:else if selectedView === "viz"}
+          {#if ready}
+            <CanvasLoadingState
+              {ready}
+              {isReconciling}
+              {isLoading}
+              {errorMessage}
+            >
+              <CanvasBuilder
+                {canvasName}
+                openSidebar={workspace.inspector.open}
+                {fileArtifact}
+              />
+            </CanvasLoadingState>
+          {/if}
+        {/if}
+      </WorkspaceEditorContainer>
+      <svelte:fragment slot="inspector">
+        {#if ready}
+          <VisualCanvasEditing
+            {canvasName}
+            {fileArtifact}
+            autoSave={selectedView === "viz" || $autoSave}
+          />
+        {/if}
+      </svelte:fragment>
+    </WorkspaceContainer>
+  </CanvasInitialization>
 {/key}


### PR DESCRIPTION
This PR refactors `CanvasProvider` to separate out its two responsibilities:

- Creates a new `CanvasInitialization` component responsible for accessing existing canvases or initializing new ones as well as providing slot props for the status of the initialization
- Creates a new `CanvasLoadingState` component that takes in these slot props and renders out the appropriate loading spinners or error messages

In all places besides the CanvasWorkspace, this results in no fundamental changes.

In CanvasWorkspace, the structure has been altered so that `CanvasInitialization` wraps the entire workspace and `CanvasLoadingState` is used around only the Canvas preview surface.

On the CanvasWorkspace, this solves a bug where the `ready` state was being reset when the canvas name changed.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
