### PR TITLE
fix: cloud project welcome page changes connector layout

### DIFF
--- a/web-admin/src/routes/[organization]/[project]/-/edit/welcome/add-data/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/welcome/add-data/+page.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import { page } from "$app/state";
-  import { onMount } from "svelte";
   import AddDataManager from "@rilldata/web-common/features/add-data/manager/AddDataManager.svelte";
   import { AddDataStep } from "@rilldata/web-common/features/add-data/manager/steps/types.ts";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
-  import { fetchAnalyzeConnectors } from "@rilldata/web-common/features/connectors/selectors.ts";
   import { projectWelcomeStatus } from "@rilldata/web-admin/features/welcome/project/welcome-status.ts";
   import { checkpointProject } from "@rilldata/web-admin/features/projects/publish-project.ts";
+  import { createRuntimeServiceAnalyzeConnectors } from "@rilldata/web-common/runtime-client";
+  import { EntityStatus } from "@rilldata/web-common/features/entity-management/types.ts";
+  import Spinner from "@rilldata/web-common/features/entity-management/Spinner.svelte";
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
@@ -19,15 +20,15 @@
 
   let project = $derived(page.params.project);
 
+  // Prefetch connectors and load into cache. We will show a spinner while this is fetching.
+  let connectorsQuery = $derived(
+    createRuntimeServiceAnalyzeConnectors(runtimeClient, {}),
+  );
+
   async function handleDone() {
     projectWelcomeStatus.setProjectWelcomeStep(project, false);
     await checkpointProject(runtimeClient);
   }
-
-  onMount(async () => {
-    // Prefetch connectors and load into cache.
-    await fetchAnalyzeConnectors(runtimeClient);
-  });
 </script>
 
 <div class="my-auto">
@@ -36,16 +37,20 @@
     <div class="text-3xl font-bold text-fg-accent">Connect your data</div>
   {/if}
   <div class="w-fit h-fit mt-4">
-    {#key data.schema}
-      <AddDataManager
-        config={{
-          welcomeScreen: true,
-        }}
-        initSchema={data.schema}
-        onStepChange={(step) => (addDataStep = step)}
-        onClose={() => window.history.back()}
-        onDone={handleDone}
-      />
-    {/key}
+    {#if $connectorsQuery.isPending}
+      <Spinner status={EntityStatus.Running} size="3rem" duration={725} />
+    {:else if $connectorsQuery.data}
+      {#key data.schema}
+        <AddDataManager
+          config={{
+            welcomeScreen: true,
+          }}
+          initSchema={data.schema}
+          onStepChange={(step) => (addDataStep = step)}
+          onClose={() => window.history.back()}
+          onDone={handleDone}
+        />
+      {/key}
+    {/if}
   </div>
 </div>

--- a/web-admin/src/routes/[organization]/[project]/-/edit/welcome/add-data/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/welcome/add-data/+page.svelte
@@ -21,8 +21,9 @@
   let project = $derived(page.params.project);
 
   // Prefetch connectors and load into cache. We will show a spinner while this is fetching.
-  let connectorsQuery = $derived(
-    createRuntimeServiceAnalyzeConnectors(runtimeClient, {}),
+  const connectorsQuery = createRuntimeServiceAnalyzeConnectors(
+    runtimeClient,
+    {},
   );
 
   async function handleDone() {
@@ -39,7 +40,8 @@
   <div class="w-fit h-fit mt-4">
     {#if $connectorsQuery.isPending}
       <Spinner status={EntityStatus.Running} size="3rem" duration={725} />
-    {:else if $connectorsQuery.data}
+    {:else}
+      <!-- TODO: add error state when connectors query errors -->
       {#key data.schema}
         <AddDataManager
           config={{

--- a/web-common/src/features/add-data/ConnectYourDataWidget.svelte
+++ b/web-common/src/features/add-data/ConnectYourDataWidget.svelte
@@ -58,7 +58,8 @@
         <Spinner status={EntityStatus.Running} size="2rem" duration={725} />
       </div>
     </div>
-  {:else}
+  {:else if topConnectors}
+    <!-- topConnectors will be defined when isPending is false. TODO: add error state -->
     <div class="primary-connectors" role="group">
       {#each topConnectors as connector (connector)}
         {@const icon = connectorIconMapping[connector]}
@@ -142,6 +143,10 @@
 
   .primary-connectors-loading {
     @apply w-[335px];
+    /* To avoid nested interactions we overlay connectors list.
+       So to match primary-connectors we add a similar absolute layout here.
+       bottom-28 makes the spinner appear in the middle.
+    */
     @apply absolute bottom-28 left-6;
   }
 

--- a/web-common/src/features/add-data/ConnectYourDataWidget.svelte
+++ b/web-common/src/features/add-data/ConnectYourDataWidget.svelte
@@ -7,12 +7,15 @@
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
   import { getSupportedTopConnectors } from "@rilldata/web-common/features/add-data/manager/selectors.ts";
   import { withEditorPrefix } from "@rilldata/web-common/layout/navigation/editor-routing.ts";
+  import { EntityStatus } from "@rilldata/web-common/features/entity-management/types.ts";
+  import Spinner from "@rilldata/web-common/features/entity-management/Spinner.svelte";
 
   export let startConnectorSelection: (name: string | null) => void = () => {};
   export let onWelcomeScreen = false;
 
   const runtimeClient = useRuntimeClient();
-  const topConnectors = getSupportedTopConnectors(runtimeClient);
+  const topConnectorsQuery = getSupportedTopConnectors(runtimeClient);
+  $: ({ data: topConnectors, isPending } = $topConnectorsQuery);
 
   function selectConnector(e: MouseEvent, connector: string) {
     e.preventDefault();
@@ -49,23 +52,33 @@
     </div>
   </svelte:element>
 
-  <div class="primary-connectors" role="group">
-    {#each $topConnectors as connector (connector)}
-      {@const icon = connectorIconMapping[connector]}
-      {@const label = connectorLabelMapping[connector] ?? connector}
-      <svelte:element
-        this={onWelcomeScreen ? "a" : "button"}
-        class="primary-connector-entry"
-        {...onWelcomeScreen
-          ? { href: withEditorPrefix(`/welcome/add-data?schema=${connector}`) }
-          : { onclick: (e) => selectConnector(e, connector) }}
-        aria-label={`Connect to ${connector}`}
-      >
-        <svelte:component this={icon} />
-        <span>{label}</span>
-      </svelte:element>
-    {/each}
-  </div>
+  {#if isPending}
+    <div class="primary-connectors-loading">
+      <div class="mx-auto w-fit">
+        <Spinner status={EntityStatus.Running} size="2rem" duration={725} />
+      </div>
+    </div>
+  {:else}
+    <div class="primary-connectors" role="group">
+      {#each topConnectors as connector (connector)}
+        {@const icon = connectorIconMapping[connector]}
+        {@const label = connectorLabelMapping[connector] ?? connector}
+        <svelte:element
+          this={onWelcomeScreen ? "a" : "button"}
+          class="primary-connector-entry"
+          {...onWelcomeScreen
+            ? {
+                href: withEditorPrefix(`/welcome/add-data?schema=${connector}`),
+              }
+            : { onclick: (e) => selectConnector(e, connector) }}
+          aria-label={`Connect to ${connector}`}
+        >
+          <svelte:component this={icon} />
+          <span>{label}</span>
+        </svelte:element>
+      {/each}
+    </div>
+  {/if}
 </div>
 
 <style lang="postcss">
@@ -125,6 +138,11 @@
   }
   .container-home .primary-connector-entry:hover {
     @apply bg-surface-hover;
+  }
+
+  .primary-connectors-loading {
+    @apply w-[335px];
+    @apply absolute bottom-28 left-6;
   }
 
   .see-more-container {

--- a/web-common/src/features/add-data/manager/selectors.ts
+++ b/web-common/src/features/add-data/manager/selectors.ts
@@ -44,8 +44,13 @@ export function getSupportedTopConnectors(runtimeClient: RuntimeClient) {
   return derived(
     isModelingSupportedForDefaultOlapDriver,
     (isModellingSupportedResp) => {
+      if (isModellingSupportedResp.isPending) {
+        return { isPending: true, data: undefined };
+      }
+
+      // TODO: handle error when there are better designs for consumers
       return {
-        isPending: isModellingSupportedResp.isPending,
+        isPending: false,
         data: isModellingSupportedResp.data
           ? TopConnectors
           : TopConnectorsWithoutModeling,

--- a/web-common/src/features/add-data/manager/selectors.ts
+++ b/web-common/src/features/add-data/manager/selectors.ts
@@ -44,9 +44,12 @@ export function getSupportedTopConnectors(runtimeClient: RuntimeClient) {
   return derived(
     isModelingSupportedForDefaultOlapDriver,
     (isModellingSupportedResp) => {
-      return isModellingSupportedResp.data
-        ? TopConnectors
-        : TopConnectorsWithoutModeling;
+      return {
+        isPending: isModellingSupportedResp.isPending,
+        data: isModellingSupportedResp.data
+          ? TopConnectors
+          : TopConnectorsWithoutModeling,
+      };
     },
   );
 }


### PR DESCRIPTION
Cloud project welcome page changes connector layout after load. This is because we do an async fetch of connectors for instance. Adding a loading state so that this is not jarring.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
