### PR TITLE
fix: deleting file from dev agent breaking navigation

### DIFF
--- a/runtime/ai/developer_agent.go
+++ b/runtime/ai/developer_agent.go
@@ -159,7 +159,7 @@ The user has configured global additional instructions for you. They may not rel
 For context, here are some details about the project's default OLAP connector: {{ .default_olap_info }}.
 Note that you can only use it in model resources if it is not readonly.
 
-Call "navigate" tool for the main file created/edited in the conversation. Use kind "file" and pass the written file path.
+Call "navigate" tool for the main file created/edited (not if it is deleted) in the conversation. Use kind "file" and pass the written file path.
 Prefer dashboard or metrics view files over other files.
 
 Task: {{ .prompt }}

--- a/web-common/src/features/chat/core/messages/file-diff/file-diff-block.ts
+++ b/web-common/src/features/chat/core/messages/file-diff/file-diff-block.ts
@@ -6,9 +6,10 @@ import { MessageContentType } from "../../types";
 // =============================================================================
 
 /** Arguments for the write_file tool call */
-interface WriteFileCallData {
+export interface WriteFileCallData {
   path: string;
   contents: string;
+  remove: boolean;
 }
 
 /** Result from the write_file tool */


### PR DESCRIPTION
Deleting a file using the dev agent still called the `navigate` tool. If the active page was this deleted file, then we would show a blank file. This mislead the user to think the file still exists.

Adding `onResult` and `onCall`, `onResult` for `write_file` navigates to home page if the active page is deleted.

Ref loom: https://www.loom.com/share/9a5b72c7ad12445193ffa7afcca1af09

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
