### PR TITLE
Dashboard preview blank state

### DIFF
--- a/web-common/src/features/explores/selectors.spec.ts
+++ b/web-common/src/features/explores/selectors.spec.ts
@@ -21,11 +21,15 @@ function makeMetricsViewSpec(timeDimensionName: string): V1MetricsViewSpec {
 }
 
 function makeGetExploreResponse({
+  exploreName = "ad_bids_explore",
+  metricsViewName = "ad_bids_metrics",
   exploreSpec,
   metricsViewSpec,
   exploreReconcileStatus = V1ReconcileStatus.RECONCILE_STATUS_IDLE,
   metricsViewReconcileStatus = V1ReconcileStatus.RECONCILE_STATUS_IDLE,
 }: {
+  exploreName?: string;
+  metricsViewName?: string;
   exploreSpec: V1ExploreSpec | undefined;
   metricsViewSpec: V1MetricsViewSpec | undefined;
   exploreReconcileStatus?: V1ReconcileStatus;
@@ -34,6 +38,9 @@ function makeGetExploreResponse({
   return {
     explore: {
       meta: {
+        name: {
+          name: exploreName,
+        },
         reconcileStatus: exploreReconcileStatus,
       },
       explore: {
@@ -44,6 +51,9 @@ function makeGetExploreResponse({
     },
     metricsView: {
       meta: {
+        name: {
+          name: metricsViewName,
+        },
         reconcileStatus: metricsViewReconcileStatus,
       },
       metricsView: {
@@ -127,5 +137,55 @@ describe("createCachedExploreValidSpecSelector", () => {
 
     expect(updatedSpecs.explore?.metricsView).toBe("ad_impressions_metrics");
     expect(updatedSpecs.metricsView?.timeDimension).toBe("created_at");
+  });
+
+  it("keeps the cached pair when only one spec is missing during reconciliation", () => {
+    const selector = createCachedExploreValidSpecSelector();
+
+    const initialSpecs = selector(
+      makeGetExploreResponse({
+        exploreSpec: makeExploreSpec("ad_bids_metrics"),
+        metricsViewSpec: makeMetricsViewSpec("timestamp"),
+      }),
+    );
+
+    const partialSpecs = selector(
+      makeGetExploreResponse({
+        exploreSpec: makeExploreSpec("ad_bids_metrics"),
+        metricsViewSpec: undefined,
+        metricsViewReconcileStatus: V1ReconcileStatus.RECONCILE_STATUS_RUNNING,
+      }),
+    );
+
+    expect(partialSpecs).toEqual(initialSpecs);
+  });
+
+  it("does not bleed cached specs across explores", () => {
+    const selector = createCachedExploreValidSpecSelector();
+
+    selector(
+      makeGetExploreResponse({
+        exploreName: "explore_a",
+        metricsViewName: "metrics_a",
+        exploreSpec: makeExploreSpec("metrics_a"),
+        metricsViewSpec: makeMetricsViewSpec("timestamp"),
+      }),
+    );
+
+    const otherExploreSpecs = selector(
+      makeGetExploreResponse({
+        exploreName: "explore_b",
+        metricsViewName: "metrics_b",
+        exploreSpec: undefined,
+        metricsViewSpec: undefined,
+        exploreReconcileStatus: V1ReconcileStatus.RECONCILE_STATUS_RUNNING,
+        metricsViewReconcileStatus: V1ReconcileStatus.RECONCILE_STATUS_RUNNING,
+      }),
+    );
+
+    expect(otherExploreSpecs).toEqual({
+      explore: undefined,
+      metricsView: undefined,
+    });
   });
 });

--- a/web-common/src/features/explores/selectors.spec.ts
+++ b/web-common/src/features/explores/selectors.spec.ts
@@ -1,0 +1,131 @@
+import type {
+  V1ExploreSpec,
+  V1GetExploreResponse,
+  V1MetricsViewSpec,
+} from "@rilldata/web-common/runtime-client";
+import { V1ReconcileStatus } from "@rilldata/web-common/runtime-client";
+import { describe, expect, it } from "vitest";
+import { createCachedExploreValidSpecSelector } from "./selectors";
+
+function makeExploreSpec(metricsViewName: string): V1ExploreSpec {
+  return {
+    metricsView: metricsViewName,
+    measures: ["impressions"],
+  } as V1ExploreSpec;
+}
+
+function makeMetricsViewSpec(timeDimensionName: string): V1MetricsViewSpec {
+  return {
+    timeDimension: timeDimensionName,
+  } as V1MetricsViewSpec;
+}
+
+function makeGetExploreResponse({
+  exploreSpec,
+  metricsViewSpec,
+  exploreReconcileStatus = V1ReconcileStatus.RECONCILE_STATUS_IDLE,
+  metricsViewReconcileStatus = V1ReconcileStatus.RECONCILE_STATUS_IDLE,
+}: {
+  exploreSpec: V1ExploreSpec | undefined;
+  metricsViewSpec: V1MetricsViewSpec | undefined;
+  exploreReconcileStatus?: V1ReconcileStatus;
+  metricsViewReconcileStatus?: V1ReconcileStatus;
+}): V1GetExploreResponse {
+  return {
+    explore: {
+      meta: {
+        reconcileStatus: exploreReconcileStatus,
+      },
+      explore: {
+        state: {
+          validSpec: exploreSpec,
+        },
+      },
+    },
+    metricsView: {
+      meta: {
+        reconcileStatus: metricsViewReconcileStatus,
+      },
+      metricsView: {
+        state: {
+          validSpec: metricsViewSpec,
+        },
+      },
+    },
+  } as V1GetExploreResponse;
+}
+
+describe("createCachedExploreValidSpecSelector", () => {
+  it("keeps the last complete valid specs while resources reconcile", () => {
+    const selector = createCachedExploreValidSpecSelector();
+
+    const initialResponse = makeGetExploreResponse({
+      exploreSpec: makeExploreSpec("ad_bids_metrics"),
+      metricsViewSpec: makeMetricsViewSpec("timestamp"),
+    });
+    const initialSpecs = selector(initialResponse);
+
+    const reconcilingResponse = makeGetExploreResponse({
+      exploreSpec: undefined,
+      metricsViewSpec: undefined,
+      exploreReconcileStatus: V1ReconcileStatus.RECONCILE_STATUS_RUNNING,
+      metricsViewReconcileStatus: V1ReconcileStatus.RECONCILE_STATUS_RUNNING,
+    });
+    const reconcilingSpecs = selector(reconcilingResponse);
+
+    expect(reconcilingSpecs).toEqual(initialSpecs);
+  });
+
+  it("does not keep stale specs once reconciliation is idle", () => {
+    const selector = createCachedExploreValidSpecSelector();
+
+    selector(
+      makeGetExploreResponse({
+        exploreSpec: makeExploreSpec("ad_bids_metrics"),
+        metricsViewSpec: makeMetricsViewSpec("timestamp"),
+      }),
+    );
+
+    const idleResponse = makeGetExploreResponse({
+      exploreSpec: undefined,
+      metricsViewSpec: undefined,
+      exploreReconcileStatus: V1ReconcileStatus.RECONCILE_STATUS_IDLE,
+      metricsViewReconcileStatus: V1ReconcileStatus.RECONCILE_STATUS_IDLE,
+    });
+    const idleSpecs = selector(idleResponse);
+
+    expect(idleSpecs).toEqual({
+      explore: undefined,
+      metricsView: undefined,
+    });
+  });
+
+  it("updates the cache when new complete specs arrive", () => {
+    const selector = createCachedExploreValidSpecSelector();
+
+    selector(
+      makeGetExploreResponse({
+        exploreSpec: makeExploreSpec("ad_bids_metrics"),
+        metricsViewSpec: makeMetricsViewSpec("timestamp"),
+      }),
+    );
+
+    selector(
+      makeGetExploreResponse({
+        exploreSpec: undefined,
+        metricsViewSpec: undefined,
+        exploreReconcileStatus: V1ReconcileStatus.RECONCILE_STATUS_RUNNING,
+      }),
+    );
+
+    const updatedSpecs = selector(
+      makeGetExploreResponse({
+        exploreSpec: makeExploreSpec("ad_impressions_metrics"),
+        metricsViewSpec: makeMetricsViewSpec("created_at"),
+      }),
+    );
+
+    expect(updatedSpecs.explore?.metricsView).toBe("ad_impressions_metrics");
+    expect(updatedSpecs.metricsView?.timeDimension).toBe("created_at");
+  });
+});

--- a/web-common/src/features/explores/selectors.ts
+++ b/web-common/src/features/explores/selectors.ts
@@ -47,6 +47,10 @@ export type ExploreValidSpecResponse = {
   metricsView: V1MetricsViewSpec | undefined;
 };
 
+function getExploreIdentity(data: V1GetExploreResponse): string | undefined {
+  return data.explore?.meta?.name?.name;
+}
+
 function getExploreValidSpecs(
   data: V1GetExploreResponse,
 ): ExploreValidSpecResponse {
@@ -63,8 +67,15 @@ function getExploreValidSpecs(
  */
 export function createCachedExploreValidSpecSelector() {
   let cachedValidSpecs: ExploreValidSpecResponse | undefined;
+  let cachedExploreIdentity: string | undefined;
 
   return (data: V1GetExploreResponse): ExploreValidSpecResponse => {
+    const currentExploreIdentity = getExploreIdentity(data);
+    if (currentExploreIdentity !== cachedExploreIdentity) {
+      cachedValidSpecs = undefined;
+      cachedExploreIdentity = currentExploreIdentity;
+    }
+
     const validSpecs = getExploreValidSpecs(data);
 
     if (validSpecs.explore && validSpecs.metricsView) {
@@ -102,7 +113,7 @@ export function useExploreValidSpec(
     { name: exploreName },
     {
       query: {
-        select: (data) => selectCachedValidSpec(data),
+        select: selectCachedValidSpec,
 
         enabled: !!exploreName,
         ...queryOptions,

--- a/web-common/src/features/explores/selectors.ts
+++ b/web-common/src/features/explores/selectors.ts
@@ -1,3 +1,4 @@
+import { resourceIsLoading } from "@rilldata/web-common/features/entity-management/resource-selectors";
 import { runtime } from "@rilldata/web-common/runtime-client/runtime-store.ts";
 import {
   type CreateQueryOptions,
@@ -45,6 +46,43 @@ export type ExploreValidSpecResponse = {
   explore: V1ExploreSpec | undefined;
   metricsView: V1MetricsViewSpec | undefined;
 };
+
+function getExploreValidSpecs(
+  data: V1GetExploreResponse,
+): ExploreValidSpecResponse {
+  return {
+    explore: data.explore?.explore?.state?.validSpec,
+    metricsView: data.metricsView?.metricsView?.state?.validSpec,
+  };
+}
+
+/**
+ * Keeps the last complete pair of explore + metrics view specs while
+ * resources are reconciling. This avoids dashboard flicker when validSpec is
+ * temporarily cleared mid-reconcile.
+ */
+export function createCachedExploreValidSpecSelector() {
+  let cachedValidSpecs: ExploreValidSpecResponse | undefined;
+
+  return (data: V1GetExploreResponse): ExploreValidSpecResponse => {
+    const validSpecs = getExploreValidSpecs(data);
+
+    if (validSpecs.explore && validSpecs.metricsView) {
+      cachedValidSpecs = validSpecs;
+      return validSpecs;
+    }
+
+    const isReconciling =
+      resourceIsLoading(data.explore) || resourceIsLoading(data.metricsView);
+
+    if (isReconciling && cachedValidSpecs) {
+      return cachedValidSpecs;
+    }
+
+    return validSpecs;
+  };
+}
+
 export function useExploreValidSpec(
   instanceId: string,
   exploreName: string,
@@ -57,16 +95,14 @@ export function useExploreValidSpec(
   >,
   queryClient?: QueryClient,
 ) {
+  const selectCachedValidSpec = createCachedExploreValidSpecSelector();
+
   return createRuntimeServiceGetExplore(
     instanceId,
     { name: exploreName },
     {
       query: {
-        select: (data) =>
-          <ExploreValidSpecResponse>{
-            explore: data.explore?.explore?.state?.validSpec,
-            metricsView: data.metricsView?.metricsView?.state?.validSpec,
-          },
+        select: (data) => selectCachedValidSpec(data),
 
         enabled: !!exploreName,
         ...queryOptions,
@@ -79,22 +115,30 @@ export function useExploreValidSpec(
 export function getExploreValidSpecQueryOptions(
   exploreNameStore: Readable<string>,
 ) {
-  return derived([runtime, exploreNameStore], ([{ instanceId }, exploreName]) =>
-    getRuntimeServiceGetExploreQueryOptions(
-      instanceId,
-      {
-        name: exploreName,
-      },
-      {
-        query: {
-          select: (data) => ({
-            exploreSpec: data.explore?.explore?.state?.validSpec,
-            metricsViewSpec: data.metricsView?.metricsView?.state?.validSpec,
-          }),
-          enabled: !!exploreName,
+  const selectCachedValidSpec = createCachedExploreValidSpecSelector();
+
+  return derived(
+    [runtime, exploreNameStore],
+    ([{ instanceId }, exploreName]) => {
+      return getRuntimeServiceGetExploreQueryOptions(
+        instanceId,
+        {
+          name: exploreName,
         },
-      },
-    ),
+        {
+          query: {
+            select: (data) => {
+              const validSpecs = selectCachedValidSpec(data);
+              return {
+                exploreSpec: validSpecs.explore,
+                metricsViewSpec: validSpecs.metricsView,
+              };
+            },
+            enabled: !!exploreName,
+          },
+        },
+      );
+    },
   );
 }
 


### PR DESCRIPTION
Fixes APP-758

Prevents the dashboard preview from going blank during reconciliation when project files are edited externally.

**Why this change?**
Previously, when `validSpec` became null during reconciliation, the frontend immediately reflected this, causing the dashboard preview to disappear. This change ensures a smoother user experience by retaining the last valid dashboard state until reconciliation completes.

**What was changed?**
Implemented a cached selector (`createCachedExploreValidSpecSelector`) that holds onto the last complete valid `explore` and `metricsView` spec. This cached spec is returned when the current response has a missing `validSpec` *and* resources are actively reconciling. Once reconciliation is idle, the cache is no longer used, allowing actual invalid states to surface. This selector was integrated into `useExploreValidSpec` and `getExploreValidSpecQueryOptions`.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
Linear Issue: [APP-758](https://linear.app/rilldata/issue/APP-758/dashboard-preview-goes-blank-during-reconciliation-when-editing-files)

<p><a href="https://cursor.com/agents/bc-146a4398-e2a5-4417-8e8e-8d915b440175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-146a4398-e2a5-4417-8e8e-8d915b440175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

