### PR TITLE
fix: watch_repo fails for preview deployments

### DIFF
--- a/admin/deployments.go
+++ b/admin/deployments.go
@@ -298,7 +298,7 @@ func (s *Service) StartDeploymentInner(ctx context.Context, depl *database.Deplo
 	frontendURL := s.URLs.WithCustomDomain(org.CustomDomain).Project(org.Name, proj.Name)
 
 	// Resolve variables based on environment
-	vars, err := s.ResolveVariables(ctx, proj.ID, depl.Environment)
+	vars, err := s.ResolveVariables(ctx, depl)
 	if err != nil {
 		return err
 	}

--- a/admin/projects.go
+++ b/admin/projects.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/rilldata/rill/admin/database"
@@ -533,8 +534,8 @@ func (s *Service) TriggerParserAndAwaitResource(ctx context.Context, depl *datab
 
 // ResolveVariables resolves the project's variables for the given environment.
 // It fetches the variable specific to the environment plus the default variables not set exclusively for the environment.
-func (s *Service) ResolveVariables(ctx context.Context, projectID, environment string) (map[string]string, error) {
-	vars, err := s.DB.FindProjectVariables(ctx, projectID, &environment)
+func (s *Service) ResolveVariables(ctx context.Context, depl *database.Deployment) (map[string]string, error) {
+	vars, err := s.DB.FindProjectVariables(ctx, depl.ProjectID, &depl.Environment)
 	if err != nil {
 		return nil, err
 	}
@@ -542,5 +543,9 @@ func (s *Service) ResolveVariables(ctx context.Context, projectID, environment s
 	for _, v := range vars {
 		res[v.Name] = v.Value
 	}
+
+	// preset variables enforced for the instance
+	// repo should only be watched for editable deployments
+	res["rill.watch_repo"] = strconv.FormatBool(depl.Editable)
 	return res, nil
 }

--- a/admin/server/deployment.go
+++ b/admin/server/deployment.go
@@ -893,7 +893,7 @@ func (s *Server) GetDeploymentConfig(ctx context.Context, req *adminv1.GetDeploy
 		UpdatedOn:   timestamppb.New(depl.UpdatedOn),
 		UsesArchive: proj.ArchiveAssetID != nil,
 	}
-	vars, err := s.admin.ResolveVariables(ctx, depl.ProjectID, depl.Environment)
+	vars, err := s.admin.ResolveVariables(ctx, depl)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/drivers/registry.go
+++ b/runtime/drivers/registry.go
@@ -178,7 +178,6 @@ func (i *Instance) Config() (InstanceConfig, error) {
 		DownloadLimitBytes:                   int64(datasize.MB * 128),
 		InteractiveSQLRowLimit:               10_000,
 		StageChanges:                         true,
-		WatchRepo:                            i.Environment == "dev",
 		ModelDefaultMaterialize:              false,
 		ModelMaterializeDelaySeconds:         0,
 		ModelConcurrentExecutionLimit:        5,


### PR DESCRIPTION
Preview deployments are created with `environment` dev but are not editable and hence should not watch repo.

closes https://linear.app/rilldata/issue/PLAT-445/fix-virtual-file-sync-rate-limit-error-on-branch-deployments

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
