### PR TITLE
Cell inspector canvas dashboards

### DIFF
--- a/web-common/src/features/canvas/CanvasDashboardWrapper.svelte
+++ b/web-common/src/features/canvas/CanvasDashboardWrapper.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { dynamicHeight } from "@rilldata/web-common/layout/layout-settings.ts";
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
+  import CellInspector from "@rilldata/web-common/components/CellInspector.svelte";
   import CanvasFilters from "./filters/CanvasFilters.svelte";
   import { getCanvasStore } from "./state-managers/state-managers";
   import ThemeProvider from "../dashboards/ThemeProvider.svelte";
@@ -60,6 +61,8 @@
         <slot />
       </div>
     </div>
+
+    <CellInspector />
   </main>
 </ThemeProvider>
 

--- a/web-common/src/features/canvas/components/kpi/KPI.svelte
+++ b/web-common/src/features/canvas/components/kpi/KPI.svelte
@@ -2,6 +2,7 @@
   import PercentageChange from "@rilldata/web-common/components/data-types/PercentageChange.svelte";
   import Chart from "@rilldata/web-common/components/time-series-chart/Chart.svelte";
   import RangeDisplay from "@rilldata/web-common/features/dashboards/time-controls/super-pill/components/RangeDisplay.svelte";
+  import { cellInspectorStore } from "@rilldata/web-common/features/dashboards/stores/cell-inspector-store";
   import { createMeasureValueFormatter } from "@rilldata/web-common/lib/number-formatting/format-measure-value";
   import { FormatPreset } from "@rilldata/web-common/lib/number-formatting/humanizer-types";
   import { formatMeasurePercentageDifference } from "@rilldata/web-common/lib/number-formatting/percentage-formatter";
@@ -86,6 +87,34 @@
     const delta = currentValue - comparisonValue;
     return `${delta >= 0 ? "+" : ""}${measureValueFormatter(delta)}`;
   }
+
+  function handleBigNumberMouseOver() {
+    const displayValue =
+      hoveredPoints?.[0]?.value != null ? currentValue : primaryTotal;
+    if (displayValue !== undefined && displayValue !== null) {
+      cellInspectorStore.updateValue(displayValue.toString());
+    }
+  }
+
+  function handleBigNumberFocus() {
+    const displayValue =
+      hoveredPoints?.[0]?.value != null ? currentValue : primaryTotal;
+    if (displayValue !== undefined && displayValue !== null) {
+      cellInspectorStore.updateValue(displayValue.toString());
+    }
+  }
+
+  function handleComparisonMouseOver() {
+    if (comparisonVal !== undefined && comparisonVal !== null) {
+      cellInspectorStore.updateValue(comparisonVal.toString());
+    }
+  }
+
+  function handleComparisonFocus() {
+    if (comparisonVal !== undefined && comparisonVal !== null) {
+      cellInspectorStore.updateValue(comparisonVal.toString());
+    }
+  }
 </script>
 
 <div class="wrapper" class:spark-right={isSparkRight}>
@@ -107,6 +136,10 @@
     <div
       class="big-number h-9 grid place-content-center"
       class:hovered-value={hoveredPoints?.[0]?.value != null}
+      role="button"
+      tabindex="0"
+      on:mouseover={handleBigNumberMouseOver}
+      on:focus={handleBigNumberFocus}
     >
       {#if primaryTotalResult.isError}
         <AlertTriangleIcon class=" text-red-300" size="34px" />
@@ -131,7 +164,13 @@
           <div class="loading h-[14px] w-6"></div>
         {:else if comparisonTotalResult.data}
           {#if comparisonOptions?.includes("previous")}
-            <span class="comparison-value">
+            <span
+              class="comparison-value"
+              role="button"
+              tabindex="0"
+              on:mouseover={handleComparisonMouseOver}
+              on:focus={handleComparisonFocus}
+            >
               {measureValueFormatter(comparisonVal)}
             </span>
           {/if}


### PR DESCRIPTION
Replicates the Cell Inspector feature from Explore to Canvas Dashboards (APP-682).

This PR integrates the `CellInspector` component into `CanvasDashboardWrapper.svelte` and adds Cell Inspector support to the `KPI.svelte` component, ensuring consistency with other dashboard components that already had this functionality.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-682](https://linear.app/rilldata/issue/APP-682/replicate-cell-inspector-feature-from-explore-to-canvas-dashboards)

<a href="https://cursor.com/background-agent?bcId=bc-b9a021ed-c2d6-4dea-aedb-5892d4e558c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b9a021ed-c2d6-4dea-aedb-5892d4e558c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Brings Cell Inspector behavior to canvas dashboards and KPI tiles for value inspection.
> 
> - Renders `CellInspector` in `CanvasDashboardWrapper.svelte` so it’s available on canvas pages
> - In `KPI.svelte`, wires `cellInspectorStore` to the big number and comparison value: on hover/focus, pushes the displayed value; adds `role="button"` and `tabindex` for keyboard accessibility
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f9865f10f05d71ef507e347af84114b85dc4499. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->