### PR TITLE
fix: chart selector icon colors adaptive to theme mode

### DIFF
--- a/web-common/src/components/icons/Heatmap.svelte
+++ b/web-common/src/components/icons/Heatmap.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   export let size = "24";
-  export let color = "currentColor";
+  export let primaryColor = "#3524C7";
+  export let secondaryColor = "#9CABFF";
 </script>
 
 <svg
@@ -10,20 +11,20 @@
   fill="none"
   xmlns="http://www.w3.org/2000/svg"
 >
-  <rect x="2" y="2" width="4" height="4" fill={color} opacity="0.2" />
-  <rect x="7" y="2" width="4" height="4" fill={color} opacity="0.4" />
-  <rect x="12" y="2" width="4" height="4" fill={color} opacity="0.6" />
-  <rect x="17" y="2" width="4" height="4" fill={color} opacity="0.8" />
-  <rect x="2" y="7" width="4" height="4" fill={color} opacity="0.3" />
-  <rect x="7" y="7" width="4" height="4" fill={color} opacity="0.5" />
-  <rect x="12" y="7" width="4" height="4" fill={color} opacity="0.7" />
-  <rect x="17" y="7" width="4" height="4" fill={color} opacity="0.9" />
-  <rect x="2" y="12" width="4" height="4" fill={color} opacity="0.4" />
-  <rect x="7" y="12" width="4" height="4" fill={color} opacity="0.6" />
-  <rect x="12" y="12" width="4" height="4" fill={color} opacity="0.8" />
-  <rect x="17" y="12" width="4" height="4" fill={color} />
-  <rect x="2" y="17" width="4" height="4" fill={color} opacity="0.5" />
-  <rect x="7" y="17" width="4" height="4" fill={color} opacity="0.7" />
-  <rect x="12" y="17" width="4" height="4" fill={color} opacity="0.9" />
-  <rect x="17" y="17" width="4" height="4" fill={color} />
+  <rect x="2" y="2" width="4" height="4" fill={secondaryColor} opacity="0.3" />
+  <rect x="7" y="2" width="4" height="4" fill={secondaryColor} opacity="0.5" />
+  <rect x="12" y="2" width="4" height="4" fill={primaryColor} opacity="0.4" />
+  <rect x="17" y="2" width="4" height="4" fill={primaryColor} opacity="0.6" />
+  <rect x="2" y="7" width="4" height="4" fill={secondaryColor} opacity="0.4" />
+  <rect x="7" y="7" width="4" height="4" fill={secondaryColor} opacity="0.7" />
+  <rect x="12" y="7" width="4" height="4" fill={primaryColor} opacity="0.6" />
+  <rect x="17" y="7" width="4" height="4" fill={primaryColor} opacity="0.8" />
+  <rect x="2" y="12" width="4" height="4" fill={secondaryColor} opacity="0.6" />
+  <rect x="7" y="12" width="4" height="4" fill={secondaryColor} opacity="0.9" />
+  <rect x="12" y="12" width="4" height="4" fill={primaryColor} opacity="0.8" />
+  <rect x="17" y="12" width="4" height="4" fill={primaryColor} />
+  <rect x="2" y="17" width="4" height="4" fill={secondaryColor} opacity="0.8" />
+  <rect x="7" y="17" width="4" height="4" fill={secondaryColor} />
+  <rect x="12" y="17" width="4" height="4" fill={primaryColor} opacity="0.9" />
+  <rect x="17" y="17" width="4" height="4" fill={primaryColor} />
 </svg>

--- a/web-common/src/features/canvas/inspector/chart/ChartTypeSelector.svelte
+++ b/web-common/src/features/canvas/inspector/chart/ChartTypeSelector.svelte
@@ -46,6 +46,8 @@
         >
           <svelte:component
             this={CANVAS_CHART_CONFIG[chart].icon}
+            primaryColor="var(--color-primary-600)"
+            secondaryColor="var(--color-primary-300)"
             size="20px"
           />
         </Button>


### PR DESCRIPTION
- Fixes heatmap icon to show colors
- Add better color support for chart icons in dark mode

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
