### PR TITLE
Increase AI max message size from 10 KB to 25 KB

### DIFF
--- a/runtime/ai/ai.go
+++ b/runtime/ai/ai.go
@@ -32,7 +32,7 @@ import (
 
 // maxMessageSizeBytes is the maximum allowed size of a message's contents.
 // Exceeding it will result in an error.
-const maxMessageSizeBytes = 10 * 1024 // 10 KB
+const maxMessageSizeBytes = 25 * 1024 // 25 KB
 
 // Tracer for instrumenting requests.
 var tracer = otel.Tracer("github.com/rilldata/rill/runtime/ai")


### PR DESCRIPTION
Seems like 10 KB may have been a bit too easy to hit