### PR TITLE
Postgres: Add `max_open_conns` (default 1) and `conn_max_lifetime` (default 1m) config properties

### DIFF
--- a/docs/docs/reference/project-files/connectors.md
+++ b/docs/docs/reference/project-files/connectors.md
@@ -1006,6 +1006,14 @@ _[string]_ - Password for authentication
 
 _[string]_ - ssl mode options: `disable`, `allow`, `prefer` or `require`. 
 
+### `max_open_conns`
+
+_[integer]_ - Maximum number of open connections to the database (defaults to 1) 
+
+### `conn_max_lifetime`
+
+_[string]_ - Maximum time a connection may be reused, as a Go duration string (defaults to 1m) 
+
 ### `log_queries`
 
 _[boolean]_ - Controls whether to log raw SQL queries 
@@ -1070,6 +1078,14 @@ _[string]_ - Password for authentication
 ### `sslmode`
 
 _[string]_ - ssl mode options: `disable`, `allow`, `prefer` or `require`. 
+
+### `max_open_conns`
+
+_[integer]_ - Maximum number of open connections to the database (defaults to 1) 
+
+### `conn_max_lifetime`
+
+_[string]_ - Maximum time a connection may be reused, as a Go duration string (defaults to 1m) 
 
 ### `log_queries`
 

--- a/runtime/drivers/postgres/postgres.go
+++ b/runtime/drivers/postgres/postgres.go
@@ -162,15 +162,17 @@ type driver struct {
 }
 
 type ConfigProperties struct {
-	DatabaseURL string `mapstructure:"database_url"`
-	DSN         string `mapstructure:"dsn"`
-	Host        string `mapstructure:"host"`
-	Port        string `mapstructure:"port"`
-	DBname      string `mapstructure:"dbname"`
-	User        string `mapstructure:"user"`
-	Password    string `mapstructure:"password"`
-	SSLMode     string `mapstructure:"sslmode"`
-	LogQueries  bool   `mapstructure:"log_queries"`
+	DatabaseURL     string `mapstructure:"database_url"`
+	DSN             string `mapstructure:"dsn"`
+	Host            string `mapstructure:"host"`
+	Port            string `mapstructure:"port"`
+	DBname          string `mapstructure:"dbname"`
+	User            string `mapstructure:"user"`
+	Password        string `mapstructure:"password"`
+	SSLMode         string `mapstructure:"sslmode"`
+	MaxOpenConns    int    `mapstructure:"max_open_conns"`
+	ConnMaxLifetime string `mapstructure:"conn_max_lifetime"`
+	LogQueries      bool   `mapstructure:"log_queries"`
 }
 
 func (c *ConfigProperties) Validate() error {
@@ -204,6 +206,24 @@ func (c *ConfigProperties) Validate() error {
 		return fmt.Errorf("postgres: Only one of 'dsn' or [%s] can be set", strings.Join(set, ", "))
 	}
 	return nil
+}
+
+func (c *ConfigProperties) resolveMaxOpenConns() int {
+	if c.MaxOpenConns == 0 {
+		return 1
+	}
+	return c.MaxOpenConns
+}
+
+func (c *ConfigProperties) resolveConnMaxLifetime() (time.Duration, error) {
+	if c.ConnMaxLifetime == "" {
+		return time.Minute, nil
+	}
+	d, err := time.ParseDuration(c.ConnMaxLifetime)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse conn_max_lifetime: %w", err)
+	}
+	return d, nil
 }
 
 func (c *ConfigProperties) ResolveDSN() string {
@@ -396,12 +416,19 @@ func (c *connection) getDB(ctx context.Context) (*sqlx.DB, error) {
 		return c.db, c.dbErr
 	}
 
+	connMaxLifetime, err := c.config.resolveConnMaxLifetime()
+	if err != nil {
+		c.dbErr = err
+		return nil, c.dbErr
+	}
+
 	c.db, c.dbErr = sqlx.Connect("pgx", c.config.ResolveDSN())
 	if c.dbErr != nil {
 		return nil, c.dbErr
 	}
+	c.db.SetMaxOpenConns(c.config.resolveMaxOpenConns())
+	c.db.SetConnMaxLifetime(connMaxLifetime)
 	c.db.SetConnMaxIdleTime(time.Minute)
-	c.db.SetMaxOpenConns(1)
 	return c.db, c.dbErr
 }
 

--- a/runtime/drivers/postgres/postgres.go
+++ b/runtime/drivers/postgres/postgres.go
@@ -401,6 +401,7 @@ func (c *connection) getDB(ctx context.Context) (*sqlx.DB, error) {
 		return nil, c.dbErr
 	}
 	c.db.SetConnMaxIdleTime(time.Minute)
+	c.db.SetMaxOpenConns(1)
 	return c.db, c.dbErr
 }
 

--- a/runtime/parser/schema/project.schema.yaml
+++ b/runtime/parser/schema/project.schema.yaml
@@ -948,6 +948,12 @@ definitions:
             sslmode:
               type: string
               description:  "ssl mode options: `disable`, `allow`, `prefer` or `require`."
+            max_open_conns:
+              type: integer
+              description: Maximum number of open connections to the database (defaults to 1)
+            conn_max_lifetime:
+              type: string
+              description: Maximum time a connection may be reused, as a Go duration string (defaults to 1m)
             log_queries:
               type: boolean
               description: Controls whether to log raw SQL queries
@@ -1002,6 +1008,12 @@ definitions:
             sslmode:
               type: string
               description: "ssl mode options: `disable`, `allow`, `prefer` or `require`."
+            max_open_conns:
+              type: integer
+              description: Maximum number of open connections to the database (defaults to 1)
+            conn_max_lifetime:
+              type: string
+              description: Maximum time a connection may be reused, as a Go duration string (defaults to 1m)
             log_queries:
               type: boolean
               description: Controls whether to log raw SQL queries


### PR DESCRIPTION
Note that these options only apply to the direct Postgres queries used for health checks and introspection, not to data ingestion queries, which are pushed down to DuckDB's and Clickhouse's native Postgres connectors.

The options can be overridden in the connector file, for example:
```yaml
# connectors/postgres.yaml
type: connector
driver: postgres
...
max_open_conns: 2
conn_max_lifetime: 2m
```