### PR TITLE
fix: fix dual colors in cloud homepage in dark mode

### DIFF
--- a/web-admin/src/components/layout/ContentContainer.svelte
+++ b/web-admin/src/components/layout/ContentContainer.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <main
-  class="bg-surface-base size-full pt-8 pb-16 lg:pt-12 flex flex-col items-center px-8 sm:px-16 lg:px-32 2xl:px-40 overflow-y-auto"
+  class="bg-surface-subtle size-full pt-8 pb-16 lg:pt-12 flex flex-col items-center px-8 sm:px-16 lg:px-32 2xl:px-40 overflow-y-auto"
   style="scrollbar-gutter: stable;"
 >
   <section class="w-full flex flex-col gap-y-3" style:max-width="{maxWidth}px">


### PR DESCRIPTION

<img width="2292" height="1005" alt="Screenshot 2026-02-19 at 20 31 40" src="https://github.com/user-attachments/assets/e2adcd12-94ae-4d08-9ef2-2bec7d4d368d" />
<img width="1898" height="1170" alt="Screenshot 2026-02-19 at 20 39 00" src="https://github.com/user-attachments/assets/70647d3a-e2f4-4c33-a5a7-5019c0505368" />


**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
