### PR TITLE
fix: reset SSE retry counter on client-initiated pause

### DIFF
--- a/web-common/src/runtime-client/sse-connection-manager.ts
+++ b/web-common/src/runtime-client/sse-connection-manager.ts
@@ -126,7 +126,6 @@ export class SSEConnectionManager {
     // Only reconnect if PAUSED (intentionally disconnected to save resources)
     // Don't reconnect if CONNECTING (already in progress) or CLOSED (fatal error)
     if (status === ConnectionStatus.PAUSED) {
-      this.retryAttempts.set(0);
       await this.reconnect();
     }
 
@@ -174,18 +173,22 @@ export class SSEConnectionManager {
     this.events.emit("error", errorArg);
   };
 
-  // This can happen in one of three situations:
+  // Fired by SSEFetchClient when the underlying fetch ends for any reason:
   // 1. The connection was paused intentionally (AbortError)
-  // 2. There has been a network error causing the connection to close (FetchError)
+  // 2. A network error caused the connection to close (FetchError)
   // 3. The application was terminated
+  // Client-initiated closes (case 1) are ignored here; pause() handles its
+  // own cleanup before setting status to PAUSED, so the guard below skips them.
   private handleCloseEvent = () => {
     const status = get(this.status);
 
+    // Only handle server-initiated or unexpected closes
     if (status !== ConnectionStatus.OPEN) return;
 
-    // Only reset retries if the connection was stable (open for a minimum duration).
-    // This prevents infinite reconnection loops when the server opens the connection
-    // but closes it immediately (e.g. auth issues, unsupported event types).
+    // Server-initiated close: reset retries if the connection was stable
+    // (open > MIN_STABLE_DURATION). Unstable connections (e.g. server opens
+    // then immediately closes) should still accumulate retries.
+    // See also: pause() resets retries for client-initiated closes.
     const wasStable =
       this.openedAt !== null &&
       Date.now() - this.openedAt >= MIN_STABLE_DURATION;
@@ -257,10 +260,15 @@ export class SSEConnectionManager {
     )
       return;
 
+    // Client-initiated close (auto-close after idle): reset retries because
+    // an intentional pause is not a connection failure.
+    // See also: handleCloseEvent() resets retries for server-initiated closes.
+    this.retryAttempts.set(0);
+
     this.status.set(ConnectionStatus.PAUSED);
 
-    // This will trigger an AbortError event and subsequently a "close" event
-    // Which we ignore based on the current status
+    // This will trigger a "close" event on the SSEFetchClient, but
+    // handleCloseEvent ignores it because status is already PAUSED.
     this.client.stop();
   }
 


### PR DESCRIPTION
`SSEConnectionManager.retryAttempts` accumulates across auto-close pause/resume cycles and is never reset, eventually showing a full-page "500 — Error connecting to runtime" error.

**How it happens:**

1. SSE connection is open, streaming normally
2. No user interaction for 120s → auto-close pauses the connection
3. User interacts → `heartbeat()` → `reconnect()` increments `retryAttempts` → connection succeeds
4. Repeat 3 more times → `retryAttempts` hits `maxRetryAttempts` (3) → status becomes `CLOSED` → `FileAndResourceWatcher.svelte` renders the error page

**Why `retryAttempts` never resets:** the only reset path is in `handleCloseEvent`, which requires status to be `OPEN`. But `pause()` sets status to `PAUSED` before the close event fires, so `handleCloseEvent` early-returns and the reset never runs.

**Fix:** reset `retryAttempts` in `pause()`. An intentional pause is not a connection failure and shouldn't consume retry budget. The retry counter now resets in two places, each handling a different close path:

- **`pause()`** — client-initiated close (auto-close after idle)
- **`handleCloseEvent()`** — server-initiated close (only when the connection was stable > 5s, to prevent infinite loops against a flapping server)

Also clarified comments so the two reset sites cross-reference each other.

Reported in [Slack](https://rilldata.slack.com/archives/C04AGHL77PS/p1773067327304389).

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---

*Developed in collaboration with Claude Code*