### PR TITLE
Add `AGENTS.md` and `.agents/skills` instruction generation

### DIFF
--- a/cli/cmd/initialize/init.go
+++ b/cli/cmd/initialize/init.go
@@ -133,7 +133,7 @@ func InitCmd(ch *cmdutil.Helper) *cobra.Command {
 				}
 
 				// Agent instructions
-				agent, err = cmdutil.SelectPrompt("Agent instructions", []string{"claude", "cursor", "all", "none"}, "claude")
+				agent, err = cmdutil.SelectPrompt("Agent instructions", agentOptions, "claude")
 				if err != nil {
 					return err
 				}
@@ -252,6 +252,7 @@ var olapOptions = []string{
 var agentOptions = []string{
 	"claude",
 	"cursor",
+	"agentsmd",
 	"all",
 	"none",
 }
@@ -268,6 +269,15 @@ func writeAgentInstructions(ctx context.Context, ch *cmdutil.Helper, repo driver
 			return fmt.Errorf("failed to add Cursor rules: %w", err)
 		}
 		ch.Printf("Added Cursor rules in .cursor\n")
+		if err := instructions.InitAgentsMD(ctx, repo, true); err != nil {
+			return fmt.Errorf("failed to add AGENTS.md files: %w", err)
+		}
+		ch.Printf("Added agent instructions in AGENTS.md and .agents\n")
+	case "agentsmd":
+		if err := instructions.InitAgentsMD(ctx, repo, true); err != nil {
+			return fmt.Errorf("failed to add AGENTS.md files: %w", err)
+		}
+		ch.Printf("Added agent instructions in AGENTS.md and .agents\n")
 	case "claude":
 		if err := instructions.InitClaudeCode(ctx, repo, true); err != nil {
 			return fmt.Errorf("failed to add Claude Code files: %w", err)

--- a/runtime/ai/instructions/agentsmd.go
+++ b/runtime/ai/instructions/agentsmd.go
@@ -1,0 +1,82 @@
+package instructions
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rilldata/rill/runtime/drivers"
+	"gopkg.in/yaml.v3"
+)
+
+// InitAgentsMD generates tool-agnostic AGENTS.md instruction files from Rill instruction files.
+// The main instructions are written to /AGENTS.md.
+// Resource-specific instructions are written as skills to /.agents/skills/<name>/SKILL.md.
+// MCP server config is written to /.mcp.json.
+// If force is false, it skips files that already exist.
+// If force is true, it overwrites any existing files.
+func InitAgentsMD(ctx context.Context, repo drivers.RepoStore, force bool) error {
+	// Load all instruction files with External=true for external editor use
+	instructions, err := LoadAll(Options{External: true})
+	if err != nil {
+		return fmt.Errorf("failed to load instructions: %w", err)
+	}
+
+	// Convert and write each instruction file
+	for path, inst := range instructions {
+		outputPath, content := convertToAgentsMDFile(path, inst)
+
+		if !force {
+			_, err := repo.Stat(ctx, outputPath)
+			if err == nil {
+				// File exists, skip
+				continue
+			}
+		}
+
+		err = repo.Put(ctx, outputPath, strings.NewReader(content))
+		if err != nil {
+			return fmt.Errorf("failed to write %q: %w", outputPath, err)
+		}
+	}
+
+	// Write MCP server config
+	err = writeMCPConfig(ctx, repo, force, "/.mcp.json", map[string]any{
+		"type": "http",
+		"url":  "http://localhost:9009/mcp",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to write MCP config: %w", err)
+	}
+
+	return nil
+}
+
+// convertToAgentsMDFile transforms a Rill instruction to AGENTS.md format.
+// development.md becomes the main /AGENTS.md file.
+// Resource files become skills at /.agents/skills/<name>/SKILL.md.
+func convertToAgentsMDFile(path string, inst *Instruction) (outputPath, content string) {
+	// development.md becomes the main AGENTS.md file (no front matter needed)
+	if path == "development.md" {
+		return "/AGENTS.md", inst.Body
+	}
+
+	// Other files become skills
+	name := fmt.Sprintf("rill-%s", strings.ReplaceAll(inst.Name, "_", "-"))
+	outputPath = "/.agents/skills/" + name + "/SKILL.md"
+
+	// Serialize front matter to YAML
+	fmBytes, _ := yaml.Marshal(&skillFrontMatter{
+		Name:        name,
+		Description: inst.Description,
+	})
+
+	// Build final content with front matter
+	var sb strings.Builder
+	sb.WriteString("---\n")
+	sb.Write(fmBytes)
+	sb.WriteString("---\n\n")
+	sb.WriteString(inst.Body)
+
+	return outputPath, sb.String()
+}

--- a/runtime/ai/instructions/claude.go
+++ b/runtime/ai/instructions/claude.go
@@ -13,7 +13,7 @@ import (
 // InitClaudeCode generates Claude Code instruction files from Rill instruction files.
 // The main instructions are written to .claude/CLAUDE.md.
 // Resource-specific instructions are written as skills to .claude/skills/<name>/SKILL.md.
-// Skills are loaded on-demand when invoked, keeping the context lean.
+// MCP server config is written to /.mcp.json.
 // If force is false, it skips files that already exist.
 // If force is true, it overwrites any existing files.
 func InitClaudeCode(ctx context.Context, repo drivers.RepoStore, force bool) error {


### PR DESCRIPTION
Contributes to https://linear.app/rilldata/issue/PLAT-425/documentationimprovement-for-ai-skills

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!