### PR TITLE
fix: canvas leaderboard runaway width in rill dev

### DIFF
--- a/web-common/src/features/canvas/components/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/canvas/components/leaderboard/LeaderboardDisplay.svelte
@@ -163,13 +163,11 @@
       class="grid-wrapper gap-px overflow-x-auto"
       style:grid-template-columns="repeat(auto-fit, minmax({estimatedTableWidth +
         LEADERBOARD_WRAPPER_PADDING}px, 1fr))"
+      bind:clientWidth={leaderboardWrapperWidth}
     >
       {#each visibleDimensions as dimension (dimension.name)}
         {#if dimension.name}
-          <div
-            class="leaderboard-wrapper"
-            bind:clientWidth={leaderboardWrapperWidth}
-          >
+          <div class="leaderboard-wrapper">
             <Leaderboard
               leaderboardShowContextForAllMeasures
               timeControlsReady


### PR DESCRIPTION
There seems to be runaway width in rill dev for canvas leaderboard. The binding of expected width seems to be on a different element.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
