### PR TITLE
Nit: Improve error message for malformed metrics query expressions

### DIFF
--- a/runtime/metricsview/astexpr.go
+++ b/runtime/metricsview/astexpr.go
@@ -56,7 +56,7 @@ func (b *sqlExprBuilder) writeExpression(e *Expression) error {
 	if e.Condition != nil {
 		return b.writeCondition(e.Condition)
 	}
-	return errors.New("invalid expression")
+	return errors.New("invalid expression (must contain one of name, val, cond, subquery)")
 }
 
 func (b *sqlExprBuilder) writeName(name string) error {


### PR DESCRIPTION
Saw the error in an AI conversation and it wasn't clear what was malformed