### PR TITLE
fix: normalize percentage metric filter values for correct comparison

### DIFF
--- a/web-common/src/features/canvas/stores/filter-manager.ts
+++ b/web-common/src/features/canvas/stores/filter-manager.ts
@@ -1,5 +1,8 @@
 import { DimensionFilterMode } from "@rilldata/web-common/features/dashboards/filters/dimension-filters/constants";
-import type { MeasureFilterEntry } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry";
+import {
+  isMeasurePercentFormat,
+  type MeasureFilterEntry,
+} from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry";
 import { type DimensionFilterItem } from "@rilldata/web-common/features/dashboards/state-managers/selectors/dimension-filters";
 import type { MeasureFilterItem } from "@rilldata/web-common/features/dashboards/state-managers/selectors/measure-filters";
 import type {
@@ -391,6 +394,7 @@ export class FilterManager {
               pinned: pinned,
               measures: measureMap,
               metricsViewNames: metricsViewNames,
+              isPercent: isMeasurePercentFormat(measureSpecs[0]),
             });
           }
         } else {

--- a/web-common/src/features/canvas/stores/filter-state.ts
+++ b/web-common/src/features/canvas/stores/filter-state.ts
@@ -1,5 +1,8 @@
 import { getFiltersFromText } from "@rilldata/web-common/features/dashboards/filters/dimension-filters/dimension-search-text-utils";
-import type { MeasureFilterEntry } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry";
+import {
+  isMeasurePercentFormat,
+  type MeasureFilterEntry,
+} from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry";
 import {
   mergeDimensionAndMeasureFilters,
   splitWhereFilter,
@@ -487,6 +490,7 @@ function processExpression({
         pinned: false,
         measures: new Map([[metricsViewName, measure]]),
         metricsViewNames: [metricsViewName],
+        isPercent: isMeasurePercentFormat(measure),
       });
     }
   });
@@ -516,6 +520,7 @@ export function getCanvasMeasureFiltersMap(
       name: measureName,
       label: measure.displayName || measure.expression || filter.measure,
       filter: filter,
+      isPercent: isMeasurePercentFormat(measure),
     };
 
     map.set(measureName, entry);

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilter.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilter.svelte
@@ -29,7 +29,8 @@
   let open = openOnMount && !filterData.filter;
   let curPinned = filterData.pinned;
 
-  $: ({ filter, pinned, label, measures, dimensionName, name } = filterData);
+  $: ({ filter, pinned, label, measures, dimensionName, name, isPercent } =
+    filterData);
 
   $: metricsViewNames = measures ? Array.from(measures.keys()) : [];
 </script>
@@ -68,6 +69,7 @@
           })?.displayName ?? ""}
           {filter}
           {label}
+          isPercent={!!isPercent}
           slot="body"
         />
       </Chip>
@@ -92,6 +94,7 @@
       {label}
       {dimensionName}
       {allDimensions}
+      isPercent={!!isPercent}
       onApply={(params) => {
         if (pinned !== curPinned) {
           toggleFilterPin?.(name, metricsViewNames);

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterBody.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterBody.svelte
@@ -17,6 +17,14 @@
   export let filter: MeasureFilterEntry | undefined;
   export let labelMaxWidth = "320px";
   export let comparisonLabel = "";
+  export let isPercent = false;
+
+  function formatDisplayValue(rawValue: string): string {
+    if (!isPercent) return rawValue;
+    const num = Number(rawValue);
+    if (Number.isNaN(num)) return rawValue;
+    return String(num * 100);
+  }
 
   let typeLabel: string | undefined;
   let shortLabel: string | undefined;
@@ -33,27 +41,42 @@
       typeLabel += ` from ${comparisonLabel}`;
     }
 
+    const showPercentSuffix =
+      filter.type === MeasureFilterType.PercentChange ||
+      (filter.type === MeasureFilterType.Value && isPercent);
+
     switch (filter.operation) {
       case MeasureFilterOperation.GreaterThan:
       case MeasureFilterOperation.GreaterThanOrEquals:
       case MeasureFilterOperation.LessThan:
       case MeasureFilterOperation.LessThanOrEquals:
       case MeasureFilterOperation.Equals:
-      case MeasureFilterOperation.NotEquals:
+      case MeasureFilterOperation.NotEquals: {
+        const displayValue =
+          filter.type === MeasureFilterType.Value
+            ? formatDisplayValue(filter.value1)
+            : filter.value1;
         shortLabel =
           AllMeasureFilterOperationOptions.find(
             (o) => o.value === filter?.operation,
           )?.shortLabel +
           " " +
-          filter.value1 +
-          (filter.type === MeasureFilterType.PercentChange ? "%" : "");
+          displayValue +
+          (showPercentSuffix ? "%" : "");
         break;
-      case MeasureFilterOperation.Between:
-        shortLabel = `(${filter.value1},${filter.value2})`;
+      }
+      case MeasureFilterOperation.Between: {
+        const v1 = formatDisplayValue(filter.value1);
+        const v2 = formatDisplayValue(filter.value2);
+        shortLabel = `(${v1},${v2})` + (showPercentSuffix ? "%" : "");
         break;
-      case MeasureFilterOperation.NotBetween:
-        shortLabel = `!(${filter.value1},${filter.value2})`;
+      }
+      case MeasureFilterOperation.NotBetween: {
+        const v1 = formatDisplayValue(filter.value1);
+        const v2 = formatDisplayValue(filter.value2);
+        shortLabel = `!(${v1},${v2})` + (showPercentSuffix ? "%" : "");
         break;
+      }
     }
   }
 </script>

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
@@ -30,12 +30,27 @@
   export let side: "top" | "right" | "bottom" | "left" = "bottom";
   export let pinned = false;
   export let showPinControl = false;
+  export let isPercent = false;
+
+  function toDisplayValue(rawValue: string): string {
+    if (!isPercent || !rawValue) return rawValue;
+    const num = Number(rawValue);
+    if (Number.isNaN(num)) return rawValue;
+    return String(num * 100);
+  }
+
+  function toRawValue(displayValue: string): string {
+    if (!isPercent || !displayValue) return displayValue;
+    const num = Number(displayValue);
+    if (Number.isNaN(num)) return displayValue;
+    return String(num / 100);
+  }
 
   const initialValues = {
     dimension: dimensionName,
     operation: filter?.operation ?? MeasureFilterOperationOptions[0].value,
-    value1: filter?.value1 ?? "",
-    value2: filter?.value2 ?? "",
+    value1: toDisplayValue(filter?.value1 ?? ""),
+    value2: toDisplayValue(filter?.value2 ?? ""),
   };
 
   const validationSchema = object().shape({
@@ -76,8 +91,8 @@
             measure: name,
             operation: values.operation,
             type: MeasureFilterType.Value,
-            value1: values.value1,
-            value2: values.value2 ?? "",
+            value1: toRawValue(values.value1),
+            value2: toRawValue(values.value2 ?? ""),
           },
         });
 
@@ -172,24 +187,34 @@
       label="Threshold"
       options={MeasureFilterOperationOptions}
     />
-    <Input
-      bind:value={$form["value1"]}
-      errors={$errors["value1"]}
-      id="value1"
-      onEnter={submit}
-      alwaysShowError
-      placeholder={isBetweenExpression ? "Lower Value" : "Enter a Number"}
-    />
+    <div class="flex items-center gap-x-1">
+      <Input
+        bind:value={$form["value1"]}
+        errors={$errors["value1"]}
+        id="value1"
+        onEnter={submit}
+        alwaysShowError
+        placeholder={isBetweenExpression ? "Lower Value" : "Enter a Number"}
+      />
+      {#if isPercent}
+        <span class="text-xs text-fg-secondary flex-none">%</span>
+      {/if}
+    </div>
 
     {#if isBetweenExpression}
-      <Input
-        bind:value={$form["value2"]}
-        errors={$errors["value2"]}
-        id="value2"
-        placeholder="Higher Value"
-        alwaysShowError
-        onEnter={submit}
-      />
+      <div class="flex items-center gap-x-1">
+        <Input
+          bind:value={$form["value2"]}
+          errors={$errors["value2"]}
+          id="value2"
+          placeholder="Higher Value"
+          alwaysShowError
+          onEnter={submit}
+        />
+        {#if isPercent}
+          <span class="text-xs text-fg-secondary flex-none">%</span>
+        {/if}
+      </div>
     {/if}
 
     <Button submitForm type="primary" form="measure">Apply</Button>

--- a/web-common/src/features/dashboards/filters/measure-filters/measure-filter-entry.spec.ts
+++ b/web-common/src/features/dashboards/filters/measure-filters/measure-filter-entry.spec.ts
@@ -1,4 +1,5 @@
 import {
+  isMeasurePercentFormat,
   mapExprToMeasureFilter,
   mapMeasureFilterToExpr,
   type MeasureFilterEntry,
@@ -13,6 +14,7 @@ import {
   createOrExpression,
 } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
 import {
+  type MetricsViewSpecMeasure,
   type V1Expression,
   V1Operation,
 } from "@rilldata/web-common/runtime-client";
@@ -220,5 +222,63 @@ describe("mapExprToMeasureFilter", () => {
     it(title, () => {
       expect(mapExprToMeasureFilter(expr)).toEqual(criteria);
     });
+  });
+});
+
+describe("isMeasurePercentFormat", () => {
+  it("returns false for undefined measure", () => {
+    expect(isMeasurePercentFormat(undefined)).toBe(false);
+  });
+
+  it("returns false for measure with no format", () => {
+    expect(isMeasurePercentFormat({} as MetricsViewSpecMeasure)).toBe(false);
+  });
+
+  it("returns true for formatPreset percentage", () => {
+    expect(
+      isMeasurePercentFormat({
+        formatPreset: "percentage",
+      } as MetricsViewSpecMeasure),
+    ).toBe(true);
+  });
+
+  it("returns false for formatPreset humanize", () => {
+    expect(
+      isMeasurePercentFormat({
+        formatPreset: "humanize",
+      } as MetricsViewSpecMeasure),
+    ).toBe(false);
+  });
+
+  it("returns true for formatD3 with percent", () => {
+    expect(
+      isMeasurePercentFormat({
+        formatD3: ".1%",
+      } as MetricsViewSpecMeasure),
+    ).toBe(true);
+  });
+
+  it("returns true for formatD3 with percent specifier", () => {
+    expect(
+      isMeasurePercentFormat({
+        formatD3: ".2%",
+      } as MetricsViewSpecMeasure),
+    ).toBe(true);
+  });
+
+  it("returns false for formatD3 without percent", () => {
+    expect(
+      isMeasurePercentFormat({
+        formatD3: ",.2f",
+      } as MetricsViewSpecMeasure),
+    ).toBe(false);
+  });
+
+  it("returns false for formatD3 currency", () => {
+    expect(
+      isMeasurePercentFormat({
+        formatD3: "$,.2f",
+      } as MetricsViewSpecMeasure),
+    ).toBe(false);
   });
 });

--- a/web-common/src/features/dashboards/filters/measure-filters/measure-filter-entry.ts
+++ b/web-common/src/features/dashboards/filters/measure-filters/measure-filter-entry.ts
@@ -10,6 +10,7 @@ import {
   isBetweenExpression,
 } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
 import {
+  type MetricsViewSpecMeasure,
   type V1Expression,
   V1Operation,
 } from "@rilldata/web-common/runtime-client";
@@ -168,4 +169,19 @@ export function measureHasSuffix(measureName: string) {
 }
 export function stripMeasureSuffix(measureName: string) {
   return measureName.replace(MeasureModifierSuffixRegex, "");
+}
+
+/**
+ * Determines if a measure uses a percentage format, meaning the underlying
+ * data is stored as a decimal (e.g. 0.8 for 80%). This is true when:
+ * - formatPreset is "percentage", OR
+ * - formatD3 contains "%" (d3-format's % specifier multiplies by 100)
+ */
+export function isMeasurePercentFormat(
+  measure: MetricsViewSpecMeasure | undefined,
+): boolean {
+  if (!measure) return false;
+  if (measure.formatPreset === "percentage") return true;
+  if (measure.formatD3 && measure.formatD3.includes("%")) return true;
+  return false;
 }

--- a/web-common/src/features/dashboards/state-managers/selectors/measure-filters.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/measure-filters.ts
@@ -1,5 +1,8 @@
 import { getMeasureDisplayName } from "@rilldata/web-common/features/dashboards/filters/getDisplayName";
-import type { MeasureFilterEntry } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry";
+import {
+  isMeasurePercentFormat,
+  type MeasureFilterEntry,
+} from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry";
 import type { DashboardDataSources } from "@rilldata/web-common/features/dashboards/state-managers/selectors/types";
 import type { AtLeast } from "@rilldata/web-common/features/dashboards/state-managers/types";
 import type { DimensionThresholdFilter } from "@rilldata/web-common/features/dashboards/stores/explore-state";
@@ -26,6 +29,7 @@ export type MeasureFilterItem = {
   filter?: MeasureFilterEntry;
   pinned?: boolean;
   metricsViewNames?: string[];
+  isPercent?: boolean;
 };
 
 export const getMeasureFilterItems = (
@@ -85,6 +89,7 @@ export function getMeasureFilterForDimension(
       name: filter.measure,
       label: measure.displayName || measure.expression || filter.measure,
       filter,
+      isPercent: isMeasurePercentFormat(measure),
     });
   });
 
@@ -105,12 +110,14 @@ export const getAllMeasureFilterItems = (
       dashData.dashboard.temporaryFilterName &&
       measureIdMap.has(dashData.dashboard.temporaryFilterName)
     ) {
+      const tempMeasure = measureIdMap.get(
+        dashData.dashboard.temporaryFilterName,
+      );
       allMeasureFilterItems.push({
         dimensionName: "",
         name: dashData.dashboard.temporaryFilterName,
-        label: getMeasureDisplayName(
-          measureIdMap.get(dashData.dashboard.temporaryFilterName),
-        ),
+        label: getMeasureDisplayName(tempMeasure),
+        isPercent: isMeasurePercentFormat(tempMeasure),
       });
     }
 

--- a/web-common/src/features/dashboards/stores/Filters.ts
+++ b/web-common/src/features/dashboards/stores/Filters.ts
@@ -3,7 +3,10 @@ import {
   getDimensionDisplayName,
   getMeasureDisplayName,
 } from "@rilldata/web-common/features/dashboards/filters/getDisplayName.ts";
-import type { MeasureFilterEntry } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry.ts";
+import {
+  isMeasurePercentFormat,
+  type MeasureFilterEntry,
+} from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry.ts";
 import { toggleDimensionFilterValue } from "@rilldata/web-common/features/dashboards/state-managers/actions/dimension-filters.ts";
 import {
   type DimensionFilterItem,
@@ -124,10 +127,12 @@ export class Filters {
       ([$measureNameMap, $measureFilterItems, tempFilter]) => {
         const itemsCopy = [...$measureFilterItems];
         if (tempFilter && $measureNameMap.has(tempFilter)) {
+          const tempMeasure = $measureNameMap.get(tempFilter);
           itemsCopy.push({
             dimensionName: "",
             name: tempFilter,
-            label: getMeasureDisplayName($measureNameMap.get(tempFilter)),
+            label: getMeasureDisplayName(tempMeasure),
+            isPercent: isMeasurePercentFormat(tempMeasure),
             // dimensions, // TODO: for canvas
           });
         }
@@ -500,6 +505,7 @@ export class Filters {
           name: filter.measure,
           label: measure.displayName || measure.expression || filter.measure,
           filter,
+          isPercent: isMeasurePercentFormat(measure),
           // dimensions, // TODO: for canvas
         };
       })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the metrics filter not functioning for percentage types (APP-779).

When a measure uses percentage format (`format_preset: "percentage"` or `format_d3` with `%`), the underlying data is stored as a decimal (e.g., 0.8 for 80%). Previously, users entering "80" in the filter threshold would send 80 to the backend instead of 0.8, making the filter ineffective.

## Changes

- **`measure-filter-entry.ts`**: Added `isMeasurePercentFormat()` utility that detects percentage-formatted measures by checking `formatPreset === "percentage"` or `formatD3` containing `%`
- **`MeasureFilterForm.svelte`**: Converts between display values (×100) and raw values (÷100) for percentage measures. Shows a `%` suffix label next to the threshold input fields
- **`MeasureFilterBody.svelte`**: Displays filter chip values multiplied by 100 with `%` suffix for percentage measures (e.g., "< 80%" instead of "< 0.8")
- **`MeasureFilter.svelte`**: Passes the `isPercent` flag from `MeasureFilterItem` to both the form and body components
- **`measure-filters.ts`** (selectors), **`Filters.ts`**, **`filter-state.ts`**, **`filter-manager.ts`**: Set `isPercent` on `MeasureFilterItem` from the measure spec at all creation points (explore dashboards, canvas, scheduled reports)

## How it works

The fix operates at the UI boundary level:
1. The `MeasureFilterEntry` stores raw decimal values (e.g., "0.8") — same as before
2. The form **displays** values multiplied by 100 (e.g., "80") and converts **back** (÷100) on submit
3. The filter chip **displays** values multiplied by 100 with "%" suffix
4. No changes to the core `mapMeasureFilterToExpr`/`mapExprToMeasureFilter` functions or URL/proto serialization — backward compatible

Closes APP-779

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [APP-779](https://linear.app/rilldata/issue/APP-779/metrics-filter-not-functioning-for-percentage-types)

<div><a href="https://cursor.com/agents/bc-6dd5baee-c94c-4d5e-bf2a-416bebf0403c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dd5baee-c94c-4d5e-bf2a-416bebf0403c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

