### PR TITLE
fix: github connect test failing in non interactive mode

### DIFF
--- a/cli/cmd/project/connect_github.go
+++ b/cli/cmd/project/connect_github.go
@@ -65,14 +65,13 @@ func GitPushCmd(ch *cmdutil.Helper) *cobra.Command {
 }
 
 func ConnectGithubFlow(ctx context.Context, ch *cmdutil.Helper, opts *DeployOpts) error {
-	if !ch.Interactive {
-		return fmt.Errorf("the GitHub connect flow requires an interactive terminal")
-	}
-
 	// Set a default org for the user if necessary
 	// (If user is not in an org, we'll create one based on their Github account later in the flow.)
 	// TODO : similar to UI workflow create a org taking user input
 	if ch.Org == "" {
+		if !ch.Interactive {
+			return fmt.Errorf("`org` must be set to use the GitHub connect flow in non-interactive mode")
+		}
 		if err := org.SetDefaultOrg(ctx, ch); err != nil {
 			return err
 		}
@@ -417,6 +416,9 @@ func githubFlow(ctx context.Context, ch *cmdutil.Helper, gitRemote string) (*adm
 
 	// If the user has not already granted access, open browser and poll for access
 	if !res.HasAccess {
+		if !ch.Interactive {
+			return nil, fmt.Errorf("the GitHub connect flow requires an interactive terminal to grant access to the GitHub repository. Please run this command in an interactive terminal and follow the instructions to grant access.")
+		}
 		// Emit start telemetry
 		ch.Telemetry(ctx).RecordBehavioralLegacy(activity.BehavioralEventGithubConnectedStart)
 
@@ -486,6 +488,9 @@ func createProjectFlow(ctx context.Context, ch *cmdutil.Helper, req *adminv1.Cre
 		if !errMsgContains(err, "a project with that name already exists in the org") {
 			return nil, err
 		}
+		if !ch.Interactive {
+			return nil, fmt.Errorf("a project with the name %q already exists in the org %q. Please provide a different name using the --name flag and try again", req.Project, req.Org)
+		}
 
 		ch.PrintfWarn("Rill project names are derived from your Github repository name.\n")
 		ch.PrintfWarn("The %q project already exists under org %q. Please enter a different name.\n", req.Project, req.Org)
@@ -518,7 +523,9 @@ func repoInSyncFlow(ch *cmdutil.Helper, gitPath, subpath, remoteName string) (bo
 	if st.LocalCommits > 0 {
 		ch.PrintfWarn("Local commits are not pushed to remote yet. These changes will not be present in the deployed project.\n")
 	}
-
+	if !ch.Interactive {
+		return false, fmt.Errorf("commit and push your changes to remote before deploying")
+	}
 	ok, err := cmdutil.YesNoPrompt("Do you want to continue", true)
 	return ok, err
 }


### PR DESCRIPTION
Instead of completely failing github-connect in non interactive mode, it now only fails if required params are not passed.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
