### PR TITLE
Share modal close

### DIFF
--- a/web-admin/src/features/dashboards/share/ShareDashboardPopover.svelte
+++ b/web-admin/src/features/dashboards/share/ShareDashboardPopover.svelte
@@ -32,12 +32,7 @@
   }
 </script>
 
-<Popover
-  bind:open={isOpen}
-  onOutsideClick={() => {
-    isOpen = false;
-  }}
->
+<Popover bind:open={isOpen}>
   <PopoverTrigger asChild let:builder>
     <Button type="secondary" builders={[builder]} selected={isOpen}
       >Share</Button


### PR DESCRIPTION
Fixes an issue where the Share Dashboard popover would not close when clicking the Share button a second time.

The `onOutsideClick` handler was removed from `ShareDashboardPopover` as it conflicted with the `bits-ui` Popover's built-in toggle functionality, causing the popover to remain open. This change aligns the Share button's behavior with other top menu buttons.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes (APP-684)
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-684](https://linear.app/rilldata/issue/APP-684/clicking-on-share-button-on-dashboards-doesnt-close-share-modal)

<a href="https://cursor.com/background-agent?bcId=bc-88b3e3f4-2025-451b-8c77-e39450c9331e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-88b3e3f4-2025-451b-8c77-e39450c9331e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

