### PR TITLE
fix: zero dev slots for projects created through UI

### DIFF
--- a/web-admin/src/features/projects/CreateProjectForm.svelte
+++ b/web-admin/src/features/projects/CreateProjectForm.svelte
@@ -90,6 +90,7 @@
             project,
             gitRemote: createdGitRepo,
             prodSlots: "4",
+            devSlots: "8",
             skipDeploy: true,
           },
         });


### PR DESCRIPTION
Matches the default dev slots of 8 from deploy API on local server.

https://github.com/rilldata/rill/blob/main/cli/pkg/local/server.go#L352

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
