### PR TITLE
feat: defer canvas pivot/table queries until component is visible

### DIFF
--- a/web-common/src/features/canvas/components/pivot/index.ts
+++ b/web-common/src/features/canvas/components/pivot/index.ts
@@ -99,6 +99,7 @@ export class PivotCanvasComponent extends BaseCanvasComponent<
       this.parent,
       derived(this.specStore, ($specStore) => $specStore.metrics_view),
       this.config,
+      this.visible,
     );
   }
 

--- a/web-common/src/features/canvas/components/pivot/util.ts
+++ b/web-common/src/features/canvas/components/pivot/util.ts
@@ -266,12 +266,13 @@ export const usePivotForCanvas = (
   canvas: CanvasEntity,
   metricsViewStore: Readable<string>,
   pivotConfig: Readable<PivotDataStoreConfig>,
+  visible: Readable<boolean>,
 ) => {
   const pivotDashboardContext: PivotDashboardContext = {
     runtimeClient: canvas.client,
     metricsViewName: metricsViewStore,
     queryClient: queryClient,
-    enabled: !!canvas,
+    enabled: visible,
   };
 
   const pivotDataStore = createPivotDataStore(

--- a/web-common/src/features/dashboards/pivot/pivot-data-store.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-data-store.ts
@@ -729,7 +729,7 @@ export const usePivotForExplore = memoizeMetricsStore<PivotDataStore>(
       runtimeClient: ctx.runtimeClient,
       metricsViewName: ctx.metricsViewName,
       queryClient: ctx.queryClient,
-      enabled: !!ctx.dashboardStore,
+      enabled: readable(!!ctx.dashboardStore),
     };
     return createPivotDataStore(pivotDashboardContext, pivotConfig);
   },

--- a/web-common/src/features/dashboards/pivot/pivot-queries.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-queries.ts
@@ -1,3 +1,4 @@
+import type { ConnectError } from "@connectrpc/connect";
 import {
   createAndExpression,
   createInExpression,
@@ -11,9 +12,8 @@ import {
   type V1MetricsViewAggregationResponse,
   type V1MetricsViewAggregationResponseDataItem,
   type V1MetricsViewAggregationSort,
+  createQueryServiceMetricsViewAggregation,
 } from "@rilldata/web-common/runtime-client";
-import type { ConnectError } from "@connectrpc/connect";
-import { createQueryServiceMetricsViewAggregation } from "@rilldata/web-common/runtime-client";
 import {
   type CreateQueryResult,
   keepPreviousData,
@@ -71,39 +71,41 @@ export function createPivotAggregationRowQuery(
     hasComparison = true;
   }
 
-  return derived([ctx.metricsViewName], ([metricsViewName], set) =>
-    createQueryServiceMetricsViewAggregation(
-      ctx.runtimeClient,
-      {
-        metricsView: metricsViewName,
-        measures: prepareMeasureForComparison(measures),
-        dimensions,
-        where: sanitiseExpression(whereFilter, undefined),
-        timeRange: {
-          start: timeRange?.start ? timeRange.start : config.time.timeStart,
-          end: timeRange?.end ? timeRange.end : config.time.timeEnd,
-          timeDimension: config.time.timeDimension,
+  return derived(
+    [ctx.metricsViewName, ctx.enabled],
+    ([metricsViewName, enabled], set) =>
+      createQueryServiceMetricsViewAggregation(
+        ctx.runtimeClient,
+        {
+          metricsView: metricsViewName,
+          measures: prepareMeasureForComparison(measures),
+          dimensions,
+          where: sanitiseExpression(whereFilter, undefined),
+          timeRange: {
+            start: timeRange?.start ? timeRange.start : config.time.timeStart,
+            end: timeRange?.end ? timeRange.end : config.time.timeEnd,
+            timeDimension: config.time.timeDimension,
+          },
+          comparisonTimeRange:
+            hasComparison && comparisonTime
+              ? {
+                  start: comparisonTime.start,
+                  end: comparisonTime.end,
+                  timeDimension: config.time.timeDimension,
+                }
+              : undefined,
+          sort,
+          limit,
+          offset,
         },
-        comparisonTimeRange:
-          hasComparison && comparisonTime
-            ? {
-                start: comparisonTime.start,
-                end: comparisonTime.end,
-                timeDimension: config.time.timeDimension,
-              }
-            : undefined,
-        sort,
-        limit,
-        offset,
-      },
-      {
-        query: {
-          enabled: ctx.enabled,
-          placeholderData: keepPreviousData,
+        {
+          query: {
+            enabled,
+            placeholderData: keepPreviousData,
+          },
         },
-      },
-      ctx.queryClient,
-    ).subscribe(set),
+        ctx.queryClient,
+      ).subscribe(set),
   );
 }
 

--- a/web-common/src/features/dashboards/pivot/types.ts
+++ b/web-common/src/features/dashboards/pivot/types.ts
@@ -44,7 +44,7 @@ export interface PivotDashboardContext {
   runtimeClient: RuntimeClient;
   metricsViewName: Readable<string>;
   queryClient: QueryClient;
-  enabled: boolean;
+  enabled: Readable<boolean>;
 }
 
 export interface PivotState {


### PR DESCRIPTION
## Pivot/Table Visibility Gating for Canvas

This change extends the **visibility-gating pattern** (already used by KPI and chart components) to the **canvas pivot/table component**.

### Key Changes

- **Visibility-based query execution**
  - Pivot queries now only fire **after the component scrolls into view**.
  - This uses the existing `IntersectionObserver` in `CanvasComponent.svelte`.

- **Reactive `enabled` flag**
  - `PivotDashboardContext.enabled` has been changed from:
    - `boolean` → `Readable<boolean>`
  - This allows the query’s `enabled` flag to **react to visibility changes**.

- **`usePivotForCanvas` update**
  - Now accepts:
    ```ts
    visible: Readable<boolean>
    ```
  - This value is passed through as the **enabled context**.

### Explore Pivot Behaviour (Unchanged)

- The **Explore pivot path (`usePivotForExplore`)** remains unaffected.
- It wraps its existing static boolean in `readable(...)`, preserving the **always-enabled behaviour**.


https://linear.app/rilldata/issue/APP-157/optimize-data-fetching-based-on-widget-visibility

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
