### PR TITLE
chore: update pivot comparison suffix

### DIFF
--- a/web-common/src/features/dashboards/pivot/types.ts
+++ b/web-common/src/features/dashboards/pivot/types.ts
@@ -14,11 +14,11 @@ import type {
 } from "@tanstack/svelte-table";
 import type { Readable } from "svelte/motion";
 
-export const COMPARISON_VALUE = "__comparison_value";
-export const COMPARISON_DELTA = "__comparison_delta";
-export const COMPARISON_PERCENT = "__comparison_percent";
+export const COMPARISON_VALUE = "__previous";
+export const COMPARISON_DELTA = "__delta_abs";
+export const COMPARISON_PERCENT = "__delta_rel";
 export const ComparisonModifierSuffixRegex =
-  /__comparison_(?:value|delta|percent)/;
+  /__(?:previous|delta_abs|delta_rel)/;
 
 export interface PivotDataState {
   isFetching: boolean;

--- a/web-common/src/features/explore-mappers/get-dashboard-from-aggregation-request.ts
+++ b/web-common/src/features/explore-mappers/get-dashboard-from-aggregation-request.ts
@@ -291,9 +291,18 @@ function getPivotStateFromRequest(
   };
 }
 
-// We use a different suffix in pivot vs rest of the app. So map them correctly to not break pivot.
-// TODO: Unify the suffix to avoid this confusion
+// Map measure filter suffixes and API suffixes to pivot suffixes
+// to handle the measure filter format (_delta, _delta_perc) for backwards compatibility
 function convertComparisonMeasureToPivotMeasures(measure: string) {
+  if (
+    measure.endsWith(COMPARISON_DELTA) ||
+    measure.endsWith(COMPARISON_PERCENT) ||
+    measure.endsWith(COMPARISON_VALUE)
+  ) {
+    return measure;
+  }
+
+  // Handle measure filter format for backwards compatibility
   switch (true) {
     case measure.endsWith(ComparisonDeltaPreviousSuffix):
       return measure.replace(ComparisonDeltaPreviousSuffix, COMPARISON_VALUE);


### PR DESCRIPTION
Updates the pivot comparison suffix so that it's inline with AI generated citation URLs.

https://rilldata.slack.com/archives/C08RDR9Q26P/p1768427502052339?thread_ts=1768424348.881859&cid=C08RDR9Q26P

One point to note is that the suffix is still not in sync with what we are using across the dashboard.

The follow prefix present in `measure-filter-entry.ts` is used in multiple places across the codebase 

```
export const ComparisonDeltaPreviousSuffix = "_prev";
export const ComparisonDeltaAbsoluteSuffix = "_delta";
export const ComparisonDeltaRelativeSuffix = "_delta_perc"
```

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
