### PR TITLE
Adding `slots` to event, with environment

### DIFF
--- a/admin/deployments.go
+++ b/admin/deployments.go
@@ -542,8 +542,7 @@ func (s *Service) NewDeploymentAnnotations(org *database.Organization, proj *dat
 		projAnnotations:    proj.Annotations,
 	}
 	slots, _ := resolveSlots(proj, environment)
-	da.projSlots = fmt.Sprint(slots)
-	da.environment = environment
+	da.slots = fmt.Sprint(slots)
 	return da
 }
 
@@ -565,14 +564,13 @@ type DeploymentAnnotations struct {
 	orgCustomDomain    string
 	projID             string
 	projName           string
-	projSlots          string
-	environment        string
+	slots              string
 	projProvisioner    string
 	projAnnotations    map[string]string
 }
 
 func (da *DeploymentAnnotations) ToMap() map[string]string {
-	res := make(map[string]string, len(da.projAnnotations)+8)
+	res := make(map[string]string, len(da.projAnnotations)+7)
 	for k, v := range da.projAnnotations {
 		res[k] = v
 	}
@@ -581,8 +579,7 @@ func (da *DeploymentAnnotations) ToMap() map[string]string {
 	res["organization_plan"] = da.orgBillingPlanName
 	res["project_id"] = da.projID
 	res["project_name"] = da.projName
-	res["project_slots"] = da.projSlots
-	res["environment"] = da.environment
+	res["slots"] = da.slots
 	res["project_provisioner"] = da.projProvisioner
 	return res
 }

--- a/admin/deployments.go
+++ b/admin/deployments.go
@@ -194,7 +194,7 @@ func (s *Service) StartDeploymentInner(ctx context.Context, depl *database.Deplo
 	}
 
 	// Prepare deployment annotations
-	annotations := s.NewDeploymentAnnotations(org, proj)
+	annotations := s.NewDeploymentAnnotations(org, proj, depl.Environment)
 
 	// Resolve slots based on environment
 	var slots int
@@ -403,7 +403,7 @@ func (s *Service) UpdateDeploymentInner(ctx context.Context, d *database.Deploym
 	}
 
 	// Prepare deployment annotations
-	annotations := s.NewDeploymentAnnotations(org, proj)
+	annotations := s.NewDeploymentAnnotations(org, proj, d.Environment)
 
 	// Resolve slots based on environment
 	var slots int
@@ -538,23 +538,28 @@ func (s *Service) IssueRuntimeManagementToken(aud string) (string, error) {
 	return jwt, nil
 }
 
-func (s *Service) NewDeploymentAnnotations(org *database.Organization, proj *database.Project) DeploymentAnnotations {
+func (s *Service) NewDeploymentAnnotations(org *database.Organization, proj *database.Project, environment string) DeploymentAnnotations {
 	var orgBillingPlanName string
 	if org.BillingPlanName != nil {
 		orgBillingPlanName = *org.BillingPlanName
 	}
-	return DeploymentAnnotations{
+	da := DeploymentAnnotations{
 		orgID:              org.ID,
 		orgName:            org.Name,
 		orgBillingPlanName: orgBillingPlanName,
 		orgCustomDomain:    org.CustomDomain,
 		projID:             proj.ID,
 		projName:           proj.Name,
-		projProdSlots:      fmt.Sprint(proj.ProdSlots),
-		projDevSlots:       fmt.Sprint(proj.DevSlots),
 		projProvisioner:    proj.Provisioner,
 		projAnnotations:    proj.Annotations,
 	}
+	switch environment {
+	case "prod":
+		da.projProdSlots = fmt.Sprint(proj.ProdSlots)
+	case "dev":
+		da.projDevSlots = fmt.Sprint(proj.DevSlots)
+	}
+	return da
 }
 
 func (s *Service) FindProvisionedRuntimeResource(ctx context.Context, deploymentID string) (*database.ProvisionerResource, bool, error) {
@@ -591,8 +596,12 @@ func (da *DeploymentAnnotations) ToMap() map[string]string {
 	res["organization_plan"] = da.orgBillingPlanName
 	res["project_id"] = da.projID
 	res["project_name"] = da.projName
-	res["project_prod_slots"] = da.projProdSlots
-	res["project_dev_slots"] = da.projDevSlots
+	if da.projProdSlots != "" {
+		res["project_prod_slots"] = da.projProdSlots
+	}
+	if da.projDevSlots != "" {
+		res["project_dev_slots"] = da.projDevSlots
+	}
 	res["project_provisioner"] = da.projProvisioner
 	return res
 }

--- a/admin/deployments.go
+++ b/admin/deployments.go
@@ -551,6 +551,7 @@ func (s *Service) NewDeploymentAnnotations(org *database.Organization, proj *dat
 		projID:             proj.ID,
 		projName:           proj.Name,
 		projProdSlots:      fmt.Sprint(proj.ProdSlots),
+		projDevSlots:       fmt.Sprint(proj.DevSlots),
 		projProvisioner:    proj.Provisioner,
 		projAnnotations:    proj.Annotations,
 	}
@@ -575,12 +576,13 @@ type DeploymentAnnotations struct {
 	projID             string
 	projName           string
 	projProdSlots      string
+	projDevSlots       string
 	projProvisioner    string
 	projAnnotations    map[string]string
 }
 
 func (da *DeploymentAnnotations) ToMap() map[string]string {
-	res := make(map[string]string, len(da.projAnnotations)+7)
+	res := make(map[string]string, len(da.projAnnotations)+8)
 	for k, v := range da.projAnnotations {
 		res[k] = v
 	}
@@ -590,6 +592,7 @@ func (da *DeploymentAnnotations) ToMap() map[string]string {
 	res["project_id"] = da.projID
 	res["project_name"] = da.projName
 	res["project_prod_slots"] = da.projProdSlots
+	res["project_dev_slots"] = da.projDevSlots
 	res["project_provisioner"] = da.projProvisioner
 	return res
 }

--- a/admin/deployments.go
+++ b/admin/deployments.go
@@ -197,15 +197,9 @@ func (s *Service) StartDeploymentInner(ctx context.Context, depl *database.Deplo
 	annotations := s.NewDeploymentAnnotations(org, proj, depl.Environment)
 
 	// Resolve slots based on environment
-	var slots int
-	switch depl.Environment {
-	case "prod":
-		slots = proj.ProdSlots
-	case "dev":
-		slots = proj.DevSlots
-	default:
-		// Invalid environment
-		return errors.New("Invalid environment, must be either 'prod' or 'dev'")
+	slots, err := resolveSlots(proj, depl.Environment)
+	if err != nil {
+		return err
 	}
 
 	// Provision the runtime
@@ -406,15 +400,9 @@ func (s *Service) UpdateDeploymentInner(ctx context.Context, d *database.Deploym
 	annotations := s.NewDeploymentAnnotations(org, proj, d.Environment)
 
 	// Resolve slots based on environment
-	var slots int
-	switch d.Environment {
-	case "prod":
-		slots = proj.ProdSlots
-	case "dev":
-		slots = proj.DevSlots
-	default:
-		// Invalid environment
-		return errors.New("Invalid environment, must be either 'prod' or 'dev'")
+	slots, err := resolveSlots(proj, d.Environment)
+	if err != nil {
+		return err
 	}
 
 	// Provision the runtime. This is idempotent and will (partially) update the existing provisioned runtime if the config has changed.
@@ -553,12 +541,9 @@ func (s *Service) NewDeploymentAnnotations(org *database.Organization, proj *dat
 		projProvisioner:    proj.Provisioner,
 		projAnnotations:    proj.Annotations,
 	}
-	switch environment {
-	case "prod":
-		da.projProdSlots = fmt.Sprint(proj.ProdSlots)
-	case "dev":
-		da.projDevSlots = fmt.Sprint(proj.DevSlots)
-	}
+	slots, _ := resolveSlots(proj, environment)
+	da.projSlots = fmt.Sprint(slots)
+	da.environment = environment
 	return da
 }
 
@@ -580,8 +565,8 @@ type DeploymentAnnotations struct {
 	orgCustomDomain    string
 	projID             string
 	projName           string
-	projProdSlots      string
-	projDevSlots       string
+	projSlots          string
+	environment        string
 	projProvisioner    string
 	projAnnotations    map[string]string
 }
@@ -596,14 +581,22 @@ func (da *DeploymentAnnotations) ToMap() map[string]string {
 	res["organization_plan"] = da.orgBillingPlanName
 	res["project_id"] = da.projID
 	res["project_name"] = da.projName
-	if da.projProdSlots != "" {
-		res["project_prod_slots"] = da.projProdSlots
-	}
-	if da.projDevSlots != "" {
-		res["project_dev_slots"] = da.projDevSlots
-	}
+	res["project_slots"] = da.projSlots
+	res["environment"] = da.environment
 	res["project_provisioner"] = da.projProvisioner
 	return res
+}
+
+// resolveSlots returns the appropriate slot count for the given environment.
+func resolveSlots(proj *database.Project, environment string) (int, error) {
+	switch environment {
+	case "prod":
+		return proj.ProdSlots, nil
+	case "dev":
+		return proj.DevSlots, nil
+	default:
+		return 0, fmt.Errorf("invalid environment %q; must be 'prod' or 'dev'", environment)
+	}
 }
 
 type provisionRuntimeOptions struct {

--- a/admin/jobs/river/deployments_health_check.go
+++ b/admin/jobs/river/deployments_health_check.go
@@ -247,7 +247,7 @@ func (w *DeploymentsHealthCheckWorker) annotationsForDeployment(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	annotations := w.admin.NewDeploymentAnnotations(org, proj)
+	annotations := w.admin.NewDeploymentAnnotations(org, proj, d.Environment)
 	return &annotations, nil
 }
 

--- a/admin/jobs/river/validate_deployments.go
+++ b/admin/jobs/river/validate_deployments.go
@@ -131,7 +131,7 @@ func (w *ValidateDeploymentsWorker) validateDeploymentsForProject(ctx context.Co
 		}
 
 		// Build annotations for the deployment
-		annotations := w.admin.NewDeploymentAnnotations(org, proj)
+		annotations := w.admin.NewDeploymentAnnotations(org, proj, depl.Environment)
 
 		// Validate each provisioned resource
 		for _, pr := range prs {

--- a/admin/server/deployment.go
+++ b/admin/server/deployment.go
@@ -953,7 +953,7 @@ func (s *Server) GetDeploymentConfig(ctx context.Context, req *adminv1.GetDeploy
 	}
 	resp.DuckdbConnectorConfig = configStructPb
 
-	annotations := s.admin.NewDeploymentAnnotations(org, proj)
+	annotations := s.admin.NewDeploymentAnnotations(org, proj, depl.Environment)
 	resp.Annotations = annotations.ToMap()
 
 	resp.FrontendUrl = s.admin.URLs.WithCustomDomain(org.CustomDomain).Project(org.Name, proj.Name)

--- a/admin/server/projects.go
+++ b/admin/server/projects.go
@@ -2178,6 +2178,7 @@ func (s *Server) projToDTO(p *database.Project, orgName string) *adminv1.Project
 		Provisioner:         p.Provisioner,
 		ProdVersion:         p.ProdVersion,
 		ProdSlots:           int64(p.ProdSlots),
+		DevSlots:            int64(p.DevSlots),
 		PrimaryBranch:       p.PrimaryBranch,
 		Subpath:             p.Subpath,
 		GitRemote:           safeStr(p.GitRemote),

--- a/admin/server/provision.go
+++ b/admin/server/provision.go
@@ -68,7 +68,7 @@ func (s *Server) Provision(ctx context.Context, req *adminv1.ProvisionRequest) (
 	if !typ.Valid() {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid type %q", req.Type)
 	}
-	annotations := s.admin.NewDeploymentAnnotations(org, proj)
+	annotations := s.admin.NewDeploymentAnnotations(org, proj, depl.Environment)
 	res, err = s.admin.Provision(ctx, &admin.ProvisionOptions{
 		DeploymentID: depl.ID,
 		Type:         typ,

--- a/runtime/registry.go
+++ b/runtime/registry.go
@@ -578,17 +578,11 @@ func (r *registryCache) emitHeartbeatForInstance(inst *drivers.Instance) {
 	attrs := instanceAnnotationsToAttribs(inst)
 	r.activity.RecordMetric(context.Background(), "data_dir_size_bytes", float64(sizeOfDir(dataDir)), attrs...)
 
-	// Emit prod_slots metric for billing
-	if v, ok := inst.Annotations["project_prod_slots"]; ok {
+	// Emit slots metric for billing
+	if v, ok := inst.Annotations["project_slots"]; ok {
 		if slots, err := strconv.Atoi(v); err == nil {
-			r.activity.RecordMetric(context.Background(), "prod_slots", float64(slots), attrs...)
-		}
-	}
-
-	// Emit dev_slots metric for billing
-	if v, ok := inst.Annotations["project_dev_slots"]; ok {
-		if slots, err := strconv.Atoi(v); err == nil {
-			r.activity.RecordMetric(context.Background(), "dev_slots", float64(slots), attrs...)
+			env := inst.Annotations["environment"]
+			r.activity.RecordMetric(context.Background(), env+"_slots", float64(slots), attrs...)
 		}
 	}
 }

--- a/runtime/registry.go
+++ b/runtime/registry.go
@@ -578,11 +578,10 @@ func (r *registryCache) emitHeartbeatForInstance(inst *drivers.Instance) {
 	attrs := instanceAnnotationsToAttribs(inst)
 	r.activity.RecordMetric(context.Background(), "data_dir_size_bytes", float64(sizeOfDir(dataDir)), attrs...)
 
-	// Emit slots metric for billing
+	// Emit slots metric for billing; environment is already included via instance annotations
 	if v, ok := inst.Annotations["project_slots"]; ok {
 		if slots, err := strconv.Atoi(v); err == nil {
-			env := inst.Annotations["environment"]
-			r.activity.RecordMetric(context.Background(), env+"_slots", float64(slots), attrs...)
+			r.activity.RecordMetric(context.Background(), "slots", float64(slots), attrs...)
 		}
 	}
 }

--- a/runtime/registry.go
+++ b/runtime/registry.go
@@ -584,6 +584,13 @@ func (r *registryCache) emitHeartbeatForInstance(inst *drivers.Instance) {
 			r.activity.RecordMetric(context.Background(), "prod_slots", float64(slots), attrs...)
 		}
 	}
+
+	// Emit dev_slots metric for billing
+	if v, ok := inst.Annotations["project_dev_slots"]; ok {
+		if slots, err := strconv.Atoi(v); err == nil {
+			r.activity.RecordMetric(context.Background(), "dev_slots", float64(slots), attrs...)
+		}
+	}
 }
 
 // updateProjectConfig updates the project config for the given instance.

--- a/runtime/registry.go
+++ b/runtime/registry.go
@@ -578,8 +578,8 @@ func (r *registryCache) emitHeartbeatForInstance(inst *drivers.Instance) {
 	attrs := instanceAnnotationsToAttribs(inst)
 	r.activity.RecordMetric(context.Background(), "data_dir_size_bytes", float64(sizeOfDir(dataDir)), attrs...)
 
-	// Emit slots metric for billing; environment is already included via instance annotations
-	if v, ok := inst.Annotations["project_slots"]; ok {
+	// Emit slots metric for billing; environment is included via instanceAnnotationsToAttribs
+	if v, ok := inst.Annotations["slots"]; ok {
 		if slots, err := strconv.Atoi(v); err == nil {
 			r.activity.RecordMetric(context.Background(), "slots", float64(slots), attrs...)
 		}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -258,8 +258,9 @@ func (r *Runtime) ReloadConfig(ctx context.Context, instanceID string) error {
 }
 
 func instanceAnnotationsToAttribs(instance *drivers.Instance) []attribute.KeyValue {
-	attrs := make([]attribute.KeyValue, 0, len(instance.Annotations)+1)
+	attrs := make([]attribute.KeyValue, 0, len(instance.Annotations)+2)
 	attrs = append(attrs, attribute.String("instance_id", instance.ID))
+	attrs = append(attrs, attribute.String("environment", instance.Environment))
 	for k, v := range instance.Annotations {
 		attrs = append(attrs, attribute.String(k, v))
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -259,8 +259,7 @@ func (r *Runtime) ReloadConfig(ctx context.Context, instanceID string) error {
 
 func instanceAnnotationsToAttribs(instance *drivers.Instance) []attribute.KeyValue {
 	attrs := make([]attribute.KeyValue, 0, len(instance.Annotations)+2)
-	attrs = append(attrs, attribute.String("instance_id", instance.ID))
-	attrs = append(attrs, attribute.String("environment", instance.Environment))
+	attrs = append(attrs, attribute.String("instance_id", instance.ID), attribute.String("environment", instance.Environment))
 	for k, v := range instance.Annotations {
 		attrs = append(attrs, attribute.String(k, v))
 	}


### PR DESCRIPTION
follow up to: https://github.com/rilldata/rill/pull/9070

  1. Emits a unified slots metric instead of prod_slots (runtime/registry.go)                                                                                      
  - Old: only emitted prod_slots from the project_prod_slots annotation — dev deployments were invisible to billing.
  - New: emits a single slots metric from a slots annotation, regardless of environment.                                                                           
                                                                                                                                                                 
  2. Tags every emitted metric with the environment (runtime/runtime.go, instanceAnnotationsToAttribs)                                                             
  - Adds attribute.String("environment", instance.Environment) to the attrs on every metric (not just slots). So downstream (billing, data_dir_size_bytes, etc.)   
  can distinguish prod vs dev.                                                                                                                                     
                                                                                                                                                                   
  3. Makes deployment annotations environment-aware (admin/deployments.go)                                                                                         
  - NewDeploymentAnnotations now takes an environment string and sets a single slots field (picked from proj.ProdSlots or proj.DevSlots via a new resolveSlots     
  helper).                                                                                                                                                         
  - Renames the struct field projProdSlots → slots and the emitted map key project_prod_slots → slots.                                                             
  - All six callers updated to pass the deployment's environment: StartDeploymentInner, UpdateDeploymentInner, DeploymentsHealthCheckWorker,                       
  ValidateDeploymentsWorker, GetDeploymentConfig, Provision.                                                                                                       
  - Slot resolution in Start/Update is extracted to the same resolveSlots helper (small dedup).                                                                    
                                                                                                                                                                   
  4. Exposes DevSlots on the Project API DTO (admin/server/projects.go)                                                                                            
  - projToDTO now populates DevSlots alongside ProdSlots, so the admin API returns both.                                                                         
                                                                                                                                                                   
  Net effect: billing and telemetry can now attribute slot usage to dev deployments as well as prod, via a single slots metric labeled with environment=prod|dev.
  This is a breaking rename of the emitted metric/annotation (prod_slots → slots, project_prod_slots → slots), so anything consuming the old names downstream needs
   to be updated.            


**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
