### PR TITLE
Allow rill-managed clickhouse & duckdb connectors to query tables

### DIFF
--- a/web-common/src/features/connectors/explorer/DatabaseExplorer.svelte
+++ b/web-common/src/features/connectors/explorer/DatabaseExplorer.svelte
@@ -13,13 +13,7 @@
   $: connectorName = connector?.name as string;
   $: hasError = !!connector?.errorMessage;
 
-  // Managed connectors without host/dsn config aren't ready for queries yet
-  $: isAwaitingConfig =
-    connector?.provision === true &&
-    !connector?.config?.dsn &&
-    !connector?.config?.host;
-
-  $: queryEnabled = !hasError && !isAwaitingConfig;
+  $: queryEnabled = !hasError;
 
   $: databaseSchemasQuery = useListDatabaseSchemas(
     instanceId,
@@ -37,8 +31,6 @@
 <div class="wrapper">
   {#if hasError}
     <span class="message pl-6">Error: {connector.errorMessage}</span>
-  {:else if isAwaitingConfig}
-    <span class="message pl-6">Configure connector to browse tables</span>
   {:else if isLoading && queryEnabled}
     <span class="message pl-6">Loading tables...</span>
   {:else if error && queryEnabled}


### PR DESCRIPTION
Managed connectors with provision=true were blocked from querying tables by an isAwaitingConfig guard that checked for dsn/host in the connector config. However, for rill-managed connectors, the DSN is obtained during on-demand provisioning in the connection cache—never surfaced to the frontend. This caused the "Configure connector to browse tables" message to appear permanently.

Remove the guard. The backend handles provisioning transparently when the connection is acquired. Query errors are already handled by existing error states.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
