### PR TITLE
fix: measure IN filter flattned into invalid filter

### DIFF
--- a/web-common/src/features/dashboards/filters/dimension-filters/split-dimension-search-text.spec.ts
+++ b/web-common/src/features/dashboards/filters/dimension-filters/split-dimension-search-text.spec.ts
@@ -4,6 +4,10 @@ import {
   splitDimensionSearchText,
 } from "web-common/src/features/dashboards/filters/dimension-filters/dimension-search-text-utils";
 import { V1Operation } from "web-common/src/runtime-client";
+import {
+  createBinaryExpression,
+  createSubQueryExpression,
+} from "@rilldata/web-common/features/dashboards/stores/filter-utils.ts";
 
 describe("splitDimensionSearchText", () => {
   it("should split by comma and return trimmed parts", () => {
@@ -72,5 +76,19 @@ describe("getFiltersFromText", () => {
       { val: "Ashwani Yadav" },
       { val: "John Doe" },
     ]);
+  });
+
+  it("should leave measure filters alone", () => {
+    const { expr } = getFiltersFromText(
+      "publisher having (total_records gte 100)",
+    );
+    const inExpr = expr.cond?.exprs?.[0];
+    expect(inExpr).toEqual(
+      createSubQueryExpression(
+        "publisher",
+        ["total_records"],
+        createBinaryExpression("total_records", V1Operation.OPERATION_GTE, 100),
+      ),
+    );
   });
 });

--- a/web-common/src/features/dashboards/stores/filter-utils.ts
+++ b/web-common/src/features/dashboards/stores/filter-utils.ts
@@ -518,7 +518,11 @@ export function flattenInExpressionValues(expr: V1Expression) {
       expr.cond.op !== V1Operation.OPERATION_NIN);
   if (notInExpr) return expr;
   const ident = expr.cond!.exprs?.[0]?.ident;
-  const vals = expr.cond!.exprs?.slice(1).flatMap((e) => e.val);
+  const valExprs = expr.cond!.exprs?.slice(1);
+  // Do not flatten measure filter. They will be of format `<dim> IN <subquery>`
+  if (valExprs?.[0]?.subquery) return expr;
+
+  const vals = valExprs?.flatMap((e) => e.val);
   if (!ident || !vals) return expr;
   return createInExpression(
     ident,


### PR DESCRIPTION
When there is a measure filter as a local filter in canvas we try to 'correct' it and unintentionally flatten it leading to invalid filter.

This adds a safeguard to ensure we ignore measure filters while flattening

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
