### PR TITLE
Add Claude Code PM skills

### DIFF
--- a/.claude/skills/pm/competitive-analysis/SKILL.md
+++ b/.claude/skills/pm/competitive-analysis/SKILL.md
@@ -13,6 +13,7 @@ Input: $ARGUMENTS
 ### 1. Define the Competitive Landscape
 
 If competitors aren't specified, ask via `AskUserQuestion`:
+
 - What product or space are we analyzing?
 - Who are the top 3–5 competitors (direct and adjacent)?
 - What is the primary job-to-be-done we're competing on?
@@ -20,6 +21,7 @@ If competitors aren't specified, ask via `AskUserQuestion`:
 ### 2. Research Competitors in Parallel
 
 Use the `Task` tool to spawn parallel `Explore` agents — one per competitor — each tasked with finding:
+
 - Product positioning and key messaging
 - Pricing model and tiers
 - Key features and differentiators
@@ -45,6 +47,7 @@ Create a table comparing all competitors across key dimensions relevant to the s
 ### 5. Pricing Comparison
 
 Document each competitor's pricing structure:
+
 - Free tier (if any)
 - Core paid plan
 - Enterprise pricing signals

--- a/.claude/skills/pm/executive-update/SKILL.md
+++ b/.claude/skills/pm/executive-update/SKILL.md
@@ -13,6 +13,7 @@ Input: $ARGUMENTS
 ### 1. Gather Context
 
 If not provided, ask via `AskUserQuestion`:
+
 - What is the audience? (CEO, board, cross-functional leadership, skip-level)
 - What format is expected? (email, Slack update, slide, verbal brief)
 - What decision or action, if any, do you need from the audience?
@@ -24,18 +25,22 @@ Write the update using the four-part SCQA framework:
 
 **Situation** (1–2 sentences)
 Set shared context. State what's true right now that the audience already knows or would agree with. This is NOT the problem — it's the stable backdrop.
+
 > Example: "We're 6 weeks into Q2, and our pipeline conversion rate has been a focus area since the Q1 review."
 
 **Complication** (1–3 sentences)
 Introduce the tension. What has changed, gone wrong, or become relevant that makes the situation require attention? This creates the "why are you telling me this" moment.
+
 > Example: "Conversion rate improved from 18% to 22%, but deal velocity slowed — average close time increased from 28 to 41 days, which puts us at risk of missing the Q2 revenue target."
 
 **Question** (1 sentence, implicit or explicit)
 The natural question the reader is now asking. Often not stated explicitly, but naming it sharpens the answer.
+
 > Example: "What's driving the slowdown and what should we do about it?"
 
 **Answer** (the bulk of the update)
 Lead with the recommendation or key insight, then support it with evidence. Structure as:
+
 - **Bottom line up front**: Your conclusion or recommendation in one sentence
 - **Supporting data**: 2–3 data points or observations that back the bottom line
 - **Next steps**: What will happen next and by when, with owners named
@@ -43,6 +48,7 @@ Lead with the recommendation or key insight, then support it with evidence. Stru
 ### 3. Calibrate for Audience
 
 Adjust the update based on audience:
+
 - **CEO / Board**: Lead with business impact and decisions needed. Skip operational detail.
 - **Cross-functional leaders**: Emphasize dependencies and what you need from them.
 - **Skip-level**: Include enough operational context to be credible, but still lead with the headline.
@@ -50,6 +56,7 @@ Adjust the update based on audience:
 ### 4. Editing Pass
 
 Review the draft against these criteria:
+
 - Can the reader understand the key message in the first 30 seconds?
 - Is every sentence earning its place — does it add information or can it be cut?
 - Are there any weasel words or passive constructions hiding uncertainty? If there's uncertainty, name it directly.

--- a/.claude/skills/pm/feature-prioritization/SKILL.md
+++ b/.claude/skills/pm/feature-prioritization/SKILL.md
@@ -21,12 +21,14 @@ Ask the user (via `AskUserQuestion`) which framework to use, or recommend based 
 ### 2. Define Scoring Criteria
 
 For RICE:
+
 - **Reach**: How many users will this affect per quarter? (estimated number)
 - **Impact**: How much will this move the needle per user? (3 = massive, 2 = significant, 1 = low, 0.5 = minimal, 0.25 = trivial)
 - **Confidence**: How confident are you in these estimates? (100% = high, 80% = medium, 50% = low)
 - **Effort**: Total person-months to build, test, and ship.
 
 For ICE:
+
 - **Impact**: 1–10 scale. How much will this move the key metric?
 - **Confidence**: 1–10 scale. How sure are you it will work?
 - **Ease**: 1–10 scale. How easy/fast is this to ship?
@@ -36,6 +38,7 @@ For Weighted Scoring, define 4–6 criteria and assign weights that sum to 100%.
 ### 3. Score Each Item
 
 Create a scoring table for each feature:
+
 - Document the score for each dimension
 - Provide a 1-sentence rationale for the score
 - Calculate the final score
@@ -43,6 +46,7 @@ Create a scoring table for each feature:
 ### 4. Output a Ranked List
 
 Present:
+
 1. A **ranked table** (highest score first) with all scores visible
 2. A **recommended top 3** to ship next, with brief justification
 3. **Items to defer or cut**, with the reason why
@@ -50,6 +54,7 @@ Present:
 ### 5. Flag Risks and Dependencies
 
 For top-ranked items, note:
+
 - Dependencies on other teams or systems
 - Technical or business risks that could invalidate the score
 - Any items that scored low but have strategic override reasons (e.g., compliance, exec mandate)

--- a/.claude/skills/pm/feedback-analysis/SKILL.md
+++ b/.claude/skills/pm/feedback-analysis/SKILL.md
@@ -13,11 +13,13 @@ Input: $ARGUMENTS
 ### 1. Ingest the Feedback
 
 Accept feedback in any of these forms:
+
 - A file path (use `Read` tool)
 - Pasted text in the conversation
 - A description of feedback themes (if raw data isn't available)
 
 If the feedback is unstructured, ask via `AskUserQuestion`:
+
 - What is the source? (NPS, support, reviews, interviews, sales calls)
 - What time period does this cover?
 - What product area or feature set does this relate to?
@@ -25,6 +27,7 @@ If the feedback is unstructured, ask via `AskUserQuestion`:
 ### 2. Categorize Each Item
 
 For each piece of feedback, identify:
+
 - **Theme**: The underlying need or pain point (not the surface request)
 - **Sentiment**: Positive / Negative / Neutral
 - **Urgency signal**: Does the user describe churn risk, workaround behavior, or blocking frustration?
@@ -33,6 +36,7 @@ For each piece of feedback, identify:
 ### 3. Extract Patterns
 
 Group feedback items by theme and count frequency. Look for:
+
 - **High-frequency pain points**: Themes that appear in 10%+ of items
 - **High-severity items**: Individual feedback pieces that signal churn, safety, or legal risk — even if rare
 - **Unmet jobs**: Things users are trying to do that the product doesn't support well
@@ -42,10 +46,12 @@ Group feedback items by theme and count frequency. Look for:
 ### 4. Prioritize Opportunities
 
 Rank the top themes using a simple 2×2:
+
 - **X-axis**: Frequency (how many users mentioned this)
 - **Y-axis**: Severity (how much does this hurt the user or the business)
 
 Quadrant labels:
+
 - High frequency + High severity → **Urgent: Fix or build now**
 - Low frequency + High severity → **Risk: Monitor and triage**
 - High frequency + Low severity → **Polish: Quick wins**
@@ -54,6 +60,7 @@ Quadrant labels:
 ### 5. Surface Insights
 
 Write a synthesis covering:
+
 - **Top 3 opportunities** with supporting evidence (quote 2–3 representative pieces of feedback for each)
 - **One thing to stop doing** (if the data suggests a feature or behavior is causing net harm)
 - **One underserved segment** that shows up in the data with distinct needs

--- a/.claude/skills/pm/go-to-market/SKILL.md
+++ b/.claude/skills/pm/go-to-market/SKILL.md
@@ -13,6 +13,7 @@ Input: $ARGUMENTS
 ### 1. Gather Launch Context
 
 If not provided, use `AskUserQuestion` to ask:
+
 - What are we launching? (new product, feature, pricing change, expansion)
 - Who is the primary target audience?
 - What is the launch date or target window?
@@ -26,6 +27,7 @@ Write a positioning statement using the Geoffrey Moore format:
 > For [target customer] who [has this need or problem], [product/feature name] is a [category] that [key benefit]. Unlike [primary alternative], our solution [key differentiator].
 
 Test the positioning against these questions:
+
 - Is the "unlike" contrast meaningful to the customer (not just internally)?
 - Does the key benefit tie directly to a measurable outcome?
 - Is the category framing right — too narrow (limits growth) or too broad (loses clarity)?
@@ -33,6 +35,7 @@ Test the positioning against these questions:
 ### 3. Audience Segmentation
 
 Define:
+
 - **Primary audience**: Who this launch is designed for first. Be specific.
 - **Secondary audience**: Who else benefits, and how messaging differs for them.
 - **Influencers and champions**: Who drives adoption within a company or community?
@@ -40,6 +43,7 @@ Define:
 ### 4. Messaging Framework
 
 Create a messaging hierarchy:
+
 - **One-liner** (10 words max): Used in headlines, subject lines, social
 - **Elevator pitch** (2–3 sentences): Used in sales, demos, outbound
 - **Full value proposition** (1 paragraph): Used in landing pages, press materials
@@ -51,6 +55,7 @@ For each audience segment, note any messaging adjustments.
 For each channel, specify: goal, tactic, owner, and expected impact.
 
 Evaluate which channels to use based on where the audience lives:
+
 - **Owned**: Blog, in-app notifications, email newsletter, changelog
 - **Earned**: Press, analyst briefings, community word-of-mouth, influencer reviews
 - **Paid**: Ads, sponsored content, events
@@ -59,6 +64,7 @@ Evaluate which channels to use based on where the audience lives:
 ### 6. Launch Timeline
 
 Create a phased timeline:
+
 - **T-4 weeks**: Internal alignment, sales enablement, beta/preview customers
 - **T-2 weeks**: Soft launch to waitlist or early adopters, collect feedback
 - **T-0 (Launch day)**: Public announcement, coordinated across all channels
@@ -67,6 +73,7 @@ Create a phased timeline:
 ### 7. Success Metrics
 
 Define:
+
 - **Primary metric**: The one number that signals launch success
 - **Leading indicators**: What to watch in the first 48–72 hours
 - **Lagging indicators**: What to evaluate at 30/60/90 days

--- a/.claude/skills/pm/metrics-framework/SKILL.md
+++ b/.claude/skills/pm/metrics-framework/SKILL.md
@@ -13,6 +13,7 @@ Input: $ARGUMENTS
 ### 1. Understand the Product Context
 
 If not provided, ask via `AskUserQuestion`:
+
 - What does the product do and who uses it?
 - What is the primary business model? (subscription, usage-based, marketplace, freemium, etc.)
 - What stage is the product at? (early/PMF search, growth, scale, mature)
@@ -21,6 +22,7 @@ If not provided, ask via `AskUserQuestion`:
 ### 2. North Star Metric
 
 Identify the North Star metric: the single number that best captures the core value the product delivers to customers. A good North Star:
+
 - Reflects customer value (not just revenue or vanity activity)
 - Is leading, not lagging (predicts future business health)
 - Is actionable — the team can affect it directly
@@ -29,6 +31,7 @@ Identify the North Star metric: the single number that best captures the core va
 Present 2–3 candidate North Star metrics and recommend one with reasoning.
 
 **Common examples by business type**:
+
 - SaaS productivity tool → Weekly active users completing core workflow
 - Marketplace → Successful transactions per month
 - Consumer app → DAU/MAU ratio (stickiness)
@@ -41,35 +44,43 @@ Validate the North Star by testing: "If this metric goes up while everything els
 Map the full customer lifecycle with 2–3 metrics per stage:
 
 **Acquisition** — How do users discover and arrive?
+
 - Sources: Organic search, paid, referral, direct, partner
 - Key metrics: New signups, CAC by channel, trial starts
 
 **Activation** — Do users experience core value quickly?
+
 - Define the "aha moment" — the action that correlates most strongly with retention
 - Key metrics: Activation rate (% reaching aha moment), time-to-value
 
 **Retention** — Do users keep coming back?
+
 - Define retention for this product (daily, weekly, monthly depending on use case)
 - Key metrics: D7/D30/D90 retention, churn rate, resurrection rate
 
 **Referral** — Do users tell others?
+
 - Key metrics: NPS, viral coefficient (K-factor), referral rate, word-of-mouth signups
 
 **Revenue** — Are we monetizing effectively?
+
 - Key metrics: MRR/ARR, ARPU, LTV, LTV:CAC ratio, expansion revenue
 
 ### 4. Input/Output Metric Pairing
 
 For each AARRR stage, pair:
+
 - **Output metric**: The outcome you're trying to achieve (lagging, harder to move quickly)
 - **Input metric**: The leading indicator or lever the team can pull to affect the output
 
 Example:
+
 > Output: D30 retention = 40% | Input: % of new users who complete onboarding within 24 hours
 
 ### 5. Instrumentation Checklist
 
 For each key metric, document:
+
 - What event or data point needs to be tracked?
 - Where does this data live today? (product analytics, data warehouse, CRM, etc.)
 - Is this metric currently being measured? If not, what's needed to instrument it?
@@ -78,6 +89,7 @@ For each key metric, document:
 ### 6. Anti-metrics
 
 Name 2–3 metrics to explicitly NOT optimize for — things that could improve without the product actually getting better:
+
 - Vanity metrics (e.g., total registered users without activity filter)
 - Metrics that can be gamed easily
 - Metrics that could be optimized at the expense of user trust

--- a/.claude/skills/pm/okr-writer/SKILL.md
+++ b/.claude/skills/pm/okr-writer/SKILL.md
@@ -4,7 +4,7 @@ allowed-tools: Read, AskUserQuestion
 argument-hint: "<team name, strategic goal, or draft OKRs to refine>"
 ---
 
-Write strong OKRs using John Doerr's *Measure What Matters* methodology — or critique and improve a draft set of OKRs the user provides.
+Write strong OKRs using John Doerr's _Measure What Matters_ methodology — or critique and improve a draft set of OKRs the user provides.
 
 Input: $ARGUMENTS
 
@@ -13,6 +13,7 @@ Input: $ARGUMENTS
 ### 1. Understand Context
 
 If not provided, ask via `AskUserQuestion`:
+
 - Is this for a company, team, or individual?
 - What time period? (quarterly is standard)
 - What is the overarching company/product goal this OKR should ladder up to?
@@ -21,12 +22,14 @@ If not provided, ask via `AskUserQuestion`:
 ### 2. OKR Fundamentals (apply throughout)
 
 **Objectives** must be:
+
 - Inspirational and qualitative — describe a destination, not a task
 - Ambitious but achievable ("moonshot" vs. "roofshot" — label which)
 - Memorable in a single sentence
 - NOT a metric (no numbers in the objective)
 
 **Key Results** must be:
+
 - Measurable and time-bound
 - Outcome-oriented (measure impact, not output or activity)
 - 3–5 per objective
@@ -35,6 +38,7 @@ If not provided, ask via `AskUserQuestion`:
 ### 3. Common Pitfalls to Check Against
 
 Flag any of the following:
+
 - **Task masquerading as KR**: "Launch feature X" is output, not outcome. Rewrite as "Feature X drives 20% increase in Y by [date]."
 - **Vanity metric**: Metrics that look good but don't signal real value (e.g., page views without conversion)
 - **Too safe**: If hitting 1.0 seems easy, push the number higher
@@ -44,6 +48,7 @@ Flag any of the following:
 ### 4. Write or Rewrite OKRs
 
 For each Objective:
+
 ```
 Objective: [Inspiring, qualitative goal]
   KR1: [Metric] from [baseline] to [target] by [date]
@@ -54,6 +59,7 @@ Objective: [Inspiring, qualitative goal]
 ### 5. Health Check
 
 After drafting, evaluate each OKR set:
+
 - Does each KR, if achieved, make the objective undeniably true?
 - Are any two KRs measuring the same thing? Consolidate if so.
 - Is there a leading indicator KR (early signal) alongside lagging KRs?

--- a/.claude/skills/pm/prd-generator/SKILL.md
+++ b/.claude/skills/pm/prd-generator/SKILL.md
@@ -13,6 +13,7 @@ Input: $ARGUMENTS
 ### 1. Clarify Scope (if input is vague)
 
 If the input lacks sufficient detail, use `AskUserQuestion` to ask:
+
 - Who is the primary user/customer affected?
 - What outcome are we trying to achieve (not the solution)?
 - What constraints exist (timeline, platform, team size)?
@@ -24,6 +25,7 @@ Frame the problem using the Jobs-to-be-Done format:
 > **When** [situation], **I want to** [motivation/job], **so I can** [expected outcome].
 
 Identify:
+
 - **Functional job**: The practical task the user is trying to accomplish
 - **Emotional job**: How they want to feel
 - **Social job**: How they want to be perceived
@@ -44,16 +46,19 @@ Goal: [Desired outcome]
 Write the full PRD with the following sections:
 
 **Overview**
+
 - Problem statement (1–2 sentences)
 - Why now (business context, urgency)
 - Success metrics (primary KPI + 1–2 supporting metrics)
 
 **Users & Segments**
+
 - Primary user persona
 - Secondary users (if any)
 - Out of scope users
 
 **Requirements**
+
 - P0 (must have for launch)
 - P1 (strongly preferred)
 - P2 (nice to have, post-launch)
@@ -61,9 +66,11 @@ Write the full PRD with the following sections:
 For each requirement, state: what the system must do, not how.
 
 **Non-Requirements**
+
 - Explicitly call out what this PRD does NOT cover to prevent scope creep.
 
 **Open Questions**
+
 - List any unresolved decisions that need stakeholder input before engineering starts.
 
 ### 5. Sprint-Ready User Stories
@@ -73,6 +80,7 @@ Convert P0 requirements into user stories using the format:
 > **As a** [user type], **I want to** [action], **so that** [benefit].
 
 For each story, include:
+
 - **Acceptance criteria** (3–5 bullet points using Given/When/Then)
 - **Story points estimate** (1, 2, 3, 5, or 8 — Fibonacci scale)
 - **Dependencies** (other stories or systems this relies on)

--- a/.claude/skills/pm/stakeholder-review/SKILL.md
+++ b/.claude/skills/pm/stakeholder-review/SKILL.md
@@ -13,6 +13,7 @@ Input: $ARGUMENTS
 ### 1. Read and Understand the Input
 
 Read the provided document thoroughly. If it's a file path, use the `Read` tool. Identify:
+
 - What type of document is this? (PRD, proposal, strategy doc, roadmap, design brief, etc.)
 - What decision or approval is being sought?
 - What is the timeline for feedback?

--- a/.claude/skills/pm/user-story/SKILL.md
+++ b/.claude/skills/pm/user-story/SKILL.md
@@ -13,6 +13,7 @@ Input: $ARGUMENTS
 ### 1. Understand the Feature
 
 If the input is a file, use `Read`. If it's vague, ask via `AskUserQuestion`:
+
 - Who is the primary user of this feature?
 - What is the "happy path" — the most common way this will be used?
 - Are there any known constraints (tech limitations, non-negotiable behaviors)?
@@ -21,6 +22,7 @@ If the input is a file, use `Read`. If it's vague, ask via `AskUserQuestion`:
 ### 2. Epic Summary (if applicable)
 
 If the input describes a large feature, first write a one-paragraph **epic summary**:
+
 - What is being built and why
 - Who it's for
 - What the scope boundaries are (what is NOT included)
@@ -28,6 +30,7 @@ If the input describes a large feature, first write a one-paragraph **epic summa
 ### 3. Break Into Stories
 
 Apply the INVEST criteria to each story:
+
 - **Independent**: Can be developed without requiring another story to be done first
 - **Negotiable**: Details can be discussed with engineering
 - **Valuable**: Delivers something meaningful to the user or system
@@ -36,6 +39,7 @@ Apply the INVEST criteria to each story:
 - **Testable**: Has clear, verifiable acceptance criteria
 
 Story format:
+
 ```
 As a [user type],
 I want to [perform an action],
@@ -45,6 +49,7 @@ so that [I achieve a benefit/outcome].
 ### 4. Acceptance Criteria
 
 For each story, write 3–6 acceptance criteria using Given/When/Then:
+
 ```
 Given [precondition or starting state]
 When [the user takes an action]
@@ -52,6 +57,7 @@ Then [the expected result occurs]
 ```
 
 Cover:
+
 - The happy path
 - Error states and validation
 - Boundary conditions (empty states, max limits)
@@ -60,6 +66,7 @@ Cover:
 ### 5. Story Point Estimates
 
 Estimate each story using Fibonacci (1, 2, 3, 5, 8):
+
 - **1 pt**: Trivial, under 2 hours, no unknowns
 - **2 pt**: Small, half a day, minimal complexity
 - **3 pt**: Medium, 1–2 days, some decisions to make
@@ -71,6 +78,7 @@ For anything 8+, flag it as a splitting candidate and suggest how to break it up
 ### 6. Edge Cases and Notes
 
 For each story, list:
+
 - **Edge cases**: Unusual but valid user behaviors to handle
 - **Out of scope**: Explicitly call out what this story does NOT cover
 - **Dependencies**: Other stories, APIs, or team work this relies on


### PR DESCRIPTION
- Adds 10 PM-focused Claude Code skills under `.claude/skills/pm/`: `competitive-analysis`, `executive-update`, `feature-prioritization`, `feedback-analysis`, `go-to-market`, `metrics-framework`, `okr-writer`, `prd-generator`, `stakeholder-review`, and `user-story`

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*