### PR TITLE
APP-836 fix: canvas pivot table should fill full widget width

### DIFF
--- a/web-common/src/features/canvas/components/pivot/CanvasPivotRenderer.svelte
+++ b/web-common/src/features/canvas/components/pivot/CanvasPivotRenderer.svelte
@@ -46,6 +46,7 @@
       />
     {:else}
       <PivotTable
+        fullWidth
         border={hasHeader}
         rounded={hasHeader}
         {pivotDataStore}

--- a/web-common/src/features/dashboards/pivot/FlatTable.svelte
+++ b/web-common/src/features/dashboards/pivot/FlatTable.svelte
@@ -29,6 +29,7 @@
   export let dataRows: PivotDataRow[];
   export let hasMeasureContextColumns: boolean;
   export let canShowDataViewer = false;
+  export let fullWidth = false;
   export let activeCell: { rowId: string; columnId: string } | null | undefined;
 
   // Table props
@@ -94,6 +95,9 @@
   }
 
   function hasBorderRight(columnId: string): boolean {
+    // Last column should not have a right border
+    if (headers.length > 0 && headers[headers.length - 1].column.id === columnId)
+      return false;
     if (!hasMeasureContextColumns) return true;
     const measureIndex = measures.findIndex((m) => m.name === columnId);
     if (measureIndex === -1) return true;
@@ -133,7 +137,8 @@
 
 <table
   role="presentation"
-  style:width="{totalLength}px"
+  style:width={fullWidth ? "100%" : "{totalLength}px"}
+  style:min-width={fullWidth ? "{totalLength}px" : undefined}
   class:with-measure={measures.length > 0}
   onclick={modified({ shift: onCellCopy, click: onCellClick })}
   onmousemove={onMouseMove}

--- a/web-common/src/features/dashboards/pivot/FlatTable.svelte
+++ b/web-common/src/features/dashboards/pivot/FlatTable.svelte
@@ -27,6 +27,7 @@
   export let dataRows: PivotDataRow[];
   export let hasMeasureContextColumns: boolean;
   export let canShowDataViewer = false;
+  export let fullWidth = false;
   export let activeCell: { rowId: string; columnId: string } | null | undefined;
 
   // Table props
@@ -134,7 +135,8 @@
 
 <table
   role="presentation"
-  style:width="{totalLength}px"
+  style:width={fullWidth ? "100%" : "{totalLength}px"}
+  style:min-width={fullWidth ? "{totalLength}px" : undefined}
   class:with-measure={measures.length > 0}
   onclick={modified({ shift: onCellCopy, click: onCellClick })}
   onmousemove={onMouseMove}
@@ -144,7 +146,7 @@
     {#each headers as header (header.id)}
       {@const length =
         $columnLengths.get(header.column.id) ?? WIDTHS.INIT_MEASURE_WIDTH}
-      <col style:width="{length}px" style:max-width="{length}px" />
+      <col style:width="{length}px" style:max-width={fullWidth ? undefined : "{length}px"} />
     {/each}
   </colgroup>
 

--- a/web-common/src/features/dashboards/pivot/FlatTable.svelte
+++ b/web-common/src/features/dashboards/pivot/FlatTable.svelte
@@ -107,39 +107,75 @@
   }
 </script>
 
-<div
-  class="absolute top-0 z-50 flex pointer-events-none"
-  style:width={fullWidth ? "100%" : "{totalLength}px"}
-  style:min-width={fullWidth ? "{totalLength}px" : undefined}
-  style:height="{totalRowSize + HEADER_HEIGHT + headerGroups.length}px"
->
-  {#each headers as header, i (header.id)}
-    {@const length =
-      $columnLengths.get(header.column.id) ?? WIDTHS.INIT_MEASURE_WIDTH}
-    {@const last = i === headers.length - 1}
-    <div
-      style:width="{length}px"
-      style:flex={fullWidth ? "1 1 {length}px" : undefined}
-      class="h-full relative"
-    >
-      <Resizer
-        side="right"
-        direction="EW"
-        min={WIDTHS.MIN_MEASURE_WIDTH}
-        max={WIDTHS.MAX_MEASURE_WIDTH}
-        dimension={length}
-        justify={last ? "end" : "center"}
-        hang={!last}
-        onUpdate={(d) =>
-          columnLengths.update((lengths) => {
-            return lengths.set(header.column.id, d);
-          })}
-      >
-        <div class="resize-bar"></div>
-      </Resizer>
+{#if fullWidth}
+  <div
+    class="resizer-table absolute top-0 z-50 pointer-events-none"
+    style:width="100%"
+    style:min-width="{totalLength}px"
+    style:height="{totalRowSize + HEADER_HEIGHT + headerGroups.length}px"
+  >
+    <div class="resizer-colgroup">
+      {#each headers as header (header.id)}
+        {@const length =
+          $columnLengths.get(header.column.id) ?? WIDTHS.INIT_MEASURE_WIDTH}
+        <div class="resizer-col" style:width="{length}px"></div>
+      {/each}
     </div>
-  {/each}
-</div>
+    <div class="resizer-row">
+      {#each headers as header, i (header.id)}
+        {@const length =
+          $columnLengths.get(header.column.id) ?? WIDTHS.INIT_MEASURE_WIDTH}
+        {@const last = i === headers.length - 1}
+        <div class="resizer-cell relative">
+          <Resizer
+            side="right"
+            direction="EW"
+            min={WIDTHS.MIN_MEASURE_WIDTH}
+            max={WIDTHS.MAX_MEASURE_WIDTH}
+            dimension={length}
+            justify={last ? "end" : "center"}
+            hang={!last}
+            onUpdate={(d) =>
+              columnLengths.update((lengths) => {
+                return lengths.set(header.column.id, d);
+              })}
+          >
+            <div class="resize-bar"></div>
+          </Resizer>
+        </div>
+      {/each}
+    </div>
+  </div>
+{:else}
+  <div
+    class="absolute top-0 z-50 flex pointer-events-none"
+    style:width="{totalLength}px"
+    style:height="{totalRowSize + HEADER_HEIGHT + headerGroups.length}px"
+  >
+    {#each headers as header, i (header.id)}
+      {@const length =
+        $columnLengths.get(header.column.id) ?? WIDTHS.INIT_MEASURE_WIDTH}
+      {@const last = i === headers.length - 1}
+      <div style:width="{length}px" class="h-full relative">
+        <Resizer
+          side="right"
+          direction="EW"
+          min={WIDTHS.MIN_MEASURE_WIDTH}
+          max={WIDTHS.MAX_MEASURE_WIDTH}
+          dimension={length}
+          justify={last ? "end" : "center"}
+          hang={!last}
+          onUpdate={(d) =>
+            columnLengths.update((lengths) => {
+              return lengths.set(header.column.id, d);
+            })}
+        >
+          <div class="resize-bar"></div>
+        </Resizer>
+      </div>
+    {/each}
+  </div>
+{/if}
 
 <table
   role="presentation"
@@ -257,6 +293,30 @@
 
   .resize-bar {
     @apply bg-primary-500 w-1 h-full;
+  }
+
+  .resizer-table {
+    display: table;
+    table-layout: fixed;
+    border-spacing: 0;
+  }
+
+  .resizer-colgroup {
+    display: table-column-group;
+  }
+
+  .resizer-col {
+    display: table-column;
+  }
+
+  .resizer-row {
+    display: table-row;
+    height: 100%;
+  }
+
+  .resizer-cell {
+    display: table-cell;
+    height: inherit;
   }
 
   table {

--- a/web-common/src/features/dashboards/pivot/FlatTable.svelte
+++ b/web-common/src/features/dashboards/pivot/FlatTable.svelte
@@ -1,8 +1,3 @@
-<script lang="ts" context="module">
-  import { writable } from "svelte/store";
-  const columnLengths = writable(new Map<string, number>());
-</script>
-
 <script lang="ts">
   import ArrowDown from "@rilldata/web-common/components/icons/ArrowDown.svelte";
   import type { MeasureColumnProps } from "@rilldata/web-common/features/dashboards/pivot/pivot-column-definition";
@@ -21,7 +16,10 @@
   } from "tanstack-table-8-svelte-5";
   import { flexRender } from "tanstack-table-8-svelte-5";
   import { cellInspectorStore } from "../stores/cell-inspector-store";
+  import { writable } from "svelte/store";
   import type { PivotDataRow } from "./types";
+
+  const columnLengths = writable(new Map<string, number>());
 
   // State props
   export let assembled: boolean;

--- a/web-common/src/features/dashboards/pivot/FlatTable.svelte
+++ b/web-common/src/features/dashboards/pivot/FlatTable.svelte
@@ -108,15 +108,20 @@
 </script>
 
 <div
-  class="w-full absolute top-0 z-50 flex pointer-events-none"
-  style:width="{totalLength}px"
+  class="absolute top-0 z-50 flex pointer-events-none"
+  style:width={fullWidth ? "100%" : "{totalLength}px"}
+  style:min-width={fullWidth ? "{totalLength}px" : undefined}
   style:height="{totalRowSize + HEADER_HEIGHT + headerGroups.length}px"
 >
   {#each headers as header, i (header.id)}
     {@const length =
       $columnLengths.get(header.column.id) ?? WIDTHS.INIT_MEASURE_WIDTH}
     {@const last = i === headers.length - 1}
-    <div style:width="{length}px" class="h-full relative">
+    <div
+      style:width="{length}px"
+      style:flex={fullWidth ? "1 1 {length}px" : undefined}
+      class="h-full relative"
+    >
       <Resizer
         side="right"
         direction="EW"

--- a/web-common/src/features/dashboards/pivot/FlatTable.svelte
+++ b/web-common/src/features/dashboards/pivot/FlatTable.svelte
@@ -94,7 +94,10 @@
 
   function hasBorderRight(columnId: string): boolean {
     // Last column should not have a right border
-    if (headers.length > 0 && headers[headers.length - 1].column.id === columnId)
+    if (
+      headers.length > 0 &&
+      headers[headers.length - 1].column.id === columnId
+    )
       return false;
     if (!hasMeasureContextColumns) return true;
     const measureIndex = measures.findIndex((m) => m.name === columnId);
@@ -146,7 +149,10 @@
     {#each headers as header (header.id)}
       {@const length =
         $columnLengths.get(header.column.id) ?? WIDTHS.INIT_MEASURE_WIDTH}
-      <col style:width="{length}px" style:max-width={fullWidth ? undefined : "{length}px"} />
+      <col
+        style:width="{length}px"
+        style:max-width={fullWidth ? undefined : "{length}px"}
+      />
     {/each}
   </colgroup>
 

--- a/web-common/src/features/dashboards/pivot/FlatTable.svelte
+++ b/web-common/src/features/dashboards/pivot/FlatTable.svelte
@@ -29,7 +29,6 @@
   export let dataRows: PivotDataRow[];
   export let hasMeasureContextColumns: boolean;
   export let canShowDataViewer = false;
-  export let fullWidth = false;
   export let activeCell: { rowId: string; columnId: string } | null | undefined;
 
   // Table props
@@ -137,8 +136,7 @@
 
 <table
   role="presentation"
-  style:width={fullWidth ? "100%" : "{totalLength}px"}
-  style:min-width={fullWidth ? "{totalLength}px" : undefined}
+  style:width="{totalLength}px"
   class:with-measure={measures.length > 0}
   onclick={modified({ shift: onCellCopy, click: onCellClick })}
   onmousemove={onMouseMove}

--- a/web-common/src/features/dashboards/pivot/NestedTable.svelte
+++ b/web-common/src/features/dashboards/pivot/NestedTable.svelte
@@ -30,6 +30,7 @@
   export let measures: MeasureColumnProps;
   export let totalsRow: PivotDataRow | undefined;
   export let canShowDataViewer = false;
+  export let fullWidth = false;
   export let activeCell: { rowId: string; columnId: string } | null | undefined;
 
   // Table props
@@ -279,14 +280,14 @@
     {#if rowDimensionName && rowDimensionWidth}
       <col
         style:width="{rowDimensionWidth}px"
-        style:max-width="{rowDimensionWidth}px"
+        style:max-width={fullWidth ? undefined : "{rowDimensionWidth}px"}
       />
     {/if}
 
     {#each measureGroups as { subHeaders }, i (i)}
       {#each subHeaders as { column: { columnDef: { name } } } (name)}
         {@const length = $measureLengths.get(name)}
-        <col style:width="{length}px" style:max-width="{length}px" />
+        <col style:width="{length}px" style:max-width={fullWidth ? undefined : "{length}px"} />
       {/each}
     {/each}
   </colgroup>

--- a/web-common/src/features/dashboards/pivot/NestedTable.svelte
+++ b/web-common/src/features/dashboards/pivot/NestedTable.svelte
@@ -271,7 +271,9 @@
   class:with-measures={hasMeasures}
   role="presentation"
   style:width={fullWidth ? "100%" : "{totalLength + rowDimensionWidth}px"}
-  style:min-width={fullWidth ? "{totalLength + rowDimensionWidth}px" : undefined}
+  style:min-width={fullWidth
+    ? "{totalLength + rowDimensionWidth}px"
+    : undefined}
   onclick={modified({ shift: onCellCopy, click: onCellClick })}
   onmousemove={onMouseMove}
   onmouseleave={onTableLeave}
@@ -287,7 +289,10 @@
     {#each measureGroups as { subHeaders }, i (i)}
       {#each subHeaders as { column: { columnDef: { name } } } (name)}
         {@const length = $measureLengths.get(name)}
-        <col style:width="{length}px" style:max-width={fullWidth ? undefined : "{length}px"} />
+        <col
+          style:width="{length}px"
+          style:max-width={fullWidth ? undefined : "{length}px"}
+        />
       {/each}
     {/each}
   </colgroup>
@@ -305,7 +310,11 @@
               class:cursor-pointer={header.column.getCanSort()}
               class:select-none={header.column.getCanSort()}
               class:flex-row-reverse={isMeasureColumn(header, i)}
-              class:border-r={shouldShowHeaderRightBorder(header, i, headerGroup.headers.length)}
+              class:border-r={shouldShowHeaderRightBorder(
+                header,
+                i,
+                headerGroup.headers.length,
+              )}
               onclick={header.column.getToggleSortingHandler()}
             >
               {#if !header.isPlaceholder}

--- a/web-common/src/features/dashboards/pivot/NestedTable.svelte
+++ b/web-common/src/features/dashboards/pivot/NestedTable.svelte
@@ -1,8 +1,3 @@
-<script lang="ts" context="module">
-  import { writable } from "svelte/store";
-  const measureLengths = writable(new Map<string, number>());
-</script>
-
 <script lang="ts">
   import ArrowDown from "@rilldata/web-common/components/icons/ArrowDown.svelte";
   import Resizer from "@rilldata/web-common/layout/Resizer.svelte";
@@ -21,7 +16,10 @@
     COLUMN_WIDTH_CONSTANTS as WIDTHS,
   } from "./pivot-column-width-utils";
   import { isShowMoreRow } from "./pivot-utils";
+  import { writable } from "svelte/store";
   import type { PivotDataRow } from "./types";
+
+  const measureLengths = writable(new Map<string, number>());
 
   // State props
   export let hasColumnDimension: boolean;

--- a/web-common/src/features/dashboards/pivot/NestedTable.svelte
+++ b/web-common/src/features/dashboards/pivot/NestedTable.svelte
@@ -202,64 +202,37 @@
   $: totalHeaderHeight = headerGroups.length * HEADER_HEIGHT;
 </script>
 
-<div
-  class="absolute top-0 z-50 flex pointer-events-none"
-  style:width={fullWidth ? "100%" : "{totalLength + rowDimensionWidth}px"}
-  style:min-width={fullWidth
-    ? "{totalLength + rowDimensionWidth}px"
-    : undefined}
-  style:height="{totalRowSize + totalHeaderHeight + headerGroups.length}px"
->
-  <div style:width="{rowDimensionWidth}px" class="sticky left-0 flex-none flex">
-    <Resizer
-      side="right"
-      direction="EW"
-      min={WIDTHS.MIN_COL_WIDTH}
-      max={WIDTHS.MAX_COL_WIDTH}
-      dimension={rowDimensionWidth}
-      onUpdate={(d) => (rowDimensionWidth = d)}
-      onMouseDown={(e) => {
-        resizingMeasure = false;
-        onResizeStart(e);
-      }}
-      onMouseUp={() => {
-        resizingMeasure = false;
-      }}
-    >
-      <div class="resize-bar"></div>
-    </Resizer>
-  </div>
-
-  {#each measureGroups as { subHeaders }, groupIndex (groupIndex)}
-    <div
-      class="h-full z-50 flex"
-      style:width="{totalMeasureWidth}px"
-      style:flex={fullWidth ? "1 1 {totalMeasureWidth}px" : undefined}
-    >
-      {#each subHeaders as { column: { columnDef: { name } } }, i (name)}
-        {@const length = $measureLengths.get(name) ?? WIDTHS.INIT_MEASURE_WIDTH}
-        {@const last =
-          i === subHeaders.length - 1 &&
-          groupIndex === measureGroups.length - 1}
-        <div
-          style:width="{length}px"
-          style:flex={fullWidth ? "1 1 {length}px" : undefined}
-          class="h-full relative"
-        >
+{#if fullWidth}
+  <div
+    class="resizer-table absolute top-0 z-50 pointer-events-none"
+    style:width="100%"
+    style:min-width="{totalLength + rowDimensionWidth}px"
+    style:height="{totalRowSize + totalHeaderHeight + headerGroups.length}px"
+  >
+    <div class="resizer-colgroup">
+      {#if rowDimensionName && rowDimensionWidth}
+        <div class="resizer-col" style:width="{rowDimensionWidth}px"></div>
+      {/if}
+      {#each measureGroups as { subHeaders } (subHeaders)}
+        {#each subHeaders as { column: { columnDef: { name } } } (name)}
+          {@const length =
+            $measureLengths.get(name) ?? WIDTHS.INIT_MEASURE_WIDTH}
+          <div class="resizer-col" style:width="{length}px"></div>
+        {/each}
+      {/each}
+    </div>
+    <div class="resizer-row">
+      {#if rowDimensionName && rowDimensionWidth}
+        <div class="resizer-cell sticky left-0 z-50 relative">
           <Resizer
             side="right"
             direction="EW"
-            min={WIDTHS.MIN_MEASURE_WIDTH}
-            max={WIDTHS.MAX_MEASURE_WIDTH}
-            dimension={length}
-            justify={last ? "end" : "center"}
-            hang={!last}
-            onUpdate={(d) =>
-              measureLengths.update((measureLengths) => {
-                return measureLengths.set(name, d);
-              })}
+            min={WIDTHS.MIN_COL_WIDTH}
+            max={WIDTHS.MAX_COL_WIDTH}
+            dimension={rowDimensionWidth}
+            onUpdate={(d) => (rowDimensionWidth = d)}
             onMouseDown={(e) => {
-              resizingMeasure = true;
+              resizingMeasure = false;
               onResizeStart(e);
             }}
             onMouseUp={() => {
@@ -269,10 +242,108 @@
             <div class="resize-bar"></div>
           </Resizer>
         </div>
+      {/if}
+      {#each measureGroups as { subHeaders }, groupIndex (groupIndex)}
+        {#each subHeaders as { column: { columnDef: { name } } }, i (name)}
+          {@const length =
+            $measureLengths.get(name) ?? WIDTHS.INIT_MEASURE_WIDTH}
+          {@const last =
+            i === subHeaders.length - 1 &&
+            groupIndex === measureGroups.length - 1}
+          <div class="resizer-cell relative">
+            <Resizer
+              side="right"
+              direction="EW"
+              min={WIDTHS.MIN_MEASURE_WIDTH}
+              max={WIDTHS.MAX_MEASURE_WIDTH}
+              dimension={length}
+              justify={last ? "end" : "center"}
+              hang={!last}
+              onUpdate={(d) =>
+                measureLengths.update((measureLengths) => {
+                  return measureLengths.set(name, d);
+                })}
+              onMouseDown={(e) => {
+                resizingMeasure = true;
+                onResizeStart(e);
+              }}
+              onMouseUp={() => {
+                resizingMeasure = false;
+              }}
+            >
+              <div class="resize-bar"></div>
+            </Resizer>
+          </div>
+        {/each}
       {/each}
     </div>
-  {/each}
-</div>
+  </div>
+{:else}
+  <div
+    class="absolute top-0 z-50 flex pointer-events-none"
+    style:width="{totalLength + rowDimensionWidth}px"
+    style:height="{totalRowSize + totalHeaderHeight + headerGroups.length}px"
+  >
+    <div
+      style:width="{rowDimensionWidth}px"
+      class="sticky left-0 flex-none flex"
+    >
+      <Resizer
+        side="right"
+        direction="EW"
+        min={WIDTHS.MIN_COL_WIDTH}
+        max={WIDTHS.MAX_COL_WIDTH}
+        dimension={rowDimensionWidth}
+        onUpdate={(d) => (rowDimensionWidth = d)}
+        onMouseDown={(e) => {
+          resizingMeasure = false;
+          onResizeStart(e);
+        }}
+        onMouseUp={() => {
+          resizingMeasure = false;
+        }}
+      >
+        <div class="resize-bar"></div>
+      </Resizer>
+    </div>
+
+    {#each measureGroups as { subHeaders }, groupIndex (groupIndex)}
+      <div class="h-full z-50 flex" style:width="{totalMeasureWidth}px">
+        {#each subHeaders as { column: { columnDef: { name } } }, i (name)}
+          {@const length =
+            $measureLengths.get(name) ?? WIDTHS.INIT_MEASURE_WIDTH}
+          {@const last =
+            i === subHeaders.length - 1 &&
+            groupIndex === measureGroups.length - 1}
+          <div style:width="{length}px" class="h-full relative">
+            <Resizer
+              side="right"
+              direction="EW"
+              min={WIDTHS.MIN_MEASURE_WIDTH}
+              max={WIDTHS.MAX_MEASURE_WIDTH}
+              dimension={length}
+              justify={last ? "end" : "center"}
+              hang={!last}
+              onUpdate={(d) =>
+                measureLengths.update((measureLengths) => {
+                  return measureLengths.set(name, d);
+                })}
+              onMouseDown={(e) => {
+                resizingMeasure = true;
+                onResizeStart(e);
+              }}
+              onMouseUp={() => {
+                resizingMeasure = false;
+              }}
+            >
+              <div class="resize-bar"></div>
+            </Resizer>
+          </div>
+        {/each}
+      </div>
+    {/each}
+  </div>
+{/if}
 
 <table
   class:with-row-dimension={hasRowDimension}
@@ -408,6 +479,30 @@
 
   .resize-bar {
     @apply bg-primary-500 w-1 h-full;
+  }
+
+  .resizer-table {
+    display: table;
+    table-layout: fixed;
+    border-spacing: 0;
+  }
+
+  .resizer-colgroup {
+    display: table-column-group;
+  }
+
+  .resizer-col {
+    display: table-column;
+  }
+
+  .resizer-row {
+    display: table-row;
+    height: 100%;
+  }
+
+  .resizer-cell {
+    display: table-cell;
+    height: inherit;
   }
 
   table {

--- a/web-common/src/features/dashboards/pivot/NestedTable.svelte
+++ b/web-common/src/features/dashboards/pivot/NestedTable.svelte
@@ -203,8 +203,11 @@
 </script>
 
 <div
-  class="w-full absolute top-0 z-50 flex pointer-events-none"
-  style:width="{totalLength + rowDimensionWidth}px"
+  class="absolute top-0 z-50 flex pointer-events-none"
+  style:width={fullWidth ? "100%" : "{totalLength + rowDimensionWidth}px"}
+  style:min-width={fullWidth
+    ? "{totalLength + rowDimensionWidth}px"
+    : undefined}
   style:height="{totalRowSize + totalHeaderHeight + headerGroups.length}px"
 >
   <div style:width="{rowDimensionWidth}px" class="sticky left-0 flex-none flex">
@@ -228,13 +231,21 @@
   </div>
 
   {#each measureGroups as { subHeaders }, groupIndex (groupIndex)}
-    <div class="h-full z-50 flex" style:width="{totalMeasureWidth}px">
+    <div
+      class="h-full z-50 flex"
+      style:width="{totalMeasureWidth}px"
+      style:flex={fullWidth ? "1 1 {totalMeasureWidth}px" : undefined}
+    >
       {#each subHeaders as { column: { columnDef: { name } } }, i (name)}
         {@const length = $measureLengths.get(name) ?? WIDTHS.INIT_MEASURE_WIDTH}
         {@const last =
           i === subHeaders.length - 1 &&
           groupIndex === measureGroups.length - 1}
-        <div style:width="{length}px" class="h-full relative">
+        <div
+          style:width="{length}px"
+          style:flex={fullWidth ? "1 1 {length}px" : undefined}
+          class="h-full relative"
+        >
           <Resizer
             side="right"
             direction="EW"

--- a/web-common/src/features/dashboards/pivot/NestedTable.svelte
+++ b/web-common/src/features/dashboards/pivot/NestedTable.svelte
@@ -32,7 +32,6 @@
   export let measures: MeasureColumnProps;
   export let totalsRow: PivotDataRow | undefined;
   export let canShowDataViewer = false;
-  export let fullWidth = false;
   export let activeCell: { rowId: string; columnId: string } | null | undefined;
 
   // Table props

--- a/web-common/src/features/dashboards/pivot/NestedTable.svelte
+++ b/web-common/src/features/dashboards/pivot/NestedTable.svelte
@@ -32,6 +32,7 @@
   export let measures: MeasureColumnProps;
   export let totalsRow: PivotDataRow | undefined;
   export let canShowDataViewer = false;
+  export let fullWidth = false;
   export let activeCell: { rowId: string; columnId: string } | null | undefined;
 
   // Table props
@@ -160,7 +161,12 @@
     );
   }
 
-  function shouldShowHeaderRightBorder(header: any, index: number): boolean {
+  function shouldShowHeaderRightBorder(
+    header: any,
+    index: number,
+    total: number,
+  ): boolean {
+    if (index === total - 1) return false;
     const isMeasure = isMeasureColumn(header, index);
     if (!isMeasure) return true;
 
@@ -188,7 +194,8 @@
     }, "");
   }
 
-  function shouldShowRightBorder(index: number): boolean {
+  function shouldShowRightBorder(index: number, total: number): boolean {
+    if (index === total - 1) return false;
     let offset = 0;
     if (!hasRowDimension) offset = 1;
     return (index + offset) % measureCount === 0;
@@ -265,7 +272,8 @@
   class:with-totals-row={!!totalsRow}
   class:with-measures={hasMeasures}
   role="presentation"
-  style:width="{totalLength + rowDimensionWidth}px"
+  style:width={fullWidth ? "100%" : "{totalLength + rowDimensionWidth}px"}
+  style:min-width={fullWidth ? "{totalLength + rowDimensionWidth}px" : undefined}
   onclick={modified({ shift: onCellCopy, click: onCellClick })}
   onmousemove={onMouseMove}
   onmouseleave={onTableLeave}
@@ -299,7 +307,7 @@
               class:cursor-pointer={header.column.getCanSort()}
               class:select-none={header.column.getCanSort()}
               class:flex-row-reverse={isMeasureColumn(header, i)}
-              class:border-r={shouldShowHeaderRightBorder(header, i)}
+              class:border-r={shouldShowHeaderRightBorder(header, i, headerGroup.headers.length)}
               onclick={header.column.getToggleSortingHandler()}
             >
               {#if !header.isPlaceholder}
@@ -343,7 +351,7 @@
             class="ui-copy-number cell truncate group/cell"
             class:active-cell={isActive}
             class:interactive-cell={canShowDataViewer}
-            class:border-r={shouldShowRightBorder(i)}
+            class:border-r={shouldShowRightBorder(i, cells.length)}
             data-value={tooltipValue}
             data-rowid={cell.row.id}
             data-columnid={cell.column.id}

--- a/web-common/src/features/dashboards/pivot/PivotTable.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTable.svelte
@@ -325,7 +325,6 @@
       {totalRowSize}
       {canShowDataViewer}
       {hasMeasureContextColumns}
-      {fullWidth}
       activeCell={$pivotState.activeCell}
       {assembled}
       {onMouseMove}
@@ -348,7 +347,6 @@
       {dataRows}
       {measures}
       {canShowDataViewer}
-      {fullWidth}
       activeCell={$pivotState.activeCell}
       {assembled}
       {scrollLeft}

--- a/web-common/src/features/dashboards/pivot/PivotTable.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTable.svelte
@@ -305,6 +305,7 @@
   class:rounded-sm={rounded}
   class:w-full={fullWidth}
   class:w-fit={!fullWidth}
+  class:auto-hide-scrollbar={fullWidth}
   class="table-wrapper relative"
   style:--row-height="{ROW_HEIGHT}px"
   style:--header-height="{HEADER_HEIGHT}px"
@@ -375,5 +376,29 @@
   .table-wrapper {
     @apply overflow-auto h-fit max-h-full max-w-full;
     @apply z-40 select-none;
+  }
+
+  .auto-hide-scrollbar {
+    scrollbar-gutter: stable;
+  }
+
+  .auto-hide-scrollbar::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+    background: transparent;
+  }
+
+  .auto-hide-scrollbar::-webkit-scrollbar-thumb {
+    background: transparent;
+    border-radius: 3px;
+  }
+
+  .auto-hide-scrollbar:hover::-webkit-scrollbar-thumb,
+  .auto-hide-scrollbar:active::-webkit-scrollbar-thumb {
+    background: rgba(0, 0, 0, 0.2);
+  }
+
+  .auto-hide-scrollbar::-webkit-scrollbar-corner {
+    background: transparent;
   }
 </style>

--- a/web-common/src/features/dashboards/pivot/PivotTable.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTable.svelte
@@ -48,6 +48,7 @@
   export let pivotState: Readable<PivotState>;
   export let canShowDataViewer = false;
   export let border = true;
+  export let fullWidth = false;
   export let overscan = 20;
   export let rounded = true;
   export let setPivotExpanded: (expanded: ExpandedState) => void;
@@ -302,6 +303,8 @@
 <div
   class:border
   class:rounded-sm={rounded}
+  class:w-full={fullWidth}
+  class:w-fit={!fullWidth}
   class="table-wrapper relative"
   style:--row-height="{ROW_HEIGHT}px"
   style:--header-height="{HEADER_HEIGHT}px"
@@ -368,7 +371,7 @@
 
 <style lang="postcss">
   .table-wrapper {
-    @apply overflow-auto h-fit max-h-full w-fit max-w-full;
+    @apply overflow-auto h-fit max-h-full max-w-full;
     @apply z-40 select-none;
   }
 </style>

--- a/web-common/src/features/dashboards/pivot/PivotTable.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTable.svelte
@@ -325,6 +325,7 @@
       {totalRowSize}
       {canShowDataViewer}
       {hasMeasureContextColumns}
+      {fullWidth}
       activeCell={$pivotState.activeCell}
       {assembled}
       {onMouseMove}
@@ -347,6 +348,7 @@
       {dataRows}
       {measures}
       {canShowDataViewer}
+      {fullWidth}
       activeCell={$pivotState.activeCell}
       {assembled}
       {scrollLeft}


### PR DESCRIPTION
- `PivotTable`'s `.table-wrapper` used `w-fit`, sizing the table to content width rather than filling the container
- When a canvas pivot widget has a title/description, the visible border exposed this gap as a separate resizable-looking box
- Added `fullWidth` prop to `PivotTable` (default `false`) that switches from `w-fit` to `w-full`; passed from `CanvasPivotRenderer` so canvas pivot tables always fill their widget card
- Explore dashboard pivot tables are unaffected

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*