### PR TITLE
Fix merge issue in docs

### DIFF
--- a/docs/api/rill/admin/v1/public.swagger.yaml
+++ b/docs/api/rill/admin/v1/public.swagger.yaml
@@ -6537,13 +6537,10 @@ definitions:
         type: string
       prefix:
         type: string
-<<<<<<< HEAD
       refresh:
         type: boolean
-=======
       attributes:
         type: object
->>>>>>> main
       createdOn:
         type: string
         format: date-time

--- a/docs/docs/reference/project-files/connectors.md
+++ b/docs/docs/reference/project-files/connectors.md
@@ -36,6 +36,7 @@ Connector YAML files define how Rill connects to external data sources and OLAP 
 ### Service Integrations
 - [**Claude**](#claude) - Claude connector for chat with your own API key
 - [**OpenAI**](#openai) - OpenAI connector for chat with your own API key
+- [**Gemini**](#gemini) - Gemini connector for chat with your own API key
 - [**Slack**](#slack) - Slack data
 
 ### _Other_
@@ -702,6 +703,52 @@ type: connector
 driver: claude
 api_key: "{{ .env.claude_api_key }}"
 model: claude-opus-4-5
+```
+
+## Gemini
+
+### `driver`
+
+_[string]_ - The driver type, must be set to "gemini" 
+
+### `api_key`
+
+_[string]_ - API key for connecting to Gemini _(required)_
+
+### `model`
+
+_[string]_ - The Gemini model to use (e.g., 'gemini-2.5-pro-preview-05-06') 
+
+### `include_thoughts`
+
+_[boolean]_ - Whether to include thinking/reasoning in the response 
+
+### `thinking_level`
+
+_[string]_ - Level of 'thinking' for the model's response (e.g., 'MINIMAL', 'LOW', 'MEDIUM', 'HIGH'). Default is 'LOW'. 
+
+### `max_output_tokens`
+
+_[number]_ - Maximum number of tokens in the response (e.g., 8192) 
+
+### `temperature`
+
+_[number]_ - Sampling temperature to use (0.0-2.0) 
+
+### `top_p`
+
+_[number]_ - Nucleus sampling parameter 
+
+### `top_k`
+
+_[number]_ - Top-K sampling parameter 
+
+```yaml
+# Example: Gemini connector configuration
+type: connector
+driver: gemini
+api_key: "{{ .env.gemini_api_key }}"
+model: gemini-2.5-pro-preview-05-06
 ```
 
 ## Pinot

--- a/proto/gen/rill/admin/v1/openapi.yaml
+++ b/proto/gen/rill/admin/v1/openapi.yaml
@@ -2307,7 +2307,7 @@ externalDocs:
 info:
     description: Rill Admin API enables programmatic management of Rill Cloud resources, including organizations, projects, and user access. It provides endpoints for creating, updating, and deleting these resources, as well as managing authentication and permissions.
     title: Rill Admin API
-    version: v0.79.5
+    version: v0.80.3
 openapi: 3.0.3
 paths:
     /v1/ai/complete:

--- a/proto/gen/rill/admin/v1/public.openapi.yaml
+++ b/proto/gen/rill/admin/v1/public.openapi.yaml
@@ -2307,7 +2307,7 @@ externalDocs:
 info:
     description: Rill Admin API enables programmatic management of Rill Cloud resources, including organizations, projects, and user access. It provides endpoints for creating, updating, and deleting these resources, as well as managing authentication and permissions.
     title: Rill Admin API
-    version: v0.79.5
+    version: v0.80.3
 openapi: 3.0.3
 paths:
     /v1/ai/complete: {}


### PR DESCRIPTION
Found this unhandled merge conflict on `main` in `docs/api/rill/admin/v1/public.swagger.yaml`:
```
<<<<<<< HEAD
      refresh:
        type: boolean
=======
      attributes:
        type: object
>>>>>>> main
```
Regenerated the docs to fix.