### PR TITLE
fix: hide discord ref for embeds

### DIFF
--- a/web-admin/src/features/projects/ProjectBuilding.svelte
+++ b/web-admin/src/features/projects/ProjectBuilding.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
+  import { page } from "$app/stores";
   import CtaContentContainer from "@rilldata/web-common/components/calls-to-action/CTAContentContainer.svelte";
   import CtaHeader from "@rilldata/web-common/components/calls-to-action/CTAHeader.svelte";
   import CtaLayoutContainer from "@rilldata/web-common/components/calls-to-action/CTALayoutContainer.svelte";
   import CtaNeedHelp from "@rilldata/web-common/components/calls-to-action/CTANeedHelp.svelte";
   import Spinner from "@rilldata/web-common/features/entity-management/Spinner.svelte";
   import { EntityStatus } from "@rilldata/web-common/features/entity-management/types";
+  import { isEmbedPage } from "@rilldata/web-common/layout/navigation/navigation-utils.ts";
+
+  const onEmbedPage = isEmbedPage($page);
 </script>
 
 <CtaLayoutContainer>
@@ -15,6 +19,8 @@
     <CtaHeader variant="bold">
       Hang tight! We're deploying your project...
     </CtaHeader>
-    <CtaNeedHelp />
+    {#if !onEmbedPage}
+      <CtaNeedHelp />
+    {/if}
   </CtaContentContainer>
 </CtaLayoutContainer>


### PR DESCRIPTION
When a project is building, hide the discord reference when embedding.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
