### PR TITLE
Allow requests to the runtime proxy from any origin

### DIFF
--- a/admin/server/server.go
+++ b/admin/server/server.go
@@ -179,12 +179,20 @@ func (s *Server) HTTPHandler(ctx context.Context) (http.Handler, error) {
 	adminv1.RegisterAIServiceServer(grpcServer, s)
 	adminv1.RegisterTelemetryServiceServer(grpcServer, s)
 
+	// Prepare CORS config.
+	// We currently only add CORS config on the transcoder and runtime proxy handlers.
+	// Other endpoints here don't need CORS config because they should not be used in cross-origin browser requests.
+	transcoderCORSMiddleware := cors.New(newCORSOptions(s.opts.AllowedOrigins, true)).Handler // Allow cookies for calls from ui.rilldata.com to admin.rilldata.com
+	runtimeProxyCORSMiddleware := cors.New(newCORSOptions([]string{"*"}, false)).Handler      // Allow any origin but no cookies. In the longer term, we should add explicit domain allowlisting per org or project.
+
 	// Add gRPC and gRPC-to-REST transcoder.
 	// This will be the fallback for REST routes like `/v1/ping` and GPRC routes like `/rill.admin.v1.AdminService/Ping`.
+	var transcoder http.Handler
 	transcoder, err := vanguardgrpc.NewTranscoder(grpcServer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create transcoder: %w", err)
 	}
+	transcoder = transcoderCORSMiddleware(transcoder)
 
 	// Add auth cookie refresh specifically for the GetCurrentUser RPC.
 	// This is sufficient to refresh the cookie on each page load without unnecessarily refreshing cookies in each API call.
@@ -195,14 +203,14 @@ func (s *Server) HTTPHandler(ctx context.Context) (http.Handler, error) {
 	mux.Handle("/rill.admin.v1.AIService/", transcoder)
 	mux.Handle("/rill.admin.v1.TelemetryService/", transcoder)
 
-	// Add runtime proxy
+	// Add runtime proxy.
 	proxyHandler := observability.Middleware(
 		"runtime-proxy",
 		s.logger,
-		s.authenticator.HTTPMiddlewareLenient(httputil.Handler(s.runtimeProxyForOrgAndProject)),
+		runtimeProxyCORSMiddleware(s.authenticator.HTTPMiddlewareLenient(httputil.Handler(s.runtimeProxyForOrgAndProject))),
 	)
-	observability.MuxHandle(mux, "/v1/orgs/{org}/projects/{project}/runtime/{path...}", proxyHandler) // Backwards compatibility
-	observability.MuxHandle(mux, "/v1/organizations/{org}/projects/{project}/runtime/{path...}", proxyHandler)
+	observability.MuxHandle(mux, "/v1/orgs/{org}/projects/{project}/runtime/{path...}", proxyHandler)
+	observability.MuxHandle(mux, "/v1/organizations/{org}/projects/{project}/runtime/{path...}", proxyHandler) // Backwards compatibility
 
 	// Add backwards compatibility alias for iframe endpoint
 	observability.MuxHandle(mux, "/v1/organizations/{org}/projects/{project}/iframe", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -260,44 +268,9 @@ func (s *Server) HTTPHandler(ctx context.Context) (http.Handler, error) {
 	// 	}
 	// })
 
-	// Build CORS options for admin server
-
-	// If the AllowedOrigins contains a "*" we want to return the requester's origin instead of "*" in the "Access-Control-Allow-Origin" header.
-	// This is useful in development. In production, we set AllowedOrigins to non-wildcard values, so this does not have security implications.
-	// Details: https://github.com/rs/cors#allow--with-credentials-security-protection
-	var allowedOriginFunc func(string) bool
-	allowedOrigins := s.opts.AllowedOrigins
-	for _, origin := range s.opts.AllowedOrigins {
-		if origin == "*" {
-			allowedOriginFunc = func(origin string) bool { return true }
-			allowedOrigins = nil
-			break
-		}
-	}
-
-	corsOpts := cors.Options{
-		AllowedOrigins:  allowedOrigins,
-		AllowOriginFunc: allowedOriginFunc,
-		AllowedMethods: []string{
-			http.MethodHead,
-			http.MethodGet,
-			http.MethodPost,
-			http.MethodPut,
-			http.MethodPatch,
-			http.MethodDelete,
-		},
-		AllowedHeaders: []string{"*"},
-		// We use cookies for browser sessions, so this is required to allow ui.rilldata.com to make authenticated requests to admin.rilldata.com
-		AllowCredentials: true,
-		// Set max age to 1 hour (default if not set is 5 seconds)
-		MaxAge: 60 * 60,
-	}
-
-	// Wrap mux with CORS middleware
-	handlerWithAuth := s.authenticator.CookieToAuthHeader(mux)
-	handlerWithCors := cors.New(corsOpts).Handler(handlerWithAuth)
-	handler := middleware.TraceMiddleware(handlerWithCors)
-
+	// Wrap mux with final middleware and return
+	handler := s.authenticator.CookieToAuthHeader(mux) // Convert auth cookies to Authorization headers
+	handler = middleware.TraceMiddleware(handler)      // OpenTelemetry tracing
 	return handler, nil
 }
 
@@ -504,4 +477,39 @@ func checkUserAgent(ctx context.Context) (context.Context, error) {
 	}
 
 	return ctx, nil
+}
+
+// newCORSOptions creates config for the CORS middleware.
+// It supports passing a wildcard "*" in allowed origins to allow all origins.
+// Pass allowCredentials=true to allow cookies to be sent in CORS requests (necessary for endpoints accessed from ui.rilldata.com).
+func newCORSOptions(allowedOrigins []string, allowCredentials bool) cors.Options {
+	// If the AllowedOrigins contains a "*" we want to return the requester's origin instead of "*" in the "Access-Control-Allow-Origin" header.
+	// This is useful in development. In production, we set AllowedOrigins to non-wildcard values, so this does not have security implications.
+	// Details: https://github.com/rs/cors#allow--with-credentials-security-protection
+	var allowedOriginFunc func(string) bool
+	for _, origin := range allowedOrigins {
+		if origin == "*" {
+			allowedOriginFunc = func(origin string) bool { return true }
+			allowedOrigins = nil
+			break
+		}
+	}
+
+	return cors.Options{
+		AllowedOrigins:  allowedOrigins,
+		AllowOriginFunc: allowedOriginFunc,
+		AllowedMethods: []string{
+			http.MethodHead,
+			http.MethodGet,
+			http.MethodPost,
+			http.MethodPut,
+			http.MethodPatch,
+			http.MethodDelete,
+		},
+		AllowedHeaders: []string{"*"},
+		// We use cookies for browser sessions, so this must be true on endpoints that ui.rilldata.com access on admin.rilldata.com.
+		AllowCredentials: allowCredentials,
+		// Set max age to 1 hour (default if not set is 5 seconds)
+		MaxAge: 60 * 60,
+	}
 }


### PR DESCRIPTION
Allows cross-origin requests specifically and only to the runtime proxy. Avoids security issues by disabling cookies on such requests (so clients must explicitly pass a valid `Authorization` header unless it's a public project).

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
