### PR TITLE
feat: dashboard theme inline editor

### DIFF
--- a/web-common/src/features/canvas/CanvasDashboardWrapper.svelte
+++ b/web-common/src/features/canvas/CanvasDashboardWrapper.svelte
@@ -5,6 +5,7 @@
   import CanvasFilters from "./filters/CanvasFilters.svelte";
   import { getCanvasStore } from "./state-managers/state-managers";
   import ThemeProvider from "../dashboards/ThemeProvider.svelte";
+  import { themePreviewOverride } from "../themes/selectors";
 
   const client = useRuntimeClient();
 
@@ -22,13 +23,15 @@
   $: ({ instanceId } = client);
 
   $: ({
-    canvasEntity: { theme },
+    canvasEntity: { theme: resolvedCanvasTheme },
   } = getCanvasStore(canvasName, instanceId));
+
+  $: effectiveTheme = $themePreviewOverride ?? $resolvedCanvasTheme;
 
   $: ({ width: clientWidth } = contentRect);
 </script>
 
-<ThemeProvider theme={$theme}>
+<ThemeProvider theme={effectiveTheme}>
   <main
     class="flex flex-col overflow-hidden"
     class:w-full={$dynamicHeight}

--- a/web-common/src/features/canvas/inspector/PageEditor.svelte
+++ b/web-common/src/features/canvas/inspector/PageEditor.svelte
@@ -31,7 +31,9 @@
 
   import CanvasTabs from "./CanvasTabs.svelte";
 
-  import { goto } from "$app/navigation";
+  import { beforeNavigate, goto } from "$app/navigation";
+  import { themeEditorStore } from "@rilldata/web-common/features/visual-editing/theme-editor-store";
+  import { buildInlineThemeObject } from "@rilldata/web-common/features/visual-editing/theme-yaml-utils";
   import DefaultFilterDisplay from "./DefaultFilterDisplay.svelte";
 
   export let updateProperties: (
@@ -42,6 +44,11 @@
   export let canvasName: string;
 
   const client = useRuntimeClient();
+
+  // Clean up theme editing state on navigation
+  beforeNavigate(() => {
+    themeEditorStore.exitEditing();
+  });
 
   $: ({
     canvasEntity: { filtersEnabledStore, _embeddedTheme },
@@ -249,18 +256,8 @@
             await updateProperties({ theme: value });
           }
         }}
-        onColorChange={async (primary, secondary, isDarkMode) => {
-          // TODO: Update to support dark mode - currently always sets light mode
-          // Use new theme structure: theme.light or theme.dark
-          const modeKey = isDarkMode ? "dark" : "light";
-          await updateProperties({
-            theme: {
-              [modeKey]: {
-                primary,
-                secondary,
-              },
-            },
-          });
+        onInlineThemeChange={async (spec) => {
+          await updateProperties({ theme: buildInlineThemeObject(spec) });
         }}
       />
     </div>

--- a/web-common/src/features/dashboards/workspace/Dashboard.svelte
+++ b/web-common/src/features/dashboards/workspace/Dashboard.svelte
@@ -18,7 +18,10 @@
   import { DashboardState_ActivePage } from "../../../proto/gen/rill/ui/v1/dashboard_pb";
   import { useRuntimeClient } from "../../../runtime-client/v2";
   import { activeDashboardTheme } from "../../themes/active-dashboard-theme";
-  import { createResolvedThemeStore } from "../../themes/selectors";
+  import {
+    createResolvedThemeStore,
+    themePreviewOverride,
+  } from "../../themes/selectors";
   import MeasuresContainer from "../big-number/MeasuresContainer.svelte";
   import DimensionDisplay from "../dimension-table/DimensionDisplay.svelte";
   import Filters from "../filters/Filters.svelte";
@@ -131,16 +134,21 @@
   let themeSource: Readable<string | null> = urlThemeName;
   $: themeSource = isEmbedded && embedThemeName ? embedThemeName : urlThemeName;
 
-  $: theme = createResolvedThemeStore(themeSource, exploreQuery, client);
+  $: resolvedTheme = createResolvedThemeStore(
+    themeSource,
+    exploreQuery,
+    client,
+  );
+  $: theme = $themePreviewOverride ?? $resolvedTheme;
 
   // Publish the resolved theme to the shared store for external components (e.g., chat in layout)
-  $: activeDashboardTheme.set($theme);
+  $: activeDashboardTheme.set(theme);
 
   // Clear the active theme when this dashboard is destroyed
   onDestroy(() => activeDashboardTheme.set(undefined));
 </script>
 
-<ThemeProvider theme={$theme}>
+<ThemeProvider {theme}>
   <article
     class="flex flex-col overflow-y-hidden bg-surface-background"
     bind:clientWidth={exploreContainerWidth}

--- a/web-common/src/features/themes/selectors.ts
+++ b/web-common/src/features/themes/selectors.ts
@@ -2,7 +2,7 @@ import {
   ResourceKind,
   useResource,
 } from "@rilldata/web-common/features/entity-management/resource-selectors";
-import { derived, type Readable } from "svelte/store";
+import { derived, writable, type Readable } from "svelte/store";
 import { Theme } from "./theme";
 import type { ConnectError } from "@connectrpc/connect";
 import type { RuntimeClient } from "@rilldata/web-common/runtime-client/v2";
@@ -10,6 +10,13 @@ import type { QueryObserverResult } from "@tanstack/svelte-query";
 import type { CanvasResponse } from "../canvas/selector";
 import type { ExploreValidSpecResponse } from "../explores/selectors";
 import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
+
+/**
+ * Writable store for live theme preview override.
+ * When set, dashboards use this theme instead of the persisted one.
+ * Cleared on save/discard to revert to the persisted theme.
+ */
+export const themePreviewOverride = writable<Theme | undefined>(undefined);
 
 export function useTheme(client: RuntimeClient, name: string) {
   return useResource(client, name, ResourceKind.Theme);

--- a/web-common/src/features/themes/theme.ts
+++ b/web-common/src/features/themes/theme.ts
@@ -100,6 +100,9 @@ export class Theme {
 }
 .dark .dashboard-theme-boundary {
   ${this.stringifyVars(darkColors)}
+}
+.light .dashboard-theme-boundary {
+  ${this.stringifyVars(lightColors)}
 }`.trim();
 
     return css;

--- a/web-common/src/features/visual-editing/ThemeInput.svelte
+++ b/web-common/src/features/visual-editing/ThemeInput.svelte
@@ -1,174 +1,180 @@
 <script lang="ts">
-  import ColorInput from "@rilldata/web-common/components/color-picker/ColorInput.svelte";
   import FieldSwitcher from "@rilldata/web-common/components/forms/FieldSwitcher.svelte";
   import InputLabel from "@rilldata/web-common/components/forms/InputLabel.svelte";
   import Select from "@rilldata/web-common/components/forms/Select.svelte";
   import type { V1ThemeSpec } from "@rilldata/web-common/runtime-client";
+  import { runtimeServicePutFile } from "@rilldata/web-common/runtime-client";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
-  import {
-    defaultPrimaryColors,
-    defaultSecondaryColors,
-  } from "../themes/color-config";
   import { useTheme } from "../themes/selectors";
   import { themeControl } from "../themes/theme-control";
+  import { themeEditorStore } from "./theme-editor-store";
+  import { buildThemeYaml } from "./theme-yaml-utils";
+  import ThemePropertySections from "./ThemePropertySections.svelte";
 
   const runtimeClient = useRuntimeClient();
-
-  const DEFAULT_PRIMARY = `hsl(${defaultPrimaryColors[500].split(" ").join(",")})`;
-  const DEFAULT_SECONDARY = `hsl(${defaultSecondaryColors[500].split(" ").join(",")})`;
-  const FALLBACK_PRIMARY = "hsl(180, 100%, 50%)";
-  const FALLBACK_SECONDARY = "lightgreen";
 
   export let themeNames: string[];
   export let theme: string | V1ThemeSpec | undefined;
   export let projectDefaultTheme: string | undefined = undefined;
   export let small = false;
   export let onThemeChange: (themeName: string | undefined) => void;
-  export let onColorChange: (
-    primary: string,
-    secondary: string,
-    isDarkMode: boolean,
-  ) => void;
-
-  let lastPresetTheme: string | undefined = undefined;
+  export let onInlineThemeChange: (spec: V1ThemeSpec) => void;
 
   $: isPresetMode = theme === undefined || typeof theme === "string";
-  $: embeddedTheme = typeof theme === "object" ? theme : undefined;
+  $: currentThemeName = typeof theme === "string" ? theme : undefined;
 
-  $: lastPresetTheme =
-    isPresetMode && typeof theme === "string" ? theme : lastPresetTheme;
+  $: themeQuery = currentThemeName
+    ? useTheme(runtimeClient, currentThemeName)
+    : !currentThemeName && projectDefaultTheme
+      ? useTheme(runtimeClient, projectDefaultTheme)
+      : undefined;
 
-  $: themeQuery =
-    theme && typeof theme === "string"
-      ? useTheme(runtimeClient, theme)
-      : !theme && projectDefaultTheme
-        ? useTheme(runtimeClient, projectDefaultTheme)
-        : undefined;
+  $: fetchedSpec = $themeQuery?.data?.theme?.spec;
+  $: themeResource = $themeQuery?.data;
 
-  $: fetchedTheme = $themeQuery?.data?.theme?.spec;
-
-  $: currentThemeSpec = embeddedTheme || fetchedTheme;
-
-  // Determine if we're in dark mode
   $: isDarkMode = $themeControl === "dark";
 
-  // Extract colors from the appropriate theme section (light or dark)
-  $: themePrimary = isDarkMode
-    ? currentThemeSpec?.dark?.primary || currentThemeSpec?.primaryColorRaw
-    : currentThemeSpec?.light?.primary || currentThemeSpec?.primaryColorRaw;
+  $: editorState = $themeEditorStore;
+  $: editing = editorState.editing;
 
-  $: themeSecondary = isDarkMode
-    ? currentThemeSpec?.dark?.secondary || currentThemeSpec?.secondaryColorRaw
-    : currentThemeSpec?.light?.secondary || currentThemeSpec?.secondaryColorRaw;
+  $: inlineSpec =
+    theme && typeof theme === "object" ? (theme as V1ThemeSpec) : undefined;
 
-  $: effectivePrimary = isPresetMode
-    ? themePrimary || DEFAULT_PRIMARY
-    : themePrimary || FALLBACK_PRIMARY;
+  $: displayValues = editing
+    ? themeEditorStore.getValues(isDarkMode)
+    : getSpecValues(isPresetMode ? fetchedSpec : inlineSpec, isDarkMode);
 
-  $: effectiveSecondary = isPresetMode
-    ? themeSecondary || DEFAULT_SECONDARY
-    : themeSecondary || FALLBACK_SECONDARY;
+  $: currentSelectValue = typeof theme === "string" ? theme : "Default";
 
-  $: currentSelectValue = isPresetMode
-    ? typeof theme === "string"
-      ? theme
-      : "Default"
-    : "Default";
+  $: hasTheme = !!currentThemeName || !!projectDefaultTheme || !isPresetMode;
 
-  function handleModeSwitch(mode: string) {
-    if (mode === "Custom") {
-      // Pass the current theme mode (light/dark)
-      onColorChange(
-        themePrimary || FALLBACK_PRIMARY,
-        themeSecondary || FALLBACK_SECONDARY,
-        isDarkMode,
-      );
-    } else {
-      onThemeChange(lastPresetTheme);
-    }
+  function getSpecValues(
+    spec: V1ThemeSpec | undefined,
+    dark: boolean,
+  ): Record<string, string> {
+    if (!spec) return {};
+    const modeColors = dark ? spec.dark : spec.light;
+    if (!modeColors) return {};
+    const result: Record<string, string> = {};
+    if (modeColors.primary) result.primary = modeColors.primary;
+    if (modeColors.secondary) result.secondary = modeColors.secondary;
+    if (modeColors.variables) Object.assign(result, modeColors.variables);
+    return result;
   }
 
   function handleThemeSelection(value: string) {
+    themeEditorStore.exitEditing();
     if (value === "Default") {
-      lastPresetTheme = undefined;
       onThemeChange(undefined);
     } else {
-      lastPresetTheme = value;
       onThemeChange(value);
     }
   }
 
-  function handleColorChange(color: string, isPrimary: boolean) {
-    if (isPrimary) {
-      // Pass the current theme mode (light/dark)
-      onColorChange(color, effectiveSecondary, isDarkMode);
+  function handleModeSwitch(_: number, field: string) {
+    if (field === "Custom") {
+      enterCustomMode();
     } else {
-      // Pass the current theme mode (light/dark)
-      onColorChange(effectivePrimary, color, isDarkMode);
+      themeEditorStore.exitEditing();
+      onThemeChange(currentThemeName);
     }
+  }
+
+  function enterCustomMode() {
+    const baseSpec: V1ThemeSpec = fetchedSpec ?? {
+      light: { primary: "hsl(180, 100%, 50%)", secondary: "lightgreen" },
+      dark: { primary: "hsl(180, 100%, 50%)", secondary: "lightgreen" },
+    };
+    onInlineThemeChange(baseSpec);
+    themeEditorStore.startCustom(baseSpec);
+  }
+
+  let saveTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function handlePropertyChange(key: string, value: string) {
+    if (!editing) {
+      const spec = isPresetMode ? fetchedSpec : inlineSpec;
+      if (spec) {
+        if (isPresetMode) {
+          const themeName = currentThemeName ?? projectDefaultTheme;
+          themeEditorStore.startEditing(spec, themeName);
+        } else {
+          themeEditorStore.startCustom(spec);
+        }
+      }
+    }
+    themeEditorStore.updateProperty(key, value, isDarkMode);
+    debouncedSave();
+  }
+
+  function debouncedSave() {
+    clearTimeout(saveTimer);
+    saveTimer = setTimeout(autoSave, 800);
+  }
+
+  async function autoSave() {
+    const spec = themeEditorStore.buildSpec();
+
+    if (!isPresetMode || editorState.mode === "custom") {
+      onInlineThemeChange(spec);
+    } else {
+      const yamlContent = buildThemeYaml(spec);
+      const filePath = themeResource?.meta?.filePaths?.[0];
+      if (!filePath) return;
+
+      await runtimeServicePutFile(runtimeClient, {
+        path: filePath,
+        blob: yamlContent,
+      });
+    }
+
+    themeEditorStore.markSaved();
   }
 </script>
 
 <div class="flex flex-col {small ? 'gap-y-2' : 'gap-y-1'}">
-  <InputLabel
-    label="Theme"
-    {small}
-    id="visual-explore-theme"
-    hint="Colors may be adjusted for legibility"
-  />
+  <InputLabel label="Theme" {small} id="visual-explore-theme" />
 
   <FieldSwitcher
     {small}
     expand
     fields={["Presets", "Custom"]}
     selected={isPresetMode ? 0 : 1}
-    onClick={(_, field) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      handleModeSwitch(field);
+    onClick={(i, field) => {
+      handleModeSwitch(i, field);
     }}
   />
 
-  <div class="gap-y-2 flex flex-col">
-    {#if isPresetMode}
-      <Select
-        size={small ? "sm" : "lg"}
-        fontSize={small ? 12 : 14}
-        sameWidth
-        onChange={handleThemeSelection}
-        value={currentSelectValue}
-        options={[
-          projectDefaultTheme ? `Default (${projectDefaultTheme})` : "Default",
-          ...themeNames,
-        ].map((value) => ({
-          value: value.startsWith("Default") ? "Default" : value,
-          label: value,
-        }))}
-        id="theme"
+  {#if isPresetMode}
+    <Select
+      size={small ? "sm" : "lg"}
+      fontSize={small ? 12 : 14}
+      sameWidth
+      onChange={handleThemeSelection}
+      value={currentSelectValue}
+      options={[
+        projectDefaultTheme ? `Default (${projectDefaultTheme})` : "Default",
+        ...themeNames,
+      ].map((value) => ({
+        value: value.startsWith("Default") ? "Default" : value,
+        label: value,
+      }))}
+      id="theme"
+    />
+  {/if}
+
+  {#if hasTheme || editing}
+    <div class="sections-container">
+      <ThemePropertySections
+        values={displayValues}
+        onPropertyChange={handlePropertyChange}
       />
-    {/if}
-
-    <ColorInput
-      {small}
-      stringColor={effectivePrimary}
-      label="Primary"
-      labelFirst
-      disabled={isPresetMode}
-      allowLightnessControl
-      onChange={(color) => {
-        handleColorChange(color, true);
-      }}
-    />
-
-    <ColorInput
-      {small}
-      stringColor={effectiveSecondary}
-      label="Secondary"
-      labelFirst
-      disabled={isPresetMode}
-      allowLightnessControl
-      onChange={(color) => {
-        handleColorChange(color, false);
-      }}
-    />
-  </div>
+    </div>
+  {/if}
 </div>
+
+<style lang="postcss">
+  .sections-container {
+    @apply max-h-[60vh] overflow-y-auto;
+  }
+</style>

--- a/web-common/src/features/visual-editing/ThemeInput.svelte
+++ b/web-common/src/features/visual-editing/ThemeInput.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Button from "@rilldata/web-common/components/button/Button.svelte";
   import FieldSwitcher from "@rilldata/web-common/components/forms/FieldSwitcher.svelte";
   import InputLabel from "@rilldata/web-common/components/forms/InputLabel.svelte";
   import Select from "@rilldata/web-common/components/forms/Select.svelte";
@@ -148,6 +149,15 @@
       }))}
       id="theme"
     />
+
+    {#if themeFilePath}
+      <div class="edit-file-btn-wrapper">
+        <Button type="secondary" small onClick={handleEditThemeFile}>
+          <Pencil size="12" />
+          Edit theme file
+        </Button>
+      </div>
+    {/if}
   {/if}
 
   {#if hasTheme || editing}
@@ -158,13 +168,6 @@
         readonly={isPresetMode}
       />
     </div>
-
-    {#if isPresetMode && themeFilePath}
-      <button type="button" class="edit-file-btn" onclick={handleEditThemeFile}>
-        <Pencil size="12" />
-        <span>Edit theme file</span>
-      </button>
-    {/if}
   {/if}
 </div>
 
@@ -173,13 +176,11 @@
     @apply max-h-[60vh] overflow-y-auto;
   }
 
-  .edit-file-btn {
-    @apply mt-1 inline-flex items-center gap-x-1.5 self-start;
-    @apply text-xs font-medium text-fg-secondary;
-    @apply px-2 py-1 rounded border border-border bg-surface-base;
+  .edit-file-btn-wrapper {
+    @apply w-full;
   }
 
-  .edit-file-btn:hover {
-    @apply bg-surface-hover text-fg-primary;
+  .edit-file-btn-wrapper :global(button) {
+    @apply w-full;
   }
 </style>

--- a/web-common/src/features/visual-editing/ThemeInput.svelte
+++ b/web-common/src/features/visual-editing/ThemeInput.svelte
@@ -2,13 +2,13 @@
   import FieldSwitcher from "@rilldata/web-common/components/forms/FieldSwitcher.svelte";
   import InputLabel from "@rilldata/web-common/components/forms/InputLabel.svelte";
   import Select from "@rilldata/web-common/components/forms/Select.svelte";
+  import { navigateToFile } from "@rilldata/web-common/layout/navigation/editor-routing";
   import type { V1ThemeSpec } from "@rilldata/web-common/runtime-client";
-  import { runtimeServicePutFile } from "@rilldata/web-common/runtime-client";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
+  import { Pencil } from "lucide-svelte";
   import { useTheme } from "../themes/selectors";
   import { themeControl } from "../themes/theme-control";
   import { themeEditorStore } from "./theme-editor-store";
-  import { buildThemeYaml } from "./theme-yaml-utils";
   import ThemePropertySections from "./ThemePropertySections.svelte";
 
   const runtimeClient = useRuntimeClient();
@@ -40,13 +40,16 @@
   $: inlineSpec =
     theme && typeof theme === "object" ? (theme as V1ThemeSpec) : undefined;
 
-  $: displayValues = editing
-    ? themeEditorStore.getValues(isDarkMode)
-    : getSpecValues(isPresetMode ? fetchedSpec : inlineSpec, isDarkMode);
+  $: displayValues =
+    editing && editorState.mode === "custom"
+      ? themeEditorStore.getValues(isDarkMode)
+      : getSpecValues(isPresetMode ? fetchedSpec : inlineSpec, isDarkMode);
 
   $: currentSelectValue = typeof theme === "string" ? theme : "Default";
 
   $: hasTheme = !!currentThemeName || !!projectDefaultTheme || !isPresetMode;
+
+  $: themeFilePath = themeResource?.meta?.filePaths?.[0];
 
   function getSpecValues(
     spec: V1ThemeSpec | undefined,
@@ -91,17 +94,12 @@
 
   let saveTimer: ReturnType<typeof setTimeout> | undefined;
 
+  // Only the Custom view is editable; Presets is view-only and routes the
+  // user to the YAML file via `Edit theme file`.
   function handlePropertyChange(key: string, value: string) {
-    if (!editing) {
-      const spec = isPresetMode ? fetchedSpec : inlineSpec;
-      if (spec) {
-        if (isPresetMode) {
-          const themeName = currentThemeName ?? projectDefaultTheme;
-          themeEditorStore.startEditing(spec, themeName);
-        } else {
-          themeEditorStore.startCustom(spec);
-        }
-      }
+    if (isPresetMode) return;
+    if (!editing && inlineSpec) {
+      themeEditorStore.startCustom(inlineSpec);
     }
     themeEditorStore.updateProperty(key, value, isDarkMode);
     debouncedSave();
@@ -109,26 +107,15 @@
 
   function debouncedSave() {
     clearTimeout(saveTimer);
-    saveTimer = setTimeout(autoSave, 800);
+    saveTimer = setTimeout(() => {
+      onInlineThemeChange(themeEditorStore.buildSpec());
+      themeEditorStore.markSaved();
+    }, 800);
   }
 
-  async function autoSave() {
-    const spec = themeEditorStore.buildSpec();
-
-    if (!isPresetMode || editorState.mode === "custom") {
-      onInlineThemeChange(spec);
-    } else {
-      const yamlContent = buildThemeYaml(spec);
-      const filePath = themeResource?.meta?.filePaths?.[0];
-      if (!filePath) return;
-
-      await runtimeServicePutFile(runtimeClient, {
-        path: filePath,
-        blob: yamlContent,
-      });
-    }
-
-    themeEditorStore.markSaved();
+  function handleEditThemeFile() {
+    if (!themeFilePath) return;
+    void navigateToFile(themeFilePath);
   }
 </script>
 
@@ -168,13 +155,31 @@
       <ThemePropertySections
         values={displayValues}
         onPropertyChange={handlePropertyChange}
+        readonly={isPresetMode}
       />
     </div>
+
+    {#if isPresetMode && themeFilePath}
+      <button type="button" class="edit-file-btn" onclick={handleEditThemeFile}>
+        <Pencil size="12" />
+        <span>Edit theme file</span>
+      </button>
+    {/if}
   {/if}
 </div>
 
 <style lang="postcss">
   .sections-container {
     @apply max-h-[60vh] overflow-y-auto;
+  }
+
+  .edit-file-btn {
+    @apply mt-1 inline-flex items-center gap-x-1.5 self-start;
+    @apply text-xs font-medium text-fg-secondary;
+    @apply px-2 py-1 rounded border border-border bg-surface-base;
+  }
+
+  .edit-file-btn:hover {
+    @apply bg-surface-hover text-fg-primary;
   }
 </style>

--- a/web-common/src/features/visual-editing/ThemePropertySections.svelte
+++ b/web-common/src/features/visual-editing/ThemePropertySections.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+  import {
+    isValidColor,
+    stringColorToHsl,
+  } from "@rilldata/web-common/components/color-picker/util";
+  import ColorSlider from "@rilldata/web-common/components/color-picker/ColorSlider.svelte";
+  import InputLabel from "@rilldata/web-common/components/forms/InputLabel.svelte";
+  import { Chip } from "@rilldata/web-common/components/chip";
+  import * as Popover from "@rilldata/web-common/components/popover";
+  import { slide } from "svelte/transition";
+  import { THEME_SECTIONS } from "./theme-property-config";
+
+  export let values: Record<string, string>;
+  export let onPropertyChange: (key: string, value: string) => void;
+
+  // Track open/closed state per section
+  let openSections: Record<string, boolean> = {};
+  for (const section of THEME_SECTIONS) {
+    openSections[section.id] = section.defaultOpen ?? false;
+  }
+
+  // Color picker state per property (keyed by prop key)
+  let colorState: Record<string, { h: number; s: number; l: number }> = {};
+
+  function getHsl(key: string, stringColor: string | undefined) {
+    if (!colorState[key]) {
+      const parsed = stringColorToHsl(stringColor);
+      colorState[key] = { h: parsed.h, s: parsed.s, l: parsed.l };
+    }
+    return colorState[key];
+  }
+
+  function updateColorState(key: string, stringColor: string | undefined) {
+    const parsed = stringColorToHsl(stringColor);
+    colorState[key] = { h: parsed.h, s: parsed.s, l: parsed.l };
+  }
+
+  function hslString(state: { h: number; s: number; l: number }) {
+    return `hsl(${state.h}, ${state.s}%, ${state.l}%)`;
+  }
+</script>
+
+<div class="sections">
+  {#each THEME_SECTIONS as section (section.id)}
+    <div class="section">
+      <Chip
+        gray
+        caret
+        active={openSections[section.id]}
+        label={section.label}
+        slideDuration={0}
+        onclick={() => {
+          openSections[section.id] = !openSections[section.id];
+        }}
+      >
+        <span slot="body" class="text-xs font-semibold">{section.label}</span>
+      </Chip>
+
+      {#if openSections[section.id]}
+        <div class="properties" transition:slide={{ duration: 150 }}>
+          {#each section.properties as prop (prop.key)}
+            {@const colorValue = values[prop.key] ?? ""}
+            {@const cs = getHsl(prop.key, colorValue)}
+            <div class="property-row">
+              <Popover.Root
+                onOpenChange={(open) => {
+                  if (open) updateColorState(prop.key, colorValue);
+                }}
+              >
+                <Popover.Trigger>
+                  {#snippet child({ props: triggerProps })}
+                    <button
+                      {...triggerProps}
+                      class="swatch"
+                      class:swatch-empty={!colorValue}
+                      style:background-color={colorValue || "#e5e7eb"}
+                    ></button>
+                  {/snippet}
+                </Popover.Trigger>
+                <Popover.Content
+                  class="w-[270px] space-y-1.5"
+                  align="start"
+                  sideOffset={10}
+                >
+                  <div class="space-y-0.5 -mt-1">
+                    <InputLabel label="Hue" id="hue-{prop.key}" />
+                    <ColorSlider
+                      mode="hue"
+                      bind:value={cs.h}
+                      hue={cs.h}
+                      color={hslString(cs)}
+                      onChange={() => {
+                        const c = `hsl(${cs.h}, ${cs.s}%, ${cs.l}%)`;
+                        values[prop.key] = c;
+                        onPropertyChange(prop.key, c);
+                      }}
+                    />
+                  </div>
+                  <div class="space-y-0.5">
+                    <InputLabel label="Saturation" id="sat-{prop.key}" />
+                    <ColorSlider
+                      mode="saturation"
+                      bind:value={cs.s}
+                      hue={cs.h}
+                      color={hslString(cs)}
+                      onChange={() => {
+                        const c = `hsl(${cs.h}, ${cs.s}%, ${cs.l}%)`;
+                        values[prop.key] = c;
+                        onPropertyChange(prop.key, c);
+                      }}
+                    />
+                  </div>
+                  <div class="space-y-0.5">
+                    <InputLabel label="Lightness" id="light-{prop.key}" />
+                    <ColorSlider
+                      mode="lightness"
+                      bind:value={cs.l}
+                      hue={cs.h}
+                      color={hslString(cs)}
+                      onChange={() => {
+                        const c = `hsl(${cs.h}, ${cs.s}%, ${cs.l}%)`;
+                        values[prop.key] = c;
+                        onPropertyChange(prop.key, c);
+                      }}
+                    />
+                  </div>
+                </Popover.Content>
+              </Popover.Root>
+
+              <span class="prop-label">{prop.label}</span>
+
+              <input
+                class="hex-input"
+                class:text-red-500={colorValue && !isValidColor(colorValue)}
+                value={colorValue}
+                placeholder=""
+                onkeydown={(e) => {
+                  if (e.key === "Enter") {
+                    e.currentTarget.blur();
+                  }
+                }}
+                onblur={(e) => {
+                  const v = e.currentTarget.value;
+                  if (v) {
+                    values[prop.key] = v;
+                    onPropertyChange(prop.key, v);
+                    updateColorState(prop.key, v);
+                  }
+                }}
+              />
+            </div>
+          {/each}
+        </div>
+      {/if}
+    </div>
+  {/each}
+</div>
+
+<style lang="postcss">
+  .sections {
+    @apply flex flex-col gap-y-1;
+  }
+
+  .properties {
+    @apply flex flex-col py-1 px-0.5;
+  }
+
+  .property-row {
+    @apply flex items-center gap-x-2.5 py-1.5 px-1 pr-2 flex-wrap;
+  }
+
+  .swatch {
+    @apply w-5 h-5 rounded flex-none border-0 cursor-pointer;
+    @apply ring-1 ring-black/10;
+  }
+
+  .swatch:hover {
+    @apply ring-2 ring-black/20;
+  }
+
+  .swatch-empty {
+    @apply bg-gray-200;
+  }
+
+  .prop-label {
+    @apply text-xs text-fg-primary flex-shrink-0;
+    width: 80px;
+  }
+
+  .hex-input {
+    @apply flex-1 min-w-0 text-xs text-right text-fg-muted;
+    @apply bg-transparent outline-none;
+    @apply border border-gray-200 rounded px-1.5 py-0.5;
+  }
+
+  .hex-input:focus {
+    @apply text-fg-primary border-primary-400;
+  }
+
+  .hex-input:disabled {
+    @apply opacity-50;
+  }
+</style>

--- a/web-common/src/features/visual-editing/ThemePropertySections.svelte
+++ b/web-common/src/features/visual-editing/ThemePropertySections.svelte
@@ -12,6 +12,12 @@
 
   export let values: Record<string, string>;
   export let onPropertyChange: (key: string, value: string) => void;
+  /**
+   * When true, render the section read-only: the color swatch is not
+   * clickable and the hex input cannot be edited. Used for the "Presets"
+   * view where the YAML file is the source of truth.
+   */
+  export let readonly = false;
 
   // Track open/closed state per section
   let openSections: Record<string, boolean> = {};
@@ -62,70 +68,78 @@
             {@const colorValue = values[prop.key] ?? ""}
             {@const cs = getHsl(prop.key, colorValue)}
             <div class="property-row">
-              <Popover.Root
-                onOpenChange={(open) => {
-                  if (open) updateColorState(prop.key, colorValue);
-                }}
-              >
-                <Popover.Trigger>
-                  {#snippet child({ props: triggerProps })}
-                    <button
-                      {...triggerProps}
-                      class="swatch"
-                      class:swatch-empty={!colorValue}
-                      style:background-color={colorValue || "#e5e7eb"}
-                    ></button>
-                  {/snippet}
-                </Popover.Trigger>
-                <Popover.Content
-                  class="w-[270px] space-y-1.5"
-                  align="start"
-                  sideOffset={10}
+              {#if readonly}
+                <div
+                  class="swatch swatch-readonly"
+                  class:swatch-empty={!colorValue}
+                  style:background-color={colorValue || "#e5e7eb"}
+                ></div>
+              {:else}
+                <Popover.Root
+                  onOpenChange={(open) => {
+                    if (open) updateColorState(prop.key, colorValue);
+                  }}
                 >
-                  <div class="space-y-0.5 -mt-1">
-                    <InputLabel label="Hue" id="hue-{prop.key}" />
-                    <ColorSlider
-                      mode="hue"
-                      bind:value={cs.h}
-                      hue={cs.h}
-                      color={hslString(cs)}
-                      onChange={() => {
-                        const c = `hsl(${cs.h}, ${cs.s}%, ${cs.l}%)`;
-                        values[prop.key] = c;
-                        onPropertyChange(prop.key, c);
-                      }}
-                    />
-                  </div>
-                  <div class="space-y-0.5">
-                    <InputLabel label="Saturation" id="sat-{prop.key}" />
-                    <ColorSlider
-                      mode="saturation"
-                      bind:value={cs.s}
-                      hue={cs.h}
-                      color={hslString(cs)}
-                      onChange={() => {
-                        const c = `hsl(${cs.h}, ${cs.s}%, ${cs.l}%)`;
-                        values[prop.key] = c;
-                        onPropertyChange(prop.key, c);
-                      }}
-                    />
-                  </div>
-                  <div class="space-y-0.5">
-                    <InputLabel label="Lightness" id="light-{prop.key}" />
-                    <ColorSlider
-                      mode="lightness"
-                      bind:value={cs.l}
-                      hue={cs.h}
-                      color={hslString(cs)}
-                      onChange={() => {
-                        const c = `hsl(${cs.h}, ${cs.s}%, ${cs.l}%)`;
-                        values[prop.key] = c;
-                        onPropertyChange(prop.key, c);
-                      }}
-                    />
-                  </div>
-                </Popover.Content>
-              </Popover.Root>
+                  <Popover.Trigger>
+                    {#snippet child({ props: triggerProps })}
+                      <button
+                        {...triggerProps}
+                        class="swatch"
+                        class:swatch-empty={!colorValue}
+                        style:background-color={colorValue || "#e5e7eb"}
+                      ></button>
+                    {/snippet}
+                  </Popover.Trigger>
+                  <Popover.Content
+                    class="w-[270px] space-y-1.5"
+                    align="start"
+                    sideOffset={10}
+                  >
+                    <div class="space-y-0.5 -mt-1">
+                      <InputLabel label="Hue" id="hue-{prop.key}" />
+                      <ColorSlider
+                        mode="hue"
+                        bind:value={cs.h}
+                        hue={cs.h}
+                        color={hslString(cs)}
+                        onChange={() => {
+                          const c = `hsl(${cs.h}, ${cs.s}%, ${cs.l}%)`;
+                          values[prop.key] = c;
+                          onPropertyChange(prop.key, c);
+                        }}
+                      />
+                    </div>
+                    <div class="space-y-0.5">
+                      <InputLabel label="Saturation" id="sat-{prop.key}" />
+                      <ColorSlider
+                        mode="saturation"
+                        bind:value={cs.s}
+                        hue={cs.h}
+                        color={hslString(cs)}
+                        onChange={() => {
+                          const c = `hsl(${cs.h}, ${cs.s}%, ${cs.l}%)`;
+                          values[prop.key] = c;
+                          onPropertyChange(prop.key, c);
+                        }}
+                      />
+                    </div>
+                    <div class="space-y-0.5">
+                      <InputLabel label="Lightness" id="light-{prop.key}" />
+                      <ColorSlider
+                        mode="lightness"
+                        bind:value={cs.l}
+                        hue={cs.h}
+                        color={hslString(cs)}
+                        onChange={() => {
+                          const c = `hsl(${cs.h}, ${cs.s}%, ${cs.l}%)`;
+                          values[prop.key] = c;
+                          onPropertyChange(prop.key, c);
+                        }}
+                      />
+                    </div>
+                  </Popover.Content>
+                </Popover.Root>
+              {/if}
 
               <span class="prop-label">{prop.label}</span>
 
@@ -134,12 +148,15 @@
                 class:text-red-500={colorValue && !isValidColor(colorValue)}
                 value={colorValue}
                 placeholder=""
+                {readonly}
+                tabindex={readonly ? -1 : 0}
                 onkeydown={(e) => {
                   if (e.key === "Enter") {
                     e.currentTarget.blur();
                   }
                 }}
                 onblur={(e) => {
+                  if (readonly) return;
                   const v = e.currentTarget.value;
                   if (v) {
                     values[prop.key] = v;
@@ -176,6 +193,14 @@
 
   .swatch:hover {
     @apply ring-2 ring-black/20;
+  }
+
+  .swatch-readonly {
+    @apply cursor-default;
+  }
+
+  .swatch-readonly:hover {
+    @apply ring-1 ring-black/10;
   }
 
   .swatch-empty {

--- a/web-common/src/features/visual-editing/theme-editor-store.ts
+++ b/web-common/src/features/visual-editing/theme-editor-store.ts
@@ -1,0 +1,152 @@
+import type {
+  V1ThemeSpec,
+  V1ThemeColors,
+} from "@rilldata/web-common/runtime-client";
+import { get, writable } from "svelte/store";
+import { Theme } from "../themes/theme";
+import { themePreviewOverride } from "../themes/selectors";
+
+interface ThemeEditorState {
+  mode: "presets" | "custom";
+  editing: boolean;
+  selectedThemeName: string | undefined;
+  baseSpec: V1ThemeSpec | undefined;
+  // Edits keyed by variable name, per light/dark mode
+  lightEdits: Record<string, string>;
+  darkEdits: Record<string, string>;
+}
+
+const initialState: ThemeEditorState = {
+  mode: "presets",
+  editing: false,
+  selectedThemeName: undefined,
+  baseSpec: undefined,
+  lightEdits: {},
+  darkEdits: {},
+};
+
+function createThemeEditorStore() {
+  const store = writable<ThemeEditorState>({ ...initialState });
+
+  function getBaseValues(
+    spec: V1ThemeSpec | undefined,
+    isDark: boolean,
+  ): Record<string, string> {
+    if (!spec) return {};
+    const modeColors: V1ThemeColors | undefined = isDark
+      ? spec.dark
+      : spec.light;
+    if (!modeColors) return {};
+
+    const result: Record<string, string> = {};
+    if (modeColors.primary) result.primary = modeColors.primary;
+    if (modeColors.secondary) result.secondary = modeColors.secondary;
+    if (modeColors.variables) {
+      Object.assign(result, modeColors.variables);
+    }
+    return result;
+  }
+
+  function buildSpecFromState(state: ThemeEditorState): V1ThemeSpec {
+    const base = state.baseSpec ?? {};
+    const lightBase = getBaseValues(base, false);
+    const darkBase = getBaseValues(base, true);
+
+    const mergedLight = { ...lightBase, ...state.lightEdits };
+    const mergedDark = { ...darkBase, ...state.darkEdits };
+
+    return {
+      light: extractThemeColors(mergedLight),
+      dark: extractThemeColors(mergedDark),
+    };
+  }
+
+  function extractThemeColors(
+    flat: Record<string, string>,
+  ): V1ThemeColors | undefined {
+    const { primary, secondary, ...rest } = flat;
+    const variables = Object.keys(rest).length > 0 ? rest : undefined;
+    if (!primary && !secondary && !variables) return undefined;
+    return { primary, secondary, variables };
+  }
+
+  function updatePreview(state: ThemeEditorState) {
+    if (!state.editing) {
+      themePreviewOverride.set(undefined);
+      return;
+    }
+    const spec = buildSpecFromState(state);
+    themePreviewOverride.set(new Theme(spec));
+  }
+
+  return {
+    subscribe: store.subscribe,
+
+    startEditing(spec: V1ThemeSpec, themeName: string | undefined) {
+      const state: ThemeEditorState = {
+        mode: "presets",
+        editing: true,
+        selectedThemeName: themeName,
+        baseSpec: spec,
+        lightEdits: { ...getBaseValues(spec, false) },
+        darkEdits: { ...getBaseValues(spec, true) },
+      };
+      store.set(state);
+      updatePreview(state);
+    },
+
+    startCustom(spec: V1ThemeSpec) {
+      const state: ThemeEditorState = {
+        mode: "custom",
+        editing: true,
+        selectedThemeName: undefined,
+        baseSpec: spec,
+        lightEdits: { ...getBaseValues(spec, false) },
+        darkEdits: { ...getBaseValues(spec, true) },
+      };
+      store.set(state);
+      updatePreview(state);
+    },
+
+    updateProperty(key: string, value: string, isDarkMode: boolean) {
+      store.update((s) => {
+        if (isDarkMode) {
+          s.darkEdits = { ...s.darkEdits, [key]: value };
+        } else {
+          s.lightEdits = { ...s.lightEdits, [key]: value };
+        }
+        updatePreview(s);
+        return s;
+      });
+    },
+
+    /** Returns the current merged spec for YAML serialization on save */
+    buildSpec(): V1ThemeSpec {
+      return buildSpecFromState(get(store));
+    },
+
+    /** Returns the flat map of values for the given mode, merging base + edits */
+    getValues(isDarkMode: boolean): Record<string, string> {
+      const state = get(store);
+      const base = getBaseValues(state.baseSpec, isDarkMode);
+      const edits = isDarkMode ? state.darkEdits : state.lightEdits;
+      return { ...base, ...edits };
+    },
+
+    markSaved() {
+      store.update((s) => {
+        const newSpec = buildSpecFromState(s);
+        s.baseSpec = newSpec;
+        updatePreview(s);
+        return s;
+      });
+    },
+
+    exitEditing() {
+      store.set({ ...initialState });
+      themePreviewOverride.set(undefined);
+    },
+  };
+}
+
+export const themeEditorStore = createThemeEditorStore();

--- a/web-common/src/features/visual-editing/theme-property-config.ts
+++ b/web-common/src/features/visual-editing/theme-property-config.ts
@@ -1,0 +1,69 @@
+export interface ThemePropertyDef {
+  key: string;
+  label: string;
+}
+
+export interface ThemeSection {
+  id: string;
+  label: string;
+  properties: ThemePropertyDef[];
+  defaultOpen?: boolean;
+}
+
+export const THEME_SECTIONS: ThemeSection[] = [
+  {
+    id: "core",
+    label: "Core",
+    defaultOpen: true,
+    properties: [
+      { key: "primary", label: "Primary" },
+      { key: "secondary", label: "Secondary" },
+    ],
+  },
+  {
+    id: "surfaces",
+    label: "Surfaces",
+    properties: [
+      { key: "surface-subtle", label: "Subtle" },
+      { key: "surface-background", label: "Background" },
+      { key: "surface-card", label: "Card" },
+    ],
+  },
+  {
+    id: "foreground",
+    label: "Text / Foreground",
+    properties: [{ key: "fg-primary", label: "Primary" }],
+  },
+  {
+    id: "kpi",
+    label: "KPI",
+    properties: [
+      { key: "kpi-positive", label: "Positive" },
+      { key: "kpi-negative", label: "Negative" },
+    ],
+  },
+  {
+    id: "qualitative",
+    label: "Qualitative Palette",
+    properties: Array.from({ length: 24 }, (_, i) => ({
+      key: `color-qualitative-${i + 1}`,
+      label: `${i + 1}`,
+    })),
+  },
+  {
+    id: "sequential",
+    label: "Sequential Palette",
+    properties: Array.from({ length: 9 }, (_, i) => ({
+      key: `color-sequential-${i + 1}`,
+      label: `${i + 1}`,
+    })),
+  },
+  {
+    id: "diverging",
+    label: "Diverging Palette",
+    properties: Array.from({ length: 11 }, (_, i) => ({
+      key: `color-diverging-${i + 1}`,
+      label: `${i + 1}`,
+    })),
+  },
+];

--- a/web-common/src/features/visual-editing/theme-yaml-utils.ts
+++ b/web-common/src/features/visual-editing/theme-yaml-utils.ts
@@ -1,0 +1,61 @@
+import type {
+  V1ThemeSpec,
+  V1ThemeColors,
+} from "@rilldata/web-common/runtime-client";
+import { stringify } from "yaml";
+
+/**
+ * Serializes a V1ThemeSpec to a YAML string matching the format
+ * expected by runtime/parser/parse_theme.go.
+ */
+export function buildThemeYaml(spec: V1ThemeSpec): string {
+  const doc: Record<string, unknown> = { type: "theme" };
+
+  const light = flattenThemeColors(spec.light);
+  if (light && Object.keys(light).length > 0) {
+    doc.light = light;
+  }
+
+  const dark = flattenThemeColors(spec.dark);
+  if (dark && Object.keys(dark).length > 0) {
+    doc.dark = dark;
+  }
+
+  return stringify(doc, { lineWidth: 0 });
+}
+
+/**
+ * Flattens V1ThemeColors into a plain object with primary/secondary at top
+ * level and variables merged in (the format the YAML parser expects).
+ */
+function flattenThemeColors(
+  colors: V1ThemeColors | undefined,
+): Record<string, string> | undefined {
+  if (!colors) return undefined;
+
+  const result: Record<string, string> = {};
+  if (colors.primary) result.primary = colors.primary;
+  if (colors.secondary) result.secondary = colors.secondary;
+  if (colors.variables) {
+    Object.assign(result, colors.variables);
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+/**
+ * Converts a V1ThemeSpec into a plain object suitable for inline embedding
+ * in an explore/canvas YAML file (e.g. `parsedDocument.set("theme", obj)`).
+ */
+export function buildInlineThemeObject(
+  spec: V1ThemeSpec,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  const light = flattenThemeColors(spec.light);
+  if (light && Object.keys(light).length > 0) result.light = light;
+
+  const dark = flattenThemeColors(spec.dark);
+  if (dark && Object.keys(dark).length > 0) result.dark = dark;
+
+  return result;
+}

--- a/web-common/src/features/workspaces/VisualExploreEditing.svelte
+++ b/web-common/src/features/workspaces/VisualExploreEditing.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { replaceState } from "$app/navigation";
+  import { beforeNavigate, replaceState } from "$app/navigation";
   import Button from "@rilldata/web-common/components/button/Button.svelte";
   import Input from "@rilldata/web-common/components/forms/Input.svelte";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
@@ -38,6 +38,8 @@
   import MeasureDimensionSelector from "../visual-editing/MeasureDimensionSelector.svelte";
   import MultiSelectInput from "../visual-editing/MultiSelectInput.svelte";
   import SidebarWrapper from "../visual-editing/SidebarWrapper.svelte";
+  import { themeEditorStore } from "../visual-editing/theme-editor-store";
+  import { buildInlineThemeObject } from "../visual-editing/theme-yaml-utils";
   import ThemeInput from "../visual-editing/ThemeInput.svelte";
 
   const itemTypes = ["measures", "dimensions"] as const;
@@ -61,6 +63,11 @@
     },
     dashboardStore,
   } = StateManagers;
+
+  // Clean up theme editing state on navigation
+  beforeNavigate(() => {
+    themeEditorStore.exitEditing();
+  });
 
   $: if (exploreSpec) metricsExplorerStore.sync(exploreName, exploreSpec);
 
@@ -518,24 +525,8 @@
           updateProperties({ theme: value });
         }
       }}
-      onColorChange={(primary, secondary, isDarkMode) => {
-        const modeKey = isDarkMode ? "dark" : "light";
-        const altMode = isDarkMode ? "light" : "dark";
-
-        // check if theme exists for alt mode
-        const setAltMode = !parsedDocument.hasIn(["theme", altMode]);
-
-        parsedDocument.setIn(["theme", modeKey, "primary"], primary);
-        parsedDocument.setIn(["theme", modeKey, "secondary"], secondary);
-
-        if (setAltMode) {
-          parsedDocument.setIn(["theme", altMode, "primary"], primary);
-          parsedDocument.setIn(["theme", altMode, "secondary"], secondary);
-        }
-
-        killState();
-
-        updateEditorContent(parsedDocument.toString(), false, autoSave);
+      onInlineThemeChange={(spec) => {
+        updateProperties({ theme: buildInlineThemeObject(spec) });
       }}
     />
 


### PR DESCRIPTION
Broken off https://github.com/rilldata/rill/pull/8511, 

This should be a great feature for rill cloud editing not having to edit a #00ff32 YAML file and do it in-line with Dashboard.

<img width="275" height="327" alt="Screenshot 2026-04-29 at 11 04 32" src="https://github.com/user-attachments/assets/5afb6c96-c51c-4c11-bda7-a27b707e0b73" />
<img width="274" height="429" alt="Screenshot 2026-04-29 at 11 14 11" src="https://github.com/user-attachments/assets/6de9bc5b-f81c-49c4-9ad3-ffe0081da59b" />


Discussed with Di in the past and came to this design, tagging for final approval

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
