### PR TITLE
Rill developer widget text

### DIFF
--- a/web-common/src/features/onboarding/OnboardingWorkspace.svelte
+++ b/web-common/src/features/onboarding/OnboardingWorkspace.svelte
@@ -64,7 +64,7 @@
       <div class="mx-auto">
         <ImportData />
       </div>
-      <Button type="primary" onClick={addSourceModal.open}>+ Connect Data</Button>
+      <Button type="primary" onClick={addSourceModal.open} large forcedStyle="height: 3rem;">+ Connect Data</Button>
     </div>
 
     <div class="my-auto text-gray-400 text-base">or</div>

--- a/web-common/src/features/onboarding/OnboardingWorkspace.svelte
+++ b/web-common/src/features/onboarding/OnboardingWorkspace.svelte
@@ -56,15 +56,15 @@
   <div class="cta-container">
     <div class="import-data-container cta-item">
       <div class="flex flex-col gap-y-1">
-        <div class="font-semibold text-base">Import data</div>
+        <div class="font-semibold text-base">Connect to your data</div>
         <div class="text-xs">
-          Add or drag a file here (Parquet, NDJSON, CSV).
+          Query OLAP engines or ingest files
         </div>
       </div>
       <div class="mx-auto">
         <ImportData />
       </div>
-      <Button type="primary" onClick={addSourceModal.open}>+ Add Data</Button>
+      <Button type="primary" onClick={addSourceModal.open}>+ Connect Data</Button>
     </div>
 
     <div class="my-auto text-gray-400 text-base">or</div>
@@ -127,7 +127,7 @@
   <div class="flex flex-col mx-auto w-fit gap-y-2 text-xs text-slate-500">
     <div class="font-semibold text-center">Tips for data workflow in rill</div>
     <ul class="list-decimal">
-      <li>Import data – Add or drag files (Parquet, NDJSON, CSV).</li>
+      <li>Connect to your data – Query OLAP engines or ingest files.</li>
       <li>Model sources – Combine and shape data with SQL.</li>
       <li>Define metrics – Create metrics and dimensions.</li>
       <li>Explore insights – Visualize data in interactive dashboards.</li>

--- a/web-local/tests/init.spec.ts
+++ b/web-local/tests/init.spec.ts
@@ -24,7 +24,7 @@ test.describe("Example project initialization", () => {
       await page.getByRole("link", { name: "Empty Project" }).click();
 
       await expect(
-        page.getByText("Import data", { exact: true }),
+        page.getByText("Connect to your data", { exact: true }),
       ).toBeVisible();
 
       await page.getByRole("link", { name: "rill.yaml" }).click();

--- a/web-local/tests/rill-yaml.spec.ts
+++ b/web-local/tests/rill-yaml.spec.ts
@@ -18,7 +18,7 @@ test.describe("Default olap_connector behavior", () => {
     page,
   }) => {
     await page.getByRole("link", { name: "Empty Project" }).click();
-    await expect(page.getByText("Import data", { exact: true })).toBeVisible();
+    await expect(page.getByText("Connect to your data", { exact: true })).toBeVisible();
 
     await page.getByRole("link", { name: "rill.yaml" }).click();
     // Wait for navigation to complete
@@ -30,7 +30,7 @@ test.describe("Default olap_connector behavior", () => {
     page,
   }) => {
     await page.getByRole("link", { name: "Empty Project" }).click();
-    await expect(page.getByText("Import data", { exact: true })).toBeVisible();
+    await expect(page.getByText("Connect to your data", { exact: true })).toBeVisible();
 
     await uploadFile(page, "AdBids.csv");
 
@@ -49,9 +49,9 @@ test.describe("Default olap_connector behavior", () => {
     page,
   }) => {
     await page.getByRole("link", { name: "Empty Project" }).click();
-    await expect(page.getByText("Import data", { exact: true })).toBeVisible();
+    await expect(page.getByText("Connect to your data", { exact: true })).toBeVisible();
 
-    await page.getByRole("button", { name: "Add Data" }).click();
+    await page.getByRole("button", { name: "Connect Data" }).click();
     await page.locator("#clickhouse").click();
     await page.getByRole("radio", { name: "Rill-managed ClickHouse" }).check();
     await page


### PR DESCRIPTION
Updates the Rill Developer home page widget text to better reflect Rill's capabilities, emphasizing direct connections to OLAP engines and data ingestion.

Specifically, this PR:
- Changes the widget title from `Import data` to `Connect to your data`.
- Updates the body text from `Add or drag a file here (Parquet, NDJSON, CSV)` to `Query OLAP engines or ingest files` to highlight OLAP query capabilities.
- Modifies the CTA button from `+ Add Data` to `+ Connect Data`.
- Updates the related tips section and relevant test files to reflect these changes.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-714](https://linear.app/rilldata/issue/APP-714/update-rill-developer-home-page-widget-text)

<a href="https://cursor.com/background-agent?bcId=bc-fefd548c-23d1-4665-9249-45505edc68c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fefd548c-23d1-4665-9249-45505edc68c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

