### PR TITLE
AI features beta flag

### DIFF
--- a/web-common/src/features/chat/layouts/sidebar/ChatToggle.svelte
+++ b/web-common/src/features/chat/layouts/sidebar/ChatToggle.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
   import Button from "../../../../components/button/Button.svelte";
   import { chatOpen, sidebarActions } from "./sidebar-store";
-
-  export let beta = false;
 </script>
 
 <Button
@@ -11,5 +9,5 @@
   onClick={sidebarActions.toggleChat}
   active={$chatOpen}
 >
-  AI {#if beta}(Beta){/if}
+  AI
 </Button>

--- a/web-common/src/features/entity-management/AddAssetButton.svelte
+++ b/web-common/src/features/entity-management/AddAssetButton.svelte
@@ -267,7 +267,7 @@
             on:click={() => (generateDataDialog = true)}
           >
             <Wand size="14px" class="stroke-accent-primary-action" /> Generate data
-            using AI (beta)
+            using AI
           </DropdownMenu.Item>
         {/if}
         <DropdownMenu.Separator />

--- a/web-common/src/layout/ApplicationHeader.svelte
+++ b/web-common/src/layout/ApplicationHeader.svelte
@@ -129,7 +129,7 @@
         <CanvasPreviewCTAs canvasName={dashboardName} />
       {/if}
     {:else if showDeveloperChat}
-      <ChatToggle beta />
+      <ChatToggle />
     {/if}
     {#if showDeployCTA}
       <DeployProjectCTA {hasValidDashboard} />


### PR DESCRIPTION
Removes 'Beta' flags from all AI features (e.g., Chat toggle, Generate data using AI CTA) as these features are now considered stable and ready for general use. Non-AI beta flags were intentionally left untouched as per the issue scope.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-764](https://linear.app/rilldata/issue/APP-764/remove-beta-flag-for-all-ai-features)

<p><a href="https://cursor.com/agents/bc-fa5d3846-4da9-48e5-aff5-a69efc38045c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa5d3846-4da9-48e5-aff5-a69efc38045c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

