### PR TITLE
Rename initial dev branch to `develop`

### DIFF
--- a/web-admin/src/features/projects/publish-project.ts
+++ b/web-admin/src/features/projects/publish-project.ts
@@ -1,7 +1,7 @@
 import { RuntimeClient } from "@rilldata/web-common/runtime-client/v2";
 import { runtimeServiceGitPush } from "@rilldata/web-common/runtime-client";
 
-export const CreateProjectBranchName = "dev";
+export const CreateProjectBranchName = "develop";
 
 /**
  * Checkpoints the current project state. Redirect should already be handled through indiviual components.

--- a/web-admin/src/routes/[organization]/[project]/-/edit/layout.spec.ts
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/layout.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { isRedirect } from "@sveltejs/kit";
+import { CreateProjectBranchName } from "@rilldata/web-admin/features/projects/publish-project";
 import { load } from "./+layout";
 
 const { isProjectWelcomeStepMock } = vi.hoisted(() => ({
@@ -40,7 +41,9 @@ describe("edit/+layout load", () => {
     expect(isRedirect(result)).toBe(true);
     if (!isRedirect(result)) return;
     expect(result.status).toBe(307);
-    expect(result.location).toBe(`/${ORG}/${PROJECT}/@dev/-/edit/welcome`);
+    expect(result.location).toBe(
+      `/${ORG}/${PROJECT}/@${CreateProjectBranchName}/-/edit/welcome`,
+    );
   });
 
   it("does not redirect when already on the welcome page", async () => {

--- a/web-admin/src/routes/[organization]/[project]/-/edit/welcome/layout.spec.ts
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/welcome/layout.spec.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import { isRedirect } from "@sveltejs/kit";
 import { CreateProjectBranchName } from "@rilldata/web-admin/features/projects/publish-project";
+import { isRedirect } from "@sveltejs/kit";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { load } from "./+layout";
 
 const { isProjectWelcomeStepMock } = vi.hoisted(() => ({
@@ -37,18 +37,24 @@ describe("edit/welcome/+layout load", () => {
   it("does not redirect when the project is still in the welcome step", async () => {
     isProjectWelcomeStepMock.mockReturnValue(true);
 
-    const result = await callLoad(`/${ORG}/${PROJECT}/@${CreateProjectBranchName}/-/edit/welcome`);
+    const result = await callLoad(
+      `/${ORG}/${PROJECT}/@${CreateProjectBranchName}/-/edit/welcome`,
+    );
     expect(result).toBeUndefined();
   });
 
   it("redirects to /-/edit on the same branch when no longer in the welcome step", async () => {
     isProjectWelcomeStepMock.mockReturnValue(false);
 
-    const result = await callLoad(`/${ORG}/${PROJECT}/@${CreateProjectBranchName}/-/edit/welcome`);
+    const result = await callLoad(
+      `/${ORG}/${PROJECT}/@${CreateProjectBranchName}/-/edit/welcome`,
+    );
     expect(isRedirect(result)).toBe(true);
     if (!isRedirect(result)) return;
     expect(result.status).toBe(307);
-    expect(result.location).toBe(`/${ORG}/${PROJECT}/@${CreateProjectBranchName}/-/edit`);
+    expect(result.location).toBe(
+      `/${ORG}/${PROJECT}/@${CreateProjectBranchName}/-/edit`,
+    );
   });
 
   it("does not redirect when no branch is present in the URL", async () => {

--- a/web-admin/src/routes/[organization]/[project]/-/edit/welcome/layout.spec.ts
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/welcome/layout.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { isRedirect } from "@sveltejs/kit";
+import { CreateProjectBranchName } from "@rilldata/web-admin/features/projects/publish-project";
 import { load } from "./+layout";
 
 const { isProjectWelcomeStepMock } = vi.hoisted(() => ({
@@ -36,18 +37,18 @@ describe("edit/welcome/+layout load", () => {
   it("does not redirect when the project is still in the welcome step", async () => {
     isProjectWelcomeStepMock.mockReturnValue(true);
 
-    const result = await callLoad(`/${ORG}/${PROJECT}/@dev/-/edit/welcome`);
+    const result = await callLoad(`/${ORG}/${PROJECT}/@${CreateProjectBranchName}/-/edit/welcome`);
     expect(result).toBeUndefined();
   });
 
   it("redirects to /-/edit on the same branch when no longer in the welcome step", async () => {
     isProjectWelcomeStepMock.mockReturnValue(false);
 
-    const result = await callLoad(`/${ORG}/${PROJECT}/@dev/-/edit/welcome`);
+    const result = await callLoad(`/${ORG}/${PROJECT}/@${CreateProjectBranchName}/-/edit/welcome`);
     expect(isRedirect(result)).toBe(true);
     if (!isRedirect(result)) return;
     expect(result.status).toBe(307);
-    expect(result.location).toBe(`/${ORG}/${PROJECT}/@dev/-/edit`);
+    expect(result.location).toBe(`/${ORG}/${PROJECT}/@${CreateProjectBranchName}/-/edit`);
   });
 
   it("does not redirect when no branch is present in the URL", async () => {


### PR DESCRIPTION
Rename the initial branch created with each new project from `dev` to `develop` — git-flow's canonical long-lived working branch. The branch isn't cleaned up after publish, so the default name should hold up long-term, not just at onboarding. `dev` also overlaps with the deployment-environment string of the same name.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*