### PR TITLE
Fix reference schema and fix SQL example in model instructions

### DIFF
--- a/docs/docs/reference/project-files/canvas-dashboards.md
+++ b/docs/docs/reference/project-files/canvas-dashboards.md
@@ -14,7 +14,7 @@ _[string]_ - Refers to the resource type and must be `canvas` _(required)_
 
 ### `display_name`
 
-_[string]_ - Refers to the display name for the canvas _(required)_
+_[string]_ - Refers to the display name for the canvas 
 
 ### `title`
 

--- a/docs/docs/reference/project-files/connectors.md
+++ b/docs/docs/reference/project-files/connectors.md
@@ -323,7 +323,7 @@ _[string]_ - Refers to the driver type and must be driver `druid` _(required)_
 
 ### `dsn`
 
-_[string]_ - Data Source Name (DSN) for connecting to Druid _(required)_
+_[string]_ - Data Source Name (DSN) for connecting to Druid 
 
 ### `username`
 
@@ -776,7 +776,7 @@ _[string]_ - Refers to the driver type and must be driver `pinot` _(required)_
 
 ### `dsn`
 
-_[string]_ - DSN(Data Source Name) for the Pinot connection _(required)_
+_[string]_ - DSN(Data Source Name) for the Pinot connection 
 
 ### `username`
 
@@ -788,7 +788,7 @@ _[string]_ - Password for authenticating with Pinot
 
 ### `broker_host`
 
-_[string]_ - Hostname of the Pinot broker _(required)_
+_[string]_ - Hostname of the Pinot broker 
 
 ### `broker_port`
 
@@ -796,7 +796,7 @@ _[integer]_ - Port number for the Pinot broker
 
 ### `controller_host`
 
-_[string]_ - Hostname of the Pinot controller _(required)_
+_[string]_ - Hostname of the Pinot controller 
 
 ### `controller_port`
 

--- a/docs/docs/reference/project-files/explore-dashboards.md
+++ b/docs/docs/reference/project-files/explore-dashboards.md
@@ -14,7 +14,7 @@ _[string]_ - Refers to the resource type and must be `explore` _(required)_
 
 ### `display_name`
 
-_[string]_ - Refers to the display name for the explore dashboard _(required)_
+_[string]_ - Refers to the display name for the explore dashboard 
 
 ### `metrics_view`
 

--- a/docs/docs/reference/project-files/metrics-views.md
+++ b/docs/docs/reference/project-files/metrics-views.md
@@ -108,7 +108,7 @@ _[array of object]_ - Used to define the numeric aggregates of columns from your
 
   - **`name`** - _[string]_ - a stable identifier for the measure _(required)_
 
-  - **`display_name`** - _[string]_ - the display name of your measure. _(required)_
+  - **`display_name`** - _[string]_ - the display name of your measure. 
 
   - **`label`** - _[string]_ - a label for your measure, deprecated use display_name 
 
@@ -118,7 +118,7 @@ _[array of object]_ - Used to define the numeric aggregates of columns from your
 
   - **`type`** - _[string]_ - Measure calculation type: "simple" for basic aggregations, "derived" for calculations using other measures, or "time_comparison" for period-over-period analysis. Defaults to "simple" unless dependencies exist. 
 
-  - **`expression`** - _[string]_ - a combination of operators and functions for aggregations _(required)_
+  - **`expression`** - _[string]_ - a combination of operators and functions for aggregations 
 
   - **`window`** - _[anyOf]_ - A measure window can be defined as a keyword string (e.g. 'time' or 'all') or an object with detailed window configuration. For more information, see the [window functions](/developers/build/metrics-view/measures/windows) documentation. 
 
@@ -250,19 +250,19 @@ _[array of object]_ - Used to define annotations that can be displayed on charts
 
   - **`connector`** - _[string]_ - Refers to the connector to use for the annotation 
 
-  - **`measures`** - _[anyOf]_ - Specifies which measures to apply the annotation to. Applies to all measures if not specified 
+  - **`measures`** - _[oneOf]_ - Specifies which measures to apply the annotation to. Applies to all measures if not specified 
 
-    - **option 1** - _[string]_ - Simple field name as a string.
+    - **option 1** - _[string]_ - Wildcard(*) selector that includes all available fields in the selection
 
-    - **option 2** - _[array of anyOf]_ - List of field selectors, each can be a string or an object with detailed configuration.
+    - **option 2** - _[array of string]_ - Explicit list of fields to include in the selection
 
-      - **option 1** - _[string]_ - Shorthand field selector, interpreted as the name.
+    - **option 3** - _[object]_ - Advanced matching using regex, DuckDB expression, or exclusion
 
-      - **option 2** - _[object]_ - Detailed field selector configuration with name and optional time grain.
+      - **`regex`** - _[string]_ - Select fields using a regular expression 
 
-        - **`name`** - _[string]_ - Name of the field to select. _(required)_
+      - **`expr`** - _[string]_ - DuckDB SQL expression to select fields based on custom logic 
 
-        - **`time_grain`** - _[string]_ - Time grain for time-based dimensions. 
+      - **`exclude`** - _[object]_ - Select all fields except those listed here 
 
 ### `security`
 

--- a/runtime/ai/instructions/data/resources/model.md
+++ b/runtime/ai/instructions/data/resources/model.md
@@ -416,7 +416,7 @@ refresh:
 connector: snowflake
 sql: |
   SELECT * FROM staging.sales
-  {{ if dev }} event_time >= '2025-01-01' AND event_time < '2025-02-01' {{ end }}
+  {{ if dev }} WHERE event_time >= '2025-01-01' AND event_time < '2025-02-01' {{ end }}
 ```
 
 ### MySQL to DuckDB

--- a/runtime/metricsview/timestamps.go
+++ b/runtime/metricsview/timestamps.go
@@ -3,11 +3,6 @@ package metricsview
 import "time"
 
 type TimestampsResult struct {
-	BaseTable TimestampsResultEntry
-	Rollups   map[string]TimestampsResultEntry
-}
-
-type TimestampsResultEntry struct {
 	Min       time.Time
 	Max       time.Time
 	Watermark time.Time

--- a/runtime/metricsview/timestamps.go
+++ b/runtime/metricsview/timestamps.go
@@ -3,6 +3,11 @@ package metricsview
 import "time"
 
 type TimestampsResult struct {
+	BaseTable TimestampsResultEntry
+	Rollups   map[string]TimestampsResultEntry
+}
+
+type TimestampsResultEntry struct {
 	Min       time.Time
 	Max       time.Time
 	Watermark time.Time

--- a/runtime/parser/schema/project.schema.yaml
+++ b/runtime/parser/schema/project.schema.yaml
@@ -359,7 +359,6 @@ definitions:
 
           required:
             - driver
-            - dsn
         - type: object
           title: DuckDB
           properties:
@@ -464,7 +463,6 @@ definitions:
               mode: "read"                                     # Set the mode for the DuckDB connection. 
           required:
             - driver
-            - db
         - type: object
           title: GCS
           properties:
@@ -499,7 +497,6 @@ definitions:
               google_application_credentials: "{{ .env.GOOGLE_APPLICATION_CREDENTIALS }}"  # Google Cloud credentials JSON string
           required:
             - driver
-            - bucket
         - type: object
           title: HTTPS
           properties:
@@ -528,7 +525,6 @@ definitions:
                 "Authorization": 'Bearer {{ .env.HTTPS_TOKEN }}'  # HTTP headers to include in the request
           required:
             - driver
-            - path
         # Note: Iceberg is not a standalone connector. It uses DuckDB's iceberg_scan() function.
         # See /developers/build/connectors/data-source/iceberg for configuration details.
         - type: object
@@ -796,9 +792,6 @@ definitions:
               timeout_ms: 30000                               # Query timeout in milliseconds
           required:
             - driver
-            - dsn
-            - broker_host
-            - controller_host
         - type: object
           title: StarRocks
           properties:
@@ -1079,7 +1072,6 @@ definitions:
 
           required:
             - driver
-            - bucket
         - type: object
           title: Slack
           properties:
@@ -2172,8 +2164,6 @@ definitions:
                 
               required:
                 - name
-                - display_name
-                - expression
 
           parent_dimensions:
             description: Optional field selectors for dimensions to inherit from the parent metrics view.
@@ -2207,46 +2197,7 @@ definitions:
                   description: Refers to the connector to use for the annotation
                 measures:
                   description: Specifies which measures to apply the annotation to. Applies to all measures if not specified
-                  anyOf:
-                    - type: string
-                      description: Simple field name as a string.
-                    - type: array
-                      description: List of field selectors, each can be a string or an object with detailed configuration.
-                      items:
-                        anyOf:
-                          - type: string
-                            description: Shorthand field selector, interpreted as the name.
-                          - type: object
-                            description: Detailed field selector configuration with name and optional time grain.
-                            properties:
-                              name:
-                                type: string
-                                description: Name of the field to select.
-                              time_grain:
-                                type: string
-                                description: Time grain for time-based dimensions.
-                                enum:
-                                  - ''
-                                  - ms
-                                  - millisecond
-                                  - s
-                                  - second
-                                  - min
-                                  - minute
-                                  - hadditionalProperties: fal
-                                  - hour
-                                  - d
-                                  - day
-                                  - w
-                                  - week
-                                  - month
-                                  - q
-                                  - quarter
-                                  - 'y'
-                                  - year
-                            required:
-                              - name
-                            additionalProperties: false
+                  $ref: '#/definitions/field_selector_properties'
           security:
               $ref: '#/definitions/security_policy_properties'
               description: Defines a security policy for the dashboard
@@ -2418,7 +2369,6 @@ definitions:
               $ref: '#/definitions/component_variable_properties'
         required:
           - type
-          - display_name
       - $ref: '#/definitions/common_properties'
 
   # Explore dashboards
@@ -2567,7 +2517,6 @@ definitions:
             $ref: '#/definitions/dashboard_security_policy_properties'
         required:
           - type
-          - display_name
           - metrics_view
       - $ref: '#/definitions/common_properties'
 
@@ -3017,7 +2966,6 @@ definitions:
 
         required:
           - type
-          - display_name
       - $ref: '#/definitions/common_properties'
 
   # Components


### PR DESCRIPTION
- Removes incorrect `required` fields from the reference JSON schema
- Replaces a broken measure selector definition for metrics view annotations
- Fixes a missing `WHERE` keyword in the Snowflake SQL example in AI instructions

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!