### PR TITLE
fix: inject query priority into proto messages for server-side scheduling

### DIFF
--- a/web-common/src/features/dashboards/time-controls/rill-time-ranges.ts
+++ b/web-common/src/features/dashboards/time-controls/rill-time-ranges.ts
@@ -91,7 +91,6 @@ export async function fetchTimeRanges({
     expressions: rillTimes,
     timeZone,
     executionTime: executionTime as any,
-    priority: 100,
     timeDimension,
   };
 

--- a/web-common/src/runtime-client/v2/request-priorities.ts
+++ b/web-common/src/runtime-client/v2/request-priorities.ts
@@ -7,9 +7,12 @@
 // Maps ConnectRPC method names to priority weights.
 // Higher priority = dispatched first.
 const MethodPriorities: Record<string, number> = {
+  // Critical: pre-dashboard-load; must complete before other dashboard queries
+  MetricsViewTimeRange: 100,
+  MetricsViewTimeRanges: 100,
+
   // High priority: user-visible data
   MetricsViewRows: 50,
-  MetricsViewTimeRange: 50,
   ColumnProfile: 45,
 
   // Medium: charts and summaries
@@ -18,11 +21,13 @@ const MethodPriorities: Record<string, number> = {
   ColumnCardinality: 35,
   MetricsViewAggregation: 30,
   MetricsViewTimeSeries: 30,
+  MetricsViewComparison: 30,
   NumericHistogram: 30,
   MetricsViewTotals: 30,
 
   // Low: exploratory queries
   MetricsViewToplist: 10,
+  MetricsViewAnnotations: 10,
   RugHistogram: 10,
   DescriptiveStatistics: 10,
 };
@@ -40,6 +45,8 @@ export function getPriorityForMethod(methodName: string): number {
 const ColumnQueryPriorities: Record<string, number> = {
   topk: 10,
   timeseries: 30,
+  "rollup-interval": 30,
+  "smallest-time-grain": 30,
   "numeric-histogram": 30,
   "rug-histogram": 10,
   "descriptive-statistics": 10,

--- a/web-common/src/runtime-client/v2/request-queue.spec.ts
+++ b/web-common/src/runtime-client/v2/request-queue.spec.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createQueueInterceptor, RequestQueue } from "./request-queue";
 
-/** Minimal mock of a ConnectRPC UnaryRequest for interceptor testing. */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function makeRequest(
-  methodName: string,
-  message: Record<string, unknown>,
-): any {
+/**
+ * Builds a minimal ConnectRPC-shaped request object.
+ * Only the fields read by createQueueInterceptor are meaningful;
+ * the rest are stubs to satisfy the interface.
+ */
+function fakeRequest(methodName: string, message: Record<string, unknown>) {
   return {
     stream: false as const,
     service: {},
@@ -17,31 +17,31 @@ function makeRequest(
     header: new Headers(),
     contextValues: {},
     message,
-  };
+  } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 describe("createQueueInterceptor", () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let run: (req: any) => Promise<any>;
-  let next: ReturnType<typeof vi.fn>;
+  let sendRequest: (req: any) => Promise<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  let transport: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     const queue = new RequestQueue({ maxConcurrent: 10 });
     const interceptor = createQueueInterceptor(queue);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    next = vi.fn().mockResolvedValue({ stream: false, message: {} }) as any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    run = interceptor(next as any);
+
+    // `transport` simulates the ConnectRPC transport layer (the `next` fn).
+    // The interceptor wraps it, giving us `sendRequest`.
+    transport = vi.fn().mockResolvedValue({ stream: false, message: {} });
+    sendRequest = interceptor(transport as any); // eslint-disable-line @typescript-eslint/no-explicit-any
   });
 
   it("injects method-derived priority when message has no priority", async () => {
     const message: Record<string, unknown> = {
       metricsViewName: "test_view",
     };
-    await run(makeRequest("MetricsViewTimeRanges", message));
+    await sendRequest(fakeRequest("MetricsViewTimeRanges", message));
 
     expect(message.priority).toBe(100);
-    expect(next).toHaveBeenCalledOnce();
+    expect(transport).toHaveBeenCalledOnce();
   });
 
   it("injects method-derived priority when message has priority 0", async () => {
@@ -49,7 +49,7 @@ describe("createQueueInterceptor", () => {
       metricsViewName: "test_view",
       priority: 0,
     };
-    await run(makeRequest("MetricsViewAggregation", message));
+    await sendRequest(fakeRequest("MetricsViewAggregation", message));
 
     expect(message.priority).toBe(30);
   });
@@ -59,14 +59,14 @@ describe("createQueueInterceptor", () => {
       metricsViewName: "test_view",
       priority: 60,
     };
-    await run(makeRequest("MetricsViewAggregation", message));
+    await sendRequest(fakeRequest("MetricsViewAggregation", message));
 
     expect(message.priority).toBe(60);
   });
 
   it("falls back to DEFAULT_PRIORITY for unknown methods", async () => {
     const message: Record<string, unknown> = {};
-    await run(makeRequest("SomeUnknownMethod", message));
+    await sendRequest(fakeRequest("SomeUnknownMethod", message));
 
     expect(message.priority).toBe(10);
   });

--- a/web-common/src/runtime-client/v2/request-queue.spec.ts
+++ b/web-common/src/runtime-client/v2/request-queue.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createQueueInterceptor, RequestQueue } from "./request-queue";
+import type { Interceptor } from "@connectrpc/connect";
+
+/** Minimal mock of a ConnectRPC UnaryRequest for interceptor testing. */
+function makeRequest(methodName: string, message: Record<string, unknown>) {
+  return {
+    stream: false as const,
+    service: {} as any,
+    method: { name: methodName } as any,
+    url: "",
+    init: {},
+    signal: new AbortController().signal,
+    header: new Headers(),
+    contextValues: {} as any,
+    message: message as any,
+  };
+}
+
+describe("createQueueInterceptor", () => {
+  let interceptor: Interceptor;
+  let next: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    const queue = new RequestQueue({ maxConcurrent: 10 });
+    interceptor = createQueueInterceptor(queue);
+    next = vi.fn().mockResolvedValue({ stream: false, message: {} });
+  });
+
+  it("injects method-derived priority when message has no priority", async () => {
+    const message: Record<string, unknown> = {
+      metricsViewName: "test_view",
+    };
+    await interceptor(next)(makeRequest("MetricsViewTimeRanges", message));
+
+    expect(message.priority).toBe(100);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("injects method-derived priority when message has priority 0", async () => {
+    const message: Record<string, unknown> = {
+      metricsViewName: "test_view",
+      priority: 0,
+    };
+    await interceptor(next)(makeRequest("MetricsViewAggregation", message));
+
+    expect(message.priority).toBe(30);
+  });
+
+  it("preserves caller-set priority when non-zero", async () => {
+    const message: Record<string, unknown> = {
+      metricsViewName: "test_view",
+      priority: 60,
+    };
+    await interceptor(next)(makeRequest("MetricsViewAggregation", message));
+
+    expect(message.priority).toBe(60);
+  });
+
+  it("falls back to DEFAULT_PRIORITY for unknown methods", async () => {
+    const message: Record<string, unknown> = {};
+    await interceptor(next)(makeRequest("SomeUnknownMethod", message));
+
+    expect(message.priority).toBe(10);
+  });
+});

--- a/web-common/src/runtime-client/v2/request-queue.spec.ts
+++ b/web-common/src/runtime-client/v2/request-queue.spec.ts
@@ -1,37 +1,44 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createQueueInterceptor, RequestQueue } from "./request-queue";
-import type { Interceptor } from "@connectrpc/connect";
 
 /** Minimal mock of a ConnectRPC UnaryRequest for interceptor testing. */
-function makeRequest(methodName: string, message: Record<string, unknown>) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeRequest(
+  methodName: string,
+  message: Record<string, unknown>,
+): any {
   return {
     stream: false as const,
-    service: {} as any,
-    method: { name: methodName } as any,
+    service: {},
+    method: { name: methodName },
     url: "",
     init: {},
     signal: new AbortController().signal,
     header: new Headers(),
-    contextValues: {} as any,
-    message: message as any,
+    contextValues: {},
+    message,
   };
 }
 
 describe("createQueueInterceptor", () => {
-  let interceptor: Interceptor;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let run: (req: any) => Promise<any>;
   let next: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     const queue = new RequestQueue({ maxConcurrent: 10 });
-    interceptor = createQueueInterceptor(queue);
-    next = vi.fn().mockResolvedValue({ stream: false, message: {} });
+    const interceptor = createQueueInterceptor(queue);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    next = vi.fn().mockResolvedValue({ stream: false, message: {} }) as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    run = interceptor(next as any);
   });
 
   it("injects method-derived priority when message has no priority", async () => {
     const message: Record<string, unknown> = {
       metricsViewName: "test_view",
     };
-    await interceptor(next)(makeRequest("MetricsViewTimeRanges", message));
+    await run(makeRequest("MetricsViewTimeRanges", message));
 
     expect(message.priority).toBe(100);
     expect(next).toHaveBeenCalledOnce();
@@ -42,7 +49,7 @@ describe("createQueueInterceptor", () => {
       metricsViewName: "test_view",
       priority: 0,
     };
-    await interceptor(next)(makeRequest("MetricsViewAggregation", message));
+    await run(makeRequest("MetricsViewAggregation", message));
 
     expect(message.priority).toBe(30);
   });
@@ -52,14 +59,14 @@ describe("createQueueInterceptor", () => {
       metricsViewName: "test_view",
       priority: 60,
     };
-    await interceptor(next)(makeRequest("MetricsViewAggregation", message));
+    await run(makeRequest("MetricsViewAggregation", message));
 
     expect(message.priority).toBe(60);
   });
 
   it("falls back to DEFAULT_PRIORITY for unknown methods", async () => {
     const message: Record<string, unknown> = {};
-    await interceptor(next)(makeRequest("SomeUnknownMethod", message));
+    await run(makeRequest("SomeUnknownMethod", message));
 
     expect(message.priority).toBe(10);
   });

--- a/web-common/src/runtime-client/v2/request-queue.ts
+++ b/web-common/src/runtime-client/v2/request-queue.ts
@@ -233,12 +233,9 @@ export class RequestQueue {
  * Extract the resource name from a ConnectRPC request message.
  * Looks for common field patterns in runtime API request messages.
  */
-function extractResourceName(req: { message: unknown }): string | undefined {
-  const msg = req.message as Record<string, unknown>;
-  // MetricsView queries use metricsViewName or metricsView
+function extractResourceName(msg: Record<string, unknown>): string | undefined {
   if (typeof msg.metricsViewName === "string") return msg.metricsViewName;
   if (typeof msg.metricsView === "string") return msg.metricsView;
-  // Column profiling queries use tableName
   if (typeof msg.tableName === "string") return msg.tableName;
   return undefined;
 }
@@ -249,11 +246,17 @@ function extractResourceName(req: { message: unknown }): string | undefined {
  */
 export function createQueueInterceptor(queue: RequestQueue): Interceptor {
   return (next) => async (req) => {
+    const msg = req.message as Record<string, unknown>;
     const priority = getPriorityForMethod(req.method.name);
-    const resourceName = extractResourceName(req);
-    const columnName = (req.message as Record<string, unknown>).columnName as
-      | string
-      | undefined;
+    const resourceName = extractResourceName(msg);
+    const columnName = msg.columnName as string | undefined;
+
+    // Inject priority into the proto message so the server can schedule
+    // accordingly (e.g. DuckDB/ClickHouse connection semaphore ordering).
+    // If the caller already set a non-zero priority, respect it.
+    if (!msg.priority) {
+      msg.priority = priority;
+    }
 
     return queue.enqueue({
       priority,


### PR DESCRIPTION
After the ConnectRPC migration, the queue interceptor only used priority for client-side request ordering but never set it on the proto message. The server saw `priority = 0` (lowest) for all dashboard queries, causing them to land in the low capacity lane of the DuckDB/ClickHouse connection semaphore.

- The interceptor now injects the method-derived priority into the proto message before sending, restoring the unified priority behavior of the old HTTP request queue
- Caller-set priorities (e.g. column profile active/inactive boost) are preserved via a non-zero check
- Added missing methods to `MethodPriorities` (`MetricsViewTimeRanges`, `MetricsViewComparison`, `MetricsViewAnnotations`) and `ColumnQueryPriorities` (`rollup-interval`, `smallest-time-grain`)
- Bumped `MetricsViewTimeRange(s)` to priority 100 since both gate dashboard rendering
- Removed the now-redundant hardcoded `priority: 100` from `rill-time-ranges.ts`

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---

*Developed in collaboration with Claude Code*