### PR TITLE
fix: pivot table sort state lost on refresh

### DIFF
--- a/web-common/src/features/dashboards/stores/test-data/store-mutations.ts
+++ b/web-common/src/features/dashboards/stores/test-data/store-mutations.ts
@@ -42,6 +42,7 @@ import {
   AD_BIDS_IMPRESSIONS_MEASURE,
   AD_BIDS_METRICS_INIT,
   AD_BIDS_PUBLISHER_DIMENSION,
+  AD_BIDS_TIMESTAMP_DIMENSION,
 } from "@rilldata/web-common/features/dashboards/stores/test-data/data";
 import {
   RandomDomains,
@@ -393,13 +394,30 @@ export const AD_BIDS_SORT_PIVOT_BY_DOMAIN_DESC: TestDashboardMutation = () =>
   ]);
 export const AD_BIDS_SORT_PIVOT_BY_TIME_DAY_ASC: TestDashboardMutation = () =>
   metricsExplorerStore.setPivotSort(AD_BIDS_EXPLORE_NAME, [
-    { id: V1TimeGrain.TIME_GRAIN_DAY, desc: false },
+    {
+      id: `${AD_BIDS_TIMESTAMP_DIMENSION}_rill_${V1TimeGrain.TIME_GRAIN_DAY}`,
+      desc: false,
+    },
   ]);
 export const AD_BIDS_SORT_PIVOT_BY_IMPRESSIONS_DESC: TestDashboardMutation =
   () =>
     metricsExplorerStore.setPivotSort(AD_BIDS_EXPLORE_NAME, [
       { id: AD_BIDS_IMPRESSIONS_MEASURE, desc: true },
     ]);
+// Matches actual TanStack Table sort id format: {timeDimension}_rill_{grain}
+export const AD_BIDS_SORT_PIVOT_BY_RILL_TIME_DAY_DESC: TestDashboardMutation =
+  () =>
+    metricsExplorerStore.setPivotSort(AD_BIDS_EXPLORE_NAME, [
+      {
+        id: `${AD_BIDS_TIMESTAMP_DIMENSION}_rill_${V1TimeGrain.TIME_GRAIN_DAY}`,
+        desc: true,
+      },
+    ]);
+// Minimized accessor format used for column-specific measure sorts
+export const AD_BIDS_SORT_PIVOT_BY_ACCESSOR_DESC: TestDashboardMutation = () =>
+  metricsExplorerStore.setPivotSort(AD_BIDS_EXPLORE_NAME, [
+    { id: "c0v2m0", desc: true },
+  ]);
 
 export const AD_BIDS_SET_PIVOT_ROW_LIMIT_10: TestDashboardMutation = () =>
   metricsExplorerStore.setPivotRowLimit(AD_BIDS_EXPLORE_NAME, 10);

--- a/web-common/src/features/dashboards/url-state/convert-partial-explore-state-to-url-params.ts
+++ b/web-common/src/features/dashboards/url-state/convert-partial-explore-state-to-url-params.ts
@@ -390,10 +390,18 @@ function toPivotUrlParams(partialExploreState: Partial<ExploreState>) {
   searchParams.set(ExploreStateURLParams.PivotColumns, colsParams);
 
   const sort = partialExploreState.pivot.sorting?.[0];
-  const sortId =
-    sort?.id in ToURLParamTimeDimensionMap
-      ? ToURLParamTimeDimensionMap[sort?.id]
-      : sort?.id;
+  let sortId = sort?.id;
+  if (sortId) {
+    if (sortId in ToURLParamTimeDimensionMap) {
+      sortId = ToURLParamTimeDimensionMap[sortId];
+    } else if (sortId.includes("_rill_")) {
+      // Handle TanStack Table time dimension format: {timeDimension}_rill_{grain}
+      const grain = sortId.split("_rill_")[1];
+      if (grain in ToURLParamTimeDimensionMap) {
+        sortId = ToURLParamTimeDimensionMap[grain];
+      }
+    }
+  }
 
   searchParams.set(ExploreStateURLParams.SortBy, sortId ?? "");
 

--- a/web-common/src/features/dashboards/url-state/convertPresetToExploreState.ts
+++ b/web-common/src/features/dashboards/url-state/convertPresetToExploreState.ts
@@ -34,7 +34,6 @@ import {
 } from "@rilldata/web-common/proto/gen/rill/ui/v1/dashboard_pb";
 import {
   type MetricsViewSpecDimension,
-  MetricsViewSpecDimensionType,
   type MetricsViewSpecMeasure,
   V1ExploreComparisonMode,
   type V1ExplorePreset,
@@ -102,7 +101,7 @@ export function convertPresetToExploreState(
   errors.push(...tddErrors);
 
   const { partialExploreState: pivotPartialState, errors: pivotErrors } =
-    fromPivotUrlParams(measures, dimensions, preset);
+    fromPivotUrlParams(measures, dimensions, preset, metricsView.timeDimension);
   Object.assign(partialExploreState, pivotPartialState);
   errors.push(...pivotErrors);
 
@@ -386,6 +385,7 @@ function fromPivotUrlParams(
   measures: Map<string, MetricsViewSpecMeasure>,
   dimensions: Map<string, MetricsViewSpecDimension>,
   preset: V1ExplorePreset,
+  timeDimension?: string,
 ): {
   partialExploreState: Partial<ExploreState>;
   errors: Error[];
@@ -471,20 +471,21 @@ function fromPivotUrlParams(
   const sorting: SortingState = [];
   if (preset.pivotSortBy) {
     const isTimeDim = preset.pivotSortBy in FromURLParamTimeDimensionMap;
-    const sortById = isTimeDim
-      ? FromURLParamTimeDimensionMap[preset.pivotSortBy]
-      : preset.pivotSortBy;
-    const isValidMeasure = !isTimeDim && measures.has(sortById);
-    const isValidDimension =
-      !isTimeDim &&
-      dimensions.get(sortById)?.type ===
-        MetricsViewSpecDimensionType.DIMENSION_TYPE_CATEGORICAL;
-    if (isTimeDim || isValidMeasure || isValidDimension) {
-      sorting.push({
-        id: sortById,
-        desc: !preset.pivotSortAsc,
-      });
+    let sortById: string;
+    if (isTimeDim) {
+      // Reconstruct TanStack Table format: {timeDimension}_rill_{grain}
+      const grain = FromURLParamTimeDimensionMap[preset.pivotSortBy];
+      sortById = timeDimension ? `${timeDimension}_rill_${grain}` : grain;
+    } else {
+      sortById = preset.pivotSortBy;
     }
+    // Allow all sort IDs through: measures, dimensions, time dimensions,
+    // and unrecognized IDs (e.g. minimized accessors like "c0v2m0") which
+    // TanStack Table will simply ignore if they don't match any column
+    sorting.push({
+      id: sortById,
+      desc: !preset.pivotSortAsc,
+    });
   }
 
   let tableMode: PivotTableMode = "nest";

--- a/web-common/src/features/dashboards/url-state/url-state-variations.spec.ts
+++ b/web-common/src/features/dashboards/url-state/url-state-variations.spec.ts
@@ -55,7 +55,9 @@ import {
   AD_BIDS_SORT_BY_VALUE,
   AD_BIDS_SORT_DESC_BY_BID_PRICE,
   AD_BIDS_SORT_DESC_BY_IMPRESSIONS,
+  AD_BIDS_SORT_PIVOT_BY_ACCESSOR_DESC,
   AD_BIDS_SORT_PIVOT_BY_IMPRESSIONS_DESC,
+  AD_BIDS_SORT_PIVOT_BY_RILL_TIME_DAY_DESC,
   AD_BIDS_SORT_PIVOT_BY_TIME_DAY_ASC,
   AD_BIDS_SWITCH_TO_STACKED_BAR_IN_TDD,
   AD_BIDS_TOGGLE_BID_DOMAIN_DIMENSION_VISIBILITY,
@@ -715,6 +717,112 @@ describe("Human readable URL state variations", () => {
       TimeComparisonOption.CONTIGUOUS,
     );
     expect(currentState.whereFilter).toEqual(AD_BIDS_LARGE_FILTER);
+  });
+
+  describe("Pivot sort state roundtrip", () => {
+    function setupAndRoundtrip() {
+      const explore: V1ExploreSpec = {
+        ...AD_BIDS_EXPLORE_INIT,
+        timeZones: ["UTC", "Asia/Kathmandu"],
+      };
+      metricsExplorerStore.init(
+        AD_BIDS_EXPLORE_NAME,
+        getInitExploreStateForTest(
+          AD_BIDS_METRICS_3_MEASURES_DIMENSIONS_WITH_TIME,
+          explore,
+          AD_BIDS_TIME_RANGE_SUMMARY,
+        ),
+      );
+      const defaultExploreUrlSearch = getRillDefaultExploreUrlParams(
+        AD_BIDS_METRICS_3_MEASURES_DIMENSIONS_WITH_TIME,
+        explore,
+        AD_BIDS_TIME_RANGE_SUMMARY.timeRangeSummary,
+      );
+      const defaultExplorePreset = getDefaultExplorePreset(
+        explore,
+        AD_BIDS_METRICS_3_MEASURES_DIMENSIONS_WITH_TIME,
+        AD_BIDS_TIME_RANGE_SUMMARY.timeRangeSummary,
+      );
+      return { explore, defaultExploreUrlSearch, defaultExplorePreset };
+    }
+
+    it("should preserve time dimension sort (rill format) after URL roundtrip", async () => {
+      const { explore, defaultExploreUrlSearch, defaultExplorePreset } =
+        setupAndRoundtrip();
+
+      await applyMutationsToDashboard(AD_BIDS_EXPLORE_NAME, [
+        AD_BIDS_OPEN_PIVOT_WITH_ALL_FIELDS,
+        AD_BIDS_SORT_PIVOT_BY_RILL_TIME_DAY_DESC,
+      ]);
+
+      const stateBeforeRoundtrip = getCleanMetricsExploreForAssertion();
+      expect(stateBeforeRoundtrip.pivot?.sorting).toEqual([
+        { id: "timestamp_rill_TIME_GRAIN_DAY", desc: true },
+      ]);
+
+      // Serialize state to URL params
+      const urlParams = getCleanedUrlParamsForGoto(
+        explore,
+        AD_BIDS_METRICS_3_MEASURES_DIMENSIONS_WITH_TIME,
+        get(metricsExplorerStore).entities[AD_BIDS_EXPLORE_NAME],
+        getTimeControlState(
+          AD_BIDS_METRICS_3_MEASURES_DIMENSIONS_WITH_TIME,
+          explore,
+          AD_BIDS_TIME_RANGE_SUMMARY.timeRangeSummary,
+          get(metricsExplorerStore).entities[AD_BIDS_EXPLORE_NAME],
+        ),
+        defaultExploreUrlSearch,
+      );
+
+      // Deserialize URL back to state (simulates page refresh)
+      const url = new URL("http://localhost");
+      url.search = urlParams.toString();
+      applyURLToExploreState(url, explore, defaultExplorePreset);
+
+      const stateAfterRoundtrip = getCleanMetricsExploreForAssertion();
+      expect(stateAfterRoundtrip.pivot?.sorting).toEqual(
+        stateBeforeRoundtrip.pivot?.sorting,
+      );
+    });
+
+    it("should preserve minimized accessor sort after URL roundtrip", async () => {
+      const { explore, defaultExploreUrlSearch, defaultExplorePreset } =
+        setupAndRoundtrip();
+
+      await applyMutationsToDashboard(AD_BIDS_EXPLORE_NAME, [
+        AD_BIDS_OPEN_PIVOT_WITH_ALL_FIELDS,
+        AD_BIDS_SORT_PIVOT_BY_ACCESSOR_DESC,
+      ]);
+
+      const stateBeforeRoundtrip = getCleanMetricsExploreForAssertion();
+      expect(stateBeforeRoundtrip.pivot?.sorting).toEqual([
+        { id: "c0v2m0", desc: true },
+      ]);
+
+      // Serialize state to URL params
+      const urlParams = getCleanedUrlParamsForGoto(
+        explore,
+        AD_BIDS_METRICS_3_MEASURES_DIMENSIONS_WITH_TIME,
+        get(metricsExplorerStore).entities[AD_BIDS_EXPLORE_NAME],
+        getTimeControlState(
+          AD_BIDS_METRICS_3_MEASURES_DIMENSIONS_WITH_TIME,
+          explore,
+          AD_BIDS_TIME_RANGE_SUMMARY.timeRangeSummary,
+          get(metricsExplorerStore).entities[AD_BIDS_EXPLORE_NAME],
+        ),
+        defaultExploreUrlSearch,
+      );
+
+      // Deserialize URL back to state (simulates page refresh)
+      const url = new URL("http://localhost");
+      url.search = urlParams.toString();
+      applyURLToExploreState(url, explore, defaultExplorePreset);
+
+      const stateAfterRoundtrip = getCleanMetricsExploreForAssertion();
+      expect(stateAfterRoundtrip.pivot?.sorting).toEqual(
+        stateBeforeRoundtrip.pivot?.sorting,
+      );
+    });
   });
 });
 


### PR DESCRIPTION
Due to an earlier regression, the pivot sort state was getting lost on refresh

- Pivot sort by time dimensions (e.g., `timestamp_rill_TIME_GRAIN_HOUR`) and minimized accessors (e.g., `c0v2m0`) were silently dropped during URL deserialization on page refresh
- Serialization now correctly maps `_rill_` format sort IDs to URL-friendly `time.{grain}` format
- Deserialization reconstructs the full `{timeDimension}_rill_{grain}` format using `metricsView.timeDimension`, and no longer drops unrecognized sort IDs (like minimized accessors)
- Updated `AD_BIDS_SORT_PIVOT_BY_TIME_DAY_ASC` test mutation to use the realistic `_rill_` format that TanStack Table actually generates


https://rilldata.slack.com/archives/C02T907FEUB/p1773768057523809

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
