### PR TITLE
fix: time series chart labeling

### DIFF
--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -589,12 +589,14 @@
                 ? bigNum
                 : null}
               mouseoverTimeFormat={(value) => {
-                /** format the date according to the time grain */
-
+                // This date comes back in the user's local timezone, but has the correct time value
+                // For rendering purposes, we can just switch the zone to the selected timezone while keeping the local time
+                // This is technically unnecessary since the time value is "correct", but it's safer in case any formatting logic depends on the zone
                 return formatDateTimeByGrain(
-                  DateTime.fromJSDate(value, {
-                    zone: $exploreState?.selectedTimezone,
-                  }),
+                  DateTime.fromJSDate(value).setZone(
+                    $exploreState?.selectedTimezone || "UTC",
+                    { keepLocalTime: true },
+                  ),
                   effectiveGrain,
                 );
               }}


### PR DESCRIPTION
Fixes a regression from https://github.com/rilldata/rill/pull/8633 where dates were being improperly converted back into a time zone for display purposes.

Following up another PR to ensure we have test coverage for this surface

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
