### PR TITLE
Route AWS SDK logging through Zap for consistent log formatting

### DIFF
--- a/runtime/drivers/athena/athena.go
+++ b/runtime/drivers/athena/athena.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/pkg/activity"
+	"github.com/rilldata/rill/runtime/pkg/awsutil"
 	"github.com/rilldata/rill/runtime/pkg/graceful"
 	"github.com/rilldata/rill/runtime/storage"
 	"go.opentelemetry.io/otel"
@@ -232,6 +233,7 @@ func (c *Connection) awsConfig(ctx context.Context, awsRegion string) (aws.Confi
 		config.WithDefaultRegion("us-east-1"),
 		// Setting the region to an empty string, will result in the region value being ignored
 		config.WithRegion(awsRegion),
+		config.WithLogger(awsutil.NewAWSLogger(c.logger)),
 	}
 
 	// If one of the static properties is specified: access key, secret key, or session token, use static credentials,

--- a/runtime/drivers/duckdb/model_executor_https_self.go
+++ b/runtime/drivers/duckdb/model_executor_https_self.go
@@ -67,7 +67,7 @@ func (e *httpsToSelfExecutor) modelInputProperties(ctx context.Context, opts *dr
 
 	m := &ModelInputProperties{}
 	// Generate secret SQL to access the http url using duckdb
-	m.InternalCreateSecretSQL, m.InternalDropSecretSQL, _, err = generateSecretSQL(ctx, opts, opts.InputConnector, parsed.Path, opts.InputProperties)
+	m.InternalCreateSecretSQL, m.InternalDropSecretSQL, _, err = generateSecretSQL(ctx, opts, opts.InputConnector, parsed.Path, opts.InputProperties, e.c.logger)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/runtime/drivers/duckdb/model_executor_objectstore_self.go
+++ b/runtime/drivers/duckdb/model_executor_objectstore_self.go
@@ -74,7 +74,7 @@ func (e *objectStoreToSelfExecutor) modelInputProperties(ctx context.Context, op
 	}
 
 	// Generate secret SQL to access the to access object store using duckdb
-	m.InternalCreateSecretSQL, m.InternalDropSecretSQL, _, err = generateSecretSQL(ctx, opts, opts.InputConnector, parsed.Path, opts.InputProperties)
+	m.InternalCreateSecretSQL, m.InternalDropSecretSQL, _, err = generateSecretSQL(ctx, opts, opts.InputConnector, parsed.Path, opts.InputProperties, e.c.logger)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/runtime/drivers/duckdb/model_executor_self.go
+++ b/runtime/drivers/duckdb/model_executor_self.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rilldata/rill/runtime/pkg/globutil"
 	"github.com/rilldata/rill/runtime/pkg/mapstructureutil"
 	"github.com/rilldata/rill/runtime/pkg/rduckdb"
+	"go.uber.org/zap"
 )
 
 type selfToSelfExecutor struct {
@@ -120,7 +121,7 @@ func (e *selfToSelfExecutor) Execute(ctx context.Context, opts *drivers.ModelExe
 		var createSecretSQLs, dropSecretSQLs []string
 		for _, connector := range connectorsForSecrets {
 			// we donnot need to pass the parsedPath we are using because of s3 region detection
-			createSecretSQL, dropSecretSQL, connectorType, err := generateSecretSQL(ctx, opts, connector, parsedPath, nil)
+			createSecretSQL, dropSecretSQL, connectorType, err := generateSecretSQL(ctx, opts, connector, parsedPath, nil, e.c.logger)
 			if err != nil {
 				// Skip creating secrets when:
 				// - autoDetected: user didn't explicitly configure the secret container
@@ -545,7 +546,7 @@ func connectorsForSecrets(modelSecrets, duckdbSecrets []string, allConnectors []
 	return configuredConnectorsForSecrets, false
 }
 
-func generateSecretSQL(ctx context.Context, opts *drivers.ModelExecuteOptions, connector, optionalBucketURL string, optionalAdditionalConfig map[string]any) (string, string, string, error) {
+func generateSecretSQL(ctx context.Context, opts *drivers.ModelExecuteOptions, connector, optionalBucketURL string, optionalAdditionalConfig map[string]any, logger *zap.Logger) (string, string, string, error) {
 	handle, release, err := opts.Env.AcquireConnector(ctx, connector)
 	if err != nil {
 		return "", "", "", err
@@ -603,7 +604,7 @@ func generateSecretSQL(ctx context.Context, opts *drivers.ModelExecuteOptions, c
 			if err != nil {
 				return "", "", "", fmt.Errorf("failed to parse path %q: %w", optionalBucketURL, err)
 			}
-			reg, err := s3.BucketRegion(ctx, s3Config, uri.Host)
+			reg, err := s3.BucketRegion(ctx, s3Config, uri.Host, logger)
 			if err != nil {
 				return "", "", "", err
 			}

--- a/runtime/drivers/duckdb/model_executor_self_objectstore.go
+++ b/runtime/drivers/duckdb/model_executor_self_objectstore.go
@@ -77,7 +77,7 @@ func (e *selfToObjectStoreExecutor) Execute(ctx context.Context, opts *drivers.M
 	var createSecretSQLs, dropSecretSQLs []string
 	for _, connector := range connectorsForSecrets {
 		// We need to pass the bucket we are using because of S3 region detection
-		createSecretSQL, dropSecretSQL, _, err := generateSecretSQL(ctx, opts, connector, bucket, nil)
+		createSecretSQL, dropSecretSQL, _, err := generateSecretSQL(ctx, opts, connector, bucket, nil, e.c.logger)
 		if err != nil {
 			// Silently ignore when auto detected connector or when using native GCS credentials (since it's not supported by DuckDB)
 			if autoDetected || errors.Is(err, errGCSUsesNativeCreds) {

--- a/runtime/drivers/redshift/redshift.go
+++ b/runtime/drivers/redshift/redshift.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/pkg/activity"
+	"github.com/rilldata/rill/runtime/pkg/awsutil"
 	"github.com/rilldata/rill/runtime/storage"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
@@ -243,6 +244,7 @@ func (c *Connection) awsConfig(ctx context.Context, awsRegion string) (aws.Confi
 		config.WithDefaultRegion("us-east-1"),
 		// Setting the region to an empty string, will result in the region value being ignored
 		config.WithRegion(awsRegion),
+		config.WithLogger(awsutil.NewAWSLogger(c.logger)),
 	}
 
 	// If one of the static properties is specified: access key, secret key, or session token, use static credentials,

--- a/runtime/drivers/s3/model_executor_olap_to_self.go
+++ b/runtime/drivers/s3/model_executor_olap_to_self.go
@@ -60,7 +60,7 @@ func (e *olapToSelfExecutor) Execute(ctx context.Context, opts *drivers.ModelExe
 		return nil, fmt.Errorf("failed to normalize output path: %w", err)
 	}
 
-	client, err := getS3Client(ctx, e.c.config, bucket)
+	client, err := getS3Client(ctx, e.c.config, bucket, e.c.logger)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/drivers/s3/model_manager.go
+++ b/runtime/drivers/s3/model_manager.go
@@ -34,7 +34,7 @@ func (c *Connection) Delete(ctx context.Context, res *drivers.ModelResult) error
 	if err != nil {
 		return err
 	}
-	client, err := getS3Client(ctx, c.config, u.Host)
+	client, err := getS3Client(ctx, c.config, u.Host, c.logger)
 	if err != nil {
 		return err
 	}

--- a/runtime/drivers/s3/object_store.go
+++ b/runtime/drivers/s3/object_store.go
@@ -29,7 +29,7 @@ func (c *Connection) ListBuckets(ctx context.Context, pageSize uint32, pageToken
 			return nil, "", fmt.Errorf("invalid page token: %w", err)
 		}
 	}
-	client, err := getS3Client(ctx, c.config, "")
+	client, err := getS3Client(ctx, c.config, "", c.logger)
 	if err != nil {
 		return nil, "", err
 	}
@@ -121,13 +121,13 @@ func (c *Connection) openBucket(ctx context.Context, bucket string, anonymous bo
 	var s3client *s3.Client
 	var err error
 	if anonymous {
-		s3client, err = getAnonymousS3Client(ctx, c.config, bucket)
+		s3client, err = getAnonymousS3Client(ctx, c.config, bucket, c.logger)
 		if err != nil {
 			return nil, err
 		}
 	} else {
 		var err error
-		s3client, err = getS3Client(ctx, c.config, bucket)
+		s3client, err = getS3Client(ctx, c.config, bucket, c.logger)
 		if err != nil {
 			return nil, err
 		}

--- a/runtime/drivers/s3/s3.go
+++ b/runtime/drivers/s3/s3.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/pkg/activity"
+	"github.com/rilldata/rill/runtime/pkg/awsutil"
 	"github.com/rilldata/rill/runtime/storage"
 	"go.uber.org/zap"
 )
@@ -171,7 +172,7 @@ var _ drivers.Handle = &Connection{}
 // Ping implements drivers.Handle.
 func (c *Connection) Ping(ctx context.Context) error {
 	if c.config.Endpoint == "" {
-		stsClient, err := getSTSClient(ctx, c.config)
+		stsClient, err := getSTSClient(ctx, c.config, c.logger)
 		if err != nil {
 			return err
 		}
@@ -290,8 +291,8 @@ func (c *Connection) AsNotifier(properties map[string]any) (drivers.Notifier, er
 }
 
 // BucketRegion returns the region to use for the given bucket.
-func BucketRegion(ctx context.Context, confProp *ConfigProperties, bucket string) (string, error) {
-	cfg, err := getAWSConfig(ctx, confProp)
+func BucketRegion(ctx context.Context, confProp *ConfigProperties, bucket string, logger *zap.Logger) (string, error) {
+	cfg, err := getAWSConfig(ctx, confProp, logger)
 	if err != nil {
 		return "", fmt.Errorf("failed to load AWS config for bucket region detection (set `region` in s3 connector yaml): %w", err)
 	}
@@ -327,9 +328,10 @@ func bucketRegionFromConfig(ctx context.Context, cfg aws.Config, confProp *Confi
 	return region, nil
 }
 
-func getAnonymousS3Client(ctx context.Context, confProp *ConfigProperties, bucket string) (*s3.Client, error) {
+func getAnonymousS3Client(ctx context.Context, confProp *ConfigProperties, bucket string, logger *zap.Logger) (*s3.Client, error) {
 	cfg := aws.Config{
 		Credentials: aws.AnonymousCredentials{},
+		Logger:      awsutil.NewAWSLogger(logger),
 	}
 	region := confProp.Region
 	// If the region is not explicitly provided in the config,
@@ -350,8 +352,8 @@ func getAnonymousS3Client(ctx context.Context, confProp *ConfigProperties, bucke
 	}), nil
 }
 
-func getS3Client(ctx context.Context, confProp *ConfigProperties, bucket string) (*s3.Client, error) {
-	cfg, err := getAWSConfig(ctx, confProp)
+func getS3Client(ctx context.Context, confProp *ConfigProperties, bucket string, logger *zap.Logger) (*s3.Client, error) {
+	cfg, err := getAWSConfig(ctx, confProp, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -381,8 +383,8 @@ func getS3Client(ctx context.Context, confProp *ConfigProperties, bucket string)
 	}), nil
 }
 
-func getSTSClient(ctx context.Context, confProp *ConfigProperties) (*sts.Client, error) {
-	cfg, err := getAWSConfig(ctx, confProp)
+func getSTSClient(ctx context.Context, confProp *ConfigProperties, logger *zap.Logger) (*sts.Client, error) {
+	cfg, err := getAWSConfig(ctx, confProp, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -397,14 +399,15 @@ func getSTSClient(ctx context.Context, confProp *ConfigProperties) (*sts.Client,
 	}), nil
 }
 
-func getAWSConfig(ctx context.Context, confProp *ConfigProperties) (aws.Config, error) {
-	provider, err := newCredentialsProvider(ctx, confProp)
+func getAWSConfig(ctx context.Context, confProp *ConfigProperties, logger *zap.Logger) (aws.Config, error) {
+	provider, err := newCredentialsProvider(ctx, confProp, logger)
 	if err != nil {
 		return aws.Config{}, fmt.Errorf("failed to get AWS credentials: %w", err)
 	}
 
 	opts := []func(*config.LoadOptions) error{
 		config.WithCredentialsProvider(provider),
+		config.WithLogger(awsutil.NewAWSLogger(logger)),
 	}
 	if confProp.Region != "" {
 		opts = append(opts, config.WithRegion(confProp.Region))
@@ -426,10 +429,10 @@ func getAWSConfig(ctx context.Context, confProp *ConfigProperties) (aws.Config, 
 }
 
 // newCredentialsProvider returns credentials for connecting to AWS.
-func newCredentialsProvider(ctx context.Context, confProp *ConfigProperties) (aws.CredentialsProvider, error) {
+func newCredentialsProvider(ctx context.Context, confProp *ConfigProperties, logger *zap.Logger) (aws.CredentialsProvider, error) {
 	// 1. If a role ARN is provided, assume it.
 	if confProp.RoleARN != "" {
-		return assumeRole(ctx, confProp)
+		return assumeRole(ctx, confProp, logger)
 	}
 
 	// 1. Explicit static credentials
@@ -443,7 +446,7 @@ func newCredentialsProvider(ctx context.Context, confProp *ConfigProperties) (aw
 
 	// 3. Allow host-based credentials
 	if confProp.AllowHostAccess {
-		cfg, err := config.LoadDefaultConfig(ctx)
+		cfg, err := config.LoadDefaultConfig(ctx, config.WithLogger(awsutil.NewAWSLogger(logger)))
 		if err != nil {
 			return nil, fmt.Errorf("failed to load AWS config: %w", err)
 		}
@@ -463,7 +466,7 @@ func newCredentialsProvider(ctx context.Context, confProp *ConfigProperties) (aw
 
 // assumeRole returns a credentials provider that assumes the role specified by the ARN using AWS SDK v2.
 // It uses stscreds.NewAssumeRoleProvider so credentials are automatically refreshed before expiration.
-func assumeRole(ctx context.Context, confProp *ConfigProperties) (aws.CredentialsProvider, error) {
+func assumeRole(ctx context.Context, confProp *ConfigProperties, logger *zap.Logger) (aws.CredentialsProvider, error) {
 	// Add session name if specified
 	sessionName := confProp.RoleSessionName
 	if sessionName == "" {
@@ -487,6 +490,7 @@ func assumeRole(ctx context.Context, confProp *ConfigProperties) (aws.Credential
 	} else if confProp.AllowHostAccess {
 		hostCfg, err := config.LoadDefaultConfig(ctx,
 			config.WithRegion(region),
+			config.WithLogger(awsutil.NewAWSLogger(logger)),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load host credentials: %w", err)
@@ -501,6 +505,7 @@ func assumeRole(ctx context.Context, confProp *ConfigProperties) (aws.Credential
 	cfg, err := config.LoadDefaultConfig(ctx,
 		config.WithRegion(region),
 		config.WithCredentialsProvider(credsProvider),
+		config.WithLogger(awsutil.NewAWSLogger(logger)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create AWS config: %w", err)

--- a/runtime/pkg/awsutil/logger.go
+++ b/runtime/pkg/awsutil/logger.go
@@ -1,0 +1,29 @@
+package awsutil
+
+import (
+	"fmt"
+
+	"github.com/aws/smithy-go/logging"
+	"go.uber.org/zap"
+)
+
+type zapLogger struct {
+	logger *zap.Logger
+}
+
+// NewAWSLogger returns a logging.Logger that routes AWS SDK log output through the given Zap logger.
+func NewAWSLogger(logger *zap.Logger) logging.Logger {
+	return &zapLogger{logger: logger.Named("aws")}
+}
+
+func (l *zapLogger) Logf(classification logging.Classification, format string, v ...any) {
+	msg := fmt.Sprintf(format, v...)
+	switch classification {
+	case logging.Warn:
+		l.logger.Warn(msg)
+	case logging.Debug:
+		l.logger.Debug(msg)
+	default:
+		l.logger.Info(msg)
+	}
+}


### PR DESCRIPTION
Hopefully this fixes an issue I saw where the following log was emitted when running `rill start`:
```
SDK 2026/03/23 16:19:05 WARN falling back to IMDSv1: operation error ec2imds: getToken, http response error StatusCode: 404, request to EC2   
IMDS failed
```

**Checklist:**
- [x] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!