### PR TITLE
Consolidate runtime JWT issuance

### DIFF
--- a/admin/server/auth/claims.go
+++ b/admin/server/auth/claims.go
@@ -49,6 +49,12 @@ func GetClaims(ctx context.Context) Claims {
 	return claims
 }
 
+// WithClaims returns a copy of ctx with the provided Claims attached.
+// Outside of this package, it should only be used for tests; the auth middleware is responsible for setting claims in production paths.
+func WithClaims(ctx context.Context, claims Claims) context.Context {
+	return context.WithValue(ctx, claimsContextKey{}, claims)
+}
+
 // anonClaims represents claims for an unauthenticated user.
 type anonClaims struct{}
 

--- a/admin/server/auth/middleware.go
+++ b/admin/server/auth/middleware.go
@@ -117,7 +117,7 @@ func (a *Authenticator) httpMiddleware(next http.Handler, lenient bool) http.Han
 			if err != nil {
 				// In lenient mode, we set anonClaims.
 				if lenient {
-					newCtx := context.WithValue(r.Context(), claimsContextKey{}, anonClaims{})
+					newCtx := WithClaims(r.Context(), anonClaims{})
 					next.ServeHTTP(w, r.WithContext(newCtx))
 					return
 				}
@@ -138,7 +138,7 @@ func (a *Authenticator) httpMiddleware(next http.Handler, lenient bool) http.Han
 			if err != nil {
 				// In lenient mode, we set anonClaims.
 				if lenient {
-					newCtx := context.WithValue(r.Context(), claimsContextKey{}, anonClaims{})
+					newCtx := WithClaims(r.Context(), anonClaims{})
 					next.ServeHTTP(w, r.WithContext(newCtx))
 					return
 				}
@@ -152,7 +152,7 @@ func (a *Authenticator) httpMiddleware(next http.Handler, lenient bool) http.Han
 		}
 
 		// No token was found. Set anonClaims.
-		newCtx := context.WithValue(r.Context(), claimsContextKey{}, anonClaims{})
+		newCtx := WithClaims(r.Context(), anonClaims{})
 		next.ServeHTTP(w, r.WithContext(newCtx))
 	})
 }
@@ -160,7 +160,7 @@ func (a *Authenticator) httpMiddleware(next http.Handler, lenient bool) http.Han
 func (a *Authenticator) parseClaimsFromBearer(ctx context.Context, authorizationHeader string) (context.Context, error) {
 	// If authorization header is not set, we set anonClaims.
 	if authorizationHeader == "" {
-		ctx = context.WithValue(ctx, claimsContextKey{}, anonClaims{})
+		ctx = WithClaims(ctx, anonClaims{})
 		return ctx, nil
 	}
 
@@ -185,7 +185,7 @@ func (a *Authenticator) parseClaimsFromToken(ctx context.Context, token string) 
 
 	// Set claims
 	claims := newAuthTokenClaims(validated, a.admin)
-	ctx = context.WithValue(ctx, claimsContextKey{}, claims)
+	ctx = WithClaims(ctx, claims)
 
 	// Set user ID in span and request log
 	if claims.OwnerType() == OwnerTypeUser {

--- a/admin/server/deployment.go
+++ b/admin/server/deployment.go
@@ -627,10 +627,10 @@ func (s *Server) GetIFrame(ctx context.Context, req *adminv1.GetIFrameRequest) (
 	req.Type = runtime.ResourceKindFromShorthand(req.Type)
 
 	// If navigation is disabled and a specific resource is requested, limit access to only that resource.
-	var overrideResources []*runtimev1.ResourceName
+	var overrideResources []database.ResourceName
 	if !req.Navigation && req.Resource != "" {
-		overrideResources = []*runtimev1.ResourceName{{
-			Kind: req.Type,
+		overrideResources = []database.ResourceName{{
+			Type: req.Type,
 			Name: req.Resource,
 		}}
 	}

--- a/admin/server/deployment.go
+++ b/admin/server/deployment.go
@@ -19,7 +19,6 @@ import (
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/pkg/observability"
-	runtimeauth "github.com/rilldata/rill/runtime/server/auth"
 	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -198,101 +197,36 @@ func (s *Server) GetDeployment(ctx context.Context, req *adminv1.GetDeploymentRe
 		}
 	}
 
-	var subject string
-	var attr map[string]any
-	var restrictResources bool
-	var resources []database.ResourceName
-	if req.For == nil && req.ExternalUserId == "" {
-		if claims.OwnerType() == auth.OwnerTypeUser {
-			subject = claims.OwnerID()
-			attr, err = s.jwtAttributesForUser(ctx, claims.OwnerID(), proj.OrganizationID, permissions)
-			if err != nil {
-				return nil, err
-			}
-			restrictResources, resources, err = s.getResourceRestrictionsForUser(ctx, proj.ID, claims.OwnerID())
-			if err != nil {
-				return nil, err
-			}
-		} else if claims.OwnerType() == auth.OwnerTypeService {
-			attr = map[string]any{"admin": true}
-			// NOTE: Intentionally leaving the `subject` empty out of caution.
-			// Some users use service accounts for generating JWTs for end users without passing req.For, and we don't want to accidentally pass a shared subject ID across those users (which could leak e.g. AI chats).
-		}
-	} else if req.For != nil {
-		switch forVal := req.For.(type) {
-		case *adminv1.GetDeploymentRequest_UserId:
-			if req.ExternalUserId != "" {
-				return nil, status.Error(codes.InvalidArgument, "external_user_id cannot be specified together with user_id")
-			}
-			subject = forVal.UserId
-			attr, restrictResources, resources, err = s.getAttributesAndResourceRestrictionsForUser(ctx, proj.OrganizationID, proj.ID, forVal.UserId, "")
-			if err != nil {
-				return nil, err
-			}
-		case *adminv1.GetDeploymentRequest_UserEmail:
-			attr, restrictResources, resources, err = s.getAttributesAndResourceRestrictionsForUser(ctx, proj.OrganizationID, proj.ID, "", forVal.UserEmail)
-			if err != nil {
-				return nil, err
-			}
-		case *adminv1.GetDeploymentRequest_Attributes:
-			attr = forVal.Attributes.AsMap()
-		default:
-			return nil, status.Error(codes.InvalidArgument, "invalid 'for' type")
-		}
-	}
-
-	// Handle external user ID (see API docstring for details)
-	if req.ExternalUserId != "" {
-		subject = subjectForExternalUser(req.ExternalUserId, proj.ID)
-	}
-
 	ttlDuration := runtimeAccessTokenEmbedTTL
 	if req.AccessTokenTtlSeconds > 0 {
 		ttlDuration = time.Duration(req.AccessTokenTtlSeconds) * time.Second
 	}
 
-	// get resource level security rules if applicable
-	rules := securityRulesFromResources(restrictResources, resources)
-
-	instancePermissions := []runtime.Permission{
-		runtime.ReadObjects,
-		runtime.ReadMetrics,
-		runtime.ReadAPI,
-		runtime.UseAI,
+	opts := &issueRuntimeTokenOptions{
+		project:            proj,
+		deployment:         depl,
+		projectPermissions: permissions,
+		externalUserID:     req.ExternalUserId,
+		ttl:                ttlDuration,
 	}
-	if depl.Environment == "dev" {
-		instancePermissions = append(instancePermissions,
-			runtime.ReadOLAP,
-			runtime.ReadProfiling,
-			runtime.ReadRepo,
-			runtime.ReadResolvers,
-		)
-		if permissions.ManageDev {
-			instancePermissions = append(instancePermissions,
-				runtime.EditRepo,
-				runtime.EditTrigger,
-			)
+	switch forVal := req.For.(type) {
+	case nil:
+		if req.ExternalUserId == "" {
+			opts.forOwner = true
 		}
-	} else if permissions.ManageProd {
-		instancePermissions = append(instancePermissions,
-			runtime.ReadResolvers,
-			runtime.EditTrigger,
-		)
+	case *adminv1.GetDeploymentRequest_UserId:
+		opts.forUserID = forVal.UserId
+	case *adminv1.GetDeploymentRequest_UserEmail:
+		opts.forUserEmail = forVal.UserEmail
+	case *adminv1.GetDeploymentRequest_Attributes:
+		opts.forUserAttributes = forVal.Attributes.AsMap()
+	default:
+		return nil, status.Error(codes.InvalidArgument, "invalid 'for' type")
 	}
 
-	// Generate JWT
-	jwt, err := s.issuer.NewToken(runtimeauth.TokenOptions{
-		AudienceURL: depl.RuntimeAudience,
-		Subject:     subject,
-		TTL:         ttlDuration,
-		InstancePermissions: map[string][]runtime.Permission{
-			depl.RuntimeInstanceID: instancePermissions,
-		},
-		Attributes:    attr,
-		SecurityRules: rules,
-	})
+	jwt, err := s.issueRuntimeToken(ctx, opts)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "could not issue jwt: %s", err.Error())
+		return nil, err
 	}
 
 	s.admin.Used.Deployment(depl.ID)
@@ -301,7 +235,7 @@ func (s *Server) GetDeployment(ctx context.Context, req *adminv1.GetDeploymentRe
 		RuntimeHost: depl.RuntimeHost,
 		InstanceId:  depl.RuntimeInstanceID,
 		AccessToken: jwt,
-		TtlSeconds:  uint32(ttlDuration.Seconds()),
+		TtlSeconds:  uint32(opts.ttl.Seconds()),
 	}, nil
 }
 
@@ -597,78 +531,36 @@ func (s *Server) GetDeploymentCredentials(ctx context.Context, req *adminv1.GetD
 		return nil, status.Error(codes.PermissionDenied, "does not have permission to manage deployment")
 	}
 
-	var subject string
-	var attr map[string]any
-	var restrictResources bool
-	var resources []database.ResourceName
-	if req.For == nil && req.ExternalUserId == "" {
-		if claims.OwnerType() == auth.OwnerTypeUser {
-			subject = claims.OwnerID()
-			attr, err = s.jwtAttributesForUser(ctx, claims.OwnerID(), proj.OrganizationID, permissions)
-			if err != nil {
-				return nil, err
-			}
-			restrictResources, resources, err = s.getResourceRestrictionsForUser(ctx, proj.ID, claims.OwnerID())
-			if err != nil {
-				return nil, err
-			}
-		}
-		// NOTE: Intentionally leaving the `subject` empty in other cases out of caution.
-		// Some users use service accounts for generating JWTs for end users without passing req.For, and we don't want to accidentally pass a shared subject ID across those users (which could leak e.g. AI chats).
-	} else if req.For != nil {
-		switch forVal := req.For.(type) {
-		case *adminv1.GetDeploymentCredentialsRequest_UserId:
-			if req.ExternalUserId != "" {
-				return nil, status.Error(codes.InvalidArgument, "external_user_id cannot be specified together with user_id")
-			}
-			subject = forVal.UserId
-			attr, restrictResources, resources, err = s.getAttributesAndResourceRestrictionsForUser(ctx, proj.OrganizationID, proj.ID, forVal.UserId, "")
-			if err != nil {
-				return nil, err
-			}
-		case *adminv1.GetDeploymentCredentialsRequest_UserEmail:
-			attr, restrictResources, resources, err = s.getAttributesAndResourceRestrictionsForUser(ctx, proj.OrganizationID, proj.ID, "", forVal.UserEmail)
-			if err != nil {
-				return nil, err
-			}
-		case *adminv1.GetDeploymentCredentialsRequest_Attributes:
-			attr = forVal.Attributes.AsMap()
-		default:
-			return nil, status.Error(codes.InvalidArgument, "invalid 'for' type")
-		}
-	}
-
-	// Handle external user ID (see API docstring for details)
-	if req.ExternalUserId != "" {
-		subject = subjectForExternalUser(req.ExternalUserId, proj.ID)
-	}
-
 	ttlDuration := runtimeAccessTokenEmbedTTL
 	if req.TtlSeconds > 0 {
 		ttlDuration = time.Duration(req.TtlSeconds) * time.Second
 	}
 
-	// get resource level security rules if applicable
-	rules := securityRulesFromResources(restrictResources, resources)
+	opts := &issueRuntimeTokenOptions{
+		project:            proj,
+		deployment:         prodDepl,
+		projectPermissions: permissions,
+		externalUserID:     req.ExternalUserId,
+		ttl:                ttlDuration,
+	}
+	switch forVal := req.For.(type) {
+	case nil:
+		if req.ExternalUserId == "" {
+			opts.forOwner = true
+		}
+	case *adminv1.GetDeploymentCredentialsRequest_UserId:
+		opts.forUserID = forVal.UserId
+	case *adminv1.GetDeploymentCredentialsRequest_UserEmail:
+		opts.forUserEmail = forVal.UserEmail
+	case *adminv1.GetDeploymentCredentialsRequest_Attributes:
+		opts.forUserAttributes = forVal.Attributes.AsMap()
+	default:
+		return nil, status.Error(codes.InvalidArgument, "invalid 'for' type")
+	}
 
-	// Generate JWT
-	jwt, err := s.issuer.NewToken(runtimeauth.TokenOptions{
-		AudienceURL: prodDepl.RuntimeAudience,
-		Subject:     subject,
-		TTL:         ttlDuration,
-		InstancePermissions: map[string][]runtime.Permission{
-			prodDepl.RuntimeInstanceID: {
-				runtime.ReadObjects,
-				runtime.ReadMetrics,
-				runtime.ReadAPI,
-				runtime.UseAI,
-			},
-		},
-		Attributes:    attr,
-		SecurityRules: rules,
-	})
+	jwt, err := s.issueRuntimeToken(ctx, opts)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "could not issue jwt: %s", err.Error())
+		return nil, err
 	}
 
 	s.admin.Used.Deployment(prodDepl.ID)
@@ -677,7 +569,7 @@ func (s *Server) GetDeploymentCredentials(ctx context.Context, req *adminv1.GetD
 		RuntimeHost: prodDepl.RuntimeHost,
 		InstanceId:  prodDepl.RuntimeInstanceID,
 		AccessToken: jwt,
-		TtlSeconds:  uint32(ttlDuration.Seconds()),
+		TtlSeconds:  uint32(opts.ttl.Seconds()),
 	}, nil
 }
 
@@ -724,61 +616,6 @@ func (s *Server) GetIFrame(ctx context.Context, req *adminv1.GetIFrameRequest) (
 		return nil, status.Error(codes.PermissionDenied, "does not have permission to manage deployment")
 	}
 
-	// Get user attributes to pass in the JWT
-	var subject string
-	var attr map[string]any
-	var restrictResources bool
-	var resources []database.ResourceName
-	if req.For == nil && req.ExternalUserId == "" {
-		if claims.OwnerType() == auth.OwnerTypeUser {
-			subject = claims.OwnerID()
-			attr, err = s.jwtAttributesForUser(ctx, claims.OwnerID(), proj.OrganizationID, permissions)
-			if err != nil {
-				return nil, err
-			}
-			restrictResources, resources, err = s.getResourceRestrictionsForUser(ctx, proj.ID, claims.OwnerID())
-			if err != nil {
-				return nil, err
-			}
-		}
-		// NOTE: Intentionally leaving the `subject` empty in other cases out of caution.
-		// Some users use service accounts for generating JWTs for end users without passing req.For, and we don't want to accidentally pass a shared subject ID across those users (which could leak e.g. AI chats).
-	} else if req.For != nil {
-		switch forVal := req.For.(type) {
-		case *adminv1.GetIFrameRequest_UserId:
-			if req.ExternalUserId != "" {
-				return nil, status.Error(codes.InvalidArgument, "external_user_id cannot be specified together with user_id")
-			}
-			subject = forVal.UserId
-			attr, restrictResources, resources, err = s.getAttributesAndResourceRestrictionsForUser(ctx, proj.OrganizationID, proj.ID, forVal.UserId, "")
-			if err != nil {
-				return nil, err
-			}
-		case *adminv1.GetIFrameRequest_UserEmail:
-			attr, restrictResources, resources, err = s.getAttributesAndResourceRestrictionsForUser(ctx, proj.OrganizationID, proj.ID, "", forVal.UserEmail)
-			if err != nil {
-				return nil, err
-			}
-		case *adminv1.GetIFrameRequest_Attributes:
-			attr = forVal.Attributes.AsMap()
-		default:
-			return nil, status.Error(codes.InvalidArgument, "invalid 'for' type")
-		}
-	}
-
-	// Handle external user ID (see API docstring for details)
-	if req.ExternalUserId != "" {
-		subject = subjectForExternalUser(req.ExternalUserId, proj.ID)
-	}
-
-	// Add an `embed` attribute for use in security policies or feature flags (as `{{.user.embed}}`).
-	if _, ok := attr["embed"]; !ok {
-		if attr == nil {
-			attr = make(map[string]any)
-		}
-		attr["embed"] = true
-	}
-
 	// Backwards compatibility for req.Type and req.Kind
 	if req.Kind != "" { // nolint:staticcheck // For backwards compatibility
 		req.Type = req.Kind // nolint:staticcheck // For backwards compatibility
@@ -789,48 +626,47 @@ func (s *Server) GetIFrame(ctx context.Context, req *adminv1.GetIFrameRequest) (
 	}
 	req.Type = runtime.ResourceKindFromShorthand(req.Type)
 
-	var rules []*runtimev1.SecurityRule
 	// If navigation is disabled and a specific resource is requested, limit access to only that resource.
+	var overrideResources []*runtimev1.ResourceName
 	if !req.Navigation && req.Resource != "" {
-		rules = append(rules, &runtimev1.SecurityRule{
-			Rule: &runtimev1.SecurityRule_TransitiveAccess{
-				TransitiveAccess: &runtimev1.SecurityRuleTransitiveAccess{
-					Resource: &runtimev1.ResourceName{
-						Kind: req.Type,
-						Name: req.Resource,
-					},
-				},
-			},
-		})
-	} else {
-		// get resource level security rules if navigation is enabled
-		rules = append(rules, securityRulesFromResources(restrictResources, resources)...)
+		overrideResources = []*runtimev1.ResourceName{{
+			Kind: req.Type,
+			Name: req.Resource,
+		}}
 	}
 
-	// Determine TTL for the access token
 	ttlDuration := runtimeAccessTokenEmbedTTL
 	if req.TtlSeconds > 0 {
 		ttlDuration = time.Duration(req.TtlSeconds) * time.Second
 	}
 
-	// Generate JWT
-	jwt, err := s.issuer.NewToken(runtimeauth.TokenOptions{
-		AudienceURL: prodDepl.RuntimeAudience,
-		Subject:     subject,
-		TTL:         ttlDuration,
-		InstancePermissions: map[string][]runtime.Permission{
-			prodDepl.RuntimeInstanceID: {
-				runtime.ReadObjects,
-				runtime.ReadMetrics,
-				runtime.ReadAPI,
-				runtime.UseAI,
-			},
-		},
-		Attributes:    attr,
-		SecurityRules: rules,
-	})
+	opts := &issueRuntimeTokenOptions{
+		project:            proj,
+		deployment:         prodDepl,
+		projectPermissions: permissions,
+		externalUserID:     req.ExternalUserId,
+		extraAttributes:    map[string]any{"embed": true},
+		overrideResources:  overrideResources,
+		ttl:                ttlDuration,
+	}
+	switch forVal := req.For.(type) {
+	case nil:
+		if req.ExternalUserId == "" {
+			opts.forOwner = true
+		}
+	case *adminv1.GetIFrameRequest_UserId:
+		opts.forUserID = forVal.UserId
+	case *adminv1.GetIFrameRequest_UserEmail:
+		opts.forUserEmail = forVal.UserEmail
+	case *adminv1.GetIFrameRequest_Attributes:
+		opts.forUserAttributes = forVal.Attributes.AsMap()
+	default:
+		return nil, status.Error(codes.InvalidArgument, "invalid 'for' type")
+	}
+
+	jwt, err := s.issueRuntimeToken(ctx, opts)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "could not issue jwt: %s", err.Error())
+		return nil, err
 	}
 
 	// Build the iframe URL search params
@@ -883,7 +719,7 @@ func (s *Server) GetIFrame(ctx context.Context, req *adminv1.GetIFrameRequest) (
 		RuntimeHost: prodDepl.RuntimeHost,
 		InstanceId:  prodDepl.RuntimeInstanceID,
 		AccessToken: jwt,
-		TtlSeconds:  uint32(ttlDuration.Seconds()),
+		TtlSeconds:  uint32(opts.ttl.Seconds()),
 	}, nil
 }
 

--- a/admin/server/deployment_test.go
+++ b/admin/server/deployment_test.go
@@ -1,0 +1,165 @@
+package server_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/rilldata/rill/admin/testadmin"
+	"github.com/rilldata/rill/cli/testcli"
+	adminv1 "github.com/rilldata/rill/proto/gen/rill/admin/v1"
+	"github.com/rilldata/rill/runtime"
+	"github.com/rilldata/rill/runtime/testruntime/testmode"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// TestDeploymentJWTs boots a real admin + runtime, deploys a trivial project, and exercises the
+// JWT-issuing admin endpoints (GetDeployment, GetDeploymentCredentials, GetIFrame) against it.
+// More assertions will be layered on top of this scaffold.
+func TestDeploymentJWTs(t *testing.T) {
+	testmode.Expensive(t)
+
+	adm := testadmin.NewWithOptionalRuntime(t, true)
+
+	// Create test users. Note: the first user becomes a superuser, so we let the second one own the org/project to avoid confounding effects.
+	_, _ = adm.NewUser(t)
+	u1, u1Client := adm.NewUser(t)
+
+	// Create empty test project
+	projectDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(projectDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "rill.yaml"), []byte("olap_connector: duckdb\n"), 0644))
+
+	// Deploy the test project.
+	// NOTE: Using testcli since it's what we've got. TODO: Move to direct API calls when we have better test utilities here.
+	owner := testcli.New(t, adm, u1Client.Token)
+	res := owner.Run(t, "org", "create", "jwt-test")
+	require.Equal(t, 0, res.ExitCode, res.Output)
+	res = owner.Run(t, "project", "deploy", "--interactive=false", "--org=jwt-test", "--project=jwt-project", "--path="+projectDir)
+	require.Equal(t, 0, res.ExitCode, res.Output)
+	depl := adm.TriggerDeployment(t, "jwt-test", "jwt-project")
+	require.NotEmpty(t, depl.RuntimeInstanceID)
+	require.Equal(t, "prod", depl.Environment)
+
+	t.Run("GetProject for project admin", func(t *testing.T) {
+		resp, err := u1Client.GetProject(t.Context(), &adminv1.GetProjectRequest{
+			Org:     "jwt-test",
+			Project: "jwt-project",
+		})
+		require.NoError(t, err)
+
+		c := decodeJWT(t, resp.Jwt)
+		require.Equal(t, u1.ID, c.Subject)
+		require.Equal(t, u1.Email, c.Attrs["email"])
+		require.Equal(t, true, c.Attrs["admin"])
+
+		perms := c.Instances[depl.RuntimeInstanceID]
+		requireHasPerms(t, perms, runtime.ReadObjects, runtime.ReadMetrics, runtime.ReadAPI, runtime.UseAI)
+		requireHasPerms(t, perms, runtime.ReadInstance, runtime.ReadResolvers, runtime.EditTrigger)
+		// Prod deployment is non-editable, so no edit-repo permissions.
+		requireLacksPerms(t, perms, runtime.EditRepo, runtime.ReadOLAP, runtime.ReadProfiling, runtime.ReadRepo)
+	})
+
+	t.Run("GetDeployment for project admin", func(t *testing.T) {
+		resp, err := u1Client.GetDeployment(t.Context(), &adminv1.GetDeploymentRequest{
+			DeploymentId: depl.ID,
+		})
+		require.NoError(t, err)
+
+		c := decodeJWT(t, resp.AccessToken)
+		require.Equal(t, u1.ID, c.Subject)
+		require.Equal(t, u1.Email, c.Attrs["email"])
+		require.Equal(t, true, c.Attrs["admin"])
+
+		perms := c.Instances[depl.RuntimeInstanceID]
+		requireHasPerms(t, perms, runtime.ReadInstance, runtime.ReadResolvers, runtime.EditTrigger)
+	})
+
+	t.Run("GetDeployment for non-Rill email", func(t *testing.T) {
+		email := "non-rill@example.com"
+
+		resp, err := u1Client.GetDeployment(t.Context(), &adminv1.GetDeploymentRequest{
+			DeploymentId: depl.ID,
+			For:          &adminv1.GetDeploymentRequest_UserEmail{UserEmail: email},
+		})
+		require.NoError(t, err)
+
+		c := decodeJWT(t, resp.AccessToken)
+		require.Empty(t, c.Subject)
+		require.Equal(t, email, c.Attrs["email"])
+		require.Equal(t, false, c.Attrs["admin"])
+
+		perms := c.Instances[depl.RuntimeInstanceID]
+		requireHasPerms(t, perms, runtime.ReadObjects, runtime.ReadMetrics, runtime.ReadAPI, runtime.UseAI)
+		requireLacksPerms(t, perms, runtime.EditTrigger, runtime.ReadInstance)
+	})
+
+	// GetDeployment with external user ID and custom attributes
+	t.Run("GetDeployment for external user ID and custom attributes", func(t *testing.T) {
+		extID := "external-customer-42"
+		customAttrs, err := structpb.NewStruct(map[string]any{
+			"email":     "embed@example.com",
+			"tenant_id": "foo",
+		})
+		require.NoError(t, err)
+
+		resp, err := u1Client.GetDeployment(t.Context(), &adminv1.GetDeploymentRequest{
+			DeploymentId:   depl.ID,
+			ExternalUserId: extID,
+			For:            &adminv1.GetDeploymentRequest_Attributes{Attributes: customAttrs},
+		})
+		require.NoError(t, err)
+
+		c := decodeJWT(t, resp.AccessToken)
+		require.True(t, strings.HasPrefix(c.Subject, "ext_"))
+		require.NotEqual(t, u1.ID, c.Subject)
+		require.Equal(t, "embed@example.com", c.Attrs["email"])
+		require.Equal(t, "foo", c.Attrs["tenant_id"])
+		require.NotContains(t, c.Attrs, "admin")
+
+		// Subject hash must be deterministic across calls with the same external id and project.
+		resp2, err := u1Client.GetDeployment(t.Context(), &adminv1.GetDeploymentRequest{
+			DeploymentId:   depl.ID,
+			ExternalUserId: extID,
+			For:            &adminv1.GetDeploymentRequest_Attributes{Attributes: customAttrs},
+		})
+		require.NoError(t, err)
+		require.Equal(t, c.Subject, decodeJWT(t, resp2.AccessToken).Subject)
+	})
+}
+
+// jwtPayload mirrors the subset of the runtime JWT payload that the assertions touch.
+type jwtPayload struct {
+	jwt.RegisteredClaims
+	System    []runtime.Permission            `json:"sys,omitempty"`
+	Instances map[string][]runtime.Permission `json:"ins,omitempty"`
+	Attrs     map[string]any                  `json:"attr,omitempty"`
+	Security  []json.RawMessage               `json:"sec,omitempty"`
+}
+
+func decodeJWT(t *testing.T, tok string) *jwtPayload {
+	t.Helper()
+	c := &jwtPayload{}
+	_, _, err := jwt.NewParser().ParseUnverified(tok, c)
+	require.NoError(t, err)
+	return c
+}
+
+func requireHasPerms(t *testing.T, got []runtime.Permission, want ...runtime.Permission) {
+	t.Helper()
+	for _, p := range want {
+		require.True(t, slices.Contains(got, p), "expected permission %v in %v", p, got)
+	}
+}
+
+func requireLacksPerms(t *testing.T, got []runtime.Permission, unwanted ...runtime.Permission) {
+	t.Helper()
+	for _, p := range unwanted {
+		require.False(t, slices.Contains(got, p), "did not expect permission %v in %v", p, got)
+	}
+}

--- a/admin/server/projects.go
+++ b/admin/server/projects.go
@@ -15,17 +15,14 @@ import (
 	"github.com/rilldata/rill/admin/server/auth"
 	adminv1 "github.com/rilldata/rill/proto/gen/rill/admin/v1"
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
-	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/pkg/email"
 	"github.com/rilldata/rill/runtime/pkg/env"
 	"github.com/rilldata/rill/runtime/pkg/observability"
-	runtimeauth "github.com/rilldata/rill/runtime/server/auth"
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 	"golang.org/x/exp/maps"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -342,141 +339,21 @@ func (s *Server) GetProject(ctx context.Context, req *adminv1.GetProjectRequest)
 		}
 	}
 
-	var attr map[string]any
-	var rules []*runtimev1.SecurityRule
-	if claims.OwnerType() == auth.OwnerTypeUser {
-		a, restrictResources, resources, err := s.getAttributesAndResourceRestrictionsForUser(ctx, proj.OrganizationID, proj.ID, claims.OwnerID(), "")
-		if err != nil {
-			return nil, err
-		}
-		attr = a
-		userRules := securityRulesFromResources(restrictResources, resources)
-		rules = append(rules, userRules...)
-	} else if claims.OwnerType() == auth.OwnerTypeService {
-		attr, err = s.jwtAttributesForService(ctx, claims.OwnerID(), permissions)
-		if err != nil {
-			return nil, err
-		}
-	} else if claims.OwnerType() == auth.OwnerTypeMagicAuthToken {
-		mdl, ok := claims.AuthTokenModel().(*database.MagicAuthToken)
-		if !ok {
-			return nil, status.Errorf(codes.Internal, "unexpected type %T for magic auth token model", claims.AuthTokenModel())
-		}
-
-		for _, r := range mdl.Resources {
-			rules = append(rules, &runtimev1.SecurityRule{
-				Rule: &runtimev1.SecurityRule_TransitiveAccess{
-					TransitiveAccess: &runtimev1.SecurityRuleTransitiveAccess{
-						Resource: &runtimev1.ResourceName{
-							Kind: r.Type,
-							Name: r.Name,
-						},
-					},
-				},
-			})
-		}
-
-		if len(mdl.Resources) == 0 {
-			// If no resources are specified, deny all access.
-			rules = append(rules, &runtimev1.SecurityRule{
-				Rule: &runtimev1.SecurityRule_Access{
-					Access: &runtimev1.SecurityRuleAccess{
-						Allow: false,
-					},
-				},
-			})
-		}
-
-		attr = mdl.Attributes
-		for mv, filter := range mdl.MetricsViewFilterJSONs {
-			expr := &runtimev1.Expression{}
-			err := protojson.Unmarshal([]byte(filter), expr)
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "could not unmarshal metrics view %q filter: %s", mv, err.Error())
-			}
-			if mv == "" {
-				return nil, status.Errorf(codes.Internal, "empty metrics view name in metrics view filter")
-			}
-			if mv == "*" { // backwards compatibility: apply to all MVs
-				rules = append(rules, &runtimev1.SecurityRule{
-					Rule: &runtimev1.SecurityRule_RowFilter{
-						RowFilter: &runtimev1.SecurityRuleRowFilter{
-							Expression: expr,
-						},
-					},
-				})
-				continue
-			}
-			rules = append(rules, &runtimev1.SecurityRule{
-				Rule: &runtimev1.SecurityRule_RowFilter{
-					RowFilter: &runtimev1.SecurityRuleRowFilter{
-						ConditionResources: []*runtimev1.ResourceName{
-							{
-								Kind: runtime.ResourceKindMetricsView,
-								Name: mv,
-							},
-						},
-						Expression: expr,
-					},
-				},
-			})
-		}
-
-		if len(mdl.Fields) > 0 {
-			rules = append(rules, &runtimev1.SecurityRule{
-				Rule: &runtimev1.SecurityRule_FieldAccess{
-					FieldAccess: &runtimev1.SecurityRuleFieldAccess{
-						Fields:    mdl.Fields,
-						Allow:     true,
-						Exclusive: true,
-					},
-				},
-			})
-		}
-	}
-
 	ttlDuration := runtimeAccessTokenDefaultTTL
 	if req.AccessTokenTtlSeconds != 0 {
 		ttlDuration = time.Duration(req.AccessTokenTtlSeconds) * time.Second
 	}
 
-	instancePermissions := []runtime.Permission{
-		runtime.ReadObjects,
-		runtime.ReadMetrics,
-		runtime.ReadAPI,
-		runtime.UseAI,
-	}
-	if permissions.ManageProject {
-		instancePermissions = append(
-			instancePermissions,
-			runtime.ReadInstance,
-			runtime.ReadResolvers,
-			runtime.EditTrigger,
-		)
-	}
-
-	var systemPermissions []runtime.Permission
-	if req.IssueSuperuserToken {
-		if !claims.Superuser(ctx) {
-			return nil, status.Error(codes.PermissionDenied, "only superusers can issue superuser tokens")
-		}
-		// NOTE: The ManageInstances permission is currently used by the runtime to skip access checks.
-		systemPermissions = append(systemPermissions, runtime.ManageInstances)
-	}
-
-	jwt, err := s.issuer.NewToken(runtimeauth.TokenOptions{
-		AudienceURL:       depl.RuntimeAudience,
-		Subject:           claims.OwnerID(),
-		TTL:               ttlDuration,
-		SystemPermissions: systemPermissions,
-		InstancePermissions: map[string][]runtime.Permission{
-			depl.RuntimeInstanceID: instancePermissions,
-		},
-		Attributes:    attr,
-		SecurityRules: rules,
+	jwt, err := s.issueRuntimeToken(ctx, &issueRuntimeTokenOptions{
+		project:            proj,
+		deployment:         depl,
+		projectPermissions: permissions,
+		forOwner:           true,
+		forManagement:      req.IssueSuperuserToken,
+		ttl:                ttlDuration,
 	})
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "could not issue jwt: %s", err.Error())
+		return nil, err
 	}
 
 	s.admin.Used.Deployment(depl.ID)

--- a/admin/server/projects.go
+++ b/admin/server/projects.go
@@ -349,7 +349,7 @@ func (s *Server) GetProject(ctx context.Context, req *adminv1.GetProjectRequest)
 		deployment:         depl,
 		projectPermissions: permissions,
 		forOwner:           true,
-		forManagement:      req.IssueSuperuserToken,
+		grantManageAll:     req.IssueSuperuserToken,
 		ttl:                ttlDuration,
 	})
 	if err != nil {

--- a/admin/server/runtime_jwt.go
+++ b/admin/server/runtime_jwt.go
@@ -33,6 +33,7 @@ type issueRuntimeTokenOptions struct {
 	// Mutually exclusive with the other for* fields.
 	forUserEmail string
 	// forUserAttributes issues the token with explicit user attributes (no extra resolution).
+	// A non-nil empty map counts as set and selects this mode.
 	// Mutually exclusive with the other for* fields.
 	forUserAttributes map[string]any
 	// externalUserID is an optional external user ID to be used when the token is issued for a non-Rill end user (usually in an embedded context).
@@ -87,7 +88,7 @@ func (s *Server) issueRuntimeToken(ctx context.Context, opts *issueRuntimeTokenO
 	switch {
 	case opts.forOwner:
 		if opts.externalUserID != "" {
-			return "", status.Error(codes.InvalidArgument, "externalUserID cannot be specified together with forOwner")
+			return "", status.Error(codes.Internal, "externalUserID cannot be specified together with forOwner")
 		}
 		switch claims.OwnerType() {
 		case auth.OwnerTypeUser:
@@ -128,7 +129,7 @@ func (s *Server) issueRuntimeToken(ctx context.Context, opts *issueRuntimeTokenO
 		}
 	case opts.forUserID != "":
 		if opts.externalUserID != "" {
-			return "", status.Error(codes.InvalidArgument, "externalUserID cannot be specified together with forUserID")
+			return "", status.Error(codes.Internal, "externalUserID cannot be specified together with forUserID")
 		}
 		subject = opts.forUserID
 		a, restrict, resources, err := s.getAttributesAndResourceRestrictionsForUser(ctx, opts.project.OrganizationID, opts.project.ID, opts.forUserID, "")
@@ -176,8 +177,11 @@ func (s *Server) issueRuntimeToken(ctx context.Context, opts *issueRuntimeTokenO
 	// NOTE: Only applicable for tokens issued for the claims owner (not possible to delegate to other end users).
 	var manageDepl bool
 	if opts.forOwner {
-		manageDepl = (opts.deployment.Environment == "prod" && opts.projectPermissions.ManageProd)
-		manageDepl = manageDepl || (opts.deployment.Environment != "prod" && opts.projectPermissions.ManageDev)
+		if opts.deployment.Environment == "prod" {
+			manageDepl = opts.projectPermissions.ManageProd
+		} else {
+			manageDepl = opts.projectPermissions.ManageDev
+		}
 	}
 
 	// Derive instance permissions from deployment config and project permissions.

--- a/admin/server/runtime_jwt.go
+++ b/admin/server/runtime_jwt.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-// issueRuntimeTokenOptions configures a call to (*Server).issueRuntimeToken.
+// issueRuntimeTokenOptions configures a call to issueRuntimeToken.
 type issueRuntimeTokenOptions struct {
 	// project the deployment belongs to.
 	project *database.Project
@@ -24,39 +24,45 @@ type issueRuntimeTokenOptions struct {
 	// projectPermissions of the claims owner.
 	// Passed separately from the claims to accommodate overrides for public projects and forced superuser access.
 	projectPermissions *adminv1.ProjectPermissions
-	// forOwner issues the token for the current claims owner (user / service / anon / magic token).
+	// forOwner issues the token for the current claims owner (user/service/anon/etc).
 	forOwner bool
-	// forManagement grants runtime.ManageInstances. May only be combined with forOwner.
-	// The helper verifies the caller is a superuser and otherwise returns PermissionDenied.
-	forManagement bool
 	// forUserID issues the token for a specific Rill user. Mutually exclusive with the other for* fields.
 	forUserID string
-	// forUserEmail issues the token for a user by email (synthesising non-admin attributes if unknown).
+	// forUserEmail issues the token for a user by email.
+	// The email does not have to correspond to an existing user; if it doesn't, synthetic attributes are generated based on the email.
 	// Mutually exclusive with the other for* fields.
 	forUserEmail string
-	// forUserAttributes issues the token with explicit attributes (no principal resolution).
+	// forUserAttributes issues the token with explicit user attributes (no extra resolution).
 	// Mutually exclusive with the other for* fields.
 	forUserAttributes map[string]any
-	// externalUserID, if non-empty, sets the JWT subject to a stable hash of the id scoped to the project.
-	// May be set on its own — in that case no principal is resolved and the token carries only the
-	// external subject (plus any extraAttributes). Cannot be combined with forUserID, whose user
-	// ID would itself be the subject.
+	// externalUserID is an optional external user ID to be used when the token is issued for a non-Rill end user (usually in an embedded context).
+	// It will be hashed and used as the JWT's subject.
+	// It cannot be combined with forOwner or forUserID.
+	// It may be set on its own, i.e. you do not have to set any of the for* fields.
 	externalUserID string
-	// extraAttributes is merged into the JWT attributes and takes precedence over principal-derived keys.
+	// grantManageAll grants runtime.ManageInstances permission.
+	// Only available for tokens with forOwner where the owner is a superuser.
+	grantManageAll bool
+	// extraAttributes will be merged into the resolved JWT attributes, but will not override attributes from other sources.
 	extraAttributes map[string]any
-	// overrideResources, when non-nil, replaces principal-derived resource-restriction rules with
-	// TransitiveAccess rules for exactly these resources. Incompatible with magic-token principals.
-	overrideResources []*runtimev1.ResourceName
+	// overrideResources optionally overrides and replaces other resource-restriction rules.
+	overrideResources []database.ResourceName
 	// ttl is how long the token is valid for.
 	ttl time.Duration
 }
 
-// issueRuntimeToken issues a runtime JWT for a deployment based on opts.
-// It centralizes subject/attribute/rule resolution and instance-permission derivation
-// that was previously duplicated across GetProject, GetDeployment, GetDeploymentCredentials,
-// GetIFrame, and the runtime proxy.
+// issueRuntimeToken issues a runtime JWT for a deployment based on the provided options and the currently authenticated user.
+// It should only be used from server handlers as it requires the context to carry auth claims.
 func (s *Server) issueRuntimeToken(ctx context.Context, opts *issueRuntimeTokenOptions) (string, error) {
-	// Validate that exactly one "for" mode is set.
+	// Get claims
+	claims := auth.GetClaims(ctx)
+	if claims == nil {
+		return "", status.Error(codes.Unauthenticated, "cannot issue runtime token without claims")
+	}
+
+	// Validate that at most one "for" mode is set.
+	// Note: it is valid to set none of them, which means no base subject/attributes/rules will be resolved.
+	// Note: forManagement is treated differently as it is a modifier on forOwner, which is checked separately below.
 	forCount := 0
 	if opts.forOwner {
 		forCount++
@@ -71,20 +77,7 @@ func (s *Server) issueRuntimeToken(ctx context.Context, opts *issueRuntimeTokenO
 		forCount++
 	}
 	if forCount > 1 {
-		return "", status.Error(codes.Internal, "issueRuntimeToken: at most one of forOwner/forUserID/forUserEmail/forUserAttributes may be set")
-	}
-	if opts.forManagement && !opts.forOwner {
-		return "", status.Error(codes.Internal, "issueRuntimeToken: forManagement requires forOwner")
-	}
-	if opts.externalUserID != "" && opts.forUserID != "" {
-		return "", status.Error(codes.InvalidArgument, "external_user_id cannot be specified together with user_id")
-	}
-
-	claims := auth.GetClaims(ctx)
-
-	// Enforce forManagement: only superusers may mint management tokens.
-	if opts.forManagement && !claims.Superuser(ctx) {
-		return "", status.Error(codes.PermissionDenied, "only superusers can issue management tokens")
+		return "", status.Error(codes.Internal, "at most one of forOwner/forUserID/forUserEmail/forUserAttributes may be set")
 	}
 
 	// Resolve principal: subject, attributes, and resource-restriction rules.
@@ -92,24 +85,10 @@ func (s *Server) issueRuntimeToken(ctx context.Context, opts *issueRuntimeTokenO
 	var attr map[string]any
 	var rules []*runtimev1.SecurityRule
 	switch {
-	case opts.forUserID != "":
-		subject = opts.forUserID
-		a, restrict, resources, err := s.getAttributesAndResourceRestrictionsForUser(ctx, opts.project.OrganizationID, opts.project.ID, opts.forUserID, "")
-		if err != nil {
-			return "", err
-		}
-		attr = a
-		rules = append(rules, securityRulesFromResources(restrict, resources)...)
-	case opts.forUserEmail != "":
-		a, restrict, resources, err := s.getAttributesAndResourceRestrictionsForUser(ctx, opts.project.OrganizationID, opts.project.ID, "", opts.forUserEmail)
-		if err != nil {
-			return "", err
-		}
-		attr = a
-		rules = append(rules, securityRulesFromResources(restrict, resources)...)
-	case opts.forUserAttributes != nil:
-		attr = opts.forUserAttributes
 	case opts.forOwner:
+		if opts.externalUserID != "" {
+			return "", status.Error(codes.InvalidArgument, "externalUserID cannot be specified together with forOwner")
+		}
 		switch claims.OwnerType() {
 		case auth.OwnerTypeUser:
 			subject = claims.OwnerID()
@@ -131,9 +110,6 @@ func (s *Server) issueRuntimeToken(ctx context.Context, opts *issueRuntimeTokenO
 			}
 			attr = a
 		case auth.OwnerTypeMagicAuthToken:
-			if opts.overrideResources != nil {
-				return "", status.Error(codes.PermissionDenied, "resource overrides are not supported for magic-token credentials")
-			}
 			subject = claims.OwnerID()
 			mdl, ok := claims.AuthTokenModel().(*database.MagicAuthToken)
 			if !ok {
@@ -150,6 +126,28 @@ func (s *Server) issueRuntimeToken(ctx context.Context, opts *issueRuntimeTokenO
 		default:
 			return "", status.Errorf(codes.InvalidArgument, "unsupported owner type %q", claims.OwnerType())
 		}
+	case opts.forUserID != "":
+		if opts.externalUserID != "" {
+			return "", status.Error(codes.InvalidArgument, "externalUserID cannot be specified together with forUserID")
+		}
+		subject = opts.forUserID
+		a, restrict, resources, err := s.getAttributesAndResourceRestrictionsForUser(ctx, opts.project.OrganizationID, opts.project.ID, opts.forUserID, "")
+		if err != nil {
+			return "", err
+		}
+		attr = a
+		rules = append(rules, securityRulesFromResources(restrict, resources)...)
+	case opts.forUserEmail != "":
+		a, restrict, resources, err := s.getAttributesAndResourceRestrictionsForUser(ctx, opts.project.OrganizationID, opts.project.ID, "", opts.forUserEmail)
+		if err != nil {
+			return "", err
+		}
+		attr = a
+		rules = append(rules, securityRulesFromResources(restrict, resources)...)
+	case opts.forUserAttributes != nil:
+		attr = opts.forUserAttributes
+	default:
+		// No principal: no subject, no attributes, no rules.
 	}
 
 	// Apply externalUserID after principal resolution so it overrides whatever subject was set.
@@ -158,62 +156,71 @@ func (s *Server) issueRuntimeToken(ctx context.Context, opts *issueRuntimeTokenO
 	}
 
 	// overrideResources replaces any principal-derived resource rules with a fresh allow-list.
-	// Magic-token principals have already been rejected above.
-	if opts.overrideResources != nil {
-		rules = rules[:0]
-		for _, r := range opts.overrideResources {
-			rules = append(rules, &runtimev1.SecurityRule{
-				Rule: &runtimev1.SecurityRule_TransitiveAccess{
-					TransitiveAccess: &runtimev1.SecurityRuleTransitiveAccess{
-						Resource: r,
-					},
-				},
-			})
-		}
+	if len(opts.overrideResources) > 0 {
+		rules = securityRulesFromResources(true, opts.overrideResources)
 	}
 
-	// Merge extraAttributes; later keys win so callers can force specific values (e.g., "embed": true).
+	// Merge extraAttributes (earlier keys win)
 	if len(opts.extraAttributes) > 0 {
 		if attr == nil {
 			attr = make(map[string]any, len(opts.extraAttributes))
 		}
 		for k, v := range opts.extraAttributes {
-			attr[k] = v
+			if _, exists := attr[k]; !exists {
+				attr[k] = v
+			}
 		}
 	}
 
-	// Derive instance permissions uniformly from deployment environment + project permissions.
+	// Check if allowed to manage the deployment's environment.
+	// NOTE: Only applicable for tokens issued for the claims owner (not possible to delegate to other end users).
+	var manageDepl bool
+	if opts.forOwner {
+		manageDepl = (opts.deployment.Environment == "prod" && opts.projectPermissions.ManageProd)
+		manageDepl = manageDepl || (opts.deployment.Environment != "prod" && opts.projectPermissions.ManageDev)
+	}
+
+	// Derive instance permissions from deployment config and project permissions.
 	instancePermissions := []runtime.Permission{
-		runtime.ReadObjects,
-		runtime.ReadMetrics,
 		runtime.ReadAPI,
+		runtime.ReadMetrics,
+		runtime.ReadObjects,
 		runtime.UseAI,
 	}
-	if opts.deployment.Environment == "dev" {
-		instancePermissions = append(instancePermissions,
-			runtime.ReadOLAP,
-			runtime.ReadProfiling,
-			runtime.ReadRepo,
+	if manageDepl {
+		instancePermissions = append(
+			instancePermissions,
+			runtime.ReadInstance,
 			runtime.ReadResolvers,
+			runtime.EditTrigger,
 		)
-		if opts.projectPermissions.ManageDev {
-			instancePermissions = append(instancePermissions, runtime.EditRepo, runtime.EditTrigger)
-		}
-	} else {
-		if opts.projectPermissions.ManageProd || opts.projectPermissions.ManageProject {
-			instancePermissions = append(instancePermissions, runtime.ReadResolvers, runtime.EditTrigger)
-		}
-		if opts.projectPermissions.ManageProject {
-			instancePermissions = append(instancePermissions, runtime.ReadInstance)
+		if opts.deployment.Editable {
+			instancePermissions = append(
+				instancePermissions,
+				runtime.ReadOLAP,
+				runtime.ReadProfiling,
+				runtime.ReadRepo,
+				runtime.EditRepo,
+			)
 		}
 	}
 
+	// Derive system permissions; only used for grantManageAll for now.
 	var systemPermissions []runtime.Permission
-	if opts.forManagement {
-		// NOTE: ManageInstances is currently used by the runtime to skip access checks.
+	if opts.grantManageAll {
+		// Must be for an owner who is a superuser
+		if !opts.forOwner {
+			return "", status.Error(codes.Internal, "grantManageAll requires forOwner")
+		}
+		if !claims.Superuser(ctx) {
+			return "", status.Error(codes.PermissionDenied, "only superusers can issue management tokens")
+		}
+
+		// NOTE: ManageInstances is currently used by the runtime to allow skipping access checks.
 		systemPermissions = append(systemPermissions, runtime.ManageInstances)
 	}
 
+	// Issue JWT.
 	jwt, err := s.issuer.NewToken(runtimeauth.TokenOptions{
 		AudienceURL:       opts.deployment.RuntimeAudience,
 		Subject:           subject,
@@ -228,7 +235,6 @@ func (s *Server) issueRuntimeToken(ctx context.Context, opts *issueRuntimeTokenO
 	if err != nil {
 		return "", status.Errorf(codes.Internal, "could not issue jwt: %s", err.Error())
 	}
-
 	return jwt, nil
 }
 
@@ -236,7 +242,6 @@ func (s *Server) issueRuntimeToken(ctx context.Context, opts *issueRuntimeTokenO
 // a resource allow-list (or blanket deny), metrics-view row filters, and a field allow-list.
 func securityRulesFromMagicAuthToken(mdl *database.MagicAuthToken) ([]*runtimev1.SecurityRule, error) {
 	var rules []*runtimev1.SecurityRule
-
 	if len(mdl.Resources) == 0 {
 		// No resources means deny all access.
 		rules = append(rules, &runtimev1.SecurityRule{

--- a/admin/server/runtime_jwt.go
+++ b/admin/server/runtime_jwt.go
@@ -1,0 +1,307 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/rilldata/rill/admin/database"
+	"github.com/rilldata/rill/admin/server/auth"
+	adminv1 "github.com/rilldata/rill/proto/gen/rill/admin/v1"
+	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
+	"github.com/rilldata/rill/runtime"
+	runtimeauth "github.com/rilldata/rill/runtime/server/auth"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// issueRuntimeTokenOptions configures a call to (*Server).issueRuntimeToken.
+type issueRuntimeTokenOptions struct {
+	// project the deployment belongs to.
+	project *database.Project
+	// deployment the token will be used for.
+	deployment *database.Deployment
+	// projectPermissions of the claims owner.
+	// Passed separately from the claims to accommodate overrides for public projects and forced superuser access.
+	projectPermissions *adminv1.ProjectPermissions
+	// forOwner issues the token for the current claims owner (user / service / anon / magic token).
+	forOwner bool
+	// forManagement grants runtime.ManageInstances. May only be combined with forOwner.
+	// The helper verifies the caller is a superuser and otherwise returns PermissionDenied.
+	forManagement bool
+	// forUserID issues the token for a specific Rill user. Mutually exclusive with the other for* fields.
+	forUserID string
+	// forUserEmail issues the token for a user by email (synthesising non-admin attributes if unknown).
+	// Mutually exclusive with the other for* fields.
+	forUserEmail string
+	// forUserAttributes issues the token with explicit attributes (no principal resolution).
+	// Mutually exclusive with the other for* fields.
+	forUserAttributes map[string]any
+	// externalUserID, if non-empty, sets the JWT subject to a stable hash of the id scoped to the project.
+	// May be set on its own — in that case no principal is resolved and the token carries only the
+	// external subject (plus any extraAttributes). Cannot be combined with forUserID, whose user
+	// ID would itself be the subject.
+	externalUserID string
+	// extraAttributes is merged into the JWT attributes and takes precedence over principal-derived keys.
+	extraAttributes map[string]any
+	// overrideResources, when non-nil, replaces principal-derived resource-restriction rules with
+	// TransitiveAccess rules for exactly these resources. Incompatible with magic-token principals.
+	overrideResources []*runtimev1.ResourceName
+	// ttl is how long the token is valid for.
+	ttl time.Duration
+}
+
+// issueRuntimeToken issues a runtime JWT for a deployment based on opts.
+// It centralizes subject/attribute/rule resolution and instance-permission derivation
+// that was previously duplicated across GetProject, GetDeployment, GetDeploymentCredentials,
+// GetIFrame, and the runtime proxy.
+func (s *Server) issueRuntimeToken(ctx context.Context, opts *issueRuntimeTokenOptions) (string, error) {
+	// Validate that exactly one "for" mode is set.
+	forCount := 0
+	if opts.forOwner {
+		forCount++
+	}
+	if opts.forUserID != "" {
+		forCount++
+	}
+	if opts.forUserEmail != "" {
+		forCount++
+	}
+	if opts.forUserAttributes != nil {
+		forCount++
+	}
+	if forCount > 1 {
+		return "", status.Error(codes.Internal, "issueRuntimeToken: at most one of forOwner/forUserID/forUserEmail/forUserAttributes may be set")
+	}
+	if opts.forManagement && !opts.forOwner {
+		return "", status.Error(codes.Internal, "issueRuntimeToken: forManagement requires forOwner")
+	}
+	if opts.externalUserID != "" && opts.forUserID != "" {
+		return "", status.Error(codes.InvalidArgument, "external_user_id cannot be specified together with user_id")
+	}
+
+	claims := auth.GetClaims(ctx)
+
+	// Enforce forManagement: only superusers may mint management tokens.
+	if opts.forManagement && !claims.Superuser(ctx) {
+		return "", status.Error(codes.PermissionDenied, "only superusers can issue management tokens")
+	}
+
+	// Resolve principal: subject, attributes, and resource-restriction rules.
+	var subject string
+	var attr map[string]any
+	var rules []*runtimev1.SecurityRule
+	switch {
+	case opts.forUserID != "":
+		subject = opts.forUserID
+		a, restrict, resources, err := s.getAttributesAndResourceRestrictionsForUser(ctx, opts.project.OrganizationID, opts.project.ID, opts.forUserID, "")
+		if err != nil {
+			return "", err
+		}
+		attr = a
+		rules = append(rules, securityRulesFromResources(restrict, resources)...)
+	case opts.forUserEmail != "":
+		a, restrict, resources, err := s.getAttributesAndResourceRestrictionsForUser(ctx, opts.project.OrganizationID, opts.project.ID, "", opts.forUserEmail)
+		if err != nil {
+			return "", err
+		}
+		attr = a
+		rules = append(rules, securityRulesFromResources(restrict, resources)...)
+	case opts.forUserAttributes != nil:
+		attr = opts.forUserAttributes
+	case opts.forOwner:
+		switch claims.OwnerType() {
+		case auth.OwnerTypeUser:
+			subject = claims.OwnerID()
+			a, err := s.jwtAttributesForUser(ctx, claims.OwnerID(), opts.project.OrganizationID, opts.projectPermissions)
+			if err != nil {
+				return "", err
+			}
+			attr = a
+			restrict, resources, err := s.getResourceRestrictionsForUser(ctx, opts.project.ID, claims.OwnerID())
+			if err != nil {
+				return "", err
+			}
+			rules = append(rules, securityRulesFromResources(restrict, resources)...)
+		case auth.OwnerTypeService:
+			subject = claims.OwnerID()
+			a, err := s.jwtAttributesForService(ctx, claims.OwnerID(), opts.projectPermissions)
+			if err != nil {
+				return "", err
+			}
+			attr = a
+		case auth.OwnerTypeMagicAuthToken:
+			if opts.overrideResources != nil {
+				return "", status.Error(codes.PermissionDenied, "resource overrides are not supported for magic-token credentials")
+			}
+			subject = claims.OwnerID()
+			mdl, ok := claims.AuthTokenModel().(*database.MagicAuthToken)
+			if !ok {
+				return "", status.Errorf(codes.Internal, "unexpected type %T for magic auth token model", claims.AuthTokenModel())
+			}
+			attr = mdl.Attributes
+			magicRules, err := securityRulesFromMagicAuthToken(mdl)
+			if err != nil {
+				return "", err
+			}
+			rules = append(rules, magicRules...)
+		case auth.OwnerTypeAnon:
+			// Anonymous principal: no subject, no attributes, no rules.
+		default:
+			return "", status.Errorf(codes.InvalidArgument, "unsupported owner type %q", claims.OwnerType())
+		}
+	}
+
+	// Apply externalUserID after principal resolution so it overrides whatever subject was set.
+	if opts.externalUserID != "" {
+		subject = subjectForExternalUser(opts.externalUserID, opts.project.ID)
+	}
+
+	// overrideResources replaces any principal-derived resource rules with a fresh allow-list.
+	// Magic-token principals have already been rejected above.
+	if opts.overrideResources != nil {
+		rules = rules[:0]
+		for _, r := range opts.overrideResources {
+			rules = append(rules, &runtimev1.SecurityRule{
+				Rule: &runtimev1.SecurityRule_TransitiveAccess{
+					TransitiveAccess: &runtimev1.SecurityRuleTransitiveAccess{
+						Resource: r,
+					},
+				},
+			})
+		}
+	}
+
+	// Merge extraAttributes; later keys win so callers can force specific values (e.g., "embed": true).
+	if len(opts.extraAttributes) > 0 {
+		if attr == nil {
+			attr = make(map[string]any, len(opts.extraAttributes))
+		}
+		for k, v := range opts.extraAttributes {
+			attr[k] = v
+		}
+	}
+
+	// Derive instance permissions uniformly from deployment environment + project permissions.
+	instancePermissions := []runtime.Permission{
+		runtime.ReadObjects,
+		runtime.ReadMetrics,
+		runtime.ReadAPI,
+		runtime.UseAI,
+	}
+	if opts.deployment.Environment == "dev" {
+		instancePermissions = append(instancePermissions,
+			runtime.ReadOLAP,
+			runtime.ReadProfiling,
+			runtime.ReadRepo,
+			runtime.ReadResolvers,
+		)
+		if opts.projectPermissions.ManageDev {
+			instancePermissions = append(instancePermissions, runtime.EditRepo, runtime.EditTrigger)
+		}
+	} else {
+		if opts.projectPermissions.ManageProd || opts.projectPermissions.ManageProject {
+			instancePermissions = append(instancePermissions, runtime.ReadResolvers, runtime.EditTrigger)
+		}
+		if opts.projectPermissions.ManageProject {
+			instancePermissions = append(instancePermissions, runtime.ReadInstance)
+		}
+	}
+
+	var systemPermissions []runtime.Permission
+	if opts.forManagement {
+		// NOTE: ManageInstances is currently used by the runtime to skip access checks.
+		systemPermissions = append(systemPermissions, runtime.ManageInstances)
+	}
+
+	jwt, err := s.issuer.NewToken(runtimeauth.TokenOptions{
+		AudienceURL:       opts.deployment.RuntimeAudience,
+		Subject:           subject,
+		TTL:               opts.ttl,
+		SystemPermissions: systemPermissions,
+		InstancePermissions: map[string][]runtime.Permission{
+			opts.deployment.RuntimeInstanceID: instancePermissions,
+		},
+		Attributes:    attr,
+		SecurityRules: rules,
+	})
+	if err != nil {
+		return "", status.Errorf(codes.Internal, "could not issue jwt: %s", err.Error())
+	}
+
+	return jwt, nil
+}
+
+// securityRulesFromMagicAuthToken builds the security rules encoded by a magic auth token:
+// a resource allow-list (or blanket deny), metrics-view row filters, and a field allow-list.
+func securityRulesFromMagicAuthToken(mdl *database.MagicAuthToken) ([]*runtimev1.SecurityRule, error) {
+	var rules []*runtimev1.SecurityRule
+
+	if len(mdl.Resources) == 0 {
+		// No resources means deny all access.
+		rules = append(rules, &runtimev1.SecurityRule{
+			Rule: &runtimev1.SecurityRule_Access{
+				Access: &runtimev1.SecurityRuleAccess{Allow: false},
+			},
+		})
+	} else {
+		for _, r := range mdl.Resources {
+			rules = append(rules, &runtimev1.SecurityRule{
+				Rule: &runtimev1.SecurityRule_TransitiveAccess{
+					TransitiveAccess: &runtimev1.SecurityRuleTransitiveAccess{
+						Resource: &runtimev1.ResourceName{
+							Kind: r.Type,
+							Name: r.Name,
+						},
+					},
+				},
+			})
+		}
+	}
+
+	for mv, filter := range mdl.MetricsViewFilterJSONs {
+		if mv == "" {
+			return nil, status.Errorf(codes.Internal, "empty metrics view name in metrics view filter")
+		}
+		expr := &runtimev1.Expression{}
+		if err := protojson.Unmarshal([]byte(filter), expr); err != nil {
+			return nil, status.Errorf(codes.Internal, "could not unmarshal metrics view %q filter: %s", mv, err.Error())
+		}
+		if mv == "*" {
+			// Backwards compatibility: "*" applies to all metrics views.
+			rules = append(rules, &runtimev1.SecurityRule{
+				Rule: &runtimev1.SecurityRule_RowFilter{
+					RowFilter: &runtimev1.SecurityRuleRowFilter{
+						Expression: expr,
+					},
+				},
+			})
+			continue
+		}
+		rules = append(rules, &runtimev1.SecurityRule{
+			Rule: &runtimev1.SecurityRule_RowFilter{
+				RowFilter: &runtimev1.SecurityRuleRowFilter{
+					ConditionResources: []*runtimev1.ResourceName{{
+						Kind: runtime.ResourceKindMetricsView,
+						Name: mv,
+					}},
+					Expression: expr,
+				},
+			},
+		})
+	}
+
+	if len(mdl.Fields) > 0 {
+		rules = append(rules, &runtimev1.SecurityRule{
+			Rule: &runtimev1.SecurityRule_FieldAccess{
+				FieldAccess: &runtimev1.SecurityRuleFieldAccess{
+					Fields:    mdl.Fields,
+					Allow:     true,
+					Exclusive: true,
+				},
+			},
+		})
+	}
+
+	return rules, nil
+}

--- a/admin/server/runtime_proxy.go
+++ b/admin/server/runtime_proxy.go
@@ -11,10 +11,7 @@ import (
 	"time"
 
 	"github.com/rilldata/rill/admin/server/auth"
-	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
-	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/pkg/httputil"
-	runtimeauth "github.com/rilldata/rill/runtime/server/auth"
 )
 
 // runtimeProxyAccessTokenTTL is the TTL for tokens minted by the runtime proxy.
@@ -62,8 +59,7 @@ func (s *Server) runtimeProxyForOrgAndProject(w http.ResponseWriter, r *http.Req
 			jwt = strings.TrimSpace(authorizationHeader[6:])
 		}
 	}
-	// If a direct JWT was not provided, we rely on admin service auth to issue a new ephemeral runtime JWT for the proxied request.
-	// TODO: This mirrors logic in GetProject. Consider refactoring to avoid duplication.
+	// If a direct JWT was not provided, issue a new ephemeral runtime JWT for the proxied request.
 	if jwt == "" {
 		permissions := claims.ProjectPermissions(r.Context(), proj.OrganizationID, depl.ProjectID)
 		if proj.Public {
@@ -79,51 +75,12 @@ func (s *Server) runtimeProxyForOrgAndProject(w http.ResponseWriter, r *http.Req
 			return httputil.Errorf(http.StatusUnauthorized, "does not have permission to access the production deployment")
 		}
 
-		var attr map[string]any
-		var rules []*runtimev1.SecurityRule
-		switch claims.OwnerType() {
-		case auth.OwnerTypeAnon:
-			// No attributes
-		case auth.OwnerTypeUser:
-			attr, err = s.jwtAttributesForUser(r.Context(), claims.OwnerID(), proj.OrganizationID, permissions)
-			if err != nil {
-				return httputil.Error(http.StatusInternalServerError, err)
-			}
-			restrictResources, resources, err := s.getResourceRestrictionsForUser(r.Context(), proj.ID, claims.OwnerID())
-			if err != nil {
-				return httputil.Error(http.StatusInternalServerError, err)
-			}
-
-			// ignore resource level security rules if the user has a full role
-			rules = securityRulesFromResources(restrictResources, resources)
-		case auth.OwnerTypeService:
-			attr, err = s.jwtAttributesForService(r.Context(), claims.OwnerID(), permissions)
-			if err != nil {
-				return httputil.Error(http.StatusInternalServerError, err)
-			}
-		default:
-			return httputil.Errorf(http.StatusBadRequest, "runtime proxy not available for owner type %q", claims.OwnerType())
-		}
-
-		instancePermissions := []runtime.Permission{
-			runtime.ReadObjects,
-			runtime.ReadMetrics,
-			runtime.ReadAPI,
-			runtime.UseAI,
-		}
-		if permissions.ManageProject {
-			instancePermissions = append(instancePermissions, runtime.EditTrigger)
-		}
-
-		jwt, err = s.issuer.NewToken(runtimeauth.TokenOptions{
-			AudienceURL: depl.RuntimeAudience,
-			Subject:     claims.OwnerID(),
-			TTL:         runtimeProxyAccessTokenTTL,
-			InstancePermissions: map[string][]runtime.Permission{
-				depl.RuntimeInstanceID: instancePermissions,
-			},
-			Attributes:    attr,
-			SecurityRules: rules,
+		jwt, err = s.issueRuntimeToken(r.Context(), &issueRuntimeTokenOptions{
+			project:            proj,
+			deployment:         depl,
+			projectPermissions: permissions,
+			forOwner:           true,
+			ttl:                runtimeProxyAccessTokenTTL,
 		})
 		if err != nil {
 			return httputil.Error(http.StatusInternalServerError, err)


### PR DESCRIPTION
- Simplifies tokens issuance by removing duplicated code
- Fixes inconsistencies in token issuance across `GetProject`, `GetDeployment`, `GetDeploymentCredentials`, `GetIFrame`, and the runtime proxy
- Fixes missing permissions for JWTs for editable deployments
- Several security improvements:
    - Dev users without `ManageDev` no longer get `ReadOLAP`, `ReadProfiling`, `ReadRepo`, `ReadResolvers`
    - Edit runtime permissions (ReadRepo, EditRepo, ReadOLAP, ReadProfiling) are now gated on the deployment's `Editable` flag, not the `Environment` value
    - Acts-as tokens (forUserID / forUserEmail / forUserAttributes / externalUserID-only) no longer inherit the caller's `ManageProd`-related permissions (like ability to trigger refreshes)
    - Magic-token security rules are now applied on every deployment RPC, not just `GetProject`, closing an owner-type fallthrough gap

This PR is required to support cloud editing.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!