### PR TITLE
fix: auth context determination

### DIFF
--- a/web-admin/src/features/projects/selectors.ts
+++ b/web-admin/src/features/projects/selectors.ts
@@ -133,6 +133,7 @@ export async function fetchProjectDeploymentDetails(
     queryKey,
     queryFn,
   });
+
   return {
     projectPermissions: projResp.projectPermissions,
     project: projResp.project,
@@ -141,7 +142,7 @@ export async function fetchProjectDeploymentDetails(
       instanceId: projResp.prodDeployment?.runtimeInstanceId,
       jwt: {
         token: projResp.jwt,
-        authContext: "magic",
+        authContext: token ? "magic" : "user",
       },
     },
   };


### PR DESCRIPTION
Removes hardcoded `authContext` in `fetchProjectDeploymentDetails` in favor of similar logic used in web-admin/src/routes/[organization]/[project]/+layout.svelte.

This fix should stop queries from being reset (and thus cancelled when inflight) by preventing `invalidateRuntimeQueries` from running as part of the `setRuntime` method of the runtime store.

This is a patch fix. The existing sequencing requires a thoughtful overhaul.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
