### PR TITLE
tweak: support comparison in ai charts

### DIFF
--- a/runtime/metricsview/charts_json_schema.go
+++ b/runtime/metricsview/charts_json_schema.go
@@ -38,6 +38,20 @@ const ChartsJSONSchema = `{
             }
           }
         },
+        "comparison_time_range": {
+          "type": "object",
+          "properties": {
+            "start": {
+              "type": "string",
+              "description": "Start time for the comparison time range."
+            },
+            "end": {
+              "type": "string",
+              "description": "End time for the comparison time range."
+            }
+          },
+          "description": "Optional comparison time range for period-over-period comparison. Only supported for cartesian chart types (bar_chart, line_chart, stacked_bar, stacked_bar_normalized)."
+        },
         "where": {
           "$ref": "#/$defs/Expression",
           "description": "Optional expression for filtering the underlying data before aggregation."

--- a/web-common/src/features/chat/core/messages/chart/ChartBlock.svelte
+++ b/web-common/src/features/chat/core/messages/chart/ChartBlock.svelte
@@ -46,10 +46,21 @@
         timeZone: "UTC",
       };
 
+  $: comparisonTimeRange = chartSpec.comparison_time_range
+    ? {
+        start: chartSpec.comparison_time_range.start,
+        end: chartSpec.comparison_time_range.end,
+        timeZone:
+          chartSpec.comparison_time_range.time_zone || timeRange.timeZone,
+      }
+    : undefined;
+
+  $: hasComparison = !!comparisonTimeRange?.start && !!comparisonTimeRange?.end;
+
   $: timeAndFilterStore = readable({
     timeRange: timeRange,
-    comparisonTimeRange: undefined,
-    showTimeComparison: false,
+    comparisonTimeRange: comparisonTimeRange,
+    showTimeComparison: hasComparison,
     where: mapResolverExpressionToV1Expression(chartSpec.where) || {
       cond: {
         op: "OPERATION_AND",

--- a/web-common/src/features/components/charts/ChartContainer.svelte
+++ b/web-common/src/features/components/charts/ChartContainer.svelte
@@ -142,6 +142,9 @@
                 dimensionsWithInlistFilter={[]}
                 filters={whereFilter}
                 displayTimeRange={$timeAndFilterStore.timeRange}
+                displayComparisonTimeRange={$timeAndFilterStore.showTimeComparison
+                  ? $timeAndFilterStore.comparisonTimeRange
+                  : undefined}
                 queryTimeStart={$timeAndFilterStore.timeRange.start}
                 queryTimeEnd={$timeAndFilterStore.timeRange.end}
                 hasBoldTimeRange={false}


### PR DESCRIPTION
Add support for comparison time range in some the AI generated charts

Part of https://linear.app/rilldata/issue/APP-725/ai-improve-analyst-agents-visualization-logic

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
