### PR TITLE
feat: In deploy don't create empty commits but push changes

### DIFF
--- a/cli/pkg/gitutil/gitcmdwrapper_test.go
+++ b/cli/pkg/gitutil/gitcmdwrapper_test.go
@@ -221,6 +221,15 @@ func TestGitPull(t *testing.T) {
 	require.Empty(t, output, "unexpected output from GitPull with remote changes")
 }
 
+func TestRunGitPush_NoNewCommits(t *testing.T) {
+	tempDir, _ := setupTestRepository(t)
+	branch := getCurrentBranch(t, tempDir)
+
+	// Push with no new commits; remote is already up to date — should not error.
+	err := RunGitPush(context.Background(), tempDir, "origin", branch)
+	require.NoError(t, err, "RunGitPush should not fail when there are no new commits")
+}
+
 func TestInferGitRepoRoot_InRepoRoot(t *testing.T) {
 	tempDir, _ := setupTestRepository(t)
 

--- a/cli/pkg/gitutil/gitutil.go
+++ b/cli/pkg/gitutil/gitutil.go
@@ -203,13 +203,12 @@ func CommitAndPush(ctx context.Context, projectPath string, config *Config, comm
 	if commitMsg == "" {
 		commitMsg = "Auto committed by Rill"
 	}
-	_, err = wt.Commit(commitMsg, &git.CommitOptions{Author: author, AllowEmptyCommits: true})
+	_, err = wt.Commit(commitMsg, &git.CommitOptions{Author: author, AllowEmptyCommits: false})
 	if err != nil {
 		if !errors.Is(err, git.ErrEmptyCommit) {
 			return fmt.Errorf("failed to commit files to git: %w", err)
 		}
-		// empty commit - nothing to cmmit
-		return nil
+		// still trigger push
 	}
 
 	// set remote and push the changes


### PR DESCRIPTION
- On deploys done in CI/CD there are no new changes but a commit is created. This commit is not written back to user's repo. On next deploy since we no longer do a force push it fails with error : `divergent branches` 
- Fix is to not do empty commits but still trigger a push.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
