### PR TITLE
fix: canvas chip widths

### DIFF
--- a/web-common/src/components/chip/core/Chip.svelte
+++ b/web-common/src/components/chip/core/Chip.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { builderActions, getAttrs, type Builder } from "bits-ui";
+  import { PinIcon } from "lucide-svelte";
   import { getContext } from "svelte";
   import type { Writable } from "svelte/store";
   import { slideRight } from "../../../lib/transitions";
@@ -7,7 +8,6 @@
   import CaretDownIcon from "../../icons/CaretDownIcon.svelte";
   import Tooltip from "../../tooltip/Tooltip.svelte";
   import TooltipContent from "../../tooltip/TooltipContent.svelte";
-  import { PinIcon } from "lucide-svelte";
 
   export let removable = false;
   export let active = false;
@@ -112,9 +112,9 @@
   }
 
   .chip {
-    @apply flex  gap-x-1;
+    @apply flex flex-none gap-x-1;
     @apply items-center justify-center;
-    @apply px-2 py-[3px] border w-full max-w-fit truncate;
+    @apply px-2 py-[3px] border w-fit;
   }
 
   .dimension {


### PR DESCRIPTION
There's a regression where the canvas inspector chips didn't take the full width of the container. 
<img width="313" height="213" alt="image" src="https://github.com/user-attachments/assets/29e5a3d8-6b16-4e08-9ae6-c451a4ef81aa" />

This PR reverts back to use fixed content sized width.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
