### PR TITLE
fix: nested measure filter form not submitting

### DIFF
--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
@@ -60,12 +60,11 @@
     }),
   });
 
-  const { form, errors, submit, enhance } = superForm(
+  const { form, formId, errors, submit, enhance } = superForm(
     defaults(initialValues, yup(validationSchema)),
     {
       SPA: true,
       validators: yup(validationSchema),
-      id: "measure",
       onUpdate({ form }) {
         if (!form.valid) return;
         const values = form.data;
@@ -146,11 +145,7 @@
     use:enhance
     autocomplete="off"
     class="flex flex-col gap-y-3"
-    id="measure"
-    onsubmit={(e) => {
-      e.preventDefault();
-      submit(e);
-    }}
+    id={$formId}
   >
     <Select
       bind:value={$form["dimension"]}
@@ -198,6 +193,6 @@
       />
     {/if}
 
-    <Button submitForm type="primary" form="measure">Apply</Button>
+    <Button submitForm type="primary" form={$formId}>Apply</Button>
   </form>
 </Popover.Content>

--- a/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
+++ b/web-common/src/features/dashboards/filters/measure-filters/MeasureFilterForm.svelte
@@ -65,6 +65,7 @@
     {
       SPA: true,
       validators: yup(validationSchema),
+      id: "measure",
       onUpdate({ form }) {
         if (!form.valid) return;
         const values = form.data;
@@ -146,6 +147,10 @@
     autocomplete="off"
     class="flex flex-col gap-y-3"
     id="measure"
+    onsubmit={(e) => {
+      e.preventDefault();
+      submit(e);
+    }}
   >
     <Select
       bind:value={$form["dimension"]}


### PR DESCRIPTION
Measure filter dropdown had its own form. Submit button was interfering with alert form preventing measure filter apply within the alert form.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
