### PR TITLE
fix: Partition Modal to use BasicTable component

### DIFF
--- a/web-common/src/features/models/partitions/PartitionsBrowser.svelte
+++ b/web-common/src/features/models/partitions/PartitionsBrowser.svelte
@@ -46,7 +46,7 @@
             View partitions
           </Dialog.Trigger>
           <Dialog.Content
-            class="max-w-screen-xl h-[80vh] flex flex-col gap-y-4"
+            class="max-w-screen-xl h-[40vh] flex flex-col gap-y-4"
           >
             <Dialog.Header>
               <Dialog.Title>Model partitions</Dialog.Title>

--- a/web-common/src/features/models/partitions/PartitionsBrowser.svelte
+++ b/web-common/src/features/models/partitions/PartitionsBrowser.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import * as Dialog from "@rilldata/web-common/components/dialog";
   import CancelCircle from "@rilldata/web-common/components/icons/CancelCircle.svelte";
+  import { Search } from "@rilldata/web-common/components/search";
   import CollapsibleSectionTitle from "../../../layout/CollapsibleSectionTitle.svelte";
   import type { V1Resource } from "../../../runtime-client";
   import PartitionsFilter from "./PartitionsFilter.svelte";
@@ -9,11 +10,20 @@
   export let resource: V1Resource;
 
   let active = true;
-
+  let open = false;
   let selectedFilter = "all";
+  let searchText = "";
 
   function onFilterChange(newValue: string) {
     selectedFilter = newValue;
+  }
+
+  function onOpenChange(value: boolean) {
+    open = value;
+    if (!value) {
+      selectedFilter = "all";
+      searchText = "";
+    }
   }
 </script>
 
@@ -31,22 +41,34 @@
         {resource.model?.state?.partitionsHaveErrors
           ? "Some partitions have errors.  "
           : "All partitions were successful.   "}
-        <Dialog.Root>
+        <Dialog.Root {open} {onOpenChange}>
           <Dialog.Trigger class="text-primary-500 font-medium">
             View partitions
           </Dialog.Trigger>
-          <Dialog.Content class="max-w-screen-xl">
+          <Dialog.Content class="max-w-screen-xl max-h-[90vh] flex flex-col">
             <Dialog.Header>
               <Dialog.Title>Model partitions</Dialog.Title>
             </Dialog.Header>
-            <div class="flex justify-end">
-              <PartitionsFilter {selectedFilter} onChange={onFilterChange} />
+            <div class="flex items-center gap-x-3 mb-4">
+              <div class="w-64">
+                <Search
+                  bind:value={searchText}
+                  placeholder="Search partitions"
+                  autofocus={false}
+                />
+              </div>
+              <div class="ml-auto">
+                <PartitionsFilter {selectedFilter} onChange={onFilterChange} />
+              </div>
             </div>
-            <PartitionsTable
-              {resource}
-              whereErrored={selectedFilter === "errors"}
-              wherePending={selectedFilter === "pending"}
-            />
+            <div class="flex-1 min-h-0 overflow-auto">
+              <PartitionsTable
+                {resource}
+                whereErrored={selectedFilter === "errors"}
+                wherePending={selectedFilter === "pending"}
+                {searchText}
+              />
+            </div>
           </Dialog.Content>
         </Dialog.Root>
       </span>

--- a/web-common/src/features/models/partitions/PartitionsBrowser.svelte
+++ b/web-common/src/features/models/partitions/PartitionsBrowser.svelte
@@ -45,21 +45,24 @@
           <Dialog.Trigger class="text-primary-500 font-medium">
             View partitions
           </Dialog.Trigger>
-          <Dialog.Content class="max-w-screen-xl max-h-[90vh] flex flex-col">
+          <Dialog.Content
+            class="max-w-screen-xl h-[80vh] flex flex-col gap-y-4"
+          >
             <Dialog.Header>
               <Dialog.Title>Model partitions</Dialog.Title>
             </Dialog.Header>
-            <div class="flex items-center gap-x-3 mb-4">
-              <div class="w-64">
+            <div class="flex flex-row items-center gap-x-4 min-h-9">
+              <div class="flex-1 min-w-0 min-h-9">
                 <Search
                   bind:value={searchText}
-                  placeholder="Search partitions"
+                  placeholder="Search"
+                  large
                   autofocus={false}
+                  showBorderOnFocus={false}
+                  retainValueOnMount
                 />
               </div>
-              <div class="ml-auto">
-                <PartitionsFilter {selectedFilter} onChange={onFilterChange} />
-              </div>
+              <PartitionsFilter {selectedFilter} onChange={onFilterChange} />
             </div>
             <div class="flex-1 min-h-0 overflow-auto">
               <PartitionsTable

--- a/web-common/src/features/models/partitions/PartitionsFilter.svelte
+++ b/web-common/src/features/models/partitions/PartitionsFilter.svelte
@@ -1,44 +1,48 @@
 <script lang="ts">
-  import * as Select from "@rilldata/web-common/components/select";
-  import Button from "../../../components/button/Button.svelte";
+  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
+  import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
+  import CaretUpIcon from "@rilldata/web-common/components/icons/CaretUpIcon.svelte";
 
   export let selectedFilter: string;
   export let onChange: (value: string) => void;
 
-  let openFilterMenu = false;
+  let open = false;
 
   const options = [
-    { value: "all", label: "all" },
-    { value: "pending", label: "pending" },
-    { value: "errors", label: "errors" },
+    { value: "all", label: "All partitions" },
+    { value: "pending", label: "Pending" },
+    { value: "errors", label: "Errored" },
   ];
+
+  $: selectedLabel =
+    options.find((o) => o.value === selectedFilter)?.label ?? "All partitions";
 </script>
 
-<Select.Root
-  type="single"
-  items={options}
-  value={selectedFilter}
-  onValueChange={(val) => {
-    if (val) onChange(val);
-  }}
-  bind:open={openFilterMenu}
->
-  <Select.Trigger class="outline-none border-none w-fit px-0 gap-x-0.5">
-    <Button type="text" label="Filter partitions">
-      <span class="text-fg-primary hover:text-inherit">
-        Showing <b>{selectedFilter}</b>
-      </span>
-    </Button>
-  </Select.Trigger>
-  <Select.Content sameWidth={false} align="end">
-    {#each options as option (option.value)}
-      <Select.Item
-        value={option.value}
-        label={option.label}
-        class={`text-xs flex items-start ${
-          selectedFilter === option.value ? "font-bold" : ""
-        }`}
-      />
-    {/each}
-  </Select.Content>
-</Select.Root>
+<DropdownMenu.Root bind:open>
+  <DropdownMenu.Trigger
+    class="min-w-fit min-h-9 flex flex-row gap-1 items-center rounded-sm border bg-input {open
+      ? 'bg-gray-200'
+      : 'hover:bg-surface-hover'} px-2 py-1"
+  >
+    <span class="text-fg-secondary font-medium">{selectedLabel}</span>
+    {#if open}
+      <CaretUpIcon size="12px" />
+    {:else}
+      <CaretDownIcon size="12px" />
+    {/if}
+  </DropdownMenu.Trigger>
+  <DropdownMenu.Content align="end" class="w-48">
+    <DropdownMenu.RadioGroup
+      value={selectedFilter}
+      onValueChange={(v) => {
+        if (v) onChange(v);
+      }}
+    >
+      {#each options as option (option.value)}
+        <DropdownMenu.RadioItem value={option.value}>
+          {option.label}
+        </DropdownMenu.RadioItem>
+      {/each}
+    </DropdownMenu.RadioGroup>
+  </DropdownMenu.Content>
+</DropdownMenu.Root>

--- a/web-common/src/features/models/partitions/PartitionsFilter.svelte
+++ b/web-common/src/features/models/partitions/PartitionsFilter.svelte
@@ -32,17 +32,15 @@
     {/if}
   </DropdownMenu.Trigger>
   <DropdownMenu.Content align="end" class="w-48">
-    <DropdownMenu.RadioGroup
-      value={selectedFilter}
-      onValueChange={(v) => {
-        if (v) onChange(v);
-      }}
-    >
-      {#each options as option (option.value)}
-        <DropdownMenu.RadioItem value={option.value}>
-          {option.label}
-        </DropdownMenu.RadioItem>
-      {/each}
-    </DropdownMenu.RadioGroup>
+    {#each options as option (option.value)}
+      <DropdownMenu.CheckboxItem
+        checked={selectedFilter === option.value}
+        onCheckedChange={(checked) => {
+          if (checked) onChange(option.value);
+        }}
+      >
+        {option.label}
+      </DropdownMenu.CheckboxItem>
+    {/each}
   </DropdownMenu.Content>
 </DropdownMenu.Root>

--- a/web-common/src/features/models/partitions/PartitionsTable.svelte
+++ b/web-common/src/features/models/partitions/PartitionsTable.svelte
@@ -55,7 +55,7 @@
     });
   })();
 
-  function formatTimestamp(ts: string | undefined) {
+  function formatTimestamp(ts: string | undefined, withMs = false) {
     return ts
       ? new Date(ts).toLocaleString(undefined, {
           month: "short",
@@ -63,7 +63,7 @@
           hour: "numeric",
           minute: "numeric",
           second: "numeric",
-          fractionalSecondDigits: 3,
+          ...(withMs ? { fractionalSecondDigits: 3 } : {}),
         })
       : "-";
   }
@@ -90,7 +90,7 @@
     {
       accessorKey: "watermark",
       header: "Watermark",
-      cell: ({ row }) => formatTimestamp(row.original.watermark),
+      cell: ({ row }) => formatTimestamp(row.original.watermark, true),
     },
     {
       accessorKey: "error",

--- a/web-common/src/features/models/partitions/PartitionsTable.svelte
+++ b/web-common/src/features/models/partitions/PartitionsTable.svelte
@@ -1,22 +1,12 @@
 <script lang="ts">
-  import {
-    type ColumnDef,
-    type Row,
-    type TableOptions,
-    createSvelteTable,
-    flexRender,
-    getCoreRowModel,
-    getSortedRowModel,
-    renderComponent,
-  } from "tanstack-table-8-svelte-5";
-  import { createVirtualizer } from "@tanstack/svelte-virtual";
-  import { writable } from "svelte/store";
+  import BasicTable from "@rilldata/web-common/components/table/BasicTable.svelte";
+  import { type ColumnDef, renderComponent } from "tanstack-table-8-svelte-5";
   import {
     type V1ModelPartition,
     type V1Resource,
   } from "../../../runtime-client";
-  import { useRuntimeClient } from "../../../runtime-client/v2";
   import { createRuntimeServiceGetModelPartitionsInfinite } from "../../../runtime-client";
+  import { useRuntimeClient } from "../../../runtime-client/v2";
   import DataCell from "./DataCell.svelte";
   import ErrorCell from "./ErrorCell.svelte";
   import TriggerPartition from "./TriggerPartition.svelte";
@@ -24,14 +14,13 @@
   export let resource: V1Resource;
   export let whereErrored: boolean;
   export let wherePending: boolean;
+  export let searchText = "";
 
   const runtimeClient = useRuntimeClient();
+  const isIncremental = !!resource.model?.spec?.incremental;
 
   $: modelName = resource?.meta?.name?.name as string;
 
-  // ==========================
-  // Infinite Query
-  // ==========================
   $: baseParams = {
     ...(whereErrored ? { errored: true } : {}),
     ...(wherePending ? { pending: true } : {}),
@@ -46,289 +35,107 @@
       },
     },
   );
-  $: ({ error } = $query);
 
-  // ==========================
-  // Table Options
-  // ==========================
-  const isIncremental = resource.model?.spec?.incremental;
+  // Auto-fetch remaining pages so client-side search and sort cover the full set.
+  $: if ($query.hasNextPage && !$query.isFetchingNextPage) {
+    void $query.fetchNextPage();
+  }
 
-  const columns: ColumnDef<V1ModelPartition>[] = [
+  $: allRows =
+    $query.data?.pages.flatMap((p) => p.partitions as V1ModelPartition[]) ?? [];
+
+  $: filteredRows = (() => {
+    if (!searchText) return allRows;
+    const q = searchText.toLowerCase();
+    return allRows.filter((row) => {
+      const key = (row.key ?? "").toLowerCase();
+      const data = JSON.stringify(row.data ?? {}).toLowerCase();
+      const error = (row.error ?? "").toLowerCase();
+      return key.includes(q) || data.includes(q) || error.includes(q);
+    });
+  })();
+
+  function formatTimestamp(ts: string | undefined) {
+    return ts
+      ? new Date(ts).toLocaleString(undefined, {
+          month: "short",
+          day: "numeric",
+          hour: "numeric",
+          minute: "numeric",
+          second: "numeric",
+          fractionalSecondDigits: 3,
+        })
+      : "-";
+  }
+
+  const columns: ColumnDef<V1ModelPartition, any>[] = [
     {
       accessorKey: "data",
       header: "Data",
       cell: ({ row }) => renderComponent(DataCell, { data: row.original.data }),
-      meta: {
-        widthPercent: 30,
-      },
+      enableSorting: false,
     },
     {
       accessorKey: "executedOn",
       header: "Executed on",
-      cell: ({ row }) =>
-        row.original.executedOn
-          ? new Date(row.original.executedOn).toLocaleString(undefined, {
-              month: "short",
-              day: "numeric",
-              hour: "numeric",
-              minute: "numeric",
-              second: "numeric",
-              fractionalSecondDigits: 3,
-            })
-          : "-",
-      meta: {
-        widthPercent: 10,
-      },
+      cell: ({ row }) => formatTimestamp(row.original.executedOn),
+      sortDescFirst: true,
     },
     {
       accessorKey: "elapsedMs",
       header: "Elapsed time",
-      cell: ({ row }) => row.original.elapsedMs + "ms",
-      meta: {
-        widthPercent: 10,
-      },
+      cell: ({ row }) => (row.original.elapsedMs ?? 0) + "ms",
     },
     {
       accessorKey: "watermark",
       header: "Watermark",
-      cell: ({ row }) =>
-        row.original.watermark
-          ? new Date(row.original.watermark).toLocaleString(undefined, {
-              month: "short",
-              day: "numeric",
-              hour: "numeric",
-              minute: "numeric",
-              second: "numeric",
-              fractionalSecondDigits: 3,
-            })
-          : "-",
-      meta: {
-        widthPercent: 10,
-      },
+      cell: ({ row }) => formatTimestamp(row.original.watermark),
     },
     {
       accessorKey: "error",
       header: "Error",
       cell: ({ row }) =>
         renderComponent(ErrorCell, { error: row.original.error }),
-      meta: {
-        widthPercent: 25,
-      },
+      enableSorting: false,
     },
     ...(isIncremental
       ? [
           {
-            accessorKey: "key",
-            header: "",
             id: "actions",
-            meta: {
-              widthPercent: 10,
-            },
+            header: "",
+            enableSorting: false,
             cell: ({ row }) =>
               renderComponent(TriggerPartition, {
-                partitionKey: (row as Row<V1ModelPartition>).original
-                  .key as string,
+                partitionKey: row.original.key as string,
                 resource,
               }),
-          },
+          } satisfies ColumnDef<V1ModelPartition, any>,
         ]
       : []),
   ];
 
-  const options = writable<TableOptions<V1ModelPartition>>({
-    data: [],
-    columns,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-  });
-  const table = createSvelteTable(options);
-  $: ({ getHeaderGroups } = $table);
+  const columnLayout = isIncremental
+    ? "minmax(0, 3fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2.5fr) minmax(0, 1fr)"
+    : "minmax(0, 3fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2.5fr)";
 
-  // Sync table data with query data
-  let allRows: V1ModelPartition[] = [];
-  $: {
-    allRows =
-      ($query.data &&
-        $query.data.pages.flatMap(
-          (page) => page.partitions as V1ModelPartition[],
-        )) ||
-      [];
-
-    options.update((old) => ({
-      ...old,
-      data: allRows,
-    }));
-  }
-  $: rows = $table.getRowModel().rows;
-
-  // ==========================
-  // Virtualizer
-  // ==========================
-  const ROW_HEIGHT = 71;
-  const OVERSCAN = 10;
-
-  let virtualListEl: HTMLDivElement;
-
-  $: virtualizer = createVirtualizer<HTMLDivElement, HTMLDivElement>({
-    count: 0,
-    getScrollElement: () => virtualListEl,
-    estimateSize: () => ROW_HEIGHT,
-    overscan: OVERSCAN,
-  });
-  $: ({
-    getVirtualItems,
-    getTotalSize,
-    setOptions,
-    options: virtualizerOptions,
-  } = $virtualizer);
-  $: virtualRows = getVirtualItems();
-
-  // Logic for infinite scroll
-  $: {
-    setOptions({
-      count: $query.hasNextPage ? allRows.length + 1 : allRows.length,
-    });
-    const lastItem = virtualRows[virtualRows.length - 1];
-    if (
-      lastItem &&
-      lastItem.index > allRows.length - 1 &&
-      $query.hasNextPage &&
-      !$query.isFetchingNextPage
-    ) {
-      void $query.fetchNextPage();
-    }
-  }
-
-  // Positioning strategy from https://github.com/TanStack/virtual/issues/585#issuecomment-1716173260
-  // (Required for sticky header)
-  $: [paddingTop, paddingBottom] =
-    virtualRows.length > 0
-      ? [
-          Math.max(0, virtualRows[0].start - virtualizerOptions.scrollMargin),
-          Math.max(0, getTotalSize() - virtualRows[virtualRows.length - 1].end),
-        ]
-      : [0, 0];
-
-  // Scroll to top when filter changes
-  $: {
-    if (virtualListEl && baseParams) {
-      virtualListEl.scrollTo({ top: 0 });
-    }
-  }
+  $: emptyText = $query.isLoading
+    ? "Loading partitions…"
+    : searchText
+      ? "No partitions match your search"
+      : "No partitions";
 </script>
 
-<div class="scroll-container" bind:this={virtualListEl}>
-  <div class="table-wrapper">
-    <table>
-      <thead>
-        {#each getHeaderGroups() as headerGroup (headerGroup.id)}
-          <tr>
-            {#each headerGroup.headers as header (header.id)}
-              {@const widthPercent = header.column.columnDef.meta?.widthPercent}
-              <th colSpan={header.colSpan} style={`width: ${widthPercent}%;`}>
-                <svelte:component
-                  this={flexRender(
-                    header.column.columnDef.header,
-                    header.getContext(),
-                  )}
-                />
-              </th>
-            {/each}
-          </tr>
-        {/each}
-      </thead>
-      <tbody>
-        {#if error}
-          <tr>
-            <td class="text-center h-16" colspan={columns.length}>
-              <span class="text-red-500 font-semibold"
-                >Error: {error.message}</span
-              >
-            </td>
-          </tr>
-        {:else if allRows.length === 0}
-          <tr>
-            <td class="text-center h-16" colspan={columns.length}>
-              <span class="text-fg-secondary">None</span>
-            </td>
-          </tr>
-        {:else}
-          <tr style:height="{paddingTop}px"></tr>
-          {#each virtualRows as virtualRow (virtualRow.index)}
-            <tr>
-              {#each rows[virtualRow.index]?.getVisibleCells() ?? [] as cell (cell.id)}
-                <td data-label={cell.column.columnDef.header}>
-                  <svelte:component
-                    this={flexRender(
-                      cell.column.columnDef.cell,
-                      cell.getContext(),
-                    )}
-                  />
-                </td>
-              {/each}
-            </tr>
-          {/each}
-          <tr style:height="{paddingBottom}px"></tr>
-        {/if}
-      </tbody>
-    </table>
+{#if $query.error}
+  <div class="flex items-center justify-center h-16">
+    <span class="text-red-500 font-semibold">
+      Error: {$query.error.message}
+    </span>
   </div>
-</div>
-
-<style lang="postcss">
-  .scroll-container {
-    @apply h-[600px];
-    @apply min-w-full;
-    @apply overflow-auto;
-  }
-
-  .table-wrapper {
-    @apply relative;
-    @apply min-w-full;
-  }
-
-  table {
-    @apply table-fixed min-w-full;
-    @apply border-separate border-spacing-0;
-  }
-  table th,
-  table td {
-    @apply px-4 py-2;
-    @apply border-b;
-  }
-  thead tr th {
-    @apply border-t;
-    @apply text-left font-semibold text-fg-secondary;
-    @apply sticky top-0 z-10 bg-surface-subtle;
-  }
-  thead tr th:first-child {
-    @apply border-l rounded-tl-sm;
-  }
-  thead tr th:last-child {
-    @apply border-r rounded-tr-sm;
-  }
-  thead tr:last-child th {
-    @apply border-b;
-  }
-  tbody tr {
-    @apply border-t;
-  }
-  tbody tr:first-child {
-    @apply border-t-0;
-  }
-  tbody td {
-    @apply border-b;
-  }
-  tbody td:first-child {
-    @apply border-l;
-  }
-  tbody td:last-child {
-    @apply border-r;
-  }
-  tbody tr:last-child td:first-child {
-    @apply rounded-bl-sm;
-  }
-  tbody tr:last-child td:last-child {
-    @apply rounded-br-sm;
-  }
-</style>
+{:else}
+  <BasicTable data={filteredRows} {columns} {columnLayout} {emptyText} />
+  {#if $query.isFetchingNextPage}
+    <div class="flex items-center justify-center py-2">
+      <span class="text-fg-secondary text-sm">Loading more…</span>
+    </div>
+  {/if}
+{/if}

--- a/web-common/src/features/models/partitions/PartitionsTable.svelte
+++ b/web-common/src/features/models/partitions/PartitionsTable.svelte
@@ -72,7 +72,8 @@
     {
       id: "data",
       header: "Data",
-      accessorFn: (row) => ((row.data?.uri as string) ?? "").toLowerCase(),
+      accessorFn: (row) =>
+        ((row.data?.uri as string) ?? row.key ?? "").toLowerCase(),
       cell: ({ row }) => renderComponent(DataCell, { data: row.original.data }),
     },
     {

--- a/web-common/src/features/models/partitions/PartitionsTable.svelte
+++ b/web-common/src/features/models/partitions/PartitionsTable.svelte
@@ -70,10 +70,10 @@
 
   const columns: ColumnDef<V1ModelPartition, any>[] = [
     {
-      accessorKey: "data",
+      id: "data",
       header: "Data",
+      accessorFn: (row) => ((row.data?.uri as string) ?? "").toLowerCase(),
       cell: ({ row }) => renderComponent(DataCell, { data: row.original.data }),
-      enableSorting: false,
     },
     {
       accessorKey: "executedOn",
@@ -115,7 +115,7 @@
   ];
 
   const columnLayout = isIncremental
-    ? "minmax(0, 3fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2.5fr) minmax(0, 1fr)"
+    ? "minmax(0, 3fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2.5fr) minmax(180px, auto)"
     : "minmax(0, 3fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2.5fr)";
 
   $: emptyText = $query.isLoading

--- a/web-common/src/features/models/partitions/PartitionsTable.svelte
+++ b/web-common/src/features/models/partitions/PartitionsTable.svelte
@@ -55,7 +55,7 @@
     });
   })();
 
-  function formatTimestamp(ts: string | undefined, withMs = false) {
+  function formatTimestamp(ts: string | undefined) {
     return ts
       ? new Date(ts).toLocaleString(undefined, {
           month: "short",
@@ -63,7 +63,6 @@
           hour: "numeric",
           minute: "numeric",
           second: "numeric",
-          ...(withMs ? { fractionalSecondDigits: 3 } : {}),
         })
       : "-";
   }
@@ -90,7 +89,7 @@
     {
       accessorKey: "watermark",
       header: "Watermark",
-      cell: ({ row }) => formatTimestamp(row.original.watermark, true),
+      cell: ({ row }) => formatTimestamp(row.original.watermark),
     },
     {
       accessorKey: "error",

--- a/web-common/src/features/projects/status/tables/ModelPartitionsDialog.svelte
+++ b/web-common/src/features/projects/status/tables/ModelPartitionsDialog.svelte
@@ -36,23 +36,24 @@
     }
   }}
 >
-  <Dialog.Content class="max-w-screen-xl max-h-[90vh] flex flex-col">
+  <Dialog.Content class="max-w-screen-xl h-[80vh] flex flex-col gap-y-4">
     <Dialog.Header>
       <Dialog.Title>Model Partitions: {modelName}</Dialog.Title>
     </Dialog.Header>
 
     {#if resource}
-      <div class="flex items-center gap-x-3 mb-4">
-        <div class="w-64">
+      <div class="flex flex-row items-center gap-x-4 min-h-9">
+        <div class="flex-1 min-w-0 min-h-9">
           <Search
             bind:value={searchText}
-            placeholder="Search partitions"
+            placeholder="Search"
+            large
             autofocus={false}
+            showBorderOnFocus={false}
+            retainValueOnMount
           />
         </div>
-        <div class="ml-auto">
-          <PartitionsFilter {selectedFilter} onChange={onFilterChange} />
-        </div>
+        <PartitionsFilter {selectedFilter} onChange={onFilterChange} />
       </div>
       <div class="flex-1 min-h-0 overflow-auto">
         <PartitionsTable

--- a/web-common/src/features/projects/status/tables/ModelPartitionsDialog.svelte
+++ b/web-common/src/features/projects/status/tables/ModelPartitionsDialog.svelte
@@ -36,7 +36,7 @@
     }
   }}
 >
-  <Dialog.Content class="max-w-screen-xl h-[80vh] flex flex-col gap-y-4">
+  <Dialog.Content class="max-w-screen-xl h-[40vh] flex flex-col gap-y-4">
     <Dialog.Header>
       <Dialog.Title>Model Partitions: {modelName}</Dialog.Title>
     </Dialog.Header>

--- a/web-common/src/features/projects/status/tables/ModelPartitionsDialog.svelte
+++ b/web-common/src/features/projects/status/tables/ModelPartitionsDialog.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import * as Dialog from "@rilldata/web-common/components/dialog";
+  import { Search } from "@rilldata/web-common/components/search";
   import PartitionsTable from "@rilldata/web-common/features/models/partitions/PartitionsTable.svelte";
   import PartitionsFilter from "@rilldata/web-common/features/models/partitions/PartitionsFilter.svelte";
   import type { V1Resource } from "@rilldata/web-common/runtime-client";
@@ -14,6 +15,7 @@
   export let onClose: () => void = () => {};
 
   let selectedFilter: PartitionFilterType = "all";
+  let searchText = "";
 
   function onFilterChange(value: string) {
     selectedFilter = value as PartitionFilterType;
@@ -29,6 +31,7 @@
   onOpenChange={(o) => {
     if (!o) {
       selectedFilter = "all";
+      searchText = "";
       onClose();
     }
   }}
@@ -39,11 +42,25 @@
     </Dialog.Header>
 
     {#if resource}
-      <div class="flex justify-end mb-4">
-        <PartitionsFilter {selectedFilter} onChange={onFilterChange} />
+      <div class="flex items-center gap-x-3 mb-4">
+        <div class="w-64">
+          <Search
+            bind:value={searchText}
+            placeholder="Search partitions"
+            autofocus={false}
+          />
+        </div>
+        <div class="ml-auto">
+          <PartitionsFilter {selectedFilter} onChange={onFilterChange} />
+        </div>
       </div>
-      <div class="flex-1 overflow-hidden">
-        <PartitionsTable {resource} {whereErrored} {wherePending} />
+      <div class="flex-1 min-h-0 overflow-auto">
+        <PartitionsTable
+          {resource}
+          {whereErrored}
+          {wherePending}
+          {searchText}
+        />
       </div>
     {/if}
   </Dialog.Content>

--- a/web-local/tests/models/incremental.spec.ts
+++ b/web-local/tests/models/incremental.spec.ts
@@ -51,8 +51,8 @@ sql: >
     await expect(page.getByText("num: 1")).toBeVisible();
 
     // Filter for the errored partitions
-    await page.getByLabel("Filter partitions", { exact: true }).click();
-    await page.getByRole("option", { name: "errors" }).click();
+    await page.getByRole("button", { name: "All partitions" }).click();
+    await page.getByRole("menuitemcheckbox", { name: "Errored" }).click();
 
     // Check that the errored partition is displayed
     const errorText = page.getByText("failed to incrementally");


### PR DESCRIPTION
Migrates the model partitions table (used in Rill Developer and Rill Cloud) from a custom tanstack-table + virtualizer to the shared `BasicTable` component, and tightens the dialog overlay layout.

- Adds a search input that filters across partition key, data, and error message.
- Adds clickable-header sorting on **Executed on** (default desc), **Elapsed time**, and **Watermark**.
- Fixes the dialog overlay: the table fills the dialog body via `flex-1 min-h-0 overflow-auto` instead of a fixed 600px height.
- Auto-fetches all pages on open so search and sort cover the full set (the errored/pending server-side filter still limits the result set).
https://www.loom.com/share/9d1ba05bf66e4336a1b290486e80cd49

<img width="2947" height="920" alt="Screenshot 2026-04-17 at 16 41 41" src="https://github.com/user-attachments/assets/2be575a6-6ac8-4a1f-b862-4818b0bc442c" />


**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*