### PR TITLE
fix: prevent horizontal scroll on Public URLs table when filters have long values

### DIFF
--- a/web-admin/src/features/public-urls/PublicURLsResourceTable.svelte
+++ b/web-admin/src/features/public-urls/PublicURLsResourceTable.svelte
@@ -99,15 +99,15 @@
     </div>
   {:else}
     <div class="border rounded-lg overflow-x-auto">
-      <table class="w-full">
+      <table class="w-full table-fixed">
         <thead>
           <tr class="bg-surface-background border-b">
             <th class="table-header">Label</th>
             <th class="table-header">Dashboard</th>
             <th class="table-header">Filters</th>
-            <th class="table-header">Expires on</th>
-            <th class="table-header">Created by</th>
-            <th class="table-header">Last accessed</th>
+            <th class="table-header w-[108px]">Expires on</th>
+            <th class="table-header w-[108px]">Created by</th>
+            <th class="table-header w-[112px]">Last accessed</th>
             <th class="table-header w-12"></th>
           </tr>
         </thead>
@@ -115,7 +115,7 @@
           {#each filteredData as row (row.id)}
             {@const filters = getFilters(row.metricsViewFilters)}
             <tr class="table-row">
-              <td class="table-cell font-medium">
+              <td class="table-cell overflow-hidden font-medium">
                 <a
                   href={row.url}
                   target="_blank"
@@ -128,38 +128,40 @@
                   </span>
                 </a>
               </td>
-              <td class="table-cell">
+              <td class="table-cell overflow-hidden">
                 <span class="truncate block">
                   {row.dashboardTitle || row.resourceName || "—"}
                 </span>
               </td>
-              <td class="table-cell">
+              <td class="table-cell overflow-hidden">
                 {#if filters.length > 0}
                   <div class="flex gap-1 flex-wrap">
                     {#each filters as filter (filter.name)}
-                      <Chip
-                        type="dimension"
-                        readOnly
-                        exclude={!filter.isInclude}
-                        compact
-                        slideDuration={0}
-                      >
-                        <span slot="body" class="text-xs truncate">
-                          <span class="font-bold"
-                            >{filter.isInclude
-                              ? ""
-                              : "Exclude "}{filter.name}</span
-                          >
-                          {#if filter.values.length === 1}
-                            {filter.values[0]}
-                          {:else if filter.values.length > 1}
-                            <span class="italic"
-                              >{filter.values[0]} +{filter.values.length -
-                                1}</span
+                      <div class="max-w-full min-w-0">
+                        <Chip
+                          type="dimension"
+                          readOnly
+                          exclude={!filter.isInclude}
+                          compact
+                          slideDuration={0}
+                        >
+                          <span slot="body" class="text-xs truncate">
+                            <span class="font-bold"
+                              >{filter.isInclude
+                                ? ""
+                                : "Exclude "}{filter.name}</span
                             >
-                          {/if}
-                        </span>
-                      </Chip>
+                            {#if filter.values.length === 1}
+                              {filter.values[0]}
+                            {:else if filter.values.length > 1}
+                              <span class="italic"
+                                >{filter.values[0]} +{filter.values.length -
+                                  1}</span
+                              >
+                            {/if}
+                          </span>
+                        </Chip>
+                      </div>
                     {/each}
                   </div>
                 {:else}
@@ -169,8 +171,10 @@
               <td class="table-cell whitespace-nowrap">
                 {formatDate(row.expiresOn)}
               </td>
-              <td class="table-cell">
-                {row.attributes?.name || "—"}
+              <td class="table-cell overflow-hidden">
+                <span class="truncate block">
+                  {row.attributes?.name || "—"}
+                </span>
               </td>
               <td class="table-cell whitespace-nowrap">
                 {formatDate(row.usedOn)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the Public URLs settings table overflowing horizontally when filter chips contain long strings (e.g., long publisher IDs).

**Changes in `PublicURLsResourceTable.svelte`:**

- **`table-fixed` layout** — constrains the table to its container width instead of auto-growing to fit content
- **Explicit widths on narrow columns** — "Expires on" (`108px`), "Created by" (`108px`), "Last accessed" (`112px`), and the actions column (`48px`). The three flexible columns (Label, Dashboard, Filters) share the remaining space equally.
- **`overflow-hidden`** on cells that may contain long text (Label, Dashboard, Filters, Created by) so content truncates instead of expanding the table
- **Constraining wrapper** around each filter Chip (`max-w-full min-w-0`) so individual chips truncate with ellipsis rather than pushing the column wider

Closes APP-805

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [APP-805](https://linear.app/rilldata/issue/APP-805/current-public-url-list-table-requires-horizontal-scroll-when-there)

<div><a href="https://cursor.com/agents/bc-64a503e9-0bb8-45f3-8db5-bcf33703f61e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64a503e9-0bb8-45f3-8db5-bcf33703f61e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

