### PR TITLE
Add support for standard Title and Description fields to custom charts

### DIFF
--- a/web-common/src/features/canvas/components/charts/custom-chart/CanvasCustomChart.svelte
+++ b/web-common/src/features/canvas/components/charts/custom-chart/CanvasCustomChart.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import ComponentHeader from "@rilldata/web-common/features/canvas/ComponentHeader.svelte";
   import CustomChartRenderer from "@rilldata/web-common/features/components/charts/custom/CustomChartRenderer.svelte";
   import { onDestroy } from "svelte";
   import AgenticChartPrompt from "./AgenticChartPrompt.svelte";
@@ -16,17 +17,34 @@
 
   $: hasValidSpec = component.isValid($specStore);
   $: hasContent = component.hasContent($specStore);
+
+  $: ({
+    title,
+    description,
+    show_description_as_tooltip,
+    time_filters,
+    dimension_filters,
+  } = $specStore);
 </script>
 
 {#if hasValidSpec || hasContent}
-  <CustomChartRenderer
-    name={component.id}
-    spec={$specStore.vega_spec}
-    whereFilter={$timeAndFilterStore?.where}
-    timeRange={$timeAndFilterStore?.timeRange}
-    metricsSQL={$specStore.metrics_sql}
-    showDataTable={editable}
-  />
+  <div class="size-full flex flex-col overflow-hidden">
+    <ComponentHeader
+      {title}
+      {description}
+      showDescriptionAsTooltip={show_description_as_tooltip}
+      filters={{ time_filters, dimension_filters }}
+      {component}
+    />
+    <CustomChartRenderer
+      name={component.id}
+      spec={$specStore.vega_spec}
+      whereFilter={$timeAndFilterStore?.where}
+      timeRange={$timeAndFilterStore?.timeRange}
+      metricsSQL={$specStore.metrics_sql}
+      showDataTable={editable}
+    />
+  </div>
 {:else}
   <AgenticChartPrompt {component} />
 {/if}


### PR DESCRIPTION
Having support for the Title and Description fields makes it possible to maintain visual consistency eg

<img width="805" height="451" alt="image" src="https://github.com/user-attachments/assets/aacd7555-3440-4daa-a1fe-fea020370c5b" />

