### PR TITLE
fix: metrics view model dropdown

### DIFF
--- a/web-common/src/features/connectors/explorer/ConnectorExplorer.svelte
+++ b/web-common/src/features/connectors/explorer/ConnectorExplorer.svelte
@@ -8,15 +8,35 @@
 
   export let store: ConnectorExplorerStore;
   export let olapOnly: boolean = false;
-  export let filterConnector: string = "";
+  /** Auto-expand this connector when the list first renders */
+  export let defaultExpanded: string = "";
 
   const client = useRuntimeClient();
 
   $: connectors = getAnalyzedConnectors(client, olapOnly);
   $: ({ data, error } = $connectors);
-  $: filteredConnectors = filterConnector
-    ? (data?.connectors?.filter((c) => c.name === filterConnector) ?? [])
-    : (data?.connectors ?? []);
+
+  // When defaultExpanded is set, pre-seed the store so only that connector
+  // starts expanded and others start collapsed.
+  let hasAutoExpanded = false;
+  $: if (defaultExpanded && data?.connectors && !hasAutoExpanded) {
+    for (const c of data.connectors) {
+      if (!c.name) continue;
+      // Pre-seed each connector before ConnectorEntry renders.
+      // This prevents getDefaultState from expanding all connectors.
+      store.store.update((state) => {
+        if (c.name! in state.expandedItems) return state;
+        return {
+          ...state,
+          expandedItems: {
+            ...state.expandedItems,
+            [c.name!]: c.name === defaultExpanded,
+          },
+        };
+      });
+    }
+    hasAutoExpanded = true;
+  }
 </script>
 
 <div class="wrapper">
@@ -25,11 +45,11 @@
       {error.message}
     </span>
   {:else if data?.connectors}
-    {#if filteredConnectors.length === 0}
+    {#if data.connectors.length === 0}
       <span class="message"> No data found. Add data to get started! </span>
     {:else}
       <ol transition:slide={{ duration }}>
-        {#each filteredConnectors as connector (connector.name)}
+        {#each data.connectors as connector (connector.name)}
           <ConnectorEntry {connector} {store} />
         {/each}
       </ol>

--- a/web-common/src/features/connectors/explorer/ConnectorExplorer.svelte
+++ b/web-common/src/features/connectors/explorer/ConnectorExplorer.svelte
@@ -8,11 +8,15 @@
 
   export let store: ConnectorExplorerStore;
   export let olapOnly: boolean = false;
+  export let filterConnector: string = "";
 
   const client = useRuntimeClient();
 
   $: connectors = getAnalyzedConnectors(client, olapOnly);
   $: ({ data, error } = $connectors);
+  $: filteredConnectors = filterConnector
+    ? (data?.connectors?.filter((c) => c.name === filterConnector) ?? [])
+    : (data?.connectors ?? []);
 </script>
 
 <div class="wrapper">
@@ -21,11 +25,11 @@
       {error.message}
     </span>
   {:else if data?.connectors}
-    {#if data.connectors.length === 0}
+    {#if filteredConnectors.length === 0}
       <span class="message"> No data found. Add data to get started! </span>
     {:else}
       <ol transition:slide={{ duration }}>
-        {#each data.connectors as connector (connector.name)}
+        {#each filteredConnectors as connector (connector.name)}
           <ConnectorEntry {connector} {store} />
         {/each}
       </ol>

--- a/web-common/src/features/workspaces/VisualMetrics.svelte
+++ b/web-common/src/features/workspaces/VisualMetrics.svelte
@@ -294,6 +294,12 @@
 
   $: tableMode = Boolean(hasValidOLAPTableSelected);
 
+  $: showConnectorExplorer =
+    !!yamlConnector ||
+    tableMode ||
+    !isModelingSupported ||
+    modelAndSourceOptions.length === 0;
+
   function createDimensions(
     rawDimensions: YAMLSeq<YAMLMap<string, string>>,
     metricsViewDimensions: MetricsViewSpecDimension[],
@@ -543,7 +549,7 @@
 <div class="wrapper">
   <div class="main-area">
     <div class="flex gap-x-4 border-b pb-4">
-      {#if tableMode || !isModelingSupported}
+      {#if showConnectorExplorer}
         <div class="flex flex-col gap-y-1 w-full">
           <InputLabel label="Table" id="table">
             <svelte:fragment slot="mode-switch">
@@ -586,7 +592,11 @@
               class="!min-w-64  overflow-hidden p-1"
             >
               <div class="size-full overflow-y-auto max-h-72">
-                <ConnectorExplorer {store} olapOnly />
+                <ConnectorExplorer
+                  {store}
+                  olapOnly
+                  filterConnector={yamlConnector}
+                />
               </div>
             </DropdownMenu.Content>
           </DropdownMenu.Root>

--- a/web-common/src/features/workspaces/VisualMetrics.svelte
+++ b/web-common/src/features/workspaces/VisualMetrics.svelte
@@ -287,9 +287,8 @@
     tables.find(
       (table) =>
         table.name === modelOrSourceOrTableName &&
-        table.database === database &&
-        (table.databaseSchema === databaseSchema ||
-          (!databaseSchema && table.databaseSchema === "default")),
+        (!database || table.database === database) &&
+        (!databaseSchema || table.databaseSchema === databaseSchema),
     );
 
   $: tableMode = Boolean(hasValidOLAPTableSelected);

--- a/web-common/src/features/workspaces/VisualMetrics.svelte
+++ b/web-common/src/features/workspaces/VisualMetrics.svelte
@@ -594,7 +594,7 @@
                 <ConnectorExplorer
                   {store}
                   olapOnly
-                  filterConnector={yamlConnector}
+                  defaultExpanded={yamlConnector}
                 />
               </div>
             </DropdownMenu.Content>


### PR DESCRIPTION
Fix missing olap for MotherDuck,
Fix populate table in visual editor properly

Add: open the current metrics view but have the others available but not opened

<img width="1040" height="323" alt="Screenshot 2026-04-16 at 12 57 02" src="https://github.com/user-attachments/assets/02041e43-9c19-487e-a117-feb1a4b4dd6c" />




**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
