### PR TITLE
fix: Consolidate resource and Table dropdown

### DIFF
--- a/web-admin/src/features/projects/status/resource-table/ActionsCell.svelte
+++ b/web-admin/src/features/projects/status/resource-table/ActionsCell.svelte
@@ -2,10 +2,13 @@
   import IconButton from "@rilldata/web-common/components/button/IconButton.svelte";
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
   import ThreeDot from "@rilldata/web-common/components/icons/ThreeDot.svelte";
+  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
+  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
   import type { V1Resource } from "@rilldata/web-common/runtime-client";
   import {
     RefreshCcwIcon,
+    LayoutGridIcon,
     CodeIcon,
     ScrollTextIcon,
     AlertCircleIcon,
@@ -14,8 +17,8 @@
 
   export let resourceKind: string;
   export let resourceName: string;
-  export let canRefresh: boolean;
   export let resource: V1Resource;
+  export let isReconciling: boolean = false;
   export let onClickRefreshDialog: (
     resourceName: string,
     resourceKind: string,
@@ -28,15 +31,25 @@
     resource: V1Resource,
   ) => void;
   export let onViewLogsClick: (name: string) => void = () => {};
+  export let onViewPartitionsClick:
+    | ((resource: V1Resource) => void)
+    | undefined = undefined;
   export let isDropdownOpen: boolean;
   export let onDropdownOpenChange: (isOpen: boolean) => void;
 
-  $: actions =
-    resourceKind === ResourceKind.Model
-      ? getAvailableModelActions(resource)
-      : [];
+  $: isModel = resourceKind === ResourceKind.Model;
+  $: isSource = resourceKind === ResourceKind.Source;
+  $: canRefresh = isModel || isSource;
+
+  $: actions = isModel ? getAvailableModelActions(resource) : [];
+  $: isPartitioned = actions.includes("viewPartitions");
   $: isIncremental = actions.includes("incrementalRefresh");
   $: hasErroredPartitions = actions.includes("refreshErrored");
+
+  $: refreshDisabled = isReconciling;
+  $: refreshTooltip = isReconciling
+    ? "Resource is currently being reconciled"
+    : "";
 </script>
 
 <DropdownMenu.Root open={isDropdownOpen} onOpenChange={onDropdownOpenChange}>
@@ -46,6 +59,7 @@
     </IconButton>
   </DropdownMenu.Trigger>
   <DropdownMenu.Content align="start">
+    <!-- Describe (always available) -->
     <DropdownMenu.Item
       class="font-normal flex items-center"
       on:click={() => onClickViewSpec(resourceName, resourceKind, resource)}
@@ -55,6 +69,8 @@
         <span class="ml-2">Describe</span>
       </div>
     </DropdownMenu.Item>
+
+    <!-- View Logs (always available) -->
     <DropdownMenu.Item
       class="font-normal flex items-center"
       on:click={() => onViewLogsClick(resourceName)}
@@ -64,39 +80,77 @@
         <span class="ml-2">View Logs</span>
       </div>
     </DropdownMenu.Item>
-    {#if canRefresh}
-      {#if hasErroredPartitions}
-        <DropdownMenu.Item
-          class="font-normal flex items-center"
-          on:click={() => onClickRefreshErroredPartitions(resourceName)}
-        >
-          <div class="flex items-center">
-            <AlertCircleIcon size="12px" />
-            <span class="ml-2">Refresh Errored Partitions</span>
-          </div>
-        </DropdownMenu.Item>
-      {/if}
+
+    <!-- View Partitions (models only, if partitioned) -->
+    {#if isPartitioned && onViewPartitionsClick}
       <DropdownMenu.Item
         class="font-normal flex items-center"
-        on:click={() =>
-          onClickRefreshDialog(resourceName, resourceKind, "full")}
+        on:click={() => onViewPartitionsClick?.(resource)}
       >
         <div class="flex items-center">
-          <RefreshCcwIcon size="12px" />
-          <span class="ml-2">Full Refresh</span>
+          <LayoutGridIcon size="12px" />
+          <span class="ml-2">View Partitions</span>
         </div>
       </DropdownMenu.Item>
-      {#if isIncremental}
+    {/if}
+
+    <!-- Refresh actions (models + sources) -->
+    {#if canRefresh}
+      <DropdownMenu.Separator />
+
+      <!-- Refresh Errored Partitions (models with errors) -->
+      {#if hasErroredPartitions}
+        <Tooltip distance={8} suppress={!refreshDisabled}>
+          <DropdownMenu.Item
+            class="font-normal flex items-center"
+            disabled={refreshDisabled}
+            on:click={() => onClickRefreshErroredPartitions(resourceName)}
+          >
+            <div class="flex items-center">
+              <AlertCircleIcon size="12px" />
+              <span class="ml-2">Refresh Errored Partitions</span>
+            </div>
+          </DropdownMenu.Item>
+          <TooltipContent slot="tooltip-content"
+            >{refreshTooltip}</TooltipContent
+          >
+        </Tooltip>
+      {/if}
+
+      <!-- Full Refresh -->
+      <Tooltip distance={8} suppress={!refreshDisabled}>
         <DropdownMenu.Item
           class="font-normal flex items-center"
+          disabled={refreshDisabled}
           on:click={() =>
-            onClickRefreshDialog(resourceName, resourceKind, "incremental")}
+            onClickRefreshDialog(resourceName, resourceKind, "full")}
         >
           <div class="flex items-center">
             <RefreshCcwIcon size="12px" />
-            <span class="ml-2">Incremental Refresh</span>
+            <span class="ml-2">Full Refresh</span>
           </div>
         </DropdownMenu.Item>
+        <TooltipContent slot="tooltip-content">{refreshTooltip}</TooltipContent>
+      </Tooltip>
+
+      <!-- Incremental Refresh (incremental models only) -->
+      {#if isIncremental}
+        <Tooltip distance={8} suppress={!refreshDisabled}>
+          <DropdownMenu.Item
+            class="font-normal flex items-center"
+            disabled={refreshDisabled}
+            on:click={() =>
+              onClickRefreshDialog(resourceName, resourceKind, "incremental")}
+          >
+            <div class="flex items-center">
+              <RefreshCcwIcon size="12px" />
+              <span class="ml-2">Incremental Refresh</span>
+            </div>
+          </DropdownMenu.Item>
+          <TooltipContent slot="tooltip-content"
+            >{refreshTooltip}</TooltipContent
+          >
+        </Tooltip>
       {/if}
     {/if}
   </DropdownMenu.Content>

--- a/web-admin/src/features/projects/status/resource-table/ProjectResourcesTable.svelte
+++ b/web-admin/src/features/projects/status/resource-table/ProjectResourcesTable.svelte
@@ -18,6 +18,7 @@
   import NameCell from "./NameCell.svelte";
   import RefreshCell from "./RefreshCell.svelte";
   import RefreshErroredPartitionsDialog from "../tables/RefreshErroredPartitionsDialog.svelte";
+  import ModelPartitionsDialog from "../tables/ModelPartitionsDialog.svelte";
   import RefreshResourceConfirmDialog from "./RefreshResourceConfirmDialog.svelte";
   import ResourceErrorMessage from "./ResourceErrorMessage.svelte";
   import ResourceSpecDialog from "./ResourceSpecDialog.svelte";
@@ -36,6 +37,9 @@
 
   let isErroredPartitionsDialogOpen = false;
   let erroredPartitionsModelName = "";
+
+  let isPartitionsDialogOpen = false;
+  let partitionsResource: V1Resource | null = null;
 
   let openDropdownResourceKey = "";
 
@@ -76,6 +80,11 @@
 
   const isDropdownOpen = (resourceKey: string) => {
     return openDropdownResourceKey === resourceKey;
+  };
+
+  const openPartitionsDialog = (resource: V1Resource) => {
+    partitionsResource = resource;
+    isPartitionsDialogOpen = true;
   };
 
   const openRefreshErroredPartitionsDialog = (resourceName: string) => {
@@ -211,14 +220,12 @@
           resourceKind: row.original.meta.name.kind,
           resourceName: row.original.meta.name.name,
           resource: row.original,
-          canRefresh:
-            !isRowReconciling &&
-            (row.original.meta.name.kind === ResourceKind.Model ||
-              row.original.meta.name.kind === ResourceKind.Source),
+          isReconciling: isRowReconciling,
           onClickRefreshDialog: openRefreshDialog,
           onClickRefreshErroredPartitions: openRefreshErroredPartitionsDialog,
           onClickViewSpec: openSpecDialog,
           onViewLogsClick: handleViewLogsClick,
+          onViewPartitionsClick: openPartitionsDialog,
           isDropdownOpen: isDropdownOpen(resourceKey),
           onDropdownOpenChange: (isOpen: boolean) =>
             setDropdownOpen(resourceKey, isOpen),
@@ -253,6 +260,14 @@
   bind:open={isErroredPartitionsDialogOpen}
   modelName={erroredPartitionsModelName}
   onRefresh={handleRefreshErroredPartitions}
+/>
+
+<ModelPartitionsDialog
+  bind:open={isPartitionsDialogOpen}
+  resource={partitionsResource}
+  onClose={() => {
+    isPartitionsDialogOpen = false;
+  }}
 />
 
 <ResourceSpecDialog

--- a/web-admin/src/features/projects/status/tables/ModelActionsCell.svelte
+++ b/web-admin/src/features/projects/status/tables/ModelActionsCell.svelte
@@ -2,6 +2,8 @@
   import IconButton from "@rilldata/web-common/components/button/IconButton.svelte";
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
   import ThreeDot from "@rilldata/web-common/components/icons/ThreeDot.svelte";
+  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
+  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import {
     RefreshCcwIcon,
     LayoutGridIcon,
@@ -13,6 +15,7 @@
   import { getAvailableModelActions } from "./model-actions";
 
   export let resource: V1Resource | undefined;
+  export let isReconciling: boolean = false;
   export let isDropdownOpen: boolean;
   export let onDropdownOpenChange: (isOpen: boolean) => void;
   export let onModelInfoClick: (resource: V1Resource) => void;
@@ -20,12 +23,17 @@
   export let onRefreshErroredClick: (resource: V1Resource) => void;
   export let onIncrementalRefreshClick: (resource: V1Resource) => void;
   export let onFullRefreshClick: (resource: V1Resource) => void;
-  export let onViewLogsClick: (name: string) => void;
+  export let onViewLogsClick: ((name: string) => void) | undefined = undefined;
 
   $: actions = getAvailableModelActions(resource);
   $: isPartitioned = actions.includes("viewPartitions");
   $: isIncremental = actions.includes("incrementalRefresh");
   $: hasErroredPartitions = actions.includes("refreshErrored");
+
+  $: refreshDisabled = isReconciling;
+  $: refreshTooltip = isReconciling
+    ? "Model is currently being reconciled"
+    : "";
 </script>
 
 {#if resource}
@@ -36,6 +44,7 @@
       </IconButton>
     </DropdownMenu.Trigger>
     <DropdownMenu.Content align="start">
+      <!-- Describe (always available) -->
       <DropdownMenu.Item
         class="font-normal flex items-center"
         on:click={() => onModelInfoClick(resource)}
@@ -46,16 +55,20 @@
         </div>
       </DropdownMenu.Item>
 
-      <DropdownMenu.Item
-        class="font-normal flex items-center"
-        on:click={() => onViewLogsClick(resource.meta?.name?.name ?? "")}
-      >
-        <div class="flex items-center">
-          <ScrollTextIcon size="12px" />
-          <span class="ml-2">View Logs</span>
-        </div>
-      </DropdownMenu.Item>
+      <!-- View Logs (always available, optional) -->
+      {#if onViewLogsClick}
+        <DropdownMenu.Item
+          class="font-normal flex items-center"
+          on:click={() => onViewLogsClick?.(resource.meta?.name?.name ?? "")}
+        >
+          <div class="flex items-center">
+            <ScrollTextIcon size="12px" />
+            <span class="ml-2">View Logs</span>
+          </div>
+        </DropdownMenu.Item>
+      {/if}
 
+      <!-- View Partitions (if partitioned, always available) -->
       {#if isPartitioned}
         <DropdownMenu.Item
           class="font-normal flex items-center"
@@ -68,40 +81,59 @@
         </DropdownMenu.Item>
       {/if}
 
-      {#if hasErroredPartitions}
-        <DropdownMenu.Item
-          class="font-normal flex items-center"
-          on:click={() => onRefreshErroredClick(resource)}
-        >
-          <div class="flex items-center">
-            <AlertCircleIcon size="12px" />
-            <span class="ml-2">Refresh Errored Partitions</span>
-          </div>
-        </DropdownMenu.Item>
-      {/if}
-
       <DropdownMenu.Separator />
 
-      <DropdownMenu.Item
-        class="font-normal flex items-center"
-        on:click={() => onFullRefreshClick(resource)}
-      >
-        <div class="flex items-center">
-          <RefreshCcwIcon size="12px" />
-          <span class="ml-2">Full Refresh</span>
-        </div>
-      </DropdownMenu.Item>
+      <!-- Refresh Errored Partitions (disabled when reconciling) -->
+      {#if hasErroredPartitions}
+        <Tooltip distance={8} suppress={!refreshDisabled}>
+          <DropdownMenu.Item
+            class="font-normal flex items-center"
+            disabled={refreshDisabled}
+            on:click={() => onRefreshErroredClick(resource)}
+          >
+            <div class="flex items-center">
+              <AlertCircleIcon size="12px" />
+              <span class="ml-2">Refresh Errored Partitions</span>
+            </div>
+          </DropdownMenu.Item>
+          <TooltipContent slot="tooltip-content"
+            >{refreshTooltip}</TooltipContent
+          >
+        </Tooltip>
+      {/if}
 
-      {#if isIncremental}
+      <!-- Full Refresh (disabled when reconciling) -->
+      <Tooltip distance={8} suppress={!refreshDisabled}>
         <DropdownMenu.Item
           class="font-normal flex items-center"
-          on:click={() => onIncrementalRefreshClick(resource)}
+          disabled={refreshDisabled}
+          on:click={() => onFullRefreshClick(resource)}
         >
           <div class="flex items-center">
             <RefreshCcwIcon size="12px" />
-            <span class="ml-2">Incremental Refresh</span>
+            <span class="ml-2">Full Refresh</span>
           </div>
         </DropdownMenu.Item>
+        <TooltipContent slot="tooltip-content">{refreshTooltip}</TooltipContent>
+      </Tooltip>
+
+      <!-- Incremental Refresh (incremental models only, disabled when reconciling) -->
+      {#if isIncremental}
+        <Tooltip distance={8} suppress={!refreshDisabled}>
+          <DropdownMenu.Item
+            class="font-normal flex items-center"
+            disabled={refreshDisabled}
+            on:click={() => onIncrementalRefreshClick(resource)}
+          >
+            <div class="flex items-center">
+              <RefreshCcwIcon size="12px" />
+              <span class="ml-2">Incremental Refresh</span>
+            </div>
+          </DropdownMenu.Item>
+          <TooltipContent slot="tooltip-content"
+            >{refreshTooltip}</TooltipContent
+          >
+        </Tooltip>
       {/if}
     </DropdownMenu.Content>
   </DropdownMenu.Root>

--- a/web-admin/src/features/projects/status/tables/ModelsTable.svelte
+++ b/web-admin/src/features/projects/status/tables/ModelsTable.svelte
@@ -6,6 +6,7 @@
     V1Resource,
   } from "@rilldata/web-common/runtime-client";
   import { V1ReconcileStatus } from "@rilldata/web-common/runtime-client";
+  import { isResourceReconciling } from "@rilldata/web-admin/lib/refetch-interval-store";
   import { compareSizes } from "./utils";
   import ModelSizeCell from "./ModelSizeCell.svelte";
   import NameCell from "../resource-table/NameCell.svelte";
@@ -104,6 +105,7 @@
         const resource = modelResources.get(tableName.toLowerCase());
         return flexRender(ModelActionsCell, {
           resource,
+          isReconciling: resource ? isResourceReconciling(resource) : false,
           isDropdownOpen: openDropdownTableName === tableName,
           onDropdownOpenChange: (isOpen: boolean) => {
             openDropdownTableName = isOpen ? tableName : "";


### PR DESCRIPTION


Action | When shown | When reconciling
-- | -- | --
Describe | Always | Enabled
View Logs | Always | Enabled
View Partitions | Partitioned models | Enabled
--- separator --- |   |  
Refresh Errored Partitions | Models with errors | Disabled + tooltip
Full Refresh | Models & Sources | Disabled + tooltip
Incremental Refresh | Incremental models only | Disabled + tooltip

<img width="1204" height="600" alt="Screenshot 2026-03-17 at 10 39 40" src="https://github.com/user-attachments/assets/6b5b2c6d-0861-41d7-9716-93ee50095bdc" />
<img width="1057" height="181" alt="Screenshot 2026-03-17 at 10 39 25" src="https://github.com/user-attachments/assets/7d642593-7e88-4476-9310-37e5bd3f2dd0" />

  Changes:
  - ActionsCell (resources page): Added isReconciling prop, onViewPartitionsClick prop, View Partitions menu item, disabled refresh items with tooltip
  instead of hiding the whole dropdown
  - ModelActionsCell (tables page): Added isReconciling prop, disabled refresh items with tooltip "Model is currently being reconciled"
  - ProjectResourcesTable: Passes isReconciling and onViewPartitionsClick, added ModelPartitionsDialog
  - ModelsTable: Passes isReconciling derived from isResourceReconciling()


**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
