### PR TITLE
Consistent AddData logo heights

### DIFF
--- a/web-common/src/features/sources/modal/AddDataModal.svelte
+++ b/web-common/src/features/sources/modal/AddDataModal.svelte
@@ -305,6 +305,10 @@
     @apply flex items-center justify-center;
   }
 
+  .connector-wrapper :global(svg) {
+    max-height: 40px;
+  }
+
   .connector-tile-button:hover {
     @apply bg-gray-100;
   }


### PR DESCRIPTION
Before
<img width="1719" height="924" alt="Screenshot 2026-02-26 at 10 50 38 AM" src="https://github.com/user-attachments/assets/f8b8b9eb-ced2-43c3-bcd1-534ed17927c1" />

After
<img width="1571" height="927" alt="Screenshot 2026-02-26 at 10 55 36 AM" src="https://github.com/user-attachments/assets/f54584ff-5198-4aee-af1d-50649313547f" />

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
