### PR TITLE
feat: enable analyst agent in Rill Developer chat

### DIFF
--- a/web-common/src/features/chat/core/conversation.ts
+++ b/web-common/src/features/chat/core/conversation.ts
@@ -85,7 +85,7 @@ export class Conversation {
   constructor(
     private readonly instanceId: string,
     initialConversationId: string,
-    private readonly agent: string = ToolName.ANALYST_AGENT,
+    private readonly agent: string = "", // Empty string lets the router agent decide
   ) {
     this.conversationIdStore = writable(initialConversationId);
 

--- a/web-common/src/features/chat/core/types.ts
+++ b/web-common/src/features/chat/core/types.ts
@@ -62,7 +62,8 @@ export const ToolName = {
 // =============================================================================
 
 export type ChatConfig = {
-  agent: string;
+  // When omitted, the router agent uses LLM classification to pick the best agent per message
+  agent?: string;
   additionalContextStoreGetter: () => Readable<
     Partial<RuntimeServiceCompleteBody>
   >;

--- a/web-common/src/features/editor/chat-utils.ts
+++ b/web-common/src/features/editor/chat-utils.ts
@@ -1,16 +1,12 @@
-import {
-  type ChatConfig,
-  ToolName,
-} from "@rilldata/web-common/features/chat/core/types.ts";
+import { type ChatConfig } from "@rilldata/web-common/features/chat/core/types.ts";
 import type { RuntimeServiceCompleteBody } from "@rilldata/web-common/runtime-client";
 import { derived, type Readable } from "svelte/store";
 import { page } from "$app/stores";
 
 export const developerChatConfig = {
-  agent: ToolName.DEVELOPER_AGENT,
   additionalContextStoreGetter: () => getActiveFileContext(),
-  emptyChatLabel: "Happy to assist you make changes to the project",
-  placeholder: "What change can I help you make...",
+  emptyChatLabel: "Ask me about your data or make changes to the project",
+  placeholder: "Ask a question or request a change...",
   minChatHeight: "min-h-[2.5rem]",
 } satisfies ChatConfig;
 


### PR DESCRIPTION
The developer chat sidebar was hardcoding `developer_agent`, so all questions — including analytical ones — were routed to the developer agent (raw SQL tools only, no metrics view tools). A customer reported that the AI chat was "running raw duckdb sql instead of using the metricsview mcp."

Now the developer chat omits the agent, letting the router agent classify each message and pick the best agent per question.