### PR TITLE
Project waking UI state

### DIFF
--- a/web-admin/src/features/billing/BillingCTAHandler.ts
+++ b/web-admin/src/features/billing/BillingCTAHandler.ts
@@ -25,7 +25,6 @@ export class BillingCTAHandler {
     let instance: BillingCTAHandler;
     if (this.instances.has(organization)) {
       instance = this.instances.get(organization)!;
-      instance.wakingProjects.set(false);
     } else {
       instance = new BillingCTAHandler(organization);
       this.instances.set(organization, instance);

--- a/web-admin/src/features/billing/banner/BillingBannerManagerForAdmins.svelte
+++ b/web-admin/src/features/billing/banner/BillingBannerManagerForAdmins.svelte
@@ -14,11 +14,31 @@
   export let organization: string;
 
   $: billingIssueMessage = useBillingIssueMessage(organization);
-  $: billingCTAHandler = new BillingCTAHandler(organization);
-  $: ({ showStartTeamPlanDialog, startTeamPlanType, teamPlanEndDate } =
-    billingCTAHandler);
+  $: billingCTAHandler = BillingCTAHandler.get(organization);
+  $: ({
+    showStartTeamPlanDialog,
+    startTeamPlanType,
+    teamPlanEndDate,
+    wakingProjects,
+  } = billingCTAHandler);
 
-  function showBillingIssueBanner(message: BillingIssueMessage | undefined) {
+  function showBillingIssueBanner(
+    message: BillingIssueMessage | undefined,
+    isWakingProjects: boolean,
+  ) {
+    if (isWakingProjects) {
+      eventBus.emit("add-banner", {
+        id: BillingBannerID,
+        priority: BillingBannerPriority,
+        message: {
+          type: "info",
+          message: "Waking projects. We’ll notify you when they’re ready.",
+          iconType: "loading",
+        },
+      });
+      return;
+    }
+
     if (!message) {
       eventBus.emit("remove-banner", BillingBannerID);
       return;
@@ -46,7 +66,7 @@
     });
   }
 
-  $: showBillingIssueBanner($billingIssueMessage.data);
+  $: showBillingIssueBanner($billingIssueMessage.data, $wakingProjects);
 </script>
 
 <StartTeamPlanDialog

--- a/web-admin/src/features/organizations/hibernating/OrganizationHibernatingForAdmins.svelte
+++ b/web-admin/src/features/organizations/hibernating/OrganizationHibernatingForAdmins.svelte
@@ -17,7 +17,7 @@
   export let organization: string;
 
   $: billingIssueMessage = useBillingIssueMessage(organization);
-  $: billingCTAHandler = new BillingCTAHandler(organization);
+  $: billingCTAHandler = BillingCTAHandler.get(organization);
   $: ({
     showStartTeamPlanDialog,
     startTeamPlanType,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes APP-626: Persists project waking UI state across navigation

Previously, navigating away from a project during its "waking" process would cause the UI to revert to the hibernation banner, even though the backend process continued. This happened because the `wakingProjects` state was being reset or not consistently accessed across page loads.

This PR ensures the "waking" UI state is correctly persisted and displayed across different pages within an organization.
- `BillingCTAHandler.get` no longer resets the `wakingProjects` state.
- `BillingBannerManagerForAdmins` and `OrganizationHibernatingForAdmins` now consistently use a shared, organization-level `BillingCTAHandler` instance to access the persistent `wakingProjects` state.
- The `BillingBannerManagerForAdmins` prioritizes displaying the "Waking projects..." banner when `wakingProjects` is active, preventing it from being overwritten by the default hibernation message.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
Linear Issue: [APP-626](https://linear.app/rilldata/issue/APP-626/when-waking-project-navigating-to-settings-causes-the-process-to-stop)

<p><a href="https://cursor.com/agents/bc-9313ef8c-a888-495c-98b8-519e6b2120f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9313ef8c-a888-495c-98b8-519e6b2120f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->