### PR TITLE
feat: Updating connector YAML files should restart the controller

### DIFF
--- a/runtime/parser/parse_connector.go
+++ b/runtime/parser/parse_connector.go
@@ -2,7 +2,9 @@ package parser
 
 import (
 	"fmt"
+	"maps"
 
+	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"google.golang.org/protobuf/types/known/structpb"
 	"gopkg.in/yaml.v3"
 )
@@ -126,4 +128,32 @@ func containsTemplating(v any) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// isEqualConnectorSpec compares two ConnectorSpec for equality. The comparison is done before templating is applied.
+func isEqualConnectorSpec(a, b *runtimev1.ConnectorSpec) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.Driver != b.Driver {
+		return false
+	}
+	if a.Provision != b.Provision {
+		return false
+	}
+	if !maps.Equal(a.Properties.AsMap(), b.Properties.AsMap()) {
+		return false
+	}
+	if !maps.Equal(a.ProvisionArgs.AsMap(), b.ProvisionArgs.AsMap()) {
+		return false
+	}
+	if len(a.TemplatedProperties) != len(b.TemplatedProperties) {
+		return false
+	}
+	for i, v := range a.TemplatedProperties {
+		if v != b.TemplatedProperties[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/runtime/reconcilers/project_parser.go
+++ b/runtime/reconcilers/project_parser.go
@@ -313,7 +313,7 @@ func (r *ProjectParserReconciler) reconcileParser(ctx context.Context, inst *dri
 	}
 
 	// not setting restartController=true when diff is actually nil prevents infinite restarts
-	updateConfig := diff == nil || diff.ModifiedDotEnv || diff.Reloaded
+	updateConfig := diff == nil || diff.ModifiedDotEnv || diff.Reloaded || diff.ModifiedConnectors
 	if updateConfig {
 		restartController := diff != nil
 		err := r.reconcileProjectConfig(ctx, parser, restartController)


### PR DESCRIPTION
closes https://linear.app/rilldata/issue/PLAT-314/rill-does-not-release-its-lock-on-local-duckdb-databases
closes https://linear.app/rilldata/issue/PLAT-30/updating-connector-yaml-files-or-variables-should-restart-the

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
