### PR TITLE
feat: refine `EditButton` popover with source-branch framing

### DIFF
--- a/web-admin/src/features/edit-session/EditBranchDialog.svelte
+++ b/web-admin/src/features/edit-session/EditBranchDialog.svelte
@@ -7,25 +7,21 @@
   } from "@rilldata/web-admin/client";
   import { getRpcErrorMessage } from "@rilldata/web-admin/components/errors/error-utils";
   import {
-    branchPathPrefix,
+    injectBranchIntoPath,
     requestSkipBranchInjection,
   } from "@rilldata/web-admin/features/branches/branch-utils";
   import { Button } from "@rilldata/web-common/components/button";
   import * as Dialog from "@rilldata/web-common/components/dialog";
-  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
   import Input from "@rilldata/web-common/components/forms/Input.svelte";
+  import * as Select from "@rilldata/web-common/components/select";
   import {
     Tabs,
     TabsContent,
     TabsList,
     TabsTrigger,
   } from "@rilldata/web-common/components/tabs";
-  import {
-    CheckIcon,
-    ChevronDownIcon,
-    GitBranchIcon,
-    GitBranchPlusIcon,
-  } from "lucide-svelte";
+  import { Select as SelectPrimitive } from "bits-ui";
+  import { GitBranchIcon, GitBranchPlusIcon } from "lucide-svelte";
   import { useDevDeployments, invalidateDeployments } from "./use-edit-session";
 
   export let open = false;
@@ -43,7 +39,6 @@
   let branchName = "";
   let currentTab: "existing" | "new" = "existing";
   let selectedBranchId = "";
-  let dropdownOpen = false;
   let createError = "";
 
   $: currentUserId = $user.data?.user?.id;
@@ -100,16 +95,20 @@
   }
 
   function editUrl(branch: string | undefined): string {
-    return `/${organization}/${project}${branchPathPrefix(branch)}/-/edit`;
+    const base = `/${organization}/${project}/-/edit`;
+    return branch ? injectBranchIntoPath(base, branch) : base;
   }
 
-  // Replaces whitespace with "-" as the user types so branch names are always
-  // valid. Space → "-" is a 1:1 swap, so cursor stays put.
+  // Strip the two characters that can't survive a round-trip:
+  //   - whitespace: not valid in git branch names
+  //   - "~": reserved by `encodeBranch` as the path-segment "/" replacement
+  // Everything else (including unicode, +, etc.) is handled by `encodeBranch`.
+  // Whitespace → "-" is a 1:1 swap; "~" is dropped. Both keep cursor position.
   function handleNameInput(
     newValue: string,
     e: Event & { currentTarget: EventTarget & HTMLElement },
   ) {
-    const sanitized = newValue.replace(/\s+/g, "-");
+    const sanitized = newValue.replace(/\s+/g, "-").replace(/~/g, "");
     if (sanitized !== newValue) {
       const target = e.currentTarget as HTMLInputElement;
       const cursorPos = target.selectionStart ?? sanitized.length;
@@ -211,69 +210,53 @@
 
         <TabsContent value="existing" class="mt-4 space-y-1.5">
           <span class="text-sm font-medium text-fg-primary">Branch</span>
-          <DropdownMenu.Root bind:open={dropdownOpen}>
-            <DropdownMenu.Trigger>
-              {#snippet child({ props })}
-                <button
-                  {...props}
-                  type="button"
-                  class="flex w-full items-center justify-between gap-2 rounded-lg border border-gray-300 bg-surface px-3 py-2.5 text-left transition-colors hover:bg-surface-hover focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/20"
-                >
-                  <span class="flex min-w-0 flex-1 items-center gap-2">
-                    <GitBranchIcon size="14" class="shrink-0 text-fg-muted" />
-                    <span class="truncate font-mono text-sm text-fg-primary">
-                      {selectedDeployment?.branch ?? sourceBranch}
+          <SelectPrimitive.Root
+            type="single"
+            value={selectedBranchId}
+            onValueChange={(val) => {
+              if (val) selectedBranchId = val;
+            }}
+          >
+            <Select.Trigger
+              class="flex h-10 w-full items-center justify-between gap-2 rounded-lg border-gray-300 bg-surface px-3 text-left"
+            >
+              <span class="flex min-w-0 flex-1 items-center gap-2">
+                <GitBranchIcon size="14" class="shrink-0 text-fg-muted" />
+                <span class="truncate font-mono text-sm text-fg-primary">
+                  {selectedDeployment?.branch ?? sourceBranch}
+                </span>
+                {#if selectedDeployment?.id === latestBranchId}
+                  <span
+                    class="shrink-0 text-[10.5px] font-medium uppercase tracking-wider text-fg-muted"
+                  >
+                    latest
+                  </span>
+                {/if}
+              </span>
+            </Select.Trigger>
+            <Select.Content sameWidth class="max-h-[280px] overflow-y-auto">
+              {#each ownDeployments as deployment (deployment.id)}
+                <Select.Item value={deployment.id ?? ""} class="py-1.5">
+                  <div class="flex flex-1 items-center gap-2">
+                    <GitBranchIcon
+                      size="13"
+                      class="shrink-0 text-fg-muted"
+                    />
+                    <span class="flex-1 truncate font-mono text-[13px]">
+                      {deployment.branch || sourceBranch}
                     </span>
-                    {#if selectedDeployment?.id === latestBranchId}
+                    {#if deployment.id === latestBranchId}
                       <span
                         class="shrink-0 text-[10.5px] font-medium uppercase tracking-wider text-fg-muted"
                       >
                         latest
                       </span>
                     {/if}
-                  </span>
-                  <ChevronDownIcon
-                    size="14"
-                    class="shrink-0 text-fg-muted transition-transform {dropdownOpen
-                      ? 'rotate-180'
-                      : ''}"
-                  />
-                </button>
-              {/snippet}
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Content
-              align="start"
-              sameWidth
-              class="max-h-[280px] overflow-y-auto"
-            >
-              {#each ownDeployments as deployment (deployment.id)}
-                {@const isSelected = deployment.id === selectedBranchId}
-                {@const isLatest = deployment.id === latestBranchId}
-                <DropdownMenu.Item
-                  onclick={() => (selectedBranchId = deployment.id ?? "")}
-                  class="flex cursor-pointer items-center gap-2 px-2 py-1.5"
-                >
-                  <GitBranchIcon size="13" class="shrink-0 text-fg-muted" />
-                  <span class="flex-1 truncate font-mono text-[13px]">
-                    {deployment.branch || sourceBranch}
-                  </span>
-                  {#if isLatest}
-                    <span
-                      class="shrink-0 text-[10.5px] font-medium uppercase tracking-wider text-fg-muted"
-                    >
-                      latest
-                    </span>
-                  {/if}
-                  {#if isSelected}
-                    <CheckIcon
-                      size="13"
-                      class="ml-1 shrink-0 text-primary-600"
-                    />
-                  {/if}
-                </DropdownMenu.Item>
+                  </div>
+                </Select.Item>
               {/each}
-            </DropdownMenu.Content>
-          </DropdownMenu.Root>
+            </Select.Content>
+          </SelectPrimitive.Root>
         </TabsContent>
 
         <TabsContent value="new" class="mt-4">

--- a/web-admin/src/features/edit-session/EditBranchDialog.svelte
+++ b/web-admin/src/features/edit-session/EditBranchDialog.svelte
@@ -1,0 +1,334 @@
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import {
+    createAdminServiceCreateDeployment,
+    createAdminServiceGetCurrentUser,
+    V1DeploymentStatus,
+  } from "@rilldata/web-admin/client";
+  import { getRpcErrorMessage } from "@rilldata/web-admin/components/errors/error-utils";
+  import {
+    branchPathPrefix,
+    requestSkipBranchInjection,
+  } from "@rilldata/web-admin/features/branches/branch-utils";
+  import { Button } from "@rilldata/web-common/components/button";
+  import * as Dialog from "@rilldata/web-common/components/dialog";
+  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
+  import Input from "@rilldata/web-common/components/forms/Input.svelte";
+  import {
+    Tabs,
+    TabsContent,
+    TabsList,
+    TabsTrigger,
+  } from "@rilldata/web-common/components/tabs";
+  import {
+    CheckIcon,
+    ChevronDownIcon,
+    GitBranchIcon,
+    GitBranchPlusIcon,
+  } from "lucide-svelte";
+  import { useDevDeployments, invalidateDeployments } from "./use-edit-session";
+
+  export let open = false;
+  export let organization: string;
+  export let project: string;
+  /** The branch currently being viewed (from the URL), if any. */
+  export let activeBranch: string | undefined = undefined;
+  /** The project's primary branch, used as the source for new branches. */
+  export let primaryBranch: string | undefined = undefined;
+
+  const user = createAdminServiceGetCurrentUser();
+  const devDeployments = useDevDeployments(organization, project);
+  const createMutation = createAdminServiceCreateDeployment();
+
+  let branchName = "";
+  let currentTab: "existing" | "new" = "existing";
+  let selectedBranchId = "";
+  let dropdownOpen = false;
+  let createError = "";
+
+  $: currentUserId = $user.data?.user?.id;
+  $: deployments = $devDeployments.data?.deployments ?? [];
+  $: sourceBranch = primaryBranch || "main";
+
+  // Editable deployments owned by the current user, sorted by most recently
+  // updated. Stopped/errored branches show so the user can resume or retry.
+  $: ownDeployments = deployments
+    .filter(
+      (d) =>
+        d.ownerUserId === currentUserId &&
+        d.editable &&
+        d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETING &&
+        d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETED,
+    )
+    .sort((a, b) => (b.updatedOn ?? "").localeCompare(a.updatedOn ?? ""));
+
+  $: latestBranchId = ownDeployments[0]?.id ?? "";
+  $: hasOwnSessions = ownDeployments.length > 0;
+  $: isStarting = $createMutation.isPending;
+
+  // Banner condition: active branch is owned but not editable
+  $: activeBranchIsNonEditable =
+    !!activeBranch &&
+    !!currentUserId &&
+    deployments.some(
+      (d) =>
+        d.branch === activeBranch &&
+        d.ownerUserId === currentUserId &&
+        !d.editable,
+    );
+
+  // Reset all state every time the dialog opens.
+  $: if (open) {
+    resetState();
+  }
+
+  $: selectedDeployment = ownDeployments.find((d) => d.id === selectedBranchId);
+
+  function resetState() {
+    branchName = "";
+    selectedBranchId = latestBranchId;
+    currentTab = hasOwnSessions ? "existing" : "new";
+    createError = "";
+  }
+
+  function handleTabChange(value: string) {
+    currentTab = value as "existing" | "new";
+    // Clear field-level errors and inputs when switching tabs so stale state
+    // from one tab doesn't bleed into the other.
+    branchName = "";
+    createError = "";
+  }
+
+  function editUrl(branch: string | undefined): string {
+    return `/${organization}/${project}${branchPathPrefix(branch)}/-/edit`;
+  }
+
+  // Replaces whitespace with "-" as the user types so branch names are always
+  // valid. Space → "-" is a 1:1 swap, so cursor stays put.
+  function handleNameInput(
+    newValue: string,
+    e: Event & { currentTarget: EventTarget & HTMLElement },
+  ) {
+    const sanitized = newValue.replace(/\s+/g, "-");
+    if (sanitized !== newValue) {
+      const target = e.currentTarget as HTMLInputElement;
+      const cursorPos = target.selectionStart ?? sanitized.length;
+      target.value = sanitized;
+      target.setSelectionRange(cursorPos, cursorPos);
+    }
+    branchName = sanitized;
+    createError = "";
+  }
+
+  async function handleCreate() {
+    if (!branchName.trim()) return;
+    createError = "";
+    const requestedBranch = branchName.trim();
+
+    // Front-run the obvious failure: same name as an existing branch.
+    if (ownDeployments.some((d) => d.branch === requestedBranch)) {
+      createError = `A branch named "${requestedBranch}" already exists.`;
+      return;
+    }
+
+    try {
+      const resp = await $createMutation.mutateAsync({
+        org: organization,
+        project,
+        data: {
+          environment: "dev",
+          editable: true,
+          branch: requestedBranch,
+        },
+      });
+      void invalidateDeployments(organization, project);
+      open = false;
+      requestSkipBranchInjection();
+      await goto(editUrl(resp.deployment?.branch));
+    } catch (err) {
+      createError =
+        getRpcErrorMessage(err as any) ?? "Failed to start edit session.";
+    }
+  }
+
+  function handleResume() {
+    if (!selectedDeployment) return;
+    requestSkipBranchInjection();
+    open = false;
+    void goto(editUrl(selectedDeployment.branch));
+  }
+</script>
+
+<Dialog.Root bind:open>
+  <Dialog.Trigger>
+    {#snippet child({ props })}
+      <div {...props} class="hidden"></div>
+    {/snippet}
+  </Dialog.Trigger>
+  <Dialog.Content>
+    <Dialog.Header>
+      <Dialog.Title>Start editing</Dialog.Title>
+      <Dialog.Description>
+        {#if hasOwnSessions}
+          Edit an existing branch or create a new one from
+          <code class="font-mono text-fg-primary">{sourceBranch}</code>.
+        {:else}
+          We'll create a branch from
+          <code class="font-mono text-fg-primary">{sourceBranch}</code>
+          for your edits.
+        {/if}
+      </Dialog.Description>
+    </Dialog.Header>
+
+    {#if activeBranchIsNonEditable}
+      <div
+        class="rounded-md border border-yellow-200 bg-yellow-50 px-3 py-2 text-xs text-yellow-800"
+      >
+        This branch is read-only. Pick another branch or create a new one.
+      </div>
+    {/if}
+
+    {#if hasOwnSessions}
+      <Tabs value={currentTab} onValueChange={handleTabChange} class="w-full">
+        <TabsList
+          class="flex h-9 w-full rounded-lg border border-gray-200 bg-surface-muted p-1"
+        >
+          <TabsTrigger
+            value="existing"
+            class="flex h-7 flex-1 items-center justify-center gap-1.5 rounded-md text-sm transition-all data-[state=active]:bg-surface-overlay data-[state=active]:font-semibold data-[state=active]:shadow-sm"
+          >
+            <GitBranchIcon size="14" />
+            Existing branch
+          </TabsTrigger>
+          <TabsTrigger
+            value="new"
+            class="flex h-7 flex-1 items-center justify-center gap-1.5 rounded-md text-sm transition-all data-[state=active]:bg-surface-overlay data-[state=active]:font-semibold data-[state=active]:shadow-sm"
+          >
+            <GitBranchPlusIcon size="14" />
+            New branch
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="existing" class="mt-4 space-y-1.5">
+          <span class="text-sm font-medium text-fg-primary">Branch</span>
+          <DropdownMenu.Root bind:open={dropdownOpen}>
+            <DropdownMenu.Trigger>
+              {#snippet child({ props })}
+                <button
+                  {...props}
+                  type="button"
+                  class="flex w-full items-center justify-between gap-2 rounded-lg border border-gray-300 bg-surface px-3 py-2.5 text-left transition-colors hover:bg-surface-hover focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/20"
+                >
+                  <span class="flex min-w-0 flex-1 items-center gap-2">
+                    <GitBranchIcon size="14" class="shrink-0 text-fg-muted" />
+                    <span class="truncate font-mono text-sm text-fg-primary">
+                      {selectedDeployment?.branch ?? sourceBranch}
+                    </span>
+                    {#if selectedDeployment?.id === latestBranchId}
+                      <span
+                        class="shrink-0 text-[10.5px] font-medium uppercase tracking-wider text-fg-muted"
+                      >
+                        latest
+                      </span>
+                    {/if}
+                  </span>
+                  <ChevronDownIcon
+                    size="14"
+                    class="shrink-0 text-fg-muted transition-transform {dropdownOpen
+                      ? 'rotate-180'
+                      : ''}"
+                  />
+                </button>
+              {/snippet}
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content
+              align="start"
+              sameWidth
+              class="max-h-[280px] overflow-y-auto"
+            >
+              {#each ownDeployments as deployment (deployment.id)}
+                {@const isSelected = deployment.id === selectedBranchId}
+                {@const isLatest = deployment.id === latestBranchId}
+                <DropdownMenu.Item
+                  onclick={() => (selectedBranchId = deployment.id ?? "")}
+                  class="flex cursor-pointer items-center gap-2 px-2 py-1.5"
+                >
+                  <GitBranchIcon size="13" class="shrink-0 text-fg-muted" />
+                  <span class="flex-1 truncate font-mono text-[13px]">
+                    {deployment.branch || sourceBranch}
+                  </span>
+                  {#if isLatest}
+                    <span
+                      class="shrink-0 text-[10.5px] font-medium uppercase tracking-wider text-fg-muted"
+                    >
+                      latest
+                    </span>
+                  {/if}
+                  {#if isSelected}
+                    <CheckIcon
+                      size="13"
+                      class="ml-1 shrink-0 text-primary-600"
+                    />
+                  {/if}
+                </DropdownMenu.Item>
+              {/each}
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+        </TabsContent>
+
+        <TabsContent value="new" class="mt-4">
+          <Input
+            id="new-branch-name"
+            label="Branch name"
+            placeholder="branch-name"
+            bind:value={branchName}
+            onInput={handleNameInput}
+            errors={createError || undefined}
+            alwaysShowError
+            capitalizeLabel={false}
+            textClass="text-sm"
+            fontFamily="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+            claimFocusOnMount
+          />
+        </TabsContent>
+      </Tabs>
+    {:else}
+      <Input
+        id="new-branch-name"
+        label="Branch name"
+        placeholder="branch-name"
+        bind:value={branchName}
+        onInput={handleNameInput}
+        errors={createError || undefined}
+        alwaysShowError
+        capitalizeLabel={false}
+        textClass="text-sm"
+        fontFamily="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+        claimFocusOnMount
+      />
+    {/if}
+
+    <Dialog.Footer>
+      <Button type="secondary" onClick={() => (open = false)}>Cancel</Button>
+      {#if hasOwnSessions && currentTab === "existing"}
+        <Button
+          type="primary"
+          disabled={!selectedBranchId || isStarting}
+          onClick={handleResume}
+        >
+          Continue editing
+        </Button>
+      {:else}
+        <Button
+          type="primary"
+          disabled={!branchName.trim() || isStarting}
+          loading={isStarting}
+          loadingCopy="Starting..."
+          onClick={handleCreate}
+        >
+          Create &amp; edit
+        </Button>
+      {/if}
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>

--- a/web-admin/src/features/edit-session/EditBranchDialog.svelte
+++ b/web-admin/src/features/edit-session/EditBranchDialog.svelte
@@ -268,9 +268,9 @@
             id="new-branch-name"
             label="Branch name"
             placeholder="branch-name"
-            size="xl"
             bind:value={branchName}
             onInput={handleNameInput}
+            onEnter={() => void handleCreate()}
             errors={createError || undefined}
             alwaysShowError
             capitalizeLabel={false}
@@ -284,9 +284,9 @@
         id="new-branch-name"
         label="Branch name"
         placeholder="branch-name"
-        size="xl"
         bind:value={branchName}
         onInput={handleNameInput}
+        onEnter={() => void handleCreate()}
         errors={createError || undefined}
         alwaysShowError
         capitalizeLabel={false}

--- a/web-admin/src/features/edit-session/EditBranchDialog.svelte
+++ b/web-admin/src/features/edit-session/EditBranchDialog.svelte
@@ -220,7 +220,7 @@
             <Select.Trigger
               class="flex h-[30px] w-full items-center justify-between gap-2 rounded-[2px] border-gray-300 bg-input px-2 text-left"
             >
-              <span class="flex min-w-0 flex-1 items-center gap-2 leading-none">
+              <div class="flex min-w-0 flex-1 items-center gap-2">
                 <GitBranchIcon size="14" class="shrink-0 text-fg-muted" />
                 <span class="truncate font-mono text-sm text-fg-primary">
                   {selectedDeployment?.branch ?? sourceBranch}
@@ -232,7 +232,7 @@
                     latest
                   </span>
                 {/if}
-              </span>
+              </div>
             </Select.Trigger>
             <Select.Content sameWidth class="max-h-[280px] overflow-y-auto">
               {#each ownDeployments as deployment (deployment.id)}

--- a/web-admin/src/features/edit-session/EditBranchDialog.svelte
+++ b/web-admin/src/features/edit-session/EditBranchDialog.svelte
@@ -218,9 +218,9 @@
             }}
           >
             <Select.Trigger
-              class="flex h-10 w-full items-center justify-between gap-2 rounded-lg border-gray-300 bg-surface px-3 text-left"
+              class="flex h-[30px] w-full items-center justify-between gap-2 rounded-[2px] border-gray-300 bg-input px-2 text-left"
             >
-              <span class="flex min-w-0 flex-1 items-center gap-2">
+              <span class="flex min-w-0 flex-1 items-center gap-2 leading-none">
                 <GitBranchIcon size="14" class="shrink-0 text-fg-muted" />
                 <span class="truncate font-mono text-sm text-fg-primary">
                   {selectedDeployment?.branch ?? sourceBranch}

--- a/web-admin/src/features/edit-session/EditBranchDialog.svelte
+++ b/web-admin/src/features/edit-session/EditBranchDialog.svelte
@@ -164,7 +164,7 @@
       <div {...props} class="hidden"></div>
     {/snippet}
   </Dialog.Trigger>
-  <Dialog.Content>
+  <Dialog.Content class="max-w-md">
     <Dialog.Header>
       <Dialog.Title>Start editing</Dialog.Title>
       <Dialog.Description>
@@ -218,20 +218,22 @@
             }}
           >
             <Select.Trigger
-              class="flex h-[30px] w-full items-center justify-between gap-2 rounded-[2px] border-gray-300 bg-input px-2 text-left"
+              class="flex h-[38px] w-full items-center justify-between gap-2 rounded-[2px] border-gray-300 bg-input px-2 text-left"
             >
               <div class="flex min-w-0 flex-1 items-center gap-2">
                 <GitBranchIcon size="14" class="shrink-0 text-fg-muted" />
-                <span class="truncate font-mono text-sm text-fg-primary">
-                  {selectedDeployment?.branch ?? sourceBranch}
-                </span>
-                {#if selectedDeployment?.id === latestBranchId}
-                  <span
-                    class="shrink-0 text-[10.5px] font-medium uppercase tracking-wider text-fg-muted"
-                  >
-                    latest
+                <div class="flex min-w-0 flex-1 items-baseline gap-2">
+                  <span class="truncate font-mono text-sm text-fg-primary">
+                    {selectedDeployment?.branch ?? sourceBranch}
                   </span>
-                {/if}
+                  {#if selectedDeployment?.id === latestBranchId}
+                    <span
+                      class="shrink-0 text-[10.5px] font-medium uppercase tracking-wider text-fg-muted"
+                    >
+                      latest
+                    </span>
+                  {/if}
+                </div>
               </div>
             </Select.Trigger>
             <Select.Content sameWidth class="max-h-[280px] overflow-y-auto">
@@ -242,16 +244,18 @@
                       size="13"
                       class="shrink-0 text-fg-muted"
                     />
-                    <span class="flex-1 truncate font-mono text-[13px]">
-                      {deployment.branch || sourceBranch}
-                    </span>
-                    {#if deployment.id === latestBranchId}
-                      <span
-                        class="shrink-0 text-[10.5px] font-medium uppercase tracking-wider text-fg-muted"
-                      >
-                        latest
+                    <div class="flex min-w-0 flex-1 items-baseline gap-2">
+                      <span class="flex-1 truncate font-mono text-[13px]">
+                        {deployment.branch || sourceBranch}
                       </span>
-                    {/if}
+                      {#if deployment.id === latestBranchId}
+                        <span
+                          class="shrink-0 text-[10.5px] font-medium uppercase tracking-wider text-fg-muted"
+                        >
+                          latest
+                        </span>
+                      {/if}
+                    </div>
                   </div>
                 </Select.Item>
               {/each}
@@ -264,12 +268,12 @@
             id="new-branch-name"
             label="Branch name"
             placeholder="branch-name"
+            size="xl"
             bind:value={branchName}
             onInput={handleNameInput}
             errors={createError || undefined}
             alwaysShowError
             capitalizeLabel={false}
-            textClass="text-sm"
             fontFamily="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
             claimFocusOnMount
           />
@@ -280,12 +284,12 @@
         id="new-branch-name"
         label="Branch name"
         placeholder="branch-name"
+        size="xl"
         bind:value={branchName}
         onInput={handleNameInput}
         errors={createError || undefined}
         alwaysShowError
         capitalizeLabel={false}
-        textClass="text-sm"
         fontFamily="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
         claimFocusOnMount
       />

--- a/web-admin/src/features/edit-session/EditBranchDialog.svelte
+++ b/web-admin/src/features/edit-session/EditBranchDialog.svelte
@@ -268,6 +268,8 @@
             id="new-branch-name"
             label="Branch name"
             placeholder="branch-name"
+            size="xl"
+            additionalClass="[&_input]:!text-sm"
             bind:value={branchName}
             onInput={handleNameInput}
             onEnter={() => void handleCreate()}
@@ -284,6 +286,8 @@
         id="new-branch-name"
         label="Branch name"
         placeholder="branch-name"
+        size="xl"
+        additionalClass="[&_input]:!text-sm"
         bind:value={branchName}
         onInput={handleNameInput}
         onEnter={() => void handleCreate()}

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -374,23 +374,28 @@
 
   /* Segmented tab control — Di's pattern (gray pill, white active) */
   .seg-list {
-    @apply mx-6 mt-5 inline-flex p-0.5 gap-0.5 self-start;
-    @apply bg-gray-100 rounded-lg w-fit;
+    @apply mx-6 mt-5 inline-flex p-1 gap-1 self-start;
+    @apply bg-slate-100 rounded-lg w-fit;
   }
 
   .seg-trigger {
-    @apply px-3.5 py-1.5 rounded-md border-0 bg-transparent;
-    @apply text-[13px] font-medium text-fg-secondary;
-    @apply transition-colors cursor-pointer;
-    @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/30;
+    @apply px-4 py-1.5 rounded-md border-0 bg-transparent;
+    @apply text-[13px] font-medium text-slate-500;
+    @apply transition-all cursor-pointer;
+    @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/40;
   }
 
   .seg-trigger.is-active {
-    @apply bg-surface text-fg-primary shadow-sm;
+    background: #ffffff;
+    color: #0f172a;
+    font-weight: 600;
+    box-shadow:
+      0 1px 2px rgba(15, 23, 42, 0.08),
+      0 0 0 1px rgba(15, 23, 42, 0.04);
   }
 
   .seg-trigger:not(.is-active):hover {
-    @apply text-fg-primary;
+    @apply text-slate-700;
   }
 
   /* Body — locks 16px gap from tabs (or subtitle when no tabs) */

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -12,8 +12,10 @@
   } from "@rilldata/web-admin/features/branches/branch-utils";
   import { Button } from "@rilldata/web-common/components/button";
   import * as Dialog from "@rilldata/web-common/components/dialog";
+  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
-  import { GitBranchIcon, PlusIcon } from "lucide-svelte";
+  import { Tabs as TabsPrimitive } from "bits-ui";
+  import { CheckIcon, ChevronDownIcon, GitBranchIcon } from "lucide-svelte";
   import { useDevDeployments, invalidateDeployments } from "./use-edit-session";
 
   export let organization: string;
@@ -29,7 +31,9 @@
 
   let open = false;
   let branchName = "";
-  let showNewBranchInput = false;
+  let currentTab: "existing" | "new" = "existing";
+  let selectedBranchId = "";
+  let dropdownOpen = false;
 
   $: currentUserId = $user.data?.user?.id;
   $: deployments = $devDeployments.data?.deployments ?? [];
@@ -50,6 +54,11 @@
         d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETED,
     )
     .sort((a, b) => (b.updatedOn ?? "").localeCompare(a.updatedOn ?? ""));
+
+  // Most-recently-updated branch — used for the "latest" tag and as the
+  // default selection in the Existing-branch dropdown.
+  $: latestDeployment = ownDeployments[0];
+  $: latestBranchId = latestDeployment?.id ?? "";
 
   // If viewing a branch the user owns, clicking the button should go straight there
   $: activeBranchDeployment = activeBranch
@@ -72,11 +81,18 @@
   $: hasOwnSessions = ownDeployments.length > 0;
   $: isStarting = $createMutation.isPending;
 
-  // Reset state when dialog opens
+  // Reset state every time the dialog opens. Default to the Existing tab
+  // when the user has branches (most users come back to resume); preselect
+  // the most-recent branch so "Continue editing" is one click away.
   $: if (open) {
     branchName = "";
-    showNewBranchInput = !hasOwnSessions;
+    currentTab = hasOwnSessions ? "existing" : "new";
+    selectedBranchId = latestBranchId;
   }
+
+  $: selectedDeployment = ownDeployments.find(
+    (d) => d.id === selectedBranchId,
+  );
 
   function editUrl(branch: string | undefined): string {
     return `/${organization}/${project}${branchPathPrefix(branch)}/-/edit`;
@@ -94,11 +110,6 @@
     void goto(directEditHref!);
   }
 
-  function handleBranchClick() {
-    requestSkipBranchInjection();
-    open = false;
-  }
-
   // Replaces whitespace with "-" as the user types so branch names are
   // always valid. Space → "-" is a 1:1 swap, so cursor stays put.
   function handleBranchNameInput(e: Event) {
@@ -110,11 +121,6 @@
       target.setSelectionRange(cursorPos, cursorPos);
     }
     branchName = sanitized;
-  }
-
-  function handleCancelNewBranch() {
-    branchName = "";
-    showNewBranchInput = false;
   }
 
   async function handleCreate() {
@@ -141,13 +147,17 @@
     }
   }
 
-  function handleKeydown(e: KeyboardEvent) {
+  function handleResume() {
+    if (!selectedDeployment) return;
+    requestSkipBranchInjection();
+    open = false;
+    void goto(editUrl(selectedDeployment.branch));
+  }
+
+  function handleNameKeydown(e: KeyboardEvent) {
     if (e.key === "Enter") {
-      void handleCreate();
-    } else if (e.key === "Escape" && hasOwnSessions && showNewBranchInput) {
       e.preventDefault();
-      e.stopPropagation();
-      handleCancelNewBranch();
+      void handleCreate();
     }
   }
 </script>
@@ -178,52 +188,109 @@
       {/snippet}
     </Dialog.Trigger>
 
-    <Dialog.Content class="max-w-md gap-0">
-      <Dialog.Header class="space-y-1">
-        <Dialog.Title class="text-base">
-          {hasOwnSessions ? "Continue editing" : "Start editing"}
+    <Dialog.Content class="!max-w-[480px] gap-0 p-0">
+      <Dialog.Header class="space-y-1 px-6 pt-6">
+        <Dialog.Title class="text-lg font-semibold tracking-tight">
+          Start editing
         </Dialog.Title>
-        <Dialog.Description class="dlg-subtitle">
-          {hasOwnSessions
-            ? "Branched from"
-            : "Create a branch to edit from"}<span class="branch-chip">
-            <GitBranchIcon size="11" />
-            {sourceBranch}
-          </span>
+        <Dialog.Description class="text-[13px] text-fg-secondary leading-snug">
+          {#if hasOwnSessions}
+            Pick up an existing branch, or create a new one from
+            <code class="dlg-code">{sourceBranch}</code>.
+          {:else}
+            We'll create a branch from
+            <code class="dlg-code">{sourceBranch}</code>
+            for your edits.
+          {/if}
         </Dialog.Description>
       </Dialog.Header>
 
       {#if activeBranchIsNonEditable}
         <div class="banner">
-          This branch isn't editable. Start a new one below{hasOwnSessions
-            ? " or switch to another"
-            : ""}.
+          This branch is read-only. Pick another branch or create a new one.
         </div>
       {/if}
 
       {#if hasOwnSessions}
-        <div class="branch-list">
-          {#each ownDeployments as deployment (deployment.id)}
-            <a
-              class="branch-row"
-              href={editUrl(deployment.branch)}
-              onclick={handleBranchClick}
-              data-sveltekit-preload-data="hover"
-            >
-              <span class="font-mono truncate">
-                {deployment.branch || sourceBranch}
-              </span>
-            </a>
-          {/each}
-        </div>
+        <TabsPrimitive.Root bind:value={currentTab} class="contents">
+          <TabsPrimitive.List class="seg-list">
+            <TabsPrimitive.Trigger value="existing" class="seg-trigger">
+              Existing branch
+            </TabsPrimitive.Trigger>
+            <TabsPrimitive.Trigger value="new" class="seg-trigger">
+              New branch
+            </TabsPrimitive.Trigger>
+          </TabsPrimitive.List>
 
-        <div class="separator"></div>
+          <TabsPrimitive.Content value="existing" class="tab-body">
+            <label class="form-label" for="existing-branch">Branch</label>
+            <DropdownMenu.Root bind:open={dropdownOpen}>
+              <DropdownMenu.Trigger>
+                {#snippet child({ props })}
+                  <button
+                    {...props}
+                    id="existing-branch"
+                    class="branch-select"
+                    class:open={dropdownOpen}
+                    type="button"
+                  >
+                    <span class="select-left">
+                      <GitBranchIcon
+                        size="14"
+                        class="text-fg-muted shrink-0"
+                      />
+                      <span class="select-name">
+                        {selectedDeployment?.branch ?? sourceBranch}
+                      </span>
+                      {#if selectedDeployment && selectedDeployment.id === latestBranchId}
+                        <span class="latest-tag">latest</span>
+                      {/if}
+                    </span>
+                    <ChevronDownIcon
+                      size="14"
+                      class="text-fg-muted shrink-0 transition-transform {dropdownOpen
+                        ? 'rotate-180'
+                        : ''}"
+                    />
+                  </button>
+                {/snippet}
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content
+                align="start"
+                sameWidth
+                class="max-h-[280px] overflow-y-auto"
+              >
+                {#each ownDeployments as deployment (deployment.id)}
+                  {@const isSelected = deployment.id === selectedBranchId}
+                  {@const isLatest = deployment.id === latestBranchId}
+                  <DropdownMenu.Item
+                    onclick={() => (selectedBranchId = deployment.id ?? "")}
+                    class="branch-option"
+                  >
+                    <GitBranchIcon
+                      size="13"
+                      class="text-fg-muted shrink-0"
+                    />
+                    <span class="font-mono text-[13px] truncate flex-1">
+                      {deployment.branch || sourceBranch}
+                    </span>
+                    {#if isLatest}
+                      <span class="latest-tag">latest</span>
+                    {/if}
+                    {#if isSelected}
+                      <CheckIcon
+                        size="13"
+                        class="text-primary-600 shrink-0 ml-1"
+                      />
+                    {/if}
+                  </DropdownMenu.Item>
+                {/each}
+              </DropdownMenu.Content>
+            </DropdownMenu.Root>
+          </TabsPrimitive.Content>
 
-        {#if showNewBranchInput}
-          <div class="form">
-            <label class="form-label" for="new-branch-name">
-              New branch name
-            </label>
+          <TabsPrimitive.Content value="new" class="tab-body">
+            <label class="form-label" for="new-branch-name">Branch name</label>
             <!-- svelte-ignore a11y_autofocus -->
             <input
               id="new-branch-name"
@@ -231,40 +298,14 @@
               type="text"
               value={branchName}
               oninput={handleBranchNameInput}
-              onkeydown={handleKeydown}
+              onkeydown={handleNameKeydown}
               placeholder="branch-name"
               autofocus
             />
-            <div class="form-actions">
-              <Button
-                type="ghost"
-                disabled={isStarting}
-                onClick={handleCancelNewBranch}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="primary"
-                disabled={!branchName.trim() || isStarting}
-                loading={isStarting}
-                loadingCopy="Starting..."
-                onClick={handleCreate}
-              >
-                Create &amp; edit
-              </Button>
-            </div>
-          </div>
-        {:else}
-          <button
-            class="new-branch-btn"
-            onclick={() => (showNewBranchInput = true)}
-          >
-            <PlusIcon size="14" />
-            <span>New branch&hellip;</span>
-          </button>
-        {/if}
+          </TabsPrimitive.Content>
+        </TabsPrimitive.Root>
       {:else}
-        <div class="form">
+        <div class="tab-body" style:margin-top="20px">
           <label class="form-label" for="new-branch-name">Branch name</label>
           <!-- svelte-ignore a11y_autofocus -->
           <input
@@ -273,83 +314,122 @@
             type="text"
             value={branchName}
             oninput={handleBranchNameInput}
-            onkeydown={handleKeydown}
+            onkeydown={handleNameKeydown}
             placeholder="branch-name"
             autofocus
           />
-          <div class="form-actions">
-            <Button
-              type="primary"
-              disabled={!branchName.trim() || isStarting}
-              loading={isStarting}
-              loadingCopy="Starting..."
-              onClick={handleCreate}
-            >
-              Create &amp; edit
-            </Button>
-          </div>
         </div>
       {/if}
+
+      <div class="dlg-footer">
+        <Button type="secondary" onClick={() => (open = false)}>Cancel</Button>
+        {#if hasOwnSessions && currentTab === "existing"}
+          <Button
+            type="primary"
+            disabled={!selectedBranchId || isStarting}
+            onClick={handleResume}
+          >
+            Continue editing
+          </Button>
+        {:else}
+          <Button
+            type="primary"
+            disabled={!branchName.trim() || isStarting}
+            loading={isStarting}
+            loadingCopy="Starting..."
+            onClick={handleCreate}
+          >
+            Create &amp; edit
+          </Button>
+        {/if}
+      </div>
     </Dialog.Content>
   </Dialog.Root>
 {/if}
 
 <style lang="postcss">
-  /* Header subtitle (Dialog.Description) — overrides muted default to read
-     as a single inline line with the source-branch chip. */
-  :global(.dlg-subtitle) {
-    @apply !text-xs !text-fg-secondary whitespace-nowrap;
+  /* Inline monospace for branch names in subtitle prose */
+  :global(.dlg-code) {
+    @apply font-mono text-[12.5px] text-fg-primary bg-transparent px-0;
   }
 
-  .branch-chip {
-    @apply ml-1 inline-flex items-center gap-x-1 align-[-2px];
-    @apply px-1.5 py-px rounded;
-    @apply text-[11.5px] font-mono font-medium text-fg-primary;
-    @apply bg-surface-subtle border border-border;
-  }
-
-  .branch-chip :global(svg) {
-    @apply text-fg-muted shrink-0;
-  }
-
+  /* Banner for non-editable active branch */
   .banner {
-    @apply mt-3 rounded-sm px-2.5 py-2;
+    @apply mx-6 mt-4 rounded-md px-3 py-2;
     @apply text-xs text-yellow-800 bg-yellow-50 border border-yellow-200;
   }
 
-  .branch-list {
-    @apply flex flex-col mt-3 -mx-1.5;
+  /* Segmented tab control — Di's pattern (gray pill, white active) */
+  :global(.seg-list) {
+    @apply mx-6 mt-5 inline-flex p-0.5 gap-0.5 self-start;
+    @apply bg-gray-100 rounded-lg;
   }
 
-  .branch-row {
-    @apply flex items-center gap-x-2 rounded-md px-3 py-2 text-sm;
-    @apply text-fg-primary hover:bg-surface-hover hover:text-fg-accent;
-    @apply cursor-pointer outline-none no-underline;
+  :global(.seg-trigger) {
+    @apply px-3.5 py-1.5 rounded-md;
+    @apply text-[13px] font-medium text-fg-secondary;
+    @apply transition-colors cursor-pointer;
+    @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/30;
   }
 
-  .separator {
-    @apply my-2 h-px bg-border;
+  :global(.seg-trigger[data-state="active"]) {
+    @apply bg-surface text-fg-primary shadow-sm;
   }
 
-  .new-branch-btn {
-    @apply flex w-full items-center gap-x-2 rounded-md px-3 py-2 text-sm font-medium;
-    @apply -mx-1.5 text-primary-600 hover:bg-surface-hover cursor-pointer;
+  :global(.seg-trigger:not([data-state="active"]):hover) {
+    @apply text-fg-primary;
   }
 
-  .form {
-    @apply flex flex-col gap-y-2 mt-3;
+  /* Body — locks 16px gap from tabs (or subtitle when no tabs) */
+  :global(.tab-body) {
+    @apply px-6 pt-4 pb-1 flex flex-col gap-1.5;
   }
 
   .form-label {
-    @apply text-xs font-medium text-fg-primary;
+    @apply text-[13px] font-medium text-fg-primary mb-1;
   }
 
   .branch-input {
-    @apply w-full text-sm font-mono px-3 py-2 rounded-md border border-gray-300;
-    @apply focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500;
+    @apply w-full font-mono text-[13.5px] px-3 py-2.5;
+    @apply bg-surface border border-gray-300 rounded-lg;
+    @apply text-fg-primary placeholder:text-fg-muted;
+    @apply focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500;
+    @apply transition-shadow;
   }
 
-  .form-actions {
-    @apply flex items-center justify-end gap-x-2 mt-2;
+  /* Existing-branch dropdown trigger */
+  .branch-select {
+    @apply flex items-center justify-between gap-2 w-full;
+    @apply px-3 py-2.5 rounded-lg;
+    @apply bg-surface border border-gray-300 text-left;
+    @apply hover:bg-surface-hover transition-colors cursor-pointer;
+    @apply focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500;
+  }
+
+  .branch-select.open {
+    @apply ring-2 ring-primary-500/20 border-primary-500;
+  }
+
+  .select-left {
+    @apply flex items-center gap-2 min-w-0 flex-1;
+  }
+
+  .select-name {
+    @apply font-mono text-[13px] text-fg-primary truncate;
+  }
+
+  .latest-tag {
+    @apply font-sans text-[10.5px] font-medium uppercase tracking-wider;
+    @apply text-fg-muted shrink-0;
+  }
+
+  :global(.branch-option) {
+    @apply flex items-center gap-2 px-2 py-1.5 cursor-pointer;
+  }
+
+  /* Footer separator and right-aligned button row */
+  .dlg-footer {
+    @apply flex items-center justify-end gap-2;
+    @apply px-6 py-4 mt-6 border-t border-border;
   }
 </style>

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -215,7 +215,7 @@
         </Dialog.Title>
         <Dialog.Description class="text-[13px] text-fg-secondary leading-snug">
           {#if hasOwnSessions}
-            Pick up an existing branch, or create a new one from
+            Edit an existing branch or create a new one from
             <code class="dlg-code">{sourceBranch}</code>.
           {:else}
             We'll create a branch from

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -259,7 +259,7 @@
 
         {#if currentTab === "existing"}
           <div class="tab-body" role="tabpanel">
-            <label class="form-label" for="existing-branch">Branch</label>
+            <span class="form-label">Branch</span>
             <DropdownMenu.Root bind:open={dropdownOpen}>
               <DropdownMenu.Trigger>
                 {#snippet child({ props })}

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -1,25 +1,16 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import {
-    createAdminServiceCreateDeployment,
     createAdminServiceGetCurrentUser,
     V1DeploymentStatus,
   } from "@rilldata/web-admin/client";
-  import { getRpcErrorMessage } from "@rilldata/web-admin/components/errors/error-utils";
   import {
     branchPathPrefix,
     requestSkipBranchInjection,
   } from "@rilldata/web-admin/features/branches/branch-utils";
   import { Button } from "@rilldata/web-common/components/button";
-  import * as Dialog from "@rilldata/web-common/components/dialog";
-  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
-  import {
-    CheckIcon,
-    ChevronDownIcon,
-    GitBranchIcon,
-    GitBranchPlusIcon,
-  } from "lucide-svelte";
-  import { useDevDeployments, invalidateDeployments } from "./use-edit-session";
+  import { useDevDeployments } from "./use-edit-session";
+  import EditBranchDialog from "./EditBranchDialog.svelte";
 
   export let organization: string;
   export let project: string;
@@ -30,485 +21,60 @@
 
   const user = createAdminServiceGetCurrentUser();
   const devDeployments = useDevDeployments(organization, project);
-  const createMutation = createAdminServiceCreateDeployment();
 
-  let open = false;
-  let branchName = "";
-  let currentTab: "existing" | "new" = "existing";
-  let selectedBranchId = "";
-  let dropdownOpen = false;
-  let createError = "";
+  let dialogOpen = false;
 
   $: currentUserId = $user.data?.user?.id;
   $: deployments = $devDeployments.data?.deployments ?? [];
   $: isLoading = $devDeployments.isLoading;
-  $: sourceBranch = primaryBranch || "main";
 
-  // Editable deployments owned by the current user (excludes ones being
-  // torn down), sorted by most recently updated. Stopped and errored
-  // branches are shown so the user can resume or retry them. Non-editable
-  // deployments (e.g. created via the CLI without `--editable`) are hidden
-  // because the edit surface cannot function against them.
-  $: ownDeployments = deployments
-    .filter(
-      (d) =>
-        d.ownerUserId === currentUserId &&
-        d.editable &&
-        d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETING &&
-        d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETED,
-    )
-    .sort((a, b) => (b.updatedOn ?? "").localeCompare(a.updatedOn ?? ""));
+  // If viewing a branch the user owns, clicking the button should go straight
+  // there — no dialog.
+  $: activeBranchDeployment =
+    activeBranch && currentUserId
+      ? deployments.find(
+          (d) =>
+            d.branch === activeBranch &&
+            d.ownerUserId === currentUserId &&
+            d.editable &&
+            d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETING &&
+            d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETED,
+        )
+      : undefined;
 
-  // Most-recently-updated branch — used for the "latest" tag and as the
-  // default selection in the Existing-branch dropdown.
-  $: latestDeployment = ownDeployments[0];
-  $: latestBranchId = latestDeployment?.id ?? "";
-
-  // If viewing a branch the user owns, clicking the button should go straight there
-  $: activeBranchDeployment = activeBranch
-    ? ownDeployments.find((d) => d.branch === activeBranch)
-    : undefined;
-
-  // True when the active branch has a deployment the user owns but which
-  // isn't editable (e.g. created via the CLI without `--editable`). Used to
-  // show a banner explaining that the user needs a new branch.
-  $: activeBranchIsNonEditable =
-    !!activeBranch &&
-    !!currentUserId &&
-    deployments.some(
-      (d) =>
-        d.branch === activeBranch &&
-        d.ownerUserId === currentUserId &&
-        !d.editable,
-    );
-
-  $: hasOwnSessions = ownDeployments.length > 0;
-  $: isStarting = $createMutation.isPending;
-
-  // Reset state every time the dialog opens. Default to the Existing tab
-  // when the user has branches (most users come back to resume); preselect
-  // the most-recent branch so "Continue editing" is one click away.
-  $: if (open) {
-    branchName = "";
-    currentTab = hasOwnSessions ? "existing" : "new";
-    selectedBranchId = latestBranchId;
-    createError = "";
-  }
-
-  // Clear the inline error when the user moves away from the New tab —
-  // the error doesn't apply elsewhere. Cleared on input via the handler
-  // (not via a reactive, which would clear it on the same keystroke).
-  $: if (currentTab !== "new") {
-    createError = "";
-  }
-
-  $: selectedDeployment = ownDeployments.find((d) => d.id === selectedBranchId);
-
-  function editUrl(branch: string | undefined): string {
-    return `/${organization}/${project}${branchPathPrefix(branch)}/-/edit`;
-  }
-
-  // When the user owns a deployment on the active branch, the button
-  // links directly to that editor (no dialog).
   $: directEditHref = activeBranchDeployment
-    ? editUrl(activeBranchDeployment.branch)
+    ? `/${organization}/${project}${branchPathPrefix(activeBranchDeployment.branch)}/-/edit`
     : undefined;
 
-  function handleButtonClick(e: MouseEvent) {
+  function handleDirectEdit(e: MouseEvent) {
     e.preventDefault();
     requestSkipBranchInjection();
     void goto(directEditHref!);
   }
-
-  // Replaces whitespace with "-" as the user types so branch names are
-  // always valid. Space → "-" is a 1:1 swap, so cursor stays put.
-  function handleBranchNameInput(e: Event) {
-    const target = e.currentTarget as HTMLInputElement;
-    const sanitized = target.value.replace(/\s+/g, "-");
-    if (sanitized !== target.value) {
-      const cursorPos = target.selectionStart ?? sanitized.length;
-      target.value = sanitized;
-      target.setSelectionRange(cursorPos, cursorPos);
-    }
-    branchName = sanitized;
-    createError = "";
-  }
-
-  async function handleCreate() {
-    if (!branchName.trim()) return;
-    createError = "";
-    const requestedBranch = branchName.trim();
-
-    // Front-run an obvious failure case: the user typed the name of a
-    // branch they already own. Catches it before the network round-trip.
-    const collision = ownDeployments.find((d) => d.branch === requestedBranch);
-    if (collision) {
-      createError = `A branch named "${requestedBranch}" already exists.`;
-      return;
-    }
-
-    try {
-      const resp = await $createMutation.mutateAsync({
-        org: organization,
-        project,
-        data: {
-          environment: "dev",
-          editable: true,
-          branch: requestedBranch,
-        },
-      });
-      void invalidateDeployments(organization, project);
-      open = false;
-      requestSkipBranchInjection();
-      await goto(editUrl(resp.deployment?.branch));
-    } catch (err) {
-      createError =
-        getRpcErrorMessage(err as any) ?? "Failed to start edit session.";
-    }
-  }
-
-  function handleResume() {
-    if (!selectedDeployment) return;
-    requestSkipBranchInjection();
-    open = false;
-    void goto(editUrl(selectedDeployment.branch));
-  }
-
-  function handleNameKeydown(e: KeyboardEvent) {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      void handleCreate();
-    }
-  }
 </script>
 
 {#if directEditHref}
-  <!-- On a branch the user owns: navigate directly, no dialog -->
   <Button
     type="secondary"
     href={directEditHref}
-    disabled={isStarting || isLoading}
-    onClick={handleButtonClick}
+    disabled={isLoading}
+    onClick={handleDirectEdit}
   >
     Edit
   </Button>
 {:else}
-  <Dialog.Root bind:open>
-    <Dialog.Trigger>
-      {#snippet child({ props })}
-        <Button
-          {...props}
-          type="secondary"
-          disabled={isStarting || isLoading}
-          loading={isStarting}
-          loadingCopy="Starting..."
-        >
-          Edit
-        </Button>
-      {/snippet}
-    </Dialog.Trigger>
-
-    <Dialog.Content class="!max-w-[480px] gap-0 p-0">
-      <Dialog.Header class="space-y-1 px-6 pt-6">
-        <Dialog.Title class="text-lg font-semibold tracking-tight">
-          Start editing
-        </Dialog.Title>
-        <Dialog.Description class="text-[13px] text-fg-secondary leading-snug">
-          {#if hasOwnSessions}
-            Edit an existing branch or create a new one from
-            <code class="dlg-code">{sourceBranch}</code>.
-          {:else}
-            We'll create a branch from
-            <code class="dlg-code">{sourceBranch}</code>
-            for your edits.
-          {/if}
-        </Dialog.Description>
-      </Dialog.Header>
-
-      {#if activeBranchIsNonEditable}
-        <div class="banner">
-          This branch is read-only. Pick another branch or create a new one.
-        </div>
-      {/if}
-
-      {#if hasOwnSessions}
-        <div role="tablist" aria-label="Edit branch options" class="seg-list">
-          <button
-            role="tab"
-            type="button"
-            aria-selected={currentTab === "existing"}
-            class="seg-trigger"
-            class:is-active={currentTab === "existing"}
-            onclick={() => (currentTab = "existing")}
-          >
-            <GitBranchIcon size="14" />
-            Existing branch
-          </button>
-          <button
-            role="tab"
-            type="button"
-            aria-selected={currentTab === "new"}
-            class="seg-trigger"
-            class:is-active={currentTab === "new"}
-            onclick={() => (currentTab = "new")}
-          >
-            <GitBranchPlusIcon size="14" />
-            New branch
-          </button>
-        </div>
-
-        {#if currentTab === "existing"}
-          <div class="tab-body" role="tabpanel">
-            <span class="form-label">Branch</span>
-            <DropdownMenu.Root bind:open={dropdownOpen}>
-              <DropdownMenu.Trigger>
-                {#snippet child({ props })}
-                  <button
-                    {...props}
-                    id="existing-branch"
-                    class="branch-select"
-                    class:open={dropdownOpen}
-                    type="button"
-                  >
-                    <span class="select-left">
-                      <GitBranchIcon size="14" class="text-fg-muted shrink-0" />
-                      <span class="select-name">
-                        {selectedDeployment?.branch ?? sourceBranch}
-                      </span>
-                      {#if selectedDeployment && selectedDeployment.id === latestBranchId}
-                        <span class="latest-tag">latest</span>
-                      {/if}
-                    </span>
-                    <ChevronDownIcon
-                      size="14"
-                      class="text-fg-muted shrink-0 transition-transform {dropdownOpen
-                        ? 'rotate-180'
-                        : ''}"
-                    />
-                  </button>
-                {/snippet}
-              </DropdownMenu.Trigger>
-              <DropdownMenu.Content
-                align="start"
-                sameWidth
-                class="max-h-[280px] overflow-y-auto"
-              >
-                {#each ownDeployments as deployment (deployment.id)}
-                  {@const isSelected = deployment.id === selectedBranchId}
-                  {@const isLatest = deployment.id === latestBranchId}
-                  <DropdownMenu.Item
-                    onclick={() => (selectedBranchId = deployment.id ?? "")}
-                    class="branch-option"
-                  >
-                    <GitBranchIcon size="13" class="text-fg-muted shrink-0" />
-                    <span class="font-mono text-[13px] truncate flex-1">
-                      {deployment.branch || sourceBranch}
-                    </span>
-                    {#if isLatest}
-                      <span class="latest-tag">latest</span>
-                    {/if}
-                    {#if isSelected}
-                      <CheckIcon
-                        size="13"
-                        class="text-primary-600 shrink-0 ml-1"
-                      />
-                    {/if}
-                  </DropdownMenu.Item>
-                {/each}
-              </DropdownMenu.Content>
-            </DropdownMenu.Root>
-          </div>
-        {:else}
-          <div class="tab-body" role="tabpanel">
-            <label class="form-label" for="new-branch-name">Branch name</label>
-            <!-- svelte-ignore a11y_autofocus -->
-            <input
-              id="new-branch-name"
-              class="branch-input"
-              class:has-error={!!createError}
-              type="text"
-              value={branchName}
-              oninput={handleBranchNameInput}
-              onkeydown={handleNameKeydown}
-              placeholder="branch-name"
-              aria-invalid={!!createError}
-              aria-describedby={createError ? "new-branch-error" : undefined}
-              autofocus
-            />
-            {#if createError}
-              <p id="new-branch-error" class="form-error">{createError}</p>
-            {/if}
-          </div>
-        {/if}
-      {:else}
-        <div class="tab-body" style:margin-top="20px">
-          <label class="form-label" for="new-branch-name">Branch name</label>
-          <!-- svelte-ignore a11y_autofocus -->
-          <input
-            id="new-branch-name"
-            class="branch-input"
-            class:has-error={!!createError}
-            type="text"
-            value={branchName}
-            oninput={handleBranchNameInput}
-            onkeydown={handleNameKeydown}
-            placeholder="branch-name"
-            aria-invalid={!!createError}
-            aria-describedby={createError ? "new-branch-error" : undefined}
-            autofocus
-          />
-          {#if createError}
-            <p id="new-branch-error" class="form-error">{createError}</p>
-          {/if}
-        </div>
-      {/if}
-
-      <div class="dlg-footer">
-        <Button type="secondary" onClick={() => (open = false)}>Cancel</Button>
-        {#if hasOwnSessions && currentTab === "existing"}
-          <Button
-            type="primary"
-            disabled={!selectedBranchId || isStarting}
-            onClick={handleResume}
-          >
-            Continue editing
-          </Button>
-        {:else}
-          <Button
-            type="primary"
-            disabled={!branchName.trim() || isStarting}
-            loading={isStarting}
-            loadingCopy="Starting..."
-            onClick={handleCreate}
-          >
-            Create &amp; edit
-          </Button>
-        {/if}
-      </div>
-    </Dialog.Content>
-  </Dialog.Root>
+  <Button
+    type="secondary"
+    disabled={isLoading}
+    onClick={() => (dialogOpen = true)}
+  >
+    Edit
+  </Button>
+  <EditBranchDialog
+    bind:open={dialogOpen}
+    {organization}
+    {project}
+    {activeBranch}
+    {primaryBranch}
+  />
 {/if}
-
-<style lang="postcss">
-  /* Inline monospace for branch names in subtitle prose */
-  :global(.dlg-code) {
-    @apply font-mono text-[12.5px] text-fg-primary bg-transparent px-0;
-  }
-
-  /* Banner for non-editable active branch */
-  .banner {
-    @apply mx-6 mt-4 rounded-md px-3 py-2;
-    @apply text-xs text-yellow-800 bg-yellow-50 border border-yellow-200;
-  }
-
-  /* Segmented tab control — Di's pattern (gray pill, lifted active) */
-  .seg-list {
-    @apply mx-6 mt-5 flex p-1 gap-1 rounded-lg;
-    background: rgb(241 245 249); /* slate-100 */
-  }
-
-  :global(.dark) .seg-list {
-    background: rgb(30 41 59); /* slate-800 */
-  }
-
-  .seg-trigger {
-    @apply flex-1 inline-flex items-center justify-center gap-1.5 px-3.5 py-1.5 rounded-md border-0;
-    @apply text-[13px] font-medium transition-all cursor-pointer;
-    @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/40;
-    background: transparent;
-    color: rgb(100 116 139); /* slate-500 */
-  }
-
-  :global(.dark) .seg-trigger {
-    color: rgb(148 163 184); /* slate-400 */
-  }
-
-  .seg-trigger:not(.is-active):hover {
-    color: rgb(51 65 85); /* slate-700 */
-  }
-
-  :global(.dark) .seg-trigger:not(.is-active):hover {
-    color: rgb(226 232 240); /* slate-200 */
-  }
-
-  .seg-trigger.is-active {
-    background: #ffffff;
-    color: rgb(15 23 42); /* slate-900 */
-    font-weight: 600;
-    box-shadow:
-      0 1px 2px rgba(15, 23, 42, 0.08),
-      0 0 0 1px rgba(15, 23, 42, 0.04);
-  }
-
-  :global(.dark) .seg-trigger.is-active {
-    background: rgb(
-      71 85 105
-    ); /* slate-600 — clearly lighter than the slate-800 container */
-    color: rgb(248 250 252); /* slate-50 */
-    box-shadow:
-      0 1px 2px rgba(0, 0, 0, 0.4),
-      0 0 0 1px rgba(255, 255, 255, 0.06);
-  }
-
-  /* Body — locks 16px gap from tabs (or subtitle when no tabs) */
-  :global(.tab-body) {
-    @apply px-6 pt-4 pb-1 flex flex-col gap-1.5;
-  }
-
-  .form-label {
-    @apply text-[13px] font-medium text-fg-primary mb-1;
-  }
-
-  .branch-input {
-    @apply w-full font-mono text-[13.5px] px-3 py-2.5;
-    @apply bg-surface border border-gray-300 rounded-lg;
-    @apply text-fg-primary placeholder:text-fg-muted;
-    @apply focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500;
-    @apply transition-shadow;
-  }
-
-  .branch-input.has-error,
-  .branch-input.has-error:focus {
-    @apply border-red-500 ring-2 ring-red-500/20;
-  }
-
-  .form-error {
-    @apply mt-1.5 text-xs text-red-600 dark:text-red-400 font-normal;
-  }
-
-  /* Existing-branch dropdown trigger */
-  .branch-select {
-    @apply flex items-center justify-between gap-2 w-full;
-    @apply px-3 py-2.5 rounded-lg;
-    @apply bg-surface border border-gray-300 text-left;
-    @apply hover:bg-surface-hover transition-colors cursor-pointer;
-    @apply focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500;
-  }
-
-  .branch-select.open {
-    @apply ring-2 ring-primary-500/20 border-primary-500;
-  }
-
-  .select-left {
-    @apply flex items-center gap-2 min-w-0 flex-1;
-  }
-
-  .select-name {
-    @apply font-mono text-[13px] text-fg-primary truncate;
-  }
-
-  .latest-tag {
-    @apply font-sans text-[10.5px] font-medium uppercase tracking-wider;
-    @apply text-fg-muted shrink-0;
-  }
-
-  :global(.branch-option) {
-    @apply flex items-center gap-2 px-2 py-1.5 cursor-pointer;
-  }
-
-  /* Footer separator and right-aligned button row */
-  .dlg-footer {
-    @apply flex items-center justify-end gap-2;
-    @apply px-6 py-4 mt-6 border-t border-border;
-  }
-</style>

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -5,7 +5,7 @@
     V1DeploymentStatus,
   } from "@rilldata/web-admin/client";
   import {
-    branchPathPrefix,
+    injectBranchIntoPath,
     requestSkipBranchInjection,
   } from "@rilldata/web-admin/features/branches/branch-utils";
   import { Button } from "@rilldata/web-common/components/button";
@@ -42,8 +42,11 @@
         )
       : undefined;
 
-  $: directEditHref = activeBranchDeployment
-    ? `/${organization}/${project}${branchPathPrefix(activeBranchDeployment.branch)}/-/edit`
+  $: directEditHref = activeBranchDeployment?.branch
+    ? injectBranchIntoPath(
+        `/${organization}/${project}/-/edit`,
+        activeBranchDeployment.branch,
+      )
     : undefined;
 
   function handleDirectEdit(e: MouseEvent) {

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -102,9 +102,7 @@
     createError = "";
   }
 
-  $: selectedDeployment = ownDeployments.find(
-    (d) => d.id === selectedBranchId,
-  );
+  $: selectedDeployment = ownDeployments.find((d) => d.id === selectedBranchId);
 
   function editUrl(branch: string | undefined): string {
     return `/${organization}/${project}${branchPathPrefix(branch)}/-/edit`;
@@ -272,10 +270,7 @@
                     type="button"
                   >
                     <span class="select-left">
-                      <GitBranchIcon
-                        size="14"
-                        class="text-fg-muted shrink-0"
-                      />
+                      <GitBranchIcon size="14" class="text-fg-muted shrink-0" />
                       <span class="select-name">
                         {selectedDeployment?.branch ?? sourceBranch}
                       </span>
@@ -445,7 +440,9 @@
   }
 
   :global(.dark) .seg-trigger.is-active {
-    background: rgb(71 85 105); /* slate-600 — clearly lighter than the slate-800 container */
+    background: rgb(
+      71 85 105
+    ); /* slate-600 — clearly lighter than the slate-800 container */
     color: rgb(248 250 252); /* slate-50 */
     box-shadow:
       0 1px 2px rgba(0, 0, 0, 0.4),

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -13,13 +13,14 @@
   import { Button } from "@rilldata/web-common/components/button";
   import * as Dialog from "@rilldata/web-common/components/dialog";
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
-  import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
+  import { Search } from "@rilldata/web-common/components/search";
   import {
     CheckIcon,
     ChevronDownIcon,
     GitBranchIcon,
     GitBranchPlusIcon,
   } from "lucide-svelte";
+  import { matchSorter } from "match-sorter";
   import { useDevDeployments, invalidateDeployments } from "./use-edit-session";
 
   export let organization: string;
@@ -38,6 +39,8 @@
   let currentTab: "existing" | "new" = "existing";
   let selectedBranchId = "";
   let dropdownOpen = false;
+  let branchSearch = "";
+  let createError = "";
 
   $: currentUserId = $user.data?.user?.id;
   $: deployments = $devDeployments.data?.deployments ?? [];
@@ -92,11 +95,30 @@
     branchName = "";
     currentTab = hasOwnSessions ? "existing" : "new";
     selectedBranchId = latestBranchId;
+    branchSearch = "";
+    createError = "";
+  }
+
+  // Clear the inline error when the user moves away from the New tab —
+  // the error doesn't apply elsewhere. Cleared on input via the handler
+  // (not via a reactive, which would clear it on the same keystroke).
+  $: if (currentTab !== "new") {
+    createError = "";
   }
 
   $: selectedDeployment = ownDeployments.find(
     (d) => d.id === selectedBranchId,
   );
+
+  // Type-ahead filter for the existing-branch dropdown. Uses fuzzy matching
+  // (match-sorter) to keep results forgiving — e.g. "fix-rev" matches
+  // "fix-revenue-dim". When the search is empty, return the full list in
+  // its existing recency order.
+  $: filteredDeployments = branchSearch.trim()
+    ? matchSorter(ownDeployments, branchSearch.trim(), {
+        keys: ["branch"],
+      })
+    : ownDeployments;
 
   function editUrl(branch: string | undefined): string {
     return `/${organization}/${project}${branchPathPrefix(branch)}/-/edit`;
@@ -125,10 +147,22 @@
       target.setSelectionRange(cursorPos, cursorPos);
     }
     branchName = sanitized;
+    createError = "";
   }
 
   async function handleCreate() {
     if (!branchName.trim()) return;
+    createError = "";
+    const requestedBranch = branchName.trim();
+
+    // Front-run an obvious failure case: the user typed the name of a
+    // branch they already own. Catches it before the network round-trip.
+    const collision = ownDeployments.find((d) => d.branch === requestedBranch);
+    if (collision) {
+      createError = `A branch named "${requestedBranch}" already exists.`;
+      return;
+    }
+
     try {
       const resp = await $createMutation.mutateAsync({
         org: organization,
@@ -136,7 +170,7 @@
         data: {
           environment: "dev",
           editable: true,
-          branch: branchName.trim(),
+          branch: requestedBranch,
         },
       });
       void invalidateDeployments(organization, project);
@@ -144,10 +178,7 @@
       requestSkipBranchInjection();
       await goto(editUrl(resp.deployment?.branch));
     } catch (err) {
-      eventBus.emit("notification", {
-        type: "error",
-        message: `Failed to start edit session: ${getRpcErrorMessage(err as any)}`,
-      });
+      createError = getRpcErrorMessage(err as any);
     }
   }
 
@@ -278,33 +309,45 @@
               <DropdownMenu.Content
                 align="start"
                 sameWidth
-                class="max-h-[280px] overflow-y-auto"
+                class="flex flex-col max-h-[320px] overflow-hidden p-0"
               >
-                {#each ownDeployments as deployment (deployment.id)}
-                  {@const isSelected = deployment.id === selectedBranchId}
-                  {@const isLatest = deployment.id === latestBranchId}
-                  <DropdownMenu.Item
-                    onclick={() => (selectedBranchId = deployment.id ?? "")}
-                    class="branch-option"
-                  >
-                    <GitBranchIcon
-                      size="13"
-                      class="text-fg-muted shrink-0"
-                    />
-                    <span class="font-mono text-[13px] truncate flex-1">
-                      {deployment.branch || sourceBranch}
-                    </span>
-                    {#if isLatest}
+                <div class="px-2 pt-2 pb-1">
+                  <Search
+                    bind:value={branchSearch}
+                    label="Search branches"
+                    placeholder="Search branches"
+                    showBorderOnFocus={false}
+                  />
+                </div>
+                <div class="flex-1 overflow-y-auto pb-1">
+                  {#each filteredDeployments as deployment (deployment.id)}
+                    {@const isSelected = deployment.id === selectedBranchId}
+                    {@const isLatest = deployment.id === latestBranchId}
+                    <DropdownMenu.Item
+                      onclick={() => (selectedBranchId = deployment.id ?? "")}
+                      class="branch-option"
+                    >
+                      <GitBranchIcon
+                        size="13"
+                        class="text-fg-muted shrink-0"
+                      />
+                      <span class="font-mono text-[13px] truncate flex-1">
+                        {deployment.branch || sourceBranch}
+                      </span>
+                      {#if isLatest}
                       <span class="latest-tag">latest</span>
                     {/if}
-                    {#if isSelected}
-                      <CheckIcon
-                        size="13"
-                        class="text-primary-600 shrink-0 ml-1"
-                      />
-                    {/if}
-                  </DropdownMenu.Item>
-                {/each}
+                      {#if isSelected}
+                        <CheckIcon
+                          size="13"
+                          class="text-primary-600 shrink-0 ml-1"
+                        />
+                      {/if}
+                    </DropdownMenu.Item>
+                  {:else}
+                    <div class="branch-empty">No branches match.</div>
+                  {/each}
+                </div>
               </DropdownMenu.Content>
             </DropdownMenu.Root>
           </div>
@@ -315,13 +358,19 @@
             <input
               id="new-branch-name"
               class="branch-input"
+              class:has-error={!!createError}
               type="text"
               value={branchName}
               oninput={handleBranchNameInput}
               onkeydown={handleNameKeydown}
               placeholder="branch-name"
+              aria-invalid={!!createError}
+              aria-describedby={createError ? "new-branch-error" : undefined}
               autofocus
             />
+            {#if createError}
+              <p id="new-branch-error" class="form-error">{createError}</p>
+            {/if}
           </div>
         {/if}
       {:else}
@@ -331,13 +380,19 @@
           <input
             id="new-branch-name"
             class="branch-input"
+            class:has-error={!!createError}
             type="text"
             value={branchName}
             oninput={handleBranchNameInput}
             onkeydown={handleNameKeydown}
             placeholder="branch-name"
+            aria-invalid={!!createError}
+            aria-describedby={createError ? "new-branch-error" : undefined}
             autofocus
           />
+          {#if createError}
+            <p id="new-branch-error" class="form-error">{createError}</p>
+          {/if}
         </div>
       {/if}
 
@@ -443,6 +498,15 @@
     @apply transition-shadow;
   }
 
+  .branch-input.has-error,
+  .branch-input.has-error:focus {
+    @apply border-red-500 ring-2 ring-red-500/20;
+  }
+
+  .form-error {
+    @apply mt-1.5 text-xs text-red-600 dark:text-red-400 font-normal;
+  }
+
   /* Existing-branch dropdown trigger */
   .branch-select {
     @apply flex items-center justify-between gap-2 w-full;
@@ -471,6 +535,10 @@
 
   :global(.branch-option) {
     @apply flex items-center gap-2 px-2 py-1.5 cursor-pointer;
+  }
+
+  .branch-empty {
+    @apply px-3 py-3 text-xs text-fg-muted text-center;
   }
 
   /* Footer separator and right-aligned button row */

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -14,7 +14,12 @@
   import * as Dialog from "@rilldata/web-common/components/dialog";
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
-  import { CheckIcon, ChevronDownIcon, GitBranchIcon } from "lucide-svelte";
+  import {
+    CheckIcon,
+    ChevronDownIcon,
+    GitBranchIcon,
+    GitBranchPlusIcon,
+  } from "lucide-svelte";
   import { useDevDeployments, invalidateDeployments } from "./use-edit-session";
 
   export let organization: string;
@@ -220,6 +225,7 @@
             class:is-active={currentTab === "existing"}
             onclick={() => (currentTab = "existing")}
           >
+            <GitBranchIcon size="14" />
             Existing branch
           </button>
           <button
@@ -230,6 +236,7 @@
             class:is-active={currentTab === "new"}
             onclick={() => (currentTab = "new")}
           >
+            <GitBranchPlusIcon size="14" />
             New branch
           </button>
         </div>
@@ -379,7 +386,7 @@
   }
 
   .seg-trigger {
-    @apply px-4 py-1.5 rounded-md border-0 bg-transparent;
+    @apply inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-md border-0 bg-transparent;
     @apply text-[13px] font-medium text-slate-500;
     @apply transition-all cursor-pointer;
     @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/40;

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -11,7 +11,7 @@
     requestSkipBranchInjection,
   } from "@rilldata/web-admin/features/branches/branch-utils";
   import { Button } from "@rilldata/web-common/components/button";
-  import * as Popover from "@rilldata/web-common/components/popover";
+  import * as Dialog from "@rilldata/web-common/components/dialog";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
   import { GitBranchIcon, PlusIcon } from "lucide-svelte";
   import { useDevDeployments, invalidateDeployments } from "./use-edit-session";
@@ -58,7 +58,7 @@
 
   // True when the active branch has a deployment the user owns but which
   // isn't editable (e.g. created via the CLI without `--editable`). Used to
-  // show a dropdown banner explaining that the user needs a new branch.
+  // show a banner explaining that the user needs a new branch.
   $: activeBranchIsNonEditable =
     !!activeBranch &&
     !!currentUserId &&
@@ -72,7 +72,7 @@
   $: hasOwnSessions = ownDeployments.length > 0;
   $: isStarting = $createMutation.isPending;
 
-  // Reset state when popover opens
+  // Reset state when dialog opens
   $: if (open) {
     branchName = "";
     showNewBranchInput = !hasOwnSessions;
@@ -83,7 +83,7 @@
   }
 
   // When the user owns a deployment on the active branch, the button
-  // links directly to that editor (no popover).
+  // links directly to that editor (no dialog).
   $: directEditHref = activeBranchDeployment
     ? editUrl(activeBranchDeployment.branch)
     : undefined;
@@ -144,15 +144,16 @@
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === "Enter") {
       void handleCreate();
-    } else if (e.key === "Escape" && hasOwnSessions) {
+    } else if (e.key === "Escape" && hasOwnSessions && showNewBranchInput) {
       e.preventDefault();
+      e.stopPropagation();
       handleCancelNewBranch();
     }
   }
 </script>
 
 {#if directEditHref}
-  <!-- On a branch the user owns: navigate directly, no popover -->
+  <!-- On a branch the user owns: navigate directly, no dialog -->
   <Button
     type="secondary"
     href={directEditHref}
@@ -162,8 +163,8 @@
     Edit
   </Button>
 {:else}
-  <Popover.Root bind:open>
-    <Popover.Trigger>
+  <Dialog.Root bind:open>
+    <Dialog.Trigger>
       {#snippet child({ props })}
         <Button
           {...props}
@@ -175,9 +176,23 @@
           Edit
         </Button>
       {/snippet}
-    </Popover.Trigger>
+    </Dialog.Trigger>
 
-    <Popover.Content align="end" padding="3" class="w-[304px]">
+    <Dialog.Content class="max-w-md gap-0">
+      <Dialog.Header class="space-y-1">
+        <Dialog.Title class="text-base">
+          {hasOwnSessions ? "Continue editing" : "Start editing"}
+        </Dialog.Title>
+        <Dialog.Description class="dlg-subtitle">
+          {hasOwnSessions
+            ? "Branched from"
+            : "Create a branch to edit from"}<span class="branch-chip">
+            <GitBranchIcon size="11" />
+            {sourceBranch}
+          </span>
+        </Dialog.Description>
+      </Dialog.Header>
+
       {#if activeBranchIsNonEditable}
         <div class="banner">
           This branch isn't editable. Start a new one below{hasOwnSessions
@@ -185,26 +200,6 @@
             : ""}.
         </div>
       {/if}
-
-      <div class="pop-header">
-        {#if hasOwnSessions}
-          <div class="pop-title">Continue editing</div>
-          <div class="pop-subtitle">
-            Branched from<span class="branch-chip">
-              <GitBranchIcon size="11" />
-              {sourceBranch}
-            </span>
-          </div>
-        {:else}
-          <div class="pop-title">Start editing</div>
-          <div class="pop-subtitle">
-            Create a branch to edit from<span class="branch-chip">
-              <GitBranchIcon size="11" />
-              {sourceBranch}
-            </span>
-          </div>
-        {/if}
-      </div>
 
       {#if hasOwnSessions}
         <div class="branch-list">
@@ -243,7 +238,6 @@
             <div class="form-actions">
               <Button
                 type="ghost"
-                small
                 disabled={isStarting}
                 onClick={handleCancelNewBranch}
               >
@@ -251,7 +245,6 @@
               </Button>
               <Button
                 type="primary"
-                small
                 disabled={!branchName.trim() || isStarting}
                 loading={isStarting}
                 loadingCopy="Starting..."
@@ -287,7 +280,6 @@
           <div class="form-actions">
             <Button
               type="primary"
-              small
               disabled={!branchName.trim() || isStarting}
               loading={isStarting}
               loadingCopy="Starting..."
@@ -298,21 +290,15 @@
           </div>
         </div>
       {/if}
-    </Popover.Content>
-  </Popover.Root>
+    </Dialog.Content>
+  </Dialog.Root>
 {/if}
 
 <style lang="postcss">
-  .pop-header {
-    @apply flex flex-col gap-y-0.5 px-1 pb-2;
-  }
-
-  .pop-title {
-    @apply text-sm font-semibold text-fg-primary;
-  }
-
-  .pop-subtitle {
-    @apply text-xs text-fg-secondary whitespace-nowrap;
+  /* Header subtitle (Dialog.Description) — overrides muted default to read
+     as a single inline line with the source-branch chip. */
+  :global(.dlg-subtitle) {
+    @apply !text-xs !text-fg-secondary whitespace-nowrap;
   }
 
   .branch-chip {
@@ -327,31 +313,31 @@
   }
 
   .banner {
-    @apply mx-0 mb-2 rounded-sm px-2 py-1.5;
+    @apply mt-3 rounded-sm px-2.5 py-2;
     @apply text-xs text-yellow-800 bg-yellow-50 border border-yellow-200;
   }
 
   .branch-list {
-    @apply flex flex-col;
+    @apply flex flex-col mt-3 -mx-1.5;
   }
 
   .branch-row {
-    @apply flex items-center gap-x-2 rounded-sm px-2 py-1.5 text-xs;
+    @apply flex items-center gap-x-2 rounded-md px-3 py-2 text-sm;
     @apply text-fg-primary hover:bg-surface-hover hover:text-fg-accent;
     @apply cursor-pointer outline-none no-underline;
   }
 
   .separator {
-    @apply -mx-1 my-1 h-px bg-border;
+    @apply my-2 h-px bg-border;
   }
 
   .new-branch-btn {
-    @apply flex w-full items-center gap-x-2 rounded-sm px-2 py-1.5 text-xs font-medium;
-    @apply text-primary-600 hover:bg-surface-hover cursor-pointer;
+    @apply flex w-full items-center gap-x-2 rounded-md px-3 py-2 text-sm font-medium;
+    @apply -mx-1.5 text-primary-600 hover:bg-surface-hover cursor-pointer;
   }
 
   .form {
-    @apply flex flex-col gap-y-2 px-1 pt-1 pb-0.5;
+    @apply flex flex-col gap-y-2 mt-3;
   }
 
   .form-label {
@@ -359,11 +345,11 @@
   }
 
   .branch-input {
-    @apply w-full text-xs font-mono px-2.5 py-2 rounded-md border border-gray-300;
+    @apply w-full text-sm font-mono px-3 py-2 rounded-md border border-gray-300;
     @apply focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500;
   }
 
   .form-actions {
-    @apply flex items-center justify-end gap-x-2 mt-0.5;
+    @apply flex items-center justify-end gap-x-2 mt-2;
   }
 </style>

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -10,17 +10,18 @@
     branchPathPrefix,
     requestSkipBranchInjection,
   } from "@rilldata/web-admin/features/branches/branch-utils";
-  import { getStatusDotClass } from "@rilldata/web-admin/features/projects/status/display-utils";
   import { Button } from "@rilldata/web-common/components/button";
   import * as Popover from "@rilldata/web-common/components/popover";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
-  import { PlusIcon } from "lucide-svelte";
+  import { GitBranchIcon, PlusIcon } from "lucide-svelte";
   import { useDevDeployments, invalidateDeployments } from "./use-edit-session";
 
   export let organization: string;
   export let project: string;
   /** The branch currently being viewed (from the URL), if any. */
   export let activeBranch: string | undefined = undefined;
+  /** The project's primary branch, used as the source for new branches. */
+  export let primaryBranch: string | undefined = undefined;
 
   const user = createAdminServiceGetCurrentUser();
   const devDeployments = useDevDeployments(organization, project);
@@ -33,6 +34,7 @@
   $: currentUserId = $user.data?.user?.id;
   $: deployments = $devDeployments.data?.deployments ?? [];
   $: isLoading = $devDeployments.isLoading;
+  $: sourceBranch = primaryBranch || "main";
 
   // Editable deployments owned by the current user (excludes ones being
   // torn down), sorted by most recently updated. Stopped and errored
@@ -80,12 +82,6 @@
     return `/${organization}/${project}${branchPathPrefix(branch)}/-/edit`;
   }
 
-  function statusDot(status: V1DeploymentStatus | undefined): string {
-    return getStatusDotClass(
-      status ?? V1DeploymentStatus.DEPLOYMENT_STATUS_UNSPECIFIED,
-    );
-  }
-
   // When the user owns a deployment on the active branch, the button
   // links directly to that editor (no popover).
   $: directEditHref = activeBranchDeployment
@@ -101,6 +97,24 @@
   function handleBranchClick() {
     requestSkipBranchInjection();
     open = false;
+  }
+
+  // Replaces whitespace with "-" as the user types so branch names are
+  // always valid. Space → "-" is a 1:1 swap, so cursor stays put.
+  function handleBranchNameInput(e: Event) {
+    const target = e.currentTarget as HTMLInputElement;
+    const sanitized = target.value.replace(/\s+/g, "-");
+    if (sanitized !== target.value) {
+      const cursorPos = target.selectionStart ?? sanitized.length;
+      target.value = sanitized;
+      target.setSelectionRange(cursorPos, cursorPos);
+    }
+    branchName = sanitized;
+  }
+
+  function handleCancelNewBranch() {
+    branchName = "";
+    showNewBranchInput = false;
   }
 
   async function handleCreate() {
@@ -130,6 +144,9 @@
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === "Enter") {
       void handleCreate();
+    } else if (e.key === "Escape" && hasOwnSessions) {
+      e.preventDefault();
+      handleCancelNewBranch();
     }
   }
 </script>
@@ -160,11 +177,7 @@
       {/snippet}
     </Popover.Trigger>
 
-    <Popover.Content
-      align="end"
-      padding="1.5"
-      class="w-auto min-w-[200px] max-w-[280px]"
-    >
+    <Popover.Content align="end" padding="3" class="w-[304px]">
       {#if activeBranchIsNonEditable}
         <div class="banner">
           This branch isn't editable. Start a new one below{hasOwnSessions
@@ -172,39 +185,106 @@
             : ""}.
         </div>
       {/if}
-      {#if hasOwnSessions}
-        <div class="section-label">Your branches</div>
-        {#each ownDeployments as deployment (deployment.id)}
-          <a
-            class="branch-row"
-            href={editUrl(deployment.branch)}
-            onclick={handleBranchClick}
-            data-sveltekit-preload-data="hover"
-          >
-            <span
-              class="inline-block size-1.5 rounded-full flex-none {statusDot(
-                deployment.status,
-              )}"
-            ></span>
-            <span class="font-mono truncate">
-              {deployment.branch || "main"}
+
+      <div class="pop-header">
+        {#if hasOwnSessions}
+          <div class="pop-title">Continue editing</div>
+          <div class="pop-subtitle">
+            Branched from<span class="branch-chip">
+              <GitBranchIcon size="11" />
+              {sourceBranch}
             </span>
-          </a>
-        {/each}
+          </div>
+        {:else}
+          <div class="pop-title">Start editing</div>
+          <div class="pop-subtitle">
+            Create a branch to edit from<span class="branch-chip">
+              <GitBranchIcon size="11" />
+              {sourceBranch}
+            </span>
+          </div>
+        {/if}
+      </div>
+
+      {#if hasOwnSessions}
+        <div class="branch-list">
+          {#each ownDeployments as deployment (deployment.id)}
+            <a
+              class="branch-row"
+              href={editUrl(deployment.branch)}
+              onclick={handleBranchClick}
+              data-sveltekit-preload-data="hover"
+            >
+              <span class="font-mono truncate">
+                {deployment.branch || sourceBranch}
+              </span>
+            </a>
+          {/each}
+        </div>
 
         <div class="separator"></div>
 
         {#if showNewBranchInput}
-          <div class="flex flex-col gap-y-1.5 px-2 pb-1.5 pt-0.5">
+          <div class="form">
+            <label class="form-label" for="new-branch-name">
+              New branch name
+            </label>
             <!-- svelte-ignore a11y_autofocus -->
             <input
+              id="new-branch-name"
               class="branch-input"
               type="text"
-              bind:value={branchName}
+              value={branchName}
+              oninput={handleBranchNameInput}
               onkeydown={handleKeydown}
               placeholder="branch-name"
               autofocus
             />
+            <div class="form-actions">
+              <Button
+                type="ghost"
+                small
+                disabled={isStarting}
+                onClick={handleCancelNewBranch}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="primary"
+                small
+                disabled={!branchName.trim() || isStarting}
+                loading={isStarting}
+                loadingCopy="Starting..."
+                onClick={handleCreate}
+              >
+                Create &amp; edit
+              </Button>
+            </div>
+          </div>
+        {:else}
+          <button
+            class="new-branch-btn"
+            onclick={() => (showNewBranchInput = true)}
+          >
+            <PlusIcon size="14" />
+            <span>New branch&hellip;</span>
+          </button>
+        {/if}
+      {:else}
+        <div class="form">
+          <label class="form-label" for="new-branch-name">Branch name</label>
+          <!-- svelte-ignore a11y_autofocus -->
+          <input
+            id="new-branch-name"
+            class="branch-input"
+            type="text"
+            value={branchName}
+            oninput={handleBranchNameInput}
+            onkeydown={handleKeydown}
+            placeholder="branch-name"
+            autofocus
+          />
+          <div class="form-actions">
             <Button
               type="primary"
               small
@@ -213,40 +293,9 @@
               loadingCopy="Starting..."
               onClick={handleCreate}
             >
-              Start editing
+              Create &amp; edit
             </Button>
           </div>
-        {:else}
-          <button
-            class="new-branch-btn"
-            onclick={() => (showNewBranchInput = true)}
-          >
-            <PlusIcon size="12" />
-            <span>New branch...</span>
-          </button>
-        {/if}
-      {:else}
-        <div class="section-label">Create a branch</div>
-        <div class="flex flex-col gap-y-1.5 px-2 pb-1.5 pt-0.5">
-          <!-- svelte-ignore a11y_autofocus -->
-          <input
-            class="branch-input"
-            type="text"
-            bind:value={branchName}
-            onkeydown={handleKeydown}
-            placeholder="branch-name"
-            autofocus
-          />
-          <Button
-            type="primary"
-            small
-            disabled={!branchName.trim() || isStarting}
-            loading={isStarting}
-            loadingCopy="Starting..."
-            onClick={handleCreate}
-          >
-            Start editing
-          </Button>
         </div>
       {/if}
     </Popover.Content>
@@ -254,19 +303,42 @@
 {/if}
 
 <style lang="postcss">
-  .section-label {
-    @apply px-2 py-1.5 text-xs text-fg-secondary font-semibold;
+  .pop-header {
+    @apply flex flex-col gap-y-0.5 px-1 pb-2;
+  }
+
+  .pop-title {
+    @apply text-sm font-semibold text-fg-primary;
+  }
+
+  .pop-subtitle {
+    @apply text-xs text-fg-secondary whitespace-nowrap;
+  }
+
+  .branch-chip {
+    @apply ml-1 inline-flex items-center gap-x-1 align-[-2px];
+    @apply px-1.5 py-px rounded;
+    @apply text-[11.5px] font-mono font-medium text-fg-primary;
+    @apply bg-surface-subtle border border-border;
+  }
+
+  .branch-chip :global(svg) {
+    @apply text-fg-muted shrink-0;
   }
 
   .banner {
-    @apply mx-0.5 mt-0.5 mb-1.5 rounded-sm px-2 py-1.5;
+    @apply mx-0 mb-2 rounded-sm px-2 py-1.5;
     @apply text-xs text-yellow-800 bg-yellow-50 border border-yellow-200;
+  }
+
+  .branch-list {
+    @apply flex flex-col;
   }
 
   .branch-row {
     @apply flex items-center gap-x-2 rounded-sm px-2 py-1.5 text-xs;
     @apply text-fg-primary hover:bg-surface-hover hover:text-fg-accent;
-    @apply cursor-pointer outline-none;
+    @apply cursor-pointer outline-none no-underline;
   }
 
   .separator {
@@ -274,12 +346,24 @@
   }
 
   .new-branch-btn {
-    @apply flex w-full items-center gap-x-2 rounded-sm px-2 py-1.5 text-xs;
+    @apply flex w-full items-center gap-x-2 rounded-sm px-2 py-1.5 text-xs font-medium;
     @apply text-primary-600 hover:bg-surface-hover cursor-pointer;
   }
 
+  .form {
+    @apply flex flex-col gap-y-2 px-1 pt-1 pb-0.5;
+  }
+
+  .form-label {
+    @apply text-xs font-medium text-fg-primary;
+  }
+
   .branch-input {
-    @apply w-full text-xs font-mono px-2 py-1 rounded border border-gray-300;
-    @apply focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500;
+    @apply w-full text-xs font-mono px-2.5 py-2 rounded-md border border-gray-300;
+    @apply focus:outline-none focus:ring-2 focus:ring-primary-500/30 focus:border-primary-500;
+  }
+
+  .form-actions {
+    @apply flex items-center justify-end gap-x-2 mt-0.5;
   }
 </style>

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -13,14 +13,12 @@
   import { Button } from "@rilldata/web-common/components/button";
   import * as Dialog from "@rilldata/web-common/components/dialog";
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
-  import { Search } from "@rilldata/web-common/components/search";
   import {
     CheckIcon,
     ChevronDownIcon,
     GitBranchIcon,
     GitBranchPlusIcon,
   } from "lucide-svelte";
-  import { matchSorter } from "match-sorter";
   import { useDevDeployments, invalidateDeployments } from "./use-edit-session";
 
   export let organization: string;
@@ -39,7 +37,6 @@
   let currentTab: "existing" | "new" = "existing";
   let selectedBranchId = "";
   let dropdownOpen = false;
-  let branchSearch = "";
   let createError = "";
 
   $: currentUserId = $user.data?.user?.id;
@@ -95,7 +92,6 @@
     branchName = "";
     currentTab = hasOwnSessions ? "existing" : "new";
     selectedBranchId = latestBranchId;
-    branchSearch = "";
     createError = "";
   }
 
@@ -109,16 +105,6 @@
   $: selectedDeployment = ownDeployments.find(
     (d) => d.id === selectedBranchId,
   );
-
-  // Type-ahead filter for the existing-branch dropdown. Uses fuzzy matching
-  // (match-sorter) to keep results forgiving — e.g. "fix-rev" matches
-  // "fix-revenue-dim". When the search is empty, return the full list in
-  // its existing recency order.
-  $: filteredDeployments = branchSearch.trim()
-    ? matchSorter(ownDeployments, branchSearch.trim(), {
-        keys: ["branch"],
-      })
-    : ownDeployments;
 
   function editUrl(branch: string | undefined): string {
     return `/${organization}/${project}${branchPathPrefix(branch)}/-/edit`;
@@ -309,45 +295,30 @@
               <DropdownMenu.Content
                 align="start"
                 sameWidth
-                class="flex flex-col max-h-[320px] overflow-hidden p-0"
+                class="max-h-[280px] overflow-y-auto"
               >
-                <div class="px-2 pt-2 pb-1">
-                  <Search
-                    bind:value={branchSearch}
-                    label="Search branches"
-                    placeholder="Search branches"
-                    showBorderOnFocus={false}
-                  />
-                </div>
-                <div class="flex-1 overflow-y-auto pb-1">
-                  {#each filteredDeployments as deployment (deployment.id)}
-                    {@const isSelected = deployment.id === selectedBranchId}
-                    {@const isLatest = deployment.id === latestBranchId}
-                    <DropdownMenu.Item
-                      onclick={() => (selectedBranchId = deployment.id ?? "")}
-                      class="branch-option"
-                    >
-                      <GitBranchIcon
-                        size="13"
-                        class="text-fg-muted shrink-0"
-                      />
-                      <span class="font-mono text-[13px] truncate flex-1">
-                        {deployment.branch || sourceBranch}
-                      </span>
-                      {#if isLatest}
+                {#each ownDeployments as deployment (deployment.id)}
+                  {@const isSelected = deployment.id === selectedBranchId}
+                  {@const isLatest = deployment.id === latestBranchId}
+                  <DropdownMenu.Item
+                    onclick={() => (selectedBranchId = deployment.id ?? "")}
+                    class="branch-option"
+                  >
+                    <GitBranchIcon size="13" class="text-fg-muted shrink-0" />
+                    <span class="font-mono text-[13px] truncate flex-1">
+                      {deployment.branch || sourceBranch}
+                    </span>
+                    {#if isLatest}
                       <span class="latest-tag">latest</span>
                     {/if}
-                      {#if isSelected}
-                        <CheckIcon
-                          size="13"
-                          class="text-primary-600 shrink-0 ml-1"
-                        />
-                      {/if}
-                    </DropdownMenu.Item>
-                  {:else}
-                    <div class="branch-empty">No branches match.</div>
-                  {/each}
-                </div>
+                    {#if isSelected}
+                      <CheckIcon
+                        size="13"
+                        class="text-primary-600 shrink-0 ml-1"
+                      />
+                    {/if}
+                  </DropdownMenu.Item>
+                {/each}
               </DropdownMenu.Content>
             </DropdownMenu.Root>
           </div>
@@ -535,10 +506,6 @@
 
   :global(.branch-option) {
     @apply flex items-center gap-2 px-2 py-1.5 cursor-pointer;
-  }
-
-  .branch-empty {
-    @apply px-3 py-3 text-xs text-fg-muted text-center;
   }
 
   /* Footer separator and right-aligned button row */

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -403,7 +403,7 @@
 
   /* Segmented tab control — Di's pattern (gray pill, lifted active) */
   .seg-list {
-    @apply mx-6 mt-5 inline-flex p-1 gap-1 self-start w-fit rounded-lg;
+    @apply mx-6 mt-5 flex p-1 gap-1 rounded-lg;
     background: rgb(241 245 249); /* slate-100 */
   }
 
@@ -412,7 +412,7 @@
   }
 
   .seg-trigger {
-    @apply inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-md border-0;
+    @apply flex-1 inline-flex items-center justify-center gap-1.5 px-3.5 py-1.5 rounded-md border-0;
     @apply text-[13px] font-medium transition-all cursor-pointer;
     @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/40;
     background: transparent;

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -14,7 +14,6 @@
   import * as Dialog from "@rilldata/web-common/components/dialog";
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
-  import { Tabs as TabsPrimitive } from "bits-ui";
   import { CheckIcon, ChevronDownIcon, GitBranchIcon } from "lucide-svelte";
   import { useDevDeployments, invalidateDeployments } from "./use-edit-session";
 
@@ -212,17 +211,31 @@
       {/if}
 
       {#if hasOwnSessions}
-        <TabsPrimitive.Root bind:value={currentTab} class="contents">
-          <TabsPrimitive.List class="seg-list">
-            <TabsPrimitive.Trigger value="existing" class="seg-trigger">
-              Existing branch
-            </TabsPrimitive.Trigger>
-            <TabsPrimitive.Trigger value="new" class="seg-trigger">
-              New branch
-            </TabsPrimitive.Trigger>
-          </TabsPrimitive.List>
+        <div role="tablist" aria-label="Edit branch options" class="seg-list">
+          <button
+            role="tab"
+            type="button"
+            aria-selected={currentTab === "existing"}
+            class="seg-trigger"
+            class:is-active={currentTab === "existing"}
+            onclick={() => (currentTab = "existing")}
+          >
+            Existing branch
+          </button>
+          <button
+            role="tab"
+            type="button"
+            aria-selected={currentTab === "new"}
+            class="seg-trigger"
+            class:is-active={currentTab === "new"}
+            onclick={() => (currentTab = "new")}
+          >
+            New branch
+          </button>
+        </div>
 
-          <TabsPrimitive.Content value="existing" class="tab-body">
+        {#if currentTab === "existing"}
+          <div class="tab-body" role="tabpanel">
             <label class="form-label" for="existing-branch">Branch</label>
             <DropdownMenu.Root bind:open={dropdownOpen}>
               <DropdownMenu.Trigger>
@@ -287,9 +300,9 @@
                 {/each}
               </DropdownMenu.Content>
             </DropdownMenu.Root>
-          </TabsPrimitive.Content>
-
-          <TabsPrimitive.Content value="new" class="tab-body">
+          </div>
+        {:else}
+          <div class="tab-body" role="tabpanel">
             <label class="form-label" for="new-branch-name">Branch name</label>
             <!-- svelte-ignore a11y_autofocus -->
             <input
@@ -302,8 +315,8 @@
               placeholder="branch-name"
               autofocus
             />
-          </TabsPrimitive.Content>
-        </TabsPrimitive.Root>
+          </div>
+        {/if}
       {:else}
         <div class="tab-body" style:margin-top="20px">
           <label class="form-label" for="new-branch-name">Branch name</label>
@@ -360,23 +373,23 @@
   }
 
   /* Segmented tab control — Di's pattern (gray pill, white active) */
-  :global(.seg-list) {
+  .seg-list {
     @apply mx-6 mt-5 inline-flex p-0.5 gap-0.5 self-start;
-    @apply bg-gray-100 rounded-lg;
+    @apply bg-gray-100 rounded-lg w-fit;
   }
 
-  :global(.seg-trigger) {
-    @apply px-3.5 py-1.5 rounded-md;
+  .seg-trigger {
+    @apply px-3.5 py-1.5 rounded-md border-0 bg-transparent;
     @apply text-[13px] font-medium text-fg-secondary;
     @apply transition-colors cursor-pointer;
     @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/30;
   }
 
-  :global(.seg-trigger[data-state="active"]) {
+  .seg-trigger.is-active {
     @apply bg-surface text-fg-primary shadow-sm;
   }
 
-  :global(.seg-trigger:not([data-state="active"]):hover) {
+  .seg-trigger:not(.is-active):hover {
     @apply text-fg-primary;
   }
 

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -162,7 +162,8 @@
       requestSkipBranchInjection();
       await goto(editUrl(resp.deployment?.branch));
     } catch (err) {
-      createError = getRpcErrorMessage(err as any);
+      createError =
+        getRpcErrorMessage(err as any) ?? "Failed to start edit session.";
     }
   }
 

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -381,36 +381,49 @@
 
   /* Segmented tab control — Di's pattern (gray pill, lifted active) */
   .seg-list {
-    @apply mx-6 mt-5 inline-flex p-1 gap-1 self-start w-fit;
-    @apply bg-slate-100 dark:bg-slate-800/70 rounded-lg;
+    @apply mx-6 mt-5 inline-flex p-1 gap-1 self-start w-fit rounded-lg;
+    background: rgb(241 245 249); /* slate-100 */
+  }
+
+  :global(.dark) .seg-list {
+    background: rgb(30 41 59); /* slate-800 */
   }
 
   .seg-trigger {
-    @apply inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-md border-0 bg-transparent;
-    @apply text-[13px] font-medium;
-    @apply text-slate-500 dark:text-slate-400;
-    @apply transition-all cursor-pointer;
+    @apply inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-md border-0;
+    @apply text-[13px] font-medium transition-all cursor-pointer;
     @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/40;
+    background: transparent;
+    color: rgb(100 116 139); /* slate-500 */
+  }
+
+  :global(.dark) .seg-trigger {
+    color: rgb(148 163 184); /* slate-400 */
+  }
+
+  .seg-trigger:not(.is-active):hover {
+    color: rgb(51 65 85); /* slate-700 */
+  }
+
+  :global(.dark) .seg-trigger:not(.is-active):hover {
+    color: rgb(226 232 240); /* slate-200 */
   }
 
   .seg-trigger.is-active {
-    @apply bg-white dark:bg-slate-700;
-    @apply text-slate-900 dark:text-slate-50;
-    @apply font-semibold;
+    background: #ffffff;
+    color: rgb(15 23 42); /* slate-900 */
+    font-weight: 600;
     box-shadow:
       0 1px 2px rgba(15, 23, 42, 0.08),
       0 0 0 1px rgba(15, 23, 42, 0.04);
   }
 
-  /* Dark-mode active pill: subtler shadow, lean on background contrast instead */
   :global(.dark) .seg-trigger.is-active {
+    background: rgb(71 85 105); /* slate-600 — clearly lighter than the slate-800 container */
+    color: rgb(248 250 252); /* slate-50 */
     box-shadow:
       0 1px 2px rgba(0, 0, 0, 0.4),
-      0 0 0 1px rgba(255, 255, 255, 0.04);
-  }
-
-  .seg-trigger:not(.is-active):hover {
-    @apply text-slate-700 dark:text-slate-200;
+      0 0 0 1px rgba(255, 255, 255, 0.06);
   }
 
   /* Body — locks 16px gap from tabs (or subtitle when no tabs) */

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -379,30 +379,38 @@
     @apply text-xs text-yellow-800 bg-yellow-50 border border-yellow-200;
   }
 
-  /* Segmented tab control — Di's pattern (gray pill, white active) */
+  /* Segmented tab control — Di's pattern (gray pill, lifted active) */
   .seg-list {
-    @apply mx-6 mt-5 inline-flex p-1 gap-1 self-start;
-    @apply bg-slate-100 rounded-lg w-fit;
+    @apply mx-6 mt-5 inline-flex p-1 gap-1 self-start w-fit;
+    @apply bg-slate-100 dark:bg-slate-800/70 rounded-lg;
   }
 
   .seg-trigger {
     @apply inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-md border-0 bg-transparent;
-    @apply text-[13px] font-medium text-slate-500;
+    @apply text-[13px] font-medium;
+    @apply text-slate-500 dark:text-slate-400;
     @apply transition-all cursor-pointer;
     @apply focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/40;
   }
 
   .seg-trigger.is-active {
-    background: #ffffff;
-    color: #0f172a;
-    font-weight: 600;
+    @apply bg-white dark:bg-slate-700;
+    @apply text-slate-900 dark:text-slate-50;
+    @apply font-semibold;
     box-shadow:
       0 1px 2px rgba(15, 23, 42, 0.08),
       0 0 0 1px rgba(15, 23, 42, 0.04);
   }
 
+  /* Dark-mode active pill: subtler shadow, lean on background contrast instead */
+  :global(.dark) .seg-trigger.is-active {
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.4),
+      0 0 0 1px rgba(255, 255, 255, 0.04);
+  }
+
   .seg-trigger:not(.is-active):hover {
-    @apply text-slate-700;
+    @apply text-slate-700 dark:text-slate-200;
   }
 
   /* Body — locks 16px gap from tabs (or subtitle when no tabs) */

--- a/web-admin/src/features/projects/ProjectHeader.svelte
+++ b/web-admin/src/features/projects/ProjectHeader.svelte
@@ -208,7 +208,7 @@
         <ViewAsUserChip />
       {/if}
       {#if $cloudEditing && onProjectPage && projectPermissions.manageDev}
-        <EditButton {organization} {project} {activeBranch} />
+        <EditButton {organization} {project} {activeBranch} {primaryBranch} />
       {/if}
       {#if onProjectPage && projectPermissions.manageProjectMembers}
         <ShareProjectPopover
@@ -231,7 +231,7 @@
           >
             <LastRefreshedDate {dashboard} />
             {#if $cloudEditing && (onMetricsExplorerPage || onCanvasDashboardPage) && projectPermissions.manageDev}
-              <EditButton {organization} {project} {activeBranch} />
+              <EditButton {organization} {project} {activeBranch} {primaryBranch} />
             {/if}
             {#if $dimensionSearch && ready}
               <GlobalDimensionSearch />
@@ -260,7 +260,7 @@
 
     {#if onCanvasDashboardPage}
       {#if $cloudEditing && projectPermissions.manageDev}
-        <EditButton {organization} {project} {activeBranch} />
+        <EditButton {organization} {project} {activeBranch} {primaryBranch} />
       {/if}
       {#if $dashboardChat && !onPublicURLPage}
         <ChatToggle />

--- a/web-admin/src/features/projects/ProjectHeader.svelte
+++ b/web-admin/src/features/projects/ProjectHeader.svelte
@@ -231,7 +231,12 @@
           >
             <LastRefreshedDate {dashboard} />
             {#if $cloudEditing && (onMetricsExplorerPage || onCanvasDashboardPage) && projectPermissions.manageDev}
-              <EditButton {organization} {project} {activeBranch} {primaryBranch} />
+              <EditButton
+                {organization}
+                {project}
+                {activeBranch}
+                {primaryBranch}
+              />
             {/if}
             {#if $dimensionSearch && ready}
               <GlobalDimensionSearch />


### PR DESCRIPTION
Refines the cloud editing branch picker that ships with the Edit button. Foundation stays Eric G's popover from APP-776 — this borrows visual character from Di's modal designs while keeping the lightweight, contextual form factor.

* Header pattern: title + subtitle with an inline branch chip ("Branched from `main`" / "Create a branch to edit from `main`"). Frames why a branch step exists for first-time users without modal ceremony.
* Type a new branch name and spaces are replaced with hyphens immediately as you type; cursor position is preserved.
* Cancel button (and Esc) collapses the inline new-branch form back to the existing-branches list.
* `primaryBranch` is wired through `ProjectHeader` so the chip reflects the real source branch, not a hardcoded string.
* Deployment status dots dropped from rows — status info belongs on the branches management surface, not the edit picker.
* CTA copy: "Start editing" → "Create & edit" on creation paths; resume (clicking an existing row) is unchanged.

Follow-up to [APP-776](https://linear.app/rilldata/issue/APP-776/ui-for-branch-deploys).

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*