### PR TITLE
fix: integrate `Explain and fix` button into `ErrorPage` CTA area

### DIFF
--- a/web-common/src/components/ErrorPage.svelte
+++ b/web-common/src/components/ErrorPage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { page } from "$app/stores";
-  import CtaButton from "@rilldata/web-common/components/calls-to-action/CTAButton.svelte";
+  import Button from "@rilldata/web-common/components/button/Button.svelte";
   import CtaContentContainer from "@rilldata/web-common/components/calls-to-action/CTAContentContainer.svelte";
   import CtaLayoutContainer from "@rilldata/web-common/components/calls-to-action/CTALayoutContainer.svelte";
   import CtaMessage from "@rilldata/web-common/components/calls-to-action/CTAMessage.svelte";
@@ -30,12 +30,10 @@
     <CtaMessage>{body}</CtaMessage>
     {#if (!fatal && !onEmbedPage) || $$slots.cta}
       <div class="cta-actions">
-        {#if !fatal && !onEmbedPage}
-          <a {href} class="back-link">
-            <CtaButton variant="secondary">Back to home</CtaButton>
-          </a>
-        {/if}
         <slot name="cta" />
+        {#if !fatal && !onEmbedPage}
+          <Button type="ghost" {href}>Back to home</Button>
+        {/if}
       </div>
     {/if}
     {#if detail}
@@ -71,11 +69,7 @@
   }
 
   .cta-actions {
-    @apply flex flex-col items-center gap-y-4;
-  }
-
-  .back-link {
-    @apply no-underline;
+    @apply flex flex-col items-center gap-y-3;
   }
 
   .detail-section {

--- a/web-common/src/components/ErrorPage.svelte
+++ b/web-common/src/components/ErrorPage.svelte
@@ -28,10 +28,15 @@
     {/if}
     <h2 class="header">{header}</h2>
     <CtaMessage>{body}</CtaMessage>
-    {#if !fatal && !onEmbedPage}
-      <a {href} class="back-link">
-        <CtaButton variant="secondary">Back to home</CtaButton>
-      </a>
+    {#if (!fatal && !onEmbedPage) || $$slots.cta}
+      <div class="cta-actions">
+        {#if !fatal && !onEmbedPage}
+          <a {href} class="back-link">
+            <CtaButton variant="secondary">Back to home</CtaButton>
+          </a>
+        {/if}
+        <slot name="cta" />
+      </div>
     {/if}
     {#if detail}
       <section class="detail-section">
@@ -63,6 +68,10 @@
 
   .header {
     @apply text-lg font-semibold;
+  }
+
+  .cta-actions {
+    @apply flex flex-col items-center gap-y-4;
   }
 
   .back-link {

--- a/web-common/src/features/canvas/CanvasLoadingState.svelte
+++ b/web-common/src/features/canvas/CanvasLoadingState.svelte
@@ -22,7 +22,7 @@
     >
       <svelte:fragment slot="cta">
         {#if filePath}
-          <ExplainAndFixErrorButton {filePath} large />
+          <ExplainAndFixErrorButton {filePath} variant="cta" />
         {/if}
       </svelte:fragment>
     </ErrorPage>

--- a/web-common/src/features/canvas/CanvasLoadingState.svelte
+++ b/web-common/src/features/canvas/CanvasLoadingState.svelte
@@ -15,16 +15,15 @@
   {#if ready}
     <slot />
   {:else if errorMessage}
-    <div class="flex flex-col items-center gap-4">
-      <ErrorPage
-        statusCode={404}
-        header="Canvas not found"
-        body={errorMessage || "An unknown error occurred."}
-      />
+    <ErrorPage
+      statusCode={404}
+      header="Canvas not found"
+      body={errorMessage || "An unknown error occurred."}
+    >
       {#if filePath}
-        <ExplainAndFixErrorButton {filePath} large />
+        <ExplainAndFixErrorButton slot="cta" {filePath} large />
       {/if}
-    </div>
+    </ErrorPage>
   {:else if isReconciling}
     <DashboardBuilding />
   {:else if isLoading}

--- a/web-common/src/features/canvas/CanvasLoadingState.svelte
+++ b/web-common/src/features/canvas/CanvasLoadingState.svelte
@@ -20,9 +20,11 @@
       header="Canvas not found"
       body={errorMessage || "An unknown error occurred."}
     >
-      {#if filePath}
-        <ExplainAndFixErrorButton slot="cta" {filePath} large />
-      {/if}
+      <svelte:fragment slot="cta">
+        {#if filePath}
+          <ExplainAndFixErrorButton {filePath} large />
+        {/if}
+      </svelte:fragment>
     </ErrorPage>
   {:else if isReconciling}
     <DashboardBuilding />

--- a/web-common/src/features/chat/ExplainAndFixErrorButton.svelte
+++ b/web-common/src/features/chat/ExplainAndFixErrorButton.svelte
@@ -1,24 +1,33 @@
 <script lang="ts">
+  import Button from "@rilldata/web-common/components/button/Button.svelte";
   import { SparklesIcon } from "lucide-svelte";
   import { sidebarActions } from "./layouts/sidebar/sidebar-store";
 
   export let filePath: string;
   export let large = false;
+  export let variant: "compact" | "cta" = "compact";
 
   function handleClick() {
     sidebarActions.startChat(`Fix the errors in \`${filePath}\``);
   }
 </script>
 
-<button
-  class={large ? "explain-error-btn large" : "explain-error-btn"}
-  on:click|stopPropagation={handleClick}
-  aria-label="Explain and fix this error with AI"
-  title="Explain and fix"
->
-  <SparklesIcon size={large ? "16px" : "14px"} />
-  <span>Explain and fix</span>
-</button>
+{#if variant === "cta"}
+  <Button type="primary" wide onClick={handleClick}>
+    <SparklesIcon size="16px" />
+    <span>Explain and fix</span>
+  </Button>
+{:else}
+  <button
+    class={large ? "explain-error-btn large" : "explain-error-btn"}
+    on:click|stopPropagation={handleClick}
+    aria-label="Explain and fix this error with AI"
+    title="Explain and fix"
+  >
+    <SparklesIcon size={large ? "16px" : "14px"} />
+    <span>Explain and fix</span>
+  </button>
+{/if}
 
 <style lang="postcss">
   .explain-error-btn {

--- a/web-common/src/features/chat/ExplainAndFixErrorButton.svelte
+++ b/web-common/src/features/chat/ExplainAndFixErrorButton.svelte
@@ -13,7 +13,7 @@
 </script>
 
 {#if variant === "cta"}
-  <Button type="primary" wide onClick={handleClick}>
+  <Button type="secondary" onClick={handleClick}>
     <SparklesIcon size="16px" />
     <span>Explain and fix</span>
   </Button>

--- a/web-common/src/features/workspaces/CanvasWorkspace.svelte
+++ b/web-common/src/features/workspaces/CanvasWorkspace.svelte
@@ -125,6 +125,7 @@
               {parseError}
               remoteContent={$remoteContent}
               {filePath}
+              showError={selectedView === "code"}
             >
               {#if selectedView === "code"}
                 <CanvasEditor

--- a/web-common/src/features/workspaces/CanvasWorkspace.svelte
+++ b/web-common/src/features/workspaces/CanvasWorkspace.svelte
@@ -125,7 +125,7 @@
               {parseError}
               remoteContent={$remoteContent}
               {filePath}
-              showError={selectedView === "code"}
+              showError={selectedView === "code" || ready}
             >
               {#if selectedView === "code"}
                 <CanvasEditor

--- a/web-common/src/features/workspaces/ExploreWorkspace.svelte
+++ b/web-common/src/features/workspaces/ExploreWorkspace.svelte
@@ -143,7 +143,9 @@
                     header="Unable to load dashboard preview"
                     statusCode={404}
                   >
-                    <ExplainAndFixErrorButton slot="cta" {filePath} large />
+                    <svelte:fragment slot="cta">
+                      <ExplainAndFixErrorButton {filePath} variant="cta" />
+                    </svelte:fragment>
                   </ErrorPage>
                 {:else if exploreName && metricsViewName}
                   <DashboardStateManager {exploreName}>

--- a/web-common/src/features/workspaces/ExploreWorkspace.svelte
+++ b/web-common/src/features/workspaces/ExploreWorkspace.svelte
@@ -127,6 +127,7 @@
               {parseError}
               remoteContent={$remoteContent}
               {filePath}
+              showError={selectedView === "code"}
             >
               {#if selectedView === "code"}
                 <ExploreEditor

--- a/web-common/src/features/workspaces/ExploreWorkspace.svelte
+++ b/web-common/src/features/workspaces/ExploreWorkspace.svelte
@@ -137,17 +137,14 @@
                 />
               {:else if selectedView === "viz"}
                 {#if parseError || rootCauseReconcileError}
-                  <div class="flex flex-col items-center gap-4">
-                    <ErrorPage
-                      body={parseError?.message ??
-                        rootCauseReconcileError ??
-                        ""}
-                      fatal
-                      header="Unable to load dashboard preview"
-                      statusCode={404}
-                    />
-                    <ExplainAndFixErrorButton {filePath} large />
-                  </div>
+                  <ErrorPage
+                    body={parseError?.message ?? rootCauseReconcileError ?? ""}
+                    fatal
+                    header="Unable to load dashboard preview"
+                    statusCode={404}
+                  >
+                    <ExplainAndFixErrorButton slot="cta" {filePath} large />
+                  </ErrorPage>
                 {:else if exploreName && metricsViewName}
                   <DashboardStateManager {exploreName}>
                     <Dashboard {metricsViewName} {exploreName} />

--- a/web-common/src/layout/workspace/WorkspaceEditorContainer.svelte
+++ b/web-common/src/layout/workspace/WorkspaceEditorContainer.svelte
@@ -35,7 +35,7 @@
   $: derivedError = parseError?.message ?? rootCauseReconcileError;
   $: effectiveError = error ?? derivedError;
   $: effectiveShowError =
-    remoteContent !== undefined ? !!remoteContent : showError;
+    showError && (remoteContent === undefined || !!remoteContent);
 </script>
 
 <div


### PR DESCRIPTION
The `ExplainAndFixErrorButton` was rendered below the `ErrorPage` component in a separate flex container on dashboard preview 404s (canvas and explore), making it look like a floating, orphaned element. Add a `cta` slot to `ErrorPage` and render the button inside it so it visually belongs to the error page.

Follow-up to #9221. Intended to be cherry-picked into `release-0.86`.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---

*Developed in collaboration with Claude Code*