### PR TITLE
fix: app crash when rill time syntax is used in comparison

### DIFF
--- a/web-common/src/features/dashboards/stores/test-data/store-mutations.ts
+++ b/web-common/src/features/dashboards/stores/test-data/store-mutations.ts
@@ -48,7 +48,11 @@ import {
   RandomPublishers,
 } from "@rilldata/web-common/features/dashboards/stores/test-data/random";
 import { TDDChart } from "@rilldata/web-common/features/dashboards/time-dimension-details/types";
-import { TimeRangePreset } from "@rilldata/web-common/lib/time/types";
+import {
+  type DashboardTimeControls,
+  type TimeRange,
+  TimeRangePreset,
+} from "@rilldata/web-common/lib/time/types";
 import { asyncWait } from "@rilldata/web-common/lib/waitUtils.ts";
 import { DashboardState_LeaderboardSortType } from "@rilldata/web-common/proto/gen/rill/ui/v1/dashboard_pb";
 import { V1TimeGrain } from "@rilldata/web-common/runtime-client";
@@ -136,7 +140,7 @@ export const AD_BIDS_CLEAR_FILTERS: TestDashboardMutation = (mut) =>
 export const AD_BIDS_SET_P7D_TIME_RANGE_FILTER: TestDashboardMutation = () =>
   metricsExplorerStore.selectTimeRange(
     AD_BIDS_EXPLORE_NAME,
-    { name: TimeRangePreset.LAST_7_DAYS } as any,
+    { name: TimeRangePreset.LAST_7_DAYS } as TimeRange,
     V1TimeGrain.TIME_GRAIN_DAY,
     undefined,
     AD_BIDS_METRICS_INIT,
@@ -144,7 +148,7 @@ export const AD_BIDS_SET_P7D_TIME_RANGE_FILTER: TestDashboardMutation = () =>
 export const AD_BIDS_SET_P4W_TIME_RANGE_FILTER: TestDashboardMutation = () =>
   metricsExplorerStore.selectTimeRange(
     AD_BIDS_EXPLORE_NAME,
-    { name: TimeRangePreset.LAST_4_WEEKS } as any,
+    { name: TimeRangePreset.LAST_4_WEEKS } as TimeRange,
     V1TimeGrain.TIME_GRAIN_WEEK,
     undefined,
     AD_BIDS_METRICS_INIT,
@@ -152,7 +156,7 @@ export const AD_BIDS_SET_P4W_TIME_RANGE_FILTER: TestDashboardMutation = () =>
 export const AD_BIDS_SET_ALL_TIME_RANGE_FILTER: TestDashboardMutation = () =>
   metricsExplorerStore.selectTimeRange(
     AD_BIDS_EXPLORE_NAME,
-    { name: TimeRangePreset.ALL_TIME } as any,
+    { name: TimeRangePreset.ALL_TIME } as TimeRange,
     V1TimeGrain.TIME_GRAIN_DAY,
     undefined,
     AD_BIDS_METRICS_INIT,
@@ -166,7 +170,7 @@ export const AD_BIDS_SET_PREVIOUS_PERIOD_COMPARE_TIME_RANGE_FILTER: TestDashboar
     metricsExplorerStore.displayTimeComparison(AD_BIDS_EXPLORE_NAME, true);
     metricsExplorerStore.setSelectedComparisonRange(
       AD_BIDS_EXPLORE_NAME,
-      { name: "rill-PP" } as any,
+      { name: "rill-PP" } as DashboardTimeControls,
       AD_BIDS_METRICS_INIT,
     );
   };
@@ -175,7 +179,7 @@ export const AD_BIDS_SET_PREVIOUS_WEEK_COMPARE_TIME_RANGE_FILTER: TestDashboardM
     metricsExplorerStore.displayTimeComparison(AD_BIDS_EXPLORE_NAME, true);
     metricsExplorerStore.setSelectedComparisonRange(
       AD_BIDS_EXPLORE_NAME,
-      { name: "rill-PW" } as any,
+      { name: "rill-PW" } as DashboardTimeControls,
       AD_BIDS_METRICS_INIT,
     );
   };
@@ -184,7 +188,7 @@ export const AD_BIDS_SET_PREVIOUS_WEEK_RILL_TIME_COMPARE_TIME_RANGE_FILTER: Test
     metricsExplorerStore.displayTimeComparison(AD_BIDS_EXPLORE_NAME, true);
     metricsExplorerStore.setSelectedComparisonRange(
       AD_BIDS_EXPLORE_NAME,
-      { name: "7D offset -7D" } as any,
+      { name: "7D offset -7D" } as DashboardTimeControls,
       AD_BIDS_METRICS_INIT,
     );
   };

--- a/web-common/src/features/dashboards/time-controls/time-control-store.ts
+++ b/web-common/src/features/dashboards/time-controls/time-control-store.ts
@@ -52,10 +52,7 @@ import { createQuery, type QueryObserverResult } from "@tanstack/svelte-query";
 import type { Readable } from "svelte/store";
 import { derived } from "svelte/store";
 import { memoizeMetricsStore } from "../state-managers/memoize-metrics-store";
-import {
-  isNewRillTimeFormat,
-  parseRillTime,
-} from "../url-state/time-ranges/parser";
+import { parseRillTime } from "../url-state/time-ranges/parser";
 import type { RillTime } from "../url-state/time-ranges/RillTime";
 import { DateTime, Interval } from "luxon";
 import { getComparisonInterval } from "@rilldata/web-common/lib/time/comparisons";
@@ -578,7 +575,7 @@ export function getComparisonTimeRange(
       DateTime.fromJSDate(timeRange.end, { zone: timezone }),
     );
 
-    if (interval.isValid && !isNewRillTimeFormat(comparisonOption)) {
+    if (interval.isValid) {
       const range = getComparisonInterval(
         interval,
         comparisonOption,

--- a/web-common/src/features/dashboards/url-state/time-ranges/parser.ts
+++ b/web-common/src/features/dashboards/url-state/time-ranges/parser.ts
@@ -14,9 +14,9 @@ export function parseRillTime(rillTimeRange: string): RillTime {
 export function isNewRillTimeFormat(rillTime: string): boolean {
   try {
     const parser = parseRillTime(rillTime);
-    return parser.isOldFormat;
-  } catch (err) {
-    return true;
+    return !parser.isOldFormat;
+  } catch {
+    return false;
   }
 }
 

--- a/web-common/src/lib/time/comparisons/index.spec.ts
+++ b/web-common/src/lib/time/comparisons/index.spec.ts
@@ -90,16 +90,47 @@ const periodicComparisonTests = [
   },
 ];
 
+const invalidComparisionTests = [
+  {
+    description: "should return undefined when comparison is invalid",
+    input: {
+      start: periodStart,
+      end: periodEnd,
+      comparison: "invalid" as TimeComparisonOption,
+    },
+    output: undefined,
+  },
+  {
+    description: "should return undefined when comparison is new syntax",
+    input: {
+      start: periodStart,
+      end: periodEnd,
+      comparison: "7D as of latest/D-7D",
+    },
+    output: undefined,
+  },
+  {
+    description:
+      "should return undefined when comparison is new syntax using offset keyword",
+    input: {
+      start: periodStart,
+      end: periodEnd,
+      comparison: "7D as of latest/D offset -7D",
+    },
+    output: undefined,
+  },
+];
+
 const getComparisonIntervalTests = [
   ...contiguousAndCustomComparisonRanges,
   ...periodicComparisonTests,
+  ...invalidComparisionTests,
 ];
 
 describe("getComparisonInterval", () => {
   getComparisonIntervalTests.forEach((test) => {
     it(test.description, () => {
       const { start, end, comparison } = test.input;
-      const { start: expectedStart, end: expectedEnd } = test.output;
       const interval = Interval.fromDateTimes(
         DateTime.fromJSDate(start, { zone: "UTC" }),
         DateTime.fromJSDate(end, { zone: "UTC" }),
@@ -110,6 +141,12 @@ describe("getComparisonInterval", () => {
         comparison,
         "UTC",
       );
+      if (test.output === undefined) {
+        expect(comparisonInterval).toBeUndefined();
+        return;
+      }
+
+      const { start: expectedStart, end: expectedEnd } = test.output;
       expect(comparisonInterval?.start.toJSDate()).toEqual(expectedStart);
       expect(comparisonInterval?.end.toJSDate()).toEqual(expectedEnd);
     });

--- a/web-common/src/lib/time/comparisons/index.ts
+++ b/web-common/src/lib/time/comparisons/index.ts
@@ -13,6 +13,7 @@ import {
   TimeOffsetType,
   TimeRangePreset,
 } from "../types";
+import { isNewRillTimeFormat } from "@rilldata/web-common/features/dashboards/url-state/time-ranges/parser.ts";
 
 export function getComparisonTransform(
   start: Date,
@@ -316,7 +317,8 @@ export function getComparisonInterval(
   comparisonRange: string | undefined,
   activeTimeZone: string,
 ): Interval<true> | undefined {
-  if (!interval || !comparisonRange) return undefined;
+  if (!interval || !comparisonRange || isNewRillTimeFormat(comparisonRange))
+    return undefined;
 
   let comparisonInterval: Interval | undefined = undefined;
 
@@ -348,7 +350,11 @@ export function getComparisonInterval(
     }
   } else {
     const normalizedRange = comparisonRange.replace(",", "/");
-    comparisonInterval = Interval.fromISO(normalizedRange).mapEndpoints((dt) =>
+    const normalizedInterval = Interval.fromISO(normalizedRange);
+    // Safeguard against unknown comparison range format.
+    if (!normalizedInterval.isValid) return undefined;
+
+    comparisonInterval = normalizedInterval.mapEndpoints((dt) =>
       dt.setZone(activeTimeZone),
     );
   }


### PR DESCRIPTION
We do not support rill time syntax in comparison from UI just yet. But backend does support it using the `offset` keyword. If LLM uses this then citation links will open with the new syntax.

This PR ensures the app doesnt crash, instead comparison will be removed. We need a bigger change to support rill time syntax in UI.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
