### PR TITLE
Restrict `get_canvas` AI tool to Rill user agents

### DIFF
--- a/runtime/ai/canvas_get.go
+++ b/runtime/ai/canvas_get.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rilldata/rill/runtime"
@@ -48,8 +49,18 @@ func (t *GetCanvas) Spec() *mcp.Tool {
 }
 
 func (t *GetCanvas) CheckAccess(ctx context.Context) (bool, error) {
+	// Must be allowed to use AI and query objects
 	s := GetSession(ctx)
-	return s.Claims().Can(runtime.ReadObjects), nil
+	if !s.Claims().Can(runtime.UseAI) || !s.Claims().Can(runtime.ReadObjects) {
+		return false, nil
+	}
+
+	// Only allow for rill user agents since it's not useful in MCP contexts.
+	if !strings.HasPrefix(s.CatalogSession().UserAgent, "rill") {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func (t *GetCanvas) Handler(ctx context.Context, args *GetCanvasArgs) (*GetCanvasResult, error) {

--- a/runtime/server/mcp_test.go
+++ b/runtime/server/mcp_test.go
@@ -71,7 +71,6 @@ explore:
 	expectedTools := []string{
 		ai.ListMetricsViewsName,
 		ai.GetMetricsViewName,
-		ai.GetCanvasName,
 		ai.QueryMetricsViewName,
 		ai.QueryMetricsViewSummaryName,
 		ai.ProjectStatusName,


### PR DESCRIPTION
Since it's not useful over MCP

**Checklist:**
- [x] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!