### PR TITLE
fix: `Back to home` href on dashboard error pages in preview mode

### DIFF
--- a/web-local/src/routes/(viz)/canvas/[name]/+page.svelte
+++ b/web-local/src/routes/(viz)/canvas/[name]/+page.svelte
@@ -12,6 +12,7 @@
     isNotFoundError,
     extractErrorStatusCode,
   } from "@rilldata/web-common/lib/errors";
+  import { previewModeStore } from "@rilldata/web-common/layout/preview-mode-store";
   import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
   import type { PageData } from "./$types";
 
@@ -32,6 +33,8 @@
     !$canvasQuery.data &&
     $canvasQuery.isError &&
     isNotFoundError($canvasQuery.error);
+
+  $: homeHref = $previewModeStore ? "/dashboards" : "/";
 </script>
 
 {#key `${runtimeClient.instanceId}::${canvasName}`}
@@ -40,9 +43,10 @@
       statusCode={extractErrorStatusCode($canvasQuery.error)}
       header="This user can't access this dashboard"
       body="The security policy for this dashboard may make contents invisible to you. If you deploy this dashboard, {$selectedMockUserStore?.email} will see a 404."
+      href={homeHref}
     />
   {:else if isCanvasNotFound}
-    <ErrorPage statusCode={404} header="Dashboard not found" />
+    <ErrorPage statusCode={404} header="Dashboard not found" href={homeHref} />
   {:else}
     <div class="flex h-full overflow-hidden">
       <div class="flex-1 overflow-hidden">

--- a/web-local/src/routes/(viz)/explore/[name]/+page.svelte
+++ b/web-local/src/routes/(viz)/explore/[name]/+page.svelte
@@ -23,6 +23,7 @@
   } from "@rilldata/web-common/lib/errors";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
   import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
+  import { previewModeStore } from "@rilldata/web-common/layout/preview-mode-store";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
   import type { PageData } from "./$types";
 
@@ -76,6 +77,8 @@
   $: mockUserHasNoAccess =
     $selectedMockUserStore && isNotFoundError($exploreResource.error);
 
+  $: homeHref = $previewModeStore ? "/dashboards" : "/";
+
   onNavigate(({ from, to }) => {
     const changedDashboard =
       !from || !to || from?.params?.name !== to?.params?.name;
@@ -97,9 +100,10 @@
     statusCode={extractErrorStatusCode($exploreResource.error)}
     header="This user can't access this dashboard"
     body="The security policy for this dashboard may make contents invisible to you. If you deploy this dashboard, {$selectedMockUserStore?.email} will see a 404."
+    href={homeHref}
   />
 {:else if isDashboardNotFound}
-  <ErrorPage statusCode={404} header="Dashboard not found" />
+  <ErrorPage statusCode={404} header="Dashboard not found" href={homeHref} />
 {:else if $exploreResource.isSuccess}
   {#if isExploreReconcilingForFirstTime($exploreResource.data)}
     <DashboardBuilding />
@@ -108,17 +112,20 @@
       header="Error building dashboard"
       body={$exploreResource.data?.explore?.meta?.reconcileError ??
         "An unknown error occurred while building the dashboard."}
+      href={homeHref}
     />
   {:else if dashboardFileHasParseError && dashboardFileHasParseError.length > 0}
     <ErrorPage
       header="Error parsing dashboard"
       body="Please check your dashboard's YAML file for errors."
+      href={homeHref}
     />
   {:else if measures.length === 0 && $selectedMockUserStore !== null}
     <ErrorPage
       statusCode={extractErrorStatusCode($exploreResource.error)}
       header="Error fetching dashboard"
       body="No measures available"
+      href={homeHref}
     />
   {:else if metricsViewName}
     <div class="h-full overflow-hidden">


### PR DESCRIPTION
- The `Back to home` button on `ErrorPage` instances in the `web-local` explore and canvas pages defaulted to `/`, which is the developer-mode home. In preview mode the home is `/dashboards`, so users landed in developer mode after errors like `Error building dashboard`.
- Derive the `href` from `previewModeStore` on both pages, matching the pattern already used in `+error.svelte`.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*