### PR TITLE
feat: step 2 Show project Status tab to editors in Cloud and Developer 

### DIFF
--- a/admin/server/runtime_jwt.go
+++ b/admin/server/runtime_jwt.go
@@ -173,14 +173,16 @@ func (s *Server) issueRuntimeToken(ctx context.Context, opts *issueRuntimeTokenO
 		}
 	}
 
-	// Check if allowed to manage the deployment's environment.
+	// Check if allowed to manage the deployment's environment, or to read its status.
 	// NOTE: Only applicable for tokens issued for the claims owner (not possible to delegate to other end users).
-	var manageDepl bool
+	var manageDepl, readDeplStatus bool
 	if opts.forOwner {
 		if opts.deployment.Environment == "prod" {
 			manageDepl = opts.projectPermissions.ManageProd
+			readDeplStatus = opts.projectPermissions.ReadProdStatus
 		} else {
 			manageDepl = opts.projectPermissions.ManageDev
+			readDeplStatus = opts.projectPermissions.ReadDevStatus
 		}
 	}
 
@@ -190,6 +192,10 @@ func (s *Server) issueRuntimeToken(ctx context.Context, opts *issueRuntimeTokenO
 		runtime.ReadMetrics,
 		runtime.ReadObjects,
 		runtime.UseAI,
+	}
+	if readDeplStatus {
+		// Status visibility: lets non-managers (e.g. editors) view the project Status page.
+		instancePermissions = append(instancePermissions, runtime.ReadInstance)
 	}
 	if manageDepl {
 		instancePermissions = append(

--- a/web-admin/src/features/projects/ProjectTabs.svelte
+++ b/web-admin/src/features/projects/ProjectTabs.svelte
@@ -50,7 +50,7 @@
     {
       route: `/${organization}/${project}${branchPrefix}/-/status`,
       label: "Status",
-      hasPermission: projectPermissions.manageProject,
+      hasPermission: projectPermissions.readProdStatus,
     },
     {
       route: `/${organization}/${project}${branchPrefix}/-/settings`,

--- a/web-admin/src/routes/[organization]/[project]/-/status/+layout.ts
+++ b/web-admin/src/routes/[organization]/[project]/-/status/+layout.ts
@@ -2,7 +2,7 @@ import { redirect } from "@sveltejs/kit";
 
 export const load = async ({ parent, params: { organization, project } }) => {
   const { projectPermissions } = await parent();
-  if (!projectPermissions?.manageProject) {
+  if (!projectPermissions?.readProdStatus) {
     throw redirect(307, `/${organization}/${project}`);
   }
 };


### PR DESCRIPTION
requires: https://github.com/rilldata/rill/pull/9359

Gate the project Status tab on `readProdStatus` instead of `manageProject` so editors can view deployment status.

- `read_prod_status` is already `true` for `admin` and `editor` roles and `false` for `viewer` (per `admin/database/postgres/migrations/0003.sql`), matching the access we want.
- Sub-pages under `/-/status` (overview, branches, resources, tables, logs) are already permitted for any user who reaches the section.
- Settings tab is unchanged; still gated on `manageProject`.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*