### PR TITLE
Explore dimensions copy indicator

### DIFF
--- a/web-common/src/components/tooltip/CopyShortcutTooltip.svelte
+++ b/web-common/src/components/tooltip/CopyShortcutTooltip.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import Tooltip from "./Tooltip.svelte";
+  import TooltipContent from "./TooltipContent.svelte";
+  import TooltipShortcutContainer from "./TooltipShortcutContainer.svelte";
+  import TooltipTitle from "./TooltipTitle.svelte";
+  import Shortcut from "./Shortcut.svelte";
+  import StackingWord from "./StackingWord.svelte";
+  import FormattedDataType from "../data-types/FormattedDataType.svelte";
+  import { isClipboardApiSupported } from "@rilldata/web-common/lib/actions/copy-to-clipboard";
+  import type { Location } from "@rilldata/web-common/lib/place-element";
+
+  export let value:
+    | string
+    | number
+    | boolean
+    | null
+    | undefined
+    | Record<string, unknown>;
+  export let type = "VARCHAR";
+  export let label = "this value";
+  export let location: Location = "top";
+  export let distance = 16;
+  export let hideAfter = 0;
+  export let maxWidth = "360px";
+  export let truncate = false;
+  export let disabled = false;
+
+  const clipboardSupported = isClipboardApiSupported();
+
+  let suppressTooltip = true;
+  let hideTimer: ReturnType<typeof setTimeout> | undefined;
+  let hasTooltipTitleSlot = false;
+
+  // Svelte injects $$slots at compile time.
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  $: hasTooltipTitleSlot = !!$$slots["tooltip-title"];
+
+  function clearHideTimer() {
+    if (!hideTimer) return;
+    clearTimeout(hideTimer);
+    hideTimer = undefined;
+  }
+
+  function showTemporarily() {
+    if (!clipboardSupported || disabled) return;
+    suppressTooltip = false;
+    if (hideAfter > 0) {
+      clearHideTimer();
+      hideTimer = setTimeout(() => {
+        suppressTooltip = true;
+      }, hideAfter);
+    }
+  }
+
+  function hideTooltip() {
+    clearHideTimer();
+    suppressTooltip = true;
+  }
+
+  onDestroy(() => {
+    clearHideTimer();
+  });
+</script>
+
+<Tooltip
+  {location}
+  {distance}
+  activeDelay={0}
+  hoverIntentTimeout={0}
+  suppress={!clipboardSupported || disabled || suppressTooltip}
+>
+  <div
+    class="contents"
+    on:pointerenter={showTemporarily}
+    on:pointerleave={hideTooltip}
+    on:focus={showTemporarily}
+    on:blur={hideTooltip}
+  >
+    <slot />
+  </div>
+  <TooltipContent slot="tooltip-content" {maxWidth}>
+    {#if hasTooltipTitleSlot}
+      <slot name="tooltip-title" />
+    {:else if value !== undefined}
+      <TooltipTitle>
+        <FormattedDataType slot="name" {type} {value} {truncate} />
+      </TooltipTitle>
+    {/if}
+    <TooltipShortcutContainer>
+      <div>
+        <StackingWord key="shift">Copy</StackingWord> {label} to clipboard
+      </div>
+      <Shortcut>
+        <span style="font-family: var(--system);">⇧</span> + Click
+      </Shortcut>
+    </TooltipShortcutContainer>
+  </TooltipContent>
+</Tooltip>

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardRow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import FormattedDataType from "@rilldata/web-common/components/data-types/FormattedDataType.svelte";
+  import CopyShortcutTooltip from "@rilldata/web-common/components/tooltip/CopyShortcutTooltip.svelte";
   import PercentageChange from "@rilldata/web-common/components/data-types/PercentageChange.svelte";
   import ExternalLink from "@rilldata/web-common/components/icons/ExternalLink.svelte";
   import { TOOLTIP_STRING_LIMIT } from "@rilldata/web-common/layout/config";
@@ -233,36 +234,44 @@
         cellInspectorStore.updateValue(dimensionValue.toString());
       }
     }}
-    class="relative size-full flex flex-none justify-between items-center leaderboard-label"
     style:background={dimensionGradients}
   >
-    <span class="truncate select-text">
-      <FormattedDataType value={dimensionValue} truncate />
-    </span>
+    <CopyShortcutTooltip
+      value={dimensionValue}
+      type="VARCHAR"
+      label="dimension value"
+      hideAfter={3000}
+    >
+      <div class="relative size-full flex flex-none justify-between items-center leaderboard-label">
+        <span class="truncate select-text">
+          <FormattedDataType value={dimensionValue} truncate />
+        </span>
 
-    {#if previousValueString && hovered}
-      <span
-        class="opacity-50 whitespace-nowrap font-normal"
-        transition:slide={{ axis: "x", duration: 200 }}
-      >
-        {previousValueString} →
-      </span>
-    {/if}
+        {#if previousValueString && hovered}
+          <span
+            class="opacity-50 whitespace-nowrap font-normal"
+            transition:slide={{ axis: "x", duration: 200 }}
+          >
+            {previousValueString} →
+          </span>
+        {/if}
 
-    {#if href}
-      <span class="external-link-wrapper">
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          {href}
-          title={href}
-          on:click|stopPropagation
-          class:hovered
-        >
-          <ExternalLink className="fill-primary-600" />
-        </a>
-      </span>
-    {/if}
+        {#if href}
+          <span class="external-link-wrapper">
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              {href}
+              title={href}
+              on:click|stopPropagation
+              class:hovered
+            >
+              <ExternalLink className="fill-primary-600" />
+            </a>
+          </span>
+        {/if}
+      </div>
+    </CopyShortcutTooltip>
   </td>
 
   {#each Object.keys(values) as measureName}
@@ -289,18 +298,27 @@
         }
       }}
     >
-      <div class="w-fit ml-auto bg-transparent" bind:contentRect={valueRect}>
-        <FormattedDataType
-          type="INTEGER"
-          value={values[measureName]
-            ? formatters[measureName]?.(values[measureName])
-            : null}
-        />
-      </div>
+      <CopyShortcutTooltip
+        value={values[measureName]
+          ? formatters[measureName]?.(values[measureName])
+          : null}
+        type="INTEGER"
+        label={`${measureName} value`}
+        hideAfter={3000}
+      >
+        <div class="w-fit ml-auto bg-transparent" bind:contentRect={valueRect}>
+          <FormattedDataType
+            type="INTEGER"
+            value={values[measureName]
+              ? formatters[measureName]?.(values[measureName])
+              : null}
+          />
+        </div>
 
-      {#if showZigZags[measureName] && !isTimeComparisonActive && !isValidPercentOfTotal(measureName)}
-        <LongBarZigZag />
-      {/if}
+        {#if showZigZags[measureName] && !isTimeComparisonActive && !isValidPercentOfTotal(measureName)}
+          <LongBarZigZag />
+        {/if}
+      </CopyShortcutTooltip>
     </td>
 
     {#if isValidPercentOfTotal(measureName) && shouldShowContextColumns(measureName)}
@@ -325,13 +343,20 @@
           }
         }}
       >
-        <PercentageChange
+        <CopyShortcutTooltip
           value={pctOfTotals[measureName]}
-          color="text-gray-500"
-        />
-        {#if showZigZags[measureName]}
-          <LongBarZigZag />
-        {/if}
+          type="RILL_PERCENTAGE_CHANGE"
+          label={`${measureName} percent of total`}
+          hideAfter={3000}
+        >
+          <PercentageChange
+            value={pctOfTotals[measureName]}
+            color="text-gray-500"
+          />
+          {#if showZigZags[measureName]}
+            <LongBarZigZag />
+          {/if}
+        </CopyShortcutTooltip>
       </td>
     {/if}
 
@@ -357,18 +382,27 @@
           }
         }}
       >
-        <FormattedDataType
-          color="text-gray-500"
-          type="INTEGER"
+        <CopyShortcutTooltip
           value={deltaAbsMap[measureName]
             ? formatters[measureName]?.(deltaAbsMap[measureName])
             : null}
-          customStyle={deltaAbsMap[measureName] !== null &&
-          deltaAbsMap[measureName] < 0
-            ? "text-red-500"
-            : ""}
-          truncate={true}
-        />
+          type="INTEGER"
+          label={`${measureName} delta`}
+          hideAfter={3000}
+        >
+          <FormattedDataType
+            color="text-gray-500"
+            type="INTEGER"
+            value={deltaAbsMap[measureName]
+              ? formatters[measureName]?.(deltaAbsMap[measureName])
+              : null}
+            customStyle={deltaAbsMap[measureName] !== null &&
+            deltaAbsMap[measureName] < 0
+              ? "text-red-500"
+              : ""}
+            truncate={true}
+          />
+        </CopyShortcutTooltip>
       </td>
     {/if}
 
@@ -392,15 +426,24 @@
           }
         }}
       >
-        <PercentageChange
+        <CopyShortcutTooltip
           value={deltaRels[measureName]
             ? formatMeasurePercentageDifference(deltaRels[measureName])
             : null}
-          color="text-gray-500"
-        />
-        {#if showZigZags[measureName]}
-          <LongBarZigZag />
-        {/if}
+          type="RILL_PERCENTAGE_CHANGE"
+          label={`${measureName} delta %`}
+          hideAfter={3000}
+        >
+          <PercentageChange
+            value={deltaRels[measureName]
+              ? formatMeasurePercentageDifference(deltaRels[measureName])
+              : null}
+            color="text-gray-500"
+          />
+          {#if showZigZags[measureName]}
+            <LongBarZigZag />
+          {/if}
+        </CopyShortcutTooltip>
       </td>
     {/if}
   {/each}


### PR DESCRIPTION
Addresses APP-657.

This PR improves the discoverability of the "Shift + Click to copy" functionality on the main dashboard. Previously, this feature was not indicated, leading to user confusion and underutilization.

A new `CopyShortcutTooltip` component has been introduced, which displays the "Shift + Click to copy" hint. This tooltip is now integrated into all dimension and measure cells within the leaderboard on the main dashboard. To ensure it remains unobtrusive, the tooltip automatically hides after 3 seconds, providing a clear visual cue without interfering with data exploration.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-657](https://linear.app/rilldata/issue/APP-657/better-ui-to-indicate-values-can-be-copied-in-explore-dimensions)

<a href="https://cursor.com/background-agent?bcId=bc-01075136-f9ae-43ee-adc5-c72ca4fb04f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-01075136-f9ae-43ee-adc5-c72ca4fb04f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

