### PR TITLE
fix: undefined checked value binding breaks forms

### DIFF
--- a/web-common/src/components/forms/Checkbox.svelte
+++ b/web-common/src/components/forms/Checkbox.svelte
@@ -14,7 +14,7 @@
     optional?: boolean;
   };
 
-  export let checked: $$Props["checked"] = undefined;
+  export let checked: $$Props["checked"] = false;
   export let disabled: $$Props["disabled"] = undefined;
   export let label: $$Props["label"] = undefined;
   export let inverse = false;


### PR DESCRIPTION
Checkbox breaks when the value being bound is undefined. This is apparent in s3 connector form after clicking advanced. This is a svelte5 feature to ensure data correctness.

Defaulting the checked to false to fix this.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
