### PR TITLE
fix: dimension filter contains mode

### DIFF
--- a/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
+++ b/web-common/src/features/dashboards/filters/dimension-filters/DimensionFilter.svelte
@@ -79,6 +79,10 @@
     pinned,
   } = filterData);
 
+  $: if (!open && filterData.mode !== curMode) {
+    resyncFilterData(filterData);
+  }
+
   // Sync proxy when selectedValues changes (for Select mode)
   $: if (!open && mode === DimensionFilterMode.Select) {
     selectedValuesProxy = structuredClone(filterData.selectedValues) ?? [];
@@ -382,6 +386,18 @@
     } else {
       await toggleDimensionValueSelections(name, [value], metricsViewNames);
     }
+  }
+
+  function resyncFilterData(filterData: DimensionFilterItem) {
+    curMode = filterData.mode;
+    curSearchText = filterData.inputText ?? "";
+    curExcludeMode = filterData.isInclude === false;
+    selectedValuesProxy = filterData.selectedValues ?? [];
+    searchedBulkValues =
+      filterData.mode === DimensionFilterMode.InList
+        ? (filterData.selectedValues ?? [])
+        : [];
+    curPinned = filterData.pinned;
   }
 </script>
 


### PR DESCRIPTION
This PR fixes a bug on Canvas where using a widget to select filters would not apply if there was an existing CONTAINS filter for the dimension.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
