### PR TITLE
Add agent onboarding instructions to CLI help and install docs

### DIFF
--- a/cli/cmd/initialize/init.go
+++ b/cli/cmd/initialize/init.go
@@ -38,6 +38,14 @@ func InitCmd(ch *cmdutil.Helper) *cobra.Command {
 		Use:   "init [<path>]",
 		Short: "Initialize a new Rill project",
 		Long:  long.String(),
+		Example: `  # Interactive initialization (prompts for all options)
+  rill init
+
+  # Create an empty DuckDB project with Claude agent instructions
+  rill init my-project --olap duckdb --agent claude
+
+  # Add Claude agent instructions to an existing Rill project
+  rill init ./existing-project --agent claude`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Assess what flags were set
 			numFlags := 0

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -39,6 +39,16 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// Instructions for agents that we add to the root help command in non-interactive environments.
+const agentInstructions = `
+For Agents:
+If you are administrating a Rill Cloud project, the CLI help menus speak for themselves (e.g. "rill project -h" or "rill user -h").
+But if you are developing a Rill project, it is imperative that you initialize and load the Rill agent instructions in the project directory.
+If you are creating a new project, use "rill init <path>" to set up a project with instructions.
+If you are working with an existing project, use "rill init <path> --agent claude" to add agent instructions to the project if it doesn't already have them.
+Make sure you load the instruction files after they are initialized. If necessary, cd into the project directory to discover them.
+`
+
 func init() {
 	cobra.EnableCommandSorting = false
 }
@@ -89,11 +99,18 @@ func Run(ctx context.Context, ver version.Version) {
 
 // RootCmd creates the root command and adds all subcommands.
 func RootCmd(ch *cmdutil.Helper) *cobra.Command {
+	// Build long description with agent instructions if in non-interactive mode
+	long := "Work with Rill projects from the command line."
+	if !ch.Interactive {
+		long += "\n\n"
+		long += strings.TrimSpace(agentInstructions)
+	}
+
 	// Root command
 	rootCmd := &cobra.Command{
 		Use:   "rill <command> [flags]",
 		Short: "A CLI for Rill",
-		Long:  `Work with Rill projects directly from the command line.`,
+		Long:  long,
 	}
 	rootCmd.Version = ch.Version.String()
 	// silence usage, usage string will only show up if missing arguments/flags

--- a/docs/docs/developers/get-started/install.md
+++ b/docs/docs/developers/get-started/install.md
@@ -117,3 +117,15 @@ brew install rilldata/tap/rill
 To uninstall Rill, you can use the following command:
 ```bash
 rill uninstall
+```
+
+## For Agents
+
+We currently recommend that agents always install using `curl` and always use the nightly.
+
+So if you are an AI agent or coding assistant, install Rill using the following command:
+```bash
+curl https://rill.sh | sh -s -- --nightly
+```
+
+After installation, run `rill -h` to see further instructions for agents working with Rill projects.


### PR DESCRIPTION
- Adds a "For Agents" section to the install docs pointing to `curl` install and `rill -h`
- Adds agent-specific instructions to `rill -h` (non-interactive mode only) guiding agents to use `rill init`
- Adds usage examples to `rill init -h`

Contributes to https://linear.app/rilldata/issue/PLAT-433/get-claude-to-vibe-code-a-rill-project-without-any-prior-manual-setup

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!