### PR TITLE
View as selector and tests

### DIFF
--- a/web-admin/src/features/navigation/TopNavigationBar.svelte
+++ b/web-admin/src/features/navigation/TopNavigationBar.svelte
@@ -4,7 +4,6 @@
   import ExploreBookmarks from "@rilldata/web-admin/features/bookmarks/ExploreBookmarks.svelte";
   import ShareDashboardPopover from "@rilldata/web-admin/features/dashboards/share/ShareDashboardPopover.svelte";
   import ShareProjectPopover from "@rilldata/web-admin/features/projects/user-management/ShareProjectPopover.svelte";
-  import { createAdminServiceGetProjectWithBearerToken } from "@rilldata/web-admin/features/public-urls/get-project-with-bearer-token";
   import Rill from "@rilldata/web-common/components/icons/Rill.svelte";
   import Breadcrumbs from "@rilldata/web-common/components/navigation/breadcrumbs/Breadcrumbs.svelte";
   import type { PathOption } from "@rilldata/web-common/components/navigation/breadcrumbs/types";
@@ -17,13 +16,16 @@
   import { runtime } from "@rilldata/web-common/runtime-client/runtime-store";
   import {
     createAdminServiceGetCurrentUser,
-    createAdminServiceGetDeploymentCredentials,
     createAdminServiceListOrganizations as listOrgs,
     createAdminServiceListProjectsForOrganization as listProjects,
     type V1Organization,
   } from "../../client";
   import ViewAsUserChip from "../../features/view-as-user/ViewAsUserChip.svelte";
   import { viewAsUserStore } from "../../features/view-as-user/viewAsUserStore";
+  import {
+    createViewAsCredentialsQuery,
+    createViewAsProjectQuery,
+  } from "../../features/view-as-user/view-as-project-permissions";
   import CreateAlert from "../alerts/CreateAlert.svelte";
   import { useAlerts } from "../alerts/selectors";
   import AvatarButton from "../authentication/AvatarButton.svelte";
@@ -72,32 +74,19 @@
   $: onPublicURLPage = isPublicURLPage($page);
   $: onOrgPage = isOrganizationPage($page);
 
-  // When "View As" is active, fetch deployment credentials for the mocked user.
+  // View As query chain (shared selectors).
   // TanStack Query deduplicates by query key, so if the project layout already
   // ran this query, we get instant cache hits with zero extra network calls.
   $: mockedUserId = $viewAsUserStore?.id;
-
-  $: mockedCredentialsQuery = createAdminServiceGetDeploymentCredentials(
-    organization,
-    project,
-    { userId: mockedUserId },
-    {
-      query: {
-        enabled: !!mockedUserId && !!organization && !!project,
-      },
-    },
+  $: mockedCredentialsQuery = createViewAsCredentialsQuery(
+    organization ?? "",
+    project ?? "",
+    mockedUserId,
   );
-
-  $: mockedProjectQuery = createAdminServiceGetProjectWithBearerToken(
-    organization,
-    project,
-    $mockedCredentialsQuery.data?.accessToken ?? "",
-    undefined,
-    {
-      query: {
-        enabled: !!$mockedCredentialsQuery.data?.accessToken,
-      },
-    },
+  $: mockedProjectQuery = createViewAsProjectQuery(
+    organization ?? "",
+    project ?? "",
+    $mockedCredentialsQuery.data?.accessToken,
   );
 
   // Use effective permissions when "View As" is active (from server)

--- a/web-admin/src/features/navigation/TopNavigationBar.svelte
+++ b/web-admin/src/features/navigation/TopNavigationBar.svelte
@@ -22,10 +22,7 @@
   } from "../../client";
   import ViewAsUserChip from "../../features/view-as-user/ViewAsUserChip.svelte";
   import { viewAsUserStore } from "../../features/view-as-user/viewAsUserStore";
-  import {
-    createViewAsCredentialsQuery,
-    createViewAsProjectQuery,
-  } from "../../features/view-as-user/view-as-project-permissions";
+  import { createViewAsState } from "../../features/view-as-user/view-as-project-permissions";
   import CreateAlert from "../alerts/CreateAlert.svelte";
   import { useAlerts } from "../alerts/selectors";
   import AvatarButton from "../authentication/AvatarButton.svelte";
@@ -74,29 +71,22 @@
   $: onPublicURLPage = isPublicURLPage($page);
   $: onOrgPage = isOrganizationPage($page);
 
-  // View As query chain (shared selectors).
+  // View As state (compound hook).
   // TanStack Query deduplicates by query key, so if the project layout already
   // ran this query, we get instant cache hits with zero extra network calls.
-  $: mockedUserId = $viewAsUserStore?.id;
-  $: mockedCredentialsQuery = createViewAsCredentialsQuery(
-    organization ?? "",
-    project ?? "",
-    mockedUserId,
-  );
-  $: mockedProjectQuery = createViewAsProjectQuery(
-    organization ?? "",
-    project ?? "",
-    $mockedCredentialsQuery.data?.accessToken,
-  );
+  $: viewAsState = createViewAsState(organization ?? "", project ?? "");
+  $: viewAsPermissions = $viewAsState.projectPermissions;
 
   // Use effective permissions when "View As" is active (from server)
   // Otherwise fall back to the props passed from the root layout
   $: effectiveManageProjectMembers =
-    $mockedProjectQuery.data?.projectPermissions?.manageProjectMembers ??
-    manageProjectMembers;
+    $viewAsState.mockedUserId && viewAsPermissions
+      ? viewAsPermissions.manageProjectMembers
+      : manageProjectMembers;
   $: effectiveCreateMagicAuthTokens =
-    $mockedProjectQuery.data?.projectPermissions?.createMagicAuthTokens ??
-    createMagicAuthTokens;
+    $viewAsState.mockedUserId && viewAsPermissions
+      ? viewAsPermissions.createMagicAuthTokens
+      : createMagicAuthTokens;
 
   $: loggedIn = !!$user.data?.user;
   $: rillLogoHref = !loggedIn ? "https://www.rilldata.com" : "/";

--- a/web-admin/src/features/view-as-user/view-as-project-permissions.ts
+++ b/web-admin/src/features/view-as-user/view-as-project-permissions.ts
@@ -1,0 +1,71 @@
+import {
+  createAdminServiceGetDeploymentCredentials,
+  type V1GetDeploymentCredentialsResponse,
+  type V1GetProjectResponse,
+  type V1ProjectPermissions,
+} from "@rilldata/web-admin/client";
+import { createAdminServiceGetProjectWithBearerToken } from "@rilldata/web-admin/features/public-urls/get-project-with-bearer-token";
+import type { CreateQueryResult } from "@tanstack/svelte-query";
+
+/**
+ * Creates a query for fetching deployment credentials for a mocked/simulated user.
+ *
+ * This is the first step in the View As query chain.
+ * TanStack Query deduplicates by query key, so multiple consumers get instant cache hits.
+ */
+export function createViewAsCredentialsQuery(
+  org: string,
+  project: string,
+  mockedUserId: string | undefined,
+): CreateQueryResult<V1GetDeploymentCredentialsResponse> {
+  return createAdminServiceGetDeploymentCredentials(
+    org,
+    project,
+    { userId: mockedUserId },
+    {
+      query: {
+        enabled: !!mockedUserId,
+      },
+    },
+  );
+}
+
+/**
+ * Creates a query for fetching project data using a mocked user's JWT.
+ *
+ * This is the second step in the View As query chain.
+ * It fetches the project using the mocked user's access token to get their permissions.
+ */
+export function createViewAsProjectQuery(
+  org: string,
+  project: string,
+  accessToken: string | undefined,
+): CreateQueryResult<V1GetProjectResponse> {
+  return createAdminServiceGetProjectWithBearerToken(
+    org,
+    project,
+    accessToken ?? "",
+    undefined,
+    {
+      query: {
+        enabled: !!accessToken,
+      },
+    },
+  );
+}
+
+/**
+ * Computes effective project permissions based on View As state.
+ *
+ * When View As is active (mockedUserId is set), returns the mocked user's permissions.
+ * Otherwise, returns the actual user's permissions.
+ */
+export function computeEffectivePermissions(
+  mockedUserId: string | undefined,
+  mockedPermissions: V1ProjectPermissions | undefined,
+  actualPermissions: V1ProjectPermissions | undefined,
+): V1ProjectPermissions | undefined {
+  return mockedUserId && mockedPermissions
+    ? mockedPermissions
+    : actualPermissions;
+}

--- a/web-admin/src/features/view-as-user/view-as-project-permissions.ts
+++ b/web-admin/src/features/view-as-user/view-as-project-permissions.ts
@@ -1,71 +1,118 @@
+import { derived, type Readable } from "svelte/store";
 import {
   createAdminServiceGetDeploymentCredentials,
   type V1GetDeploymentCredentialsResponse,
-  type V1GetProjectResponse,
   type V1ProjectPermissions,
 } from "@rilldata/web-admin/client";
 import { createAdminServiceGetProjectWithBearerToken } from "@rilldata/web-admin/features/public-urls/get-project-with-bearer-token";
-import type { CreateQueryResult } from "@tanstack/svelte-query";
+import { viewAsUserStore } from "./viewAsUserStore";
 
-/**
- * Creates a query for fetching deployment credentials for a mocked/simulated user.
- *
- * This is the first step in the View As query chain.
- * TanStack Query deduplicates by query key, so multiple consumers get instant cache hits.
- */
-export function createViewAsCredentialsQuery(
-  org: string,
-  project: string,
-  mockedUserId: string | undefined,
-): CreateQueryResult<V1GetDeploymentCredentialsResponse> {
-  return createAdminServiceGetDeploymentCredentials(
-    org,
-    project,
-    { userId: mockedUserId },
-    {
-      query: {
-        enabled: !!mockedUserId,
-      },
-    },
-  );
+export interface ViewAsState {
+  /** The mocked user's ID, or undefined when View As is inactive */
+  mockedUserId: string | undefined;
+  /** The mocked user's deployment credentials (for RuntimeProvider) */
+  deploymentCredentials: V1GetDeploymentCredentialsResponse | undefined;
+  /** The mocked user's project permissions, or undefined when View As is inactive */
+  projectPermissions: V1ProjectPermissions | undefined;
+  /** Whether the View As queries are currently loading */
+  isLoading: boolean;
 }
 
 /**
- * Creates a query for fetching project data using a mocked user's JWT.
+ * Creates a compound store that encapsulates the entire View As query chain:
+ * viewAsUserStore → GetDeploymentCredentials → GetProjectWithBearerToken → permissions
  *
- * This is the second step in the View As query chain.
- * It fetches the project using the mocked user's access token to get their permissions.
+ * This hook eliminates duplication between consumers and ensures consistent
+ * handling of the mocked user's permissions across the app.
+ *
+ * TanStack Query deduplicates by query key, so multiple consumers calling this
+ * hook get instant cache hits with zero extra network calls.
+ *
+ * @param org - Organization name
+ * @param project - Project name
+ * @returns A readable store containing the View As state
  */
-export function createViewAsProjectQuery(
+export function createViewAsState(
   org: string,
   project: string,
-  accessToken: string | undefined,
-): CreateQueryResult<V1GetProjectResponse> {
-  return createAdminServiceGetProjectWithBearerToken(
-    org,
-    project,
-    accessToken ?? "",
-    undefined,
-    {
-      query: {
-        enabled: !!accessToken,
+): Readable<ViewAsState> {
+  return derived(viewAsUserStore, ($viewAsUser, set) => {
+    const mockedUserId = $viewAsUser?.id;
+
+    if (!mockedUserId) {
+      set({
+        mockedUserId: undefined,
+        deploymentCredentials: undefined,
+        projectPermissions: undefined,
+        isLoading: false,
+      });
+      return;
+    }
+
+    const credentialsQuery = createAdminServiceGetDeploymentCredentials(
+      org,
+      project,
+      { userId: mockedUserId },
+      {
+        query: {
+          enabled: true,
+        },
       },
-    },
-  );
+    );
+
+    const unsubCredentials = credentialsQuery.subscribe(($credentialsQuery) => {
+      const accessToken = $credentialsQuery.data?.accessToken;
+
+      if (!accessToken) {
+        set({
+          mockedUserId,
+          deploymentCredentials: $credentialsQuery.data,
+          projectPermissions: undefined,
+          isLoading: $credentialsQuery.isLoading,
+        });
+        return;
+      }
+
+      const projectQuery = createAdminServiceGetProjectWithBearerToken(
+        org,
+        project,
+        accessToken,
+        undefined,
+        {
+          query: {
+            enabled: true,
+          },
+        },
+      );
+
+      const unsubProject = projectQuery.subscribe(($projectQuery) => {
+        set({
+          mockedUserId,
+          deploymentCredentials: $credentialsQuery.data,
+          projectPermissions: $projectQuery.data?.projectPermissions,
+          isLoading: $credentialsQuery.isLoading || $projectQuery.isLoading,
+        });
+      });
+
+      return unsubProject;
+    });
+
+    return unsubCredentials;
+  });
 }
 
 /**
- * Computes effective project permissions based on View As state.
+ * Computes effective project permissions by merging actual permissions with
+ * mocked permissions when View As is active.
  *
- * When View As is active (mockedUserId is set), returns the mocked user's permissions.
- * Otherwise, returns the actual user's permissions.
+ * When View As is active and mocked permissions are available, returns the
+ * mocked permissions. Otherwise, returns the actual user's permissions.
  */
-export function computeEffectivePermissions(
-  mockedUserId: string | undefined,
-  mockedPermissions: V1ProjectPermissions | undefined,
+export function getEffectivePermissions(
+  viewAsState: ViewAsState,
   actualPermissions: V1ProjectPermissions | undefined,
 ): V1ProjectPermissions | undefined {
-  return mockedUserId && mockedPermissions
-    ? mockedPermissions
+  return viewAsState.mockedUserId && viewAsState.projectPermissions
+    ? viewAsState.projectPermissions
     : actualPermissions;
 }

--- a/web-admin/src/features/view-as-user/viewAsUserStore.ts
+++ b/web-admin/src/features/view-as-user/viewAsUserStore.ts
@@ -22,6 +22,9 @@ function createViewAsUserStore() {
     initForProject(org: string, project: string): void {
       if (!browser) return;
 
+      // Avoid redundant sessionStorage reads when scope hasn't changed
+      if (currentScope?.org === org && currentScope?.project === project) return;
+
       currentScope = { org, project };
       const key = getStorageKey(org, project);
 

--- a/web-admin/src/features/view-as-user/viewAsUserStore.ts
+++ b/web-admin/src/features/view-as-user/viewAsUserStore.ts
@@ -23,7 +23,8 @@ function createViewAsUserStore() {
       if (!browser) return;
 
       // Avoid redundant sessionStorage reads when scope hasn't changed
-      if (currentScope?.org === org && currentScope?.project === project) return;
+      if (currentScope?.org === org && currentScope?.project === project)
+        return;
 
       currentScope = { org, project };
       const key = getStorageKey(org, project);

--- a/web-admin/src/routes/[organization]/[project]/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/+layout.svelte
@@ -49,9 +49,8 @@
   import { cloudVersion } from "@rilldata/web-admin/features/telemetry/initCloudMetrics";
   import { viewAsUserStore } from "@rilldata/web-admin/features/view-as-user/viewAsUserStore";
   import {
-    createViewAsCredentialsQuery,
-    createViewAsProjectQuery,
-    computeEffectivePermissions,
+    createViewAsState,
+    getEffectivePermissions,
   } from "@rilldata/web-admin/features/view-as-user/view-as-project-permissions";
   import ErrorPage from "@rilldata/web-common/components/ErrorPage.svelte";
   import { metricsService } from "@rilldata/web-common/metrics/initMetrics";
@@ -132,28 +131,17 @@
   $: projectQuery = onPublicURLPage ? tokenProjectQuery : cookieProjectQuery;
 
   /**
-   * View As query chain (shared selectors).
-   * GetDeploymentCredentials → GetProjectWithBearerToken → effective permissions
+   * View As state (compound hook).
+   * Encapsulates: viewAsUserStore → GetDeploymentCredentials → GetProjectWithBearerToken
    */
-  $: mockedUserId = $viewAsUserStore?.id;
-  $: mockedUserDeploymentCredentialsQuery = createViewAsCredentialsQuery(
-    organization,
-    project,
-    mockedUserId,
-  );
-  $: ({ data: mockedUserDeploymentCredentials } =
-    $mockedUserDeploymentCredentialsQuery);
-  $: mockedUserProjectQuery = createViewAsProjectQuery(
-    organization,
-    project,
-    mockedUserDeploymentCredentials?.accessToken,
-  );
+  $: viewAsState = createViewAsState(organization, project);
+  $: ({ mockedUserId, deploymentCredentials: mockedUserDeploymentCredentials } =
+    $viewAsState);
 
   $: ({ data: projectData, error: projectError } = $projectQuery);
 
-  $: effectiveProjectPermissions = computeEffectivePermissions(
-    mockedUserId,
-    $mockedUserProjectQuery.data?.projectPermissions,
+  $: effectiveProjectPermissions = getEffectivePermissions(
+    $viewAsState,
     projectData?.projectPermissions,
   );
 

--- a/web-admin/tests/view-as.spec.ts
+++ b/web-admin/tests/view-as.spec.ts
@@ -26,9 +26,7 @@ test.describe("View As", () => {
     await viewAsMenuItem.click();
 
     // Verify the View As popover content is visible
-    await expect(
-      adminPage.getByPlaceholder("Search for users"),
-    ).toBeVisible();
+    await expect(adminPage.getByPlaceholder("Search for users")).toBeVisible();
     await expect(
       adminPage.getByText("Test your security policies"),
     ).toBeVisible();
@@ -39,7 +37,9 @@ test.describe("View As", () => {
   }) => {
     // Navigate to dashboard
     await adminPage.goto(TEST_DASHBOARD_URL);
-    await expect(adminPage.getByText("Requests")).toBeVisible({ timeout: 15000 });
+    await expect(adminPage.getByText("Requests")).toBeVisible({
+      timeout: 15000,
+    });
 
     // Open the avatar menu
     await adminPage.getByRole("img", { name: "avatar" }).click();
@@ -52,9 +52,7 @@ test.describe("View As", () => {
     await viewAsMenuItem.click();
 
     // Verify the View As popover content is visible
-    await expect(
-      adminPage.getByPlaceholder("Search for users"),
-    ).toBeVisible();
+    await expect(adminPage.getByPlaceholder("Search for users")).toBeVisible();
   });
 
   test("Admin can select a user to view as", async ({ adminPage }) => {
@@ -69,9 +67,7 @@ test.describe("View As", () => {
     await adminPage.getByRole("menuitem", { name: "View as" }).click();
 
     // Wait for users to load
-    await expect(
-      adminPage.getByPlaceholder("Search for users"),
-    ).toBeVisible();
+    await expect(adminPage.getByPlaceholder("Search for users")).toBeVisible();
 
     // Select the first user in the list (the admin user itself)
     const userItems = adminPage.locator('[role="option"]');
@@ -81,12 +77,8 @@ test.describe("View As", () => {
     await firstUser.click();
 
     // Verify the View As chip is displayed
-    await expect(
-      adminPage.getByText(`Viewing as`),
-    ).toBeVisible();
-    await expect(
-      adminPage.getByText(userEmail?.trim() ?? ""),
-    ).toBeVisible();
+    await expect(adminPage.getByText(`Viewing as`)).toBeVisible();
+    await expect(adminPage.getByText(userEmail?.trim() ?? "")).toBeVisible();
   });
 
   test("View As state persists across page refresh", async ({ adminPage }) => {
@@ -99,9 +91,7 @@ test.describe("View As", () => {
     await adminPage.getByRole("menuitem", { name: "View as" }).click();
 
     // Wait for users to load and select the first one
-    await expect(
-      adminPage.getByPlaceholder("Search for users"),
-    ).toBeVisible();
+    await expect(adminPage.getByPlaceholder("Search for users")).toBeVisible();
     const userItems = adminPage.locator('[role="option"]');
     const firstUser = userItems.first();
     await expect(firstUser).toBeVisible({ timeout: 10000 });
@@ -117,9 +107,7 @@ test.describe("View As", () => {
     // Verify the View As state persists after refresh
     await expect(adminPage.getByLabel("Project title")).toBeVisible();
     await expect(adminPage.getByText("Viewing as")).toBeVisible();
-    await expect(
-      adminPage.getByText(userEmail?.trim() ?? ""),
-    ).toBeVisible();
+    await expect(adminPage.getByText(userEmail?.trim() ?? "")).toBeVisible();
   });
 
   test("View As state persists when navigating within the same project", async ({
@@ -134,9 +122,7 @@ test.describe("View As", () => {
     await adminPage.getByRole("menuitem", { name: "View as" }).click();
 
     // Wait for users to load and select the first one
-    await expect(
-      adminPage.getByPlaceholder("Search for users"),
-    ).toBeVisible();
+    await expect(adminPage.getByPlaceholder("Search for users")).toBeVisible();
     const userItems = adminPage.locator('[role="option"]');
     const firstUser = userItems.first();
     await expect(firstUser).toBeVisible({ timeout: 10000 });
@@ -148,13 +134,13 @@ test.describe("View As", () => {
 
     // Navigate to a dashboard within the same project
     await adminPage.goto(TEST_DASHBOARD_URL);
-    await expect(adminPage.getByText("Requests")).toBeVisible({ timeout: 15000 });
+    await expect(adminPage.getByText("Requests")).toBeVisible({
+      timeout: 15000,
+    });
 
     // Verify the View As state persists
     await expect(adminPage.getByText("Viewing as")).toBeVisible();
-    await expect(
-      adminPage.getByText(userEmail?.trim() ?? ""),
-    ).toBeVisible();
+    await expect(adminPage.getByText(userEmail?.trim() ?? "")).toBeVisible();
   });
 
   test("View As state clears when navigating to a different project", async ({
@@ -169,9 +155,7 @@ test.describe("View As", () => {
     await adminPage.getByRole("menuitem", { name: "View as" }).click();
 
     // Wait for users to load and select the first one
-    await expect(
-      adminPage.getByPlaceholder("Search for users"),
-    ).toBeVisible();
+    await expect(adminPage.getByPlaceholder("Search for users")).toBeVisible();
     const userItems = adminPage.locator('[role="option"]');
     const firstUser = userItems.first();
     await expect(firstUser).toBeVisible({ timeout: 10000 });
@@ -200,9 +184,7 @@ test.describe("View As", () => {
     await adminPage.getByRole("menuitem", { name: "View as" }).click();
 
     // Wait for users to load and select the first one
-    await expect(
-      adminPage.getByPlaceholder("Search for users"),
-    ).toBeVisible();
+    await expect(adminPage.getByPlaceholder("Search for users")).toBeVisible();
     const userItems = adminPage.locator('[role="option"]');
     const firstUser = userItems.first();
     await expect(firstUser).toBeVisible({ timeout: 10000 });
@@ -231,9 +213,7 @@ test.describe("View As", () => {
     await adminPage.getByRole("menuitem", { name: "View as" }).click();
 
     // Wait for users to load and select the first one
-    await expect(
-      adminPage.getByPlaceholder("Search for users"),
-    ).toBeVisible();
+    await expect(adminPage.getByPlaceholder("Search for users")).toBeVisible();
     const userItems = adminPage.locator('[role="option"]');
     const firstUser = userItems.first();
     await expect(firstUser).toBeVisible({ timeout: 10000 });
@@ -250,9 +230,7 @@ test.describe("View As", () => {
     await adminPage.getByText("Viewing as").click();
 
     // Verify the dropdown is open with user search
-    await expect(
-      adminPage.getByPlaceholder("Search for users"),
-    ).toBeVisible();
+    await expect(adminPage.getByPlaceholder("Search for users")).toBeVisible();
 
     // Get users list again - there might be different number of users now
     const newUserItems = adminPage.locator('[role="option"]');

--- a/web-admin/tests/view-as.spec.ts
+++ b/web-admin/tests/view-as.spec.ts
@@ -1,0 +1,296 @@
+import { expect } from "@playwright/test";
+import { test } from "./setup/base";
+
+test.describe("View As", () => {
+  test.describe.configure({ mode: "serial" });
+
+  const TEST_PROJECT_URL = "/e2e/openrtb";
+  const TEST_DASHBOARD_URL = "/e2e/openrtb/explore/auction_explore";
+  const DIFFERENT_PROJECT_URL = "/e2e/AdBids";
+
+  test("Admin can access View As menu from project home", async ({
+    adminPage,
+  }) => {
+    // Navigate to project home page
+    await adminPage.goto(TEST_PROJECT_URL);
+    await expect(adminPage.getByLabel("Project title")).toBeVisible();
+
+    // Open the avatar menu
+    await adminPage.getByRole("img", { name: "avatar" }).click();
+
+    // Verify View As menu item is visible (requires manageProject permission)
+    const viewAsMenuItem = adminPage.getByRole("menuitem", { name: "View as" });
+    await expect(viewAsMenuItem).toBeVisible();
+
+    // Open the View As submenu
+    await viewAsMenuItem.click();
+
+    // Verify the View As popover content is visible
+    await expect(
+      adminPage.getByPlaceholder("Search for users"),
+    ).toBeVisible();
+    await expect(
+      adminPage.getByText("Test your security policies"),
+    ).toBeVisible();
+  });
+
+  test("Admin can access View As menu from dashboard page", async ({
+    adminPage,
+  }) => {
+    // Navigate to dashboard
+    await adminPage.goto(TEST_DASHBOARD_URL);
+    await expect(adminPage.getByText("Requests")).toBeVisible({ timeout: 15000 });
+
+    // Open the avatar menu
+    await adminPage.getByRole("img", { name: "avatar" }).click();
+
+    // Verify View As menu item is visible
+    const viewAsMenuItem = adminPage.getByRole("menuitem", { name: "View as" });
+    await expect(viewAsMenuItem).toBeVisible();
+
+    // Open the View As submenu
+    await viewAsMenuItem.click();
+
+    // Verify the View As popover content is visible
+    await expect(
+      adminPage.getByPlaceholder("Search for users"),
+    ).toBeVisible();
+  });
+
+  test("Admin can select a user to view as", async ({ adminPage }) => {
+    // Navigate to project home
+    await adminPage.goto(TEST_PROJECT_URL);
+    await expect(adminPage.getByLabel("Project title")).toBeVisible();
+
+    // Open the avatar menu
+    await adminPage.getByRole("img", { name: "avatar" }).click();
+
+    // Open the View As submenu
+    await adminPage.getByRole("menuitem", { name: "View as" }).click();
+
+    // Wait for users to load
+    await expect(
+      adminPage.getByPlaceholder("Search for users"),
+    ).toBeVisible();
+
+    // Select the first user in the list (the admin user itself)
+    const userItems = adminPage.locator('[role="option"]');
+    const firstUser = userItems.first();
+    await expect(firstUser).toBeVisible({ timeout: 10000 });
+    const userEmail = await firstUser.textContent();
+    await firstUser.click();
+
+    // Verify the View As chip is displayed
+    await expect(
+      adminPage.getByText(`Viewing as`),
+    ).toBeVisible();
+    await expect(
+      adminPage.getByText(userEmail?.trim() ?? ""),
+    ).toBeVisible();
+  });
+
+  test("View As state persists across page refresh", async ({ adminPage }) => {
+    // Navigate to project home
+    await adminPage.goto(TEST_PROJECT_URL);
+    await expect(adminPage.getByLabel("Project title")).toBeVisible();
+
+    // Open the avatar menu and select a user
+    await adminPage.getByRole("img", { name: "avatar" }).click();
+    await adminPage.getByRole("menuitem", { name: "View as" }).click();
+
+    // Wait for users to load and select the first one
+    await expect(
+      adminPage.getByPlaceholder("Search for users"),
+    ).toBeVisible();
+    const userItems = adminPage.locator('[role="option"]');
+    const firstUser = userItems.first();
+    await expect(firstUser).toBeVisible({ timeout: 10000 });
+    const userEmail = await firstUser.textContent();
+    await firstUser.click();
+
+    // Verify the View As chip is displayed
+    await expect(adminPage.getByText("Viewing as")).toBeVisible();
+
+    // Refresh the page
+    await adminPage.reload();
+
+    // Verify the View As state persists after refresh
+    await expect(adminPage.getByLabel("Project title")).toBeVisible();
+    await expect(adminPage.getByText("Viewing as")).toBeVisible();
+    await expect(
+      adminPage.getByText(userEmail?.trim() ?? ""),
+    ).toBeVisible();
+  });
+
+  test("View As state persists when navigating within the same project", async ({
+    adminPage,
+  }) => {
+    // Navigate to project home
+    await adminPage.goto(TEST_PROJECT_URL);
+    await expect(adminPage.getByLabel("Project title")).toBeVisible();
+
+    // Open the avatar menu and select a user
+    await adminPage.getByRole("img", { name: "avatar" }).click();
+    await adminPage.getByRole("menuitem", { name: "View as" }).click();
+
+    // Wait for users to load and select the first one
+    await expect(
+      adminPage.getByPlaceholder("Search for users"),
+    ).toBeVisible();
+    const userItems = adminPage.locator('[role="option"]');
+    const firstUser = userItems.first();
+    await expect(firstUser).toBeVisible({ timeout: 10000 });
+    const userEmail = await firstUser.textContent();
+    await firstUser.click();
+
+    // Verify the View As chip is displayed
+    await expect(adminPage.getByText("Viewing as")).toBeVisible();
+
+    // Navigate to a dashboard within the same project
+    await adminPage.goto(TEST_DASHBOARD_URL);
+    await expect(adminPage.getByText("Requests")).toBeVisible({ timeout: 15000 });
+
+    // Verify the View As state persists
+    await expect(adminPage.getByText("Viewing as")).toBeVisible();
+    await expect(
+      adminPage.getByText(userEmail?.trim() ?? ""),
+    ).toBeVisible();
+  });
+
+  test("View As state clears when navigating to a different project", async ({
+    adminPage,
+  }) => {
+    // Navigate to project home
+    await adminPage.goto(TEST_PROJECT_URL);
+    await expect(adminPage.getByLabel("Project title")).toBeVisible();
+
+    // Open the avatar menu and select a user
+    await adminPage.getByRole("img", { name: "avatar" }).click();
+    await adminPage.getByRole("menuitem", { name: "View as" }).click();
+
+    // Wait for users to load and select the first one
+    await expect(
+      adminPage.getByPlaceholder("Search for users"),
+    ).toBeVisible();
+    const userItems = adminPage.locator('[role="option"]');
+    const firstUser = userItems.first();
+    await expect(firstUser).toBeVisible({ timeout: 10000 });
+    await firstUser.click();
+
+    // Verify the View As chip is displayed
+    await expect(adminPage.getByText("Viewing as")).toBeVisible();
+
+    // Navigate to a different project
+    await adminPage.goto(DIFFERENT_PROJECT_URL);
+    await expect(adminPage.getByLabel("Project title")).toBeVisible();
+
+    // Verify the View As state is cleared
+    await expect(adminPage.getByText("Viewing as")).not.toBeVisible();
+  });
+
+  test("Admin can clear View As state using the chip remove button", async ({
+    adminPage,
+  }) => {
+    // Navigate to project home
+    await adminPage.goto(TEST_PROJECT_URL);
+    await expect(adminPage.getByLabel("Project title")).toBeVisible();
+
+    // Open the avatar menu and select a user
+    await adminPage.getByRole("img", { name: "avatar" }).click();
+    await adminPage.getByRole("menuitem", { name: "View as" }).click();
+
+    // Wait for users to load and select the first one
+    await expect(
+      adminPage.getByPlaceholder("Search for users"),
+    ).toBeVisible();
+    const userItems = adminPage.locator('[role="option"]');
+    const firstUser = userItems.first();
+    await expect(firstUser).toBeVisible({ timeout: 10000 });
+    await firstUser.click();
+
+    // Verify the View As chip is displayed
+    await expect(adminPage.getByText("Viewing as")).toBeVisible();
+
+    // Click the remove button on the chip
+    const removeButton = adminPage.getByLabel("Clear view");
+    await removeButton.click();
+
+    // Verify the View As chip is removed
+    await expect(adminPage.getByText("Viewing as")).not.toBeVisible();
+  });
+
+  test("Admin can change the viewed user using the chip dropdown", async ({
+    adminPage,
+  }) => {
+    // Navigate to project home
+    await adminPage.goto(TEST_PROJECT_URL);
+    await expect(adminPage.getByLabel("Project title")).toBeVisible();
+
+    // Open the avatar menu and select a user
+    await adminPage.getByRole("img", { name: "avatar" }).click();
+    await adminPage.getByRole("menuitem", { name: "View as" }).click();
+
+    // Wait for users to load and select the first one
+    await expect(
+      adminPage.getByPlaceholder("Search for users"),
+    ).toBeVisible();
+    const userItems = adminPage.locator('[role="option"]');
+    const firstUser = userItems.first();
+    await expect(firstUser).toBeVisible({ timeout: 10000 });
+    const firstUserEmail = await firstUser.textContent();
+    await firstUser.click();
+
+    // Verify the View As chip is displayed with the first user
+    await expect(adminPage.getByText("Viewing as")).toBeVisible();
+    await expect(
+      adminPage.getByText(firstUserEmail?.trim() ?? ""),
+    ).toBeVisible();
+
+    // Click on the chip to open the dropdown
+    await adminPage.getByText("Viewing as").click();
+
+    // Verify the dropdown is open with user search
+    await expect(
+      adminPage.getByPlaceholder("Search for users"),
+    ).toBeVisible();
+
+    // Get users list again - there might be different number of users now
+    const newUserItems = adminPage.locator('[role="option"]');
+    const userCount = await newUserItems.count();
+
+    if (userCount > 1) {
+      // Select a different user (second one)
+      const secondUser = newUserItems.nth(1);
+      const secondUserEmail = await secondUser.textContent();
+      await secondUser.click();
+
+      // Verify the chip now shows the new user
+      await expect(adminPage.getByText("Viewing as")).toBeVisible();
+      await expect(
+        adminPage.getByText(secondUserEmail?.trim() ?? ""),
+      ).toBeVisible();
+    }
+  });
+
+  // NOTE: The following test requires a viewer user to be set up in the e2e environment.
+  // Currently, the viewerPage fixture is not fully configured (viewer.json is not created in setup.ts).
+  // This test is commented out until the viewer fixture is properly set up.
+  //
+  // test("Effective permissions update correctly when viewing as a viewer", async ({
+  //   adminPage,
+  // }) => {
+  //   // Navigate to dashboard as admin
+  //   await adminPage.goto(TEST_DASHBOARD_URL);
+  //   await expect(adminPage.getByText("Requests")).toBeVisible({ timeout: 15000 });
+  //
+  //   // Verify the Share button is visible for admin
+  //   const shareButton = adminPage.getByRole("button", { name: "Share" });
+  //   await expect(shareButton).toBeVisible();
+  //
+  //   // Select a viewer user via View As
+  //   // ... (implementation depends on having a viewer user in the project)
+  //
+  //   // Verify the Share button is hidden for viewer
+  //   await expect(shareButton).not.toBeVisible();
+  // });
+});

--- a/web-admin/tests/view-as.spec.ts
+++ b/web-admin/tests/view-as.spec.ts
@@ -272,25 +272,25 @@ test.describe("View As", () => {
     }
   });
 
-  // NOTE: The following test requires a viewer user to be set up in the e2e environment.
+  // This test requires a viewer user to be set up in the e2e environment.
   // Currently, the viewerPage fixture is not fully configured (viewer.json is not created in setup.ts).
-  // This test is commented out until the viewer fixture is properly set up.
-  //
-  // test("Effective permissions update correctly when viewing as a viewer", async ({
-  //   adminPage,
-  // }) => {
-  //   // Navigate to dashboard as admin
-  //   await adminPage.goto(TEST_DASHBOARD_URL);
-  //   await expect(adminPage.getByText("Requests")).toBeVisible({ timeout: 15000 });
-  //
-  //   // Verify the Share button is visible for admin
-  //   const shareButton = adminPage.getByRole("button", { name: "Share" });
-  //   await expect(shareButton).toBeVisible();
-  //
-  //   // Select a viewer user via View As
-  //   // ... (implementation depends on having a viewer user in the project)
-  //
-  //   // Verify the Share button is hidden for viewer
-  //   await expect(shareButton).not.toBeVisible();
-  // });
+  test.skip("Effective permissions update correctly when viewing as a viewer", async ({
+    adminPage,
+  }) => {
+    // Navigate to dashboard as admin
+    await adminPage.goto(TEST_DASHBOARD_URL);
+    await expect(adminPage.getByText("Requests")).toBeVisible({
+      timeout: 15000,
+    });
+
+    // Verify the Share button is visible for admin
+    const shareButton = adminPage.getByRole("button", { name: "Share" });
+    await expect(shareButton).toBeVisible();
+
+    // TODO: Select a viewer user via View As
+    // Implementation depends on having a viewer user in the project
+
+    // Verify the Share button is hidden for viewer
+    await expect(shareButton).not.toBeVisible();
+  });
 });

--- a/web-admin/tests/view-as.spec.ts
+++ b/web-admin/tests/view-as.spec.ts
@@ -2,8 +2,6 @@ import { expect } from "@playwright/test";
 import { test } from "./setup/base";
 
 test.describe("View As", () => {
-  test.describe.configure({ mode: "serial" });
-
   const TEST_PROJECT_URL = "/e2e/openrtb";
   const TEST_DASHBOARD_URL = "/e2e/openrtb/explore/auction_explore";
   const DIFFERENT_PROJECT_URL = "/e2e/AdBids";
@@ -236,18 +234,22 @@ test.describe("View As", () => {
     const newUserItems = adminPage.locator('[role="option"]');
     const userCount = await newUserItems.count();
 
-    if (userCount > 1) {
-      // Select a different user (second one)
-      const secondUser = newUserItems.nth(1);
-      const secondUserEmail = await secondUser.textContent();
-      await secondUser.click();
+    // Skip if only one user exists - the core assertion requires multiple users
+    test.skip(
+      userCount <= 1,
+      "Test requires multiple users in the project to verify user switching",
+    );
 
-      // Verify the chip now shows the new user
-      await expect(adminPage.getByText("Viewing as")).toBeVisible();
-      await expect(
-        adminPage.getByText(secondUserEmail?.trim() ?? ""),
-      ).toBeVisible();
-    }
+    // Select a different user (second one)
+    const secondUser = newUserItems.nth(1);
+    const secondUserEmail = await secondUser.textContent();
+    await secondUser.click();
+
+    // Verify the chip now shows the new user
+    await expect(adminPage.getByText("Viewing as")).toBeVisible();
+    await expect(
+      adminPage.getByText(secondUserEmail?.trim() ?? ""),
+    ).toBeVisible();
   });
 
   // This test requires a viewer user to be set up in the e2e environment.


### PR DESCRIPTION
This PR addresses the follow-up feedback for the "View As" feature (APP-765) by improving code structure, efficiency, and test coverage.

**Key Changes:**

*   **Shared View As Project Permissions Selector:** Extracted the `GetDeploymentCredentials` → `GetProjectWithBearerToken` → effective permissions query chain into a new shared selector (`useViewAsProjectPermissions`). This deduplicates logic previously duplicated in `ProjectLayout` and `TopNavigationBar`, making the code more maintainable and reducing component complexity.
*   **E2E Tests for View As:** Added comprehensive Playwright tests to cover critical scenarios for the "View As" feature, including UI visibility, state persistence across refreshes and navigation, and state clearing. This significantly improves test coverage for a security-adjacent feature. (Note: Effective permissions assertions are commented out pending `viewerPage` fixture setup).
*   **Optimized `initForProject`:** Implemented an early return in `initForProject` to prevent redundant `sessionStorage` reads when the project scope has not changed, improving efficiency.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
Linear Issue: [APP-765](https://linear.app/rilldata/issue/APP-765/follow-up-on-extending-view-as-feature)

<p><a href="https://cursor.com/agents/bc-62acd633-3d5c-461e-a4a8-cb5d4cc0d020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62acd633-3d5c-461e-a4a8-cb5d4cc0d020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

