### PR TITLE
fix: download report crashing the app breaking download

### DIFF
--- a/web-admin/src/features/projects/download-report.ts
+++ b/web-admin/src/features/projects/download-report.ts
@@ -1,6 +1,5 @@
 // TODO: move this file once other parts are merged
 
-import { Timestamp } from "@bufbuild/protobuf";
 import {
   queryServiceExportReport,
   type RpcStatus,
@@ -43,7 +42,10 @@ export function createDownloadReportMutation<
 
     const exportResp = await queryServiceExportReport(client, {
       report: data.reportId,
-      executionTime: Timestamp.fromJson(data.executionTime),
+      // Our new API types expect Message types, but we call `fromJson`.
+      // So technically this needs to be json.
+      // TODO: fix types
+      executionTime: data.executionTime as any,
       originBaseUrl: data.originBaseUrl,
     });
     const downloadUrl = `${data.host}${exportResp.downloadUrlPath}`;


### PR DESCRIPTION
In our recent orval refactor our API types got moved to `Partial<RequestMessage>`. But we call `fromJson` internally which means we need to pass json objects.

This is a hotfix for report downloads. We need to figure out a long term solution for the API types issues.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
