### PR TITLE
chore(docker): switch dev services to `unless-stopped` restart policy

### DIFF
--- a/cli/cmd/devtool/data/cloud-deps.docker-compose.yml
+++ b/cli/cmd/devtool/data/cloud-deps.docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 # Service template
 x-service: &service
-  restart: always
+  restart: unless-stopped
   deploy:
     # Default resource limits for services
     resources:


### PR DESCRIPTION
This PR updates our devtool's Docker Compose defaults to use `restart: unless-stopped`. This prevents previously stopped services from auto-resurrecting when restarting Docker Desktop.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
