### PR TITLE
Remove unsafe-eval

### DIFF
--- a/web-admin/svelte.config.js
+++ b/web-admin/svelte.config.js
@@ -38,9 +38,14 @@ const config = {
         "default-src": ["self"],
         "script-src": [
           "self",
+          // Injected by the Pylon widget at runtime; exact subdomain is unknown without CSP reports.
           "https://*.app-us1.com/",
-          //https://support.usepylon.com/articles/5968160735-chat-widget-debugging-guide
-          "https://*.usepylon.com",
+          // widget.usepylon.com is the confirmed entry point (initPylonWidget.ts).
+          // The remaining *.usepylon.com and *.pusher.com entries below are loaded
+          // dynamically by the Pylon widget — narrow further once CSP violation reports
+          // confirm the exact subdomains.
+          // https://support.usepylon.com/articles/5968160735-chat-widget-debugging-guide
+          "https://widget.usepylon.com",
           "https://*.pusher.com",
           ...(dev ? ["http:"] : []),
           // Hash of the inline script injected by the Pylon chat widget at runtime.

--- a/web-admin/svelte.config.js
+++ b/web-admin/svelte.config.js
@@ -46,7 +46,8 @@ const config = {
           // confirm the exact subdomains.
           // https://support.usepylon.com/articles/5968160735-chat-widget-debugging-guide
           "https://widget.usepylon.com",
-          "https://*.pusher.com",
+          // Pusher JS SDK is likely bundled, but kept for Pylon's dynamic script injection.
+          "https://js.pusher.com",
           ...(dev ? ["http:"] : []),
           // Hash of the inline script injected by the Pylon chat widget at runtime.
           // If Pylon updates their widget, this hash may need to be refreshed.
@@ -73,11 +74,13 @@ const config = {
           "https://*.rilldata.com",
           "https://*.rilldata.io",
           "https://*.rilldata.in",
+          // *.usepylon.com: Pylon widget makes internal requests to unknown subdomains.
           "https://*.usepylon.com",
           "https://docs.google.com",
           "https://storage.googleapis.com",
           "https://cdn.prod.website-files.com",
-          "wss://*.pusher.com",
+          // Pusher cluster confirmed from HAR (ws-us3). Update if cluster changes.
+          "wss://ws-us3.pusher.com",
           ...(dev ? ["http://localhost:*", "ws://localhost:*"] : []),
         ],
         "font-src": [

--- a/web-admin/svelte.config.js
+++ b/web-admin/svelte.config.js
@@ -39,6 +39,7 @@ const config = {
         "script-src": [
           "self",
           "https://*.app-us1.com/",
+          //https://support.usepylon.com/articles/5968160735-chat-widget-debugging-guide
           "https://*.usepylon.com",
           "https://*.pusher.com",
           ...(dev ? ["http:"] : []),
@@ -71,7 +72,6 @@ const config = {
           "https://docs.google.com",
           "https://storage.googleapis.com",
           "https://cdn.prod.website-files.com",
-          "https://*.stripe.com",
           "wss://*.pusher.com",
           ...(dev ? ["http://localhost:*", "ws://localhost:*"] : []),
         ],

--- a/web-admin/svelte.config.js
+++ b/web-admin/svelte.config.js
@@ -52,7 +52,7 @@ const config = {
         ],
         // style-src keeps 'unsafe-inline': runtime style injection from
         // CodeMirror and other libraries cannot be hash-attributed.
-        "style-src": ["self", "unsafe-inline"],
+        "style-src": ["self", "unsafe-inline", "https://widget.usepylon.com"],
         "img-src": [...(dev ? ["http:"] : []), "https:", "data:", "blob:"],
         "frame-src": [
           "self",
@@ -71,6 +71,7 @@ const config = {
           "https://*.rilldata.com",
           "https://*.rilldata.io",
           "https://*.rilldata.in",
+          "https://apichatwidget.usepylon.com",
           "https://docs.google.com",
           "https://storage.googleapis.com",
           "https://cdn.prod.website-files.com",
@@ -81,6 +82,7 @@ const config = {
         "font-src": [
           "self",
           "https://fonts.gstatic.com",
+          "https://widget.usepylon.com",
         ],
       },
     },

--- a/web-admin/svelte.config.js
+++ b/web-admin/svelte.config.js
@@ -38,7 +38,6 @@ const config = {
         "default-src": ["self"],
         "script-src": [
           "self",
-          "unsafe-eval",
           "https://*.app-us1.com/",
           "https://*.usepylon.com",
           "https://*.pusher.com",

--- a/web-admin/svelte.config.js
+++ b/web-admin/svelte.config.js
@@ -16,8 +16,9 @@ const dev = adminFrontendURL?.includes("localhost");
 // connect-src covers all subdomains in whichever environment is being built,
 // without statically listing all three TLDs.
 let rillWildcard = "https://*.rilldata.com"; // fallback for local dev
-if (adminFrontendURL && !dev) {
-  const hostname = new URL(adminFrontendURL).hostname; // e.g. "admin.rilldata.com"
+const adminURL = process.env.RILL_UI_PUBLIC_RILL_ADMIN_URL;
+if (adminURL && !dev) {
+  const hostname = new URL(adminURL).hostname; // e.g. "admin.rilldata.com"
   const baseDomain = hostname.split(".").slice(1).join("."); // e.g. "rilldata.com"
   rillWildcard = `https://*.${baseDomain}`;
 }

--- a/web-admin/svelte.config.js
+++ b/web-admin/svelte.config.js
@@ -38,13 +38,10 @@ const config = {
         "default-src": ["self"],
         "script-src": [
           "self",
-          // Injected by the Pylon widget at runtime; exact subdomain is unknown without CSP reports.
-          "https://*.app-us1.com/",
-          // widget.usepylon.com is the confirmed entry point (initPylonWidget.ts).
-          // The remaining *.usepylon.com and *.pusher.com entries below are loaded
-          // dynamically by the Pylon widget — narrow further once CSP violation reports
-          // confirm the exact subdomains.
-          // https://support.usepylon.com/articles/5968160735-chat-widget-debugging-guide
+          // ActiveCampaign: our app loads diffuser.js which chains to prism and trackcmp.
+          "https://diffuser-cdn.app-us1.com",
+          "https://prism.app-us1.com",
+          "https://trackcmp.net",
           "https://widget.usepylon.com",
           // Pusher JS SDK is likely bundled, but kept for Pylon's dynamic script injection.
           "https://js.pusher.com",
@@ -55,7 +52,7 @@ const config = {
         ],
         // style-src keeps 'unsafe-inline': runtime style injection from
         // CodeMirror and other libraries cannot be hash-attributed.
-        "style-src": ["self", "unsafe-inline", "https://*.usepylon.com"],
+        "style-src": ["self", "unsafe-inline"],
         "img-src": [...(dev ? ["http:"] : []), "https:", "data:", "blob:"],
         "frame-src": [
           "self",
@@ -74,8 +71,6 @@ const config = {
           "https://*.rilldata.com",
           "https://*.rilldata.io",
           "https://*.rilldata.in",
-          // *.usepylon.com: Pylon widget makes internal requests to unknown subdomains.
-          "https://*.usepylon.com",
           "https://docs.google.com",
           "https://storage.googleapis.com",
           "https://cdn.prod.website-files.com",
@@ -86,7 +81,6 @@ const config = {
         "font-src": [
           "self",
           "https://fonts.gstatic.com",
-          "https://*.usepylon.com",
         ],
       },
     },

--- a/web-admin/svelte.config.js
+++ b/web-admin/svelte.config.js
@@ -75,7 +75,6 @@ const config = {
           "https://docs.google.com",
           "https://storage.googleapis.com",
           "https://cdn.prod.website-files.com",
-          // Pusher cluster confirmed from HAR (ws-us3). Update if cluster changes.
           "wss://ws-us3.pusher.com",
           ...(dev ? ["http://localhost:*", "ws://localhost:*"] : []),
         ],

--- a/web-admin/svelte.config.js
+++ b/web-admin/svelte.config.js
@@ -9,7 +9,18 @@ import { fileURLToPath } from "url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 dotenv({ path: resolve(__dirname, "../.env"), override: false });
 
-const dev = process.env.RILL_ADMIN_FRONTEND_URL?.includes("localhost");
+const adminFrontendURL = process.env.RILL_ADMIN_FRONTEND_URL;
+const dev = adminFrontendURL?.includes("localhost");
+
+// Derive *.rilldata.com / *.rilldata.io / *.rilldata.in from the env URL so
+// connect-src covers all subdomains in whichever environment is being built,
+// without statically listing all three TLDs.
+let rillWildcard = "https://*.rilldata.com"; // fallback for local dev
+if (adminFrontendURL && !dev) {
+  const hostname = new URL(adminFrontendURL).hostname; // e.g. "admin.rilldata.com"
+  const baseDomain = hostname.split(".").slice(1).join("."); // e.g. "rilldata.com"
+  rillWildcard = `https://*.${baseDomain}`;
+}
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -68,9 +79,7 @@ const config = {
         "base-uri": ["self"],
         "connect-src": [
           "self",
-          "https://*.rilldata.com",
-          "https://*.rilldata.io",
-          "https://*.rilldata.in",
+          rillWildcard,
           "https://apichatwidget.usepylon.com",
           "https://docs.google.com",
           "https://storage.googleapis.com",


### PR DESCRIPTION
 Removed 'unsafe-eval' from the script-src directive in web-admin/svelte.config.js. Vega charts use vega-interpreter (with ast: true, expr: expressionInterpreter) as of commit 8350025d3, which makes them CSP-compliant without eval. No    other direct uses of eval() or new Function() were found in the codebase.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
