### PR TITLE
Replace `Done` with `Exit` button in header of cloud editor

### DIFF
--- a/web-admin/src/features/edit-session/EditActions.svelte
+++ b/web-admin/src/features/edit-session/EditActions.svelte
@@ -3,7 +3,7 @@
   import { Button } from "@rilldata/web-common/components/button";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
-  import { GitPullRequestCreateArrow } from "lucide-svelte";
+  import { GitPullRequestCreateArrow, LogOut } from "lucide-svelte";
   import CommitPopover from "./CommitPopover.svelte";
 
   export let organization: string;
@@ -20,13 +20,6 @@
   }
 </script>
 
-<Tooltip distance={8}>
-  <Button type="secondary" href={closeHref} onClick={handleClose}>Done</Button>
-  <TooltipContent slot="tooltip-content" maxWidth="200px">
-    <span class="text-xs">Return to project home</span>
-  </TooltipContent>
-</Tooltip>
-
 <CommitPopover />
 
 <Tooltip distance={8}>
@@ -36,5 +29,15 @@
   </Button>
   <TooltipContent slot="tooltip-content" maxWidth="200px">
     <span class="text-xs">Coming soon</span>
+  </TooltipContent>
+</Tooltip>
+
+<Tooltip distance={8}>
+  <Button type="secondary" href={closeHref} onClick={handleClose}>
+    <LogOut size="14" />
+    Exit
+  </Button>
+  <TooltipContent slot="tooltip-content" maxWidth="200px">
+    <span class="text-xs">Return to project home</span>
   </TooltipContent>
 </Tooltip>


### PR DESCRIPTION
- Renames the secondary close button from "Done" to "Exit" and adds a `LogOut` icon.
- Moves the button to the right of the "Open PR" button to match the updated design.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*