### PR TITLE
fix: go cover should not run in short mode

### DIFF
--- a/.github/workflows/go-cover.yml
+++ b/.github/workflows/go-cover.yml
@@ -25,7 +25,7 @@ jobs:
         # Build list of packages to include in coverage, excluding generated code in 'proto/gen'
         PACKAGES=$(go list ./... | grep -v 'proto/gen/' | tr '\n' ',' | sed -e 's/,$//' | sed -e 's/github.com\/rilldata\/rill/./g')
         # Run tests with coverage output
-        go test ./... -timeout 60m -short -v -race -covermode=atomic -coverprofile=coverage.out -coverpkg=$PACKAGES
+        go test ./... -timeout 60m -v -race -covermode=atomic -coverprofile=coverage.out -coverpkg=$PACKAGES
       env:
         RILL_RUNTIME_TEST_MODE: expensive
         RILL_RUNTIME_DRUID_TEST_DSN: ${{ secrets.RILL_RUNTIME_DRUID_TEST_DSN }}


### PR DESCRIPTION
Expensive tests are skipped in short mode even if var is set : https://github.com/rilldata/rill/blob/103905b09f4599c4387a787fd6b344663d2401d7/runtime/testruntime/testmode/expensive.go#L24-L29


**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
