### PR TITLE
fix: default snap for XTD time ranges

### DIFF
--- a/web-common/src/features/dashboards/url-state/time-ranges/RillTime.ts
+++ b/web-common/src/features/dashboards/url-state/time-ranges/RillTime.ts
@@ -246,7 +246,7 @@ export class RillPeriodToGrainInterval implements RillTimeInterval {
   }
 
   public getGrain() {
-    return GrainAliasToV1TimeGrain[this.grain];
+    return getLowerOrderGrain(GrainAliasToV1TimeGrain[this.grain]);
   }
 
   public toString() {

--- a/web-common/src/features/dashboards/url-state/time-ranges/rill-time.spec.ts
+++ b/web-common/src/features/dashboards/url-state/time-ranges/rill-time.spec.ts
@@ -7,7 +7,10 @@ import {
   type RillTimeAsOfLabel,
   RillTimeLabel,
 } from "@rilldata/web-common/features/dashboards/url-state/time-ranges/RillTime.ts";
-import { GrainAliasToV1TimeGrain } from "@rilldata/web-common/lib/time/new-grains";
+import {
+  getLowerOrderGrain,
+  GrainAliasToV1TimeGrain,
+} from "@rilldata/web-common/lib/time/new-grains";
 import { V1TimeGrain } from "@rilldata/web-common/runtime-client";
 import type { DateTimeUnit } from "luxon";
 import nearley from "nearley";
@@ -98,7 +101,7 @@ function getMultiPeriodTestCases(n: number): TestCase[] {
 
 function getPeriodToDateTestCases(): TestCase[] {
   return GRAINS.map((g) => {
-    const protoGrain = GrainAliasToV1TimeGrain[g];
+    const protoGrain = getLowerOrderGrain(GrainAliasToV1TimeGrain[g]);
     const label = capitalizeFirstChar(`${GRAIN_TO_LUXON[g]} to date`);
     return <TestCase[]>[
       [`${g}TD as of watermark/${g}`, label, true, protoGrain, undefined],
@@ -111,6 +114,8 @@ function getPeriodToDateTestCases(): TestCase[] {
       ],
 
       [`${g}TD as of watermark/h`, label, true, protoGrain, undefined],
+
+      [`${g}TD`, label, false, protoGrain, undefined],
     ];
   }).flat();
 }


### PR DESCRIPTION
Default snap selected for XTD was equal to the grain, eg: for MTD the snap was month. This is incorrect since snapping by month for MTD will give 0 length range.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
