### PR TITLE
nit: add themeing to AI Bar

### DIFF
--- a/web-admin/src/routes/-/embed/+layout.svelte
+++ b/web-admin/src/routes/-/embed/+layout.svelte
@@ -12,6 +12,8 @@
   import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors.ts";
   import { featureFlags } from "@rilldata/web-common/features/feature-flags";
   import DashboardChat from "@rilldata/web-common/features/chat/DashboardChat.svelte";
+  import ThemeProvider from "@rilldata/web-common/features/dashboards/ThemeProvider.svelte";
+  import { activeDashboardTheme } from "@rilldata/web-common/features/themes/active-dashboard-theme";
   import {
     createIframeRPCHandler,
     emitNotification,
@@ -134,12 +136,14 @@
     authContext="embed"
   >
     {#if showTopBar}
-      <div
-        class="flex items-center w-full pr-4 py-1 min-h-[2.5rem]"
-        class:border-b={!onProjectPage}
-      >
-        <EmbedHeader {activeResource} {navigationEnabled} />
-      </div>
+      <ThemeProvider theme={$activeDashboardTheme} applyLayout={false}>
+        <div
+          class="flex items-center w-full pr-4 py-1 min-h-[2.5rem] bg-surface-subtle"
+          class:border-b={!onProjectPage}
+        >
+          <EmbedHeader {activeResource} {navigationEnabled} />
+        </div>
+      </ThemeProvider>
     {/if}
 
     <div class="flex h-full overflow-hidden">


### PR DESCRIPTION
Are we removing this theme bar anytime soon? it doesnt get themes applied, looks weird

<img width="1486" height="137" alt="Screenshot 2026-04-09 at 17 49 01" src="https://github.com/user-attachments/assets/6b2ee896-411c-4559-83ec-578de0df212f" />

new: (mind the colors)

<img width="2504" height="143" alt="Screenshot 2026-04-10 at 9 05 55" src="https://github.com/user-attachments/assets/321fad82-7257-4be2-8f7a-d785d215349e" />


**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
