### PR TITLE
Grant admins `ReadInstance` permission

### DIFF
--- a/admin/server/projects.go
+++ b/admin/server/projects.go
@@ -432,7 +432,12 @@ func (s *Server) GetProject(ctx context.Context, req *adminv1.GetProjectRequest)
 		runtime.UseAI,
 	}
 	if permissions.ManageProject {
-		instancePermissions = append(instancePermissions, runtime.EditTrigger, runtime.ReadResolvers)
+		instancePermissions = append(
+			instancePermissions,
+			runtime.ReadInstance,
+			runtime.ReadResolvers,
+			runtime.EditTrigger,
+		)
 	}
 
 	var systemPermissions []runtime.Permission


### PR DESCRIPTION
Enables admins to get info about the project's connectors when calling `GetInstance` with `sensitive: true`.

**Checklist:**
- [x] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
