### PR TITLE
fix: Add more error msgs to skip clickhouse error logging

### DIFF
--- a/runtime/drivers/clickhouse/embed.go
+++ b/runtime/drivers/clickhouse/embed.go
@@ -524,6 +524,7 @@ func parseErrorCode(msg string) int {
 // Exceptions are usually accompanied by an error code, which is a number that can be used to identify the type of error.
 // This function checks for specific error codes that are considered user errors.
 // As of writing this is not an exhaustive list so if you find an error that is not to be logged add the error code here.
+// The full list of error codes is here : https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp
 func isUserError(code int) bool {
 	switch code {
 	case 16: // no such column in table
@@ -534,7 +535,7 @@ func isUserError(code int) bool {
 		return true
 	case 50: // unknown type
 		return true
-	case 38, 42, 43, 44, 46, 47, 51, 52, 53, 57, 60, 62, 63, 81, 82, 179: // different query syntax error
+	case 38, 41, 42, 43, 44, 46, 47, 48, 51, 52, 53, 57, 60, 62, 63, 70, 80, 81, 82, 117, 127, 179, 195, 251: // different query syntax error
 		return true
 	case 181, 182, 183, 184, 215: // aggregate syntax error
 		return true
@@ -542,7 +543,8 @@ func isUserError(code int) bool {
 		return true
 	case 394: // query was cancelled
 		return true
-
+	case 236: // aborted in normal operation
+		return true
 	default:
 		return false
 	}


### PR DESCRIPTION
closes https://linear.app/rilldata/issue/PLAT-350/investigate-and-reduce-log-level-of-clickhouse-code-236-errors

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
