### PR TITLE
Fix for connector biquery and refactoring

### DIFF
--- a/runtime/resolvers/testdata/connector_bigquery.yaml
+++ b/runtime/resolvers/testdata/connector_bigquery.yaml
@@ -1,40 +1,31 @@
 expensive: true
 connectors:
   - clickhouse
-  - gcs
+  - gcs_s3_compat
   - bigquery
 project_files:
-  all_datatypes_clickhouse.yaml:
+  gcs_hmac.yaml:
+    type: connector
+    driver: gcs
+    key_id: '{{.env.connector.gcs_s3_compat.key_id }}'
+    secret: '{{.env.connector.gcs_s3_compat.secret }}'
+  model_bigquery_to_clickhouse.yaml:
     type: model
     connector: bigquery
     # not support for parquet export from bigquery geography_col,json_col,range_date_col,range_datetime_col,range_timestamp_col,array_json_col,array_geography_col,array_range_date_col,array_range_datetime_col,array_range_timestamp_col, array_struct_col,struct_col
     sql: "select int_col,float_col,numeric_col,bignumeric_col,bool_col,string_col,bytes_col,date_col,datetime_col,time_col,timestamp_col,array_int_col,array_float_col,array_numeric_col,array_bignumeric_col,array_bool_col,array_string_col,array_bytes_col,array_date_col,array_datetime_col,array_time_col,array_timestamp_col from rilldata.integration_test.all_datatypes"
     stage:
-      connector: gcs
+      connector: gcs_hmac
       path: gs://integration-test.rilldata.com/biquery_clickhouse_stage/
     output:
       connector: clickhouse
-  all_datatypes_column_duckdb.yaml:
-    type: model
-    connector: bigquery
-    materialize: true
-    sql: "select int_col,float_col,numeric_col,bignumeric_col,bool_col,string_col,bytes_col,date_col,datetime_col,time_col,timestamp_col,json_col,geography_col,range_date_col,range_datetime_col,range_timestamp_col,array_int_col,array_float_col,array_numeric_col,array_bignumeric_col,array_bool_col,array_string_col,array_bytes_col,array_date_col,array_datetime_col,array_time_col,array_timestamp_col,array_json_col,array_geography_col,array_range_date_col,array_range_datetime_col,array_range_timestamp_col,array_struct_col,struct_col from rilldata.integration_test.all_datatypes"
-    output:
-      connector: duckdb
-  all_datatypes_star_duckdb.yaml:
-    type: model
-    connector: bigquery
-    materialize: true
-    sql: "select * from rilldata.integration_test.all_datatypes"
-    output:
-      connector: duckdb
-  external_google_sheet_duckdb.yaml:
+  model_bigquery_to_duckdb_for_external_google_sheet.yaml:
     type: model
     connector: bigquery
     sql: "select * from rilldata.integration_test.external_google_sheet"
     output:
       connector: duckdb
-  partition_overwrite_bigquery.yaml:
+  model_bigquery_to_duckdb_for_partition_overwrite.yaml:
     type: model
     connector: "bigquery"
     project_id: "rilldata"
@@ -47,38 +38,99 @@ project_files:
         number,
         1 AS partition_id
       FROM UNNEST(GENERATE_ARRAY(1, 10)) AS number;
+  model_bigquery_to_duckdb_for_select_star.yaml:
+    type: model
+    connector: bigquery
+    materialize: true
+    sql: "select * from rilldata.integration_test.all_datatypes"
+    output:
+      connector: duckdb
+  model_bigquery_to_duckdb_for_selected_columns.yaml:
+    type: model
+    connector: bigquery
+    materialize: true
+    sql: "select int_col,float_col,numeric_col,bignumeric_col,bool_col,string_col,bytes_col,date_col,datetime_col,time_col,timestamp_col,json_col,geography_col,range_date_col,range_datetime_col,range_timestamp_col,array_int_col,array_float_col,array_numeric_col,array_bignumeric_col,array_bool_col,array_string_col,array_bytes_col,array_date_col,array_datetime_col,array_time_col,array_timestamp_col,array_json_col,array_geography_col,array_range_date_col,array_range_datetime_col,array_range_timestamp_col,array_struct_col,struct_col from rilldata.integration_test.all_datatypes"
+    output:
+      connector: duckdb
 tests:
-  - name: query_all_datatypes_star_duckdb
+  - name: test_all_results_for_model_bigquery_to_clickhouse
     resolver: sql
     properties:
-      sql: "select * from all_datatypes_star_duckdb order by int_col"
+      sql: "select * from model_bigquery_to_clickhouse order by int_col"
+      connector: clickhouse
     result_csv: |
-      int_col,float_col,numeric_col,bignumeric_col,bool_col,string_col,bytes_col,date_col,datetime_col,time_col,timestamp_col,json_col,geography_col,range_date_col,range_datetime_col,range_timestamp_col,array_int_col,array_float_col,array_numeric_col,array_bignumeric_col,array_bool_col,array_string_col,array_bytes_col,array_date_col,array_datetime_col,array_time_col,array_timestamp_col,array_json_col,array_geography_col,array_range_date_col,array_range_datetime_col,array_range_timestamp_col,array_struct_col,struct_col
-      0,0,0,0,false,,,1970-01-01,1970-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,{},POINT(0 0),"{""end"":""1970-01-02"",""start"":""1970-01-01""}","{""end"":""1970-01-01T00:00:01Z"",""start"":""1970-01-01T00:00:00Z""}","{""end"":""1970-01-01T00:00:01Z"",""start"":""1970-01-01T00:00:00Z""}",[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],"{""field_array_bignumeric"":[],""field_array_bool"":[],""field_array_bytes"":[],""field_array_date"":[],""field_array_datetime"":[],""field_array_float"":[],""field_array_geography"":[],""field_array_int"":[],""field_array_json"":[],""field_array_numeric"":[],""field_array_string"":[],""field_array_time"":[],""field_array_timestamp"":[],""field_bignumeric"":0,""field_bool"":false,""field_bytes"":"""",""field_date"":""1970-01-01"",""field_datetime"":""1970-01-01T00:00:00Z"",""field_float"":0,""field_geography"":""POINT(0 0)"",""field_int"":0,""field_json"":""{}"",""field_numeric"":0,""field_string"":"""",""field_time"":""0001-01-01T00:00:00Z"",""field_timestamp"":""1970-01-01T00:00:00Z""}"
-      1,1.1,123.45,1e+38,true,sample1,YWJj,2023-01-01,2023-01-01T12:34:56Z,0001-01-01T12:34:56Z,2023-01-01T12:34:56Z,"{""key"":""value1""}",POINT(1 2),"{""end"":""2023-02-01"",""start"":""2023-01-01""}","{""end"":""2024-01-01T12:34:56Z"",""start"":""2023-01-01T12:34:56Z""}","{""end"":""2024-01-01T12:34:56Z"",""start"":""2023-01-01T12:34:56Z""}",[1],[1.1],[123.45],[1e+38],[true],"[""sample1""]","[""YWJj""]","[""2023-01-01""]","[""2023-01-01T12:34:56Z""]","[""0001-01-01T12:34:56Z""]","[""2023-01-01T12:34:56Z""]","[""{\""key\"":\""value1\""}""]","[""POINT(1 2)""]","[{""end"":""2023-02-01"",""start"":""2023-01-01""}]","[{""end"":""2024-01-01T12:34:56Z"",""start"":""2023-01-01T12:34:56Z""}]","[{""end"":""2024-01-01T12:34:56Z"",""start"":""2023-01-01T12:34:56Z""}]","[{""field_bignumeric"":1e+38,""field_bool"":true,""field_bytes"":""YWJj"",""field_date"":""2023-01-01"",""field_datetime"":""2023-01-01T12:34:56Z"",""field_float"":1.1,""field_geography"":""POINT(1 2)"",""field_int"":1,""field_json"":""{\""key\"":\""value1\""}"",""field_numeric"":123.45,""field_string"":""sample1"",""field_time"":""0001-01-01T12:34:56Z"",""field_timestamp"":""2023-01-01T12:34:56Z""}]","{""field_array_bignumeric"":[1e+38],""field_array_bool"":[true],""field_array_bytes"":[""YWJj""],""field_array_date"":[""2023-01-01""],""field_array_datetime"":[""2023-01-01T12:34:56Z""],""field_array_float"":[1.1],""field_array_geography"":[""POINT(1 2)""],""field_array_int"":[1],""field_array_json"":[""{\""key\"":\""value1\""}""],""field_array_numeric"":[123.45],""field_array_string"":[""sample1""],""field_array_time"":[""0001-01-01T12:34:56Z""],""field_array_timestamp"":[""2023-01-01T12:34:56Z""],""field_bignumeric"":1e+38,""field_bool"":true,""field_bytes"":""YWJj"",""field_date"":""2023-01-01"",""field_datetime"":""2023-01-01T12:34:56Z"",""field_float"":1.1,""field_geography"":""POINT(1 2)"",""field_int"":1,""field_json"":""{\""key\"":\""value1\""}"",""field_numeric"":123.45,""field_string"":""sample1"",""field_time"":""0001-01-01T12:34:56Z"",""field_timestamp"":""2023-01-01T12:34:56Z""}"
-      ,,,,,,,,,,,,,,,,[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],
-  - name: query_all_datatypes_column_duckdb
+      int_col,float_col,numeric_col,bignumeric_col,bool_col,string_col,bytes_col,date_col,datetime_col,time_col,timestamp_col,array_int_col,array_float_col,array_numeric_col,array_bignumeric_col,array_bool_col,array_string_col,array_bytes_col,array_date_col,array_datetime_col,array_time_col,array_timestamp_col
+      0,0,0,0,false,,,1970-01-01,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,[],[],[],[],[],[],[],[],[],[],[]
+      1,1.1,123.45,1e+38,true,sample1,abc,2023-01-01,2023-01-01T12:34:56Z,1970-01-01T12:34:56Z,2023-01-01T12:34:56Z,[1],[1.1],"[""123.45""]","[""99999999999999999999999999999999999999.99""]",[true],"[""sample1""]","[""abc""]","[""2023-01-01""]","[""2023-01-01T12:34:56Z""]","[""1970-01-01T12:34:56Z""]","[""2023-01-01T12:34:56Z""]"
+      ,,,,,,,,,,,[],[],[],[],[],[],[],[],[],[],[]
+  - name: test_schema_for_model_bigquery_to_clickhouse
     resolver: sql
     properties:
-      sql: "select array_bignumeric_col,array_bool_col,array_bytes_col,array_date_col,array_datetime_col,array_float_col,array_geography_col,array_int_col,array_json_col,array_numeric_col,array_range_date_col,array_range_datetime_col,array_range_timestamp_col,array_string_col,array_struct_col,array_time_col,array_timestamp_col,bignumeric_col,bool_col,bytes_col,date_col,datetime_col,float_col,geography_col,int_col,json_col,numeric_col,range_date_col,range_datetime_col,range_timestamp_col,string_col,struct_col,time_col,timestamp_col from all_datatypes_column_duckdb order by int_col"
+      sql: |
+        select name, type from system.columns where `table` = 'model_bigquery_to_clickhouse'
+      connector: clickhouse
     result_csv: |
-      array_bignumeric_col,array_bool_col,array_bytes_col,array_date_col,array_datetime_col,array_float_col,array_geography_col,array_int_col,array_json_col,array_numeric_col,array_range_date_col,array_range_datetime_col,array_range_timestamp_col,array_string_col,array_struct_col,array_time_col,array_timestamp_col,bignumeric_col,bool_col,bytes_col,date_col,datetime_col,float_col,geography_col,int_col,json_col,numeric_col,range_date_col,range_datetime_col,range_timestamp_col,string_col,struct_col,time_col,timestamp_col
-      [],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],0,false,,1970-01-01,1970-01-01T00:00:00Z,0,POINT(0 0),0,{},0,"{""end"":""1970-01-02"",""start"":""1970-01-01""}","{""end"":""1970-01-01T00:00:01Z"",""start"":""1970-01-01T00:00:00Z""}","{""end"":""1970-01-01T00:00:01Z"",""start"":""1970-01-01T00:00:00Z""}",,"{""field_array_bignumeric"":[],""field_array_bool"":[],""field_array_bytes"":[],""field_array_date"":[],""field_array_datetime"":[],""field_array_float"":[],""field_array_geography"":[],""field_array_int"":[],""field_array_json"":[],""field_array_numeric"":[],""field_array_string"":[],""field_array_time"":[],""field_array_timestamp"":[],""field_bignumeric"":0,""field_bool"":false,""field_bytes"":"""",""field_date"":""1970-01-01"",""field_datetime"":""1970-01-01T00:00:00Z"",""field_float"":0,""field_geography"":""POINT(0 0)"",""field_int"":0,""field_json"":""{}"",""field_numeric"":0,""field_string"":"""",""field_time"":""0001-01-01T00:00:00Z"",""field_timestamp"":""1970-01-01T00:00:00Z""}",0001-01-01T00:00:00Z,1970-01-01T00:00:00Z
-      [1e+38],[true],"[""YWJj""]","[""2023-01-01""]","[""2023-01-01T12:34:56Z""]",[1.1],"[""POINT(1 2)""]",[1],"[""{\""key\"":\""value1\""}""]",[123.45],"[{""end"":""2023-02-01"",""start"":""2023-01-01""}]","[{""end"":""2024-01-01T12:34:56Z"",""start"":""2023-01-01T12:34:56Z""}]","[{""end"":""2024-01-01T12:34:56Z"",""start"":""2023-01-01T12:34:56Z""}]","[""sample1""]","[{""field_bignumeric"":1e+38,""field_bool"":true,""field_bytes"":""YWJj"",""field_date"":""2023-01-01"",""field_datetime"":""2023-01-01T12:34:56Z"",""field_float"":1.1,""field_geography"":""POINT(1 2)"",""field_int"":1,""field_json"":""{\""key\"":\""value1\""}"",""field_numeric"":123.45,""field_string"":""sample1"",""field_time"":""0001-01-01T12:34:56Z"",""field_timestamp"":""2023-01-01T12:34:56Z""}]","[""0001-01-01T12:34:56Z""]","[""2023-01-01T12:34:56Z""]",1e+38,true,YWJj,2023-01-01,2023-01-01T12:34:56Z,1.1,POINT(1 2),1,"{""key"":""value1""}",123.45,"{""end"":""2023-02-01"",""start"":""2023-01-01""}","{""end"":""2024-01-01T12:34:56Z"",""start"":""2023-01-01T12:34:56Z""}","{""end"":""2024-01-01T12:34:56Z"",""start"":""2023-01-01T12:34:56Z""}",sample1,"{""field_array_bignumeric"":[1e+38],""field_array_bool"":[true],""field_array_bytes"":[""YWJj""],""field_array_date"":[""2023-01-01""],""field_array_datetime"":[""2023-01-01T12:34:56Z""],""field_array_float"":[1.1],""field_array_geography"":[""POINT(1 2)""],""field_array_int"":[1],""field_array_json"":[""{\""key\"":\""value1\""}""],""field_array_numeric"":[123.45],""field_array_string"":[""sample1""],""field_array_time"":[""0001-01-01T12:34:56Z""],""field_array_timestamp"":[""2023-01-01T12:34:56Z""],""field_bignumeric"":1e+38,""field_bool"":true,""field_bytes"":""YWJj"",""field_date"":""2023-01-01"",""field_datetime"":""2023-01-01T12:34:56Z"",""field_float"":1.1,""field_geography"":""POINT(1 2)"",""field_int"":1,""field_json"":""{\""key\"":\""value1\""}"",""field_numeric"":123.45,""field_string"":""sample1"",""field_time"":""0001-01-01T12:34:56Z"",""field_timestamp"":""2023-01-01T12:34:56Z""}",0001-01-01T12:34:56Z,2023-01-01T12:34:56Z
-      [],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],,,,,,,,,,,,,,,,,
-  - name: query_all_external_google_sheet_duckdb
+      name,type
+      int_col,Nullable(Int64)
+      float_col,Nullable(Float64)
+      numeric_col,"Nullable(Decimal(38, 9))"
+      bignumeric_col,"Nullable(Decimal(76, 38))"
+      bool_col,Nullable(Bool)
+      string_col,Nullable(String)
+      bytes_col,Nullable(String)
+      date_col,Nullable(Date32)
+      datetime_col,Nullable(DateTime64(6))
+      time_col,Nullable(DateTime64(6))
+      timestamp_col,Nullable(DateTime64(6))
+      array_int_col,Array(Nullable(Int64))
+      array_float_col,Array(Nullable(Float64))
+      array_numeric_col,"Array(Nullable(Decimal(38, 9)))"
+      array_bignumeric_col,"Array(Nullable(Decimal(76, 38)))"
+      array_bool_col,Array(Nullable(Bool))
+      array_string_col,Array(Nullable(String))
+      array_bytes_col,Array(Nullable(String))
+      array_date_col,Array(Nullable(Date32))
+      array_datetime_col,Array(Nullable(DateTime64(6)))
+      array_time_col,Array(Nullable(DateTime64(6)))
+      array_timestamp_col,Array(Nullable(DateTime64(6)))
+  - name: test_all_results_for_model_bigquery_to_duckdb_for_external_google_sheet
     resolver: sql
     properties:
-      sql: "select bool_col,date_col,datetime_col,float_col,int_col,string_col,time_col,timestamp_col from external_google_sheet_duckdb order by int_col"
+      sql: "select bool_col,date_col,datetime_col,float_col,int_col,string_col,time_col,timestamp_col from model_bigquery_to_duckdb_for_external_google_sheet order by int_col"
     result_csv: |
       bool_col,date_col,datetime_col,float_col,int_col,string_col,time_col,timestamp_col
       false,1970-01-01,1970-01-01T00:00:00Z,0,0,,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z
       true,2023-01-01,2023-01-01T12:34:56Z,1.1,1,sample1,0001-01-01T12:34:56Z,2023-01-01T12:34:56Z
       ,,,,,,,
-  - name: query_all_datatypes_duckdb
+  - name: test_partitions_count_for_model_bigquery_to_duckdb_for_partition_overwrite
     resolver: sql
     properties:
-      sql: "describe all_datatypes_star_duckdb"
+      sql: "SELECT COUNT(*) AS count, COUNT(DISTINCT __rill_partition) AS partitions, MIN(number) AS min_num, MAX(number) AS max_num FROM model_bigquery_to_duckdb_for_partition_overwrite"
+    result_csv: |
+      count,partitions,min_num,max_num
+      20,2,1,10
+  - name: test_all_results_for_model_bigquery_to_duckdb_for_selected_columns
+    resolver: sql
+    properties:
+      sql: "select array_bignumeric_col,array_bool_col,array_bytes_col,array_date_col,array_datetime_col,array_float_col,array_geography_col,array_int_col,array_json_col,array_numeric_col,array_range_date_col,array_range_datetime_col,array_range_timestamp_col,array_string_col,array_struct_col,array_time_col,array_timestamp_col,bignumeric_col,bool_col,bytes_col,date_col,datetime_col,float_col,geography_col,int_col,json_col,numeric_col,range_date_col,range_datetime_col,range_timestamp_col,string_col,struct_col,time_col,timestamp_col from model_bigquery_to_duckdb_for_selected_columns order by int_col"
+    result_csv: |
+      array_bignumeric_col,array_bool_col,array_bytes_col,array_date_col,array_datetime_col,array_float_col,array_geography_col,array_int_col,array_json_col,array_numeric_col,array_range_date_col,array_range_datetime_col,array_range_timestamp_col,array_string_col,array_struct_col,array_time_col,array_timestamp_col,bignumeric_col,bool_col,bytes_col,date_col,datetime_col,float_col,geography_col,int_col,json_col,numeric_col,range_date_col,range_datetime_col,range_timestamp_col,string_col,struct_col,time_col,timestamp_col
+      [],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],0,false,,1970-01-01,1970-01-01T00:00:00Z,0,POINT(0 0),0,{},0,"{""end"":""1970-01-02"",""start"":""1970-01-01""}","{""end"":""1970-01-01T00:00:01Z"",""start"":""1970-01-01T00:00:00Z""}","{""end"":""1970-01-01T00:00:01Z"",""start"":""1970-01-01T00:00:00Z""}",,"{""field_array_bignumeric"":[],""field_array_bool"":[],""field_array_bytes"":[],""field_array_date"":[],""field_array_datetime"":[],""field_array_float"":[],""field_array_geography"":[],""field_array_int"":[],""field_array_json"":[],""field_array_numeric"":[],""field_array_string"":[],""field_array_time"":[],""field_array_timestamp"":[],""field_bignumeric"":0,""field_bool"":false,""field_bytes"":"""",""field_date"":""1970-01-01"",""field_datetime"":""1970-01-01T00:00:00Z"",""field_float"":0,""field_geography"":""POINT(0 0)"",""field_int"":0,""field_json"":""{}"",""field_numeric"":0,""field_string"":"""",""field_time"":""0001-01-01T00:00:00Z"",""field_timestamp"":""1970-01-01T00:00:00Z""}",0001-01-01T00:00:00Z,1970-01-01T00:00:00Z
+      [1e+38],[true],"[""YWJj""]","[""2023-01-01""]","[""2023-01-01T12:34:56Z""]",[1.1],"[""POINT(1 2)""]",[1],"[""{\""key\"":\""value1\""}""]",[123.45],"[{""end"":""2023-02-01"",""start"":""2023-01-01""}]","[{""end"":""2024-01-01T12:34:56Z"",""start"":""2023-01-01T12:34:56Z""}]","[{""end"":""2024-01-01T12:34:56Z"",""start"":""2023-01-01T12:34:56Z""}]","[""sample1""]","[{""field_bignumeric"":1e+38,""field_bool"":true,""field_bytes"":""YWJj"",""field_date"":""2023-01-01"",""field_datetime"":""2023-01-01T12:34:56Z"",""field_float"":1.1,""field_geography"":""POINT(1 2)"",""field_int"":1,""field_json"":""{\""key\"":\""value1\""}"",""field_numeric"":123.45,""field_string"":""sample1"",""field_time"":""0001-01-01T12:34:56Z"",""field_timestamp"":""2023-01-01T12:34:56Z""}]","[""0001-01-01T12:34:56Z""]","[""2023-01-01T12:34:56Z""]",1e+38,true,YWJj,2023-01-01,2023-01-01T12:34:56Z,1.1,POINT(1 2),1,"{""key"":""value1""}",123.45,"{""end"":""2023-02-01"",""start"":""2023-01-01""}","{""end"":""2024-01-01T12:34:56Z"",""start"":""2023-01-01T12:34:56Z""}","{""end"":""2024-01-01T12:34:56Z"",""start"":""2023-01-01T12:34:56Z""}",sample1,"{""field_array_bignumeric"":[1e+38],""field_array_bool"":[true],""field_array_bytes"":[""YWJj""],""field_array_date"":[""2023-01-01""],""field_array_datetime"":[""2023-01-01T12:34:56Z""],""field_array_float"":[1.1],""field_array_geography"":[""POINT(1 2)""],""field_array_int"":[1],""field_array_json"":[""{\""key\"":\""value1\""}""],""field_array_numeric"":[123.45],""field_array_string"":[""sample1""],""field_array_time"":[""0001-01-01T12:34:56Z""],""field_array_timestamp"":[""2023-01-01T12:34:56Z""],""field_bignumeric"":1e+38,""field_bool"":true,""field_bytes"":""YWJj"",""field_date"":""2023-01-01"",""field_datetime"":""2023-01-01T12:34:56Z"",""field_float"":1.1,""field_geography"":""POINT(1 2)"",""field_int"":1,""field_json"":""{\""key\"":\""value1\""}"",""field_numeric"":123.45,""field_string"":""sample1"",""field_time"":""0001-01-01T12:34:56Z"",""field_timestamp"":""2023-01-01T12:34:56Z""}",0001-01-01T12:34:56Z,2023-01-01T12:34:56Z
+      [],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],,,,,,,,,,,,,,,,,
+  - name: test_all_results_for_model_bigquery_to_duckdb_for_select_star
+    resolver: sql
+    properties:
+      sql: "select * from model_bigquery_to_duckdb_for_select_star order by int_col"
+    result_csv: |
+      int_col,float_col,numeric_col,bignumeric_col,bool_col,string_col,bytes_col,date_col,datetime_col,time_col,timestamp_col,json_col,geography_col,range_date_col,range_datetime_col,range_timestamp_col,array_int_col,array_float_col,array_numeric_col,array_bignumeric_col,array_bool_col,array_string_col,array_bytes_col,array_date_col,array_datetime_col,array_time_col,array_timestamp_col,array_json_col,array_geography_col,array_range_date_col,array_range_datetime_col,array_range_timestamp_col,array_struct_col,struct_col
+      0,0,0,0,false,,,1970-01-01,1970-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,{},POINT(0 0),"{""end"":""1970-01-02"",""start"":""1970-01-01""}","{""end"":""1970-01-01T00:00:01Z"",""start"":""1970-01-01T00:00:00Z""}","{""end"":""1970-01-01T00:00:01Z"",""start"":""1970-01-01T00:00:00Z""}",[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],"{""field_array_bignumeric"":[],""field_array_bool"":[],""field_array_bytes"":[],""field_array_date"":[],""field_array_datetime"":[],""field_array_float"":[],""field_array_geography"":[],""field_array_int"":[],""field_array_json"":[],""field_array_numeric"":[],""field_array_string"":[],""field_array_time"":[],""field_array_timestamp"":[],""field_bignumeric"":0,""field_bool"":false,""field_bytes"":"""",""field_date"":""1970-01-01"",""field_datetime"":""1970-01-01T00:00:00Z"",""field_float"":0,""field_geography"":""POINT(0 0)"",""field_int"":0,""field_json"":""{}"",""field_numeric"":0,""field_string"":"""",""field_time"":""0001-01-01T00:00:00Z"",""field_timestamp"":""1970-01-01T00:00:00Z""}"
+      1,1.1,123.45,1e+38,true,sample1,YWJj,2023-01-01,2023-01-01T12:34:56Z,0001-01-01T12:34:56Z,2023-01-01T12:34:56Z,"{""key"":""value1""}",POINT(1 2),"{""end"":""2023-02-01"",""start"":""2023-01-01""}","{""end"":""2024-01-01T12:34:56Z"",""start"":""2023-01-01T12:34:56Z""}","{""end"":""2024-01-01T12:34:56Z"",""start"":""2023-01-01T12:34:56Z""}",[1],[1.1],[123.45],[1e+38],[true],"[""sample1""]","[""YWJj""]","[""2023-01-01""]","[""2023-01-01T12:34:56Z""]","[""0001-01-01T12:34:56Z""]","[""2023-01-01T12:34:56Z""]","[""{\""key\"":\""value1\""}""]","[""POINT(1 2)""]","[{""end"":""2023-02-01"",""start"":""2023-01-01""}]","[{""end"":""2024-01-01T12:34:56Z"",""start"":""2023-01-01T12:34:56Z""}]","[{""end"":""2024-01-01T12:34:56Z"",""start"":""2023-01-01T12:34:56Z""}]","[{""field_bignumeric"":1e+38,""field_bool"":true,""field_bytes"":""YWJj"",""field_date"":""2023-01-01"",""field_datetime"":""2023-01-01T12:34:56Z"",""field_float"":1.1,""field_geography"":""POINT(1 2)"",""field_int"":1,""field_json"":""{\""key\"":\""value1\""}"",""field_numeric"":123.45,""field_string"":""sample1"",""field_time"":""0001-01-01T12:34:56Z"",""field_timestamp"":""2023-01-01T12:34:56Z""}]","{""field_array_bignumeric"":[1e+38],""field_array_bool"":[true],""field_array_bytes"":[""YWJj""],""field_array_date"":[""2023-01-01""],""field_array_datetime"":[""2023-01-01T12:34:56Z""],""field_array_float"":[1.1],""field_array_geography"":[""POINT(1 2)""],""field_array_int"":[1],""field_array_json"":[""{\""key\"":\""value1\""}""],""field_array_numeric"":[123.45],""field_array_string"":[""sample1""],""field_array_time"":[""0001-01-01T12:34:56Z""],""field_array_timestamp"":[""2023-01-01T12:34:56Z""],""field_bignumeric"":1e+38,""field_bool"":true,""field_bytes"":""YWJj"",""field_date"":""2023-01-01"",""field_datetime"":""2023-01-01T12:34:56Z"",""field_float"":1.1,""field_geography"":""POINT(1 2)"",""field_int"":1,""field_json"":""{\""key\"":\""value1\""}"",""field_numeric"":123.45,""field_string"":""sample1"",""field_time"":""0001-01-01T12:34:56Z"",""field_timestamp"":""2023-01-01T12:34:56Z""}"
+      ,,,,,,,,,,,,,,,,[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],
+  - name: test_schema_for_model_bigquery_to_duckdb_for_select_star
+    resolver: sql
+    properties:
+      sql: "describe model_bigquery_to_duckdb_for_select_star"
     result_csv: |
       column_name,column_type,null,key,default,extra
       int_col,BIGINT,YES,,,
@@ -115,50 +167,3 @@ tests:
       array_range_timestamp_col,"STRUCT(""start"" TIMESTAMP WITH TIME ZONE, ""end"" TIMESTAMP WITH TIME ZONE)[]",YES,,,
       array_struct_col,"STRUCT(field_int BIGINT, field_float DOUBLE, field_numeric DECIMAL(38,9), field_bignumeric DOUBLE, field_bool BOOLEAN, field_string VARCHAR, field_bytes BLOB, field_date DATE, field_datetime TIMESTAMP, field_time TIME, field_timestamp TIMESTAMP WITH TIME ZONE, field_json VARCHAR, field_geography VARCHAR)[]",YES,,,
       struct_col,"STRUCT(field_int BIGINT, field_float DOUBLE, field_numeric DECIMAL(38,9), field_bignumeric DOUBLE, field_bool BOOLEAN, field_string VARCHAR, field_bytes BLOB, field_date DATE, field_datetime TIMESTAMP, field_time TIME, field_timestamp TIMESTAMP WITH TIME ZONE, field_json VARCHAR, field_geography VARCHAR, field_array_int BIGINT[], field_array_float DOUBLE[], field_array_numeric DECIMAL(38,9)[], field_array_bignumeric DOUBLE[], field_array_bool BOOLEAN[], field_array_string VARCHAR[], field_array_bytes BLOB[], field_array_date DATE[], field_array_datetime TIMESTAMP[], field_array_time TIME[], field_array_timestamp TIMESTAMP WITH TIME ZONE[], field_array_json VARCHAR[], field_array_geography VARCHAR[])",YES,,,
-  - name: query_all_result_clickhouse
-    resolver: sql
-    properties:
-      sql: "select * from all_datatypes_clickhouse order by int_col"
-      connector: clickhouse
-    result_csv: |
-      int_col,float_col,numeric_col,bignumeric_col,bool_col,string_col,bytes_col,date_col,datetime_col,time_col,timestamp_col,array_int_col,array_float_col,array_numeric_col,array_bignumeric_col,array_bool_col,array_string_col,array_bytes_col,array_date_col,array_datetime_col,array_time_col,array_timestamp_col
-      0,0,0,0,false,,,1970-01-01,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,[],[],[],[],[],[],[],[],[],[],[]
-      1,1.1,123.45,1e+38,true,sample1,abc,2023-01-01,2023-01-01T12:34:56Z,1970-01-01T12:34:56Z,2023-01-01T12:34:56Z,[1],[1.1],"[""123.45""]","[""99999999999999999999999999999999999999.99""]",[true],"[""sample1""]","[""abc""]","[""2023-01-01""]","[""2023-01-01T12:34:56Z""]","[""1970-01-01T12:34:56Z""]","[""2023-01-01T12:34:56Z""]"
-      ,,,,,,,,,,,[],[],[],[],[],[],[],[],[],[],[]
-  - name: query_all_datatypes_clickhouse
-    resolver: sql
-    properties:
-      sql: |
-        select name, type from system.columns where `table` = 'all_datatypes_clickhouse'
-      connector: clickhouse
-    result_csv: |
-      name,type
-      int_col,Nullable(Int64)
-      float_col,Nullable(Float64)
-      numeric_col,"Nullable(Decimal(38, 9))"
-      bignumeric_col,"Nullable(Decimal(76, 38))"
-      bool_col,Nullable(Bool)
-      string_col,Nullable(String)
-      bytes_col,Nullable(String)
-      date_col,Nullable(Date32)
-      datetime_col,Nullable(DateTime64(6))
-      time_col,Nullable(DateTime64(6))
-      timestamp_col,Nullable(DateTime64(6))
-      array_int_col,Array(Nullable(Int64))
-      array_float_col,Array(Nullable(Float64))
-      array_numeric_col,"Array(Nullable(Decimal(38, 9)))"
-      array_bignumeric_col,"Array(Nullable(Decimal(76, 38)))"
-      array_bool_col,Array(Nullable(Bool))
-      array_string_col,Array(Nullable(String))
-      array_bytes_col,Array(Nullable(String))
-      array_date_col,Array(Nullable(Date32))
-      array_datetime_col,Array(Nullable(DateTime64(6)))
-      array_time_col,Array(Nullable(DateTime64(6)))
-      array_timestamp_col,Array(Nullable(DateTime64(6)))
-  - name: partition_overwrite_bigquery
-    resolver: sql
-    properties:
-      sql: "SELECT COUNT(*) AS count, COUNT(DISTINCT __rill_partition) AS partitions, MIN(number) AS min_num, MAX(number) AS max_num FROM partition_overwrite_bigquery"
-    result_csv: |
-      count,partitions,min_num,max_num
-      20,2,1,10

--- a/runtime/resolvers/testdata/connector_delta.yaml
+++ b/runtime/resolvers/testdata/connector_delta.yaml
@@ -2,31 +2,31 @@ expensive: true
 connectors:
   - gcs_s3_compat
 project_files:
-  gcs.yaml:
+  gcs_hmac.yaml:
     type: connector
     driver: gcs
     key_id: '{{.env.connector.gcs_s3_compat.key_id }}'
     secret: '{{.env.connector.gcs_s3_compat.secret }}'
-  delta_gcs_with_secrets.yaml:
+  model_delta_to_duckdb_with_gcs_hmac.yaml:
     type: model
     connector: duckdb
-    create_secrets_from_connectors: gcs
+    create_secrets_from_connectors: gcs_hmac
     materialize: true
     sql: |
       SELECT *
       FROM delta_scan('gs://integration-test.rilldata.com/delta/orders_delta')
 tests:
-  - name: test_delta_gcs_row_count
+  - name: test_row_count_for_model_delta_to_duckdb_with_gcs_hmac
     resolver: sql
     properties:
-      sql: "SELECT count(*) as count FROM delta_gcs_with_secrets"
+      sql: "SELECT count(*) as count FROM model_delta_to_duckdb_with_gcs_hmac"
     result_csv: |
       count
       1000
-  - name: test_delta_gcs_schema
+  - name: test_schema_for_model_delta_to_duckdb_with_gcs_hmac
     resolver: sql
     properties:
-      sql: "describe delta_gcs_with_secrets"
+      sql: "describe model_delta_to_duckdb_with_gcs_hmac"
     result_csv: |
       column_name,column_type,null,key,default,extra
       order_id,BIGINT,YES,,,

--- a/runtime/resolvers/testdata/connector_gcs.yaml
+++ b/runtime/resolvers/testdata/connector_gcs.yaml
@@ -3,148 +3,75 @@ connectors:
   - gcs
   - gcs_s3_compat
 project_files:
-  all_datatypes_clickhouse_csv.yaml:
+  gcs_hmac.yaml:
+    type: connector
+    driver: gcs
+    key_id: '{{.env.connector.gcs_s3_compat.key_id }}'
+    secret: '{{.env.connector.gcs_s3_compat.secret }}'
+  model_gcs_to_clickhouse_for_csv.yaml:
     type: model
     materialize: true
     connector: clickhouse
     output: clickhouse
     sql: "SELECT * FROM gcs('gs://integration-test.rilldata.com/csv_test/all_datatypes.csv', '{{.env.connector.gcs_s3_compat.key_id}}', '{{.env.connector.gcs_s3_compat.secret}}', 'CSVWithNames')"
-  all_datatypes_clickhouse_glob.yaml:
+  model_gcs_to_clickhouse_for_glob.yaml:
     type: model
     materialize: true
     connector: clickhouse
     output: clickhouse
     sql: "SELECT * FROM gcs('gs://integration-test.rilldata.com/glob_test/y=202*/a*.csv', '{{.env.connector.gcs_s3_compat.key_id}}', '{{.env.connector.gcs_s3_compat.secret}}', 'CSVWithNames')"
-  all_datatypes_clickhouse_parquet.yaml:
+  model_gcs_to_clickhouse_for_parquet.yaml:
     type: model
     materialize: true
     connector: clickhouse
     output: clickhouse
     sql: "SELECT * FROM gcs('gs://integration-test.rilldata.com/parquet_test/all_datatypes.parquet', '{{.env.connector.gcs_s3_compat.key_id}}', '{{.env.connector.gcs_s3_compat.secret}}', 'Parquet')"
-  all_datatypes_duckdb_model_csv.yaml:
+  model_gcs_to_duckdb_for_csv.yaml:
     type: model
     connector: duckdb
     materialize: true
-    pre_exec: "CREATE SECRET secret1 (TYPE gcs, KEY_ID '{{.env.connector.gcs_s3_compat.key_id}}', SECRET '{{.env.connector.gcs_s3_compat.secret}}', REGION 'us-east-1')"
+    create_secrets_from_connectors: gcs_hmac
     sql: "select * from read_csv('gs://integration-test.rilldata.com/csv_test/all_datatypes.csv', auto_detect=true, ignore_errors=1, header=true)"
-  all_datatypes_duckdb_model_glob.yaml:
+  model_gcs_to_duckdb_for_glob.yaml:
     type: model
     connector: duckdb
     materialize: true
-    pre_exec: "CREATE SECRET secret1 (TYPE gcs, KEY_ID '{{.env.connector.gcs_s3_compat.key_id}}', SECRET '{{.env.connector.gcs_s3_compat.secret}}', REGION 'us-east-1')"
+    create_secrets_from_connectors: gcs_hmac
     sql: "select * from read_csv('gs://integration-test.rilldata.com/glob_test/y=202*/a*.csv', auto_detect=true, ignore_errors=1, header=true)"
-  all_datatypes_duckdb_model_parquet.yaml:
+  model_gcs_to_duckdb_for_parquet.yaml:
     type: model
     connector: duckdb
     materialize: true
-    pre_exec: "CREATE SECRET secret1 (TYPE gcs, KEY_ID '{{.env.connector.gcs_s3_compat.key_id}}', SECRET '{{.env.connector.gcs_s3_compat.secret}}', REGION 'us-east-1')"
+    create_secrets_from_connectors: gcs_hmac
     sql: "select * from read_parquet('gs://integration-test.rilldata.com/parquet_test/all_datatypes.parquet')"
-  all_datatypes_duckdb_source_csv.yaml:
-    type: source
+  model_gcs_to_duckdb_using_path_for_csv.yaml:
+    type: model
     connector: gcs
-    uri: "gs://integration-test.rilldata.com/csv_test/all_datatypes.csv"
-  all_datatypes_duckdb_source_glob.yaml:
-    type: source
+    path: "gs://integration-test.rilldata.com/csv_test/all_datatypes.csv"
+  model_gcs_to_duckdb_using_path_for_glob.yaml:
+    type: model
     connector: gcs
-    uri: "gs://integration-test.rilldata.com/glob_test/y=202*/a*.csv"
-  all_datatypes_duckdb_source_parquet.yaml:
-    type: source
-    connector: duckdb
-    sql: "select * from read_parquet('gs://integration-test.rilldata.com/parquet_test/all_datatypes.parquet')"
+    path: "gs://integration-test.rilldata.com/glob_test/y=202*/a*.csv"
+  model_gcs_to_duckdb_using_path_for_parquet.yaml:
+    type: model
+    connector: gcs
+    path: "gs://integration-test.rilldata.com/parquet_test/all_datatypes.parquet"
 tests:
-  - name: query_all_result_duckdb_source_csv
+  - name: test_all_results_for_model_gcs_to_clickhouse_for_csv
     resolver: sql
     properties:
-      sql: "select * from all_datatypes_duckdb_source_csv order by id"
-    result_csv: |
-      id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col
-      1,true,123,45678901234,1.23,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,0001-01-01T00:02:03.456Z,0001-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,[1 2 3],['apple' 'banana' 'cherry'],"[('key1', 10), ('key2', 20)]","{'field_int_col': 42, 'field_float_col': 3.140000104904175, 'field_string_col': 'example'}"
-      2,false,0,0,0,0,,0000000000000000,,0,1970-01-01,0001-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0000000000000000,[],[],[],"{'field_int_col': 0, 'field_float_col': 0.0, 'field_string_col': ''}"
-      3,,,,,,,,,,,,,,,,,,,
-  - name: query_all_datatypes_duckdb_source_csv
-    resolver: sql
-    properties:
-      sql: "describe all_datatypes_duckdb_source_csv"
-    result_csv: |
-      column_name,column_type,null,key,default,extra
-      id,BIGINT,YES,,,
-      boolean_col,BOOLEAN,YES,,,
-      int32_col,BIGINT,YES,,,
-      int64_col,BIGINT,YES,,,
-      float_col,DOUBLE,YES,,,
-      double_col,DOUBLE,YES,,,
-      byte_array_col,VARCHAR,YES,,,
-      fixed_len_byte_array_col,VARCHAR,YES,,,
-      string_col,VARCHAR,YES,,,
-      decimal_col,DOUBLE,YES,,,
-      date_col,DATE,YES,,,
-      time_millis_col,TIME,YES,,,
-      time_micros_col,TIME,YES,,,
-      timestamp_millis_col,TIMESTAMP,YES,,,
-      timestamp_micros_col,TIMESTAMP,YES,,,
-      uuid_col,VARCHAR,YES,,,
-      list_int_col,VARCHAR,YES,,,
-      list_string_col,VARCHAR,YES,,,
-      map_col,VARCHAR,YES,,,
-      struct_col,VARCHAR,YES,,,
-  - name: query_all_result_duckdb_model_csv
-    resolver: sql
-    properties:
-      sql: "select * from all_datatypes_duckdb_model_csv order by id"
-    result_csv: |
-      id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col
-      1,true,123,45678901234,1.23,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,0001-01-01T00:02:03.456Z,0001-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,[1 2 3],['apple' 'banana' 'cherry'],"[('key1', 10), ('key2', 20)]","{'field_int_col': 42, 'field_float_col': 3.140000104904175, 'field_string_col': 'example'}"
-      2,false,0,0,0,0,,0000000000000000,,0,1970-01-01,0001-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0000000000000000,[],[],[],"{'field_int_col': 0, 'field_float_col': 0.0, 'field_string_col': ''}"
-      3,,,,,,,,,,,,,,,,,,,
-  - name: query_all_datatypes_duckdb_model_csv
-    resolver: sql
-    properties:
-      sql: "describe all_datatypes_duckdb_model_csv"
-    result_csv: |
-      column_name,column_type,null,key,default,extra
-      id,BIGINT,YES,,,
-      boolean_col,BOOLEAN,YES,,,
-      int32_col,BIGINT,YES,,,
-      int64_col,BIGINT,YES,,,
-      float_col,DOUBLE,YES,,,
-      double_col,DOUBLE,YES,,,
-      byte_array_col,VARCHAR,YES,,,
-      fixed_len_byte_array_col,VARCHAR,YES,,,
-      string_col,VARCHAR,YES,,,
-      decimal_col,DOUBLE,YES,,,
-      date_col,DATE,YES,,,
-      time_millis_col,TIME,YES,,,
-      time_micros_col,TIME,YES,,,
-      timestamp_millis_col,TIMESTAMP,YES,,,
-      timestamp_micros_col,TIMESTAMP,YES,,,
-      uuid_col,VARCHAR,YES,,,
-      list_int_col,VARCHAR,YES,,,
-      list_string_col,VARCHAR,YES,,,
-      map_col,VARCHAR,YES,,,
-      struct_col,VARCHAR,YES,,,
-  - name: query_all_result_clickhouse_csv
-    resolver: sql
-    properties:
-      sql: "select * from all_datatypes_clickhouse_csv order by id"
+      sql: "select * from model_gcs_to_clickhouse_for_csv order by id"
       connector: clickhouse
     result_csv: |
       id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col
       1,True,123,45678901234,1.23,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,00:02:03.456000,00:02:03.456789,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,[1 2 3],['apple' 'banana' 'cherry'],"[('key1', 10), ('key2', 20)]","{'field_int_col': 42, 'field_float_col': 3.140000104904175, 'field_string_col': 'example'}"
       2,False,0,0,0,0,,0000000000000000,,0,1970-01-01,00:00:00,00:00:00,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0000000000000000,[],[],[],"{'field_int_col': 0, 'field_float_col': 0.0, 'field_string_col': ''}"
       3,,,,,,,,,,,,,,,,,,,
-  - name: query_table_type_clickhouse_csv
-    resolver: sql
-    properties:
-      sql: "select name, engine from system.tables where name = 'all_datatypes_clickhouse_csv'"
-      connector: clickhouse
-    result_csv: |
-      name,engine
-      all_datatypes_clickhouse_csv,MergeTree
-  - name: query_all_datatypes_clickhouse_csv
+  - name: test_schema_for_model_gcs_to_clickhouse_for_csv
     resolver: sql
     properties:
       sql: |
-        select name, type from system.columns where `table` = 'all_datatypes_clickhouse_csv'
+        select name, type from system.columns where `table` = 'model_gcs_to_clickhouse_for_csv'
       connector: clickhouse
     result_csv: |
       name,type
@@ -168,142 +95,18 @@ tests:
       list_string_col,Nullable(String)
       map_col,Nullable(String)
       struct_col,Nullable(String)
-  - name: query_all_result_duckdb_source_parquet
+  - name: test_table_engine_for_model_gcs_to_clickhouse_for_csv
     resolver: sql
     properties:
-      sql: "select * from all_datatypes_duckdb_source_parquet order by id"
-    result_csv: |
-      id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col
-      1,true,123,45678901234,1.2300000190734863,3.14159,YWJjZA==,MTIzNDU2Nzg5MGFiY2RlZg==,hello,123.45,2024-03-06,0001-01-01T00:02:03.456Z,0001-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,dXVpZGFiY2QxMjM0ZWZnaA==,"[1,2,3]","[""apple"",""banana"",""cherry""]","{""key1"":10,""key2"":20}","{""field_float_col"":3.140000104904175,""field_int_col"":42,""field_string_col"":""example""}"
-      2,false,0,0,0,0,,MDAwMDAwMDAwMDAwMDAwMA==,,0,1970-01-01,0001-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,MDAwMDAwMDAwMDAwMDAwMA==,[],[],{},"{""field_float_col"":0,""field_int_col"":0,""field_string_col"":""""}"
-      3,,,,,,,,,,,,,,,,,,,
-  - name: query_all_datatypes_duckdb_source_parquet
-    resolver: sql
-    properties:
-      sql: "describe all_datatypes_duckdb_source_parquet"
-    result_csv: |
-      column_name,column_type,null,key,default,extra
-      id,INTEGER,YES,,,
-      boolean_col,BOOLEAN,YES,,,
-      int32_col,INTEGER,YES,,,
-      int64_col,BIGINT,YES,,,
-      float_col,FLOAT,YES,,,
-      double_col,DOUBLE,YES,,,
-      byte_array_col,BLOB,YES,,,
-      fixed_len_byte_array_col,BLOB,YES,,,
-      string_col,VARCHAR,YES,,,
-      decimal_col,"DECIMAL(10,2)",YES,,,
-      date_col,DATE,YES,,,
-      time_millis_col,TIME WITH TIME ZONE,YES,,,
-      time_micros_col,TIME WITH TIME ZONE,YES,,,
-      timestamp_millis_col,TIMESTAMP,YES,,,
-      timestamp_micros_col,TIMESTAMP,YES,,,
-      uuid_col,BLOB,YES,,,
-      list_int_col,INTEGER[],YES,,,
-      list_string_col,VARCHAR[],YES,,,
-      map_col,"MAP(VARCHAR, INTEGER)",YES,,,
-      struct_col,"STRUCT(field_int_col INTEGER, field_float_col FLOAT, field_string_col VARCHAR)",YES,,,
-  - name: query_all_result_duckdb_model_parquet
-    resolver: sql
-    properties:
-      sql: "select * from all_datatypes_duckdb_model_parquet order by id"
-    result_csv: |
-      id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col
-      1,true,123,45678901234,1.2300000190734863,3.14159,YWJjZA==,MTIzNDU2Nzg5MGFiY2RlZg==,hello,123.45,2024-03-06,0001-01-01T00:02:03.456Z,0001-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,dXVpZGFiY2QxMjM0ZWZnaA==,"[1,2,3]","[""apple"",""banana"",""cherry""]","{""key1"":10,""key2"":20}","{""field_float_col"":3.140000104904175,""field_int_col"":42,""field_string_col"":""example""}"
-      2,false,0,0,0,0,,MDAwMDAwMDAwMDAwMDAwMA==,,0,1970-01-01,0001-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,MDAwMDAwMDAwMDAwMDAwMA==,[],[],{},"{""field_float_col"":0,""field_int_col"":0,""field_string_col"":""""}"
-      3,,,,,,,,,,,,,,,,,,,
-  - name: query_all_datatypes_duckdb_model_parquet
-    resolver: sql
-    properties:
-      sql: "describe all_datatypes_duckdb_model_parquet"
-    result_csv: |
-      column_name,column_type,null,key,default,extra
-      id,INTEGER,YES,,,
-      boolean_col,BOOLEAN,YES,,,
-      int32_col,INTEGER,YES,,,
-      int64_col,BIGINT,YES,,,
-      float_col,FLOAT,YES,,,
-      double_col,DOUBLE,YES,,,
-      byte_array_col,BLOB,YES,,,
-      fixed_len_byte_array_col,BLOB,YES,,,
-      string_col,VARCHAR,YES,,,
-      decimal_col,"DECIMAL(10,2)",YES,,,
-      date_col,DATE,YES,,,
-      time_millis_col,TIME WITH TIME ZONE,YES,,,
-      time_micros_col,TIME WITH TIME ZONE,YES,,,
-      timestamp_millis_col,TIMESTAMP,YES,,,
-      timestamp_micros_col,TIMESTAMP,YES,,,
-      uuid_col,BLOB,YES,,,
-      list_int_col,INTEGER[],YES,,,
-      list_string_col,VARCHAR[],YES,,,
-      map_col,"MAP(VARCHAR, INTEGER)",YES,,,
-      struct_col,"STRUCT(field_int_col INTEGER, field_float_col FLOAT, field_string_col VARCHAR)",YES,,,
-  - name: query_all_result_clickhouse_parquet
-    resolver: sql
-    properties:
-      sql: "select * from all_datatypes_clickhouse_parquet order by id"
+      sql: "select name, engine from system.tables where name = 'model_gcs_to_clickhouse_for_csv'"
       connector: clickhouse
     result_csv: |
-      id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col
-      1,true,123,45678901234,1.2300000190734863,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,1970-01-01T00:02:03.456Z,1970-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,"[1,2,3]","[""apple"",""banana"",""cherry""]","{""key1"":10,""key2"":20}","{""FIELD_FLOAT_COL"":null,""FIELD_INT_COL"":null,""FIELD_STRING_COL"":null,""field_float_col"":3.14,""field_int_col"":42,""field_string_col"":""example""}"
-      2,false,0,0,0,0,,0000000000000000,,0,1970-01-01,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0000000000000000,[],[],{},"{""FIELD_FLOAT_COL"":null,""FIELD_INT_COL"":null,""FIELD_STRING_COL"":null,""field_float_col"":0,""field_int_col"":0,""field_string_col"":""""}"
-      3,,,,,,,,,,,,,,,,[],[],{},"{""FIELD_FLOAT_COL"":null,""FIELD_INT_COL"":null,""FIELD_STRING_COL"":null,""field_float_col"":null,""field_int_col"":null,""field_string_col"":null}"
-  - name: query_all_datatypes_clickhouse_parquet
+      name,engine
+      model_gcs_to_clickhouse_for_csv,MergeTree
+  - name: test_all_results_for_model_gcs_to_clickhouse_for_glob
     resolver: sql
     properties:
-      sql: |
-        select name, type from system.columns where `table` = 'all_datatypes_clickhouse_parquet'
-      connector: clickhouse
-    result_csv: |
-      name,type
-      id,Nullable(Int32)
-      boolean_col,Nullable(Bool)
-      int32_col,Nullable(Int32)
-      int64_col,Nullable(Int64)
-      float_col,Nullable(Float32)
-      double_col,Nullable(Float64)
-      byte_array_col,Nullable(String)
-      fixed_len_byte_array_col,Nullable(FixedString(16))
-      string_col,Nullable(String)
-      decimal_col,"Nullable(Decimal(10, 2))"
-      date_col,Nullable(Date32)
-      time_millis_col,Nullable(DateTime64(3))
-      time_micros_col,Nullable(DateTime64(6))
-      timestamp_millis_col,Nullable(DateTime64(3))
-      timestamp_micros_col,Nullable(DateTime64(6))
-      uuid_col,Nullable(FixedString(16))
-      list_int_col,Array(Nullable(Int32))
-      list_string_col,Array(Nullable(String))
-      map_col,"Map(String, Nullable(Int32))"
-      struct_col,"Tuple(field_int_col Nullable(Int32), field_float_col Nullable(Float32), field_string_col Nullable(String))"
-  - name: query_all_result_duckdb_source_glob
-    resolver: sql
-    properties:
-      sql: "select * from all_datatypes_duckdb_source_glob order by id"
-    result_csv: |
-      id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col,y
-      1,true,123,45678901234,1.23,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,0001-01-01T00:02:03.456Z,0001-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,[1 2 3],['apple' 'banana' 'cherry'],"[('key1', 10), ('key2', 20)]","{'field_int_col': 42, 'field_float_col': 3.140000104904175, 'field_string_col': 'example'}",2024
-      2,false,0,0,0,0,,0000000000000000,,0,1970-01-01,0001-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0000000000000000,[],[],[],"{'field_int_col': 0, 'field_float_col': 0.0, 'field_string_col': ''}",2024
-      3,,,,,,,,,,,,,,,,,,,,2024
-      4,true,123,45678901234,1.23,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,0001-01-01T00:02:03.456Z,0001-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,[1 2 3],['apple' 'banana' 'cherry'],"[('key1', 10), ('key2', 20)]","{'field_int_col': 42, 'field_float_col': 3.140000104904175, 'field_string_col': 'example'}",2023
-      5,false,0,0,0,0,,0000000000000000,,0,1970-01-01,0001-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0000000000000000,[],[],[],"{'field_int_col': 0, 'field_float_col': 0.0, 'field_string_col': ''}",2023
-      6,,,,,,,,,,,,,,,,,,,,2023
-  - name: query_all_result_duckdb_model_glob
-    resolver: sql
-    properties:
-      sql: "select * from all_datatypes_duckdb_model_glob order by id"
-    result_csv: |
-      id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col,y
-      1,true,123,45678901234,1.23,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,0001-01-01T00:02:03.456Z,0001-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,[1 2 3],['apple' 'banana' 'cherry'],"[('key1', 10), ('key2', 20)]","{'field_int_col': 42, 'field_float_col': 3.140000104904175, 'field_string_col': 'example'}",2024
-      2,false,0,0,0,0,,0000000000000000,,0,1970-01-01,0001-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0000000000000000,[],[],[],"{'field_int_col': 0, 'field_float_col': 0.0, 'field_string_col': ''}",2024
-      3,,,,,,,,,,,,,,,,,,,,2024
-      4,true,123,45678901234,1.23,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,0001-01-01T00:02:03.456Z,0001-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,[1 2 3],['apple' 'banana' 'cherry'],"[('key1', 10), ('key2', 20)]","{'field_int_col': 42, 'field_float_col': 3.140000104904175, 'field_string_col': 'example'}",2023
-      5,false,0,0,0,0,,0000000000000000,,0,1970-01-01,0001-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0000000000000000,[],[],[],"{'field_int_col': 0, 'field_float_col': 0.0, 'field_string_col': ''}",2023
-      6,,,,,,,,,,,,,,,,,,,,2023
-  - name: query_all_result_clickhouse_glob
-    resolver: sql
-    properties:
-      sql: "select * from all_datatypes_clickhouse_glob order by id"
+      sql: "select * from model_gcs_to_clickhouse_for_glob order by id"
       connector: clickhouse
       # time is converted to datetime like 2025-01-01T00:02:03.456Z but should be 1970-01-01T00:02:03.456Z, which is wrong.
     result_csv: |
@@ -314,3 +117,185 @@ tests:
       4,True,123,45678901234,1.23,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,00:02:03.456000,00:02:03.456789,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,[1 2 3],['apple' 'banana' 'cherry'],"[('key1', 10), ('key2', 20)]","{'field_int_col': 42, 'field_float_col': 3.140000104904175, 'field_string_col': 'example'}"
       5,False,0,0,0,0,,0000000000000000,,0,1970-01-01,00:00:00,00:00:00,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0000000000000000,[],[],[],"{'field_int_col': 0, 'field_float_col': 0.0, 'field_string_col': ''}"
       6,,,,,,,,,,,,,,,,,,,
+  - name: test_all_result_for_model_gcs_to_clickhouse_for_parquet
+    resolver: sql
+    properties:
+      sql: "select * from model_gcs_to_clickhouse_for_parquet order by id"
+      connector: clickhouse
+    result_csv: |
+      id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col
+      1,true,123,45678901234,1.2300000190734863,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,1970-01-01T00:02:03.456Z,1970-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,"[1,2,3]","[""apple"",""banana"",""cherry""]","{""key1"":10,""key2"":20}","{""FIELD_FLOAT_COL"":null,""FIELD_INT_COL"":null,""FIELD_STRING_COL"":null,""field_float_col"":3.14,""field_int_col"":42,""field_string_col"":""example""}"
+      2,false,0,0,0,0,,0000000000000000,,0,1970-01-01,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0000000000000000,[],[],{},"{""FIELD_FLOAT_COL"":null,""FIELD_INT_COL"":null,""FIELD_STRING_COL"":null,""field_float_col"":0,""field_int_col"":0,""field_string_col"":""""}"
+      3,,,,,,,,,,,,,,,,[],[],{},"{""FIELD_FLOAT_COL"":null,""FIELD_INT_COL"":null,""FIELD_STRING_COL"":null,""field_float_col"":null,""field_int_col"":null,""field_string_col"":null}"
+  - name: test_schema_for_model_gcs_to_clickhouse_for_parquet
+    resolver: sql
+    properties:
+      sql: |
+        select name, type from system.columns where `table` = 'all_datatypes_clickhouse_parquet'
+      connector: clickhouse
+    result_csv: |
+      name,type
+  - name: test_all_for_results_model_gcs_to_duckdb_for_csv
+    resolver: sql
+    properties:
+      sql: "select * from model_gcs_to_duckdb_for_csv order by id"
+    result_csv: |
+      id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col
+      1,true,123,45678901234,1.23,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,0001-01-01T00:02:03.456Z,0001-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,[1 2 3],['apple' 'banana' 'cherry'],"[('key1', 10), ('key2', 20)]","{'field_int_col': 42, 'field_float_col': 3.140000104904175, 'field_string_col': 'example'}"
+      2,false,0,0,0,0,,0000000000000000,,0,1970-01-01,0001-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0000000000000000,[],[],[],"{'field_int_col': 0, 'field_float_col': 0.0, 'field_string_col': ''}"
+      3,,,,,,,,,,,,,,,,,,,
+  - name: test_schema_for_model_gcs_to_duckdb_for_csv
+    resolver: sql
+    properties:
+      sql: "describe model_gcs_to_duckdb_for_csv"
+    result_csv: |
+      column_name,column_type,null,key,default,extra
+      id,BIGINT,YES,,,
+      boolean_col,BOOLEAN,YES,,,
+      int32_col,BIGINT,YES,,,
+      int64_col,BIGINT,YES,,,
+      float_col,DOUBLE,YES,,,
+      double_col,DOUBLE,YES,,,
+      byte_array_col,VARCHAR,YES,,,
+      fixed_len_byte_array_col,VARCHAR,YES,,,
+      string_col,VARCHAR,YES,,,
+      decimal_col,DOUBLE,YES,,,
+      date_col,DATE,YES,,,
+      time_millis_col,TIME,YES,,,
+      time_micros_col,TIME,YES,,,
+      timestamp_millis_col,TIMESTAMP,YES,,,
+      timestamp_micros_col,TIMESTAMP,YES,,,
+      uuid_col,VARCHAR,YES,,,
+      list_int_col,VARCHAR,YES,,,
+      list_string_col,VARCHAR,YES,,,
+      map_col,VARCHAR,YES,,,
+      struct_col,VARCHAR,YES,,,
+  - name: test_all_results_for_model_gcs_to_duckdb_for_glob
+    resolver: sql
+    properties:
+      sql: "select * from model_gcs_to_duckdb_for_glob order by id"
+    result_csv: |
+      id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col,y
+      1,true,123,45678901234,1.23,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,0001-01-01T00:02:03.456Z,0001-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,[1 2 3],['apple' 'banana' 'cherry'],"[('key1', 10), ('key2', 20)]","{'field_int_col': 42, 'field_float_col': 3.140000104904175, 'field_string_col': 'example'}",2024
+      2,false,0,0,0,0,,0000000000000000,,0,1970-01-01,0001-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0000000000000000,[],[],[],"{'field_int_col': 0, 'field_float_col': 0.0, 'field_string_col': ''}",2024
+      3,,,,,,,,,,,,,,,,,,,,2024
+      4,true,123,45678901234,1.23,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,0001-01-01T00:02:03.456Z,0001-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,[1 2 3],['apple' 'banana' 'cherry'],"[('key1', 10), ('key2', 20)]","{'field_int_col': 42, 'field_float_col': 3.140000104904175, 'field_string_col': 'example'}",2023
+      5,false,0,0,0,0,,0000000000000000,,0,1970-01-01,0001-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0000000000000000,[],[],[],"{'field_int_col': 0, 'field_float_col': 0.0, 'field_string_col': ''}",2023
+      6,,,,,,,,,,,,,,,,,,,,2023
+  - name: test_all_results_for_model_gcs_to_duckdb_for_parquet
+    resolver: sql
+    properties:
+      sql: "select * from model_gcs_to_duckdb_for_parquet order by id"
+    result_csv: |
+      id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col
+      1,true,123,45678901234,1.2300000190734863,3.14159,YWJjZA==,MTIzNDU2Nzg5MGFiY2RlZg==,hello,123.45,2024-03-06,0001-01-01T00:02:03.456Z,0001-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,dXVpZGFiY2QxMjM0ZWZnaA==,"[1,2,3]","[""apple"",""banana"",""cherry""]","{""key1"":10,""key2"":20}","{""field_float_col"":3.140000104904175,""field_int_col"":42,""field_string_col"":""example""}"
+      2,false,0,0,0,0,,MDAwMDAwMDAwMDAwMDAwMA==,,0,1970-01-01,0001-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,MDAwMDAwMDAwMDAwMDAwMA==,[],[],{},"{""field_float_col"":0,""field_int_col"":0,""field_string_col"":""""}"
+      3,,,,,,,,,,,,,,,,,,,
+  - name: test_schema_for_model_gcs_to_duckdb_for_parquet
+    resolver: sql
+    properties:
+      sql: "describe model_gcs_to_duckdb_for_parquet"
+    result_csv: |
+      column_name,column_type,null,key,default,extra
+      id,INTEGER,YES,,,
+      boolean_col,BOOLEAN,YES,,,
+      int32_col,INTEGER,YES,,,
+      int64_col,BIGINT,YES,,,
+      float_col,FLOAT,YES,,,
+      double_col,DOUBLE,YES,,,
+      byte_array_col,BLOB,YES,,,
+      fixed_len_byte_array_col,BLOB,YES,,,
+      string_col,VARCHAR,YES,,,
+      decimal_col,"DECIMAL(10,2)",YES,,,
+      date_col,DATE,YES,,,
+      time_millis_col,TIME WITH TIME ZONE,YES,,,
+      time_micros_col,TIME WITH TIME ZONE,YES,,,
+      timestamp_millis_col,TIMESTAMP,YES,,,
+      timestamp_micros_col,TIMESTAMP,YES,,,
+      uuid_col,BLOB,YES,,,
+      list_int_col,INTEGER[],YES,,,
+      list_string_col,VARCHAR[],YES,,,
+      map_col,"MAP(VARCHAR, INTEGER)",YES,,,
+      struct_col,"STRUCT(field_int_col INTEGER, field_float_col FLOAT, field_string_col VARCHAR)",YES,,,
+  - name: test_all_results_for_model_gcs_to_duckdb_using_path_for_csv
+    resolver: sql
+    properties:
+      sql: "select * from model_gcs_to_duckdb_using_path_for_csv order by id"
+    result_csv: |
+      id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col
+      1,true,123,45678901234,1.23,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,0001-01-01T00:02:03.456Z,0001-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,[1 2 3],['apple' 'banana' 'cherry'],"[('key1', 10), ('key2', 20)]","{'field_int_col': 42, 'field_float_col': 3.140000104904175, 'field_string_col': 'example'}"
+      2,false,0,0,0,0,,0000000000000000,,0,1970-01-01,0001-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0000000000000000,[],[],[],"{'field_int_col': 0, 'field_float_col': 0.0, 'field_string_col': ''}"
+      3,,,,,,,,,,,,,,,,,,,
+  - name: test_schema_for_model_gcs_to_duckdb_using_path_for_csv
+    resolver: sql
+    properties:
+      sql: "describe model_gcs_to_duckdb_using_path_for_csv"
+    result_csv: |
+      column_name,column_type,null,key,default,extra
+      id,BIGINT,YES,,,
+      boolean_col,BOOLEAN,YES,,,
+      int32_col,BIGINT,YES,,,
+      int64_col,BIGINT,YES,,,
+      float_col,DOUBLE,YES,,,
+      double_col,DOUBLE,YES,,,
+      byte_array_col,VARCHAR,YES,,,
+      fixed_len_byte_array_col,VARCHAR,YES,,,
+      string_col,VARCHAR,YES,,,
+      decimal_col,DOUBLE,YES,,,
+      date_col,DATE,YES,,,
+      time_millis_col,TIME,YES,,,
+      time_micros_col,TIME,YES,,,
+      timestamp_millis_col,TIMESTAMP,YES,,,
+      timestamp_micros_col,TIMESTAMP,YES,,,
+      uuid_col,VARCHAR,YES,,,
+      list_int_col,VARCHAR,YES,,,
+      list_string_col,VARCHAR,YES,,,
+      map_col,VARCHAR,YES,,,
+      struct_col,VARCHAR,YES,,,
+  - name: test_all_results_for_model_gcs_to_duckdb_using_path_for_glob
+    resolver: sql
+    properties:
+      sql: "select * from model_gcs_to_duckdb_using_path_for_glob order by id"
+    result_csv: |
+      id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col,y
+      1,true,123,45678901234,1.23,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,0001-01-01T00:02:03.456Z,0001-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,[1 2 3],['apple' 'banana' 'cherry'],"[('key1', 10), ('key2', 20)]","{'field_int_col': 42, 'field_float_col': 3.140000104904175, 'field_string_col': 'example'}",2024
+      2,false,0,0,0,0,,0000000000000000,,0,1970-01-01,0001-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0000000000000000,[],[],[],"{'field_int_col': 0, 'field_float_col': 0.0, 'field_string_col': ''}",2024
+      3,,,,,,,,,,,,,,,,,,,,2024
+      4,true,123,45678901234,1.23,3.14159,abcd,1234567890abcdef,hello,123.45,2024-03-06,0001-01-01T00:02:03.456Z,0001-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,uuidabcd1234efgh,[1 2 3],['apple' 'banana' 'cherry'],"[('key1', 10), ('key2', 20)]","{'field_int_col': 42, 'field_float_col': 3.140000104904175, 'field_string_col': 'example'}",2023
+      5,false,0,0,0,0,,0000000000000000,,0,1970-01-01,0001-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,0000000000000000,[],[],[],"{'field_int_col': 0, 'field_float_col': 0.0, 'field_string_col': ''}",2023
+      6,,,,,,,,,,,,,,,,,,,,2023
+  - name: test_all_results_for_model_gcs_to_duckdb_using_path_for_parquet
+    resolver: sql
+    properties:
+      sql: "select * from model_gcs_to_duckdb_using_path_for_parquet order by id"
+    result_csv: |
+      id,boolean_col,int32_col,int64_col,float_col,double_col,byte_array_col,fixed_len_byte_array_col,string_col,decimal_col,date_col,time_millis_col,time_micros_col,timestamp_millis_col,timestamp_micros_col,uuid_col,list_int_col,list_string_col,map_col,struct_col
+      1,true,123,45678901234,1.2300000190734863,3.14159,YWJjZA==,MTIzNDU2Nzg5MGFiY2RlZg==,hello,123.45,2024-03-06,0001-01-01T00:02:03.456Z,0001-01-01T00:02:03.456789Z,2024-03-06T12:34:56.789Z,2024-03-06T12:34:56.789123Z,dXVpZGFiY2QxMjM0ZWZnaA==,"[1,2,3]","[""apple"",""banana"",""cherry""]","{""key1"":10,""key2"":20}","{""field_float_col"":3.140000104904175,""field_int_col"":42,""field_string_col"":""example""}"
+      2,false,0,0,0,0,,MDAwMDAwMDAwMDAwMDAwMA==,,0,1970-01-01,0001-01-01T00:00:00Z,0001-01-01T00:00:00Z,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z,MDAwMDAwMDAwMDAwMDAwMA==,[],[],{},"{""field_float_col"":0,""field_int_col"":0,""field_string_col"":""""}"
+      3,,,,,,,,,,,,,,,,,,,
+  - name: test_schema_for_model_gcs_to_duckdb_using_path_for_parquet
+    resolver: sql
+    properties:
+      sql: "describe model_gcs_to_duckdb_using_path_for_parquet"
+    result_csv: |
+      column_name,column_type,null,key,default,extra
+      id,INTEGER,YES,,,
+      boolean_col,BOOLEAN,YES,,,
+      int32_col,INTEGER,YES,,,
+      int64_col,BIGINT,YES,,,
+      float_col,FLOAT,YES,,,
+      double_col,DOUBLE,YES,,,
+      byte_array_col,BLOB,YES,,,
+      fixed_len_byte_array_col,BLOB,YES,,,
+      string_col,VARCHAR,YES,,,
+      decimal_col,"DECIMAL(10,2)",YES,,,
+      date_col,DATE,YES,,,
+      time_millis_col,TIME WITH TIME ZONE,YES,,,
+      time_micros_col,TIME WITH TIME ZONE,YES,,,
+      timestamp_millis_col,TIMESTAMP,YES,,,
+      timestamp_micros_col,TIMESTAMP,YES,,,
+      uuid_col,BLOB,YES,,,
+      list_int_col,INTEGER[],YES,,,
+      list_string_col,VARCHAR[],YES,,,
+      map_col,"MAP(VARCHAR, INTEGER)",YES,,,
+      struct_col,"STRUCT(field_int_col INTEGER, field_float_col FLOAT, field_string_col VARCHAR)",YES,,,

--- a/runtime/resolvers/testdata/connector_iceberg.yaml
+++ b/runtime/resolvers/testdata/connector_iceberg.yaml
@@ -2,32 +2,32 @@ expensive: true
 connectors:
   - gcs_s3_compat
 project_files:
-  gcs.yaml:
+  gcs_hmac.yaml:
     type: connector
     driver: gcs
     key_id: '{{.env.connector.gcs_s3_compat.key_id }}'
     secret: '{{.env.connector.gcs_s3_compat.secret }}'
-  iceberg_gcs_with_secrets.yaml:
+  model_iceberg_to_duckdb_with_gcs_hmac.yaml:
     type: model
     connector: duckdb
-    create_secrets_from_connectors: gcs
+    create_secrets_from_connectors: gcs_hmac
     materialize: true
     sql: |
       SELECT *
       FROM iceberg_scan('gs://integration-test.rilldata.com/iceberg/lineitem_iceberg',
         allow_moved_paths = true)
 tests:
-  - name: test_iceberg_gcs_with_secrets_row_count
+  - name: test_row_count_for_model_iceberg_to_duckdb_with_gcs_hmac
     resolver: sql
     properties:
-      sql: "select count(*) as count from iceberg_gcs_with_secrets"
+      sql: "select count(*) as count from model_iceberg_to_duckdb_with_gcs_hmac"
     result_csv: |
       count
       51793
-  - name: test_iceberg_gcs_with_secrets_schema
+  - name: test_schema_for_model_iceberg_to_duckdb_with_gcs_hmac
     resolver: sql
     properties:
-      sql: "describe iceberg_gcs_with_secrets"
+      sql: "describe model_iceberg_to_duckdb_with_gcs_hmac"
     result_csv: |
       column_name,column_type,null,key,default,extra
       l_orderkey,INTEGER,YES,,,


### PR DESCRIPTION
1. adding gcs_hmac connector for biquery to fix test. 
2. also renamed gcs to gcs_hmac in places where it requires hmac.
3. refactoring model project file name with model_ prefix so that gcs_hmac connector comes first when run with --update flag.
4. updating model names and test name to make it more clear.


**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
