### PR TITLE
fix: disable explain anomaly in explore editor

### DIFF
--- a/web-common/src/features/dashboards/time-series/measure-selection/measure-selection.ts
+++ b/web-common/src/features/dashboards/time-series/measure-selection/measure-selection.ts
@@ -9,6 +9,9 @@ import type {
   GraphicScale,
   SimpleDataGraphicConfiguration,
 } from "@rilldata/web-common/components/data-graphic/state/types";
+import { featureFlags } from "@rilldata/web-common/features/feature-flags.ts";
+import { getExploreNameStore } from "@rilldata/web-common/features/dashboards/nav-utils.ts";
+import { derived } from "svelte/store";
 
 export class MeasureSelection {
   public readonly measure = writable<string | null>(null);
@@ -103,6 +106,15 @@ export class MeasureSelection {
       `What dimensions have noticeably changed, as compared to other time windows?`;
 
     sidebarActions.startChat(prompt);
+  }
+
+  public getEnabledStore() {
+    return derived(
+      [featureFlags.dashboardChat, getExploreNameStore()],
+      ([dashboardChat, exploreName]) => {
+        return Boolean(dashboardChat && exploreName);
+      },
+    );
   }
 }
 


### PR DESCRIPTION
Explain anomaly feature is available in explore editor. Disabling it since it doesnt make sense there.

Closes APP-666

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
