### PR TITLE
Return error instead of silently exiting when repo file limit is exceeded

### DIFF
--- a/cli/pkg/local/app.go
+++ b/cli/pkg/local/app.go
@@ -88,8 +88,7 @@ func NewApp(ctx context.Context, opts *AppOptions) (*App, error) {
 		_, err = repo.ListGlob(ctx, "**", false)
 		if err != nil {
 			if errors.Is(err, drivers.ErrRepoListLimitExceeded) {
-				opts.Ch.PrintfError("The project directory exceeds the limit of %d files. Please open Rill against a directory with fewer files or set \"ignore_paths\" in rill.yaml.\n", drivers.RepoListLimit)
-				return nil, nil
+				return nil, fmt.Errorf("the project directory exceeds the limit of %d files; please open Rill against a directory with fewer files or set \"ignore_paths\" in rill.yaml", drivers.RepoListLimit)
 			}
 			return nil, fmt.Errorf("failed to list project files: %w", err)
 		}


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/rilldata/rill/pull/8419 where `NewApp` returns `nil, nil`, causing a nil pointer panic.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!