### PR TITLE
perf: reduce TDD page latency with draw batching and DOM optimizations

### DIFF
--- a/web-common/src/features/dashboards/pivot/RegularTable.svelte
+++ b/web-common/src/features/dashboards/pivot/RegularTable.svelte
@@ -113,8 +113,6 @@
       th.setAttribute("title", value.value);
     }
 
-    th.onmouseover = () => cellInspectorStore.updateValue(value?.value);
-    th.onfocus = () => cellInspectorStore.updateValue(value?.value);
     const maybeWidth = getRowHeaderWidth(x);
     if (maybeWidth) {
       th.style.width = `${maybeWidth}px`;
@@ -147,9 +145,6 @@
     const value = meta?.value;
     td.setAttribute("__col", String(x));
     td.setAttribute("__row", String(y));
-
-    td.onmouseover = () => cellInspectorStore.updateValue(value);
-    td.onfocus = () => cellInspectorStore.updateValue(value);
 
     const maybeWidth = getColumnWidth(x);
     if (maybeWidth) {
@@ -249,45 +244,65 @@
     handlerCache.set(type, handler);
   }
 
+  function inspectCellValue(evt: MouseEvent) {
+    const target = evt.target as HTMLTableCellElement;
+    if (!target) return;
+    const meta = table.getMeta(target);
+    if (meta?.value !== undefined) {
+      const val =
+        typeof meta.value === "object" && meta.value !== null
+          ? (meta.value as { value?: string }).value
+          : meta.value;
+      cellInspectorStore.updateValue(val);
+    }
+  }
+
   $: {
-    if (table && onMouseDown) {
-      const handler = (evt: MouseEvent) =>
-        onMouseDown ? onMouseDown(evt, table) : undefined;
-      const hoverHandler = (evt: MouseEvent) =>
-        onMouseHover ? onMouseHover(evt, table) : undefined;
+    if (table) {
+      const hoverHandler = (evt: MouseEvent) => {
+        if (onMouseHover) onMouseHover(evt, table);
+        if (evt.type === "mouseover") inspectCellValue(evt);
+      };
       addHandler("mouseover", hoverHandler);
       addHandler("mouseout", hoverHandler);
-      addHandler("mousedown", handler);
+
+      if (onMouseDown) {
+        const handler = (evt: MouseEvent) =>
+          onMouseDown ? onMouseDown(evt, table) : undefined;
+        addHandler("mousedown", handler);
+      }
     }
   }
 
   let lastColumnSizer: null | ((x: number) => number | void) = null;
   let lastRowHeaderSizer: null | ((x: number) => number | void) = null;
   function styleListener() {
-    for (const td of Array.from(table?.querySelectorAll("tbody td") || [])) {
-      style_td(td as HTMLTableCellElement);
+    const tbody = table?.querySelector("tbody");
+    const thead = table?.querySelector("thead");
+
+    if (tbody) {
+      const cells = tbody.querySelectorAll("td");
+      for (let i = 0; i < cells.length; i++) {
+        style_td(cells[i] as HTMLTableCellElement);
+      }
+      const headers = tbody.querySelectorAll("th");
+      for (let i = 0; i < headers.length; i++) {
+        style_row_th(headers[i] as HTMLTableCellElement);
+      }
     }
 
-    for (const th of Array.from(table?.querySelectorAll("tbody th") || [])) {
-      style_row_th(th as HTMLTableCellElement);
+    if (thead) {
+      const ths = thead.querySelectorAll("th");
+      for (let i = 0; i < ths.length; i++) {
+        const th = ths[i] as HTMLTableCellElement;
+        if (th.classList.contains("rt-group-corner")) {
+          style_row_corner(th);
+        } else {
+          style_column_th(th);
+        }
+      }
     }
 
-    for (const th of Array.from(
-      table?.querySelectorAll("thead th:not(.rt-group-corner)") || [],
-    )) {
-      style_column_th(th as HTMLTableCellElement);
-    }
-
-    for (const th of Array.from(
-      table?.querySelectorAll("thead th.rt-group-corner") || [],
-    )) {
-      style_row_corner(th as HTMLTableCellElement);
-    }
-    /**
-     * If the column sizer or row header sizer function has
-     * changed since last style call, invalidate the table column
-     * width caches so horizontal scrolling is  properly calculated
-     * */
     if (
       lastColumnSizer !== getColumnWidth ||
       lastRowHeaderSizer !== getRowHeaderWidth

--- a/web-common/src/features/dashboards/time-dimension-details/TDDTable.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/TDDTable.svelte
@@ -25,6 +25,7 @@
   import type { MetricsViewSpecMeasure } from "@rilldata/web-common/runtime-client";
   import { lastKnownPosition } from "./time-dimension-data-store";
   import type { TDDComparison, TableData, TablePosition } from "./types";
+  import { onDestroy } from "svelte";
 
   export let dimensionLabel: string;
   export let measureLabel: string;
@@ -64,6 +65,20 @@
 
   let pivot;
 
+  let drawRafId: number | null = null;
+  function scheduleDraw() {
+    if (drawRafId === null) {
+      drawRafId = requestAnimationFrame(() => {
+        drawRafId = null;
+        pivot?.draw();
+      });
+    }
+  }
+
+  onDestroy(() => {
+    if (drawRafId !== null) cancelAnimationFrame(drawRafId);
+  });
+
   let rowIdxHover: number | undefined;
   let colIdxHover: number | undefined;
   let hoveringPin = false;
@@ -82,45 +97,43 @@
     return tableData?.columnHeaderData?.slice(pos.x0, pos.x1);
   }
 
+  const CELL_BG_CLASSES_TO_REMOVE = [
+    "border-b",
+    "bg-surface-hover",
+    "bg-gray-100",
+    "bg-gray-200",
+    "bg-primary-50",
+    "bg-primary-100",
+    "bg-primary-200",
+    "bg-surface-hover/50",
+    "bg-surface-base",
+  ];
+
   const renderCell: PivotRenderCallback = (data) => {
-    const classesToAdd = ["text-right"];
-    const classesToRemove = [
-      "border-b",
-      "bg-surface-hover",
-      "bg-gray-100",
-      "bg-gray-200",
-      "bg-primary-50",
-      "bg-primary-100",
-      "bg-primary-200",
-      "bg-surface-hover/50",
-      "bg-gray-100",
-      "bg-gray-200",
-    ];
+    const el = data.element;
+    const classList = el.classList;
 
-    if (pinIndex > -1 && comparing === "dimension" && data.y === pinIndex + 1) {
-      classesToAdd.push("border-b");
-    }
+    classList.remove(...CELL_BG_CLASSES_TO_REMOVE);
+    classList.add("text-right");
 
-    if (comparing === "time" && data.y === 2) {
-      classesToAdd.push("border-b");
-    }
+    const showBorder =
+      (pinIndex > -1 &&
+        comparing === "dimension" &&
+        data.y === pinIndex + 1) ||
+      (comparing === "time" && data.y === 2);
+    classList.toggle("border-b", showBorder);
 
     const palette = data.y === 0 ? "fixed" : "default";
-
-    classesToAdd.push(
-      getClassForCell(
-        palette,
-        rowIdxHover ?? highlightedRow,
-        colIdxHover ?? highlightedColStart,
-        colIdxHover ?? highlightedColEnd,
-        data.y,
-        data.x,
-      ),
+    const bgClass = getClassForCell(
+      palette,
+      rowIdxHover ?? highlightedRow,
+      colIdxHover ?? highlightedColStart,
+      colIdxHover ?? highlightedColEnd,
+      data.y,
+      data.x,
     );
-    // Update DOM with consolidated class operations
-    data.element.classList.toggle("font-semibold", Boolean(data.y == 0));
-    data.element.classList.remove(...classesToRemove);
-    data.element.classList.add(...classesToAdd);
+    classList.add(bgClass);
+    classList.toggle("font-semibold", data.y === 0);
   };
 
   const renderColumnHeader: PivotRenderCallback = (data) => {
@@ -134,7 +147,7 @@
     highlightedColEnd;
     highlightedRow;
     tableData?.selectedValues;
-    pivot?.draw();
+    scheduleDraw();
   }
 
   const getPinIcon = () => {
@@ -181,15 +194,21 @@
     };
   };
 
+  const ROW_HEADER_BG_CLASSES_TO_REMOVE = [
+    "bg-surface-hover",
+    "bg-surface-hover/50",
+    "bg-gray-100",
+    "bg-gray-200",
+    "bg-surface-base",
+  ];
+
   const renderRowHeader: PivotRenderCallback = ({ value, x, y, element }) => {
-    const showBorder =
+    element.classList.toggle(
+      "border-b",
       (pinIndex > -1 && comparing === "dimension" && y === pinIndex + 1) ||
-      (comparing === "time" && y === 2);
-    if (showBorder) {
-      element.classList.add("border-b");
-    } else {
-      element.classList.remove("border-b");
-    }
+        (comparing === "time" && y === 2),
+    );
+
     const total =
       value.value !== undefined
         ? isNaN(Number(value.value)) || x == 0
@@ -197,36 +216,26 @@
           : formatter(Number(value.value))
         : "...";
 
-    const cellBgColor = getClassForCell(
-      "fixed",
-      rowIdxHover,
-      colIdxHover ?? highlightedColStart,
-      colIdxHover ?? highlightedColEnd,
-      y,
-      x - tableData?.fixedColCount,
-    );
     if (x > 0) {
-      element.classList.remove(
-        "bg-surface-hover",
-        "bg-surface-hover/50",
-        "bg-gray-100",
-        "bg-gray-200",
+      const cellBgColor = getClassForCell(
+        "fixed",
+        rowIdxHover,
+        colIdxHover ?? highlightedColStart,
+        colIdxHover ?? highlightedColEnd,
+        y,
+        x - tableData?.fixedColCount,
       );
+      element.classList.remove(...ROW_HEADER_BG_CLASSES_TO_REMOVE);
       element.classList.add(cellBgColor);
     }
     if (x === 0) {
       element.classList.add("pl-0");
       const marker = getMarker(value, y);
 
-      // Gray out rows which are not included
-      if (marker.muted) {
-        element?.parentElement?.classList.add("text-fg-muted");
-      } else {
-        element?.parentElement?.classList.remove("text-fg-muted");
-      }
+      element?.parentElement?.classList.toggle("text-fg-muted", marker.muted);
 
       const fontWeight = y === 0 ? "font-semibold" : "font-normal";
-      return `<div class="flex items-center pointer-events-none  w-full h-full overflow-hidden pr-2 gap-1">
+      return `<div class="flex items-center pointer-events-none w-full h-full overflow-hidden pr-2 gap-1">
         <div class="w-5 shrink-0 h-full flex items-center justify-center">${marker.icon}</div>
         <div class="truncate text-xs ${value.value === null ? "italic text-fg-muted" : ""} ${fontWeight}">${total}</div></div>`;
     } else if (x === 1)
@@ -235,7 +244,7 @@
         ${value.spark}
         </div>`;
     else
-      return `<div class="text-xs pointer-events-none  font-normal text-right" >${total}</div>`;
+      return `<div class="text-xs pointer-events-none font-normal text-right" >${total}</div>`;
   };
 
   const renderRowCorner: PivotRenderCallback = (data) => {
@@ -335,24 +344,28 @@
       handleEvent(evt, table, "pin", () => (newHoveringPin = true));
     }
 
+    let needsDraw = false;
+
     if (hoveringPin !== newHoveringPin) {
       hoveringPin = newHoveringPin;
-      pivot?.draw();
+      needsDraw = true;
     }
 
-    if (newRowIdxHover !== rowIdxHover && newColIdxHover !== colIdxHover) {
+    if (newRowIdxHover !== rowIdxHover || newColIdxHover !== colIdxHover) {
       rowIdxHover = newRowIdxHover;
       colIdxHover = newColIdxHover;
       onHighlight(colIdxHover, rowIdxHover);
-      pivot?.draw();
+      needsDraw = true;
     }
+
+    if (needsDraw) scheduleDraw();
   };
 
   function resetHighlight() {
     rowIdxHover = undefined;
     colIdxHover = undefined;
     onHighlight(colIdxHover, rowIdxHover);
-    pivot?.draw();
+    scheduleDraw();
   }
 
   // Scroll to previous position in case of dashboard refresh during reconcile
@@ -373,10 +386,12 @@
   }
 
   // Hack: for some reason, not enough columns are being drawn on first render.
-  // Force a second initial render to workaround it.
+  // Force a second initial render to workaround it (one-shot).
+  let initialExtraDrawDone = false;
   $: {
-    if (pivot) {
-      setTimeout(pivot.draw, 0);
+    if (pivot && !initialExtraDrawDone) {
+      initialExtraDrawDone = true;
+      setTimeout(() => pivot?.draw(), 0);
     }
   }
 

--- a/web-common/src/features/dashboards/time-dimension-details/util.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/util.ts
@@ -37,40 +37,26 @@ export function transposeArray(
   return columnarBody;
 }
 
+const BG_BASE = "bg-surface-base";
+const BG_HIGHLIGHTED = "bg-surface-hover/50";
+const BG_DOUBLE_HIGHLIGHTED = "bg-surface-hover";
+
 export function getClassForCell(
-  palette: "fixed" | "default",
+  _palette: "fixed" | "default",
   highlightedRow: number | undefined,
   highlightedColStart: number | undefined,
   highlightedColEnd: number | undefined,
   rowIdx: number,
   colIdx: number,
 ) {
-  const bgColors = {
-    fixed: {
-      base: "bg-surface-base",
-      highlighted: "bg-surface-hover/50",
-      doubleHighlighted: "bg-surface-hover",
-    },
-    default: {
-      base: "bg-surface-base",
-      highlighted: "bg-surface-hover/50",
-      doubleHighlighted: "bg-surface-hover",
-    },
-  };
-
-  // Determine background color based on store
   const isRowHighlighted = highlightedRow === rowIdx;
   const isColHighlighted =
     highlightedColStart !== undefined &&
     highlightedColEnd !== undefined &&
     colIdx >= highlightedColStart &&
     colIdx <= highlightedColEnd;
-  const isHighlighted = isRowHighlighted || isColHighlighted;
-  const isDoubleHighlighted = isRowHighlighted && isColHighlighted;
 
-  let colorName = bgColors[palette].base;
-  if (isDoubleHighlighted) colorName = bgColors[palette].doubleHighlighted;
-  else if (isHighlighted) colorName = bgColors[palette].highlighted;
-
-  return colorName;
+  if (isRowHighlighted && isColHighlighted) return BG_DOUBLE_HIGHLIGHTED;
+  if (isRowHighlighted || isColHighlighted) return BG_HIGHLIGHTED;
+  return BG_BASE;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses the TDD page latency issue (APP-789) where scrolling and hovering on the Time Dimension Detail table causes significant lag. The root causes were: multiple redundant `draw()` calls per animation frame, per-cell DOM event handler allocation on every draw cycle, and unnecessary object/array allocations in hot render paths.

## Changes

### 1. Batch draw calls with `requestAnimationFrame` (`TDDTable.svelte`)
- Introduced `scheduleDraw()` which coalesces multiple `draw()` requests into a single frame via `requestAnimationFrame`
- Replaced all direct `pivot?.draw()` calls (from reactive blocks, hover handlers, mouseleave) with `scheduleDraw()`
- Previously, a single hover event could trigger 2+ draws: one from `handleMouseHover` and another from the reactive block tracking `highlightedColStart`/`highlightedColEnd`

### 2. Remove per-cell event handlers (`RegularTable.svelte`)
- Removed `td.onmouseover` and `th.onmouseover`/`th.onfocus` assignments from `style_td` and `style_row_th`
- These were creating new closures for every visible cell on every draw cycle, triggering `cellInspectorStore.updateValue` on every mouse movement
- Replaced with a single table-level event delegation handler via `inspectCellValue()`

### 3. Optimize `styleListener` DOM queries (`RegularTable.svelte`)
- Replaced four separate `querySelectorAll` + `Array.from` calls with targeted `querySelector("tbody")`/`querySelector("thead")` lookups
- Use direct `for` loops over `NodeList` instead of creating intermediate arrays

### 4. Reduce per-cell allocations (`TDDTable.svelte`)
- Hoisted `classesToRemove` arrays to module-level constants (`CELL_BG_CLASSES_TO_REMOVE`, `ROW_HEADER_BG_CLASSES_TO_REMOVE`) instead of allocating on every `renderCell` call
- Simplified class manipulation using `classList.toggle()` instead of conditional push + batch add

### 5. Fix hover condition bug (`TDDTable.svelte`)
- Changed `&&` to `||` in `handleMouseHover` so highlight updates when either row OR column changes, not only when both change simultaneously

### 6. Make setTimeout hack one-shot (`TDDTable.svelte`)
- The `setTimeout(pivot.draw, 0)` workaround was re-triggering on every `pivot` reference change; now gated with `initialExtraDrawDone` flag

### 7. Optimize `getClassForCell` (`util.ts`)
- Hoisted the background color constants to module scope, eliminating per-call object allocation

## Impact
These changes primarily reduce the number of full table redraws during interaction (hover, scroll) and reduce the per-cell work during each draw cycle. For a typical TDD view with YTD daily data (~365 columns, 12 rows), this eliminates hundreds of redundant closure allocations and multiple redundant draw passes per frame.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [APP-789](https://linear.app/rilldata/issue/APP-789/tdd-page-has-a-lot-of-latency)

<div><a href="https://cursor.com/agents/bc-ac55a909-23f4-4627-b3a7-cdbf7eeb5ece"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac55a909-23f4-4627-b3a7-cdbf7eeb5ece"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

