### PR TITLE
fix: custom range picker when selected range is of zero length

### DIFF
--- a/runtime/pkg/rilltime/rilltime_test.go
+++ b/runtime/pkg/rilltime/rilltime_test.go
@@ -473,6 +473,10 @@ func TestEval_Misc(t *testing.T) {
 		{"3W18D23h as of latest-3Y", "2022-04-04T07:32:36Z", "2022-05-14T06:32:36Z", timeutil.TimeGrainWeek, 1, 1},
 
 		{"7D as of latest/D+1D offset -1M", "2025-04-08T00:00:00Z", "2025-04-15T00:00:00Z", timeutil.TimeGrainDay, 1, 1},
+
+		// MTD with truncating to month
+		{"MTD as of now/M", "2025-05-01T00:00:00Z", "2025-05-01T00:00:00Z", timeutil.TimeGrainMillisecond, 1, 1},
+		{"MTD as of latest/M+1M", "2025-06-01T00:00:00Z", "2025-06-01T00:00:00Z", timeutil.TimeGrainMillisecond, 1, 1},
 	}
 
 	runTests(t, testCases, now, minTime, maxTime, watermark, nil)

--- a/web-common/src/components/date-picker/Day.svelte
+++ b/web-common/src/components/date-picker/Day.svelte
@@ -46,6 +46,16 @@
   ): OverlapType | undefined {
     const evaluatedInterval = potentialInterval ?? interval;
 
+    const isZeroInterval = evaluatedInterval.start.equals(
+      evaluatedInterval.end,
+    );
+    // Safeguard for zero intervals. Show as a full circle for the relevant day only.
+    if (isZeroInterval) {
+      return areSameDay(evaluatedInterval.start, date)
+        ? OverlapType.FULL_INTERVAL
+        : undefined;
+    }
+
     if (areSameDay(evaluatedInterval.start, date)) {
       if (areSameDay(evaluatedInterval.end.minus({ millisecond: 1 }), date))
         return OverlapType.FULL_INTERVAL;

--- a/web-common/src/features/dashboards/time-controls/super-pill/components/CalendarPlusDateInput.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/CalendarPlusDateInput.svelte
@@ -24,7 +24,11 @@
   let anchorDay: DateTime<true> | undefined = undefined;
 
   $: startDate = inputInterval?.start;
-  $: endDate = inputInterval.end.minus({ millisecond: 1 });
+  // Do not deduct 1ms if the interval is of zero length to avoid having end before start.
+  $: isZeroInterval = inputInterval?.start.equals(inputInterval.end);
+  $: endDate = isZeroInterval
+    ? inputInterval?.end
+    : inputInterval?.end.minus({ millisecond: 1 });
 
   $: adjustedMinDate = minDate?.startOf("day");
   $: adjustedMaxDate = maxDate

--- a/web-common/src/features/dashboards/time-controls/super-pill/new-time-dropdown/RangePickerV2.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/new-time-dropdown/RangePickerV2.svelte
@@ -508,8 +508,8 @@
             minTimeGrain={V1TimeGrainToDateTimeUnit[
               smallestTimeGrain ?? V1TimeGrain.TIME_GRAIN_MINUTE
             ]}
-            {maxDate}
             {minDate}
+            {maxDate}
             onApply={() => {
               if (searchValue) handleRangeSelect(searchValue);
             }}


### PR DESCRIPTION
When the selected range is of zero length we end up showing end data as being before start date. Ensure we do not deduct 1ms when the selected interval is of zero length.

Note that this purely a visual fix. Actual selected range and the one used in queries does not change.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
