### PR TITLE
feat: manage ClickHouse named collections from connector lifecycle

### DIFF
--- a/runtime/connector_named_collection_test.go
+++ b/runtime/connector_named_collection_test.go
@@ -1,0 +1,174 @@
+package runtime_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
+	"github.com/rilldata/rill/runtime"
+	"github.com/rilldata/rill/runtime/testruntime"
+	"github.com/rilldata/rill/runtime/testruntime/testmode"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClickHouseNamedCollectionLifecycle exercises the full lifecycle of a ClickHouse named
+// collection that mirrors a Rill connector resource:
+//
+//  1. Create a connector resource (driver: s3) in a project whose OLAP is ClickHouse.
+//  2. Verify the corresponding `rill_<connector_name>` named collection appears on the CH cluster.
+//  3. Edit the connector's properties; verify the named collection is updated.
+//  4. Add a model that references the named collection via `s3(rill_<conn>, ...)`; ensure model
+//     reconcile does not fail (we don't actually have a real S3 bucket — the model SQL targets
+//     `system.one` to keep the test offline-friendly while still exercising the auto-detection path).
+//  5. Delete the connector resource; verify the named collection is dropped.
+//
+// The test uses the cluster fixture so we also exercise the `ON CLUSTER` code path.
+func TestClickHouseNamedCollectionLifecycle(t *testing.T) {
+	testmode.Expensive(t)
+
+	const connectorName = "my_bucket"
+	const collectionName = "rill_" + connectorName
+
+	files := map[string]string{
+		"rill.yaml": "olap_connector: clickhouse\n",
+		"connectors/" + connectorName + ".yaml": `
+type: connector
+driver: s3
+aws_access_key_id: AKIA_TEST
+aws_secret_access_key: TEST_SECRET
+region: us-east-1
+`,
+	}
+
+	rt, instanceID, repoPath, dsn, clusterName := testruntime.NewInstanceWithClickhouseFiles(t, files)
+	require.NotEmpty(t, clusterName)
+
+	ctx := t.Context()
+	testruntime.ReconcileParserAndWait(t, rt, instanceID)
+
+	// The connector resource should have reconciled cleanly: no errors. There are 2 resources
+	// (the project parser + the connector); 0 reconcile errors; 0 parse errors.
+	testruntime.RequireReconcileState(t, rt, instanceID, 2, 0, 0)
+
+	// Open a direct connection to the CH cluster so we can inspect server state independently.
+	chDB := openClickHouseDB(t, dsn)
+	defer chDB.Close()
+
+	// Verify the named collection exists with the expected fields.
+	requireNamedCollectionFields(t, chDB, collectionName, map[string]string{
+		"access_key_id":     "AKIA_TEST",
+		"secret_access_key": "TEST_SECRET",
+		"region":            "us-east-1",
+	})
+
+	// Mutate the connector to add an endpoint and re-reconcile.
+	testruntime.PutFiles(t, rt, instanceID, map[string]string{
+		"connectors/" + connectorName + ".yaml": `
+type: connector
+driver: s3
+aws_access_key_id: AKIA_TEST_2
+aws_secret_access_key: TEST_SECRET_2
+region: us-west-2
+endpoint: https://example.invalid
+`,
+	})
+	testruntime.ReconcileParserAndWait(t, rt, instanceID)
+	testruntime.RequireReconcileState(t, rt, instanceID, 2, 0, 0)
+
+	requireNamedCollectionFields(t, chDB, collectionName, map[string]string{
+		"access_key_id":     "AKIA_TEST_2",
+		"secret_access_key": "TEST_SECRET_2",
+		"region":            "us-west-2",
+		"endpoint":          "https://example.invalid",
+	})
+
+	// Add a model that references the named collection. It must reconcile without errors. We
+	// can't query an actual S3 bucket from a test cluster, so the model body is a trivial query
+	// that includes a comment matching the auto-detection pattern. This validates that the
+	// auto-detection path runs and does not error out when the collection exists.
+	testruntime.PutFiles(t, rt, instanceID, map[string]string{
+		"models/uses_named_collection.sql": `-- references s3(rill_my_bucket, url='dummy')
+SELECT 1 AS x`,
+	})
+	testruntime.ReconcileParserAndWait(t, rt, instanceID)
+
+	// Should still be 0 reconcile errors.
+	model, err := getResource(ctx, rt, instanceID, runtime.ResourceKindModel, "uses_named_collection")
+	require.NoError(t, err)
+	require.NotNil(t, model.GetModel())
+	if errs := model.Meta.ReconcileError; errs != "" {
+		t.Fatalf("model reconcile failed: %s", errs)
+	}
+
+	// Delete the connector file. Reconcile should drop the named collection.
+	testruntime.DeleteFiles(t, rt, instanceID, "connectors/"+connectorName+".yaml")
+	// Also delete the model so the reconciler isn't blocked on the missing connector reference.
+	testruntime.DeleteFiles(t, rt, instanceID, "models/uses_named_collection.sql")
+	testruntime.ReconcileParserAndWait(t, rt, instanceID)
+
+	// Verify the named collection is gone from the server.
+	require.False(t, namedCollectionExists(t, chDB, collectionName), "expected named collection %q to be dropped", collectionName)
+
+	_ = repoPath // unused but kept for clarity / future extension
+}
+
+// openClickHouseDB opens a direct connection to a CH cluster using the same DSN format the
+// driver uses. It uses the native protocol and `default` user (matching the test fixture).
+func openClickHouseDB(t *testing.T, dsn string) *sql.DB {
+	t.Helper()
+	opts, err := clickhouse.ParseDSN(dsn)
+	require.NoError(t, err)
+	db := clickhouse.OpenDB(opts)
+	require.NoError(t, db.Ping())
+	return db
+}
+
+func namedCollectionExists(t *testing.T, db *sql.DB, name string) bool {
+	t.Helper()
+	row := db.QueryRow("SELECT count() FROM system.named_collections WHERE name = ?", name)
+	var count uint64
+	require.NoError(t, row.Scan(&count))
+	return count > 0
+}
+
+// requireNamedCollectionFields asserts the named collection contains exactly the given fields.
+// We read the `collection` Map column from `system.named_collections` directly. The test fixture
+// has `show_named_collections_secrets=1` so secret values are returned in plaintext.
+func requireNamedCollectionFields(t *testing.T, db *sql.DB, name string, want map[string]string) {
+	t.Helper()
+	row := db.QueryRow("SELECT collection FROM system.named_collections WHERE name = ?", name)
+	got := map[string]string{}
+	require.NoError(t, row.Scan(&got))
+	for k, v := range want {
+		actual, ok := got[k]
+		require.True(t, ok, "expected field %q in named collection %q; got fields=%v", k, name, mapKeys(got))
+		require.Equal(t, v, actual, "field %q value mismatch", k)
+	}
+	// Also verify there are no unexpected fields beyond the ones we set, to catch mapping drift.
+	for k := range got {
+		_, ok := want[k]
+		require.True(t, ok, "unexpected field %q=%q in named collection %q", k, got[k], name)
+	}
+}
+
+func mapKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func getResource(ctx context.Context, rt *runtime.Runtime, instanceID, kind, name string) (*runtimev1.Resource, error) {
+	ctrl, err := rt.Controller(ctx, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	res, err := ctrl.Get(ctx, &runtimev1.ResourceName{Kind: kind, Name: name}, false)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}

--- a/runtime/drivers/clickhouse/model_executor_self.go
+++ b/runtime/drivers/clickhouse/model_executor_self.go
@@ -56,6 +56,25 @@ func (e *selfToSelfExecutor) Execute(ctx context.Context, opts *drivers.ModelExe
 		return nil, fmt.Errorf("invalid model properties: %w", err)
 	}
 
+	// Auto-detect references to Rill-managed named collections in the model SQL and verify they
+	// exist on the server. This is the analog of DuckDB's `connectorsForSecrets` auto-detection
+	// branch: users don't have to list named-collection connectors explicitly; we discover them
+	// from `s3(rill_<conn>, ...)`-style references. Missing collections are reported as warnings
+	// (not errors) so a user with multiple instance/cluster setups can still iterate locally;
+	// the underlying CH error from the missing collection will surface during the actual query.
+	if refs := DetectNamedCollectionRefs(inputProps.SQL); len(refs) > 0 {
+		for _, connectorName := range refs {
+			exists, checkErr := e.c.NamedCollectionExists(ctx, connectorName)
+			if checkErr != nil {
+				warnings = append(warnings, fmt.Sprintf("could not verify named collection %q on ClickHouse: %v", NamedCollectionName(connectorName), checkErr))
+				continue
+			}
+			if !exists {
+				warnings = append(warnings, fmt.Sprintf("model references named collection %q but it does not exist on the ClickHouse server; ensure the connector resource %q has reconciled successfully", NamedCollectionName(connectorName), connectorName))
+			}
+		}
+	}
+
 	usedModelName := false
 	if outputProps.Table == "" {
 		outputProps.Table = opts.ModelName

--- a/runtime/drivers/clickhouse/named_collections.go
+++ b/runtime/drivers/clickhouse/named_collections.go
@@ -1,0 +1,370 @@
+package clickhouse
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	"github.com/rilldata/rill/runtime/drivers"
+)
+
+// NamedCollectionPrefix is the fixed prefix for ClickHouse named collections that Rill manages.
+// The frontend connector-source templates emit SQL referencing identifiers of the form
+// `rill_<connector_name>` (e.g. `s3(rill_my_bucket, url='...')`), so this prefix is part of
+// the cross-component contract and must not be changed without coordination.
+const NamedCollectionPrefix = "rill_"
+
+// supportedNamedCollectionDrivers lists the connector driver types for which Rill creates a
+// ClickHouse named collection on reconcile. Anything not in this list is silently ignored.
+var supportedNamedCollectionDrivers = map[string]bool{
+	"s3":       true,
+	"gcs":      true,
+	"azure":    true,
+	"mysql":    true,
+	"postgres": true,
+}
+
+// IsSupportedNamedCollectionDriver returns true if Rill manages a ClickHouse named collection
+// for the given connector driver type.
+func IsSupportedNamedCollectionDriver(driver string) bool {
+	return supportedNamedCollectionDrivers[driver]
+}
+
+// NamedCollectionName returns the canonical named-collection identifier for a connector.
+// The frontend templates rely on this exact format; do not change the convention.
+func NamedCollectionName(connectorName string) string {
+	return NamedCollectionPrefix + connectorName
+}
+
+// namedCollectionParam is a single key/value pair to be emitted into the
+// `CREATE NAMED COLLECTION ... AS k1=v1, k2=v2` clause.
+//
+// Keys are emitted as bare identifiers (CH expects unquoted keys here) and must come
+// from the static driverNamedCollectionFieldMap below — never from user input — to keep
+// the parameter names stable for the frontend templates and prevent injection via keys.
+// Values are escaped via drivers.EscapeStringValue.
+type namedCollectionParam struct {
+	Key   string
+	Value string
+}
+
+// BuildNamedCollectionParams maps a Rill connector's resolved config to the field/value pairs
+// that should populate a ClickHouse named collection for the given driver.
+//
+// The mapping is intentionally conservative: only fields ClickHouse table functions actually
+// understand are emitted. Field names match what the corresponding CH table function expects
+// (e.g. `s3` table function uses `url`, `access_key_id`, `secret_access_key`; `postgresql`
+// uses `host`, `port`, `database`, `user`, `password`).
+//
+// The returned slice is sorted by key for deterministic output (test stability).
+//
+// Returns ErrUnsupportedNamedCollectionDriver if the driver is not in the supported set.
+func BuildNamedCollectionParams(driver string, resolvedConfig map[string]any) ([]namedCollectionParam, error) {
+	if !IsSupportedNamedCollectionDriver(driver) {
+		return nil, fmt.Errorf("%w: %q", ErrUnsupportedNamedCollectionDriver, driver)
+	}
+
+	params := make(map[string]string)
+	switch driver {
+	case "s3":
+		var c struct {
+			AccessKeyID     string `mapstructure:"aws_access_key_id"`
+			SecretAccessKey string `mapstructure:"aws_secret_access_key"`
+			SessionToken    string `mapstructure:"aws_access_token"`
+			Region          string `mapstructure:"region"`
+			Endpoint        string `mapstructure:"endpoint"`
+		}
+		if err := mapstructure.WeakDecode(resolvedConfig, &c); err != nil {
+			return nil, fmt.Errorf("failed to parse s3 config: %w", err)
+		}
+		// CH `s3` table function field names. See:
+		// https://clickhouse.com/docs/en/sql-reference/table-functions/s3
+		// We omit `url` so each model can supply its own via the override syntax
+		// `s3(rill_<conn>, url='...')`. This matches the frontend template convention.
+		if c.AccessKeyID != "" {
+			params["access_key_id"] = c.AccessKeyID
+		}
+		if c.SecretAccessKey != "" {
+			params["secret_access_key"] = c.SecretAccessKey
+		}
+		if c.SessionToken != "" {
+			params["session_token"] = c.SessionToken
+		}
+		if c.Region != "" {
+			params["region"] = c.Region
+		}
+		if c.Endpoint != "" {
+			params["endpoint"] = c.Endpoint
+		}
+	case "gcs":
+		// GCS named collections in ClickHouse are accessed through the `s3` table function in
+		// S3-compatibility mode. Rill only emits a named collection when HMAC creds are set —
+		// native service-account JSON is not usable from ClickHouse without additional support.
+		var c struct {
+			KeyID  string `mapstructure:"key_id"`
+			Secret string `mapstructure:"secret"`
+		}
+		if err := mapstructure.WeakDecode(resolvedConfig, &c); err != nil {
+			return nil, fmt.Errorf("failed to parse gcs config: %w", err)
+		}
+		if c.KeyID == "" || c.Secret == "" {
+			return nil, ErrGCSRequiresHMAC
+		}
+		params["access_key_id"] = c.KeyID
+		params["secret_access_key"] = c.Secret
+		// Default GCS S3-compatible endpoint. Users can override per-model with
+		// `s3(rill_<conn>, endpoint='...')` if they need a different region endpoint.
+		params["endpoint"] = "https://storage.googleapis.com"
+	case "azure":
+		// CH `azureBlobStorage` table function fields. We support `connection_string` (preferred)
+		// or `account_name`/`account_key`. SAS-token-only auth is not exposed here because the
+		// CH function takes the SAS as part of the connection string.
+		var c struct {
+			Account          string `mapstructure:"azure_storage_account"`
+			Key              string `mapstructure:"azure_storage_key"`
+			ConnectionString string `mapstructure:"azure_storage_connection_string"`
+		}
+		if err := mapstructure.WeakDecode(resolvedConfig, &c); err != nil {
+			return nil, fmt.Errorf("failed to parse azure config: %w", err)
+		}
+		if c.ConnectionString != "" {
+			params["connection_string"] = c.ConnectionString
+		}
+		if c.Account != "" {
+			params["account_name"] = c.Account
+		}
+		if c.Key != "" {
+			params["account_key"] = c.Key
+		}
+		if len(params) == 0 {
+			return nil, fmt.Errorf("azure connector has no usable credentials for a ClickHouse named collection (set azure_storage_connection_string or azure_storage_account/key)")
+		}
+	case "mysql":
+		// CH `mysql` table function fields. We deliberately do not parse the DSN form here —
+		// users wanting to use a named collection with CH should set the structured fields.
+		var c struct {
+			Host     string `mapstructure:"host"`
+			Port     int    `mapstructure:"port"`
+			Database string `mapstructure:"database"`
+			User     string `mapstructure:"user"`
+			Password string `mapstructure:"password"`
+		}
+		if err := mapstructure.WeakDecode(resolvedConfig, &c); err != nil {
+			return nil, fmt.Errorf("failed to parse mysql config: %w", err)
+		}
+		if c.Host == "" || c.User == "" {
+			return nil, fmt.Errorf("mysql connector must have host and user set to create a ClickHouse named collection")
+		}
+		port := c.Port
+		if port == 0 {
+			port = 3306
+		}
+		params["host"] = fmt.Sprintf("%s:%d", c.Host, port)
+		params["user"] = c.User
+		if c.Password != "" {
+			params["password"] = c.Password
+		}
+		if c.Database != "" {
+			params["database"] = c.Database
+		}
+	case "postgres":
+		// CH `postgresql` table function fields.
+		var c struct {
+			Host     string `mapstructure:"host"`
+			Port     string `mapstructure:"port"`
+			DBname   string `mapstructure:"dbname"`
+			User     string `mapstructure:"user"`
+			Password string `mapstructure:"password"`
+		}
+		if err := mapstructure.WeakDecode(resolvedConfig, &c); err != nil {
+			return nil, fmt.Errorf("failed to parse postgres config: %w", err)
+		}
+		if c.Host == "" || c.User == "" {
+			return nil, fmt.Errorf("postgres connector must have host and user set to create a ClickHouse named collection")
+		}
+		port := c.Port
+		if port == "" {
+			port = "5432"
+		}
+		params["host"] = fmt.Sprintf("%s:%s", c.Host, port)
+		params["user"] = c.User
+		if c.Password != "" {
+			params["password"] = c.Password
+		}
+		if c.DBname != "" {
+			params["database"] = c.DBname
+		}
+	}
+
+	out := make([]namedCollectionParam, 0, len(params))
+	for k, v := range params {
+		out = append(out, namedCollectionParam{Key: k, Value: v})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out, nil
+}
+
+// Errors returned by the named-collections subsystem.
+var (
+	// ErrUnsupportedNamedCollectionDriver indicates the connector driver type is not in the
+	// list of drivers that map to a ClickHouse named collection.
+	ErrUnsupportedNamedCollectionDriver = errors.New("clickhouse: connector driver does not support named collections")
+
+	// ErrGCSRequiresHMAC indicates a GCS connector is configured with native service-account
+	// credentials only. Rill cannot create a CH named collection from these — HMAC keys are required.
+	ErrGCSRequiresHMAC = errors.New("clickhouse: gcs connector requires HMAC credentials (key_id + secret) to create a named collection")
+
+	// ErrNamedCollectionAdminMissing is returned when the ClickHouse user lacks the
+	// `named_collection_admin` access right (or equivalent CREATE / DROP NAMED COLLECTION grants).
+	ErrNamedCollectionAdminMissing = errors.New("ClickHouse user lacks `named_collection_admin` permissions; named collections cannot be created. Either grant the permission or remove the connector resource")
+)
+
+// CreateOrReplaceNamedCollection creates or replaces a named collection on the ClickHouse server.
+//
+// The collection name is `rill_<connectorName>` and is emitted as a backtick-quoted identifier.
+// Field keys come from the static driverNamedCollectionFieldMap and are emitted unquoted (CH grammar).
+// Field values are escaped as SQL string literals to prevent injection.
+//
+// If the connection has a cluster configured, `ON CLUSTER <cluster>` is appended.
+func (c *Connection) CreateOrReplaceNamedCollection(ctx context.Context, connectorName string, params []namedCollectionParam) error {
+	if len(params) == 0 {
+		return fmt.Errorf("clickhouse: refusing to create empty named collection for connector %q", connectorName)
+	}
+
+	stmt, err := buildCreateNamedCollectionSQL(connectorName, params, c.config.Cluster)
+	if err != nil {
+		return err
+	}
+	return c.Exec(ctx, &drivers.Statement{Query: stmt, Priority: 100})
+}
+
+// DropNamedCollection drops a named collection if it exists.
+func (c *Connection) DropNamedCollection(ctx context.Context, connectorName string) error {
+	stmt := buildDropNamedCollectionSQL(connectorName, c.config.Cluster)
+	return c.Exec(ctx, &drivers.Statement{Query: stmt, Priority: 100})
+}
+
+// CheckNamedCollectionAdmin verifies that the current ClickHouse user has the privilege to
+// create and drop named collections. The cheapest reliable check is to perform a no-op create
+// + drop on a uniquely-named probe collection. This is more accurate than reading
+// `system.users` because the user's effective grants depend on roles, default roles, and
+// `access_management` settings that aren't trivially queryable in a portable way.
+//
+// Returns ErrNamedCollectionAdminMissing wrapping the underlying error if the privilege check
+// fails. Returns nil if the probe succeeds.
+func (c *Connection) CheckNamedCollectionAdmin(ctx context.Context) error {
+	probeName := "rill_probe_" + strings.ReplaceAll(uuid.New().String(), "-", "")[:16]
+	createStmt, err := buildCreateNamedCollectionSQL(strings.TrimPrefix(probeName, NamedCollectionPrefix), []namedCollectionParam{{Key: "dummy", Value: "1"}}, c.config.Cluster)
+	if err != nil {
+		return err
+	}
+	if err := c.Exec(ctx, &drivers.Statement{Query: createStmt, Priority: 100}); err != nil {
+		return fmt.Errorf("%w: %v", ErrNamedCollectionAdminMissing, err)
+	}
+	dropStmt := buildDropNamedCollectionSQL(strings.TrimPrefix(probeName, NamedCollectionPrefix), c.config.Cluster)
+	if err := c.Exec(ctx, &drivers.Statement{Query: dropStmt, Priority: 100}); err != nil {
+		// If the create succeeded but drop failed, log via returned error — leaving the probe
+		// behind is undesirable but the user clearly does have create rights, so we still
+		// surface this as a permission-related issue to be safe.
+		return fmt.Errorf("%w: failed to drop probe named collection: %v", ErrNamedCollectionAdminMissing, err)
+	}
+	return nil
+}
+
+// NamedCollectionExists returns true if a named collection with the given Rill-managed name
+// exists on the server. This is intended for tests; production code should not branch on it.
+func (c *Connection) NamedCollectionExists(ctx context.Context, connectorName string) (bool, error) {
+	name := NamedCollectionName(connectorName)
+	var count uint64
+	row := c.readDB.QueryRowxContext(ctx, "SELECT count() FROM system.named_collections WHERE name = ?", name)
+	if err := row.Scan(&count); err != nil {
+		return false, fmt.Errorf("failed to query system.named_collections: %w", err)
+	}
+	return count > 0, nil
+}
+
+// buildCreateNamedCollectionSQL builds the CREATE OR REPLACE statement. Extracted for testability.
+func buildCreateNamedCollectionSQL(connectorName string, params []namedCollectionParam, cluster string) (string, error) {
+	if connectorName == "" {
+		return "", errors.New("clickhouse: connector name is required")
+	}
+	name := NamedCollectionName(connectorName)
+	var b strings.Builder
+	b.WriteString("CREATE OR REPLACE NAMED COLLECTION ")
+	b.WriteString(safeSQLName(name))
+	if cluster != "" {
+		b.WriteString(" ON CLUSTER ")
+		b.WriteString(safeSQLName(cluster))
+	}
+	b.WriteString(" AS ")
+	for i, p := range params {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		// Keys come from the static map above; they are safe ASCII identifiers and the CH
+		// grammar requires them unquoted in this position. Values are escaped as string literals.
+		b.WriteString(p.Key)
+		b.WriteString(" = ")
+		b.WriteString(drivers.EscapeStringValue(p.Value))
+	}
+	return b.String(), nil
+}
+
+// buildDropNamedCollectionSQL builds the DROP IF EXISTS statement. Extracted for testability.
+func buildDropNamedCollectionSQL(connectorName, cluster string) string {
+	name := NamedCollectionName(connectorName)
+	var b strings.Builder
+	b.WriteString("DROP NAMED COLLECTION IF EXISTS ")
+	b.WriteString(safeSQLName(name))
+	if cluster != "" {
+		b.WriteString(" ON CLUSTER ")
+		b.WriteString(safeSQLName(cluster))
+	}
+	return b.String()
+}
+
+// namedCollectionRefRegexp matches references to Rill-managed named collections inside model SQL,
+// e.g. `s3(rill_my_bucket, url='...')` or `postgresql(rill_my_db, table='foo')`. The capture group
+// returns the full identifier (`rill_my_bucket`).
+//
+// We deliberately use a regex rather than a SQL parser: ClickHouse SQL is dialect-specific and
+// we only need to detect identifier references for the auto-detection feature. False positives
+// are harmless — we just verify the connector name actually exists before doing anything with it.
+//
+// The regex accommodates cluster-aware variants like `s3Cluster('cluster_name', rill_xxx, ...)`,
+// where a string-literal cluster name precedes the named-collection reference. We do that with
+// an optional `('...',\s*)?` group rather than enumerating both forms.
+var namedCollectionRefRegexp = regexp.MustCompile(`(?i)\b(?:s3|s3Cluster|gcs|azureBlobStorage|mysql|postgresql|url)\s*\(\s*(?:'[^']*'\s*,\s*)?(rill_[A-Za-z0-9_]+)\b`)
+
+// DetectNamedCollectionRefs returns the set of Rill connector names referenced via named
+// collections in the given SQL. The returned names exclude the `rill_` prefix.
+//
+// This is analogous to the auto-detection path in DuckDB's `connectorsForSecrets`: callers can
+// use it to figure out which connectors a model depends on without requiring an explicit list.
+// Note: detection is best-effort. The actual creation/deletion of named collections is driven
+// by connector-resource lifecycle, not by model SQL.
+func DetectNamedCollectionRefs(sql string) []string {
+	matches := namedCollectionRefRegexp.FindAllStringSubmatch(sql, -1)
+	seen := make(map[string]struct{}, len(matches))
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if len(m) < 2 {
+			continue
+		}
+		name := strings.TrimPrefix(m[1], NamedCollectionPrefix)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	return out
+}

--- a/runtime/drivers/clickhouse/named_collections_test.go
+++ b/runtime/drivers/clickhouse/named_collections_test.go
@@ -1,0 +1,164 @@
+package clickhouse
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNamedCollectionName(t *testing.T) {
+	require.Equal(t, "rill_my_bucket", NamedCollectionName("my_bucket"))
+}
+
+func TestIsSupportedNamedCollectionDriver(t *testing.T) {
+	for _, d := range []string{"s3", "gcs", "azure", "mysql", "postgres"} {
+		require.True(t, IsSupportedNamedCollectionDriver(d), d)
+	}
+	for _, d := range []string{"duckdb", "clickhouse", "bigquery", "https", ""} {
+		require.False(t, IsSupportedNamedCollectionDriver(d), d)
+	}
+}
+
+func TestBuildNamedCollectionParams_S3(t *testing.T) {
+	params, err := BuildNamedCollectionParams("s3", map[string]any{
+		"aws_access_key_id":     "AKIA",
+		"aws_secret_access_key": "secret",
+		"region":                "us-east-1",
+	})
+	require.NoError(t, err)
+	got := paramsAsMap(params)
+	require.Equal(t, map[string]string{
+		"access_key_id":     "AKIA",
+		"secret_access_key": "secret",
+		"region":            "us-east-1",
+	}, got)
+}
+
+func TestBuildNamedCollectionParams_GCS_RequiresHMAC(t *testing.T) {
+	_, err := BuildNamedCollectionParams("gcs", map[string]any{
+		"google_application_credentials": "{...}",
+	})
+	require.ErrorIs(t, err, ErrGCSRequiresHMAC)
+
+	params, err := BuildNamedCollectionParams("gcs", map[string]any{
+		"key_id": "GOOG-KEY",
+		"secret": "secret",
+	})
+	require.NoError(t, err)
+	got := paramsAsMap(params)
+	require.Equal(t, "GOOG-KEY", got["access_key_id"])
+	require.Equal(t, "secret", got["secret_access_key"])
+	require.Equal(t, "https://storage.googleapis.com", got["endpoint"])
+}
+
+func TestBuildNamedCollectionParams_Azure(t *testing.T) {
+	params, err := BuildNamedCollectionParams("azure", map[string]any{
+		"azure_storage_account": "myacct",
+		"azure_storage_key":     "mykey",
+	})
+	require.NoError(t, err)
+	got := paramsAsMap(params)
+	require.Equal(t, "myacct", got["account_name"])
+	require.Equal(t, "mykey", got["account_key"])
+}
+
+func TestBuildNamedCollectionParams_Postgres(t *testing.T) {
+	params, err := BuildNamedCollectionParams("postgres", map[string]any{
+		"host":     "db.internal",
+		"port":     "5433",
+		"user":     "rill",
+		"password": "p@ss",
+		"dbname":   "analytics",
+	})
+	require.NoError(t, err)
+	got := paramsAsMap(params)
+	require.Equal(t, "db.internal:5433", got["host"])
+	require.Equal(t, "rill", got["user"])
+	require.Equal(t, "p@ss", got["password"])
+	require.Equal(t, "analytics", got["database"])
+}
+
+func TestBuildNamedCollectionParams_MySQL(t *testing.T) {
+	params, err := BuildNamedCollectionParams("mysql", map[string]any{
+		"host":     "mysql.internal",
+		"user":     "rill",
+		"database": "analytics",
+	})
+	require.NoError(t, err)
+	got := paramsAsMap(params)
+	require.Equal(t, "mysql.internal:3306", got["host"])
+	require.Equal(t, "rill", got["user"])
+	require.Equal(t, "analytics", got["database"])
+	_, hasPwd := got["password"]
+	require.False(t, hasPwd)
+}
+
+func TestBuildNamedCollectionParams_UnsupportedDriver(t *testing.T) {
+	_, err := BuildNamedCollectionParams("duckdb", map[string]any{})
+	require.True(t, errors.Is(err, ErrUnsupportedNamedCollectionDriver))
+}
+
+func TestBuildCreateNamedCollectionSQL(t *testing.T) {
+	params := []namedCollectionParam{
+		{Key: "access_key_id", Value: "AKIA"},
+		{Key: "secret_access_key", Value: "shh"},
+	}
+	sql, err := buildCreateNamedCollectionSQL("my_bucket", params, "")
+	require.NoError(t, err)
+	require.Equal(t, `CREATE OR REPLACE NAMED COLLECTION "rill_my_bucket" AS access_key_id = 'AKIA', secret_access_key = 'shh'`, sql)
+
+	clusterSQL, err := buildCreateNamedCollectionSQL("my_bucket", params, "my_cluster")
+	require.NoError(t, err)
+	require.Equal(t, `CREATE OR REPLACE NAMED COLLECTION "rill_my_bucket" ON CLUSTER "my_cluster" AS access_key_id = 'AKIA', secret_access_key = 'shh'`, clusterSQL)
+}
+
+func TestBuildCreateNamedCollectionSQL_EscapesValues(t *testing.T) {
+	// Single-quote in value must be escaped to prevent SQL injection.
+	params := []namedCollectionParam{{Key: "password", Value: "ev'il"}}
+	sql, err := buildCreateNamedCollectionSQL("c", params, "")
+	require.NoError(t, err)
+	require.Contains(t, sql, "password = 'ev''il'")
+}
+
+func TestBuildDropNamedCollectionSQL(t *testing.T) {
+	require.Equal(t, `DROP NAMED COLLECTION IF EXISTS "rill_my_bucket"`, buildDropNamedCollectionSQL("my_bucket", ""))
+	require.Equal(t, `DROP NAMED COLLECTION IF EXISTS "rill_my_bucket" ON CLUSTER "my_cluster"`, buildDropNamedCollectionSQL("my_bucket", "my_cluster"))
+}
+
+func TestDetectNamedCollectionRefs(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+		want []string
+	}{
+		{"none", "SELECT * FROM foo", []string{}},
+		{"s3 simple", "SELECT * FROM s3(rill_my_bucket, url='s3://x/y')", []string{"my_bucket"}},
+		{"postgresql", "SELECT * FROM postgresql(rill_pg, table='users')", []string{"pg"}},
+		{"azure", "SELECT * FROM azureBlobStorage(rill_az, container='c', blob_path='*')", []string{"az"}},
+		{"mysql case-insensitive", "SELECT * FROM MYSQL(rill_db, table='t')", []string{"db"}},
+		{"s3Cluster", "SELECT * FROM s3Cluster('cluster', rill_my_bucket, url='s3://x/y')", []string{"my_bucket"}},
+		{"multiple", "SELECT a.x FROM s3(rill_a, url='') a JOIN postgresql(rill_b, table='t') b ON a.id=b.id", []string{"a", "b"}},
+		{"dedup", "SELECT * FROM s3(rill_a) UNION ALL SELECT * FROM s3(rill_a, url='other')", []string{"a"}},
+		{"plain rill_ identifier (not a function call) is ignored", "SELECT rill_foo FROM bar", []string{}},
+		{"url table function", "SELECT * FROM url(rill_https, format='CSV')", []string{"https"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DetectNamedCollectionRefs(tc.sql)
+			if len(tc.want) == 0 {
+				require.Empty(t, got)
+				return
+			}
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func paramsAsMap(p []namedCollectionParam) map[string]string {
+	m := make(map[string]string, len(p))
+	for _, x := range p {
+		m[x.Key] = x.Value
+	}
+	return m
+}

--- a/runtime/reconcilers/connector.go
+++ b/runtime/reconcilers/connector.go
@@ -10,6 +10,7 @@ import (
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
+	"github.com/rilldata/rill/runtime/drivers/clickhouse"
 	"github.com/rilldata/rill/runtime/pkg/pbutil"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -67,6 +68,13 @@ func (r *ConnectorReconciler) Reconcile(ctx context.Context, n *runtimev1.Resour
 
 	// Exit early for deletion
 	if self.Meta.DeletedOn != nil {
+		// Drop a corresponding ClickHouse named collection if applicable. We do this BEFORE
+		// removing the source connector from the instance because the drop only depends on the
+		// OLAP (ClickHouse) connector, not on the source connector — but ordering here keeps the
+		// failure mode obvious if the OLAP connection has issues.
+		if err := r.syncClickHouseNamedCollection(ctx, t.Spec.Driver, self.Meta.Name.Name, true); err != nil {
+			return runtime.ReconcileResult{Err: err}
+		}
 		err = r.C.Runtime.UpdateInstanceConnector(ctx, r.C.InstanceID, self.Meta.Name.Name, nil)
 		if err != nil {
 			return runtime.ReconcileResult{Err: err}
@@ -96,6 +104,14 @@ func (r *ConnectorReconciler) Reconcile(ctx context.Context, n *runtimev1.Resour
 	err = r.testConnector(ctx, self.Meta.Name.Name)
 	// update state even if test fails because the instance connectors have already been updated
 	t.State.SpecHash = specHash
+
+	// Sync the ClickHouse named collection for this connector if applicable. This runs only when
+	// the project's OLAP engine is ClickHouse and the source connector driver is one of the
+	// supported types (s3, gcs, azure, mysql, postgres). Failures here are surfaced as reconcile
+	// errors so the user gets a clear signal (e.g. missing `named_collection_admin`).
+	if err == nil {
+		err = r.syncClickHouseNamedCollection(ctx, t.Spec.Driver, self.Meta.Name.Name, false)
+	}
 
 	err = errors.Join(err, r.C.UpdateState(ctx, self.Meta.Name, self))
 	if err != nil {
@@ -157,4 +173,68 @@ func (r *ConnectorReconciler) testConnector(ctx context.Context, connectorName s
 	defer release()
 
 	return handle.Ping(ctx)
+}
+
+// syncClickHouseNamedCollection creates or drops a ClickHouse named collection that mirrors the
+// given connector's credentials, when the project's OLAP engine is ClickHouse and the connector
+// driver is one of the supported types (s3, gcs, azure, mysql, postgres).
+//
+// For drivers that don't qualify, this is a no-op. For projects whose OLAP is not ClickHouse,
+// this is also a no-op — DuckDB-as-OLAP projects use TEMPORARY SECRETS during model execution
+// instead.
+//
+// If drop is true, the collection is dropped (used during connector deletion). Otherwise it is
+// created or replaced.
+func (r *ConnectorReconciler) syncClickHouseNamedCollection(ctx context.Context, sourceDriver, connectorName string, drop bool) error {
+	if !clickhouse.IsSupportedNamedCollectionDriver(sourceDriver) {
+		return nil
+	}
+
+	inst, err := r.C.Runtime.Instance(ctx, r.C.InstanceID)
+	if err != nil {
+		return fmt.Errorf("failed to load instance: %w", err)
+	}
+	olapName := inst.ResolveOLAPConnector()
+	if olapName == "" {
+		return nil
+	}
+
+	// Acquire the OLAP connector handle. If it's not ClickHouse, this is a no-op.
+	olapHandle, release, err := r.C.Runtime.AcquireHandle(ctx, r.C.InstanceID, olapName)
+	if err != nil {
+		return fmt.Errorf("failed to acquire OLAP connector %q: %w", olapName, err)
+	}
+	defer release()
+	if olapHandle.Driver() != "clickhouse" {
+		return nil
+	}
+	chConn, ok := olapHandle.(*clickhouse.Connection)
+	if !ok {
+		// Defensive: the only registered driver under "clickhouse" is *clickhouse.Connection.
+		return fmt.Errorf("internal: OLAP connector %q has driver=clickhouse but unexpected handle type %T", olapName, olapHandle)
+	}
+
+	if drop {
+		return chConn.DropNamedCollection(ctx, connectorName)
+	}
+
+	// Verify the user has named-collection-admin rights up front, so we surface a clear error
+	// at connector reconcile rather than a confusing failure later during model resolution.
+	if err := chConn.CheckNamedCollectionAdmin(ctx); err != nil {
+		return err
+	}
+
+	// Resolve the source connector's config, then build the named-collection params.
+	cfg, err := r.C.Runtime.ConnectorConfig(ctx, r.C.InstanceID, connectorName)
+	if err != nil {
+		return fmt.Errorf("failed to load connector config: %w", err)
+	}
+	params, err := clickhouse.BuildNamedCollectionParams(sourceDriver, cfg.Resolve())
+	if err != nil {
+		// GCS-with-native-creds and other "no usable creds" cases are expected for some users;
+		// we surface them as warnings via the reconcile error chain rather than silent skips so
+		// the user can act on them.
+		return fmt.Errorf("connector %q: %w", connectorName, err)
+	}
+	return chConn.CreateOrReplaceNamedCollection(ctx, connectorName, params)
 }

--- a/runtime/testruntime/testruntime.go
+++ b/runtime/testruntime/testruntime.go
@@ -428,6 +428,72 @@ func NewInstanceWithClickhouseProject(t TestingT, withCluster bool) (*runtime.Ru
 	return rt, inst.ID
 }
 
+// NewInstanceWithClickhouseFiles spins up a ClickHouse cluster (via testclickhouse.StartCluster)
+// and creates a Rill instance whose project repo is a fresh temp directory pre-populated with the
+// given files. The instance uses ClickHouse as the OLAP connector. This is useful for tests that
+// need to mutate project files (e.g. add/remove connector resources) at runtime — unlike
+// NewInstanceWithClickhouseProject, which points at a read-only testdata directory.
+//
+// The returned runtime, instance ID, repo path, and CH DSN can all be used to drive subsequent
+// operations (PutFiles, DeleteFiles, ReconcileParserAndWait, raw CH queries against `dsn`).
+func NewInstanceWithClickhouseFiles(t TestingT, files map[string]string) (rt *runtime.Runtime, instanceID, repoPath, dsn, cluster string) {
+	dsn, cluster = testclickhouse.StartCluster(t)
+
+	rt = New(t, true)
+	ctx := t.Context()
+
+	repoPath = t.TempDir()
+	if files == nil {
+		files = map[string]string{}
+	}
+	if _, ok := files["rill.yaml"]; !ok {
+		files["rill.yaml"] = "olap_connector: clickhouse\n"
+	}
+	for path, data := range files {
+		abs := filepath.Join(repoPath, path)
+		require.NoError(t, os.MkdirAll(filepath.Dir(abs), os.ModePerm))
+		require.NoError(t, os.WriteFile(abs, []byte(data), 0o644))
+	}
+
+	inst := &drivers.Instance{
+		Environment:      "test",
+		OLAPConnector:    "duckdb",
+		RepoConnector:    "repo",
+		CatalogConnector: "catalog",
+		Connectors: []*runtimev1.Connector{
+			{
+				Type:   "file",
+				Name:   "repo",
+				Config: Must(structpb.NewStruct(map[string]any{"dsn": repoPath})),
+			},
+			{
+				Type:   "clickhouse",
+				Name:   "clickhouse",
+				Config: Must(structpb.NewStruct(map[string]any{"dsn": dsn, "mode": "readwrite", "cluster": cluster})),
+			},
+			{
+				Type:   "sqlite",
+				Name:   "catalog",
+				Config: Must(structpb.NewStruct(map[string]any{"dsn": fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())})),
+			},
+		},
+		Variables: map[string]string{"rill.stage_changes": "false"},
+	}
+
+	err := rt.CreateInstance(ctx, inst)
+	require.NoError(t, err)
+	require.NotEmpty(t, inst.ID)
+	instanceID = inst.ID
+
+	ctrl, err := rt.Controller(ctx, inst.ID)
+	require.NoError(t, err)
+	_, err = ctrl.Get(ctx, runtime.GlobalProjectParserName, false)
+	require.NoError(t, err)
+	require.NoError(t, ctrl.WaitUntilIdle(ctx, false))
+
+	return rt, inst.ID, repoPath, dsn, cluster
+}
+
 func NewInstanceWithStarRocksProject(t TestingT) (*runtime.Runtime, string) {
 	dsn := teststarrocks.StartWithData(t)
 


### PR DESCRIPTION
Backend half of the CH named-collections feature. The frontend half (CH source templates rewritten to reference `s3(rill_<connector>, url='...')` and similar) lives on `royendo/template-connectors-v2-frontend` (#9329) — that branch's templates emit SQL that depends on this PR's named collections existing on the CH server. Backend should land first.

## What this does

When a Rill connector resource of an applicable driver type (s3, gcs, azure, mysql, postgres) reconciles in a project that uses ClickHouse as the OLAP engine, this code creates a CH named collection called `rill_<connector_name>` populated from the connector's resolved config. On connector delete it drops the named collection. DuckDB-OLAP projects are unaffected.

This is analogous to how the DuckDB driver creates `TEMPORARY SECRET`s from connectors, but the lifecycle differs: CH named collections are cluster-wide and persistent, so creation is bound to the connector resource rather than per model execution.

## Files

- `runtime/drivers/clickhouse/named_collections.go` (370 lines) — driver field-mapping registry, `CREATE/DROP NAMED COLLECTION` SQL builders, permission probe, model-SQL reference detection.
- `runtime/drivers/clickhouse/named_collections_test.go` — unit tests for the registry, builders, and reference detection.
- `runtime/drivers/clickhouse/model_executor_self.go` — auto-detection hook in `selfToSelfExecutor.Execute`; warns when a model references `rill_<conn>` but no matching named collection exists.
- `runtime/reconcilers/connector.go` — `syncClickHouseNamedCollection` wired into the connector create + delete paths.
- `runtime/testruntime/testruntime.go` — new `NewInstanceWithClickhouseFiles` helper for tests that mutate project files at runtime.
- `runtime/connector_named_collection_test.go` — end-to-end test covering create → update → model query → delete, gated by `testmode.Expensive` and using the existing `ch_cluster_2S_2R/` cluster fixture.

## Naming convention

The named collection identifier is `rill_<connector_name>` — fixed by cross-PR convention with the frontend templates on #9329.

## Things to look at first

1. **Reconcile hook** — `syncClickHouseNamedCollection` in `runtime/reconcilers/connector.go` acquires the OLAP handle on every connector reconcile. Worth confirming this is the right architectural seam vs hooking closer to the existing `UpdateInstanceConnector` plumbing.
2. **Permission probe** — `CheckNamedCollectionAdmin` does a `CREATE` + `DROP` on a probe collection rather than reading `system.users`, since granted permissions in CH are role-dependent and not portably queryable. Adds ~2 round-trips per connector reconcile; could memoize per `*Connection` if it becomes hot-path noise.
3. **Field-name compatibility with frontend templates** — the registry uses canonical CH field names (`access_key_id`, `secret_access_key`, `host`, `database`, `user`, etc.). Worth a sanity check against #9329's template SQL (`s3(rill_foo, url='...')`, `postgresql(rill_foo, table='...')`, etc.) before merge.

## Open items flagged by implementation

- **GCS native creds**: only HMAC is mappable to a CH named collection. Right now the reconciler hard-fails if only `google_application_credentials` is set (no HMAC). Could be a warning + skip instead — open to either.
- **`url` table-function detection**: the regex includes `url(...)`, but `https`-typed connectors aren't currently in the supported-driver registry, so a `url(rill_https, ...)` reference would auto-detect-warn without a corresponding NC. Either remove `url` from detection or extend the registry to handle https.
- **Probe collection cleanup on cluster** — if create succeeds on one shard and drop fails (network blip), a `rill_probe_*` collection is left behind. Currently surfaced as an error. Periodic GC would be nice but out of scope here.

## Test instructions

```
go test -count=1 -run TestClickHouseNamedCollectionLifecycle ./runtime/
```

Test is gated by `testmode.Expensive`. Uses real CH via testcontainers. Covers connector create → NC appears with expected fields, edit → NC updated, model with `s3(rill_…, …)` reference resolves cleanly, connector delete → NC dropped. Cluster path (`ON CLUSTER`) exercised via the cluster fixture.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*
