### PR TITLE
fix: nav tab underline sticks to stale position after sibling tabs mount

### DIFF
--- a/web-admin/src/components/nav/Tab.svelte
+++ b/web-admin/src/components/nav/Tab.svelte
@@ -16,23 +16,28 @@
 
   let size: number = 0;
   let left: number = 0;
-
-  $: if (selected && size) width.set(size);
-  $: if (selected && left) position.set(left);
-
-  const observer = new ResizeObserver((entries) => {
-    for (const entry of entries) {
-      if (entry.target instanceof HTMLElement) {
-        left = entry.target.offsetLeft;
-        size = entry.target.clientWidth;
-      }
-    }
-  });
-
   let element: HTMLAnchorElement;
 
+  $: if (selected && size) {
+    width.set(size);
+    position.set(left);
+  }
+
+  function measure() {
+    if (!element) return;
+    left = element.offsetLeft;
+    size = element.clientWidth;
+  }
+
   onMount(() => {
+    // Observe self for size changes AND the parent nav so we re-measure when
+    // sibling tabs mount/unmount (feature flags, permissions). ResizeObserver
+    // does not fire on pure offsetLeft changes, so without this the underline
+    // sticks to a stale position after sibling layout shifts.
+    const observer = new ResizeObserver(measure);
     observer.observe(element);
+    if (element.parentElement) observer.observe(element.parentElement);
+    return () => observer.disconnect();
   });
 </script>
 

--- a/web-admin/src/features/organizations/OrganizationTabs.svelte
+++ b/web-admin/src/features/organizations/OrganizationTabs.svelte
@@ -50,7 +50,7 @@
       {/each}
     </nav>
 
-    {#if $width && $position}
+    {#if $width}
       <span
         style:width="{$width}px"
         style:transform="translateX({$position}px) "

--- a/web-admin/src/features/projects/ProjectTabs.svelte
+++ b/web-admin/src/features/projects/ProjectTabs.svelte
@@ -93,7 +93,7 @@
     {/each}
   </nav>
 
-  {#if $width && $position}
+  {#if $width}
     <span style:width="{$width}px" style:transform="translateX({$position}px) "
     ></span>
   {/if}


### PR DESCRIPTION
- \`ResizeObserver\` in \`Tab.svelte\` only fires on size changes. When sibling tabs in \`ProjectTabs\`/\`OrganizationTabs\` mounted async (feature flags, \`projectPermissions\`), the selected tab's cached \`offsetLeft\` stayed stale and the underline landed under the wrong tab in prod.
- Fix: also observe the parent nav so sibling add/remove triggers a re-measure on the selected tab. Clean up the observer on unmount.
- Also set \`position\` when the selected tab's \`offsetLeft === 0\`, and drop the \`\$position\` truthiness gate in the parent templates so the first tab still shows the underline.

When AI is disabled
- Before:
<img width="507" height="50" alt="Screenshot 2026-04-20 at 10 12 56" src="https://github.com/user-attachments/assets/a987b8e0-905f-48a4-86a3-91d9db0fa4d9" />
After:
<img width="564" height="96" alt="Screenshot 2026-04-20 at 10 12 14" src="https://github.com/user-attachments/assets/9dbcb4bc-0640-44b2-a673-c2ad197f9d34" />


**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*