### PR TITLE
fix: hide share conversation button in Rill Developer

### DIFF
--- a/web-common/src/features/chat/layouts/fullpage/FullPageChat.svelte
+++ b/web-common/src/features/chat/layouts/fullpage/FullPageChat.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { beforeNavigate } from "$app/navigation";
   import { page } from "$app/stores";
+  import { featureFlags } from "@rilldata/web-common/features/feature-flags";
   import { projectChat } from "@rilldata/web-common/features/project/chat-context.ts";
   import { onMount } from "svelte";
   import { runtime } from "../../../../runtime-client/runtime-store";
@@ -16,6 +17,8 @@
     conversationSidebarCollapsed,
     toggleConversationSidebar,
   } from "./fullpage-store";
+
+  const { adminServer } = featureFlags;
 
   $: ({ instanceId } = $runtime);
   $: organization = $page.params.organization;
@@ -72,7 +75,7 @@
 
   <!-- Main Chat Area -->
   <div class="chat-main">
-    {#if currentConversation?.id}
+    {#if currentConversation?.id && $adminServer}
       <div class="chat-header">
         <ShareChatPopover
           conversationId={currentConversation.id}

--- a/web-common/src/features/chat/layouts/sidebar/SidebarHeader.svelte
+++ b/web-common/src/features/chat/layouts/sidebar/SidebarHeader.svelte
@@ -3,6 +3,7 @@
   import IconButton from "../../../../components/button/IconButton.svelte";
   import Close from "../../../../components/icons/Close.svelte";
   import PlusIcon from "../../../../components/icons/PlusIcon.svelte";
+  import { featureFlags } from "@rilldata/web-common/features/feature-flags";
   import { type V1Conversation } from "../../../../runtime-client";
   import { runtime } from "../../../../runtime-client/runtime-store";
   import type { ConversationManager } from "../../core/conversation-manager";
@@ -12,6 +13,8 @@
   export let conversationManager: ConversationManager;
   export let onNewConversation: () => void;
   export let onClose: () => void;
+
+  const { adminServer } = featureFlags;
 
   $: ({ instanceId } = $runtime);
   $: organization = $page.params.organization;
@@ -46,13 +49,15 @@
       <svelte:fragment slot="tooltip-content">New conversation</svelte:fragment>
     </IconButton>
 
-    <ShareChatPopover
-      conversationId={currentConversationDto?.id}
-      {instanceId}
-      {organization}
-      {project}
-      disabled={!currentConversationDto?.id}
-    />
+    {#if $adminServer}
+      <ShareChatPopover
+        conversationId={currentConversationDto?.id}
+        {instanceId}
+        {organization}
+        {project}
+        disabled={!currentConversationDto?.id}
+      />
+    {/if}
 
     <ConversationHistoryMenu
       {conversations}


### PR DESCRIPTION
- Guard `ShareChatPopover` behind the `adminServer` feature flag in both `SidebarHeader` and `FullPageChat`
- Sharing is a cloud-only feature; the button was rendering in Rill Developer with no functionality

Closes [APP-733](https://linear.app/rilldata/issue/APP-733/hide-share-conversation-button-in-rill-dev)

---

*Developed in collaboration with Claude Code*

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!