### PR TITLE
fix: remove null values from inline chat context

### DIFF
--- a/web-common/src/features/chat/core/context/inline-context.spec.ts
+++ b/web-common/src/features/chat/core/context/inline-context.spec.ts
@@ -3,6 +3,7 @@ import {
   type InlineContext,
   convertPromptValueToContext,
   convertContextToInlinePrompt,
+  normalizeInlineContext,
 } from "@rilldata/web-common/features/chat/core/context/inline-context.ts";
 import { describe, it, expect } from "vitest";
 
@@ -18,6 +19,8 @@ describe("should convert to and from inline prompt", () => {
         type: InlineContextType.MetricsView,
         metricsView: "adbids",
         value: "adbids",
+        column: null as any, // This can be null when passed from tiptap. Adding this here as a sanity check.
+        columnType: undefined,
       },
       expectedPrompt: `<chat-reference>type="metricsView" metricsView="adbids"</chat-reference>`,
     },
@@ -85,7 +88,7 @@ describe("should convert to and from inline prompt", () => {
           .replace("<chat-reference>", "")
           .replace("</chat-reference>", ""),
       );
-      expect(convertedCtx).toEqual(ctx);
+      expect(convertedCtx).toEqual(normalizeInlineContext(ctx));
     });
   }
 });

--- a/web-common/src/features/chat/core/context/inline-context.ts
+++ b/web-common/src/features/chat/core/context/inline-context.ts
@@ -106,7 +106,9 @@ export function convertContextToInlinePrompt(ctx: InlineContext) {
     const isComputedKey = key === "value" || key === "label";
     const isNonStringKey = key === "values";
     if (isComputedKey || isNonStringKey) continue;
-    if (ctx[key] !== undefined) parts.push(`${key}="${ctx[key]}"`);
+    const value = ctx[key];
+    const hasValue = value !== undefined && value !== null;
+    if (hasValue) parts.push(`${key}="${value}"`);
   }
 
   // TODO: dimension value support


### PR DESCRIPTION
Inline chat context included null values bloating the prompt. Making sure to remove them before building the prompt text.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
