### PR TITLE
increase time range bins for spine select to 1500

### DIFF
--- a/runtime/metricsview/ast.go
+++ b/runtime/metricsview/ast.go
@@ -1107,8 +1107,8 @@ func (a *AST) buildSpineSelect(alias string, spine *Spine, tr *TimeRange) (*Sele
 	if spine.TimeRange != nil {
 		// if spine generates more than 1000 values then return an error
 		bins := timeutil.ApproximateBins(spine.TimeRange.Start, spine.TimeRange.End, spine.TimeRange.Grain.ToTimeutil())
-		if bins > 1000 {
-			return nil, errors.New("failed to apply time spine: time range has more than 1000 bins")
+		if bins > 1500 {
+			return nil, errors.New("failed to apply time spine: time range has more than 1500 bins")
 		}
 
 		timeDim := a.MetricsView.TimeDimension


### PR DESCRIPTION
To accommodate 24 hrs on minute grain use case.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
