### PR TITLE
feat: Add `percentMode` config and improve percentage formatting for funnel charts

### DIFF
--- a/runtime/ai/create_chart.go
+++ b/runtime/ai/create_chart.go
@@ -254,6 +254,29 @@ func validateChartFields(chartType string, spec map[string]any, mvSpec *runtimev
 				return fmt.Errorf("invalid measure fields: %w", err)
 			}
 		}
+		// Optional enum-valued funnel fields. Cross-validation between breakdownMode
+		// and color (e.g. color "stage" requires dimension mode) is enforced by the
+		// chart renderer, which falls back to sensible defaults; we only reject typos here.
+		if breakdownMode, ok := spec["breakdownMode"]; ok {
+			if err := validateEnum("breakdownMode", breakdownMode, []string{"dimension", "measures"}); err != nil {
+				return err
+			}
+		}
+		if mode, ok := spec["mode"]; ok {
+			if err := validateEnum("mode", mode, []string{"width", "order"}); err != nil {
+				return err
+			}
+		}
+		if color, ok := spec["color"]; ok {
+			if err := validateEnum("color", color, []string{"stage", "measure", "name", "value"}); err != nil {
+				return err
+			}
+		}
+		if percentMode, ok := spec["percentMode"]; ok {
+			if err := validateEnum("percentMode", percentMode, []string{"top", "previous"}); err != nil {
+				return err
+			}
+		}
 
 	case "donut_chart", "pie_chart":
 		if colorField, ok := pathutil.GetPath(spec, "color.field"); ok {
@@ -334,6 +357,20 @@ func validateField(availableFields map[string]bool, field any) error {
 		return fmt.Errorf("field %q not found in metrics view", fieldStr)
 	}
 	return nil
+}
+
+// validateEnum checks that value is a string and one of the allowed options.
+func validateEnum(name string, value any, allowed []string) error {
+	str, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("%q must be a string", name)
+	}
+	for _, a := range allowed {
+		if str == a {
+			return nil
+		}
+	}
+	return fmt.Errorf("%q must be one of %v, got %q", name, allowed, str)
 }
 
 // validateFieldsArray validates an array of field names
@@ -852,6 +889,14 @@ number_of_commits: measure
 ### 7. Funnel Chart (` + "`funnel_chart`" + `)
 **Use for:** Showing flow through a process with decreasing values at each stage or measure
 
+**Funnel-specific fields:**
+- ` + "`breakdownMode`" + ` (required): ` + "`\"dimension\"`" + ` (one measure split by a stage dimension) or ` + "`\"measures\"`" + ` (multiple measures, one per stage)
+- ` + "`mode`" + `: ` + "`\"width\"`" + ` (bar width proportional to value, default) or ` + "`\"order\"`" + ` (bars shrink by fixed ratio in rank order)
+- ` + "`color`" + `:
+  - In ` + "`dimension`" + ` mode: ` + "`\"stage\"`" + ` (distinct color per stage) or ` + "`\"measure\"`" + ` (gradient by value)
+  - In ` + "`measures`" + ` mode: ` + "`\"name\"`" + ` (distinct color per measure) or ` + "`\"value\"`" + ` (gradient by value)
+- ` + "`percentMode`" + `: ` + "`\"top\"`" + ` (default; on-bar % is relative to the top stage) or ` + "`\"previous\"`" + ` (on-bar % is relative to the prior stage). The tooltip always shows both, regardless of this setting. Choose ` + "`\"previous\"`" + ` when the user asks about stage-to-stage drop-off or step conversion; choose ` + "`\"top\"`" + ` when they ask about overall conversion from the entry point.
+
 Example Specification with 1 dimension and 1 measure breakdown
 
 Field details:
@@ -875,6 +920,7 @@ total_users_measure: measure
       "type": "quantitative"
     },
     "mode": "width",
+    "percentMode": "top",
     "stage": {
       "field": "stage",
       "limit": 15,
@@ -884,7 +930,7 @@ total_users_measure: measure
 }
 ` + "```" + `
 
-Example Specification with multiple measures breakdown
+Example Specification with multiple measures breakdown and stage-to-stage percentages
 
 Field details:
 bids: metrics_view
@@ -910,7 +956,8 @@ impressions, video_starts, video_completes: measures
       ]
     },
     "metrics_view": "bids",
-    "mode": "width"
+    "mode": "width",
+    "percentMode": "previous"
   }
 }
 ` + "```" + `

--- a/runtime/ai/instructions/data/resources/canvas.md
+++ b/runtime/ai/instructions/data/resources/canvas.md
@@ -674,6 +674,7 @@ funnel_chart:
   breakdownMode: dimension
   color: stage
   mode: width
+  percentMode: top
   stage:
     field: funnel_stage
     type: nominal
@@ -683,7 +684,7 @@ funnel_chart:
     type: quantitative
 ```
 
-**With multiple measures breakdown:**
+**With multiple measures breakdown and step-to-step percentages:**
 
 ```yaml
 funnel_chart:
@@ -692,6 +693,7 @@ funnel_chart:
   breakdownMode: measures
   color: value
   mode: width
+  percentMode: previous
   measure:
     field: impressions
     type: quantitative
@@ -705,6 +707,11 @@ funnel_chart:
 **Breakdown modes and color options:**
 - `breakdownMode: dimension` with `color: stage` (different colors per stage) or `color: measure` (similar colors by value)
 - `breakdownMode: measures` with `color: name` (different colors per measure) or `color: value` (similar colors by value)
+
+**Percent mode (`percentMode`):**
+- `top` (default): the on-bar percentage label is each stage's value as a share of the top stage. Use for overall conversion ("how many of the entry-point users reached this stage").
+- `previous`: the on-bar percentage label is each stage's value as a share of the immediately prior stage. Use for stage-to-stage drop-off ("what fraction of the previous stage continued").
+- The tooltip always shows both `% of top` and `% of previous` regardless of this setting, so users can disambiguate without the author surfacing both.
 
 ### Pivot
 

--- a/runtime/canvas/component.go
+++ b/runtime/canvas/component.go
@@ -166,7 +166,22 @@ func validateFunnelChart(props map[string]any, metricsViews map[string]*runtimev
 		}
 	}
 
-	return validateOptionalDimensionField(mv, mvn, props, "stage.field")
+	if err := validateOptionalDimensionField(mv, mvn, props, "stage.field"); err != nil {
+		return err
+	}
+
+	// Optional enum-valued funnel fields. The renderer falls back to defaults for
+	// unknown values, but we reject typos here so authors get a clear error.
+	if err := validateOptionalStringEnum(props, "breakdownMode", []string{"dimension", "measures"}); err != nil {
+		return err
+	}
+	if err := validateOptionalStringEnum(props, "mode", []string{"width", "order"}); err != nil {
+		return err
+	}
+	if err := validateOptionalStringEnum(props, "color", []string{"stage", "measure", "name", "value"}); err != nil {
+		return err
+	}
+	return validateOptionalStringEnum(props, "percentMode", []string{"top", "previous"})
 }
 
 // validateHeatmap validates properties for heatmap.
@@ -474,6 +489,24 @@ func getOptionalPathString(props map[string]any, path string) (string, bool, err
 		return "", false, fmt.Errorf("renderer property %q is malformed: must be a string", path)
 	}
 	return s, true, nil
+}
+
+// validateOptionalStringEnum validates that an optional string field at the given
+// path, if present, equals one of the allowed values.
+func validateOptionalStringEnum(props map[string]any, path string, allowed []string) error {
+	value, ok, err := getOptionalPathString(props, path)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	for _, a := range allowed {
+		if value == a {
+			return nil
+		}
+	}
+	return fmt.Errorf("renderer property %q must be one of %v, got %q", path, allowed, value)
 }
 
 // metricsViewHasDimension returns true if the metrics view has a dimension with the given name.

--- a/runtime/metricsview/charts_json_schema.go
+++ b/runtime/metricsview/charts_json_schema.go
@@ -103,6 +103,11 @@ const ChartsJSONSchema = `{
           "type": "string",
           "description": "Display mode for the chart."
         },
+        "percentMode": {
+          "type": "string",
+          "enum": ["top", "previous"],
+          "description": "For funnel charts: reference for the on-bar percentage label. 'top' shows each stage as % of the top stage; 'previous' shows each stage as % of the prior stage. Tooltip always shows both regardless of this setting."
+        },
         "show_data_labels": {
           "type": "boolean",
           "description": "Whether to show data labels on the chart."

--- a/web-common/src/features/canvas/components/charts/variants/FunnelChart.ts
+++ b/web-common/src/features/canvas/components/charts/variants/FunnelChart.ts
@@ -96,6 +96,17 @@ export class FunnelChartComponent extends BaseChart<FunnelCanvasChartSpec> {
         ],
       },
     },
+    percentMode: {
+      type: "switcher_tab",
+      label: "Percent of",
+      meta: {
+        default: "top",
+        options: [
+          { label: "Top", value: "top" },
+          { label: "Previous", value: "previous" },
+        ],
+      },
+    },
   };
 
   constructor(resource: V1Resource, parent: CanvasEntity, path: ComponentPath) {
@@ -258,6 +269,7 @@ export class FunnelChartComponent extends BaseChart<FunnelCanvasChartSpec> {
       mode: "width",
       color: "stage",
       breakdownMode: "dimension",
+      percentMode: "top",
     };
   }
 }

--- a/web-common/src/features/components/charts/funnel/FunnelChartProvider.ts
+++ b/web-common/src/features/components/charts/funnel/FunnelChartProvider.ts
@@ -30,6 +30,7 @@ import { getFilterWithNullHandling } from "../query-util";
 export type FunnelMode = "width" | "order";
 export type FunnelColorMode = "stage" | "measure" | "name" | "value";
 export type FunnelBreakdownMode = "dimension" | "measures";
+export type FunnelPercentMode = "top" | "previous";
 
 export type FunnelChartSpec = {
   metrics_view: string;
@@ -38,6 +39,7 @@ export type FunnelChartSpec = {
   stage?: FieldConfig<"nominal">;
   mode?: FunnelMode;
   color?: FunnelColorMode;
+  percentMode?: FunnelPercentMode;
 };
 
 export type FunnelChartDefaultOptions = {

--- a/web-common/src/features/components/charts/funnel/spec.ts
+++ b/web-common/src/features/components/charts/funnel/spec.ts
@@ -283,7 +283,10 @@ export function generateVLFunnelChartSpec(
 
   // Main bar layer
   const barLayer: UnitSpec<Field> = {
-    mark: "bar",
+    mark: {
+      type: "bar",
+      cornerRadius: 4,
+    },
     encoding: {
       x: {
         field: "funnel_width",

--- a/web-common/src/features/components/charts/funnel/spec.ts
+++ b/web-common/src/features/components/charts/funnel/spec.ts
@@ -11,7 +11,7 @@ import {
 } from "../builder";
 import type { ChartDataResult } from "../types";
 import { resolveCSSVariable } from "../util";
-import type { FunnelChartSpec } from "./FunnelChartProvider";
+import type { FunnelChartSpec, FunnelPercentMode } from "./FunnelChartProvider";
 import {
   createFunnelSortEncoding,
   getFormatType,
@@ -51,72 +51,98 @@ function createModeTransforms(
   }
 }
 
+// Format a numeric percentage (0-100) at one decimal, then drop a trailing `.0`
+// so 32.1% stays "32.1%" but 32.0% becomes "32%". Keeps round numbers clean
+// while letting neighboring values stay visually distinct.
+function formatPercentExpr(valueExpr: string): string {
+  return (
+    `(!isValid(${valueExpr}) ? '' : ` +
+    `replace(format(${valueExpr}, '.1f'), /\\.0$/, '') + '%')`
+  );
+}
+
 function createPercentageTransforms(
   measureField: string | undefined,
   funnelSort: string[] | null,
   stageField: string | undefined,
   isMultiMeasure: boolean,
+  percentMode: FunnelPercentMode | undefined,
 ): Transform[] {
+  const valueExpr = isMultiMeasure
+    ? "datum.value"
+    : `datum['${sanitizeValueForVega(measureField!)}']`;
+  const transforms: Transform[] = [];
+
   if (isMultiMeasure) {
-    return [
-      {
-        window: [
-          {
-            op: "first_value",
-            field: "value",
-            as: "reference_value",
-          },
-        ],
-      },
-      {
-        calculate: `round((datum.value / datum.reference_value) * 100) + '%'`,
-        as: "percentage",
-      },
-    ];
-  } else {
-    const transforms: Transform[] = [];
-
-    if (Array.isArray(funnelSort) && funnelSort.length > 0 && stageField) {
-      // Use joinaggregate to create a reference value field
-      const firstStageInSort = funnelSort[0];
-      transforms.push(
-        {
-          // Mark rows that match the first stage in custom sort
-          calculate: `datum['${sanitizeValueForVega(stageField)}'] === '${sanitizeValueForVega(firstStageInSort)}' ? datum['${sanitizeValueForVega(measureField!)}'] : 0`,
-          as: "is_reference_stage",
-        },
-        {
-          // Use joinaggregate to get the maximum value where is_reference_stage > 0
-          // This gives us the measure value for the first stage in custom sort
-          joinaggregate: [
-            {
-              op: "max",
-              field: "is_reference_stage",
-              as: "reference_value",
-            },
-          ],
-        },
-      );
-    } else {
-      // For non-custom sort, use the first value in data order
-      transforms.push({
-        window: [
-          {
-            op: "first_value",
-            field: measureField!,
-            as: "reference_value",
-          },
-        ],
-      });
-    }
-
+    // Multi-measure: rows arrive in fold order, which matches the user-configured
+    // measure order. Use that as the funnel order for both reference computations.
     transforms.push({
-      calculate: `round((datum['${sanitizeValueForVega(measureField!)}'] / datum.reference_value) * 100) + '%'`,
-      as: "percentage",
+      window: [
+        { op: "first_value", field: "value", as: "top_value" },
+        { op: "lag", field: "value", as: "prev_value" },
+      ],
     });
+  } else if (Array.isArray(funnelSort) && funnelSort.length > 0 && stageField) {
+    // Custom sort: explicit stage order. Tag each row with its position in the
+    // sort array so we can derive both top and previous values via window ops.
+    const sanitizedStage = sanitizeValueForVega(stageField);
+    const positionExpr =
+      funnelSort
+        .map(
+          (stage, idx) =>
+            `datum['${sanitizedStage}'] === '${sanitizeValueForVega(stage)}' ? ${idx} : `,
+        )
+        .join("") + `${funnelSort.length}`;
 
-    return transforms;
+    transforms.push(
+      { calculate: positionExpr, as: "funnel_position" },
+      {
+        window: [
+          { op: "first_value", field: measureField!, as: "top_value" },
+          { op: "lag", field: measureField!, as: "prev_value" },
+        ],
+        sort: [{ field: "funnel_position", order: "ascending" }],
+      },
+    );
+  } else {
+    // Default sort: data is sorted by measure (asc/desc) at query time, so first
+    // row is the top of the funnel and lag returns the immediately prior stage.
+    transforms.push({
+      window: [
+        { op: "first_value", field: measureField!, as: "top_value" },
+        { op: "lag", field: measureField!, as: "prev_value" },
+      ],
+    });
   }
+
+  transforms.push(
+    {
+      calculate: `(${valueExpr} / datum.top_value) * 100`,
+      as: "pct_of_top_num",
+    },
+    {
+      // Top stage has no previous; show 100% there.
+      calculate: `!isValid(datum.prev_value) ? 100 : (${valueExpr} / datum.prev_value) * 100`,
+      as: "pct_of_prev_num",
+    },
+    {
+      calculate: formatPercentExpr("datum.pct_of_top_num"),
+      as: "pct_of_top",
+    },
+    {
+      calculate: formatPercentExpr("datum.pct_of_prev_num"),
+      as: "pct_of_previous",
+    },
+    {
+      calculate:
+        percentMode === "previous"
+          ? "datum.pct_of_previous"
+          : "datum.pct_of_top",
+      as: "percentage",
+    },
+  );
+
+  return transforms;
 }
 
 export function generateVLFunnelChartSpec(
@@ -165,6 +191,19 @@ export function generateVLFunnelChartSpec(
     ? { field: "Measure", type: "nominal" as const }
     : createPositionEncoding(config.stage, data);
 
+  const percentTooltipFields = [
+    {
+      field: "pct_of_top",
+      title: "% of top",
+      type: "nominal" as const,
+    },
+    {
+      field: "pct_of_previous",
+      title: "% of previous",
+      type: "nominal" as const,
+    },
+  ];
+
   const tooltip = isMultiMeasure
     ? [
         {
@@ -173,8 +212,12 @@ export function generateVLFunnelChartSpec(
           title: "Measure",
         },
         { field: "value", title: "Value", type: "quantitative" as const },
+        ...percentTooltipFields,
       ]
-    : createDefaultTooltipEncoding([config.stage, config.measure], data);
+    : [
+        ...createDefaultTooltipEncoding([config.stage, config.measure], data),
+        ...percentTooltipFields,
+      ];
 
   const funnelSort = isMultiMeasure
     ? getMultiMeasures(config.measure)
@@ -214,6 +257,7 @@ export function generateVLFunnelChartSpec(
       Array.isArray(funnelSort) ? funnelSort : null,
       config.stage?.field,
       isMultiMeasure,
+      config.percentMode,
     );
 
     transforms.push(...modeTransforms, ...percentageTransforms);
@@ -301,6 +345,7 @@ export function generateVLFunnelChartSpec(
     mark: {
       type: "text",
       fontWeight: 600,
+      fontSize: 14,
       dx: {
         expr: `-(scale('x', datum['funnel_width']) / 2)`,
       },


### PR DESCRIPTION
- Add `percentMode` (`top` | `previous`, default `top`) to funnel chart spec so authors can pick whether on-bar percentages reference the top of the funnel or the previous stage.
- Tooltip now always shows both `% of top` and `% of previous` regardless of the configured mode, so end-users can disambiguate without the author surfacing both.
- Switch percentage formatting to one decimal with trailing `.0` stripped (`32%`, `32.1%`) so neighboring values stay visually distinct while round numbers stay clean.

Closes https://linear.app/rilldata/issue/APP-821/canvas-funnel-chart-percentage-ambiguous-add-reference-label-decimal

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
