### PR TITLE
fix: canvas and explore visual editing e2e test flakyness

### DIFF
--- a/web-common/src/features/entity-management/file-and-resource-watcher.ts
+++ b/web-common/src/features/entity-management/file-and-resource-watcher.ts
@@ -239,11 +239,11 @@ export class FileAndResourceWatcher {
   private async handleResourceEvent(res: V1WatchResourcesResponse) {
     // Log resource status to the browser console during e2e tests. Currently, our e2e tests make assertions
     // based on these logs. However, the e2e tests really should make UI-based assertions.
-    if (import.meta.env.VITE_PLAYWRIGHT_TEST) {
-      console.log(
-        `[${res.resource?.meta?.reconcileStatus}] ${res.name?.kind}/${res.name?.name}`,
-      );
-    }
+    // if (import.meta.env.VITE_PLAYWRIGHT_TEST) {
+    console.log(
+      `[${res.resource?.meta?.reconcileStatus} (${res.resource?.meta?.stateVersion})] ${res.name?.kind}/${res.name?.name}`,
+    );
+    // }
 
     // Type guards
     if (!res?.event || !res?.name || !res?.name?.name || !res?.name?.kind) {
@@ -300,8 +300,18 @@ export class FileAndResourceWatcher {
         if (
           res.resource.meta.stateVersion ===
           previousResource?.meta?.stateVersion
-        )
+        ) {
+          console.log(
+            `[${res.resource?.meta?.reconcileStatus} (${res.resource?.meta?.stateVersion})] ${res.name?.kind}/${res.name?.name}` +
+              ` Skipping invalidation (${previousResource?.meta?.stateVersion})`,
+          );
           return;
+        } else {
+          console.log(
+            `[${res.resource?.meta?.reconcileStatus} (${res.resource?.meta?.stateVersion})] ${res.name?.kind}/${res.name?.name}` +
+              ` Invalidating`,
+          );
+        }
 
         // Refetch `ListResources` queries
         void queryClient.refetchQueries({

--- a/web-common/src/features/entity-management/file-and-resource-watcher.ts
+++ b/web-common/src/features/entity-management/file-and-resource-watcher.ts
@@ -15,6 +15,7 @@ import {
   getRuntimeServiceListFilesQueryKey,
   getRuntimeServiceListResourcesQueryKey,
   V1FileEvent,
+  V1ReconcileStatus,
   type V1Resource,
   V1ResourceEvent,
   type V1WatchFilesResponse,
@@ -239,11 +240,11 @@ export class FileAndResourceWatcher {
   private async handleResourceEvent(res: V1WatchResourcesResponse) {
     // Log resource status to the browser console during e2e tests. Currently, our e2e tests make assertions
     // based on these logs. However, the e2e tests really should make UI-based assertions.
-    // if (import.meta.env.VITE_PLAYWRIGHT_TEST) {
-    console.log(
-      `[${res.resource?.meta?.reconcileStatus} (${res.resource?.meta?.stateVersion})] ${res.name?.kind}/${res.name?.name}`,
-    );
-    // }
+    if (import.meta.env.VITE_PLAYWRIGHT_TEST) {
+      console.log(
+        `[${res.resource?.meta?.reconcileStatus}] ${res.name?.kind}/${res.name?.name}`,
+      );
+    }
 
     // Type guards
     if (!res?.event || !res?.name || !res?.name?.name || !res?.name?.kind) {
@@ -296,21 +297,17 @@ export class FileAndResourceWatcher {
           return;
         }
 
-        // Proceed to query invalidations only when the resource state has changed
-        if (
+        const resourceVersionChanged =
           res.resource.meta.stateVersion ===
-          previousResource?.meta?.stateVersion
-        ) {
-          console.log(
-            `[${res.resource?.meta?.reconcileStatus} (${res.resource?.meta?.stateVersion})] ${res.name?.kind}/${res.name?.name}` +
-              ` Skipping invalidation (${previousResource?.meta?.stateVersion})`,
-          );
+          previousResource?.meta?.stateVersion;
+        const resourceFinishedReconciling =
+          previousResource?.meta?.reconcileStatus !==
+            V1ReconcileStatus.RECONCILE_STATUS_IDLE &&
+          res.resource.meta.reconcileStatus ===
+            V1ReconcileStatus.RECONCILE_STATUS_IDLE;
+        // Proceed to query invalidations only when the resource state has changed
+        if (!resourceVersionChanged && !resourceFinishedReconciling) {
           return;
-        } else {
-          console.log(
-            `[${res.resource?.meta?.reconcileStatus} (${res.resource?.meta?.stateVersion})] ${res.name?.kind}/${res.name?.name}` +
-              ` Invalidating`,
-          );
         }
 
         // Refetch `ListResources` queries

--- a/web-common/src/features/visual-editing/MeasureDimensionSelector.svelte
+++ b/web-common/src/features/visual-editing/MeasureDimensionSelector.svelte
@@ -47,12 +47,6 @@
         onSelectAll();
         excludeProxy = excludeMode;
       } else if (field === "subset") {
-        console.log("selectedProxy", [...selectedProxy.values()]);
-        console.log(
-          "items",
-          items,
-          items.map(({ name }) => name).filter(isString),
-        );
         if (selectedProxy.size) {
           setItems(Array.from(selectedProxy), excludeProxy);
         } else {

--- a/web-common/src/features/visual-editing/MeasureDimensionSelector.svelte
+++ b/web-common/src/features/visual-editing/MeasureDimensionSelector.svelte
@@ -47,6 +47,12 @@
         onSelectAll();
         excludeProxy = excludeMode;
       } else if (field === "subset") {
+        console.log("selectedProxy", [...selectedProxy.values()]);
+        console.log(
+          "items",
+          items,
+          items.map(({ name }) => name).filter(isString),
+        );
         if (selectedProxy.size) {
           setItems(Array.from(selectedProxy), excludeProxy);
         } else {


### PR DESCRIPTION
Based on logs there are cases where list of resources is not refetched leading to errors in E2E. In canvas tests it fails stating metrics view not found and visual editing doesnt populate measures and dimensions from metrics views.

When metrics view is queued for reconcile and the page is opened the internal state would have a state with a particular version. Once reconcile ends we would not refetch since version didnt change. So adding additional checks when state changes to idle.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
