### PR TITLE
tweak: canvas conversational dev agent improvements

### DIFF
--- a/runtime/ai/instructions/data/resources/canvas.md
+++ b/runtime/ai/instructions/data/resources/canvas.md
@@ -174,6 +174,11 @@ When building a new canvas dashboard, follow this recommended structure:
 - **Part-to-whole**: Use `donut_chart` or `stacked_bar_normalized`
 - **Two-dimensional patterns**: Use `heatmap`
 - **Dual-metric comparison**: Use `combo_chart` for two measures with different scales
+- **Funnel analysis**: Use `funnel_chart` to visualize sequential stage drop-offs
+
+
+# Field guidelines
+The field names are case sensitive and should match exactly to the fields present in the metrics view.
 
 **Time dimension restrictions:**
 The time dimension (timeseries field from the metrics view) is special and can ONLY be used in the x-axis field for temporal charts. Never use the time dimension in:
@@ -268,7 +273,7 @@ leaderboard:
     - total_revenue
     - average_order_value
     - order_count
-  num_rows: 15
+  num_rows: 7
 ```
 
 **Important:** Never use time dimensions in leaderboard dimensions. Leaderboards are for categorical ranking, not time-series analysis.

--- a/web-common/src/features/canvas/components/charts/validate.ts
+++ b/web-common/src/features/canvas/components/charts/validate.ts
@@ -41,7 +41,7 @@ export function validateChartSchema(
       if (timeDimensions.length > 0 && timeDimension !== timeDimensions[0]) {
         return {
           isValid: false,
-          error: `Invalid time dimension ${timeDimension} selected`,
+          error: `Invalid time dimension ${timeDimension} in metrics view ${metrics_view}`,
         };
       }
 
@@ -50,7 +50,7 @@ export function validateChartSchema(
         const invalidMeasures = validateMeasuresRes.invalidMeasures.join(", ");
         return {
           isValid: false,
-          error: `Invalid measure ${invalidMeasures} selected`,
+          error: `Invalid measure ${invalidMeasures} in metrics view ${metrics_view}`,
         };
       }
 
@@ -62,7 +62,7 @@ export function validateChartSchema(
 
         return {
           isValid: false,
-          error: `Invalid dimension(s) ${invalidDimensions} selected`,
+          error: `Invalid dimension(s) ${invalidDimensions} in metrics view ${metrics_view}`,
         };
       }
       return {

--- a/web-common/src/features/components/ComponentError.svelte
+++ b/web-common/src/features/components/ComponentError.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import CopyIcon from "@rilldata/web-common/components/icons/CopyIcon.svelte";
   import CrossIcon from "@rilldata/web-common/components/icons/CrossIcon.svelte";
+  import { copyToClipboard } from "@rilldata/web-common/lib/actions/copy-to-clipboard";
 
   export let error: string | undefined;
 </script>
@@ -11,6 +13,15 @@
   <div class="error-message">
     {error ?? "Component Error"}
   </div>
+  {#if error}
+    <button
+      class="p-2 rounded hover:bg-red-100 active:bg-red-200 transition-colors"
+      on:click={() => copyToClipboard(error, "Copied error to clipboard")}
+      title="Copy error to clipboard"
+    >
+      <CopyIcon size="14px" />
+    </button>
+  {/if}
 </div>
 
 <style lang="postcss">


### PR DESCRIPTION
- Improve Canvas prompt
- Add copy icon in `ComponentError` so easily copy and paste to Developer agent

https://linear.app/rilldata/issue/APP-676/edit-canvas-dashboards-with-ai

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
