### PR TITLE
fix: hide AI toggle on public URL dashboards

### DIFF
--- a/web-admin/src/features/navigation/TopNavigationBar.svelte
+++ b/web-admin/src/features/navigation/TopNavigationBar.svelte
@@ -240,7 +240,7 @@
             {#if $dimensionSearch}
               <GlobalDimensionSearch />
             {/if}
-            {#if $dashboardChat}
+            {#if $dashboardChat && !onPublicURLPage}
               <ChatToggle />
             {/if}
             {#if hasUserAccess}


### PR DESCRIPTION
The AI feature has broken conversation persistence for magic auth token users (conversations don't persist properly since tokens lack a user ID). Hide the toggle until the feature is properly supported for share URLs.

Addresses [this Slack conversation](https://rilldata.slack.com/archives/C08RDR9Q26P/p1769010755883949)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
