### PR TITLE
fix: remove redudnant totals query in dimension table

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionDisplay.svelte
@@ -111,7 +111,9 @@
     instanceId,
     metricsViewName,
     {
-      measures: filteredMeasures,
+      measures: filteredMeasures.filter(
+        (m) => !m.comparisonValue && !m.comparisonDelta && !m.comparisonRatio,
+      ),
       where: sanitiseExpression(
         mergeDimensionAndMeasureFilters(
           getFiltersForOtherDimensions(whereFilter, dimensionName),
@@ -120,7 +122,6 @@
         undefined,
       ),
       timeRange,
-      comparisonTimeRange,
     },
     {
       query: {


### PR DESCRIPTION
We have a redundant totals query in dimension table to calculate percent of total. We only need the current total and not comparison totals. Updating it to only query the current total similar to bignum.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
