### PR TITLE
fix: skip client-side JWT expiry check for embedded dashboards

### DIFF
--- a/web-common/src/runtime-client/http-client.ts
+++ b/web-common/src/runtime-client/http-client.ts
@@ -48,6 +48,10 @@ const CHECK_RUNTIME_STORE_FOR_JWT_INTERVAL = 50; // Interval to recheck JWT fres
  * If the JWT has expired, or is close to expiring, wait for a fresh one.
  */
 async function maybeWaitForFreshJWT(jwt: JWT): Promise<JWT> {
+  // Embeds communicate directly with the runtime and have no admin server connection to refresh tokens.
+  // The backend issues embed JWTs with a 24h TTL, so skip the client-side expiry check.
+  if (jwt.authContext === "embed") return jwt;
+
   // This is the approximate time at which the JWT will expire. We could parse the JWT to get the exact
   // expiration time, but it's better to treat tokens as opaque.
   let jwtExpiresAt = jwt.receivedAt + RUNTIME_ACCESS_TOKEN_DEFAULT_TTL;


### PR DESCRIPTION
Embedded iframes stop sending requests after exactly 30 minutes and show a loading state. The root cause: the frontend assumes all JWTs expire in 30 minutes (`RUNTIME_ACCESS_TOKEN_DEFAULT_TTL`), but the backend issues embed JWTs with a 24-hour TTL (`runtimeAccessTokenEmbedTTL`). Since embeds communicate directly with the runtime and have no admin server connection to refresh tokens, `maybeWaitForFreshJWT` enters an infinite busy-wait loop once the assumed expiry passes.

The fix skips the client-side expiry check for `authContext === "embed"`, letting the backend's 24h TTL govern token validity.

Reported in [Slack](https://rilldata.slack.com/archives/CTZ8XBQ85/p1770928468977039).

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---

*Developed in collaboration with Claude Code*