### PR TITLE
fix: update resource key for public url dashboard title

### DIFF
--- a/web-admin/src/routes/[organization]/[project]/-/settings/public-urls/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/settings/public-urls/+page.svelte
@@ -47,8 +47,9 @@
   $: dashboards = useDashboards(instanceId);
 
   $: allRowsWithDashboardTitle = allRows.map((token) => {
+    const tokenResource = token.resources?.[0];
     const dashboard = $dashboards.data?.find(
-      (d) => d.meta.name.name === token.resourceName,
+      (d) => d.meta.name.name === tokenResource?.name,
     );
     return {
       ...token,


### PR DESCRIPTION
Use the `resources` key for find the relevant dashboard for a shared magic token.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
