### PR TITLE
fix: duplicate OLAP engine and AI connector in 

### DIFF
--- a/web-admin/src/features/projects/status/overview/DeploymentSection.svelte
+++ b/web-admin/src/features/projects/status/overview/DeploymentSection.svelte
@@ -243,7 +243,10 @@
         <div class="info-row">
           <span class="info-label">{dataLabel}</span>
           <span class="info-value">
-            <a href="/{organization}/{project}/-/status/tables" class="repo-link">
+            <a
+              href="/{organization}/{project}/-/status/tables"
+              class="repo-link"
+            >
               {formatMemorySize(dataSizeBytes)}
             </a>
           </span>

--- a/web-admin/src/features/projects/status/overview/DeploymentSection.svelte
+++ b/web-admin/src/features/projects/status/overview/DeploymentSection.svelte
@@ -238,42 +238,17 @@
           {/if}
         </span>
       </div>
-    {/if}
 
-    {#if version}
-      <div class="info-row">
-        <span class="info-label">Runtime</span>
-        <span class="info-value">{version}</span>
-      </div>
-    {/if}
-
-    <div class="info-row">
-      <span class="info-label">OLAP Engine</span>
-      <span class="info-value">{olapEngineLabel}</span>
-    </div>
-
-    <div class="info-row">
-      <span class="info-label">AI Connector</span>
-      <span class="info-value">
-        {#if aiConnector && aiConnector.name !== "admin"}
-          {formatConnectorName(aiConnector.type)}
-          <span class="text-fg-tertiary text-xs ml-1">({aiConnector.name})</span
-          >
-        {:else}
-          Rill Managed
-        {/if}
-      </span>
-    </div>
-
-    {#if dataSizeBytes !== undefined}
-      <div class="info-row">
-        <span class="info-label">{dataLabel}</span>
-        <span class="info-value">
-          <a href="/{organization}/{project}/-/status/tables" class="repo-link">
-            {formatMemorySize(dataSizeBytes)}
-          </a>
-        </span>
-      </div>
+      {#if dataSizeBytes !== undefined}
+        <div class="info-row">
+          <span class="info-label">{dataLabel}</span>
+          <span class="info-value">
+            <a href="/{organization}/{project}/-/status/tables" class="repo-link">
+              {formatMemorySize(dataSizeBytes)}
+            </a>
+          </span>
+        </div>
+      {/if}
     {/if}
   </div>
 </OverviewCard>


### PR DESCRIPTION
Removes duplicate OLAP Engine and AI Connector rows in the deployment status overview. The rows were rendered twice due to a misplaced `{/if}` closing tag.

fixed in https://github.com/rilldata/rill/pull/9120 but not merged in tmie

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*