### PR TITLE
User management dropdown alignment

### DIFF
--- a/web-admin/src/features/organizations/user-management/table/groups/GroupActionsCell.svelte
+++ b/web-admin/src/features/organizations/user-management/table/groups/GroupActionsCell.svelte
@@ -20,7 +20,7 @@
       <ThreeDot size="16px" />
     </IconButton>
   </DropdownMenu.Trigger>
-  <DropdownMenu.Content align="start">
+  <DropdownMenu.Content align="end">
     <DropdownMenu.Item
       class="font-normal flex items-center"
       on:click={() => {

--- a/web-admin/src/features/organizations/user-management/table/users/UserActionsCell.svelte
+++ b/web-admin/src/features/organizations/user-management/table/users/UserActionsCell.svelte
@@ -81,7 +81,7 @@
         <ThreeDot size="16px" />
       </IconButton>
     </DropdownMenu.Trigger>
-    <DropdownMenu.Content align="start">
+    <DropdownMenu.Content align="end">
       {#if role === OrgUserRoles.Guest && !pendingAcceptance}
         <DropdownMenu.Item
           class="font-normal flex items-center"

--- a/web-admin/src/features/organizations/user-management/table/users/UserGroupsCell.svelte
+++ b/web-admin/src/features/organizations/user-management/table/users/UserGroupsCell.svelte
@@ -39,7 +39,7 @@
         <CaretDownIcon size="12px" />
       {/if}
     </Dropdown.Trigger>
-    <Dropdown.Content>
+    <Dropdown.Content align="start">
       {#if isPending}
         Loading...
       {:else if error}

--- a/web-admin/src/features/organizations/user-management/table/users/UserProjectsCell.svelte
+++ b/web-admin/src/features/organizations/user-management/table/users/UserProjectsCell.svelte
@@ -51,7 +51,7 @@
         <CaretDownIcon size="12px" />
       {/if}
     </Dropdown.Trigger>
-    <Dropdown.Content>
+    <Dropdown.Content align="start">
       {#if isPending}
         Loading...
       {:else if error}


### PR DESCRIPTION
Fixes dropdown alignment in the User Management table to meet UI conventions and prevent overflow.

Previously, dropdowns in columns like "Groups" and "Projects" were center-aligned, and 3-dot action menus were left-aligned, leading to awkward positioning and potential overflow.

This PR updates the `Dropdown.Content` and `DropdownMenu.Content` components to use the `align` prop:
- **`UserGroupsCell.svelte`** and **`UserProjectsCell.svelte`**: Set `align="start"` for default left alignment.
- **`UserActionsCell.svelte`** and **`GroupActionsCell.svelte`**: Set `align="end"` for right alignment, ensuring 3-dot menus open away from the table's right edge.

This leverages the `bits-ui` component's built-in collision detection for robust, viewport-aware positioning without custom logic.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
Linear Issue: [APP-669](https://linear.app/rilldata/issue/APP-669/fix-alignment-behavior-for-dropdowns-in-user-management-table-cells)

<a href="https://cursor.com/background-agent?bcId=bc-c8baaaad-a372-4ec1-a2ab-c65047549595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c8baaaad-a372-4ec1-a2ab-c65047549595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns dropdown menus consistently across User Management.
> 
> - Set `align="end"` for action menus in `UserActionsCell.svelte` and `GroupActionsCell.svelte`
> - Set `align="start"` for list dropdowns in `UserGroupsCell.svelte` and `UserProjectsCell.svelte`
> - Uses `align` on `Dropdown.Content`/`DropdownMenu.Content` to control positioning
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35cfc54e38a233e636f56257dfa3c5689ae336cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->