### PR TITLE
DuckDB Managed JSON Schema

### DIFF
--- a/web-common/src/features/templates/schemas/duckdb.ts
+++ b/web-common/src/features/templates/schemas/duckdb.ts
@@ -15,7 +15,7 @@ export const duckdbSchema: MultiStepFormSchema = {
       type: "string",
       title: "Connection type",
       enum: ["rill-managed", "self-hosted"],
-      default: "self-hosted",
+      default: "rill-managed",
       "x-display": "radio",
       "x-enum-labels": ["Rill-managed DuckDB", "Self-hosted DuckDB"],
       "x-ui-only": true,


### PR DESCRIPTION
This PR adds "Rill-managed DuckDB" as a connector type option alongside "Self-hosted DuckDB". The Rill-managed option requires no configuration - Rill handles infrastructure setup. The self-hosted option continues to require a path to an external DuckDB database.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
