### PR TITLE
fix: managed repo deploy failure

### DIFF
--- a/admin/server/github.go
+++ b/admin/server/github.go
@@ -1138,7 +1138,7 @@ func (s *Server) pushAssetToGit(ctx context.Context, assetID, remote, branch, to
 		Password:      token,
 		DefaultBranch: branch,
 	}
-	return cligitutil.CommitAndPush(ctx, projPath, config, "", author)
+	return cligitutil.CommitAndPush(ctx, projPath, config, "", author, false)
 }
 
 func (s *Server) githubAppInstallationURL(state githubConnectState) (string, error) {

--- a/cli/cmd/deploy/deploy_test.go
+++ b/cli/cmd/deploy/deploy_test.go
@@ -203,7 +203,7 @@ func testSelfHostedDeploy(t *testing.T, adminClient *client.Client, ghClient *gi
 	err = gitutil.CommitAndPush(t.Context(), tempDir, &gitutil.Config{
 		Remote:        authCloneURL,
 		DefaultBranch: "main",
-	}, "", author)
+	}, "", author, false)
 	require.NoError(t, err, "failed to push to github repo")
 
 	// deploy project backed by github
@@ -276,7 +276,7 @@ func testSelfHostedMonorepoDeploy(t *testing.T, adminClient *client.Client, ghCl
 	err = gitutil.CommitAndPush(t.Context(), tempDir, &gitutil.Config{
 		Remote:        authGitURL(t, *repo.CloneURL, token),
 		DefaultBranch: "main",
-	}, "", author)
+	}, "", author, false)
 	require.NoError(t, err, "failed to push to github repo")
 
 	// Clone two separate copies of the same repo to simulate independent working directories

--- a/cli/cmd/project/connect_github.go
+++ b/cli/cmd/project/connect_github.go
@@ -335,7 +335,7 @@ func createGithubRepoFlow(ctx context.Context, ch *cmdutil.Helper, localGitPath 
 		Password:      pollRes.AccessToken,
 		DefaultBranch: branch,
 	}
-	err = gitutil.CommitAndPush(ctx, localGitPath, config, "", author)
+	err = gitutil.CommitAndPush(ctx, localGitPath, config, "", author, false)
 	if err != nil {
 		return fmt.Errorf("failed to push local project to Github: %w", err)
 	}

--- a/cli/pkg/cmdutil/githelper.go
+++ b/cli/pkg/cmdutil/githelper.go
@@ -107,7 +107,8 @@ func (g *GitHelper) PushToNewManagedRepo(ctx context.Context, primaryBranch stri
 		ManagedRepo:       true,
 	}
 
-	err = gitutil.CommitAndPush(ctx, g.localPath, config, "", author)
+	// set force to true to discard any auto-init commit
+	err = gitutil.CommitAndPush(ctx, g.localPath, config, "", author, true)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/pkg/cmdutil/helper.go
+++ b/cli/pkg/cmdutil/helper.go
@@ -636,7 +636,7 @@ func (h *Helper) CommitAndSafePush(ctx context.Context, root string, config *git
 		if err != nil {
 			return fmt.Errorf("local is behind remote and failed to sync with remote: %w", err)
 		}
-		return gitutil.CommitAndPush(ctx, root, config, commitMsg, author)
+		return gitutil.CommitAndPush(ctx, root, config, commitMsg, author, false)
 	case "2":
 		// Instead of a force push, we do a merge with favourLocal=true to ensure we don't lose history.
 		// This is not equivalent to a force push but is safer for users.
@@ -650,7 +650,7 @@ func (h *Helper) CommitAndSafePush(ctx context.Context, root string, config *git
 		if err != nil {
 			return fmt.Errorf("local is behind remote and failed to sync with remote: %w", err)
 		}
-		return gitutil.CommitAndPush(ctx, root, config, commitMsg, author)
+		return gitutil.CommitAndPush(ctx, root, config, commitMsg, author, false)
 	default:
 		return fmt.Errorf("aborting deploy")
 	}

--- a/cli/pkg/gitutil/gitcmdwrapper.go
+++ b/cli/pkg/gitutil/gitcmdwrapper.go
@@ -171,8 +171,12 @@ func RunUpstreamMerge(ctx context.Context, remote, path, branch string, favourLo
 	return nil
 }
 
-func RunGitPush(ctx context.Context, path, remoteName, branchName string) error {
-	cmd := exec.CommandContext(ctx, "git", "-C", path, "push", remoteName, branchName)
+func RunGitPush(ctx context.Context, path, remoteName, branchName string, force bool) error {
+	args := []string{"-C", path, "push", remoteName, branchName}
+	if force {
+		args = append(args, "--force")
+	}
+	cmd := exec.CommandContext(ctx, "git", args...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		var execErr *exec.ExitError
 		if errors.As(err, &execErr) {

--- a/cli/pkg/gitutil/gitcmdwrapper_test.go
+++ b/cli/pkg/gitutil/gitcmdwrapper_test.go
@@ -226,7 +226,7 @@ func TestRunGitPush_NoNewCommits(t *testing.T) {
 	branch := getCurrentBranch(t, tempDir)
 
 	// Push with no new commits; remote is already up to date — should not error.
-	err := RunGitPush(context.Background(), tempDir, "origin", branch)
+	err := RunGitPush(context.Background(), tempDir, "origin", branch, false)
 	require.NoError(t, err, "RunGitPush should not fail when there are no new commits")
 }
 

--- a/cli/pkg/gitutil/gitutil.go
+++ b/cli/pkg/gitutil/gitutil.go
@@ -150,7 +150,10 @@ func ExtractRemotes(projectPath string, detectDotGit bool) ([]Remote, error) {
 	return res, nil
 }
 
-func CommitAndPush(ctx context.Context, projectPath string, config *Config, commitMsg string, author *object.Signature) error {
+// CommitAndPush stages all changes in the given projectPath, commits with the given commitMsg and author, and pushes to the remote specified in config.
+// If force is true, it will force push the changes to the remote.
+// Force should be avoided. As of writing only used to throw away the initial commit created by github for managed git repos.
+func CommitAndPush(ctx context.Context, projectPath string, config *Config, commitMsg string, author *object.Signature, force bool) error {
 	// init git repo
 	repo, err := git.PlainInitWithOptions(projectPath, &git.PlainInitOptions{
 		InitOptions: git.InitOptions{
@@ -220,7 +223,7 @@ func CommitAndPush(ctx context.Context, projectPath string, config *Config, comm
 	if config.Username == "" {
 		// If no credentials are provided we assume that is user's self managed repo and auth is already set in git
 		// go-git does not support pushing to a private repo without auth so we will trigger the git command directly
-		return RunGitPush(ctx, projectPath, config.RemoteName(), config.DefaultBranch)
+		return RunGitPush(ctx, projectPath, config.RemoteName(), config.DefaultBranch, force)
 	}
 
 	u, err := url.Parse(config.Remote)
@@ -228,7 +231,7 @@ func CommitAndPush(ctx context.Context, projectPath string, config *Config, comm
 		return fmt.Errorf("failed to parse remote URL: %w", err)
 	}
 	u.User = url.UserPassword(config.Username, config.Password)
-	return RunGitPush(ctx, projectPath, u.String(), config.DefaultBranch)
+	return RunGitPush(ctx, projectPath, u.String(), config.DefaultBranch, force)
 }
 
 func Clone(ctx context.Context, path string, c *Config) (*git.Repository, error) {

--- a/runtime/drivers/file/repo.go
+++ b/runtime/drivers/file/repo.go
@@ -645,13 +645,13 @@ func (c *connection) CommitAndPush(ctx context.Context, message string, force bo
 		if err != nil {
 			return fmt.Errorf("local is behind remote and failed to sync with remote: %w", err)
 		}
-		return gitutil.CommitAndPush(ctx, c.root, gitConfig, message, author)
+		return gitutil.CommitAndPush(ctx, c.root, gitConfig, message, author, false)
 	}
 	err = gitutil.RunUpstreamMerge(ctx, gitConfig.RemoteName(), c.root, gitConfig.DefaultBranch, false)
 	if err != nil {
 		return fmt.Errorf("local is behind remote and failed to sync with remote: %w", err)
 	}
-	return gitutil.CommitAndPush(ctx, c.root, gitConfig, message, author)
+	return gitutil.CommitAndPush(ctx, c.root, gitConfig, message, author, false)
 }
 
 func (c *connection) MergeToBranch(ctx context.Context, branch string, force bool) (resErr error) {


### PR DESCRIPTION
The github repo is now created with `autoinit=true`. This is to ensure that in the first mile journey in UI, a deployment can be created without any changes pushed to primary branch.
The CLI assumed repo is empty so never did force push. Only do force push for new managed repo now.

**Alternate solutions considered**
1. Fix runtime to not assume that there will always be a commit in primary branch : Avoided it because it makes things simpler to assume there is always a commit in primary branch.
2. Accept auto-init parameter in the API : Since there are only two callers so handled it in CLI directly.
