### PR TITLE
fix: prevent horizontal scrollbar from covering last row in metrics t…

### DIFF
--- a/web-common/src/features/visual-metrics-editing/MetricsTable.svelte
+++ b/web-common/src/features/visual-metrics-editing/MetricsTable.svelte
@@ -49,6 +49,7 @@
 
   $: wrapperWidth = wrapperRect.width;
   $: expressionWidth = Math.max(180, wrapperRect.width * 0.25);
+  $: hasHorizontalOverflow = tableWidth > wrapperWidth;
 
   $: filteredIndices = items
     .map((_, i) => i)
@@ -123,7 +124,8 @@
 <div
   class="wrapper"
   style:max-height="{Math.max(80, ((filteredIndices?.length ?? 0) + 1) * 40) +
-    1}px"
+    1 +
+    (hasHorizontalOverflow ? 15 : 0)}px"
   onscroll={(e) => {
     scroll = e.currentTarget.scrollLeft;
   }}


### PR DESCRIPTION
…able

The wrapper's max-height was calculated to exactly fit header + rows, leaving no room for the horizontal scrollbar when content overflowed. Reserve scrollbar height when tableWidth exceeds wrapperWidth so the scrollbar sits below content.
before:
<img width="749" height="66" alt="Screenshot 2026-04-22 at 12 27 57" src="https://github.com/user-attachments/assets/b3228a4f-7121-4188-8d06-11a37ed295a5" />
after:
<img width="742" height="74" alt="Screenshot 2026-04-22 at 12 28 01" src="https://github.com/user-attachments/assets/9fe7193f-bb5d-47e6-ba85-11494af65afb" />


**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
