### PR TITLE
fix: pixel-based truncation for branch pill in header

### DIFF
--- a/web-admin/src/features/branches/BranchSelector.svelte
+++ b/web-admin/src/features/branches/BranchSelector.svelte
@@ -60,9 +60,7 @@
   $: currentDeployment = isOnBranch
     ? deployments.find((d) => d.branch === activeBranch)
     : deployments.find(isProdDeployment);
-  $: branchLabel = isOnBranch
-    ? (activeBranch ?? "")
-    : (primaryBranch ?? "");
+  $: branchLabel = isOnBranch ? (activeBranch ?? "") : (primaryBranch ?? "");
 
   function getDeploymentHref(deployment: V1Deployment): string {
     const basePath = removeBranchFromPath($page.url.pathname);

--- a/web-admin/src/features/branches/BranchSelector.svelte
+++ b/web-admin/src/features/branches/BranchSelector.svelte
@@ -60,14 +60,9 @@
   $: currentDeployment = isOnBranch
     ? deployments.find((d) => d.branch === activeBranch)
     : deployments.find(isProdDeployment);
-  $: triggerLabel = isOnBranch
-    ? truncateBranch(activeBranch ?? "")
-    : truncateBranch(primaryBranch ?? "");
-
-  function truncateBranch(branch: string): string {
-    if (branch.length <= 20) return branch;
-    return branch.slice(0, 19) + "…";
-  }
+  $: branchLabel = isOnBranch
+    ? (activeBranch ?? "")
+    : (primaryBranch ?? "");
 
   function getDeploymentHref(deployment: V1Deployment): string {
     const basePath = removeBranchFromPath($page.url.pathname);
@@ -96,10 +91,10 @@
     <DropdownMenu.Root bind:open>
       <DropdownMenu.Trigger>
         {#snippet child({ props })}
-          <button {...props} class="chip">
+          <button {...props} class="chip" title={branchLabel}>
             <span class="status-dot {statusDot(currentDeployment?.status)}"
             ></span>
-            <span>{triggerLabel}</span>
+            <span class="branch-label">{branchLabel}</span>
             <span class="caret" class:open>
               <CaretDownIcon size="10px" />
             </span>
@@ -162,6 +157,10 @@
 
   .status-dot {
     @apply size-1.5 rounded-full flex-none;
+  }
+
+  .branch-label {
+    @apply truncate max-w-[200px];
   }
 
   .caret {

--- a/web-admin/src/features/projects/ProjectHeader.svelte
+++ b/web-admin/src/features/projects/ProjectHeader.svelte
@@ -183,11 +183,10 @@
         {#if editContext && activeBranch}
           <li class="flex items-center mr-2">
             <span
-              class="flex items-center gap-x-1 px-2 py-0 rounded-2xl border bg-primary-50 border-primary-200 text-primary-800"
+              class="inline-block truncate max-w-[200px] px-2 py-0 rounded-2xl border bg-primary-50 border-primary-200 text-primary-800"
+              title={activeBranch}
             >
-              {activeBranch.length > 12
-                ? activeBranch.slice(0, 11) + "…"
-                : activeBranch}
+              {activeBranch}
             </span>
           </li>
         {:else if !onPublicURLPage && projectPermissions?.readDev}


### PR DESCRIPTION
- Branch pill in the cloud header was truncating at a fixed character count (12 in edit context, 20 in `BranchSelector`), which truncated narrow branch names too aggressively and ignored available space.
- Switched both chips to CSS truncation (`truncate max-w-[200px]`) so they cut off at the actual pixel boundary and surface the full branch name on hover via `title`.
- Removed the now-unused `truncateBranch` helper from `BranchSelector.svelte`.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
*Developed in collaboration with Claude Code*