### PR TITLE
APP-815: fix: chat context component missing runtime client

### DIFF
--- a/web-common/src/features/chat/core/context/editor-plugins.ts
+++ b/web-common/src/features/chat/core/context/editor-plugins.ts
@@ -15,13 +15,19 @@ import {
   normalizeInlineContext,
   parseInlineAttr,
 } from "@rilldata/web-common/features/chat/core/context/inline-context.ts";
+import {
+  RUNTIME_CONTEXT_KEY,
+  RuntimeClient,
+} from "@rilldata/web-common/runtime-client/v2";
 
 export function getEditorPlugins({
   placeholder,
   onSubmit,
+  runtimeClient,
 }: {
   placeholder: string;
   onSubmit: () => void;
+  runtimeClient: RuntimeClient;
 }) {
   const sharedEditorStore = new SharedEditorStore();
 
@@ -33,7 +39,7 @@ export function getEditorPlugins({
       placeholder,
     }),
     EditorSubmitExtension.configure({ onSubmit, sharedEditorStore }),
-    configureInlineContextTipTapExtension(sharedEditorStore),
+    configureInlineContextTipTapExtension(sharedEditorStore, runtimeClient),
     UndoRedo,
   ];
 
@@ -96,6 +102,7 @@ const EditorSubmitExtension = Extension.create(() => {
 
 type InlineContextOptions = MentionOptions<never, InlineContext> & {
   sharedEditorStore: SharedEditorStore;
+  runtimeClient: RuntimeClient;
 };
 
 // Add the startMention command to the Commands type.
@@ -119,6 +126,7 @@ const InlineContextExtension = Mention.extend<InlineContextOptions>({
       // These have to be configured for the extension to work
       manager: {} as ConversationManager,
       sharedEditorStore: {} as SharedEditorStore,
+      runtimeClient: {} as RuntimeClient,
     };
   },
 
@@ -179,7 +187,7 @@ const InlineContextExtension = Mention.extend<InlineContextOptions>({
       // We need this here to make sure the component is rendered inline.
       target.className = "inline-block";
 
-      const sharedEditorStore = this.options.sharedEditorStore;
+      const { sharedEditorStore, runtimeClient } = this.options;
 
       // Create the inline chat context component. Pass the wrapper as the target.
       const comp = new InlineContextComponent({
@@ -207,6 +215,7 @@ const InlineContextExtension = Mention.extend<InlineContextOptions>({
               }
             : { mode: "readonly" },
         },
+        context: new Map([[RUNTIME_CONTEXT_KEY, runtimeClient]]),
       });
       sharedEditorStore.componentAdded(comp);
 
@@ -227,12 +236,14 @@ const InlineContextExtension = Mention.extend<InlineContextOptions>({
  */
 export function configureInlineContextTipTapExtension(
   sharedEditorStore: SharedEditorStore,
+  runtimeClient: RuntimeClient,
 ) {
   let comp: InlineContextPicker | null = null;
   let selected = false;
 
   return InlineContextExtension.configure({
     sharedEditorStore,
+    runtimeClient,
     suggestion: {
       char: "@",
       allowSpaces: true,
@@ -252,6 +263,7 @@ export function configureInlineContextTipTapExtension(
               },
               focusEditor: () => props.editor.commands.focus(),
             },
+            context: new Map([[RUNTIME_CONTEXT_KEY, runtimeClient]]),
           });
           sharedEditorStore.contextOpen = true;
         },

--- a/web-common/src/features/chat/core/input/ChatInput.svelte
+++ b/web-common/src/features/chat/core/input/ChatInput.svelte
@@ -10,6 +10,7 @@
   import type { ChatConfig } from "@rilldata/web-common/features/chat/core/types.ts";
   import Button from "@rilldata/web-common/components/button/Button.svelte";
   import { ArrowUp } from "lucide-svelte";
+  import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
 
   export let conversationManager: ConversationManager;
   export let onSend: (() => void) | undefined = undefined;
@@ -19,6 +20,8 @@
   export let inline = false;
 
   let value = "";
+
+  const runtimeClient = useRuntimeClient();
 
   $: ({ placeholder, additionalContextStoreGetter } = config);
   $: additionalContextStore = additionalContextStoreGetter();
@@ -87,6 +90,7 @@
       extensions: getEditorPlugins({
         placeholder,
         onSubmit: () => void sendMessage(),
+        runtimeClient,
       }),
       content: "",
       editorProps: {

--- a/web-common/src/features/chat/core/messages/text/UserMessage.svelte
+++ b/web-common/src/features/chat/core/messages/text/UserMessage.svelte
@@ -5,8 +5,11 @@
   import { onMount } from "svelte";
   import type { V1Message } from "../../../../../runtime-client";
   import { extractMessageText } from "../../utils";
+  import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
 
   export let message: V1Message;
+
+  const runtimeClient = useRuntimeClient();
 
   let element: HTMLDivElement;
   let editor: Editor;
@@ -23,6 +26,7 @@
       extensions: getEditorPlugins({
         placeholder: "",
         onSubmit: () => {},
+        runtimeClient,
       }),
       content,
     });


### PR DESCRIPTION
Chat context dropdown is handled by tiptap so it is rendered outside of svelte component tree. So we need to explicitly pass runtime client as context.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
