### PR TITLE
Expanded table tooltip colors

### DIFF
--- a/web-local/tests/explores/annotations.spec.ts
+++ b/web-local/tests/explores/annotations.spec.ts
@@ -138,29 +138,14 @@ function expectedDates(
   return new Set(dates);
 }
 
-async function waitForTotalRecordsButton(page: Page, timeoutMs = 20_000) {
-  await expect(
-    page.getByRole("button", { name: /Total records/ }).first(),
-  ).toBeVisible({ timeout: timeoutMs });
-}
-
-async function waitForTotalRecordsButtonWithSingleReload(page: Page) {
-  // This setup is occasionally flaky in CI due transient runtime connection
-  // issues. Reload once before failing to avoid a false-negative.
-  try {
-    await waitForTotalRecordsButton(page);
-  } catch {
-    await page.reload();
-    await waitForTotalRecordsButton(page);
-  }
-}
-
 async function setupDashboard(page: Page, dashboardTZ: string) {
   await page.getByLabel("/dashboards").click();
   await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
 
   // Wait for the base project to finish reconciling
-  await waitForTotalRecordsButtonWithSingleReload(page);
+  await expect(
+    page.getByRole("button", { name: /Total records/ }).first(),
+  ).toBeVisible({ timeout: 30_000 });
 
   // Write annotation files while still in the editor view. This triggers
   // re-reconciliation in the background.
@@ -174,7 +159,10 @@ async function setupDashboard(page: Page, dashboardTZ: string) {
   const base = new URL(page.url()).origin;
   const exploreUrl = `${base}/explore/AdBids_metrics_explore?tz=${encodeURIComponent(dashboardTZ)}`;
   await page.goto(exploreUrl);
-  await waitForTotalRecordsButtonWithSingleReload(page);
+
+  await expect(
+    page.getByRole("button", { name: /Total records/ }).first(),
+  ).toBeVisible({ timeout: 30_000 });
 
   // Wait for annotation query responses to arrive and the chart to
   // finish re-rendering. Without this, menu interactions race against


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes APP-782

Addresses an issue where tooltip values in expanded dimension tables were unreadable in light mode due to dark text on a dark background. The `FormattedDataType` component within the tooltip in `Cell.svelte` now explicitly uses `color="text-fg-inverse"` to ensure proper contrast.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
Linear Issue: [APP-782](https://linear.app/rilldata/issue/APP-782/values-are-the-wrong-color-in-tooltips-in-expanded-dimension-tables)

<p><a href="https://cursor.com/agents/bc-d4c1236b-4732-48b9-a2cd-8c013b64be15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4c1236b-4732-48b9-a2cd-8c013b64be15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->