### PR TITLE
better error msg for time spine failure

### DIFF
--- a/runtime/metricsview/ast.go
+++ b/runtime/metricsview/ast.go
@@ -1105,10 +1105,10 @@ func (a *AST) buildSpineSelect(alias string, spine *Spine, tr *TimeRange) (*Sele
 	}
 
 	if spine.TimeRange != nil {
-		// if spine generates more than 1000 values then return an error
+		// if spine generates more than 1500 values then return an error
 		bins := timeutil.ApproximateBins(spine.TimeRange.Start, spine.TimeRange.End, spine.TimeRange.Grain.ToTimeutil())
 		if bins > 1500 {
-			return nil, errors.New("failed to apply time spine: time range has more than 1500 bins")
+			return nil, fmt.Errorf("failed to apply time spine: time range has more than 1500 bins for %q grain, move to a larger grain", spine.TimeRange.Grain)
 		}
 
 		timeDim := a.MetricsView.TimeDimension


### PR DESCRIPTION
Have seen applications not zooming out grain on increasing time range, this just gives better error msg until then.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
