### PR TITLE
Guest user modal update

### DIFF
--- a/web-admin/src/features/organizations/user-management/dialogs/AddGuestsDialog.svelte
+++ b/web-admin/src/features/organizations/user-management/dialogs/AddGuestsDialog.svelte
@@ -248,7 +248,10 @@
         {:else if projects.length === 0}
           <div class="text-xs text-slate-500">No projects</div>
         {:else}
-          <Dropdown.Root bind:open={projectDropdownOpen}>
+          <Dropdown.Root
+            bind:open={projectDropdownOpen}
+            closeOnItemClick={false}
+          >
             <Dropdown.Trigger
               class="min-w-[260px] flex flex-row justify-between gap-1 items-center rounded-sm border border-gray-300 {projectDropdownOpen
                 ? 'bg-slate-200'


### PR DESCRIPTION
This PR addresses APP-668 by updating the `Add guest users` modal:

*   **Preselects the first project:** If the organization has at least one project, the first project in the list is now preselected by default when the modal opens. This improves user experience by providing a sensible default.
*   **Keeps project access multi-select dropdown open:** The project selection dropdown now remains open after selecting or deselecting options, allowing users to make multiple selections without re-opening the dropdown each time. This was achieved by switching to `onCheckedChange` for the dropdown items.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [X] Linked the issues it closes (APP-668)
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-668](https://linear.app/rilldata/issue/APP-668/update-add-guest-users-feature-modal)

<a href="https://cursor.com/background-agent?bcId=bc-85283c39-55d8-4fc2-b0c2-61a06970bfe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-85283c39-55d8-4fc2-b0c2-61a06970bfe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

