### PR TITLE
Left navigation scroll behavior

### DIFF
--- a/web-admin/src/components/nav/LeftNav.svelte
+++ b/web-admin/src/components/nav/LeftNav.svelte
@@ -12,7 +12,7 @@
   }[];
 </script>
 
-<div class="nav-items" style:min-width={minWidth}>
+<div class="nav-sidebar" style:min-width={minWidth}>
   <!-- if hasPermission is not provided, it will be undefined -->
   {#each navItems as { label, route, hasPermission = true } (route)}
     {#if hasPermission}
@@ -26,7 +26,15 @@
 </div>
 
 <style lang="postcss">
-  .nav-items {
-    @apply flex flex-col gap-y-2;
+  .nav-sidebar {
+    @apply flex flex-col gap-y-2 shrink-0;
+  }
+
+  @media (min-width: 768px) {
+    .nav-sidebar {
+      position: sticky;
+      top: 0;
+      align-self: flex-start;
+    }
   }
 </style>

--- a/web-admin/src/routes/[organization]/-/settings/+layout.svelte
+++ b/web-admin/src/routes/[organization]/-/settings/+layout.svelte
@@ -34,21 +34,27 @@
 </script>
 
 <ContentContainer title="Organization settings" maxWidth={1100}>
-  <div class="container flex-col md:flex-row">
+  <div class="settings-layout">
     <LeftNav
       {basePage}
       baseRoute="/[organization]/-/settings"
       {navItems}
       minWidth="180px"
     />
-    <div class="flex flex-col gap-y-6 w-full">
+    <div class="flex flex-col gap-y-6 w-full min-w-0">
       <slot />
     </div>
   </div>
 </ContentContainer>
 
 <style lang="postcss">
-  .container {
-    @apply flex pt-6 gap-6 max-w-full overflow-hidden;
+  .settings-layout {
+    @apply flex flex-col pt-6 gap-6 max-w-full;
+  }
+
+  @media (min-width: 768px) {
+    .settings-layout {
+      @apply flex-row items-start;
+    }
   }
 </style>

--- a/web-admin/src/routes/[organization]/-/users/+layout.svelte
+++ b/web-admin/src/routes/[organization]/-/users/+layout.svelte
@@ -38,14 +38,22 @@
 </script>
 
 <ContentContainer title="Manage users" maxWidth={1100}>
-  <div class="container flex-col md:flex-row">
+  <div class="settings-layout">
     <LeftNav {basePage} baseRoute="/[organization]/-/users" {navItems} />
-    <slot />
+    <div class="flex flex-col gap-y-6 w-full min-w-0">
+      <slot />
+    </div>
   </div>
 </ContentContainer>
 
 <style lang="postcss">
-  .container {
-    @apply flex pt-6 gap-6 max-w-full overflow-hidden;
+  .settings-layout {
+    @apply flex flex-col pt-6 gap-6 max-w-full;
+  }
+
+  @media (min-width: 768px) {
+    .settings-layout {
+      @apply flex-row items-start;
+    }
   }
 </style>

--- a/web-admin/src/routes/[organization]/[project]/-/settings/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/settings/+layout.svelte
@@ -24,19 +24,27 @@
 </script>
 
 <ContentContainer title="Project settings" maxWidth={1100}>
-  <div class="container flex-col md:flex-row">
+  <div class="settings-layout">
     <LeftNav
       {basePage}
       baseRoute="/[organization]/[project]/-/settings"
       {navItems}
       minWidth="180px"
     />
-    <slot />
+    <div class="flex flex-col gap-y-6 w-full min-w-0">
+      <slot />
+    </div>
   </div>
 </ContentContainer>
 
 <style lang="postcss">
-  .container {
-    @apply flex pt-6 gap-6 max-w-full overflow-hidden;
+  .settings-layout {
+    @apply flex flex-col pt-6 gap-6 max-w-full;
+  }
+
+  @media (min-width: 768px) {
+    .settings-layout {
+      @apply flex-row items-start;
+    }
   }
 </style>


### PR DESCRIPTION
Fixes APP-712: Implements sticky left navigation on organization and project settings pages, preventing it from scrolling past the top of the screen.

The previous attempts to fix this caused PostCSS parsing errors due to responsive Tailwind variants (`md:flex-row`) inside `@apply` directives. This PR resolves it by:
- Using explicit CSS `@media` queries for responsive styling of the layout and sticky navigation.
- Applying `position: sticky`, `top: 0`, and `align-self: flex-start` to the left nav on medium+ screens.
- Ensuring content areas have `min-w-0` to prevent overflow within the flex container.

This replicates the desired Vercel-like behavior where the page header scrolls away, but the left nav remains fixed.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-712](https://linear.app/rilldata/issue/APP-712/make-sure-that-the-left-nav-doesnt-scroll-when-user-scrolls-down-the)

<a href="https://cursor.com/background-agent?bcId=bc-886f632d-e9b0-42f0-9a39-0901de55e280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-886f632d-e9b0-42f0-9a39-0901de55e280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

