### PR TITLE
ignore .github dir

### DIFF
--- a/runtime/drivers/repo.go
+++ b/runtime/drivers/repo.go
@@ -154,6 +154,7 @@ type Commit struct {
 var ignoredPaths = []string{
 	"/tmp",
 	"/.git",
+	"/.github",
 	"/node_modules",
 	"/.DS_Store",
 	"/.vscode",


### PR DESCRIPTION
any reason to not ignore, users might have github workflows that will get parsed and throw error

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
