### PR TITLE
feat: improve embed test observability

### DIFF
--- a/web-admin/tests/embeds.spec.ts
+++ b/web-admin/tests/embeds.spec.ts
@@ -15,13 +15,18 @@ function expectMessageContaining(
       messages.length > 0
         ? messages.map((m, i) => `  [${i}]: ${m}`).join("\n")
         : "  (no messages captured)";
-    expect.soft(found, `No message containing expected substring.
+    expect
+      .soft(
+        found,
+        `No message containing expected substring.
 
 Expected substring:
   ${expectedSubstring}
 
 Received messages:
-${formattedMessages}`).toBeTruthy();
+${formattedMessages}`,
+      )
+      .toBeTruthy();
   }
 }
 
@@ -40,13 +45,18 @@ function expectMessageMatching(
       messages.length > 0
         ? messages.map((m, i) => `  [${i}]: ${m}`).join("\n")
         : "  (no messages captured)";
-    expect.soft(found, `No message matching expected condition.
+    expect
+      .soft(
+        found,
+        `No message matching expected condition.
 
 Expected:
   ${description}
 
 Received messages:
-${formattedMessages}`).toBeTruthy();
+${formattedMessages}`,
+      )
+      .toBeTruthy();
   }
 }
 
@@ -450,7 +460,7 @@ test.describe("Embeds", () => {
           (msg.includes(`"themeMode":"light"`) ||
             msg.includes(`"themeMode":"dark"`) ||
             msg.includes(`"themeMode":"system"`)),
-        'message with id:3001 and themeMode light/dark/system',
+        "message with id:3001 and themeMode light/dark/system",
       );
     });
 


### PR DESCRIPTION
Adds better error observability to embed tests by replacing silent .toBeTruthy() assertions with helper functions that display expected vs received messages on failure.

Failed tests now show what was expected and all captured messages:
```
Expected substring: {"id":1337,"result":true}

Received messages:
  [0]: ["stateChange",{"method":"stateChange","params":{...}}]
  [1]: ["ready",{"method":"ready"}]
```

Changes

- Added expectMessageContaining() helper for simple substring matching
- Added expectMessageMatching() helper for complex predicate-based matching (OR/AND conditions)
- Updated all 20+ message assertions to use these helpers
- Helpers stay silent on success, only output on failure

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
