### PR TITLE
Fix CSP error for Pylon chat widget inline script

### DIFF
--- a/web-admin/svelte.config.js
+++ b/web-admin/svelte.config.js
@@ -42,6 +42,9 @@ const config = {
           "https://*.app-us1.com/",
           "https://*.usepylon.com",
           "https://*.pusher.com",
+          // Hash of the inline script injected by the Pylon chat widget at runtime.
+          // If Pylon updates their widget, this hash may need to be refreshed.
+          "sha256-q7DzCTpmdcQlqCarsIE22KTL5subp7TPBUdWqrL6HJw=",
         ],
         // style-src keeps 'unsafe-inline': runtime style injection from
         // CodeMirror and other libraries cannot be hash-attributed.


### PR DESCRIPTION
Add the SHA-256 hash of the inline script injected by the Pylon widget at runtime to the `script-src` CSP directive. SvelteKit's hash mode only covers build-time inline scripts; Pylon's runtime-injected script needs its hash listed explicitly.

INSERT DESCRIPTION HERE

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
