### PR TITLE
Increase SQLite backup max size to 5 GB

### DIFF
--- a/runtime/drivers/sqlite/backups.go
+++ b/runtime/drivers/sqlite/backups.go
@@ -24,7 +24,7 @@ import (
 
 var (
 	// Maximum size of the SQLite snapshot for backup.
-	backupMaxSizeBytes int64 = 1024 * 1024 * 1024 // 1 GB
+	backupMaxSizeBytes int64 = 5 * 1024 * 1024 * 1024 // 5 GB
 
 	// Max time a backup may run for.
 	backupMaxDuration = 10 * time.Minute


### PR DESCRIPTION
Fixes failing backup for a project with a very high number of MCP sessions logged.