### PR TITLE
fix: measure filter apply

### DIFF
--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
@@ -60,34 +60,36 @@
     }),
   });
 
-  const { form, errors, submit, enhance } = superForm(
+  const { form, errors, validateForm, enhance } = superForm(
     defaults(initialValues, yup(validationSchema)),
     {
       SPA: true,
       validators: yup(validationSchema),
       dataType: "json",
-      onUpdate({ form }) {
-        if (!form.valid) return;
-        const values = form.data;
-
-        onApply({
-          dimension: values.dimension,
-          oldDimension: dimensionName,
-          filter: {
-            measure: name,
-            operation: values.operation,
-            type: MeasureFilterType.Value,
-            value1: values.value1,
-            value2: values.value2 ?? "",
-          },
-        });
-
-        open = false;
-      },
       invalidateAll: false,
       resetForm: false,
     },
   );
+
+  async function submit() {
+    const result = await validateForm({ update: true });
+    if (!result.valid) return;
+    const values = result.data;
+
+    onApply({
+      dimension: values.dimension,
+      oldDimension: dimensionName,
+      filter: {
+        measure: name,
+        operation: values.operation,
+        type: MeasureFilterType.Value,
+        value1: values.value1,
+        value2: values.value2 ?? "",
+      },
+    });
+
+    open = false;
+  }
 
   $: ({ operation } = $form);
 
@@ -148,7 +150,7 @@
     id="measure"
     onsubmit={(e) => {
       e.preventDefault();
-      submit(e);
+      void submit();
     }}
     use:enhance
   >
@@ -198,6 +200,6 @@
       />
     {/if}
 
-    <Button submitForm type="primary" form="measure">Apply</Button>
+    <Button type="primary" onClick={submit}>Apply</Button>
   </form>
 </Popover.Content>

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
@@ -200,6 +200,21 @@
       />
     {/if}
 
-    <Button type="primary" onClick={submit}>Apply</Button>
+    <button
+      type="button"
+      style="background: red; color: white; padding: 8px;"
+      onclick={() => console.log("DEBUG: native button clicked")}
+    >
+      DEBUG native click
+    </button>
+    <Button
+      type="primary"
+      onClick={() => {
+        console.log("DEBUG: Apply Button onClick fired");
+        void submit();
+      }}
+    >
+      Apply
+    </Button>
   </form>
 </Popover.Content>

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
@@ -60,7 +60,7 @@
     }),
   });
 
-  const { form, errors, validateForm, enhance } = superForm(
+  const { form, errors, validateForm } = superForm(
     defaults(initialValues, yup(validationSchema)),
     {
       SPA: true,
@@ -144,16 +144,7 @@
       />
     </div>
   {/if}
-  <form
-    autocomplete="off"
-    class="flex flex-col gap-y-3"
-    id="measure"
-    onsubmit={(e) => {
-      e.preventDefault();
-      void submit();
-    }}
-    use:enhance
-  >
+  <div class="flex flex-col gap-y-3">
     <Select
       bind:value={$form["dimension"]}
       id="dimension"
@@ -200,21 +191,6 @@
       />
     {/if}
 
-    <button
-      type="button"
-      style="background: red; color: white; padding: 8px;"
-      onclick={() => console.log("DEBUG: native button clicked")}
-    >
-      DEBUG native click
-    </button>
-    <Button
-      type="primary"
-      onClick={() => {
-        console.log("DEBUG: Apply Button onClick fired");
-        void submit();
-      }}
-    >
-      Apply
-    </Button>
-  </form>
+    <Button type="primary" onClick={submit}>Apply</Button>
+  </div>
 </Popover.Content>

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
@@ -65,6 +65,7 @@
     {
       SPA: true,
       validators: yup(validationSchema),
+      dataType: "json",
       onUpdate({ form }) {
         if (!form.valid) return;
         const values = form.data;

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
@@ -142,10 +142,14 @@
     </div>
   {/if}
   <form
-    use:enhance
     autocomplete="off"
     class="flex flex-col gap-y-3"
     id="measure"
+    onsubmit={(e) => {
+      e.preventDefault();
+      submit(e);
+    }}
+    use:enhance
   >
     <Select
       bind:value={$form["dimension"]}


### PR DESCRIPTION
Fix bug where the alert modal for measure filter was unable to apply. Likely due to Svelte 5 upgrade

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
