### PR TITLE
Update CSP to allow app-us1.com

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,7 +11,7 @@
   [headers.values]
     Content-Security-Policy = """\
       default-src 'self'; \
-      script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.usepylon.com https://*.pusher.com; \
+      script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.app-us1.com/  https://*.usepylon.com https://*.pusher.com; \
       style-src 'self' 'unsafe-inline' https://*.usepylon.com; \
       img-src https: data: blob:; \
       frame-src 'self' https://www.youtube.com/ https://www.loom.com/ https://www.vimeo.com https://portal.withorb.com blob: data:; \


### PR DESCRIPTION
Loading the script 'https://diffuser-cdn.app-us1.com/diffuser/diffuser.js' violates the following Content Security Policy directive

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
