### PR TITLE
fix: logged out user not able to view a public canvas dashboard

### DIFF
--- a/web-admin/src/features/bookmarks/selectors.ts
+++ b/web-admin/src/features/bookmarks/selectors.ts
@@ -53,7 +53,7 @@ export function getBookmarksQueryOptions(
         },
         {
           query: {
-            enabled: hasUser && !!projectId,
+            enabled: Boolean(hasUser && !!projectId),
           },
         },
       );

--- a/web-admin/src/features/navigation/TopNavigationBar.svelte
+++ b/web-admin/src/features/navigation/TopNavigationBar.svelte
@@ -181,6 +181,7 @@
   });
   $: exploreSpec = $exploreQuery.data?.explore?.explore?.state?.validSpec;
   $: isDashboardValid = !!exploreSpec;
+  $: hasUserAccess = $user.isSuccess && $user.data.user && !onPublicURLPage;
 
   $: publicURLDashboardTitle =
     $exploreQuery.data?.explore?.explore?.state?.validSpec?.displayName ||
@@ -242,7 +243,7 @@
             {#if $dashboardChat}
               <ChatToggle />
             {/if}
-            {#if $user.isSuccess && $user.data.user && !onPublicURLPage}
+            {#if hasUserAccess}
               <ExploreBookmarks
                 {organization}
                 {project}
@@ -259,7 +260,7 @@
       {/if}
     {/if}
 
-    {#if onCanvasDashboardPage}
+    {#if onCanvasDashboardPage && hasUserAccess}
       <CanvasBookmarks {organization} {project} canvasName={dashboard} />
       <ShareDashboardPopover createMagicAuthTokens={false} />
     {/if}


### PR DESCRIPTION
Bookmark queries were fired even in logged out user context for canvas.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
