### PR TITLE
Raise tool call size limit to 100 KB

### DIFF
--- a/runtime/ai/ai.go
+++ b/runtime/ai/ai.go
@@ -32,7 +32,7 @@ import (
 
 // maxMessageSizeBytes is the maximum allowed size of a message's contents.
 // Exceeding it will result in an error.
-const maxMessageSizeBytes = 25 * 1024 // 25 KB
+const maxMessageSizeBytes = 100 * 1024 // 100 KB
 
 // Tracer for instrumenting requests.
 var tracer = otel.Tracer("github.com/rilldata/rill/runtime/ai")


### PR DESCRIPTION
Temporary workaround until we have better truncation