### PR TITLE
feat: Other bucket and perc of total tooltip for circular charts

### DIFF
--- a/web-common/src/features/canvas/components/charts/variants/CircularChart.ts
+++ b/web-common/src/features/canvas/components/charts/variants/CircularChart.ts
@@ -45,6 +45,10 @@ export class CircularChartComponent extends BaseChart<CircularCanvasChartSpec> {
       type: "number",
       label: "Inner Radius (%)",
     },
+    show_other: {
+      type: "boolean",
+      label: 'Show "Other" bucket',
+    },
     color: {
       type: "positional",
       label: "Color",
@@ -135,6 +139,7 @@ export class CircularChartComponent extends BaseChart<CircularCanvasChartSpec> {
     return {
       metrics_view: metricsViewName,
       innerRadius: 50,
+      show_other: true,
       color: {
         type: "nominal",
         field: randomDimension,

--- a/web-common/src/features/canvas/components/charts/variants/CircularChart.ts
+++ b/web-common/src/features/canvas/components/charts/variants/CircularChart.ts
@@ -29,6 +29,7 @@ export type CircularCanvasChartSpec = BaseChartConfig & CircularChartSpecBase;
 
 export class CircularChartComponent extends BaseChart<CircularCanvasChartSpec> {
   private provider: CircularChartProvider;
+  private isTruncated = false;
 
   static chartInputParams: Record<string, ComponentInputParam> = {
     measure: {
@@ -88,6 +89,10 @@ export class CircularChartComponent extends BaseChart<CircularCanvasChartSpec> {
     this.provider.combinedWhere.subscribe((where) => {
       this.componentFilters = where;
     });
+
+    this.provider.isTruncated.subscribe((value) => {
+      this.isTruncated = value;
+    });
   }
 
   getChartSpecificOptions(): Record<string, ComponentInputParam> {
@@ -97,6 +102,9 @@ export class CircularChartComponent extends BaseChart<CircularCanvasChartSpec> {
     if (colorMappingSelector) {
       colorMappingSelector.values = this.provider.customColorValues;
     }
+
+    inputParams.show_other.showInUI = this.isTruncated;
+
     return inputParams;
   }
 

--- a/web-common/src/features/canvas/inspector/ParamMapper.svelte
+++ b/web-common/src/features/canvas/inspector/ParamMapper.svelte
@@ -145,8 +145,11 @@
               checked={config.meta?.invertBoolean
                 ? !$specStore[key]
                 : $specStore[key]}
-              onclick={() => {
-                component.updateProperty(key, !localParamValues[key]);
+              onCheckedChange={(next) => {
+                component.updateProperty(
+                  key,
+                  config.meta?.invertBoolean ? !next : next,
+                );
               }}
               small
             />

--- a/web-common/src/features/canvas/inspector/fields/SingleFieldInput.svelte
+++ b/web-common/src/features/canvas/inspector/fields/SingleFieldInput.svelte
@@ -31,13 +31,17 @@
   $: timeDimension = getTimeDimensionForMetricView(metricName);
 
   $: isTimeSelected = $timeDimension && selectedItem === $timeDimension;
+  $: effectiveExcludedValues =
+    type === "dimension" && !includeTime && $timeDimension
+      ? [...(excludedValues ?? []), $timeDimension]
+      : excludedValues;
   $: fieldData = useMetricFieldData(
     ctx,
     metricName,
     [type],
     searchableItems,
     searchValue,
-    excludedValues,
+    effectiveExcludedValues,
   );
 </script>
 

--- a/web-common/src/features/components/charts/builder.ts
+++ b/web-common/src/features/components/charts/builder.ts
@@ -40,6 +40,7 @@ import type {
   ColorDef,
   Field,
   MarkPropDef,
+  OrderFieldDef,
   PositionFieldDef,
 } from "vega-lite/types_unstable/channeldef.js";
 import type { Encoding } from "vega-lite/types_unstable/encoding.js";
@@ -232,12 +233,14 @@ export function createOpacityEncoding(paramName: string) {
   };
 }
 
-export function createOrderEncoding(field: FieldConfig | undefined) {
+export function createOrderEncoding(
+  field: FieldConfig | undefined,
+): OrderFieldDef<Field> {
   if (!field || field.type === "value") return {};
   return {
     field: sanitizeValueForVega(field.field),
     type: field.type,
-    order: "descending",
+    sort: "descending",
   };
 }
 

--- a/web-common/src/features/components/charts/circular/CircularChartProvider.ts
+++ b/web-common/src/features/components/charts/circular/CircularChartProvider.ts
@@ -28,12 +28,18 @@ import {
   type Writable,
 } from "svelte/store";
 import { getFilterWithNullHandling } from "../query-util";
+import {
+  OTHER_VALUE,
+  OTHER_VALUE_DOMAIN_KEY,
+  TOTAL_DOMAIN_KEY,
+} from "./constants";
 
 export type CircularChartSpec = {
   metrics_view: string;
   measure?: FieldConfig<"quantitative">;
   color?: FieldConfig<"nominal">;
   innerRadius?: number;
+  show_other?: boolean;
 };
 
 export type CircularChartDefaultOptions = {
@@ -51,6 +57,7 @@ export class CircularChartProvider {
 
   customColorValues: string[] = [];
   totalsValue: number | undefined = undefined;
+  otherValue: number | undefined = undefined;
 
   combinedWhere: Writable<V1Expression | undefined> = writable(undefined);
 
@@ -83,10 +90,10 @@ export class CircularChartProvider {
     let colorSort: V1MetricsViewAggregationSort | undefined;
     let limit: number;
     const colorDimensionName = config.color?.field;
-    const showTotal = config.measure?.showTotal;
+    const showOther = !!colorDimensionName && config.show_other === true;
 
     if (colorDimensionName) {
-      limit = config.color?.limit || this.defaultColorLimit;
+      limit = config.color?.limit ?? this.defaultColorLimit;
       dimensions = [{ name: colorDimensionName }];
       colorSort = this.getColorSort(config);
     }
@@ -127,13 +134,14 @@ export class CircularChartProvider {
 
     const topNColorQuery = createQuery(topNColorQueryOptionsStore);
 
+    // The total query feeds the optional center-label total AND the
+    // percent-of-total tooltip entry
     const totalQueryOptionsStore = derived(
       [timeAndFilterStore, visibleStore],
       ([$timeAndFilterStore, $visible]) => {
         const { timeRange, where, hasTimeSeries } = $timeAndFilterStore;
         const enabled =
           $visible &&
-          !!showTotal &&
           (!hasTimeSeries || (!!timeRange?.start && !!timeRange?.end)) &&
           !!config.measure?.field;
 
@@ -158,9 +166,75 @@ export class CircularChartProvider {
 
     const totalQuery = createQuery(totalQueryOptionsStore);
 
+    const otherQueryOptionsStore = derived(
+      [timeAndFilterStore, topNColorQuery, visibleStore],
+      ([$timeAndFilterStore, $topNColorQuery, $visible]) => {
+        const { timeRange, where, hasTimeSeries } = $timeAndFilterStore;
+        const topNData = $topNColorQuery?.data?.data;
+        const customSortValues = Array.isArray(config.color?.sort)
+          ? config.color.sort
+          : undefined;
+
+        const visibleValues = customSortValues
+          ? customSortValues
+          : topNData
+            ? topNData.map((d) => d[colorDimensionName!] as string)
+            : undefined;
+
+        const enabled =
+          $visible &&
+          showOther &&
+          !!visibleValues &&
+          visibleValues.length > 0 &&
+          (!hasTimeSeries || (!!timeRange?.start && !!timeRange?.end)) &&
+          !!config.measure?.field &&
+          !!colorDimensionName;
+
+        const baseWhere = getFilterWithNullHandling(where, config.color);
+        let otherWhere = baseWhere;
+        if (enabled && colorDimensionName && visibleValues) {
+          const notInExpr = createInExpression(
+            colorDimensionName,
+            visibleValues,
+            true,
+          );
+          otherWhere = mergeFilters(baseWhere, notInExpr);
+        }
+
+        return getQueryServiceMetricsViewAggregationQueryOptions(
+          client,
+          {
+            metricsView: config.metrics_view,
+            measures,
+            where: otherWhere,
+            timeRange,
+          },
+          {
+            query: {
+              enabled,
+            },
+          },
+        );
+      },
+    );
+
+    const otherQuery = createQuery(otherQueryOptionsStore);
+
     const queryOptionsStore = derived(
-      [timeAndFilterStore, topNColorQuery, totalQuery, visibleStore],
-      ([$timeAndFilterStore, $topNColorQuery, $totalQuery, $visible]) => {
+      [
+        timeAndFilterStore,
+        topNColorQuery,
+        totalQuery,
+        otherQuery,
+        visibleStore,
+      ],
+      ([
+        $timeAndFilterStore,
+        $topNColorQuery,
+        $totalQuery,
+        $otherQuery,
+        $visible,
+      ]) => {
         const { timeRange, where, hasTimeSeries } = $timeAndFilterStore;
         const topNColorData = $topNColorQuery?.data?.data;
         const enabled =
@@ -215,10 +289,18 @@ export class CircularChartProvider {
           },
         );
 
-        if (showTotal && config.measure?.field) {
+        if (config.measure?.field) {
           this.totalsValue = $totalQuery?.data?.data?.[0]?.[
             config.measure?.field
           ] as number;
+
+          const otherRaw = $otherQuery?.data?.data?.[0]?.[
+            config.measure?.field
+          ] as number | null | undefined;
+          this.otherValue =
+            showOther && typeof otherRaw === "number" ? otherRaw : undefined;
+        } else {
+          this.otherValue = undefined;
         }
 
         return queryOptions;
@@ -270,14 +352,21 @@ export class CircularChartProvider {
     const result: Record<string, string[] | number[] | undefined> = {};
 
     if (isFieldConfig(config.color)) {
+      const baseValues =
+        this.customColorValues.length > 0 ? [...this.customColorValues] : [];
+      if (this.otherValue !== undefined) {
+        baseValues.push(OTHER_VALUE);
+      }
       result[config.color.field] =
-        this.customColorValues.length > 0
-          ? [...this.customColorValues]
-          : undefined;
+        baseValues.length > 0 ? baseValues : undefined;
     }
 
-    if (config.measure?.showTotal && this.totalsValue) {
-      result["total"] = [this.totalsValue];
+    if (this.totalsValue !== undefined) {
+      result[TOTAL_DOMAIN_KEY] = [this.totalsValue];
+    }
+
+    if (this.otherValue !== undefined) {
+      result[OTHER_VALUE_DOMAIN_KEY] = [this.otherValue];
     }
 
     return result;

--- a/web-common/src/features/components/charts/circular/CircularChartProvider.ts
+++ b/web-common/src/features/components/charts/circular/CircularChartProvider.ts
@@ -60,6 +60,7 @@ export class CircularChartProvider {
   otherValue: number | undefined = undefined;
 
   combinedWhere: Writable<V1Expression | undefined> = writable(undefined);
+  isTruncated: Writable<boolean> = writable(false);
 
   constructor(
     spec: Readable<CircularChartSpec>,
@@ -112,6 +113,9 @@ export class CircularChartProvider {
 
         const topNWhere = getFilterWithNullHandling(where, config.color);
 
+        // drives the "Other" UI affordance
+        const probeLimit = limit ? limit + 1 : undefined;
+
         return getQueryServiceMetricsViewAggregationQueryOptions(
           client,
           {
@@ -121,7 +125,7 @@ export class CircularChartProvider {
             sort: colorSort ? [colorSort] : undefined,
             where: topNWhere,
             timeRange,
-            limit: limit?.toString(),
+            limit: probeLimit?.toString(),
           },
           {
             query: {
@@ -178,7 +182,9 @@ export class CircularChartProvider {
         const visibleValues = customSortValues
           ? customSortValues
           : topNData
-            ? topNData.map((d) => d[colorDimensionName!] as string)
+            ? topNData
+                .slice(0, limit)
+                .map((d) => d[colorDimensionName!] as string)
             : undefined;
 
         const enabled =
@@ -252,10 +258,14 @@ export class CircularChartProvider {
         // Apply topN filter for color dimension
         if (Array.isArray(config.color?.sort)) {
           topColorValues = config.color.sort;
-        } else if (topNColorData?.length && colorDimensionName) {
-          topColorValues = topNColorData.map(
-            (d) => d[colorDimensionName] as string,
-          );
+          this.isTruncated.set(false);
+        } else if (topNColorData && colorDimensionName) {
+          // topN was queried with limit+1; if we got the extra row back,
+          // there are more values than the limit and the chart is truncated
+          this.isTruncated.set(topNColorData.length > limit);
+          topColorValues = topNColorData
+            .slice(0, limit)
+            .map((d) => d[colorDimensionName] as string);
         }
 
         if (colorDimensionName) {

--- a/web-common/src/features/components/charts/circular/constants.ts
+++ b/web-common/src/features/components/charts/circular/constants.ts
@@ -1,0 +1,13 @@
+// Visible label for the synthetic remainder slice.
+export const OTHER_VALUE = "Other";
+
+// Domain-values keys used to ferry derived values from the provider to the
+// spec generator via `ChartDataResult.domainValues`.
+export const TOTAL_DOMAIN_KEY = "total";
+export const OTHER_VALUE_DOMAIN_KEY = "__other_value";
+
+// Synthetic field added by the percent-of-total transform.
+export const PERCENT_OF_TOTAL_FIELD = "__percent_of_total";
+
+// Tooltip column title for the percent-of-total entry.
+export const PERCENT_OF_TOTAL_TITLE = "% of total";

--- a/web-common/src/features/components/charts/circular/constants.ts
+++ b/web-common/src/features/components/charts/circular/constants.ts
@@ -9,5 +9,9 @@ export const OTHER_VALUE_DOMAIN_KEY = "__other_value";
 // Synthetic field added by the percent-of-total transform.
 export const PERCENT_OF_TOTAL_FIELD = "__percent_of_total";
 
+// Synthetic field used to pin the "Other" slice to the end of the arc order
+// regardless of how rows sort by measure or category.
+export const OTHER_SORT_KEY_FIELD = "__other_sort_key";
+
 // Tooltip column title for the percent-of-total entry.
 export const PERCENT_OF_TOTAL_TITLE = "% of total";

--- a/web-common/src/features/components/charts/circular/pie.ts
+++ b/web-common/src/features/components/charts/circular/pie.ts
@@ -5,6 +5,7 @@ import type { Config } from "vega-lite";
 import type { Field } from "vega-lite/types_unstable/channeldef.js";
 import type { LayerSpec } from "vega-lite/types_unstable/spec/layer.js";
 import type { UnitSpec } from "vega-lite/types_unstable/spec/unit.js";
+import type { Transform } from "vega-lite/types_unstable/transform.js";
 import {
   createColorEncoding,
   createConfigWithLegend,
@@ -16,6 +17,13 @@ import {
 } from "../builder";
 import type { ChartDataResult } from "../types";
 import type { CircularChartSpec } from "./CircularChartProvider";
+import {
+  OTHER_VALUE,
+  OTHER_VALUE_DOMAIN_KEY,
+  PERCENT_OF_TOTAL_FIELD,
+  PERCENT_OF_TOTAL_TITLE,
+  TOTAL_DOMAIN_KEY,
+} from "./constants";
 
 function getInnerRadius(innerRadiusPercentage: number | undefined) {
   if (!innerRadiusPercentage) return 0;
@@ -46,11 +54,30 @@ export function generateVLPieChartSpec(
   config: CircularChartSpec,
   data: ChartDataResult,
 ): VisualizationSpec {
-  const totalValue = data.domainValues?.["total"]?.[0];
+  const totalValue = data.domainValues?.[TOTAL_DOMAIN_KEY]?.[0];
   const shouldShowTotal =
     totalValue !== undefined && config.measure?.showTotal === true;
 
   const measureMetaData = config.measure && data.fields[config.measure.field];
+
+  const validPercentOfTotal =
+    measureMetaData &&
+    "validPercentOfTotal" in measureMetaData &&
+    measureMetaData.validPercentOfTotal === true;
+
+  // Show "% of total" in the tooltip when the measure supports it
+  const showPercentOfTotal = Boolean(
+    config.measure?.field &&
+      typeof totalValue === "number" &&
+      validPercentOfTotal,
+  );
+
+  // Inject the synthetic "Other" row when the provider has set it.
+  const otherValue = data.domainValues?.[OTHER_VALUE_DOMAIN_KEY]?.[0];
+  const hasOther =
+    typeof otherValue === "number" &&
+    !!config.color?.field &&
+    !!config.measure?.field;
 
   /**
    * The layout property is not typed in the current version of Vega-Lite.
@@ -81,6 +108,15 @@ export function generateVLPieChartSpec(
     data,
   );
 
+  if (showPercentOfTotal) {
+    tooltip.push({
+      field: PERCENT_OF_TOTAL_FIELD,
+      title: PERCENT_OF_TOTAL_TITLE,
+      type: "quantitative",
+      format: ".1%",
+    });
+  }
+
   const arcLayer: LayerSpec<Field> | UnitSpec<Field> = {
     mark: {
       type: "arc",
@@ -94,6 +130,29 @@ export function generateVLPieChartSpec(
       tooltip,
     },
   };
+
+  if (hasOther && config.color?.field && config.measure?.field) {
+    const colorField = config.color.field;
+    const measureField = config.measure.field;
+    const otherRow: Record<string, unknown> = {
+      [colorField]: OTHER_VALUE,
+      [measureField]: otherValue,
+    };
+    arcLayer.data = {
+      values: [...data.data, otherRow],
+    };
+  }
+
+  if (showPercentOfTotal && config.measure?.field) {
+    const measureFieldRaw = config.measure.field;
+    const transforms: Transform[] = [
+      {
+        calculate: `datum['${measureFieldRaw}'] / ${totalValue}`,
+        as: PERCENT_OF_TOTAL_FIELD,
+      },
+    ];
+    arcLayer.transform = transforms;
+  }
 
   if (shouldShowTotal && totalValue !== undefined) {
     const spec = createMultiLayerBaseSpec();
@@ -136,6 +195,12 @@ export function generateVLPieChartSpec(
     const spec = createSingleLayerBaseSpec("arc");
     spec.mark = arcLayer.mark;
     spec.encoding = arcLayer.encoding;
+    if (arcLayer.data) {
+      spec.data = arcLayer.data;
+    }
+    if (arcLayer.transform) {
+      spec.transform = arcLayer.transform;
+    }
 
     return {
       ...spec,

--- a/web-common/src/features/components/charts/circular/pie.ts
+++ b/web-common/src/features/components/charts/circular/pie.ts
@@ -18,6 +18,7 @@ import {
 import type { ChartDataResult } from "../types";
 import type { CircularChartSpec } from "./CircularChartProvider";
 import {
+  OTHER_SORT_KEY_FIELD,
   OTHER_VALUE,
   OTHER_VALUE_DOMAIN_KEY,
   PERCENT_OF_TOTAL_FIELD,
@@ -101,7 +102,15 @@ export function generateVLPieChartSpec(
 
   const theta = createPositionEncoding(config.measure, data);
   const color = createColorEncoding(config.color, data);
-  const order = createOrderEncoding(config.measure);
+  // When "Other" is in the data, order arcs by a synthetic key that pins
+  // "Other" to the end. Otherwise, fall back to ordering by the measure.
+  const order = hasOther
+    ? {
+        field: OTHER_SORT_KEY_FIELD,
+        type: "quantitative" as const,
+        sort: "descending" as const,
+      }
+    : createOrderEncoding(config.measure);
 
   const tooltip = createDefaultTooltipEncoding(
     [config.color, config.measure],
@@ -143,14 +152,22 @@ export function generateVLPieChartSpec(
     };
   }
 
+  const transforms: Transform[] = [];
   if (showPercentOfTotal && config.measure?.field) {
-    const measureFieldRaw = config.measure.field;
-    const transforms: Transform[] = [
-      {
-        calculate: `datum['${measureFieldRaw}'] / ${totalValue}`,
-        as: PERCENT_OF_TOTAL_FIELD,
-      },
-    ];
+    transforms.push({
+      calculate: `datum['${config.measure.field}'] / ${totalValue}`,
+      as: PERCENT_OF_TOTAL_FIELD,
+    });
+  }
+  if (hasOther && config.color?.field && config.measure?.field) {
+    // Pin "Other" to the end of the arc order: give it -Infinity so it always
+    // sorts last under `order: descending` regardless of its measure value.
+    transforms.push({
+      calculate: `datum['${config.color.field}'] === '${OTHER_VALUE}' ? -1/0 : datum['${config.measure.field}']`,
+      as: OTHER_SORT_KEY_FIELD,
+    });
+  }
+  if (transforms.length > 0) {
     arcLayer.transform = transforms;
   }
 

--- a/web-common/src/features/components/charts/util.ts
+++ b/web-common/src/features/components/charts/util.ts
@@ -7,6 +7,7 @@ import chroma from "chroma-js";
 import merge from "deepmerge";
 import type { Config } from "vega-lite";
 import { getChroma } from "../../themes/theme-utils";
+import { OTHER_VALUE } from "./circular/constants";
 import {
   ChartSortType,
   type ChartDataResult,
@@ -175,6 +176,8 @@ export function isDomainStringArray(
     : false;
 }
 
+export const OTHER_BUCKET_COLOR = "var(--color-gray-400)";
+
 export function getColorForValues(
   colorValues: string[] | undefined,
   // if provided, use the colors for mentioned values
@@ -187,9 +190,12 @@ export function getColorForValues(
     const overrideColor = overrideColorMapping?.find(
       (mapping) => mapping.value === value,
     );
+    const isOther = value === OTHER_VALUE;
     const colorVar =
       overrideColor?.color ||
-      COMPARISON_COLORS[index % COMPARISON_COLORS.length];
+      (isOther
+        ? OTHER_BUCKET_COLOR
+        : COMPARISON_COLORS[index % COMPARISON_COLORS.length]);
 
     return {
       value,


### PR DESCRIPTION

- Added `show_other` to the circular chart spec. When true, dimension values outside the visible top-N are rolled up into a single neutral-gray "Other" slice. Default is off, so existing dashboards are unchanged.
- Surfaced `show_other` as a top-level boolean toggle in the canvas chart inspector and enabled it by default for newly-created circular charts.
- Added a "% of total" entry to the circular chart tooltip when the selected measure has `valid_percent_of_total: true`.

https://linear.app/rilldata/issue/APP-818/canvas-pie-chart-unreadable-with-many-slices-add-other-grouping-hover

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
