### PR TITLE
fix: merge strategy is memory intensive

### DIFF
--- a/runtime/drivers/duckdb/crud.go
+++ b/runtime/drivers/duckdb/crud.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime/drivers"
@@ -129,8 +128,8 @@ func (c *connection) insertTableAsSelect(ctx context.Context, name, sql string, 
 			}
 
 			// Create a temporary table with the new data
-			tmp := uuid.New().String()
-			_, err := conn.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s AS (%s\n)", safeSQLName(tmp), sql))
+			tmp := fmt.Sprintf("__rill_temp_%s", name)
+			_, err := conn.ExecContext(ctx, fmt.Sprintf("CREATE OR REPLACE TABLE %s AS (%s\n)", safeSQLName(tmp), sql))
 			if err != nil {
 				return err
 			}
@@ -198,8 +197,8 @@ func (c *connection) insertTableAsSelect(ctx context.Context, name, sql string, 
 			}
 
 			// Create a temporary table with the new data
-			tmp := uuid.New().String()
-			_, err := conn.ExecContext(ctx, fmt.Sprintf("CREATE TABLE %s AS (%s\n)", safeSQLName(tmp), sql))
+			tmp := fmt.Sprintf("__rill_temp_%s", name)
+			_, err := conn.ExecContext(ctx, fmt.Sprintf("CREATE OR REPLACE TABLE %s AS (%s\n)", safeSQLName(tmp), sql))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
closes https://linear.app/rilldata/issue/PLAT-437/improve-oomes-in-duckdb-when-ingesting-partitions-with-merge-strategy

1. The underlying assumption that incoming partition is small is not always true. When creating a big memory table duckdb generates big tmp files (probably because it is never compressed). When ingesting from that temporary table to disk table, it starts generating more tmp files (probably because there is no free memory).
2. In one of the customer's dataset, their existing dataset has ~55 mil rows, they are trying to pull ~90 mil rows in one partition.
3. The `delete` and `insert` statements executed in merge are probably not intensive. I tried by copying a big table and doing delete followed by insert. Both executed pretty fast, did not generate any tmp files if `preserve_insertion_order` is false.


**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
