### PR TITLE
ignore schema for ch, druid and pinot

### DIFF
--- a/runtime/drivers/olap.go
+++ b/runtime/drivers/olap.go
@@ -332,8 +332,7 @@ func (d Dialect) EscapeTable(db, schema, table string) string {
 		sb.WriteString(d.EscapeIdentifier(db))
 		sb.WriteString(".")
 	}
-	// schema isn't supported for ClickHouse, Druid and Pinot
-	if schema != "" && !(d == DialectClickHouse || d == DialectDruid || d == DialectPinot) {
+	if schema != "" {
 		sb.WriteString(d.EscapeIdentifier(schema))
 		sb.WriteString(".")
 	}

--- a/runtime/metricsview/executor/executor_validate.go
+++ b/runtime/metricsview/executor/executor_validate.go
@@ -90,6 +90,17 @@ func (e *Executor) ValidateAndNormalizeMetricsView(ctx context.Context) (*Valida
 		}
 	}
 
+	// db and schema validation
+	// make sure for olaps like Druid and Pinot both database and database_schema are not set
+	// for Clickhouse we allow only database_schema as we already use that in OLAPInformationSchema.Lookup(...)
+	// not doing any validation for duckdb as we ignore database and database_schema in Dialect.EscapeTable(...) so not to break any existing metrics view
+	if (e.olap.Dialect() == drivers.DialectDruid || e.olap.Dialect() == drivers.DialectPinot) && mv.Database != "" && mv.DatabaseSchema != "" {
+		res.OtherErrs = append(res.OtherErrs, fmt.Errorf("only one of database or database_schema can be set for %s as it only supports one level of namespacing", e.olap.Dialect().String()))
+	}
+	if e.olap.Dialect() == drivers.DialectClickHouse && mv.Database != "" {
+		res.OtherErrs = append(res.OtherErrs, fmt.Errorf("database cannot be set for clickHouse, set database_schema instead"))
+	}
+
 	cols := make(map[string]*runtimev1.StructType_Field, len(t.Schema.Fields))
 	for _, f := range t.Schema.Fields {
 		cols[strings.ToLower(f.Name)] = f


### PR DESCRIPTION
prevents cryptic errors when schema is defined unintentionally 

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
