### PR TITLE
feat: block non-semantic, neutral text classes

### DIFF
--- a/eslint-plugin-rill/index.js
+++ b/eslint-plugin-rill/index.js
@@ -1,0 +1,7 @@
+import noDisallowedTailwindTextColors from "./no-disallowed-tailwind-text-colors.js";
+
+export default {
+  rules: {
+    "no-disallowed-tailwind-text-colors": noDisallowedTailwindTextColors,
+  },
+};

--- a/eslint-plugin-rill/no-disallowed-tailwind-text-colors.js
+++ b/eslint-plugin-rill/no-disallowed-tailwind-text-colors.js
@@ -32,9 +32,9 @@ export default {
     const sourceCode = context.sourceCode ?? context.getSourceCode();
 
     return {
-      // Check Svelte HTML attributes (class="...")
+      // Check Svelte HTML attributes (class="..." and className="...")
       SvelteAttribute(node) {
-        if (node.key?.name === "class") {
+        if (node.key?.name === "class" || node.key?.name === "className") {
           for (const valueNode of node.value) {
             if (valueNode.type === "SvelteLiteral") {
               reportAllMatches(valueNode.value, context, valueNode);

--- a/eslint-plugin-rill/no-disallowed-tailwind-text-colors.js
+++ b/eslint-plugin-rill/no-disallowed-tailwind-text-colors.js
@@ -1,0 +1,81 @@
+/**
+ * ESLint rule to disallow certain Tailwind text color classes.
+ * Disallows: text-gray-*, text-neutral-*, text-slate-*, text-stone-*, text-zinc-*
+ */
+
+const DISALLOWED_PATTERN = /\btext-(gray|neutral|slate|stone|zinc)-\d{1,3}\b/g;
+const ERROR_MESSAGE =
+  'Disallowed Tailwind text color class: "{{ className }}". Use semantic color classes instead.';
+
+function reportAllMatches(value, context, node) {
+  if (typeof value !== "string") return;
+
+  for (const match of value.matchAll(DISALLOWED_PATTERN)) {
+    context.report({
+      node,
+      message: ERROR_MESSAGE,
+      data: { className: match[0] },
+    });
+  }
+}
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow non-semantic Tailwind text color classes (gray, neutral, slate, stone, zinc)",
+    },
+    schema: [],
+  },
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+
+    return {
+      // Check string literals in JS/TS
+      Literal(node) {
+        reportAllMatches(node.value, context, node);
+      },
+      // Check template literals
+      TemplateElement(node) {
+        reportAllMatches(node.value.raw, context, node);
+      },
+      // Check Svelte HTML attributes (class="...")
+      SvelteAttribute(node) {
+        if (node.key?.name === "class") {
+          for (const valueNode of node.value) {
+            if (valueNode.type === "SvelteLiteral") {
+              reportAllMatches(valueNode.value, context, valueNode);
+            }
+          }
+        }
+      },
+      // Check Svelte shorthand class directives (class:text-gray-500)
+      SvelteDirective(node) {
+        if (node.kind === "Class" && node.key?.name) {
+          const className = node.key.name.name || node.key.name;
+          reportAllMatches(className, context, node);
+        }
+      },
+      // Check Svelte <style> blocks
+      SvelteStyleElement(node) {
+        const styleText = sourceCode.getText(node);
+        const nodeStart = node.range[0];
+
+        for (const match of styleText.matchAll(DISALLOWED_PATTERN)) {
+          const matchStart = nodeStart + match.index;
+          const matchEnd = matchStart + match[0].length;
+
+          context.report({
+            loc: {
+              start: sourceCode.getLocFromIndex(matchStart),
+              end: sourceCode.getLocFromIndex(matchEnd),
+            },
+            message: ERROR_MESSAGE,
+            data: { className: match[0] },
+          });
+        }
+      },
+    };
+  },
+};

--- a/eslint-plugin-rill/no-disallowed-tailwind-text-colors.js
+++ b/eslint-plugin-rill/no-disallowed-tailwind-text-colors.js
@@ -32,14 +32,6 @@ export default {
     const sourceCode = context.sourceCode ?? context.getSourceCode();
 
     return {
-      // Check string literals in JS/TS
-      Literal(node) {
-        reportAllMatches(node.value, context, node);
-      },
-      // Check template literals
-      TemplateElement(node) {
-        reportAllMatches(node.value.raw, context, node);
-      },
       // Check Svelte HTML attributes (class="...")
       SvelteAttribute(node) {
         if (node.key?.name === "class") {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -67,9 +67,9 @@ export default [
   {
     ignores: [
       "**/.storybook/*",
-      "**/.svelte-kit/",
+      "**/.svelte-kit/**",
       "**/gen/*",
-      "**/node_modules",
+      "**/node_modules/**",
       "**/playwright.config.js",
       "**/postcss.config.cjs",
       "**/svelte.config.js",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ import eslintPluginSvelte from "eslint-plugin-svelte";
 import globals from "globals";
 import tsEslint from "typescript-eslint";
 import { globalIgnores } from "eslint/config";
+import rillPlugin from "./eslint-plugin-rill/index.js";
 
 export default [
   js.configs.recommended,
@@ -20,6 +21,9 @@ export default [
   },
   ...eslintPluginSvelte.configs["flat/prettier"],
   {
+    plugins: {
+      rill: rillPlugin,
+    },
     languageOptions: {
       ecmaVersion: "latest",
       sourceType: "module",
@@ -32,6 +36,7 @@ export default [
       },
     },
     rules: {
+      "rill/no-disallowed-tailwind-text-colors": "error",
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-unused-vars": [
         "error",
@@ -68,6 +73,7 @@ export default [
       "**/playwright.config.js",
       "**/postcss.config.cjs",
       "**/svelte.config.js",
+      "eslint-plugin-rill/*",
       "web-admin/build/*",
       "web-admin/playwright-report/*",
       "web-admin/playwright/*",

--- a/scripts/web-test-code-quality.sh
+++ b/scripts/web-test-code-quality.sh
@@ -72,6 +72,26 @@ echo "== NPM Install =="
 # https://typicode.github.io/husky/how-to.html#ci-server-and-docker
 HUSKY=0 npm install
 
+echo ""
+echo "== Check for disallowed Tailwind text color classes =="
+# Always check all web directories - this is fast and enforces consistent color usage
+disallowed_matches=$(grep -rn --include='*.svelte' --include='*.ts' --include='*.js' \
+  --exclude-dir='.svelte-kit' --exclude-dir='node_modules' --exclude-dir='build' \
+  -E 'text-(gray|neutral|slate|stone|zone)-[0-9]+' \
+  web-admin web-common web-local 2>/dev/null || true)
+
+if [[ -n "$disallowed_matches" ]]; then
+  echo "ERROR: Found disallowed Tailwind text color classes."
+  echo "Use semantic color classes instead of: text-gray-*, text-neutral-*, text-slate-*, text-stone-*, text-zone-*"
+  echo ""
+  echo "$disallowed_matches"
+  if [[ "$FAIL_FAST" == "true" ]]; then
+    exit 1
+  else
+    exit_code=1
+  fi
+fi
+
 if [[ "$COMMON" == "true" ]]; then
   echo ""
   echo "== lint and type checks for web common =="

--- a/scripts/web-test-code-quality.sh
+++ b/scripts/web-test-code-quality.sh
@@ -72,26 +72,6 @@ echo "== NPM Install =="
 # https://typicode.github.io/husky/how-to.html#ci-server-and-docker
 HUSKY=0 npm install
 
-echo ""
-echo "== Check for disallowed Tailwind text color classes =="
-# Always check all web directories - this is fast and enforces consistent color usage
-disallowed_matches=$(grep -rn --include='*.svelte' --include='*.ts' --include='*.js' \
-  --exclude-dir='.svelte-kit' --exclude-dir='node_modules' --exclude-dir='build' \
-  -E 'text-(gray|neutral|slate|stone|zone)-[0-9]+' \
-  web-admin web-common web-local 2>/dev/null || true)
-
-if [[ -n "$disallowed_matches" ]]; then
-  echo "ERROR: Found disallowed Tailwind text color classes."
-  echo "Use semantic color classes instead of: text-gray-*, text-neutral-*, text-slate-*, text-stone-*, text-zone-*"
-  echo ""
-  echo "$disallowed_matches"
-  if [[ "$FAIL_FAST" == "true" ]]; then
-    exit 1
-  else
-    exit_code=1
-  fi
-fi
-
 if [[ "$COMMON" == "true" ]]; then
   echo ""
   echo "== lint and type checks for web common =="

--- a/web-admin/src/features/alerts/history/NoAlertRunsYet.svelte
+++ b/web-admin/src/features/alerts/history/NoAlertRunsYet.svelte
@@ -7,7 +7,7 @@
 >
   <div class="flex flex-col justify-center items-center">
     <div class="relative">
-      <AlertCircleOutline className="text-gray-300 w-12 h-12" />
+      <AlertCircleOutline className="text-icon-muted w-12 h-12" />
     </div>
   </div>
   <div

--- a/web-admin/src/features/dashboards/DashboardErrored.svelte
+++ b/web-admin/src/features/dashboards/DashboardErrored.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <div class="flex flex-col justify-center items-center h-3/5 space-y-6 m-auto">
-  <CancelCircleInverse size="7em" className="text-gray-200" />
+  <CancelCircleInverse size="7em" className="text-icon-muted" />
   <div class="flex flex-col items-center space-y-2">
     <h1 class="text-lg font-semibold">
       Sorry, your dashboard isn't working right now!

--- a/web-admin/src/features/organizations/hibernating/OrganizationHibernatingForAdmins.svelte
+++ b/web-admin/src/features/organizations/hibernating/OrganizationHibernatingForAdmins.svelte
@@ -55,7 +55,7 @@
 {#if $wakingProjects}
   <div class="flex flex-col justify-center items-center gap-y-6 my-20">
     <div class="flex flex-col gap-y-2">
-      <LoadingCircleOutline size="104px" className="text-gray-300" />
+      <LoadingCircleOutline size="104px" className="text-icon-muted" />
       <CTAHeader>Hang tight! We're waking up your projects...</CTAHeader>
       <CTANeedHelp />
     </div>
@@ -68,7 +68,7 @@
         <svelte:component
           this={IconMap[issueForHibernation.iconType]}
           size="104px"
-          className="text-gray-300"
+          className="text-icon-muted"
           gradientStopColor="slate-200"
         />
       {/if}

--- a/web-admin/src/features/organizations/hibernating/OrganizationHibernatingForViewers.svelte
+++ b/web-admin/src/features/organizations/hibernating/OrganizationHibernatingForViewers.svelte
@@ -7,7 +7,7 @@
 
 <div class="flex flex-col justify-center items-center gap-y-6 my-20">
   <div class="flex flex-col gap-y-2">
-    <MoonCircleOutline size="104px" className="text-gray-300" />
+    <MoonCircleOutline size="104px" className="text-icon-muted" />
     <CTAHeader variant="bold">This org’s projects are hibernating</CTAHeader>
     <CTAMessage>
       Please reach out to your administrator to regain access.

--- a/web-admin/src/features/organizations/settings/LogoSettings.svelte
+++ b/web-admin/src/features/organizations/settings/LogoSettings.svelte
@@ -132,7 +132,7 @@
           {#if organizationLogoDarkUrl}
             Dark Logo
           {:else}
-            <span class="text-slate-500">Dark Logo</span>
+            <span class="text-icon-default">Dark Logo</span>
           {/if}
         </div>
         <UploadImagePopover

--- a/web-admin/src/features/organizations/user-management/table/groups/GroupCompositeCell.svelte
+++ b/web-admin/src/features/organizations/user-management/table/groups/GroupCompositeCell.svelte
@@ -93,7 +93,9 @@
       getRandomBgColor(name),
     )}
   >
-    <span class="text-sm text-white font-semibold">{getInitials(name)}</span>
+    <span class="text-sm text-fg-primary font-semibold"
+      >{getInitials(name)}</span
+    >
   </div>
   <div class="flex flex-col text-left">
     <span class="text-sm font-medium text-fg-primary flex flex-row gap-x-1">
@@ -114,7 +116,7 @@
       </div>
       <TooltipContent slot="tooltip-content">
         {#if (usersCount ?? 0) === 0}
-          <div class="text-xs text-gray-300 px-1 py-0.5">No users</div>
+          <div class="text-xs text-fg-muted px-1 py-0.5">No users</div>
         {:else if $listUsergroupMemberUsers.isLoading}
           <div class="px-1 py-0.5">
             <Spinner

--- a/web-admin/src/features/projects/environment-variables/ActivityCell.svelte
+++ b/web-admin/src/features/projects/environment-variables/ActivityCell.svelte
@@ -19,7 +19,7 @@
       <TimeAgo datetime={updatedOn} />
     </div>
     <TooltipContent slot="tooltip-content">
-      <span class="text-xs text-gray-50 font-medium">
+      <span class="text-xs font-medium">
         {fullDate}
       </span>
     </TooltipContent>

--- a/web-admin/src/features/projects/status/ProjectParseErrors.svelte
+++ b/web-admin/src/features/projects/status/ProjectParseErrors.svelte
@@ -49,7 +49,7 @@
               {error.message}
             </span>
             {#if error.filePath}
-              <span class="text-stone-500 font-semibold shrink-0">
+              <span class="text-fg-muted font-semibold shrink-0">
                 {error.filePath}
               </span>
             {/if}

--- a/web-admin/src/features/projects/status/RefreshCell.svelte
+++ b/web-admin/src/features/projects/status/RefreshCell.svelte
@@ -33,7 +33,7 @@
       {formattedDate}
     </div>
     <TooltipContent slot="tooltip-content">
-      <span class="text-xs text-gray-50 font-medium">
+      <span class="text-xs font-medium">
         {full}
       </span>
     </TooltipContent>

--- a/web-admin/src/features/projects/user-management/GeneralAccessSelectorDropdown.svelte
+++ b/web-admin/src/features/projects/user-management/GeneralAccessSelectorDropdown.svelte
@@ -144,7 +144,7 @@
               getRandomBgColor(`Everyone at ${organization}`),
             )}
           >
-            <span class="text-sm text-white font-semibold"
+            <span class="text-sm text-fg-primary font-semibold"
               >{getInitials(`Everyone at ${organization}`)}</span
             >
           </div>
@@ -220,7 +220,7 @@
         <div
           class="h-5 w-5 flex items-center justify-center bg-primary-600 rounded-sm"
         >
-          <span class="text-xs text-white font-semibold"
+          <span class="text-xs text-fg-primary font-semibold"
             >{organization[0].toUpperCase()}</span
           >
         </div>

--- a/web-admin/src/features/scheduled-reports/history/NoRunsYet.svelte
+++ b/web-admin/src/features/scheduled-reports/history/NoRunsYet.svelte
@@ -7,7 +7,7 @@
 >
   <div class="flex flex-col justify-center items-center">
     <div class="relative">
-      <ReportIcon className="text-gray-300 w-12 h-12" />
+      <ReportIcon className="text-icon-muted w-12 h-12" />
     </div>
   </div>
   <div

--- a/web-common/src/components/avatar/Avatar.svelte
+++ b/web-common/src/components/avatar/Avatar.svelte
@@ -41,12 +41,12 @@
       <Avatar.Image {src} {alt} />
       {#if alt}
         <!-- Show a fallback if the image fails to load -->
-        <Avatar.Fallback class={cn(fontSize, "text-white")}>
+        <Avatar.Fallback class={cn(fontSize, "text-fg-primary")}>
           {getInitials(alt ?? "")}
         </Avatar.Fallback>
       {/if}
     {:else if alt}
-      <Avatar.Fallback class={cn(fontSize, "text-white")}>
+      <Avatar.Fallback class={cn(fontSize, "text-fg-primary")}>
         {getInitials(alt)}
       </Avatar.Fallback>
     {:else}

--- a/web-common/src/components/avatar/AvatarListItem.svelte
+++ b/web-common/src/components/avatar/AvatarListItem.svelte
@@ -50,7 +50,9 @@
         getRandomBgColor(email ?? name),
       )}
     >
-      <span class="text-sm text-white font-semibold">{getInitials(name)}</span>
+      <span class="text-sm text-fg-primary font-semibold"
+        >{getInitials(name)}</span
+      >
     </div>
   {/if}
   <div class="flex flex-col text-left">

--- a/web-common/src/components/button/Button.svelte
+++ b/web-common/src/components/button/Button.svelte
@@ -255,6 +255,10 @@
     @apply text-fg-muted p-0;
   }
 
+  .text:focus {
+    @apply shadow-none;
+  }
+
   .text:hover {
     @apply text-primary-700;
   }
@@ -287,6 +291,10 @@
     @apply font-normal text-fg-muted;
     @apply h-6 px-1.5 rounded-sm;
     @apply gap-x-1.5;
+  }
+
+  .toolbar:focus {
+    @apply shadow-none;
   }
 
   .toolbar:hover:not(:disabled) {

--- a/web-common/src/components/button/classes.ts
+++ b/web-common/src/components/button/classes.ts
@@ -2,7 +2,7 @@ export const disabledClasses = `disabled:cursor-not-allowed disabled:text-fg-pri
 
 export const levels = {
   info: {
-    primary: `bg-gray-800 text-white border rounded-sm border-gray-800 hover:bg-gray-700 hover:border-gray-700 focus:ring-primary-300`,
+    primary: `bg-gray-800 text-fg-primary border rounded-sm border-gray-800 hover:bg-gray-700 hover:border-gray-700 focus:ring-primary-300`,
     secondary:
       "text-fg-primary border rounded-sm border-gray-300 shadow-sm hover:bg-surface-hover hover:text-fg-primary hover:border-gray-300 focus:ring-primary-300",
     highlighted:

--- a/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampTooltipContent.svelte
+++ b/web-common/src/components/data-graphic/compositions/timestamp-profile/TimestampTooltipContent.svelte
@@ -47,7 +47,7 @@
           {#if zooming}<span>Zoomed</span>{:else}<span>Zooming</span>{/if}
           to {formatInteger(zoomedRows)} row{#if zoomedRows !== 1}s{/if}
         </div>
-        <div class="text-right text-gray-300 font-normal not-italic">
+        <div class="text-right text-fg-inverse font-normal not-italic">
           {formatBigNumberPercentage(zoomedRows / totalRows)}
         </div>
       </div>

--- a/web-common/src/components/date-picker/Day.svelte
+++ b/web-common/src/components/date-picker/Day.svelte
@@ -92,7 +92,7 @@
 >
   <div
     class="day {overlapClass}"
-    class:text-fg-secondary={outOfMonth}
+    class:text-fg-disabled={outOfMonth}
     class:potential={!!potentialInterval}
     class:anchor={areSameDay(anchorDay, date)}
   >
@@ -108,11 +108,11 @@
   }
 
   .day:disabled {
-    @apply pointer-events-none text-gray-300;
+    @apply pointer-events-none text-fg-disabled;
   }
 
   button:hover .day:not(.potential) {
-    @apply bg-primary-300 text-white;
+    @apply bg-primary-300 text-fg-primary;
   }
 
   button:hover .day:not(.in-range, .start, .end) {
@@ -123,7 +123,7 @@
   .start.potential,
   .end.potential,
   .full-interval.potential {
-    @apply bg-gray-200 text-fg-primary;
+    @apply bg-surface-hover text-fg-primary;
   }
 
   .in-range,
@@ -131,7 +131,7 @@
   .end,
   .full-interval,
   .anchor.potential {
-    @apply bg-primary-400 text-white;
+    @apply bg-primary-400 text-fg-primary;
   }
 
   .end,

--- a/web-common/src/components/dialog/tabs/NumberedCircle.svelte
+++ b/web-common/src/components/dialog/tabs/NumberedCircle.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <div
-  class="w-[18px] h-[18px] text-white rounded-full inline-flex items-center justify-center {bgColor}"
+  class="w-[18px] h-[18px] text-fg-primary rounded-full inline-flex items-center justify-center {bgColor}"
 >
   {number}
 </div>

--- a/web-common/src/components/forms/Checkbox.svelte
+++ b/web-common/src/components/forms/Checkbox.svelte
@@ -41,7 +41,7 @@
     )}
   >
     <CheckboxPrimitive.Indicator
-      class={cn("flex items-center justify-center text-white")}
+      class={cn("flex items-center justify-center text-fg-primary")}
     >
       <Check class="h-3.5 w-3.5" />
     </CheckboxPrimitive.Indicator>

--- a/web-common/src/components/forms/IconSwitcher.svelte
+++ b/web-common/src/components/forms/IconSwitcher.svelte
@@ -29,7 +29,7 @@
       </Tooltip.Trigger>
 
       <Tooltip.Content class="z-[1000]" sideOffset={8}>
-        <div class="bg-gray-700 text-white rounded p-2 pt-1 pb-1">
+        <div class="bg-gray-700 text-fg-primary rounded p-2 pt-1 pb-1">
           {tooltip}
         </div>
       </Tooltip.Content>

--- a/web-common/src/components/icons/SendIcon.svelte
+++ b/web-common/src/components/icons/SendIcon.svelte
@@ -5,7 +5,7 @@
   export let disabled = false;
 
   $: backgroundClass = disabled ? "fill-gray-300" : "fill-primary-400";
-  $: arrowClass = "text-gray-100";
+  $: arrowClass = "text-fg-primary";
 </script>
 
 <svg

--- a/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
+++ b/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
@@ -24,7 +24,7 @@
   let active = false;
 
   const toggleButtonBaseClass =
-    "flex h-[26px] w-[42px] items-center justify-center rounded-sm text-icon-muted transition-colors hover:bg-surface-hover hover:text-fg-primary active:bg-gray-300 disabled:text-gray-300 disabled:cursor-not-allowed";
+    "flex h-[26px] w-[42px] items-center justify-center rounded-sm text-icon-muted transition-colors hover:bg-surface-hover hover:text-fg-primary active:bg-surface-active disabled:text-fg-disabled disabled:cursor-not-allowed";
 
   $: allItemsMap = new Map(allItems.map((item) => [item.name, item]));
   $: numAvailable = allItems?.length ?? 0;

--- a/web-common/src/components/tooltip/LongDescription.svelte
+++ b/web-common/src/components/tooltip/LongDescription.svelte
@@ -9,7 +9,7 @@
   /** we are setting the tooltip content code block styling here, since this is sometimes 
 programmatically returned by the runtime **/
   :global(.long-tooltip-description code) {
-    @apply px-2 py-1 bg-gray-900 text-gray-100 rounded break-words w-max;
+    @apply px-2 py-1 bg-gray-900 text-fg-primary rounded break-words w-max;
     transform: translateX(-0.5rem);
     display: block;
   }

--- a/web-common/src/components/tooltip/Shortcut.svelte
+++ b/web-common/src/components/tooltip/Shortcut.svelte
@@ -1,3 +1,3 @@
-<div class="text-right dark:text-fg-secondary text-gray-400">
+<div class="text-right dark:text-fg-inverse/30">
   <slot />
 </div>

--- a/web-common/src/components/tooltip/TooltipDescription.svelte
+++ b/web-common/src/components/tooltip/TooltipDescription.svelte
@@ -1,4 +1,4 @@
-<p class="text-fg-muted dark:text-fg-secondary my-1 w-full line-clamp-15">
+<p class="text-fg-inverse/90 my-1 w-full line-clamp-15">
   <slot />
 </p>
 

--- a/web-common/src/components/tooltip/TooltipShortcutContainer.svelte
+++ b/web-common/src/components/tooltip/TooltipShortcutContainer.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <div
-  class=" grid gap-x-6 items-baseline dark:text-fg-muted text-gray-300"
+  class=" grid gap-x-6 items-baseline dark:text-fg-muted text-fg-inverse/60"
   class:pb-1={padBottom}
   class:pt-1={padTop}
   style="grid-template-columns: auto max-content"

--- a/web-common/src/components/virtualized-table/VirtualTableRow.svelte
+++ b/web-common/src/components/virtualized-table/VirtualTableRow.svelte
@@ -136,7 +136,7 @@
     box-shadow: 2px 0 0 0px var(--color-gray-200);
   }
 
-  .selected {
-    @apply text-black font-bold;
+  .selected td:not(:first-of-type) {
+    @apply bg-surface-active font-bold;
   }
 </style>

--- a/web-common/src/features/alerts/PreviewEmpty.svelte
+++ b/web-common/src/features/alerts/PreviewEmpty.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <div class="pt-5 pb-10 flex flex-col justify-center items-center gap-1">
-  <TableIcon size="32px" className="text-gray-300" />
+  <TableIcon size="32px" className="text-icon-muted" />
   <div class="flex flex-col justify-center items-center text-sm">
     <div class="text-fg-secondary font-semibold">{topLine}</div>
     <div class="text-fg-secondary font-normal">

--- a/web-common/src/features/alerts/data-tab/NoFiltersSelected.svelte
+++ b/web-common/src/features/alerts/data-tab/NoFiltersSelected.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <div class="flex flex-col items-center pt-5 pb-10 gap-y-1">
-  <Filter size="32px" className="text-gray-300" />
+  <Filter size="32px" className="text-icon-muted" />
   <div class="flex flex-col items-center">
     <h3 class="text-sm font-semibold text-fg-secondary">No filters selected</h3>
     <span class="text-sm text-fg-secondary">

--- a/web-common/src/features/canvas/AddComponentDropdown.svelte
+++ b/web-common/src/features/canvas/AddComponentDropdown.svelte
@@ -75,7 +75,7 @@
         use:builder.action
         class:pr-3.5={open}
         aria-label="Add widget"
-        class="shadow-lg flex group hover:rounded-3xl w-fit gap-x-1 p-2 hover:pr-3.5 absolute bottom-3 right-3 items-center justify-center z-50 rounded-full bg-primary-600 text-white hover:bg-primary-500"
+        class="shadow-lg flex group hover:rounded-3xl w-fit gap-x-1 p-2 hover:pr-3.5 absolute bottom-3 right-3 items-center justify-center z-50 rounded-full bg-primary-600 text-fg-primary hover:bg-primary-500"
       >
         <Plus size="20px" />
 

--- a/web-common/src/features/chat/core/context/InlineContext.svelte
+++ b/web-common/src/features/chat/core/context/InlineContext.svelte
@@ -95,7 +95,7 @@
           </span>
         </Tooltip.Trigger>
         <!-- TODO: we do not have the correct styles for tooltip. Update app wise in a future PR. -->
-        <Tooltip.Content class="bg-black text-white">
+        <Tooltip.Content class="bg-black text-fg-primary">
           {tooltip}
         </Tooltip.Content>
       </Tooltip.Root>

--- a/web-common/src/features/chat/core/context/picker/SimpleOption.svelte
+++ b/web-common/src/features/chat/core/context/picker/SimpleOption.svelte
@@ -38,7 +38,7 @@
     {/if}
   </div>
   {#if icon}
-    <div class="text-gray-500">
+    <div class="text-fg-muted">
       <svelte:component this={icon} size="16px" />
     </div>
   {:else}

--- a/web-common/src/features/column-profile/column-types/sparks/NullPercentageSpark.svelte
+++ b/web-common/src/features/column-profile/column-types/sparks/NullPercentageSpark.svelte
@@ -30,9 +30,10 @@
       <span
         style:font-size="{COLUMN_PROFILE_CONFIG.fontSize}px"
         class="ui-copy-number"
-        class:text-gray-300={nullCount === 0}
-        >{singleDigitPercentage(percentage)}</span
+        class:text-fg-muted={nullCount === 0}
       >
+        {singleDigitPercentage(percentage)}
+      </span>
     </BarAndLabel>
     <TooltipContent slot="tooltip-content">
       {#if nullCount > 0}

--- a/web-common/src/features/dashboards/granular-access-policies/ViewAsButton.svelte
+++ b/web-common/src/features/dashboards/granular-access-policies/ViewAsButton.svelte
@@ -78,7 +78,7 @@
     <DropdownMenu.Separator />
     <DropdownMenu.Item
       href={`/files/rill.yaml?addMockUser=true`}
-      class="flex gap-x-2 items-center text-black font-normal"
+      class="flex gap-x-2 items-center text-fg-primary font-normal"
     >
       <Add color={iconColor} size="16px" />
       Add mock user

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -135,7 +135,6 @@
     class:w-full={$dynamicHeight}
     class:size-full={!$dynamicHeight}
   >
-    <div class="whatever" class:text-slate-100={true}>"text-slate-100"</div>
     <div
       id="header"
       class="border-b w-fit min-w-full flex flex-col bg-surface-subtle slide"

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -135,6 +135,7 @@
     class:w-full={$dynamicHeight}
     class:size-full={!$dynamicHeight}
   >
+    <div class="whatever" class:text-slate-100={true}>"text-slate-100"</div>
     <div
       id="header"
       class="border-b w-fit min-w-full flex flex-col bg-surface-subtle slide"

--- a/web-common/src/features/models/inspector/WithModelResultTooltip.svelte
+++ b/web-common/src/features/models/inspector/WithModelResultTooltip.svelte
@@ -19,11 +19,11 @@
       </svelte:fragment>
     </TooltipTitle>
     <div class="pb-1 leading-4">
-      <p class="text-gray-200">
+      <p class="text-fg-inverse/90">
         <slot name="tooltip-description" />
       </p>
       {#if modelHasError}
-        <p class="italic pt-2 text-gray-100">
+        <p class="italic pt-2 text-fg-inverse/60">
           <span
             class="inline-grid place-items-center"
             style:transform="translateY(1px)"

--- a/web-common/src/features/project/MergeConflictResolutionDialog.svelte
+++ b/web-common/src/features/project/MergeConflictResolutionDialog.svelte
@@ -27,10 +27,10 @@
         >
           <AlertCircleIcon class="text-yellow-700 -mt-0.5" size={28} />
           <div class="flex flex-col gap-y-1">
-            <h3 class="text-base font-medium text-black">
+            <h3 class="text-base font-medium text-fg-secondary">
               What are merge conflicts?
             </h3>
-            <div class="text-sm text-fg-secondary">
+            <div class="text-sm text-fg-tertiary">
               Conflicts occur when same part of the file has been changed in
               different ways. You need to choose which version to keep.
             </div>

--- a/web-common/src/features/project/deploy/DeployError.svelte
+++ b/web-common/src/features/project/deploy/DeployError.svelte
@@ -37,14 +37,14 @@
   <Button type="primary" href={planUpgradeUrl} wide>Upgrade</Button>
   <Button type="secondary" noStroke wide onClick={onBack}>Back</Button>
 {:else if isGithubNoAccessError}
-  <CancelCircleInverse size="7rem" className="text-gray-200" />
+  <CancelCircleInverse size="7rem" className="text-icon-muted" />
   <CTAHeader variant="bold">{deployError.title}</CTAHeader>
   <CTAMessage>{deployError.message}</CTAMessage>
   <CTAButton variant="secondary" href={githubAccessUrl}>
     Retry connection
   </CTAButton>
 {:else}
-  <CancelCircleInverse size="7rem" className="text-gray-200" />
+  <CancelCircleInverse size="7rem" className="text-icon-muted" />
   <CTAHeader variant="bold">{deployError.title}</CTAHeader>
   <CTAMessage>{deployError.message}</CTAMessage>
   {#if deployError.type === DeployErrorType.Unknown}

--- a/web-common/src/features/resource-graph/graph-canvas/ResourceNode.svelte
+++ b/web-common/src/features/resource-graph/graph-canvas/ResourceNode.svelte
@@ -305,7 +305,7 @@
   .toolbar-open-btn {
     @apply h-7 px-3 rounded-[2px] border flex items-center justify-center gap-x-1.5 shadow-sm transition-colors;
     @apply text-xs font-medium;
-    @apply bg-primary-600 text-white border-primary-600;
+    @apply bg-primary-600 text-fg-primary border-primary-600;
   }
 
   .toolbar-open-btn:focus {

--- a/web-common/src/features/resource-graph/shared/errors/ErrorBoundary.svelte
+++ b/web-common/src/features/resource-graph/shared/errors/ErrorBoundary.svelte
@@ -176,7 +176,7 @@
   }
 
   .btn-primary {
-    @apply rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white;
+    @apply rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-fg-primary;
   }
 
   .btn-primary:hover {

--- a/web-common/src/features/sources/modal/FileDrop.svelte
+++ b/web-common/src/features/sources/modal/FileDrop.svelte
@@ -74,7 +74,7 @@
     role="presentation"
   >
     <div
-      class="grid place-content-center grid-gap-2 text-white m-auto p-6 break-all text-3xl"
+      class="grid place-content-center grid-gap-2 text-fg-primary m-auto p-6 break-all text-3xl"
     >
       <span class="place-content-center">
         drop your files to add new source

--- a/web-common/src/features/welcome/TitleContent.svelte
+++ b/web-common/src/features/welcome/TitleContent.svelte
@@ -40,9 +40,9 @@
     on:click={openShowAddSourceModal}
   >
     <div
-      class="flex flex-row gap-x-1 items-center text-sm font-medium text-white"
+      class="flex flex-row gap-x-1 items-center text-sm font-medium text-fg-primary"
     >
-      <Add className="text-white" />
+      <Add className="text-fg-primary" />
       Connect your data
     </div>
   </button>

--- a/web-common/src/features/workspaces/VisualMetrics.svelte
+++ b/web-common/src/features/workspaces/VisualMetrics.svelte
@@ -687,7 +687,7 @@
 
       {#if totalSelected}
         <div
-          class="bg-surface-subtle rounded-[2px] z-20 shadow-md flex gap-x-0 h-8 text-gray-700 border border-slate-100 absolute right-0"
+          class="bg-surface-subtle rounded-[2px] z-20 shadow-md flex gap-x-0 h-8 text-fg-secondary border border-slate-100 absolute right-0"
         >
           <div class="px-2 flex items-center">
             {totalSelected}

--- a/web-common/src/layout/BlockingOverlayContainer.svelte
+++ b/web-common/src/layout/BlockingOverlayContainer.svelte
@@ -23,12 +23,12 @@
 <Overlay {bg}>
   <div
     transition:fly|global={{ duration: 200, y: 16 }}
-    class="text-white text-center flex flex-col gap-y-4"
+    class="text-fg-primary text-center flex flex-col gap-y-4"
     style:width="540px"
   >
     <div class="flex flex-col gap-y-3">
       <div
-        class="grid place-content-center grid-gap-2 text-white m-auto p-6 break-all"
+        class="grid place-content-center grid-gap-2 text-fg-primary m-auto p-6 break-all"
         style:font-size="48px"
       >
         <div class="on" style="--length: {2000 + Math.random() * 5000}ms;">

--- a/web-common/tailwind.config.ts
+++ b/web-common/tailwind.config.ts
@@ -4,6 +4,14 @@ import {
   TailwindColors,
 } from "./src/features/themes/color-config";
 
+const blockedTextColors = ["gray", "neutral", "slate", "stone", "zinc"];
+
+const TEXT_BLOCKLIST = blockedTextColors
+  .map((color) => {
+    return TailwindColorSpacing.map((spacing) => `text-${color}-${spacing}`);
+  })
+  .flat();
+
 function generateTailwindVariables() {
   const colors: Record<string, Record<string, string>> = {};
 
@@ -155,4 +163,5 @@ export default {
       },
     },
   },
+  blocklist: TEXT_BLOCKLIST,
 } satisfies Config;

--- a/web-local/src/routes/(misc)/deploy/+page.svelte
+++ b/web-local/src/routes/(misc)/deploy/+page.svelte
@@ -116,7 +116,7 @@
   </CTAHeader>
   <CTANeedHelp />
 {:else if error}
-  <CancelCircleInverse size="7rem" className="text-gray-200" />
+  <CancelCircleInverse size="7rem" className="text-icon-muted" />
   <CTAHeader variant="bold">Oops! An error occurred</CTAHeader>
   <CTAMessage>{error.message}</CTAMessage>
 {/if}


### PR DESCRIPTION
## Summary

This PR adds a custom eslint rule that checks for usage of `neutral`, `zinc`, `slate`, `stone` and `gray` Tailwind colors in `text-` prefixed utility classes. It also adds these potential classes to the Tailwind config blocklist so that they aren't generated to begin with.

<img width="833" height="156" alt="Screenshot 2026-01-27 at 3 01 16 PM" src="https://github.com/user-attachments/assets/a5d306b6-a3e7-42b4-818e-e172254e6d02" />


To comply with the new rule, this PR also removes any remaining classes that followed this pattern.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
