### PR TITLE
fix: duplicate Y-axis labels when dynamic scale is enabled

### DIFF
--- a/web-common/src/features/dashboards/time-series/measure-chart/MeasureChartBody.svelte
+++ b/web-common/src/features/dashboards/time-series/measure-chart/MeasureChartBody.svelte
@@ -46,7 +46,7 @@
     HoverState,
     TimeSeriesPoint,
   } from "./types";
-  import { dateToIndex, snapIndex } from "./utils";
+  import { dateToIndex, formatUniqueTickLabels, snapIndex } from "./utils";
 
   const chartId = Math.random().toString(36).slice(2, 11);
   const CLICK_THRESHOLD_PX = 4;
@@ -185,6 +185,12 @@
     return measureFormatter(value);
   };
   $: axisFormatter = createMeasureValueFormatter(measure, "axis");
+  $: defaultFormatter = createMeasureValueFormatter(measure, "table");
+  $: yTickLabels = formatUniqueTickLabels(
+    yTicks,
+    axisFormatter,
+    defaultFormatter,
+  );
 
   // Annotations
   $: annotationGroups = groupAnnotations(
@@ -440,7 +446,7 @@
       plotWidth={pb.width}
       plotTop={pb.top}
       plotHeight={pb.height}
-      {axisFormatter}
+      {yTickLabels}
     />
 
     <!-- Chart body -->

--- a/web-common/src/features/dashboards/time-series/measure-chart/MeasureChartGrid.svelte
+++ b/web-common/src/features/dashboards/time-series/measure-chart/MeasureChartGrid.svelte
@@ -9,20 +9,20 @@
   export let plotWidth: number;
   export let plotTop: number;
   export let plotHeight: number;
-  export let axisFormatter: (value: number) => string;
+  export let yTickLabels: string[];
 
   const DASH = "1,1.5";
 </script>
 
 <g class="y-axis">
-  {#each yTicks as tick (tick)}
+  {#each yTicks as tick, i (tick)}
     <text
       class="fill-fg-muted text-[11px]"
       text-anchor="start"
       x={plotLeft + plotWidth + 4}
       y={yScale(tick) + 4}
     >
-      {axisFormatter(tick)}
+      {yTickLabels[i]}
     </text>
     <line
       class="stroke-gray-300"

--- a/web-common/src/features/dashboards/time-series/measure-chart/utils.ts
+++ b/web-common/src/features/dashboards/time-series/measure-chart/utils.ts
@@ -69,3 +69,23 @@ export function barCenterX(
     singleBarWidth / 2
   );
 }
+
+/**
+ * Formats tick values ensuring all labels are visually distinct.
+ *
+ * Uses the primary formatter (axis) as the first pass. If any labels
+ * are duplicated, falls back to the secondary formatter (table),
+ * which uses higher precision from the same formatting system.
+ */
+export function formatUniqueTickLabels(
+  ticks: number[],
+  primaryFormatter: (n: number) => string,
+  fallbackFormatter: (n: number) => string,
+): string[] {
+  if (ticks.length <= 1) return ticks.map(primaryFormatter);
+
+  const labels = ticks.map(primaryFormatter);
+  if (new Set(labels).size === labels.length) return labels;
+
+  return ticks.map(fallbackFormatter);
+}


### PR DESCRIPTION
When the "Dynamic Y-axis scale" toggle is enabled and the data range is narrow, Y-axis tick labels can all show the same value (e.g., "$4k, $4k, $4k, $4k").

- Add `formatUniqueTickLabels` in `utils.ts` that formats ticks with the axis
  formatter first, then falls back to the table formatter (higher precision)
  if any labels are duplicated
- Pass pre-computed `yTickLabels` to `MeasureChartGrid` instead of the raw
  `axisFormatter` function

https://linear.app/rilldata/issue/APP-855/duplicate-axis-labels-in-measure-charts

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
