### PR TITLE
APP-882: Route cloud editor `Exit` button by publish state

### DIFF
--- a/web-admin/src/features/edit-session/EditActions.svelte
+++ b/web-admin/src/features/edit-session/EditActions.svelte
@@ -1,25 +1,23 @@
 <script lang="ts">
-  import { branchPathPrefix } from "@rilldata/web-admin/features/branches/branch-utils";
   import { Button } from "@rilldata/web-common/components/button";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { extractErrorMessage } from "@rilldata/web-common/lib/errors";
   import { createRuntimeServiceGitStatus } from "@rilldata/web-common/runtime-client";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
-  import { GitBranch, LogOut } from "lucide-svelte";
+  import { GitBranch } from "lucide-svelte";
   import CommitPopover from "./CommitPopover.svelte";
+  import ExitButton from "./ExitButton.svelte";
   import MergePopover from "./MergePopover.svelte";
   import PublishPopover from "./PublishPopover.svelte";
 
   export let organization: string;
   export let project: string;
-  export let branch: string;
   export let primaryBranch: string | undefined = undefined;
 
   const client = useRuntimeClient();
   const gitStatusQuery = createRuntimeServiceGitStatus(client, {});
 
-  $: closeHref = `/${organization}/${project}${branchPathPrefix(branch)}`;
   $: managedGit = $gitStatusQuery.data?.managedGit;
   $: gitStatusLoaded = $gitStatusQuery.data !== undefined;
   // Show the parent-level error UI only when GitStatus has never loaded.
@@ -50,12 +48,4 @@
   </Tooltip>
 {/if}
 
-<Tooltip distance={8}>
-  <Button type="secondary" href={closeHref}>
-    <LogOut size="14" />
-    Exit
-  </Button>
-  <TooltipContent slot="tooltip-content" maxWidth="200px">
-    <span class="text-xs">Return to project home</span>
-  </TooltipContent>
-</Tooltip>
+<ExitButton {organization} {project} />

--- a/web-admin/src/features/edit-session/ExitButton.svelte
+++ b/web-admin/src/features/edit-session/ExitButton.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import { createAdminServiceListDeployments } from "@rilldata/web-admin/client";
+  import { requestSkipBranchInjection } from "@rilldata/web-admin/features/branches/branch-utils";
+  import { isProdDeployment } from "@rilldata/web-admin/features/branches/deployment-utils";
+  import { Button } from "@rilldata/web-common/components/button";
+  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
+  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
+  import { LogOut } from "lucide-svelte";
+
+  export let organization: string;
+  export let project: string;
+
+  const deploymentsQuery = createAdminServiceListDeployments(
+    organization,
+    project,
+    {},
+  );
+
+  // While the query is loading, default `hasProdDeployment` to false so a
+  // click during the loading window routes to the org page (the safe
+  // default for an unpublished project). TanStack typically has this query
+  // warm from PublishPopover, so the loading window is rare.
+  $: hasProdDeployment =
+    $deploymentsQuery.data?.deployments?.some(isProdDeployment) ?? false;
+  $: href = hasProdDeployment
+    ? `/${organization}/${project}`
+    : `/${organization}`;
+
+  // The project layout's beforeNavigate hook re-injects the active @branch
+  // into project-scoped URLs. Exit wants the bare URL, so request a skip
+  // before SvelteKit intercepts the anchor click. Harmless when href is
+  // the org page (the layout doesn't inject for non-project URLs).
+  function handleClick() {
+    requestSkipBranchInjection();
+  }
+</script>
+
+<Tooltip distance={8}>
+  <Button type="secondary" {href} onClick={handleClick}>
+    <LogOut size="14" />
+    Exit
+  </Button>
+  <TooltipContent slot="tooltip-content" maxWidth="200px">
+    <span class="text-xs">
+      {hasProdDeployment ? "Return to project home" : "Return to organization"}
+    </span>
+  </TooltipContent>
+</Tooltip>

--- a/web-admin/src/features/projects/ProjectHeader.svelte
+++ b/web-admin/src/features/projects/ProjectHeader.svelte
@@ -201,12 +201,7 @@
       {#if $developerChat}
         <ChatToggle />
       {/if}
-      <EditActions
-        {organization}
-        {project}
-        branch={activeBranch ?? ""}
-        {primaryBranch}
-      />
+      <EditActions {organization} {project} {primaryBranch} />
     {:else}
       {#if $viewAsUserStore}
         <ViewAsUserChip />


### PR DESCRIPTION
- For an unpublished project (no production deployment yet), `Exit` now sends the user back to the org page instead of a project home that hasn't been provisioned.
- For a published project, `Exit` lands on the project home on the production branch (the bare `/{org}/{project}` URL with no `@branch` segment).
- Extracts the button into a dedicated `ExitButton.svelte` since it now owns the deployments-list query and its own click handler. `requestSkipBranchInjection()` runs before the anchor click is intercepted so the project layout doesn't re-inject the editor's `@branch` into the target URL.
- Tooltip flips between "Return to project home" and "Return to organization" based on the same state.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
*Developed in collaboration with Claude Code*