### PR TITLE
fix: changing timezone doesnt update the data until range re-select

### DIFF
--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -276,7 +276,7 @@
     );
   }
 
-  async function onSelectRange(alias: string) {
+  async function onSelectRange(alias: string, tz = activeTimeZone) {
     // If we don't have a valid time range, early return
     if (!allTimeRange?.end) return;
 
@@ -297,7 +297,7 @@
     const { interval, grain } = await deriveInterval(
       alias,
       metricsViewName,
-      activeTimeZone,
+      tz,
       selectedTimeDimension,
     );
 
@@ -366,7 +366,7 @@
     } as DashboardTimeControls);
   }
 
-  function onSelectTimeZone(timeZone: string) {
+  async function onSelectTimeZone(timeZone: string) {
     if (!interval?.isValid) return;
 
     if (selectedRangeAlias === TimeRangePreset.CUSTOM) {
@@ -379,8 +379,10 @@
           ?.setZone(timeZone, { keepLocalTime: true })
           .toJSDate(),
       });
+    } else if (selectedRangeAlias) {
+      // Trigger range selection so that MetricsViewTimeRanges is called with the new time zone
+      await onSelectRange(selectedRangeAlias, timeZone);
     }
-
     metricsExplorerStore.setTimeZone($exploreName, timeZone);
   }
 


### PR DESCRIPTION
Triggering range selection when timezone is changed. This is probably not the cleanest.

Closes APP-723

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
