### PR TITLE
fix: show error notification when dashboard export fails

### DIFF
--- a/web-common/src/features/exports/ExportMenu.svelte
+++ b/web-common/src/features/exports/ExportMenu.svelte
@@ -15,6 +15,8 @@
   import { onMount } from "svelte";
   import type TScheduledReportDialog from "../scheduled-reports/ScheduledReportDialog.svelte";
   import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
+  import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
+  import { extractErrorMessage } from "@rilldata/web-common/lib/errors";
 
   const runtimeClient = useRuntimeClient();
 
@@ -46,19 +48,26 @@
     includeHeader?: boolean;
   }) {
     const { format, includeHeader = false } = options;
-    const result = await $exportDash.mutateAsync({
-      query: exportQuery as any,
-      format: format as any,
-      includeHeader,
-      // Include metadata for CSV/XLSX exports in Cloud context.
-      ...(includeHeader &&
-        $adminServer && {
-          originDashboard: { name: exploreName, kind: ResourceKind.Explore },
-          originUrl: window.location.href,
-        }),
-    });
-    const downloadUrl = `${runtimeClient.host}${result.downloadUrlPath}`;
-    window.open(downloadUrl, "_self");
+    try {
+      const result = await $exportDash.mutateAsync({
+        query: exportQuery as any,
+        format: format as any,
+        includeHeader,
+        // Include metadata for CSV/XLSX exports in Cloud context.
+        ...(includeHeader &&
+          $adminServer && {
+            originDashboard: { name: exploreName, kind: ResourceKind.Explore },
+            originUrl: window.location.href,
+          }),
+      });
+      const downloadUrl = `${runtimeClient.host}${result.downloadUrlPath}`;
+      window.open(downloadUrl, "_self");
+    } catch (err) {
+      eventBus.emit("notification", {
+        message: `Export failed: ${extractErrorMessage(err)}`,
+        type: "error",
+      });
+    }
   }
 
   // Only import the Scheduled Report dialog if in the Cloud context.


### PR DESCRIPTION
- Export errors (e.g., download token exceeding size limit due to too many filter values) were silently swallowed — only visible in the browser network tab
- Wrap `mutateAsync()` in `ExportMenu.svelte` with a try/catch and emit an error notification via the existing event bus

Example error with an artificially low size limit:
<img width="3456" height="2086" alt="image" src="https://github.com/user-attachments/assets/ed56b616-4598-4694-93a9-bee09c55e6b2" />

Slack thread: https://rilldata.slack.com/archives/C02T907FEUB/p1772735448837339

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
*Developed in collaboration with Claude Code*