### PR TITLE
feat: add `EnvVarName` to `PropertySpec` and annotate driver specs

### DIFF
--- a/runtime/drivers/athena/athena.go
+++ b/runtime/drivers/athena/athena.go
@@ -43,6 +43,7 @@ var spec = drivers.Spec{
 			Placeholder: "your_access_key_id",
 			Required:    true,
 			Secret:      true,
+			EnvVarName:  "AWS_ACCESS_KEY_ID",
 		},
 		{
 			Key:         "aws_secret_access_key",
@@ -52,6 +53,7 @@ var spec = drivers.Spec{
 			Placeholder: "your_secret_access_key",
 			Required:    true,
 			Secret:      true,
+			EnvVarName:  "AWS_SECRET_ACCESS_KEY",
 		},
 		{
 			Key:         "output_location",

--- a/runtime/drivers/azure/azure.go
+++ b/runtime/drivers/azure/azure.go
@@ -29,14 +29,16 @@ var spec = drivers.Spec{
 			Secret: true,
 		},
 		{
-			Key:    "azure_storage_key",
-			Type:   drivers.StringPropertyType,
-			Secret: true,
+			Key:        "azure_storage_key",
+			Type:       drivers.StringPropertyType,
+			Secret:     true,
+			EnvVarName: "AZURE_STORAGE_KEY",
 		},
 		{
-			Key:    "azure_storage_sas_token",
-			Type:   drivers.StringPropertyType,
-			Secret: true,
+			Key:        "azure_storage_sas_token",
+			Type:       drivers.StringPropertyType,
+			Secret:     true,
+			EnvVarName: "AZURE_STORAGE_SAS_TOKEN",
 		},
 		{
 			Key:         "azure_storage_connection_string",
@@ -45,6 +47,7 @@ var spec = drivers.Spec{
 			Description: "Azure connection string for storage account",
 			Placeholder: "Paste your Azure connection string here",
 			Secret:      true,
+			EnvVarName:  "AZURE_STORAGE_CONNECTION_STRING",
 		},
 	},
 	SourceProperties: []*drivers.PropertySpec{

--- a/runtime/drivers/bigquery/bigquery.go
+++ b/runtime/drivers/bigquery/bigquery.go
@@ -43,6 +43,7 @@ var spec = drivers.Spec{
 			Description: "GCP credentials as JSON string",
 			Placeholder: "Paste your GCP service account JSON here",
 			Secret:      true,
+			EnvVarName:  "GOOGLE_APPLICATION_CREDENTIALS",
 			Required:    true,
 		},
 	},

--- a/runtime/drivers/clickhouse/clickhouse.go
+++ b/runtime/drivers/clickhouse/clickhouse.go
@@ -67,6 +67,7 @@ var spec = drivers.Spec{
 			DisplayName: "Connection string",
 			Placeholder: "clickhouse://localhost:9000?username=default&password=password",
 			Secret:      true,
+			EnvVarName:  "CLICKHOUSE_DSN",
 			NoPrompt:    true,
 		},
 		{
@@ -106,6 +107,7 @@ var spec = drivers.Spec{
 			Description: "Password to connect to the ClickHouse server",
 			Placeholder: "Database password",
 			Secret:      true,
+			EnvVarName:  "CLICKHOUSE_PASSWORD",
 			Hint:        "Password to your database",
 		},
 		{

--- a/runtime/drivers/connectors.go
+++ b/runtime/drivers/connectors.go
@@ -47,7 +47,12 @@ type PropertySpec struct {
 	Default     string
 	Placeholder string
 	Secret      bool
-	NoPrompt    bool
+	// EnvVarName is the conventional env var name for this property (e.g. AWS_ACCESS_KEY_ID, GOOGLE_APPLICATION_CREDENTIALS).
+	// It must be specified explicitly because the mapping doesn't follow a mechanical pattern;
+	// some keys use well-known names shared across drivers (AWS_*), others add infixes (AZURE_STORAGE_*),
+	// and others diverge entirely from the key name (GCS key_id -> GCP_ACCESS_KEY_ID).
+	EnvVarName string
+	NoPrompt   bool
 }
 
 // PropertyType is an enum of types supported for connector properties.

--- a/runtime/drivers/druid/druid.go
+++ b/runtime/drivers/druid/druid.go
@@ -42,6 +42,7 @@ var spec = drivers.Spec{
 			DisplayName: "Connection string",
 			Placeholder: "https://example.com/druid/v2/sql/avatica-protobuf?authentication=BASIC&avaticaUser=username&avaticaPassword=password",
 			Secret:      true,
+			EnvVarName:  "DRUID_DSN",
 			NoPrompt:    true,
 		},
 		{
@@ -76,6 +77,7 @@ var spec = drivers.Spec{
 			Description: "Password to connect to the Druid server",
 			Placeholder: "password",
 			Secret:      true,
+			EnvVarName:  "DRUID_PASSWORD",
 		},
 		{
 			Key:         "ssl",

--- a/runtime/drivers/duckdb/duckdb.go
+++ b/runtime/drivers/duckdb/duckdb.go
@@ -105,6 +105,7 @@ var motherduckSpec = drivers.Spec{
 			Key:         "token",
 			Type:        drivers.StringPropertyType,
 			Secret:      true,
+			EnvVarName:  "MOTHERDUCK_TOKEN",
 			Required:    true,
 			DisplayName: "Token",
 			Description: "MotherDuck token",

--- a/runtime/drivers/gcs/gcs.go
+++ b/runtime/drivers/gcs/gcs.go
@@ -37,6 +37,7 @@ var spec = drivers.Spec{
 			Description: "GCP credentials as JSON string",
 			Placeholder: "Paste your GCP service account JSON here",
 			Secret:      true,
+			EnvVarName:  "GOOGLE_APPLICATION_CREDENTIALS",
 		},
 		{
 			Key:         "key_id",
@@ -45,6 +46,7 @@ var spec = drivers.Spec{
 			Description: "HMAC access key ID for S3-compatible authentication",
 			Hint:        "Optional S3-compatible Key ID when used in compatibility mode",
 			Secret:      true,
+			EnvVarName:  "GCP_ACCESS_KEY_ID",
 		},
 		{
 			Key:         "secret",
@@ -53,6 +55,7 @@ var spec = drivers.Spec{
 			Description: "HMAC secret access key for S3-compatible authentication",
 			Hint:        "Optional S3-compatible Secret when used in compatibility mode",
 			Secret:      true,
+			EnvVarName:  "GCP_SECRET_ACCESS_KEY",
 		},
 	},
 	SourceProperties: []*drivers.PropertySpec{

--- a/runtime/drivers/mysql/mysql.go
+++ b/runtime/drivers/mysql/mysql.go
@@ -38,6 +38,7 @@ var spec = drivers.Spec{
 			Placeholder: "mysql://user:password@host:3306/my-db",
 			Hint:        "Can be configured here or by setting the 'connector.mysql.dsn' environment variable (using '.env' or '--env')",
 			Secret:      true,
+			EnvVarName:  "MYSQL_DSN",
 		},
 		{
 			Key:         "user",
@@ -54,6 +55,7 @@ var spec = drivers.Spec{
 			Placeholder: "your_password",
 			Hint:        "MySQL password for authentication",
 			Secret:      true,
+			EnvVarName:  "MYSQL_PASSWORD",
 		},
 		{
 			Key:         "host",

--- a/runtime/drivers/pinot/pinot.go
+++ b/runtime/drivers/pinot/pinot.go
@@ -36,6 +36,7 @@ var spec = drivers.Spec{
 			DisplayName: "Connection string",
 			Placeholder: "http(s)://username:password@localhost:8000?controller=localhost:9000",
 			Secret:      true,
+			EnvVarName:  "PINOT_DSN",
 			NoPrompt:    true,
 		},
 		{
@@ -86,6 +87,7 @@ var spec = drivers.Spec{
 			Description: "Password to connect to the Pinot server",
 			Placeholder: "password",
 			Secret:      true,
+			EnvVarName:  "PINOT_PASSWORD",
 		},
 		{
 			Key:         "ssl",

--- a/runtime/drivers/postgres/postgres.go
+++ b/runtime/drivers/postgres/postgres.go
@@ -39,6 +39,7 @@ var spec = drivers.Spec{
 			Placeholder: "postgresql://postgres:postgres@localhost:5432/postgres",
 			Hint:        "Can be configured here or by setting the 'connector.postgres.dsn' environment variable (using '.env' or '--env').",
 			Secret:      true,
+			EnvVarName:  "POSTGRES_DSN",
 		},
 		{
 			Key:         "host",
@@ -71,6 +72,7 @@ var spec = drivers.Spec{
 			Placeholder: "your_password",
 			Hint:        "Postgres password for authentication",
 			Secret:      true,
+			EnvVarName:  "POSTGRES_PASSWORD",
 		},
 		{
 			Key:         "dbname",

--- a/runtime/drivers/redshift/redshift.go
+++ b/runtime/drivers/redshift/redshift.go
@@ -40,6 +40,7 @@ var spec = drivers.Spec{
 			Placeholder: "your_access_key_id",
 			Required:    true,
 			Secret:      true,
+			EnvVarName:  "AWS_ACCESS_KEY_ID",
 		},
 		{
 			Key:         "aws_secret_access_key",
@@ -49,6 +50,7 @@ var spec = drivers.Spec{
 			Placeholder: "your_secret_access_key",
 			Required:    true,
 			Secret:      true,
+			EnvVarName:  "AWS_SECRET_ACCESS_KEY",
 		},
 		{
 			Key:         "workgroup",

--- a/runtime/drivers/s3/s3.go
+++ b/runtime/drivers/s3/s3.go
@@ -33,6 +33,7 @@ var spec = drivers.Spec{
 			Description: "AWS access key ID for explicit credentials",
 			Placeholder: "Enter your AWS access key ID",
 			Secret:      true,
+			EnvVarName:  "AWS_ACCESS_KEY_ID",
 			Required:    true,
 		},
 		{
@@ -42,6 +43,7 @@ var spec = drivers.Spec{
 			Description: "AWS secret access key for explicit credentials",
 			Placeholder: "Enter your AWS secret access key",
 			Secret:      true,
+			EnvVarName:  "AWS_SECRET_ACCESS_KEY",
 			Required:    true,
 		},
 		{
@@ -66,6 +68,7 @@ var spec = drivers.Spec{
 			Key:         "aws_role_arn",
 			Type:        drivers.StringPropertyType,
 			Secret:      true,
+			EnvVarName:  "AWS_ROLE_ARN",
 			Description: "AWS Role ARN to assume",
 		},
 		{

--- a/runtime/drivers/salesforce/salesforce.go
+++ b/runtime/drivers/salesforce/salesforce.go
@@ -35,14 +35,16 @@ var spec = drivers.Spec{
 			Secret: false,
 		},
 		{
-			Key:    "password",
-			Type:   drivers.StringPropertyType,
-			Secret: true,
+			Key:        "password",
+			Type:       drivers.StringPropertyType,
+			Secret:     true,
+			EnvVarName: "SALESFORCE_PASSWORD",
 		},
 		{
-			Key:    "key",
-			Type:   drivers.StringPropertyType,
-			Secret: true,
+			Key:        "key",
+			Type:       drivers.StringPropertyType,
+			Secret:     true,
+			EnvVarName: "SALESFORCE_KEY",
 		},
 		{
 			Key:    "endpoint",
@@ -99,6 +101,7 @@ var spec = drivers.Spec{
 			Hint:        "Your Salesforce password, optionally followed by a security token if required.",
 			Placeholder: "your_password",
 			Secret:      true,
+			EnvVarName:  "SALESFORCE_PASSWORD",
 		},
 		{
 			Key:         "key",
@@ -108,6 +111,7 @@ var spec = drivers.Spec{
 			Hint:        "Paste your JWT private key for token-based authentication. Used with Connected App and Client ID.",
 			Placeholder: "your_jwt_key",
 			Secret:      true,
+			EnvVarName:  "SALESFORCE_KEY",
 		},
 		{
 			Key:         "endpoint",

--- a/runtime/drivers/snowflake/snowflake.go
+++ b/runtime/drivers/snowflake/snowflake.go
@@ -44,6 +44,7 @@ var spec = drivers.Spec{
 			Placeholder: "<username>@<account_identifier>/<database>/<schema>?warehouse=<warehouse>&role=<role>&authenticator=SNOWFLAKE_JWT&privateKey=<privateKey_base64_url_encoded>",
 			Hint:        "Can be configured here or by setting the 'connector.snowflake.dsn' environment variable (using '.env' or '--env').",
 			Secret:      true,
+			EnvVarName:  "SNOWFLAKE_DSN",
 		},
 		{
 			Key:         "account",
@@ -69,6 +70,7 @@ var spec = drivers.Spec{
 			Placeholder: "your_password",
 			Hint:        "Your Snowflake database password. This will be stored securely and used to authenticate your connection.",
 			Secret:      true,
+			EnvVarName:  "SNOWFLAKE_PASSWORD",
 		},
 		{
 			Key:         "database",


### PR DESCRIPTION
as part of effort to slim: https://github.com/rilldata/rill/pull/8981, 

- Adds an `EnvVarName` metadata field to `drivers.PropertySpec` so driver specs can declare the conventional env var name for each secret property (e.g. `AWS_ACCESS_KEY_ID`, `GOOGLE_APPLICATION_CREDENTIALS`).
- Populates `EnvVarName` on secret properties across 14 driver specs: `athena`, `azure`, `bigquery`, `clickhouse`, `druid`, `duckdb` (motherduck), `gcs`, `mysql`, `pinot`, `postgres`, `redshift`, `s3`, `salesforce`, `snowflake`.
- The mapping isn't mechanical — some keys share well-known names across drivers (`AWS_*`), others add infixes (`AZURE_STORAGE_*`), and some diverge entirely (GCS `key_id` → `GCP_ACCESS_KEY_ID`) — so the field has to be explicit.
- No consumers in this PR; the field will be read by upcoming declarative template work.


**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*