### PR TITLE
chore: remove `createEventDispatcher` from graph components

### DIFF
--- a/web-common/src/features/resource-graph/embedding/GraphOverlay.svelte
+++ b/web-common/src/features/resource-graph/embedding/GraphOverlay.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { ResourceGraphGrouping } from "../graph-canvas/graph-builder";
   import GraphCanvas from "../graph-canvas/GraphCanvas.svelte";
-  import { createEventDispatcher } from "svelte";
   import { FIT_VIEW_CONFIG } from "../shared/config";
 
   export let group: ResourceGraphGrouping | null = null;
@@ -9,16 +8,15 @@
   export let mode: "inline" | "fullscreen" | "modal" = "inline";
   export let showControls = true;
   export let showCloseButton = true;
+  export let onClose: () => void;
 
   // Fit view configuration for better centering
   export let fitViewPadding: number = FIT_VIEW_CONFIG.PADDING;
   export let fitViewMinZoom: number = FIT_VIEW_CONFIG.MIN_ZOOM;
   export let fitViewMaxZoom: number = FIT_VIEW_CONFIG.MAX_ZOOM;
 
-  const dispatch = createEventDispatcher<{ close: void }>();
-
   function handleClose() {
-    dispatch("close");
+    onClose();
   }
 
   function handleKeydown(e: KeyboardEvent) {

--- a/web-common/src/features/resource-graph/embedding/ResourceGraph.svelte
+++ b/web-common/src/features/resource-graph/embedding/ResourceGraph.svelte
@@ -457,7 +457,7 @@
               open={isExpanded}
               mode={overlayMode}
               {showControls}
-              on:close={() => handleExpandChange(null)}
+              onClose={() => handleExpandChange(null)}
             />
           {:else if isExpanded}
             <!-- Inline expansion within grid -->
@@ -482,7 +482,7 @@
               {fitViewPadding}
               {fitViewMinZoom}
               {fitViewMaxZoom}
-              on:expand={() => handleExpandChange(null)}
+              onExpand={() => handleExpandChange(null)}
             />
           {:else}
             <!-- Collapsed card view -->
@@ -508,7 +508,7 @@
                 {fitViewPadding}
                 {fitViewMinZoom}
                 {fitViewMaxZoom}
-                on:expand={() => handleExpandChange(group.id)}
+                onExpand={() => handleExpandChange(group.id)}
               />
             </slot>
           {/if}

--- a/web-common/src/features/resource-graph/graph-canvas/GraphCanvas.svelte
+++ b/web-common/src/features/resource-graph/graph-canvas/GraphCanvas.svelte
@@ -77,8 +77,8 @@
   export let fitViewPadding: number = FIT_VIEW_CONFIG.PADDING;
   export let fitViewMinZoom: number = FIT_VIEW_CONFIG.MIN_ZOOM;
   export let fitViewMaxZoom: number = FIT_VIEW_CONFIG.MAX_ZOOM;
-  import { createEventDispatcher } from "svelte";
-  const dispatch = createEventDispatcher<{ expand: void }>();
+  export let onExpand: () => void = () => {};
+
   // Tie Svelte Flow theme to the app theme
   import { themeControl } from "../../themes/theme-control";
   // Derive Svelte Flow color mode from global theme
@@ -311,7 +311,7 @@
           class="expand-btn"
           aria-label="Expand graph"
           title="Expand"
-          on:click={() => dispatch("expand")}
+          on:click={() => onExpand()}
         >
           ⤢
         </button>


### PR DESCRIPTION
Replace `createEventDipsatcher` from DAG components to use callback function props.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
