### PR TITLE
fix: overlapping text in pivot dimension column

### DIFF
--- a/web-common/src/features/dashboards/pivot/NestedTable.svelte
+++ b/web-common/src/features/dashboards/pivot/NestedTable.svelte
@@ -15,12 +15,12 @@
     type DimensionColumnProps,
     type MeasureColumnProps,
   } from "./pivot-column-definition";
-  import { isShowMoreRow } from "./pivot-utils";
   import {
     calculateMeasureWidth,
     calculateRowDimensionWidth,
     COLUMN_WIDTH_CONSTANTS as WIDTHS,
   } from "./pivot-column-width-utils";
+  import { isShowMoreRow } from "./pivot-utils";
   import type { PivotDataRow } from "./types";
 
   // State props
@@ -445,12 +445,12 @@
 
   .with-row-dimension tr > th:first-of-type {
     @apply sticky left-0 z-20;
-    /* @apply bg-surface-subtle; */
+    @apply bg-surface-base;
   }
 
   .with-row-dimension tr > td:first-of-type {
     @apply sticky left-0 z-10;
-    /* @apply bg-surface-subtle; */
+    @apply bg-surface-base;
   }
 
   .with-row-dimension tr:hover > td:first-of-type {


### PR DESCRIPTION
Apply background color to sticky dimension column in nested pivot table to avoid overlapping text on scroll

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
