### PR TITLE
fix: ai conversaion access errors are hidden

### DIFF
--- a/web-admin/src/components/errors/user-facing-errors.ts
+++ b/web-admin/src/components/errors/user-facing-errors.ts
@@ -51,6 +51,15 @@ export function createUserFacingError(
       header: "Project not found",
       body: "The project you requested could not be found. Please check that you have provided a valid project name.",
     };
+  } else if (
+    status === 400 &&
+    message.includes("failed to find the conversation")
+  ) {
+    return {
+      statusCode: 404,
+      header: "Conversation not found",
+      body: "Please check that you have the correct link or if you have access to it.",
+    };
   } else if (status === 404 && message === "resource not found") {
     return {
       statusCode: 404,

--- a/web-common/src/features/chat/core/citation-url-utils.ts
+++ b/web-common/src/features/chat/core/citation-url-utils.ts
@@ -38,24 +38,9 @@ export async function fetchMessage(
     // 200 response should always have a message.
     return toolCallResp.message!;
   } catch (e) {
-    const apiError = e.response?.data?.message ?? "";
-    switch (true) {
-      case apiError.includes("failed to find the conversation"):
-        throw error(
-          404,
-          new Error(
-            "Failed to get conversation. Check if you have access to it.",
-          ),
-        );
-
-      case apiError.includes("failed to find the call"):
-        throw error(
-          404,
-          new Error(
-            "Failed to get tool call for query. Check if you have access to it or if the call was deleted.",
-          ),
-        );
-    }
+    const apiError = e.response?.data?.message;
+    // Rethrow api error. Top level message will just be InternalError
+    if (apiError) throw error(400, new Error(apiError));
     throw e;
   }
 }


### PR DESCRIPTION
Improves AI conversation access errors by re-throwing the API error.

Updated to show better error,
<img width="809" height="446" alt="Screenshot 2026-04-16 at 11 10 50 AM" src="https://github.com/user-attachments/assets/0b4fbabc-6239-4acc-80fc-61812913477e" />

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
