### PR TITLE
fix: open query test failing due to project not initialised

### DIFF
--- a/web-local/tests/explores/open-query.spec.ts
+++ b/web-local/tests/explores/open-query.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "@playwright/test";
 import { test } from "../setup/base";
+import { waitForReconciliation } from "../utils/wait-for-reconciliation.ts";
 
 test.describe("Query-to-Explore routing", () => {
   test.use({ project: "AdBids" });
@@ -8,6 +9,9 @@ test.describe("Query-to-Explore routing", () => {
     // Get the current URL to construct the correct baseURL with the dynamic port
     const currentUrl = new URL(page.url());
     const baseUrl = `${currentUrl.protocol}//${currentUrl.host}`;
+
+    await page.goto(baseUrl);
+    await waitForReconciliation(page);
 
     // Open the metrics view query
     await page.goto(


### PR DESCRIPTION
Open query test opens the dashboard immediately. If dashboard is reconciling then we seem to show an error page, this needs to be handled separately. For now making sure project is reconciled before opening the page.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
