### PR TITLE
fix: explain action not auto submitting prompt

### DIFF
--- a/web-common/src/features/chat/core/input/ChatInput.svelte
+++ b/web-common/src/features/chat/core/input/ChatInput.svelte
@@ -72,7 +72,7 @@
 
   function startChat(prompt: string) {
     editor.commands.setContent(prompt);
-    draftMessageStore.set(prompt);
+    // Wait for `value` and `canSend` to update before sending the message.`
     tick().then(sendMessage).catch(console.error);
   }
 


### PR DESCRIPTION
Currently explain action on a measure just populates the chat input. To avoid another user action we should submit the chat directly.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
