### PR TITLE
fix: incorrect leaderboard width in canvas

### DIFF
--- a/web-common/src/features/canvas/components/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/canvas/components/leaderboard/LeaderboardDisplay.svelte
@@ -163,11 +163,13 @@
       class="grid-wrapper gap-px overflow-x-auto"
       style:grid-template-columns="repeat(auto-fit, minmax({estimatedTableWidth +
         LEADERBOARD_WRAPPER_PADDING}px, 1fr))"
-      bind:clientWidth={leaderboardWrapperWidth}
     >
       {#each visibleDimensions as dimension (dimension.name)}
         {#if dimension.name}
-          <div class="leaderboard-wrapper">
+          <div
+            class="leaderboard-wrapper"
+            bind:clientWidth={leaderboardWrapperWidth}
+          >
             <Leaderboard
               leaderboardShowContextForAllMeasures
               timeControlsReady

--- a/web-common/src/features/canvas/components/leaderboard/util.ts
+++ b/web-common/src/features/canvas/components/leaderboard/util.ts
@@ -1,6 +1,8 @@
+import { MEASURES_PADDING } from "@rilldata/web-common/features/dashboards/leaderboard/leaderboard-widths.ts";
+
 export const MIN_DIMENSION_COLUMN_WIDTH = 150;
 export const DEFAULT_DIMENSION_COLUMN_WIDTH = 164;
-export const LEADERBOARD_WRAPPER_PADDING = 56;
+export const LEADERBOARD_WRAPPER_PADDING = 56 + MEASURES_PADDING;
 
 export function getDimensionColumnWidth(
   wrapperWidth: number,


### PR DESCRIPTION
Leaderboard widths are not correct and there is overlap of the bars.
<img width="1062" height="248" alt="Screenshot 2026-01-07 at 12 17 18 PM" src="https://github.com/user-attachments/assets/0f189588-4c47-432d-9f5c-7afbeb46a706" />

Reverts https://github.com/rilldata/rill/pull/8568 and fixes the underlying issue in a correct way

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
