### PR TITLE
fix: smart refetch interval when no resources present

### DIFF
--- a/web-admin/src/lib/refetch-interval-store.ts
+++ b/web-admin/src/lib/refetch-interval-store.ts
@@ -84,12 +84,6 @@ export function createSmartRefetchInterval(
 
   const resources = query.state.data.resources;
 
-  // If there are no resources at all, use a fixed refetch interval
-  // This handles the case during initial deployment creation when parser hasn't run yet
-  if (resources.length === 0) {
-    return INITIAL_REFETCH_INTERVAL;
-  }
-
   // Get or initialize state from WeakMap
   const currentState = queryRefetchStateMap.get(query) || {};
   const updatedState = updateSmartRefetchMeta(resources, currentState);


### PR DESCRIPTION
When no resources are present, the `createSmartRefetchInterval` returns 200ms. As such, resource queries are infinitely refetched every 200ms when viewing a project tab with an empty table.

I'm not sure what the intended behavior is, but the previous comment suggests there may have been a reason to refetch at least once. This PR simply removes the offending line, but it may need tweaking.

<img width="1298" height="851" alt="Screenshot 2025-12-24 at 2 27 13 PM" src="https://github.com/user-attachments/assets/d7bded7f-5fd3-4cfb-943b-cbf035fc10a2" />



**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
