### PR TITLE
Disable cgroup memory observer in embedded ClickHouse config

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -83,6 +83,10 @@ Rules for contributing backend features in Rill:
 
 Frontend conventions are being formalized in `.claude/rules/frontend.md` (coming soon).
 
+## Tool Usage
+
+- **WebFetch and WebSearch lose information.** Both tools use small models to summarize content, and they regularly drop items from long lists, tables, or dense pages. When researching reference documentation (e.g. finding all config settings, API parameters, or CLI flags matching a pattern), download the raw page and search it directly: `curl -sL 'https://...' | sed 's/<[^>]*>//g' | grep -i 'pattern'`. This ensures completeness that summarization cannot guarantee.
+
 ## Tips
 
 - **Monorepo**: Uses npm workspaces (frontend) and Go modules (backend)

--- a/runtime/drivers/clickhouse/embed.go
+++ b/runtime/drivers/clickhouse/embed.go
@@ -353,8 +353,9 @@ func (e *embedClickHouse) getConfigContent() ([]byte, error) {
 
     <mlock_executable>true</mlock_executable>
 
-    <!-- Disable cgroup memory observer; it causes errors on WSL where cgroup files are unavailable -->
+    <!-- Disable cgroup memory usage; it causes errors on WSL where cgroup files are unavailable -->
     <cgroups_memory_usage_observer_wait_time>0</cgroups_memory_usage_observer_wait_time>
+    <memory_worker_use_cgroup>false</memory_worker_use_cgroup>
 
     <users>
         <default>


### PR DESCRIPTION
**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!