### PR TITLE
Cell inspector lock bug

### DIFF
--- a/web-common/src/components/CellInspector.svelte
+++ b/web-common/src/components/CellInspector.svelte
@@ -53,9 +53,15 @@
   }
 
   function handleClickOutside(event: MouseEvent) {
-    if (isOpen && container && !container.contains(event.target as Node)) {
-      cellInspectorStore.close();
+    if (!isOpen || !container || container.contains(event.target as Node))
+      return;
+
+    if (isLocked) {
+      // Keep the inspector visible while locked, even when interacting elsewhere
+      return;
     }
+
+    cellInspectorStore.close();
   }
 
   // FIXME: Hoist the keyboard event listener to the top level; centralize the hotkeys


### PR DESCRIPTION
Ensures the Cell Inspector remains open when locked, even when clicking outside of it. This fixes APP-399, allowing users to reference locked cell details while interacting with the dashboard.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
Linear Issue: [APP-399](https://linear.app/rilldata/issue/APP-399/cell-inspector-lock-not-working)

<a href="https://cursor.com/background-agent?bcId=bc-c7675312-ce53-46dc-b6fb-3085ca92102c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7675312-ce53-46dc-b6fb-3085ca92102c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure Cell Inspector stays open when locked by ignoring outside clicks, with minor guard/early-return refactor in the click-outside handler.
> 
> - **Click-outside behavior updated in `CellInspector.svelte`:** Early-return if not open/inside click; when `isLocked`, ignore outside clicks to keep the inspector visible; otherwise close as before.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa3725fb1bdd84d26ed52374884f1daae789f946. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->