### PR TITLE
fix: align share action `Copy URL` button with design system

### DIFF
--- a/web-admin/src/features/dashboards/share/ShareDashboardPopover.svelte
+++ b/web-admin/src/features/dashboards/share/ShareDashboardPopover.svelte
@@ -58,6 +58,7 @@
           </h3>
           <Button
             type="secondary"
+            class="w-full"
             onClick={() => {
               onCopy();
             }}
@@ -66,7 +67,7 @@
               <Check size="16px" />
               Copied URL
             {:else}
-              <Link size="16px" className="text-primary-500" />
+              <Link size="16px" />
               Copy URL for this view
             {/if}
           </Button>

--- a/web-admin/src/features/projects/user-management/CopyInviteLinkButton.svelte
+++ b/web-admin/src/features/projects/user-management/CopyInviteLinkButton.svelte
@@ -25,15 +25,9 @@
       <span class="font-medium text-xs text-fg-secondary"> URL copied </span>
     </div>
   {:else}
-    <Button
-      type="secondary"
-      class="flex flex-row items-center"
-      forcedStyle="min-height: 24px !important; height: 24px !important;  "
-      onClick={onCopy}
-      compact
-    >
-      <Link size="12px" />
-      <span class="font-medium text-xs">Copy URL</span>
+    <Button type="secondary" onClick={onCopy}>
+      <Link size="16px" />
+      Copy URL
     </Button>
   {/if}
 {/if}

--- a/web-admin/src/features/projects/user-management/CopyInviteLinkButton.svelte
+++ b/web-admin/src/features/projects/user-management/CopyInviteLinkButton.svelte
@@ -25,8 +25,8 @@
       <span class="font-medium text-xs text-fg-secondary"> URL copied </span>
     </div>
   {:else}
-    <Button type="secondary" onClick={onCopy}>
-      <Link size="16px" />
+    <Button type="secondary" small onClick={onCopy}>
+      <Link size="12px" />
       Copy URL
     </Button>
   {/if}

--- a/web-common/src/components/button/Button.svelte
+++ b/web-common/src/components/button/Button.svelte
@@ -139,7 +139,6 @@
   .secondary {
     --focus-color: var(--color-primary-600);
     @apply bg-transparent border border-accent-primary-action text-accent-primary-action;
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
   }
 
   :global(.dark) .secondary {

--- a/web-common/src/components/button/Button.svelte
+++ b/web-common/src/components/button/Button.svelte
@@ -139,6 +139,7 @@
   .secondary {
     --focus-color: var(--color-primary-600);
     @apply bg-transparent border border-accent-primary-action text-accent-primary-action;
+    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
   }
 
   :global(.dark) .secondary {


### PR DESCRIPTION
- Remove hardcoded `text-primary-500` icon color in `ShareDashboardPopover`; icon now inherits `accent-primary-action` from the secondary button
- Make the Copy URL button full-width in `ShareDashboardPopover`
- Remove non-standard `forcedStyle` 24px height and `compact` overrides from `CopyInviteLinkButton`; use standard secondary button sizing
- Add `shadow-xs` to the secondary button variant in `Button.svelte` per the [Rill Design System](https://www.figma.com/design/9OCPgWkDL4mAQzaSQxV7Lt/Rill-Design-System---ShadCN-based?node-id=17085-177606)

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*