### PR TITLE
fix: guard project and org admin routes against direct URL access

### DIFF
--- a/web-admin/src/routes/[organization]/-/settings/+layout.ts
+++ b/web-admin/src/routes/[organization]/-/settings/+layout.ts
@@ -5,12 +5,17 @@ import {
 } from "@rilldata/web-admin/client";
 import { getNeverSubscribedIssue } from "@rilldata/web-admin/features/billing/issues/getMessageForCancelledIssue";
 import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient.js";
-import { error } from "@sveltejs/kit";
+import { error, redirect } from "@sveltejs/kit";
 import { isAxiosError } from "axios";
 import type { PageLoad } from "./$types";
 
 export const load: PageLoad = async ({ parent, params }) => {
-  const { issues } = await parent();
+  const { issues, organizationPermissions } = await parent();
+
+  if (!organizationPermissions?.manageOrg) {
+    throw redirect(307, `/${params.organization}`);
+  }
+
   const neverSubscribed = !!getNeverSubscribedIssue(issues);
 
   const queryKey = getAdminServiceGetBillingSubscriptionQueryKey(

--- a/web-admin/src/routes/[organization]/[project]/-/settings/+layout.ts
+++ b/web-admin/src/routes/[organization]/[project]/-/settings/+layout.ts
@@ -1,0 +1,8 @@
+import { redirect } from "@sveltejs/kit";
+
+export const load = async ({ parent, params: { organization, project } }) => {
+  const { projectPermissions } = await parent();
+  if (!projectPermissions?.manageProject) {
+    throw redirect(307, `/${organization}/${project}`);
+  }
+};

--- a/web-admin/src/routes/[organization]/[project]/-/status/+layout.ts
+++ b/web-admin/src/routes/[organization]/[project]/-/status/+layout.ts
@@ -1,0 +1,8 @@
+import { redirect } from "@sveltejs/kit";
+
+export const load = async ({ parent, params: { organization, project } }) => {
+  const { projectPermissions } = await parent();
+  if (!projectPermissions?.manageProject) {
+    throw redirect(307, `/${organization}/${project}`);
+  }
+};


### PR DESCRIPTION
- Add redirect guards on `/-/status/*`, `/-/settings/*`, and `/[organization]/-/settings/*` so users without the required permissions are redirected to a page they can access, rather than rendering a broken page or hitting 403s.
- Status and project settings gate on `manageProject`; org settings gates on `manageOrg`. These match the existing nav-tab visibility, so URL-paste behaves the same as clicking a hidden tab.
- Frontend guards are UX, not security — the backend already enforces these permissions on every relevant endpoint. This change just stops users from landing on a page that would 403 every API call.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*