### PR TITLE
fix: blank page for missing explores

### DIFF
--- a/web-admin/src/features/navigation/TopNavigationBar.svelte
+++ b/web-admin/src/features/navigation/TopNavigationBar.svelte
@@ -246,9 +246,10 @@
           <StateManagersProvider
             metricsViewName={exploreSpec.metricsView}
             exploreName={dashboard}
+            let:ready
           >
             <LastRefreshedDate {dashboard} />
-            {#if $dimensionSearch}
+            {#if $dimensionSearch && ready}
               <GlobalDimensionSearch />
             {/if}
             {#if $dashboardChat && !onPublicURLPage}

--- a/web-common/src/features/explores/ExplorePreviewCTAs.svelte
+++ b/web-common/src/features/explores/ExplorePreviewCTAs.svelte
@@ -40,11 +40,13 @@
   {#if $explorePolicyCheck.data || $metricsPolicyCheck.data || $rillYamlPolicyCheck.data}
     <ViewAsButton />
   {/if}
-  <StateManagersProvider {metricsViewName} {exploreName}>
+  <StateManagersProvider {metricsViewName} {exploreName} let:ready>
     {#if $dashboardChat}
       <ChatToggle />
     {/if}
-    <GlobalDimensionSearch />
+    {#if ready}
+      <GlobalDimensionSearch />
+    {/if}
   </StateManagersProvider>
   {#if !$readOnly}
     <DropdownMenu.Root>


### PR DESCRIPTION
Missing explores show a blank page instead of a nice error message. There was an unhandled exception that caused this.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
