### PR TITLE
utz tz for embedded ch

### DIFF
--- a/runtime/drivers/clickhouse/embed.go
+++ b/runtime/drivers/clickhouse/embed.go
@@ -329,6 +329,8 @@ func (e *embedClickHouse) getConfigContent() ([]byte, error) {
 	}
 
 	config := []byte(fmt.Sprintf(`<clickhouse>
+    <timezone>UTC</timezone>
+
     <logger>
         <level>debug</level>
         <console>true</console>

--- a/runtime/drivers/olap.go
+++ b/runtime/drivers/olap.go
@@ -601,9 +601,9 @@ func (d Dialect) DateTruncExpr(dim *runtimev1.MetricsViewSpec_Dimension, grain r
 
 		if tz == "" {
 			if shift == "" {
-				return fmt.Sprintf("date_trunc('%s', %s, 'UTC')::DateTime64", specifier, expr), nil
+				return fmt.Sprintf("date_trunc('%s', %s)::DateTime64", specifier, expr), nil
 			}
-			return fmt.Sprintf("date_trunc('%s', %s + INTERVAL %s, 'UTC')::DateTime64 - INTERVAL %s", specifier, expr, shift, shift), nil
+			return fmt.Sprintf("date_trunc('%s', %s + INTERVAL %s)::DateTime64 - INTERVAL %s", specifier, expr, shift, shift), nil
 		}
 
 		if shift == "" {


### PR DESCRIPTION
The tz argument in `date_trunc` throws error for grains bigger than `day` when applied on `DATE` types column. 
```
The timezone argument of function dateTrunc with datepart 'month' is allowed only when the 2nd argument has the type DateTime: In scope SELECT CAST(date_trunc('month', measurement_date, 'UTC'), 'DateTime64') 
```
This argument was added to prevent issues in rill developer with embedded CH returning results in local timezone thus causing time spine join to fail. So hardcoding the tz for embedded to UTC in the config.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
