### PR TITLE
Add `wait_until_idle` and `tail_logs` to `project_status` AI tool

### DIFF
--- a/runtime/ai/instructions/data/development.md
+++ b/runtime/ai/instructions/data/development.md
@@ -231,7 +231,7 @@ Your workflow will depend on the kind of task you are undertaking. Here follows 
 5. **Profile the data**: Before creating a metrics view, look at the schema of the underlying model/table to understand its shape. This informs which dimensions and measures you create. Consider using the SQL query tool to do a couple well-chosen queries to the table to get row counts, cardinality of important columns, example column values, date ranges, or similar. Be very careful not to run too many queries or expensive queries.
 6. **Create or update the metrics view**: Define dimensions and measures using columns in the underlying model/table. Start small with one time dimension (timeseries), up to 10 dimensions and up to 5 measures, and add more later if relevant.
 7. **Ensure there are dashboards**: Create an explore dashboard for drill-down analysis of the metrics view if one doesn't already exist. If the user wants an overview or report-style view, also create a canvas dashboard with components from one or more metrics views.
-8. **Keep iterating until errors are fixed:** At each stage, if there are parse or reconcile errors, keep updating the relevant file(s) to fix the error.
+8. **Check for errors and keep iterating until they are fixed:** At each stage, check if there is a parse or reconcile error, and if there is, keep updating the relevant file(s) to fix the error.
 
 ### Available tools
 
@@ -239,9 +239,9 @@ The following tools are typically available for project development:
 {% if not .external %}
 - `file_list`, `file_search` and `file_read` for accessing existing files in the project
 - `develop_file` for delegating file development to a sub-agent, which handles writing and iterating on errors
-- `file_write` for directly creating, updating or deleting a file (available to sub-agents; waits for parse/reconcile and returns resource status)
+- `file_write` for directly creating, updating or deleting a file (available to sub-agents only); `file_write` will wait for parse/reconcile and return the resource status, so if you use it, you don't need to separately call `project_status`
 {% end %}
-- `project_status` for checking resource names and their current status (idle, running, error); supports `wait_until_idle` to block until reconciliation completes, and includes recent instance logs by default
+- `project_status` for checking resource names and their current status (idle, running, error); supports `wait_until_idle` to block until reconciliation completes (use this if you just made a change and want to wait until it succeeds/errors), and includes recent instance logs by default
 - `query_sql` for running SQL against a connector; use `SELECT` statements with `LIMIT` clauses and low timeouts, and be mindful of performance or making too many queries
 - `query_metrics_view` for querying a metrics view; useful for answering data questions and validating dashboard behavior
 - `list_tables` and `show_table` for accessing the information schema of a database connector
@@ -272,5 +272,5 @@ Avoid these mistakes when developing a project:
 - **Doing too much introspection/profiling:** Reading files, introspecting connectors, profiling models/tables can be time consuming and easily load too much context. Stay disciplined and don't do too much open-ended exploration or unnecessarily look into other levels of the DAG, especially if your task is a small/surgical edit.
 - **Not using the `develop_file` tool:** You should plan the changes you want to make first, then delegate each change separately to the `develop_file` tool. When calling `develop_file`, pass in any relevant context from your investigation/planning/profiling phase.
 - **Doing too much at a time:** Consider the minimal amount of work to accomplish your current task. It's better to make changes incrementally and let the user guide your work.
-- **Don't stop if there are errors:** When a file has an error after you made changes, keep looping until you have done your best to fix the error. You should not give up easily, the user does expect you to try and fix errors.
+- **Don't stop if there are errors:** When a file has an error after you made changes, keep looping until you have done your best to fix the error. You should not give up easily, the user expects you to try and fix errors.
 {% end %}

--- a/runtime/ai/project_status.go
+++ b/runtime/ai/project_status.go
@@ -25,7 +25,7 @@ type ProjectStatusArgs struct {
 	Path                        string `json:"path,omitempty" jsonschema:"Optional filter to only return resources declared in the specified file path."`
 	WaitUntilIdle               bool   `json:"wait_until_idle,omitempty" jsonschema:"If true, waits until all resources have finished reconciling before returning the status. Set this if you have recently updated a resource and want to know if it parsed and reconciled successfully."`
 	WaitUntilIdleTimeoutSeconds int    `json:"wait_until_idle_timeout_seconds,omitempty" jsonschema:"Timeout in seconds for wait_until_idle. Defaults to 60. Only override if you anticipate large workloads."`
-	TailLogs                    int    `json:"tail_logs,omitempty" jsonschema:"Number of recent log entries to include in the response. Defaults to 0."`
+	TailLogsCount               int    `json:"tail_logs_count,omitempty" jsonschema:"Number of recent log entries to include in the response. Defaults to 0."`
 }
 
 type ProjectStatusResult struct {
@@ -153,12 +153,12 @@ func (t *ProjectStatus) Handler(ctx context.Context, args *ProjectStatusArgs) (*
 
 	// Get recent logs
 	var logs []map[string]any
-	if args.TailLogs > 0 {
+	if args.TailLogsCount > 0 {
 		logBuffer, err := t.Runtime.InstanceLogs(ctx, s.InstanceID())
 		if err != nil {
 			return nil, err
 		}
-		entries := logBuffer.GetLogs(true, args.TailLogs, runtimev1.LogLevel_LOG_LEVEL_DEBUG)
+		entries := logBuffer.GetLogs(true, args.TailLogsCount, runtimev1.LogLevel_LOG_LEVEL_DEBUG)
 		logs = make([]map[string]any, 0, len(entries))
 		for _, entry := range entries {
 			l := map[string]any{

--- a/runtime/ai/project_status_test.go
+++ b/runtime/ai/project_status_test.go
@@ -85,7 +85,7 @@ measures:
 	t.Run("tail logs", func(t *testing.T) {
 		var res *ai.ProjectStatusResult
 		_, err := s.CallTool(t.Context(), ai.RoleUser, ai.ProjectStatusName, &res, &ai.ProjectStatusArgs{
-			TailLogs: 100,
+			TailLogsCount: 100,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, res)


### PR DESCRIPTION
- `wait_until_idle` blocks until all resources finish reconciling before returning status (default 60s timeout, configurable)
- `tail_logs` includes the last N instance log entries in the response (default 100, all levels including debug)

**Checklist:**
- [x] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!