### PR TITLE
fix: editor autocomplete higlight styling

### DIFF
--- a/web-common/src/components/editor/theme.ts
+++ b/web-common/src/components/editor/theme.ts
@@ -7,7 +7,6 @@ const blue = "var(--color-blue-800)";
 const purple = "var(--color-purple-700)";
 const invalid = "var(--color-red-600)";
 const emerald = "var(--color-emerald-700)";
-const emeraldHighlight = "var(--color-emerald-400)";
 const gray = "var(--fg-muted)";
 const amber = "var(--color-amber-600)";
 const highlightBackground = "var(--line-highlight)";
@@ -103,9 +102,13 @@ export const editorTheme = EditorView.theme(
       borderBottomColor: tooltipBackground,
     },
     ".cm-tooltip-autocomplete": {
-      padding: "0",
+      padding: "0.25rem",
+      backgroundColor: "var(--popover)",
+      color: "var(--popover-foreground)",
+      border: "solid 1px var(--border)",
       "& > ul > li[aria-selected]": {
-        color: emeraldHighlight,
+        backgroundColor: "var(--popover-accent)",
+        color: "var(--popover-foreground)",
       },
     },
   },


### PR DESCRIPTION
Improving autocomplete styling to be more legible - 

<img width="735" height="84" alt="image" src="https://github.com/user-attachments/assets/41232566-946d-4400-9780-b87a179ccf3f" />

https://linear.app/rilldata/issue/APP-724/investigate-dark-mode-regression-issue

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
