### PR TITLE
Add devcontainer for Rill Developer in GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,8 +7,8 @@
     }
   },
   "hostRequirements": {
-    "cpus": 4,
-    "memory": "8gb"
+    "cpus": 8,
+    "memory": "16gb"
   },
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",


### PR DESCRIPTION
Configures a development environment for running `rill devtool start local`:
- Go (latest devcontainer image)
- Node.js LTS
- Increased Node heap size to prevent OOM during builds
- GOTOOLCHAIN=auto for Go version compatibility
- Port forwarding for runtime (9009) and frontend dev server (3001)
- Minimum 8 CPUs / 16GB RAM for reasonable build performance

Note: This does not support Rill Cloud development, which requires Docker for its dependencies (Postgres, Redis, etc.).

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
