### PR TITLE
fix: auto scroll not working for the final assistant message

### DIFF
--- a/web-common/src/features/chat/core/messages/Messages.svelte
+++ b/web-common/src/features/chat/core/messages/Messages.svelte
@@ -46,7 +46,8 @@
   $: isConversationEmpty =
     ($getConversationQuery.data?.messages?.length ?? 0) === 0;
 
-  // Track previous block count to detect new content
+  // Track previous block count to detect new content and previous block type to detect block changing.
+  // This is used to determine whether to scroll to bottom of messages container or not.
   let previousBlockCount = 0;
   let previousBlockType = "";
 
@@ -61,24 +62,24 @@
   }
 
   // Auto-scroll behavior:
-  // - Always scroll when new blocks are added (new message sent or response started)
+  // - Always scroll when new blocks are added or if the last block changes (new message sent or response started)
   // - Only scroll during streaming if user is near the bottom (respect scroll position)
   afterUpdate(() => {
     const currentBlockCount = blocks.length;
     const currentBlockType = blocks[currentBlockCount - 1]?.type ?? "";
-    const hasNewBlocks =
+    const hasBlockChanged =
       currentBlockCount > previousBlockCount ||
       currentBlockType !== previousBlockType;
     previousBlockCount = currentBlockCount;
     previousBlockType = currentBlockType;
 
     if (messagesContainer && layout === "sidebar") {
-      if (hasNewBlocks || isNearBottom(messagesContainer)) {
+      if (hasBlockChanged || isNearBottom(messagesContainer)) {
         scrollToBottom(messagesContainer);
       }
     } else if (layout === "fullpage") {
       const parentWrapper = messagesContainer.closest(".chat-messages-wrapper");
-      if (parentWrapper && (hasNewBlocks || isNearBottom(parentWrapper))) {
+      if (parentWrapper && (hasBlockChanged || isNearBottom(parentWrapper))) {
         scrollToBottom(parentWrapper);
       }
     }


### PR DESCRIPTION
In chat history we autoscroll to the bottom if the user was already at the bottom. We do this by checking if a new block has come in. But if the block type changes then the scroll height could change, especially when a long large assistant message block replaces the "working" block.

Adding an additional check for block type change to fix this.


This simulates a conversation by modifying query cache of an existing conversaiont. Call this on mount somewhere. Running on a rill developer file edit chat will give the best results.
```
import type { Conversation } from "@rilldata/web-common/features/chat/core/conversation.ts";
import { asyncWait, waitUntil } from "@rilldata/web-common/lib/waitUtils.ts";
import { get } from "svelte/store";
import {
  getRuntimeServiceGetConversationQueryKey,
  type V1Message,
} from "@rilldata/web-common/runtime-client";
import { runtime } from "@rilldata/web-common/runtime-client/runtime-store.ts";
import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient.ts";

export async function simulateConversation(
  conversation: Conversation,
  beforeStart: () => void,
) {
  const convQuery = conversation.getConversationQuery();
  await waitUntil(() => !get(convQuery).isPending);

  const resp = get(convQuery).data;
  if (!resp || !resp.messages) return;

  const queryKey = getRuntimeServiceGetConversationQueryKey(
    get(runtime).instanceId,
    conversation.conversationId,
  );
  const messages: V1Message[] = [];
  const updateQueryCache = (message: V1Message) => {
    messages.push({
      ...message,
      createdOn: new Date().toISOString(),
      updatedOn: new Date().toISOString(),
    });
    queryClient.setQueryData(queryKey, {
      conversation: resp.conversation,
      messages,
    });
  };

  beforeStart();
  conversation.isStreaming.set(true);

  updateQueryCache(resp.messages[0]);
  for (let i = 1; i < resp.messages.length; i++) {
    const prev = new Date(resp.messages[i - 1].createdOn!);
    const now = new Date(resp.messages[i].updatedOn!);
    // Dividing by 5 to speed things up.
    await asyncWait((now.getTime() - prev.getTime()) / 5);

    updateQueryCache(resp.messages[i]);
  }

  await asyncWait(500); 
  conversation.isStreaming.set(false);
}
```

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
