### PR TITLE
Stop coercing ssl true in clickhouse cloud dsn save anyway

### DIFF
--- a/web-common/src/features/sources/modal/utils.ts
+++ b/web-common/src/features/sources/modal/utils.ts
@@ -96,11 +96,11 @@ export function applyClickHouseCloudRequirements(
   // Only force SSL for ClickHouse Cloud when the user is using individual params.
   // DSN strings encapsulate their own protocol, so we should not inject `ssl` there.
   const isDsnBased = "dsn" in values;
-  if (
+  const shouldEnforceSSL =
     connectorName === "clickhouse" &&
     connectorType === "clickhouse-cloud" &&
-    !isDsnBased
-  ) {
+    !isDsnBased;
+  if (shouldEnforceSSL) {
     return { ...values, ssl: true } as Record<string, unknown>;
   }
   return values;


### PR DESCRIPTION
This PR stops forcing `ssl: true` for ClickHouse Cloud DSN Save Anyway. This skips the ClickHouse Cloud SSL injection when the form payload contains a DSN. Closes https://linear.app/rilldata/issue/APP-659/save-anyways-bug-on-dsn-chc

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
