### PR TITLE
fix: show Error in connector workspace

### DIFF
--- a/web-local/src/routes/(application)/(workspace)/files/[...file]/+page.svelte
+++ b/web-local/src/routes/(application)/(workspace)/files/[...file]/+page.svelte
@@ -46,7 +46,7 @@
     inferredResourceKind,
     path,
     getResource,
-    getParseError,
+    getAllErrors,
   } = fileArtifact);
 
   $: resourceKind = <ResourceKind | undefined>$resourceName?.kind;
@@ -62,9 +62,9 @@
       ? [customYAMLwithJSONandSQL]
       : getExtensionsForFile(path);
 
-  // Parse error for the editor banner
-  $: parseErrorQuery = getParseError(queryClient, instanceId);
-  $: parseError = $parseErrorQuery;
+  // Errors for the editor banner (parse + reconcile)
+  $: allErrorsStore = getAllErrors(queryClient, instanceId);
+  $: allErrors = $allErrorsStore;
 
   onMount(() => {
     expandDirectory(path);
@@ -103,7 +103,7 @@
           filePath={path}
           hasUnsavedChanges={$hasUnsavedChanges}
         />
-        <WorkspaceEditorContainer slot="body" error={parseError?.message}>
+        <WorkspaceEditorContainer slot="body" error={allErrors[0]?.message}>
           <Editor
             {fileArtifact}
             {extensions}


### PR DESCRIPTION
Looks like some changes to the error/connector workspace no longer shows error message.

needs cherrypick into release-083


**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
