### PR TITLE
fix: `query.cache_hit` is not populated in rill cloud metrics 

### DIFF
--- a/runtime/resolver.go
+++ b/runtime/resolver.go
@@ -15,6 +15,7 @@ import (
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/pkg/jsonval"
+	"github.com/rilldata/rill/runtime/pkg/observability"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -119,7 +120,7 @@ func (r *Runtime) Resolve(ctx context.Context, opts *ResolveOptions) (res Resolv
 	ctx, span := tracer.Start(ctx, "runtime.Resolve", trace.WithAttributes(attribute.String("resolver", opts.Resolver)))
 	var cacheHit bool
 	defer func() {
-		span.SetAttributes(attribute.Bool("cache_hit", cacheHit))
+		observability.AddRequestAttributes(ctx, attribute.Bool("query.cache_hit", cacheHit))
 		if resErr != nil {
 			span.SetAttributes(attribute.String("err", resErr.Error()))
 		}


### PR DESCRIPTION
closes https://linear.app/rilldata/issue/DATA-624/cache-hit-is-not-correctly-populated-in-internal-rill-cloud-metrics

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
