### PR TITLE
fix: time grain selection unstable e2e tests

### DIFF
--- a/web-local/tests/explores/time-grain-derivation.spec.ts
+++ b/web-local/tests/explores/time-grain-derivation.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "@playwright/test";
 import { test } from "../setup/base";
+import { waitForReconciliation } from "../utils/wait-for-reconciliation.ts";
 
 test.describe("Time grain derivation from URL", () => {
   test.use({ project: "AdBids" });
@@ -13,15 +14,16 @@ test.describe("Time grain derivation from URL", () => {
     const currentUrl = new URL(page.url());
     const baseUrl = `${currentUrl.protocol}//${currentUrl.host}`;
 
+    // Wait for all resources to reconcile
+    await waitForReconciliation(page);
+
     await page.goto(
       `${baseUrl}/explore/AdBids_metrics_explore?tr=${encodeURIComponent(timeRange)}`,
     );
 
     // Wait for the time grain selector to appear and contain the expected grain
     const timeGrainSelector = page.getByLabel("Select aggregation grain");
-    await expect(timeGrainSelector).toContainText(`by ${expectedGrain}`, {
-      timeout: 10000,
-    });
+    await expect(timeGrainSelector).toContainText(`by ${expectedGrain}`);
 
     // Check the grain parameter in the URL
     const url = new URL(page.url());


### PR DESCRIPTION
Since we are trying to immediately navigate to a dashboard it fails to load. Making sure resources have reconciled before navigating to the dashboard.

Note that this PR doesnt fix the load issue, that needs to be handled separately. (https://github.com/rilldata/rill/pull/8858)

Closes APP-735

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
