### PR TITLE
Refactor project lookup to return bool instead of sentinel error

### DIFF
--- a/cli/cmd/project/connect_github.go
+++ b/cli/cmd/project/connect_github.go
@@ -543,13 +543,12 @@ func projectNamePrompt(ctx context.Context, ch *cmdutil.Helper, orgName string) 
 				if name == "" {
 					return fmt.Errorf("empty name")
 				}
-				exists, err := projectExists(ctx, ch, orgName, name)
+				_, exists, err := getProject(ctx, ch, orgName, name)
 				if err != nil {
-					return fmt.Errorf("project already exists at %s/%s", orgName, name)
+					return fmt.Errorf("failed to check project name: %w", err)
 				}
 				if exists {
-					// this should always be true but adding this check from completeness POV
-					return fmt.Errorf("project with name %q already exists in the org", name)
+					return fmt.Errorf("project already exists at %s/%s", orgName, name)
 				}
 				return nil
 			},

--- a/cli/cmd/project/deploy.go
+++ b/cli/cmd/project/deploy.go
@@ -84,11 +84,11 @@ func (o *DeployOpts) ValidateAndApplyDefaults(ctx context.Context, ch *cmdutil.H
 
 	// check if specified project already exists
 	if o.Name != "" && ch.Org != "" {
-		p, err := getProject(ctx, ch, ch.Org, o.Name)
-		if err != nil && !errors.Is(err, cmdutil.ErrNoMatchingProject) {
+		p, exists, err := getProject(ctx, ch, ch.Org, o.Name)
+		if err != nil {
 			return err
 		}
-		if p != nil {
+		if exists {
 			if ch.Interactive {
 				if err := cmdutil.ConfirmPrompt(fmt.Sprintf("Project with name %q already exists. Do you want to push current changes to the existing project?", o.Name), true); err != nil {
 					return err
@@ -594,11 +594,10 @@ func orgNamePrompt(ctx context.Context, ch *cmdutil.Helper) (string, error) {
 
 				exists, err := orgExists(ctx, ch, name)
 				if err != nil {
-					return fmt.Errorf("org name %q is already taken", name)
+					return fmt.Errorf("failed to check org name: %w", err)
 				}
 
 				if exists {
-					// this should always be true but adding this check from completeness POV
 					return fmt.Errorf("org with name %q already exists", name)
 				}
 				return nil
@@ -632,33 +631,22 @@ func orgExists(ctx context.Context, ch *cmdutil.Helper, name string) (bool, erro
 	return true, nil
 }
 
-func projectExists(ctx context.Context, ch *cmdutil.Helper, org, project string) (bool, error) {
-	_, err := getProject(ctx, ch, org, project)
-	if err != nil {
-		if errors.Is(err, cmdutil.ErrNoMatchingProject) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
-}
-
-func getProject(ctx context.Context, ch *cmdutil.Helper, org, project string) (*adminv1.Project, error) {
+func getProject(ctx context.Context, ch *cmdutil.Helper, org, project string) (*adminv1.Project, bool, error) {
 	c, err := ch.Client()
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	p, err := c.GetProject(ctx, &adminv1.GetProjectRequest{Org: org, Project: project})
 	if err != nil {
 		if st, ok := status.FromError(err); ok {
 			if st.Code() == codes.NotFound {
-				return nil, cmdutil.ErrNoMatchingProject
+				return nil, false, nil
 			}
 		}
-		return nil, err
+		return nil, false, err
 	}
-	return p.Project, nil
+	return p.Project, true, nil
 }
 
 func errMsgContains(err error, msg string) bool {

--- a/cli/pkg/cmdutil/helper.go
+++ b/cli/pkg/cmdutil/helper.go
@@ -38,7 +38,7 @@ const (
 	telemetryIntakePassword = "lkh8T90ozWJP/KxWnQ81PexRzpdghPdzuB0ly2/86TeUU8q/bKiVug==" // nolint:gosec // secret is safe for public use
 )
 
-var ErrNoMatchingProject = fmt.Errorf("no matching project found")
+var ErrInferProjectFailed = fmt.Errorf("could not infer project")
 
 type Helper struct {
 	*printer.Printer
@@ -372,8 +372,8 @@ func (h *Helper) InferProjectName(ctx context.Context, pathToProject, hint strin
 
 	projects, err := h.InferProjects(ctx, h.Org, pathToProject)
 	if err != nil {
-		if errors.Is(err, ErrNoMatchingProject) {
-			return "", errorfWithHint("could not infer project")
+		if errors.Is(err, ErrInferProjectFailed) {
+			return "", errorfWithHint("%w", err)
 		}
 		return "", errorfWithHint("failed to infer project: %w", err)
 	}
@@ -437,7 +437,7 @@ func (h *Helper) InferProjects(ctx context.Context, org, path string) ([]*adminv
 		return nil, err
 	}
 	if len(resp.Projects) == 0 {
-		return nil, ErrNoMatchingProject
+		return nil, ErrInferProjectFailed
 	}
 
 	if org == "" {
@@ -451,7 +451,7 @@ func (h *Helper) InferProjects(ctx context.Context, org, path string) ([]*adminv
 		}
 	}
 	if len(orgFiltered) == 0 {
-		return nil, ErrNoMatchingProject
+		return nil, ErrInferProjectFailed
 	}
 	// cleanup rill managed remote
 	if len(orgFiltered) == 1 && orgFiltered[0].ManagedGitId == "" && req.RillMgdGitRemote != "" {

--- a/cli/pkg/local/admin.go
+++ b/cli/pkg/local/admin.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/rilldata/rill/cli/pkg/cmdutil"
@@ -58,6 +59,10 @@ func (l *localAdminService) ListDeployments(ctx context.Context) ([]*drivers.Dep
 
 	projects, err := l.ch.InferProjects(ctx, l.ch.Org, l.root)
 	if err != nil {
+		if errors.Is(err, cmdutil.ErrInferProjectFailed) {
+			// Succeed with an empty list
+			return nil, nil
+		}
 		return nil, err
 	}
 	project := projects[0] // InferProjects always returns at least one project in case of no error

--- a/cli/pkg/local/app.go
+++ b/cli/pkg/local/app.go
@@ -97,7 +97,7 @@ func NewApp(ctx context.Context, opts *AppOptions) (*App, error) {
 	// Always attempt to pull env for any valid Rill project (after projectPath is set)
 	if opts.PullEnv && opts.Ch.IsAuthenticated() && IsProjectInit(opts.ProjectPath) {
 		err := env.PullVars(ctx, opts.Ch, opts.ProjectPath, "", opts.Environment, false)
-		if err != nil && !errors.Is(err, cmdutil.ErrNoMatchingProject) {
+		if err != nil && !errors.Is(err, cmdutil.ErrInferProjectFailed) {
 			opts.Ch.PrintfWarn("Warning: failed to pull environment credentials: %v\n", err)
 		}
 	}

--- a/cli/pkg/local/git.go
+++ b/cli/pkg/local/git.go
@@ -35,7 +35,7 @@ func (s *Server) GitStatus(ctx context.Context, r *connect.Request[localv1.GitSt
 	// TODO: cache project inference
 	projects, err := s.app.ch.InferProjects(ctx, s.app.ch.Org, s.app.ProjectPath)
 	if err != nil {
-		if !errors.Is(err, cmdutil.ErrNoMatchingProject) {
+		if !errors.Is(err, cmdutil.ErrInferProjectFailed) {
 			return nil, err
 		}
 		// if not connected to a project do not return local/remote changes info
@@ -120,7 +120,7 @@ func (s *Server) GitPull(ctx context.Context, r *connect.Request[localv1.GitPull
 
 	projects, err := s.app.ch.InferProjects(ctx, s.app.ch.Org, s.app.ProjectPath)
 	if err != nil {
-		if !errors.Is(err, cmdutil.ErrNoMatchingProject) {
+		if !errors.Is(err, cmdutil.ErrInferProjectFailed) {
 			return nil, err
 		}
 		return nil, errors.New("repo is not connected to a project")
@@ -167,7 +167,7 @@ func (s *Server) GitPush(ctx context.Context, r *connect.Request[localv1.GitPush
 
 	projects, err := s.app.ch.InferProjects(ctx, s.app.ch.Org, s.app.ProjectPath)
 	if err != nil {
-		if !errors.Is(err, cmdutil.ErrNoMatchingProject) {
+		if !errors.Is(err, cmdutil.ErrInferProjectFailed) {
 			return nil, err
 		}
 		return nil, errors.New("repo is not connected to a project")

--- a/cli/pkg/local/server.go
+++ b/cli/pkg/local/server.go
@@ -661,7 +661,7 @@ func (s *Server) GetCurrentProject(ctx context.Context, r *connect.Request[local
 
 	projects, err := s.app.ch.InferProjects(ctx, s.app.ch.Org, s.app.ProjectPath)
 	if err != nil {
-		if errors.Is(err, cmdutil.ErrNoMatchingProject) {
+		if errors.Is(err, cmdutil.ErrInferProjectFailed) {
 			return connect.NewResponse(&localv1.GetCurrentProjectResponse{
 				LocalProjectName: localProjectName,
 			}), nil
@@ -742,7 +742,7 @@ func (s *Server) ListMatchingProjects(ctx context.Context, r *connect.Request[lo
 
 	projects, err := s.app.ch.InferProjects(ctx, "", s.app.ProjectPath)
 	if err != nil {
-		if errors.Is(err, cmdutil.ErrNoMatchingProject) {
+		if errors.Is(err, cmdutil.ErrInferProjectFailed) {
 			return connect.NewResponse(&localv1.ListMatchingProjectsResponse{
 				Projects: nil,
 			}), nil

--- a/runtime/server/git.go
+++ b/runtime/server/git.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/go-git/go-git/v5"
-	"github.com/rilldata/rill/cli/pkg/cmdutil"
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/drivers"
@@ -44,7 +43,7 @@ func (s *Server) ListGitBranches(ctx context.Context, req *runtimev1.ListGitBran
 	defer release()
 
 	deployments, err := admin.ListDeployments(ctx)
-	if err != nil && !errors.Is(err, drivers.ErrNotAuthenticated) && !errors.Is(err, cmdutil.ErrNoMatchingProject) {
+	if err != nil && !errors.Is(err, drivers.ErrNotAuthenticated) {
 		return nil, fmt.Errorf("failed to list deployments: %w", err)
 	}
 


### PR DESCRIPTION
- Fixes a place where the error got rewritten, leading to accidental `Warning: failed to pull environment credentials:` in `rill validate`
- Changes `ErrNoMatchingProject` to `ErrInferProjectFailed` to make it less confusing (it's not clear to the user that inference is happening, so "matching" the previous error didn't accurately convey what went wrong)
- Removes a reference to the `cli` package from the `runtime`

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!