### PR TITLE
Add `CODEOWNERS` requiring applications team review for frontend code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,8 @@
 /cli/     @rilldata/platform
 /proto/   @rilldata/platform
 /runtime/ @rilldata/platform
+
+/web-admin/       @rilldata/applications
+/web-common/      @rilldata/applications
+/web-integration/ @rilldata/applications
+/web-local/       @rilldata/applications


### PR DESCRIPTION
Adds `@rilldata/applications` as code owners for the frontend directories (`web-admin/`, `web-common/`, `web-integration/`, `web-local/`), mirroring the backend setup in #9291.