### PR TITLE
fix: generate data modal ux tweaks

### DIFF
--- a/web-common/src/features/sample-data/GenerateSampleData.svelte
+++ b/web-common/src/features/sample-data/GenerateSampleData.svelte
@@ -54,14 +54,14 @@
       <div class="hidden"></div>
     {/if}
   </Dialog.Trigger>
-  <Dialog.Content>
-    <Dialog.Header>
-      <Dialog.Title>Generate sample data</Dialog.Title>
-      <Dialog.Description>
-        <div>What is the business context or domain of your data?</div>
-      </Dialog.Description>
-    </Dialog.Header>
+  <Dialog.Content noClose>
     <form id={FORM_ID} on:submit|preventDefault={submit} use:enhance>
+      <Dialog.Header>
+        <Dialog.Title>Generate sample data</Dialog.Title>
+        <Dialog.Description>
+          <div>What is the business context or domain of your data?</div>
+        </Dialog.Description>
+      </Dialog.Header>
       <textarea
         class="prompt-input"
         bind:value={$form.prompt}
@@ -73,16 +73,21 @@
         <div class="error">{$errors.prompt?.[0]}</div>
       {/if}
 
-      <Button type="primary" large form={FORM_ID} onClick={submit}>
-        Generate
-      </Button>
+      <Dialog.Footer>
+        <Button type="secondary" large onClick={() => (open = false)}>
+          Cancel
+        </Button>
+        <Button type="primary" large form={FORM_ID} onClick={submit}>
+          Generate
+        </Button>
+      </Dialog.Footer>
     </form>
   </Dialog.Content>
 </Dialog.Root>
 
 <style lang="postcss">
   .prompt-input {
-    @apply w-full p-2 min-h-[2.5rem];
+    @apply w-full my-4 p-2 min-h-[2.5rem];
     @apply border border-gray-300 rounded-[2px];
     @apply text-sm leading-relaxed;
   }


### PR DESCRIPTION
Addressing a few UX concerns with the generate data modal
- Primary CTA button should be bottom right
- No “x” button in top right. Add a secondary `Cancel` button to the left of the `Generate` button
- Add more padding between the prompt box and the button

<img width="667" height="317" alt="Screenshot 2025-12-17 at 12 00 03 PM" src="https://github.com/user-attachments/assets/d9059e53-243a-4196-9ee3-12f3e0adef81" />

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
