### PR TITLE
refac: pivot error page to show trace id, shorter message

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotError.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotError.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
+  import CopyIcon from "@rilldata/web-common/components/icons/CopyIcon.svelte";
+  import { copyToClipboard } from "@rilldata/web-common/lib/actions/copy-to-clipboard";
   import type { PivotQueryError } from "./types";
 
   export let errors: PivotQueryError[];
+
+  const MAX_ERROR_LENGTH = 500;
 
   function removeDuplicates(errors: PivotQueryError[]): PivotQueryError[] {
     const seen = new Set();
@@ -16,11 +20,37 @@
     });
   }
 
+  function truncateMessage(message: string): string {
+    if (message.length <= MAX_ERROR_LENGTH) {
+      return message;
+    }
+    return message.slice(0, MAX_ERROR_LENGTH) + "...";
+  }
+
+  function handleCopyError(error: PivotQueryError) {
+    const fullError = `${error.statusCode}${error.traceId ? ` (Trace ID: ${error.traceId})` : ""}: ${error.message}`;
+    copyToClipboard(fullError, "Error message copied to clipboard");
+  }
+
+  function getUniqueTraceIds(errors: PivotQueryError[]): string[] {
+    const traceIds = errors
+      .map((error) => error.traceId)
+      .filter((id): id is string => id !== undefined && id !== null);
+    return [...new Set(traceIds)];
+  }
+
+  $: traceIds = getUniqueTraceIds(errors);
+
   let uniqueErrors = removeDuplicates(errors);
 </script>
 
 <div class="flex flex-col items-center w-full h-full">
   <span class="text-3xl font-normal m-2">Sorry, unexpected query error!</span>
+  {#if traceIds.length > 0}
+    <div class="text-sm ui-copy mt-1">
+      <b>Trace ID{traceIds.length !== 1 ? "s" : ""}</b>: {traceIds.join(", ")}
+    </div>
+  {/if}
   <div class="text-base text-gray-600 mt-4">
     One or more APIs failed with the following error{uniqueErrors.length !== 1
       ? "s"
@@ -28,9 +58,21 @@
   </div>
 
   {#each uniqueErrors as error}
-    <div class="flex text-base gap-x-2">
-      <span class="text-red-600 font-semibold">{error.statusCode} :</span>
-      <span class="text-gray-800">{error.message}</span>
+    <div class="flex text-base gap-x-2 items-start max-w-4xl">
+      <span class="text-red-600 font-semibold whitespace-nowrap"
+        >{error.statusCode}:</span
+      >
+      <span class="text-gray-800 flex-1 break-words">
+        {truncateMessage(error.message ?? "")}
+      </span>
+      <button
+        class="flex-shrink-0 p-1 hover:bg-gray-100 rounded transition-colors cursor-pointer"
+        on:click={() => handleCopyError(error)}
+        title="Copy full error message"
+        aria-label="Copy error message to clipboard"
+      >
+        <CopyIcon size="16px" color="#6B7280" />
+      </button>
     </div>
   {/each}
 </div>

--- a/web-common/src/features/dashboards/pivot/pivot-utils.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-utils.ts
@@ -640,6 +640,7 @@ export function getErrorFromResponse(
   return {
     statusCode: queryResult?.error?.response?.status || null,
     message: queryResult?.error?.response?.data?.message,
+    traceId: queryResult?.error?.traceId,
   };
 }
 

--- a/web-common/src/features/dashboards/pivot/types.ts
+++ b/web-common/src/features/dashboards/pivot/types.ts
@@ -84,6 +84,7 @@ export interface PivotTimeConfig {
 export interface PivotQueryError {
   statusCode: number | null;
   message?: string;
+  traceId?: string;
 }
 
 /**


### PR DESCRIPTION
Refactor Pivot error page to
- show X-Trace-id
- truncate longer error messages
- add copy icon to copy full error message


Mock layout
<img width="914" height="308" alt="Screenshot 2026-01-13 at 5 47 03 PM" src="https://github.com/user-attachments/assets/ee55227c-e002-4c09-b3c3-6f1c4b80b9db" />

https://linear.app/rilldata/issue/APP-616/nicer-error-messages-in-pivot

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
