### PR TITLE
feat: add generate data CTA in cloud welcome flow

### DIFF
--- a/web-admin/src/routes/[organization]/[project]/-/edit/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/+page.svelte
@@ -1,7 +1,16 @@
 <script lang="ts">
+  import { GeneratingMessage } from "@rilldata/web-common/components/generating-message";
+  import { generatingSampleData } from "@rilldata/web-common/features/sample-data/generate-sample-data.ts";
+  import { generatingCanvas } from "@rilldata/web-common/features/canvas/ai-generation/generateCanvas";
   import OnboardingWorkspace from "@rilldata/web-common/features/onboarding/OnboardingWorkspace.svelte";
 </script>
 
 <div class="flex size-full overflow-hidden bg-surface-subtle">
-  <OnboardingWorkspace />
+  {#if $generatingSampleData}
+    <GeneratingMessage title="Generating your sample data..." />
+  {:else if $generatingCanvas}
+    <GeneratingMessage title="Generating your Canvas dashboard..." />
+  {:else}
+    <OnboardingWorkspace />
+  {/if}
 </div>

--- a/web-admin/src/routes/[organization]/[project]/-/edit/welcome/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/welcome/+page.svelte
@@ -6,6 +6,7 @@
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
   import { projectWelcomeStatus } from "@rilldata/web-admin/features/welcome/project/welcome-status.ts";
   import { checkpointProject } from "@rilldata/web-admin/features/projects/publish-project.ts";
+  import OnboardingGenerateSampleData from "@rilldata/web-common/features/add-data/OnboardingGenerateSampleData.svelte";
 
   const runtimeClient = useRuntimeClient();
 
@@ -15,6 +16,10 @@
     projectWelcomeStatus.setProjectWelcomeStep(project, false);
     await checkpointProject(runtimeClient);
   }
+
+  function handleGenerateSampleData() {
+    projectWelcomeStatus.setProjectWelcomeStep(project, false);
+  }
 </script>
 
 <div class="my-auto">
@@ -23,6 +28,7 @@
   <div class="flex flex-col py-6 gap-[28px]">
     <div class="flex flex-col mx-auto md:flex-row gap-x-12 gap-y-6">
       <ConnectYourDataWidget onWelcomeScreen />
+      <OnboardingGenerateSampleData onGenerate={handleGenerateSampleData} />
     </div>
 
     <p class="text-base font-normal text-fg-secondary text-center">

--- a/web-common/src/features/add-data/OnboardingGenerateSampleData.svelte
+++ b/web-common/src/features/add-data/OnboardingGenerateSampleData.svelte
@@ -8,6 +8,7 @@
   import { Button } from "@rilldata/web-common/components/button";
 
   export let open = false;
+  export let onGenerate: () => void;
 
   const runtimeClient = useRuntimeClient();
 
@@ -29,6 +30,9 @@
       if (!form.valid) return;
       const values = form.data;
       void generateSampleData(runtimeClient, true, values.prompt);
+      // Use a timeout so that onGenerate can call goto.
+      // Using goto inside a for submission gets blocked.
+      setTimeout(() => onGenerate());
       open = false;
     },
     invalidateAll: false,

--- a/web-local/src/routes/(misc)/welcome/+page.svelte
+++ b/web-local/src/routes/(misc)/welcome/+page.svelte
@@ -14,6 +14,7 @@
     MetricsEventSpace,
   } from "@rilldata/web-common/metrics/service/MetricsTypes.ts";
   import { waitUntil } from "@rilldata/web-common/lib/waitUtils.ts";
+  import { WelcomeStatus } from "@rilldata/web-common/features/welcome/status.ts";
 
   onMount(async () => {
     await waitUntil(() => !!behaviourEvent);
@@ -25,6 +26,10 @@
       {},
     );
   });
+
+  function handleGenerateSampleData() {
+    WelcomeStatus.set(false);
+  }
 </script>
 
 <div class="my-auto">
@@ -33,7 +38,7 @@
   <div class="flex flex-col py-6 gap-[28px]">
     <div class="flex flex-col mx-auto md:flex-row gap-x-12 gap-y-6">
       <ConnectYourDataWidget onWelcomeScreen />
-      <OnboardingGenerateSampleData />
+      <OnboardingGenerateSampleData onGenerate={handleGenerateSampleData} />
     </div>
 
     <p class="text-base font-normal text-fg-secondary text-center">


### PR DESCRIPTION
Cloud welcome flow was missing the generate data CTA. Added that and `Generating your sample data...` message to the home page.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
