### PR TITLE
fix: update AI button tooltip to remove Rill branding in `ChatToggle.svelte`

### DIFF
--- a/web-common/src/features/chat/layouts/sidebar/ChatToggle.svelte
+++ b/web-common/src/features/chat/layouts/sidebar/ChatToggle.svelte
@@ -30,6 +30,6 @@
     {/snippet}
   </Tooltip.Trigger>
   <Tooltip.Content side="bottom">
-    Open Rill AI {isMac ? "⌘" : "Ctrl"} + J
+    Open Conversational AI {isMac ? "⌘" : "Ctrl"} + J
   </Tooltip.Content>
 </Tooltip.Root>


### PR DESCRIPTION
- Changed tooltip text from `'Open Rill AI'` to `'Open Conversational AI'` in `ChatToggle.svelte` to support white-label embedding use cases. Keyboard shortcut is preserved.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*