### PR TITLE
fix: public connector model import failure leading to dead back click

### DIFF
--- a/web-common/src/features/connectors/code-utils.ts
+++ b/web-common/src/features/connectors/code-utils.ts
@@ -4,6 +4,7 @@ import {
   type ConnectorDriverProperty,
   getRuntimeServiceGetFileQueryKey,
   runtimeServiceGetFile,
+  type V1GetFileResponse,
 } from "../../runtime-client";
 import type { RuntimeClient } from "../../runtime-client/v2";
 import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts";
@@ -313,12 +314,20 @@ export async function unsetResourceEnvVars(
   queryClient: QueryClient,
   yaml: string,
 ) {
-  const envBlob = await queryClient.fetchQuery({
-    queryKey: getRuntimeServiceGetFileQueryKey(runtimeClient.instanceId, {
-      path: ".env",
-    }),
-    queryFn: () => runtimeServiceGetFile(runtimeClient, { path: ".env" }),
-  });
+  let envBlob: V1GetFileResponse | undefined = undefined;
+  try {
+    envBlob = await queryClient.fetchQuery({
+      queryKey: getRuntimeServiceGetFileQueryKey(runtimeClient.instanceId, {
+        path: ".env",
+      }),
+      queryFn: () => runtimeServiceGetFile(runtimeClient, { path: ".env" }),
+    });
+  } catch (error) {
+    if (error.message?.includes("no such file or directory")) {
+      return "";
+    }
+    throw error;
+  }
 
   // Get the existing env and remove the resource's env vars
   let blob = envBlob?.blob ?? "";


### PR DESCRIPTION
When using a public connector during the welcome flow. Any failure in model import lead to dead back click. We were trying to read non existent `.env` file.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
