### PR TITLE
Table column overlapping

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/DimensionFilterGutter.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionFilterGutter.svelte
@@ -30,13 +30,13 @@
 </script>
 
 <div
-  class="sticky left-0 top-0 z-20 bg-transparent"
+  class="sticky left-0 top-0 z-20 bg-surface-background"
   style:height="{totalHeight}px"
   style:width="{config.indexWidth}px"
 >
   <div
     style:height="{config.columnHeaderHeight}px"
-    class="sticky left-0 top-0 bg-transparent z-40 flex items-center"
+    class="sticky left-0 top-0 bg-surface-background z-40 flex items-center"
   >
     <DimensionCompareMenu
       {dimensionName}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardCell.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardCell.svelte
@@ -123,6 +123,10 @@
   }
 
   td.dimension-cell {
-    @apply sticky left-0 z-30;
+    @apply sticky left-0 z-30 bg-surface-background;
+  }
+
+  :global(tr:hover) td.dimension-cell {
+    @apply bg-popover-accent;
   }
 </style>

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
@@ -233,7 +233,7 @@
   }
 
   th[data-dimension-header] {
-    @apply sticky left-0 z-30 bg-transparent text-left;
+    @apply sticky left-0 z-30 bg-surface-background text-left;
   }
 
   th:not(:first-of-type) {

--- a/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
@@ -71,7 +71,7 @@
   bind:clientHeight={sidebarHeight}
   transition:slide={{ axis: "x" }}
 >
-  <div class="input-wrapper sticky top-0 z-10">
+  <div class="input-wrapper sticky top-0 z-10 bg-surface-background">
     <Search theme background bind:value={searchText} />
   </div>
 


### PR DESCRIPTION
Resolves APP-766.
Sticky table elements (fixed columns, headers, and the pivot sidebar search bar) had transparent backgrounds, leading to content overlap during horizontal and vertical scrolling. This PR applies `bg-surface-background` to these components to ensure they are opaque, preventing visual artifacts. Hover states for sticky cells were also updated for consistency.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
Linear Issue: [APP-766](https://linear.app/rilldata/issue/APP-766/table-columns-are-overlapping)

<p><a href="https://cursor.com/agents/bc-0d8d1225-1dcd-4968-8fde-955ce867b6c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d8d1225-1dcd-4968-8fde-955ce867b6c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

