### PR TITLE
fix: rill logo when forced to be dark mode

### DIFF
--- a/web-common/src/components/icons/Rill.svelte
+++ b/web-common/src/components/icons/Rill.svelte
@@ -7,7 +7,7 @@
     mode === "adapt"
       ? "fill-primary-700 dark:fill-neutral-900"
       : mode === "dark"
-        ? "fill-neutral-50"
+        ? "fill-neutral-900"
         : "fill-primary-700";
 </script>
 


### PR DESCRIPTION
When the rill logo is forced to be in dark mode there is no contrast https://rilldata.slack.com/archives/C02T907FEUB/p1771339150429649

Fixing this by matching the adapt mode.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
