### PR TITLE
Improve empty dashboard error message for NULL timestamps

### DIFF
--- a/web-common/src/features/dashboards/state-managers/loaders/DashboardStateDataLoader.ts
+++ b/web-common/src/features/dashboards/state-managers/loaders/DashboardStateDataLoader.ts
@@ -22,6 +22,8 @@ import {
 import type { AfterNavigate } from "@sveltejs/kit";
 import { createQuery, type QueryClient } from "@tanstack/svelte-query";
 import { Settings } from "luxon";
+import { featureFlags } from "@rilldata/web-common/features/feature-flags";
+import { selectedMockUserStore } from "@rilldata/web-common/features/dashboards/granular-access-policies/stores";
 import { derived, get } from "svelte/store";
 
 /**
@@ -253,14 +255,18 @@ export class DashboardStateDataLoader {
           fullTimeRange.data?.timeRangeSummary?.min === null &&
           fullTimeRange.data?.timeRangeSummary?.max === null
         ) {
-          // The timeRangeSummary is null when there are 0 rows of data.
-          // Notably, this happens when a security policy fully restricts a user from reading any data.
-          // Show a different error in this case.
+          // The timeRangeSummary is null when there are 0 rows of data or all timestamp values are NULL.
+          // In Cloud (or Developer with a mock user), access policies may be restricting data.
+          // In Developer without a mock user, the issue is more likely data configuration.
+          const isCloudOrMockUser =
+            get(featureFlags.adminServer) ||
+            get(selectedMockUserStore) !== null;
+          const message = isCloudOrMockUser
+            ? "This dashboard currently has no data to display. This may be due to the data source configuration or access permissions."
+            : "This dashboard currently has no data to display. Check that your data source has rows and the time dimension column contains non-NULL values.";
           return {
             data: undefined,
-            error: new Error(
-              "This dashboard currently has no data to display. This may be due to access permissions.",
-            ),
+            error: new Error(message),
             isFetching: false,
             isLoading: false,
           };


### PR DESCRIPTION
- When all timestamp values in a time dimension column are NULL, `min()` and `max()` return NULL, and the dashboard showed "This may be due to access permissions" — misleading since the user has data
- In Rill Developer (without mock user): show a message hinting at NULL timestamps / empty data source, since there are no access policies
- In Cloud or Developer with mock user active: mention data source configuration or access permissions

<img width="1728" height="1035" alt="image" src="https://github.com/user-attachments/assets/dbc6ea51-2b38-4d68-a142-507f15c247c2" />

<img width="1728" height="1035" alt="image" src="https://github.com/user-attachments/assets/327bded9-1b8f-41b6-80d6-7cccb860d50c" />

Closes [#8739](https://github.com/rilldata/rill/issues/8739)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---

*Developed in collaboration with Claude Code*