### PR TITLE
fix: apply org custom domain to embed iframe URLs

### DIFF
--- a/admin/server/deployment.go
+++ b/admin/server/deployment.go
@@ -819,7 +819,13 @@ func (s *Server) GetIFrame(ctx context.Context, req *adminv1.GetIFrameRequest) (
 		iframeQuery[k] = v
 	}
 
-	iFrameURL, err := s.admin.URLs.Embed(iframeQuery)
+	// Fetch the org to apply its custom domain (if any) to the embed URL
+	org, err := s.admin.DB.FindOrganization(ctx, proj.OrganizationID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "could not find organization: %s", err.Error())
+	}
+
+	iFrameURL, err := s.admin.URLs.WithCustomDomain(org.CustomDomain).Embed(iframeQuery)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "could not construct iframe url: %s", err.Error())
 	}


### PR DESCRIPTION
- `GetIFrame()` was not applying the org's custom domain when constructing the embed URL, causing embedded dashboards to always use `ui.rilldata.com` as the iframe origin
- Customers who embed Rill dashboards and configure a custom domain (e.g., `analytics.mycompany.com`) now get embed URLs that use their custom domain instead of exposing the Rill vendor URL
- Follows the same pattern already used in `GetDeploymentConfig()`: fetch the org, pass `org.CustomDomain` to `WithCustomDomain()`

Addresses [this Slack message](https://rilldata.slack.com/archives/CTZ8XBQ85/p1772726422059289).

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---

*Developed in collaboration with Claude Code*