### PR TITLE
Fix dashboard loading error flash

### DIFF
--- a/web-common/src/features/dashboards/state-managers/loaders/DashboardStateDataLoader.ts
+++ b/web-common/src/features/dashboards/state-managers/loaders/DashboardStateDataLoader.ts
@@ -254,6 +254,7 @@ export class DashboardStateDataLoader {
 
         if (
           !fullTimeRange.isLoading &&
+          !fullTimeRange.isFetching &&
           fullTimeRange.data?.timeRangeSummary?.min == null &&
           fullTimeRange.data?.timeRangeSummary?.max == null
         ) {


### PR DESCRIPTION
There is a small flash of dashboard loading error when loading a new dashboard. This fixes it. 