### PR TITLE
nit: show connector icon at bottom of collapsed AI chat sidebar

### DIFF
--- a/web-admin/src/routes/[organization]/[project]/-/ai/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/ai/+layout.svelte
@@ -30,6 +30,13 @@
         Connect your own client
       </Button>
     </svelte:fragment>
+    <svelte:fragment slot="sidebar-collapsed-footer">
+      <span title="Connect your own client">
+        <Button type="secondary" square onClick={() => (mcpDialogOpen = true)}>
+          <APIIcon size="14px" className="!fill-current" />
+        </Button>
+      </span>
+    </svelte:fragment>
   </ProjectChat>
 
   <MCPConnectDialog

--- a/web-admin/src/routes/[organization]/[project]/-/ai/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/ai/+layout.svelte
@@ -31,11 +31,14 @@
       </Button>
     </svelte:fragment>
     <svelte:fragment slot="sidebar-collapsed-footer">
-      <span title="Connect your own client">
-        <Button type="secondary" square onClick={() => (mcpDialogOpen = true)}>
-          <APIIcon size="14px" className="!fill-current" />
-        </Button>
-      </span>
+      <Button
+        type="secondary"
+        square
+        label="Connect your own client"
+        onClick={() => (mcpDialogOpen = true)}
+      >
+        <APIIcon size="14px" className="!fill-current" />
+      </Button>
     </svelte:fragment>
   </ProjectChat>
 

--- a/web-common/src/features/chat/ProjectChat.svelte
+++ b/web-common/src/features/chat/ProjectChat.svelte
@@ -6,4 +6,7 @@
   <svelte:fragment slot="sidebar-footer">
     <slot name="sidebar-footer" />
   </svelte:fragment>
+  <svelte:fragment slot="sidebar-collapsed-footer">
+    <slot name="sidebar-collapsed-footer" />
+  </svelte:fragment>
 </FullPageChat>

--- a/web-common/src/features/chat/layouts/fullpage/ConversationSidebar.svelte
+++ b/web-common/src/features/chat/layouts/fullpage/ConversationSidebar.svelte
@@ -58,6 +58,10 @@
         </Button>
       </span>
     </div>
+
+    <div class="collapsed-footer">
+      <slot name="collapsed-footer" />
+    </div>
   {:else}
     <!-- Expanded state: full sidebar -->
     <div class="conversation-sidebar-header">
@@ -134,6 +138,10 @@
 
   .collapsed-actions {
     @apply flex flex-col gap-2 p-3 items-center;
+  }
+
+  .collapsed-footer {
+    @apply flex flex-col gap-2 p-3 items-center mt-auto;
   }
 
   .conversation-sidebar-header {

--- a/web-common/src/features/chat/layouts/fullpage/FullPageChat.svelte
+++ b/web-common/src/features/chat/layouts/fullpage/FullPageChat.svelte
@@ -73,6 +73,9 @@
     <svelte:fragment slot="footer">
       <slot name="sidebar-footer" />
     </svelte:fragment>
+    <svelte:fragment slot="collapsed-footer">
+      <slot name="sidebar-collapsed-footer" />
+    </svelte:fragment>
   </ConversationSidebar>
 
   <!-- Main Chat Area -->


### PR DESCRIPTION
Adds a `sidebar-collapsed-footer` slot so the "Connect your own client" action stays accessible (as a square icon button) when the conversation sidebar is collapsed on the `/-/ai` page.

INSERT DESCRIPTION HERE

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
