### PR TITLE
fix: alert submit e2e failures because of reactive superform creation

### DIFF
--- a/web-admin/tests/alerts.spec.ts
+++ b/web-admin/tests/alerts.spec.ts
@@ -16,7 +16,7 @@ test.describe.serial("Alerts", () => {
 
       await adminPage.getByRole("button", { name: "Create alert" }).click();
 
-      const alertForm = adminPage.locator("form#create-alert-form");
+      const alertForm = adminPage.locator("form");
 
       // Select "Last 6 hours" as time range
       await interactWithTimeRangeMenu(alertForm, async () => {
@@ -159,7 +159,7 @@ test.describe.serial("Alerts", () => {
       // Edit the alert
       await adminPage.getByRole("button", { name: "Edit" }).click();
 
-      const alertForm = adminPage.locator("form#edit-alert-form");
+      const alertForm = adminPage.locator("form");
 
       // Select "Last 24 hours" as time range
       await interactWithTimeRangeMenu(alertForm, async () => {
@@ -291,7 +291,7 @@ test.describe.serial("Alerts", () => {
 
       await adminPage.getByRole("button", { name: "Create alert" }).click();
 
-      const alertForm = adminPage.locator("form#create-alert-form");
+      const alertForm = adminPage.locator("form");
 
       // Select "App Site Name" as split by dimension
       await adminPage.getByLabel("Split by dimension", { exact: true }).click();
@@ -356,7 +356,7 @@ test.describe.serial("Alerts", () => {
       // Edit the alert
       await adminPage.getByRole("button", { name: "Edit" }).click();
 
-      const alertForm = adminPage.locator("form#edit-alert-form");
+      const alertForm = adminPage.locator("form");
 
       // Go to criteria tab
       await alertForm.getByRole("button", { name: "Next" }).click();

--- a/web-common/src/features/alerts/AlertForm.svelte
+++ b/web-common/src/features/alerts/AlertForm.svelte
@@ -153,10 +153,9 @@
       invalidateAll: false,
     },
   );
-  $: ({ form, errors, enhance, submitting, submit, tainted, validate } =
+  $: ({ form, formId, errors, enhance, submitting, submit, tainted, validate } =
     superFormInstance);
 
-  $: formId = isCreateForm ? "create-alert-form" : "edit-alert-form";
   $: dialogTitle = isCreateForm ? "Create Alert" : "Edit Alert";
 
   const tabs = ["Data", "Criteria", "Delivery"];
@@ -290,7 +289,7 @@
 <form
   autocomplete="off"
   class="flex flex-col gap-y-3"
-  id={formId}
+  id={$formId}
   onsubmit={(e) => {
     e.preventDefault();
     submit(e);
@@ -336,7 +335,7 @@
     {#if currentTabIndex !== 2}
       <Button type="primary" onClick={handleNextTab}>Next</Button>
     {:else}
-      <Button type="primary" disabled={$submitting} form={formId} submitForm>
+      <Button type="primary" disabled={$submitting} form={$formId} submitForm>
         {isCreateForm ? "Create" : "Update"}
       </Button>
     {/if}


### PR DESCRIPTION
We need to keep the form instance reactive to ensure data from explore updates the alert form. But this is causing issues around submit. Using the form id from the superForms to try and combat this.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
