### PR TITLE
fix: use getParseError instead of getAllErrors in file editor

### DIFF
--- a/web-common/src/features/metrics-views/errors.ts
+++ b/web-common/src/features/metrics-views/errors.ts
@@ -79,25 +79,3 @@ export function mapParseErrorToLine(
   }
   return runtimeErrorToLine(error.message, yaml);
 }
-
-// TODO: double check error
-export function mapParseErrorsToLines(
-  errors: Array<V1ParseError>,
-  yaml: string,
-): LineStatus[] {
-  if (!errors) return [];
-  return errors
-    .map((error) => {
-      if (error.startLocation) {
-        // if line is provided, no need to parse
-        // TODO: check if we need to strip anything
-        return <LineStatus>{
-          line: error.startLocation.line,
-          message: error.message,
-          level: "error",
-        };
-      }
-      return runtimeErrorToLine(error.message, yaml);
-    })
-    .filter((error) => error.message !== ConfigErrors.Malformed);
-}

--- a/web-local/src/routes/(application)/(workspace)/files/[...file]/+page.svelte
+++ b/web-local/src/routes/(application)/(workspace)/files/[...file]/+page.svelte
@@ -8,7 +8,6 @@
   import { getExtensionsForFile } from "@rilldata/web-common/features/editor/getExtensionsForFile";
   import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
   import { directoryState } from "@rilldata/web-common/features/file-explorer/directory-store";
-  import { mapParseErrorsToLines } from "@rilldata/web-common/features/metrics-views/errors";
   import CanvasWorkspace from "@rilldata/web-common/features/workspaces/CanvasWorkspace.svelte";
   import ExploreWorkspace from "@rilldata/web-common/features/workspaces/ExploreWorkspace.svelte";
   import MetricsWorkspace from "@rilldata/web-common/features/workspaces/MetricsWorkspace.svelte";
@@ -44,9 +43,8 @@
     resourceName,
     inferredResourceKind,
     path,
-    remoteContent,
     getResource,
-    getAllErrors,
+    getParseError,
   } = fileArtifact);
 
   $: resourceKind = <ResourceKind | undefined>$resourceName?.kind;
@@ -62,12 +60,9 @@
       ? [customYAMLwithJSONandSQL]
       : getExtensionsForFile(path);
 
-  $: allErrorsQuery = getAllErrors(queryClient, instanceId);
-  $: allErrors = $allErrorsQuery;
-
-  $: errors = mapParseErrorsToLines(allErrors, $remoteContent ?? "");
-
-  $: mainError = errors?.at(0);
+  // Parse error for the editor banner
+  $: parseErrorQuery = getParseError(queryClient, instanceId);
+  $: parseError = $parseErrorQuery;
 
   onMount(() => {
     expandDirectory(path);
@@ -104,7 +99,7 @@
           filePath={path}
           hasUnsavedChanges={$hasUnsavedChanges}
         />
-        <WorkspaceEditorContainer slot="body" error={mainError?.message}>
+        <WorkspaceEditorContainer slot="body" error={parseError?.message}>
           <Editor
             {fileArtifact}
             {extensions}


### PR DESCRIPTION
The file editor page (`+page.svelte`) was using `getAllErrors`, which conflates parse errors and reconcile errors into a single `V1ParseError[]`. It then converted them to `LineStatus[]` via `mapParseErrorsToLines`—only to extract `.message` from the first one for the error banner. This caused a type error (`LineStatus` object passed where `string` was expected) and muddied the error semantics.

- Use `getParseError` (parse errors only) instead of `getAllErrors`, matching the pattern in ExploreWorkspace, CanvasWorkspace, and MetricsWorkspace
- Pass `parseError?.message` directly to `WorkspaceEditorContainer`
- Remove the unnecessary `mapParseErrorsToLines` conversion from this file
- Delete the now-dead `mapParseErrorsToLines` function from `errors.ts`

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---

*Developed in collaboration with Claude Code*