### PR TITLE
Polish `rill login` with better hints and interactive handling

### DIFF
--- a/cli/cmd/auth/login.go
+++ b/cli/cmd/auth/login.go
@@ -16,8 +16,6 @@ import (
 
 // LoginCmd is the command for logging into a Rill account.
 func LoginCmd(ch *cmdutil.Helper) *cobra.Command {
-	var orgName string
-
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Authenticate with the Rill API",
@@ -39,8 +37,7 @@ func LoginCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 
 			// Set default org after login
-			interactive := orgName == ""
-			err = SelectOrgFlow(ctx, ch, interactive, orgName)
+			err = SelectOrgFlow(ctx, ch, false)
 			if err != nil {
 				return err
 			}
@@ -49,7 +46,6 @@ func LoginCmd(ch *cmdutil.Helper) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&orgName, "org", "o", "", "Organization to use")
 	return cmd
 }
 
@@ -122,7 +118,9 @@ func LoginWithTelemetry(ctx context.Context, ch *cmdutil.Helper, redirectURL str
 	return nil
 }
 
-func SelectOrgFlow(ctx context.Context, ch *cmdutil.Helper, interactive bool, requestedOrg string) error {
+func SelectOrgFlow(ctx context.Context, ch *cmdutil.Helper, forceNoninteractive bool) error {
+	interactive := ch.Interactive && !forceNoninteractive
+
 	client, err := ch.Client()
 	if err != nil {
 		return err
@@ -136,9 +134,7 @@ func SelectOrgFlow(ctx context.Context, ch *cmdutil.Helper, interactive bool, re
 	}
 
 	if len(res.Organizations) == 0 {
-		if interactive {
-			ch.PrintfWarn("You are not part of an org. Run `rill org create` to create one.\n")
-		}
+		ch.PrintfWarn("You are not part of an org. Run `rill org create` to create one.\n")
 		return nil
 	}
 
@@ -148,21 +144,8 @@ func SelectOrgFlow(ctx context.Context, ch *cmdutil.Helper, interactive bool, re
 	}
 
 	defaultOrg := orgNames[0]
-	if requestedOrg != "" {
-		// Verify the requested org exists
-		found := false
-		for _, name := range orgNames {
-			if name == requestedOrg {
-				defaultOrg = requestedOrg
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("organization %q not found", requestedOrg)
-		}
-	} else if interactive && len(orgNames) > 1 {
-		defaultOrg, err = cmdutil.SelectPrompt("Select default org (to change later, run `rill org switch`).", orgNames, defaultOrg)
+	if interactive && len(orgNames) > 1 {
+		defaultOrg, err = cmdutil.SelectPrompt("Select default org", orgNames, defaultOrg)
 		if err != nil {
 			return err
 		}
@@ -175,7 +158,7 @@ func SelectOrgFlow(ctx context.Context, ch *cmdutil.Helper, interactive bool, re
 	ch.Org = defaultOrg
 
 	if interactive {
-		ch.Printf("Set default organization to %q. Change using `rill org switch`.\n", defaultOrg)
+		ch.Printf("Set default org to %q (hint: to change, run `rill org switch`).\n", defaultOrg)
 	}
 	return nil
 }

--- a/cli/cmd/auth/login.go
+++ b/cli/cmd/auth/login.go
@@ -157,8 +157,6 @@ func SelectOrgFlow(ctx context.Context, ch *cmdutil.Helper, forceNoninteractive 
 	}
 	ch.Org = defaultOrg
 
-	if interactive {
-		ch.Printf("Set default org to %q (hint: to change, run `rill org switch`).\n", defaultOrg)
-	}
+	ch.Printf("Set default org to %q (hint: to change, run `rill org switch`).\n", defaultOrg)
 	return nil
 }

--- a/cli/cmd/devtool/switch-env.go
+++ b/cli/cmd/devtool/switch-env.go
@@ -53,7 +53,7 @@ func SwitchEnvCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			ch.PrintfSuccess("Set default env to %q (%q)\n", toEnv, adminenv.AdminURL(toEnv))
 
-			return auth.SelectOrgFlow(cmd.Context(), ch, ch.Interactive, "")
+			return auth.SelectOrgFlow(cmd.Context(), ch, false)
 		},
 	}
 
@@ -125,7 +125,7 @@ func switchEnvToDevTemporarily(ctx context.Context, ch *cmdutil.Helper) {
 	var prevOrg string
 	if authenticated {
 		prevOrg = ch.Org
-		err = auth.SelectOrgFlow(ctx, ch, false, "")
+		err = auth.SelectOrgFlow(ctx, ch, true)
 		if err != nil {
 			logWarn.Printf("Failed to select org in dev environment: %v\n", err)
 		}

--- a/cli/cmd/sudo/user/assume.go
+++ b/cli/cmd/sudo/user/assume.go
@@ -101,7 +101,7 @@ func AssumeCmd(ch *cmdutil.Helper) *cobra.Command {
 			}
 
 			// Select org for new user
-			err = auth.SelectOrgFlow(ctx, ch, true, "")
+			err = auth.SelectOrgFlow(ctx, ch, false)
 			if err != nil {
 				return err
 			}

--- a/docs/docs/reference/cli/login.md
+++ b/docs/docs/reference/cli/login.md
@@ -10,12 +10,6 @@ Authenticate with the Rill API
 rill login [flags]
 ```
 
-### Flags
-
-```
-  -o, --org string   Organization to use
-```
-
 ### Global flags
 
 ```


### PR DESCRIPTION
- Removes the unused `--org` flag from `rill auth login`
- Ensures correct (non)interative handling
- Cleans up log messages

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!