### PR TITLE
Add project_prod_slots as event

### DIFF
--- a/runtime/registry.go
+++ b/runtime/registry.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -576,6 +577,13 @@ func (r *registryCache) emitHeartbeatForInstance(inst *drivers.Instance) {
 	// Add instance annotations as attributes to pass organization id, project id, etc.
 	attrs := instanceAnnotationsToAttribs(inst)
 	r.activity.RecordMetric(context.Background(), "data_dir_size_bytes", float64(sizeOfDir(dataDir)), attrs...)
+
+	// Emit prod_slots metric for billing
+	if v, ok := inst.Annotations["project_prod_slots"]; ok {
+		if slots, err := strconv.Atoi(v); err == nil {
+			r.activity.RecordMetric(context.Background(), "prod_slots", float64(slots), attrs...)
+		}
+	}
 }
 
 // updateProjectConfig updates the project config for the given instance.


### PR DESCRIPTION
In order to check project_prod slots hourly, need to add to event stream and also update rill-cloud-metrics' billing API to ensure its read into Orb

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
