### PR TITLE
fix:  canvas dashboard flashes 404 on load due to race condition

### DIFF
--- a/web-common/src/features/canvas/CanvasInitialization.svelte
+++ b/web-common/src/features/canvas/CanvasInitialization.svelte
@@ -18,11 +18,6 @@
   } from "@rilldata/web-common/runtime-client";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
   import { createQueryServiceResolveCanvas } from "@rilldata/web-common/runtime-client";
-  import {
-    ResourceKind,
-    useResource,
-  } from "../entity-management/resource-selectors";
-
   const PollIntervalWhenDashboardFirstReconciling = 1000;
   const PollIntervalWhenDashboardErrored = 5000;
 
@@ -38,8 +33,6 @@
   $: ({ url } = $page);
 
   $: existingStore = getCanvasStoreUnguarded(canvasName, instanceId);
-
-  $: resourceQuery = useResource(client, canvasName, ResourceKind.Canvas, {});
 
   $: fetchedCanvasQuery = !existingStore
     ? createQueryServiceResolveCanvas(
@@ -72,11 +65,7 @@
   $: isReconciling =
     !existingStore && !validSpec && !reconcileError && !isLoading;
 
-  $: resource = resourceQuery ? $resourceQuery?.data : undefined;
-
-  $: reconcileErrorMessage = !validSpec
-    ? reconcileError || resource?.meta?.reconcileError
-    : undefined;
+  $: reconcileErrorMessage = !validSpec ? reconcileError : undefined;
 
   $: resolvedStore = getResolvedStore(
     fetchedCanvas,


### PR DESCRIPTION
On page load, `CanvasInitialization` ran two independent queries: the authoritative `createQueryServiceResolveCanvas` (which returns `validSpec`) and a secondary `useResource` call (which returns lightweight resource metadata). The `reconcileErrorMessage` derived state used both as sources:

```ts
$: reconcileErrorMessage = !validSpec
  ? reconcileError || resource?.meta?.reconcileError
  : undefined;
```

The `useResource` query could resolve first — before `fetchedCanvas` loaded — with a `reconcileError` already set (e.g. `"dependency error: ..."`). At that moment `validSpec` was still `undefined`, so `CanvasLoadingState` would briefly show the **404 page** before the resolve-canvas response arrived.

### Changes

* Removed the `resource?.meta?.reconcileError` fallback from `reconcileErrorMessage`.
  Error state is now driven solely by the **resolve-canvas query**, which is the authoritative source for canvas readiness.

https://linear.app/rilldata/issue/APP-721/canvas-dashboard-flashes-with-404-error-before-loading

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
