### PR TITLE
Restore `unsafe-eval` in web-admin CSP

### DIFF
--- a/web-admin/src/features/edit-session/EditBranchDialog.svelte
+++ b/web-admin/src/features/edit-session/EditBranchDialog.svelte
@@ -240,10 +240,7 @@
               {#each ownDeployments as deployment (deployment.id)}
                 <Select.Item value={deployment.id ?? ""} class="py-1.5">
                   <div class="flex flex-1 items-center gap-2">
-                    <GitBranchIcon
-                      size="13"
-                      class="shrink-0 text-fg-muted"
-                    />
+                    <GitBranchIcon size="13" class="shrink-0 text-fg-muted" />
                     <div class="flex min-w-0 flex-1 items-baseline gap-2">
                       <span class="flex-1 truncate font-mono text-[13px]">
                         {deployment.branch || sourceBranch}

--- a/web-admin/svelte.config.js
+++ b/web-admin/svelte.config.js
@@ -50,6 +50,11 @@ const config = {
         "default-src": ["self"],
         "script-src": [
           "self",
+          // @exodus/schemasafe (used by the Add Data connector forms) compiles
+          // JSON schemas into validators at runtime via the Function()
+          // constructor, which CSP treats as eval. Until we move to a
+          // standalone-compiled validator, 'unsafe-eval' is required.
+          "unsafe-eval",
           // ActiveCampaign: our app loads diffuser.js which chains to prism and trackcmp.
           "https://diffuser-cdn.app-us1.com",
           "https://prism.app-us1.com",


### PR DESCRIPTION
PR #9287 removed `'unsafe-eval'` from `script-src` after concluding no remaining call sites needed it. That scan missed `@exodus/schemasafe` (used by `web-common/src/features/sources/modal/jsonSchemaValidator.ts`), which compiles JSON schemas into validators at runtime via `Function(...)` — exactly what `unsafe-eval` blocks.

- Repro: open the Add Data modal in Rill Cloud and pick any connector. The form fails to render and the console shows `Uncaught EvalError: ...violates the following Content Security Policy directive because 'unsafe-eval' is not an allowed source of script`.
- Fix: re-add `'unsafe-eval'` to `script-src` with a comment explaining why it is required.
- Follow-up: a proper removal would either pre-compile connector validators at build time (schemasafe supports standalone output) or migrate the connector forms off JSON Schema. Worth a separate ticket if tightening CSP is a priority.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*