### PR TITLE
fix: copy value formatting of column headers

### DIFF
--- a/web-common/src/components/virtualized-table/VirtualTable.svelte
+++ b/web-common/src/components/virtualized-table/VirtualTable.svelte
@@ -214,10 +214,16 @@
     if (!hovering) return;
 
     if (e.shiftKey) {
-      let exportedValue = formatDataTypeAsDuckDbQueryString(
-        hovering.value,
-        hovering.type,
-      );
+      let exportedValue = "";
+      if (hovering?.isHeader) {
+        exportedValue =
+          hovering.value === null ? "null" : hovering.value.toString();
+      } else {
+        exportedValue = formatDataTypeAsDuckDbQueryString(
+          hovering.value,
+          hovering.type,
+        );
+      }
 
       copyToClipboard(exportedValue);
 


### PR DESCRIPTION
We are trying to format column header values using the column type. This will be incorrect for things like timestamp.

Closes APP-702

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
