### PR TITLE
fix: remove empty fields from dashboard chat context

### DIFF
--- a/runtime/ai/analyst_agent.go
+++ b/runtime/ai/analyst_agent.go
@@ -25,17 +25,17 @@ var _ Tool[*AnalystAgentArgs, *AnalystAgentResult] = (*AnalystAgent)(nil)
 
 type AnalystAgentArgs struct {
 	Prompt     string   `json:"prompt"`
-	Explore    string   `json:"explore" yaml:"explore" jsonschema:"Optional explore dashboard name. If provided, the exploration will be limited to this dashboard."`
-	Dimensions []string `json:"dimensions" yaml:"dimensions" jsonschema:"Optional list of dimensions for queries. If provided, the queries will be limited to these dimensions."`
-	Measures   []string `json:"measures" yaml:"measures" jsonschema:"Optional list of measures for queries. If provided, the queries will be limited to these measures."`
+	Explore    string   `json:"explore,omitempty" yaml:"explore" jsonschema:"Optional explore dashboard name. If provided, the exploration will be limited to this dashboard."`
+	Dimensions []string `json:"dimensions,omitempty" yaml:"dimensions" jsonschema:"Optional list of dimensions for queries. If provided, the queries will be limited to these dimensions."`
+	Measures   []string `json:"measures,omitempty" yaml:"measures" jsonschema:"Optional list of measures for queries. If provided, the queries will be limited to these measures."`
 
-	Canvas              string                             `json:"canvas" yaml:"canvas" jsonschema:"Optional canvas name. If provided, the exploration will be limited to this canvas."`
-	CanvasComponent     string                             `json:"canvas_component" yaml:"canvas_component" jsonschema:"Optional canvas component name. If provided, the exploration will be limited to this canvas component."`
-	WherePerMetricsView map[string]*metricsview.Expression `json:"where_per_metrics_view" yaml:"where_per_metrics_view" jsonschema:"Optional filter for queries per metrics view. If provided, this filter will be applied to queries for each metrics view."`
+	Canvas              string                             `json:"canvas,omitempty" yaml:"canvas" jsonschema:"Optional canvas name. If provided, the exploration will be limited to this canvas."`
+	CanvasComponent     string                             `json:"canvas_component,omitempty" yaml:"canvas_component" jsonschema:"Optional canvas component name. If provided, the exploration will be limited to this canvas component."`
+	WherePerMetricsView map[string]*metricsview.Expression `json:"where_per_metrics_view,omitempty" yaml:"where_per_metrics_view" jsonschema:"Optional filter for queries per metrics view. If provided, this filter will be applied to queries for each metrics view."`
 
-	Where     *metricsview.Expression `json:"where" yaml:"where" jsonschema:"Optional filter for queries. If provided, this filter will be applied to all queries."`
-	TimeStart time.Time               `json:"time_start" yaml:"time_start" jsonschema:"Optional start time for queries. time_end must be provided if time_start is provided."`
-	TimeEnd   time.Time               `json:"time_end" yaml:"time_end" jsonschema:"Optional end time for queries. time_start must be provided if time_end is provided."`
+	Where     *metricsview.Expression `json:"where,omitempty" yaml:"where" jsonschema:"Optional filter for queries. If provided, this filter will be applied to all queries."`
+	TimeStart time.Time               `json:"time_start,omitempty" yaml:"time_start" jsonschema:"Optional start time for queries. time_end must be provided if time_start is provided."`
+	TimeEnd   time.Time               `json:"time_end,omitempty" yaml:"time_end" jsonschema:"Optional end time for queries. time_start must be provided if time_end is provided."`
 }
 
 func (a *AnalystAgentArgs) ToLLM() *aiv1.ContentBlock {

--- a/runtime/metricsview/query.go
+++ b/runtime/metricsview/query.go
@@ -31,33 +31,33 @@ type Query struct {
 }
 
 type Dimension struct {
-	Name    string            `json:"name" mapstructure:"name"`
-	Compute *DimensionCompute `json:"compute" mapstructure:"compute"`
+	Name    string            `json:"name,omitempty" mapstructure:"name"`
+	Compute *DimensionCompute `json:"compute,omitempty" mapstructure:"compute"`
 }
 
 type DimensionCompute struct {
-	TimeFloor *DimensionComputeTimeFloor `json:"time_floor" mapstructure:"time_floor"`
+	TimeFloor *DimensionComputeTimeFloor `json:"time_floor,omitempty" mapstructure:"time_floor"`
 }
 
 type DimensionComputeTimeFloor struct {
-	Dimension string    `json:"dimension" mapstructure:"dimension"`
-	Grain     TimeGrain `json:"grain" mapstructure:"grain"`
+	Dimension string    `json:"dimension,omitempty" mapstructure:"dimension"`
+	Grain     TimeGrain `json:"grain,omitempty" mapstructure:"grain"`
 }
 
 type Measure struct {
-	Name    string          `json:"name" mapstructure:"name"`
-	Compute *MeasureCompute `json:"compute" mapstructure:"compute"`
+	Name    string          `json:"name,omitempty" mapstructure:"name"`
+	Compute *MeasureCompute `json:"compute,omitempty" mapstructure:"compute"`
 }
 
 type MeasureCompute struct {
-	Count           bool                           `json:"count" mapstructure:"count"`
-	CountDistinct   *MeasureComputeCountDistinct   `json:"count_distinct" mapstructure:"count_distinct"`
-	ComparisonValue *MeasureComputeComparisonValue `json:"comparison_value" mapstructure:"comparison_value"`
-	ComparisonDelta *MeasureComputeComparisonDelta `json:"comparison_delta" mapstructure:"comparison_delta"`
-	ComparisonRatio *MeasureComputeComparisonRatio `json:"comparison_ratio" mapstructure:"comparison_ratio"`
-	PercentOfTotal  *MeasureComputePercentOfTotal  `json:"percent_of_total" mapstructure:"percent_of_total"`
-	URI             *MeasureComputeURI             `json:"uri" mapstructure:"uri"`
-	ComparisonTime  *MeasureComputeComparisonTime  `json:"comparison_time" mapstructure:"comparison_time"`
+	Count           bool                           `json:"count,omitempty" mapstructure:"count"`
+	CountDistinct   *MeasureComputeCountDistinct   `json:"count_distinct,omitempty" mapstructure:"count_distinct"`
+	ComparisonValue *MeasureComputeComparisonValue `json:"comparison_value,omitempty" mapstructure:"comparison_value"`
+	ComparisonDelta *MeasureComputeComparisonDelta `json:"comparison_delta,omitempty" mapstructure:"comparison_delta"`
+	ComparisonRatio *MeasureComputeComparisonRatio `json:"comparison_ratio,omitempty" mapstructure:"comparison_ratio"`
+	PercentOfTotal  *MeasureComputePercentOfTotal  `json:"percent_of_total,omitempty" mapstructure:"percent_of_total"`
+	URI             *MeasureComputeURI             `json:"uri,omitempty" mapstructure:"uri"`
+	ComparisonTime  *MeasureComputeComparisonTime  `json:"comparison_time,omitempty" mapstructure:"comparison_time"`
 }
 
 func (q *Query) AsMap() (map[string]any, error) {
@@ -221,10 +221,10 @@ func (tr *TimeRange) AsMap() (map[string]any, error) {
 }
 
 type Expression struct {
-	Name      string     `json:"name" mapstructure:"name"`
-	Value     any        `json:"val" mapstructure:"val"`
-	Condition *Condition `json:"cond" mapstructure:"cond"`
-	Subquery  *Subquery  `json:"subquery" mapstructure:"subquery"`
+	Name      string     `json:"name,omitempty" mapstructure:"name"`
+	Value     any        `json:"val,omitempty" mapstructure:"val"`
+	Condition *Condition `json:"cond,omitempty" mapstructure:"cond"`
+	Subquery  *Subquery  `json:"subquery,omitempty" mapstructure:"subquery"`
 }
 
 func (e *Expression) AsMap() (map[string]any, error) {
@@ -244,15 +244,15 @@ func (e *Expression) AsMap() (map[string]any, error) {
 }
 
 type Condition struct {
-	Operator    Operator      `json:"op" mapstructure:"op"`
-	Expressions []*Expression `json:"exprs" mapstructure:"exprs"`
+	Operator    Operator      `json:"op,omitempty" mapstructure:"op"`
+	Expressions []*Expression `json:"exprs,omitempty" mapstructure:"exprs"`
 }
 
 type Subquery struct {
-	Dimension Dimension   `json:"dimension" mapstructure:"dimension"`
-	Measures  []Measure   `json:"measures" mapstructure:"measures"`
-	Where     *Expression `json:"where" mapstructure:"where"`
-	Having    *Expression `json:"having" mapstructure:"having"`
+	Dimension Dimension   `json:"dimension,omitempty" mapstructure:"dimension"`
+	Measures  []Measure   `json:"measures,omitempty" mapstructure:"measures"`
+	Where     *Expression `json:"where,omitempty" mapstructure:"where"`
+	Having    *Expression `json:"having,omitempty" mapstructure:"having"`
 }
 
 type Operator string


### PR DESCRIPTION
Analyst agent args had a lot of empty values. This gets especially bad when filters are present and every level has things like `name: ""`, `cond: null` etc. Adding `omitempty` to make json marshaller remove empty fields.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
