### PR TITLE
Canvas KPI x-axis label

### DIFF
--- a/web-common/src/components/time-series-chart/Chart.svelte
+++ b/web-common/src/components/time-series-chart/Chart.svelte
@@ -17,6 +17,7 @@
   import type { ChartDataPoint } from "./types";
 
   const THROTTLE_MS = 16;
+  const MIN_WIDTH_FOR_DYNAMIC_LABEL = 200;
 
   export let primaryData: V1TimeSeriesValue[];
   export let secondaryData: V1TimeSeriesValue[] = [];
@@ -241,11 +242,14 @@
         {@const interval = getHoveredInterval(hoveredPoints[0].originalDate)}
         {@const comparisonPoint =
           hasComparison && hoveredPoints[1] ? hoveredPoints[1] : null}
+        {@const useDynamicPosition = width >= MIN_WIDTH_FOR_DYNAMIC_LABEL}
         {#if interval.isValid}
           <span
             class="absolute flex whitespace-nowrap gap-x-1"
-            style:transform="translateX(-{percentage}%)"
-            style:left="{percentage}%"
+            style:transform="translateX(-{useDynamicPosition
+              ? percentage
+              : 50}%)"
+            style:left="{useDynamicPosition ? percentage : 50}%"
           >
             <RangeDisplay {interval} {timeGrain} />
             {#if comparisonPoint}


### PR DESCRIPTION
Fixes APP-741

The x-axis label on KPI sparklines was moving in the opposite direction to the mouse when hovering over narrow charts, creating a confusing user experience. This PR introduces a width threshold (200px) in `Chart.svelte`. When the chart is narrower than this, the x-axis label will now remain stationary and centered, preventing the erratic movement.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-741](https://linear.app/rilldata/issue/APP-741/canvas-kpi-x-axis-label-moving-around-when-hovering-over-chart)

<p><a href="https://cursor.com/background-agent?bcId=bc-120e0580-c213-465a-8633-8fc6e547975b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-120e0580-c213-465a-8633-8fc6e547975b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

