### PR TITLE
Share Claude Code rules: code review, docs, plans, pull requests

### DIFF
--- a/.claude/rules/code-review.md
+++ b/.claude/rules/code-review.md
@@ -1,21 +1,17 @@
-## GitHub PR Comments and Reviews
+## Code Review
 
 ### Review Focus Areas
 
-**Readability and simplicity.** Code should be easy to understand and maintain. Prioritize clear naming, straightforward structure, and minimal indirection. Complexity should be justified by actual requirements, not hypothetical futures.
-
-**Clean abstractions and semantic APIs.** Abstractions should earn their place by simplifying the codebase—push back on over-engineering. When they exist, they should be well-bounded and elegant. API signatures should be semantic and clear: parameter names, method names, and interface shapes should make correct usage obvious.
+**Readability and simplicity.** Code should be easy to understand and maintain. Prioritize clear naming, straightforward structure, and minimal indirection. Abstractions should earn their place by simplifying the codebase — push back on over-engineering. When they exist, they should be well-bounded, and their APIs should be semantic: parameter names, method names, and interface shapes should make correct usage obvious. Complexity should be justified by actual requirements, not hypothetical futures.
 
 ### Posting Guidelines
 
-Before posting any comments or reviews on GitHub pull requests, adhere to the following guidelines:
-
-1. Never post without my permission. Always show me a draft and ask me to approve it before posting.
-2. Always end the post with an attribution footer in exactly this format:
+1. Never post without the user's explicit approval. Always show a draft and ask for approval before posting.
+2. Do not ask the author questions that can be answered by reading the code. If tempted to ask, search the codebase to find the answer yourself.
+3. Sequence feedback in order of significance — most important issues first.
+4. Do not provide an "Overview" or "Summary" section that describes what the PR is about. The author knows what the PR is about.
+5. Do not be patronizing. Assume the reader is intelligent and capable.
+6. Use full sentences and proper grammar. Avoid shorthand, abbreviations, or informal language.
+7. Always end the post with an attribution footer in exactly this format:
    - A horizontal rule (`---`)
    - Followed by italicized text: `*Developed in collaboration with Claude Code*`
-3. Use full sentences and proper grammar. Avoid shorthand, abbreviations, or informal language.
-4. Don't be patronizing. Assume the reader is intelligent and capable.
-5. Don't provide an "Overview" or "Summary" section that describes what the PR is about. The author knows what the PR is about.
-6. Sequence feedback in order of significance—most important issues first.
-7. We should not ask the author questions that we can answer ourselves by looking through the code. If tempted to ask the author an answerable question, stop and search the code to find the answer yourself.

--- a/.claude/rules/docs.md
+++ b/.claude/rules/docs.md
@@ -2,18 +2,14 @@
 paths: docs/docs/**/*
 ---
 
-## Documentation Principles
+## Documentation
 
-When writing or reviewing documentation in `docs/`:
+1. **Progressive complexity** — Start with the simplest useful example, then build toward advanced configuration and edge cases. Readers should be able to stop reading at any point and have something that works.
 
-1. **Sidebar labels follow resource naming** — Items in the Build section should use the resource type name (e.g., "Alerts" not "Code Alerts").
+2. **Consider information architecture** — Do not just append new content. Consider where it belongs, how it relates to neighboring pages, and whether the existing structure still makes sense. Sometimes the right move is integrating into an existing section; sometimes it means restructuring.
 
-2. **Add connective prose** — Don't just present code snippets. Add 1-2 sentences of explanatory context before each section explaining what it does and when to use it.
+3. **Reflect the product's true abstractions** — Use the same terms and concepts the product uses. Do not invent simplified mental models that diverge from how the system actually works — these create confusion when readers encounter the real thing. If a concept is complex, explain it clearly rather than replacing it with a lossy approximation.
 
-3. **Link to related concepts** — When referencing concepts documented elsewhere (Custom APIs, Metrics Views, etc.), link to their documentation pages.
+4. **Be consistent** — Match the conventions of neighboring pages: heading structure, title casing, label style, section ordering, and tone. When adding a new page, use a similar page as a template rather than inventing a new format.
 
-4. **Explain use cases** — For configuration options, explain when and why you'd use each option, not just what it does.
-
-5. **Promote important concepts** — If a concept only appears buried in an example, consider giving it its own dedicated section or subsection.
-
-6. **Navigation labels prefer single words** — Top navigation labels should be concise (e.g., "Developers" not "Developer Docs", "Guide" not "User Guide"). URL paths should match labels and be short (`/developers/`, `/guide/`). When splitting documentation for different audiences, base the split on user activity (code-based vs UI-based) rather than product names, which may change over time.
+5. **Keep navigation labels concise** — Prefer single words for top nav (e.g., "Developers" not "Developer Docs"). Sidebar labels should use the resource type name (e.g., "Alerts" not "Code Alerts"). URL paths should match labels and be short (`/developers/`, `/guide/`).

--- a/.claude/rules/plans.md
+++ b/.claude/rules/plans.md
@@ -1,5 +1,7 @@
-## Plans
+---
+paths: .claude/plans/**/*
+---
 
-When drafting technical design documents, follow these guidelines:
+## Plans
 
 1. Assume the reader is another member of the team who is reading the plan with fresh eyes. Do not reference prior conversations that a fresh reader would not know about.

--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -1,4 +1,6 @@
-## Branch Naming
+## Pull Requests
+
+### Branch Naming
 
 Prefix branch names with your username, followed by a short description:
 
@@ -7,17 +9,12 @@ username/fix-share-button-visibility
 username/add-activation-metric
 ```
 
-The Linear ticket and authorship information belong in the PR, not the branch name. Branch names are ephemeral — they get deleted after merge.
+### Creating Pull Requests
 
-## PR Titles
-
-Use backticks around code identifiers (function names, variable names, file names) in PR titles.
-
-## Creating Pull Requests
-
-1. Use the repo's PR template (`.github/PULL_REQUEST_TEMPLATE.md`). Replace the `INSERT DESCRIPTION HERE` placeholder with the description, but keep the checklist intact — the author will check the boxes themselves.
-2. Link to the relevant Linear issue or Slack message after the description but before the checklist. Use the format `Closes [APP-123](url)` for Linear issues.
-3. Keep the description concise — a few bullet points, not paragraphs. No "Summary" or "Overview" headers.
-4. End the PR body (after the checklist) with an attribution footer in exactly this format:
+1. Use backticks around code identifiers (function names, variable names, file names) in PR titles.
+2. Use the repo's PR template (`.github/PULL_REQUEST_TEMPLATE.md`). Replace the `INSERT DESCRIPTION HERE` placeholder with the description, but keep the checklist intact — the author will check the boxes themselves.
+3. Link to the relevant Linear issue or Slack message after the description but before the checklist. Use the format `Closes [APP-123](url)` for Linear issues.
+4. Keep the description concise — a few bullet points, not paragraphs. No "Summary" or "Overview" headers.
+5. End the PR body (after the checklist) with an attribution footer in exactly this format:
    - A horizontal rule (`---`)
    - Followed by italicized text: `*Developed in collaboration with Claude Code*`


### PR DESCRIPTION
- Commit four `.claude/rules/` files that guide Claude Code behavior:
  - `code-review.md` — review focus areas (readability, clean abstractions) and posting guidelines
  - `docs.md` — documentation principles scoped to `docs/docs/**/*`
  - `plans.md` — technical design document guidelines scoped to `.claude/plans/**/*`
  - `pull-requests.md` — branch naming and PR creation conventions

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
*Developed in collaboration with Claude Code*