### PR TITLE
feat: scope project view to dashboards while `View As` is active

### DIFF
--- a/web-admin/src/features/projects/ProjectTabs.svelte
+++ b/web-admin/src/features/projects/ProjectTabs.svelte
@@ -5,6 +5,7 @@
   } from "@rilldata/web-admin//components/nav/Tab.svelte";
   import Tab from "@rilldata/web-admin/components/nav/Tab.svelte";
   import { removeBranchFromPath } from "@rilldata/web-admin/features/branches/branch-utils";
+  import { viewAsUserStore } from "@rilldata/web-admin/features/view-as-user/viewAsUserStore";
   import { featureFlags } from "@rilldata/web-common/features/feature-flags";
   import { type V1ProjectPermissions } from "../../client";
 
@@ -16,48 +17,59 @@
 
   const { chat, reports, alerts } = featureFlags;
 
-  $: tabs = [
-    {
-      route: `/${organization}/${project}${branchPrefix}`,
-      label: "Home",
-      hasPermission: true,
-    },
-    {
-      route: `/${organization}/${project}${branchPrefix}/-/ai`,
-      label: "AI",
-      hasPermission: $chat,
-    },
-    {
-      route: `/${organization}/${project}${branchPrefix}/-/dashboards`,
-      label: "Dashboards",
-      hasPermission: true,
-    },
-    {
-      route: `/${organization}/${project}${branchPrefix}/-/query`,
-      label: "Query",
-      hasPermission: false,
-    },
-    {
-      route: `/${organization}/${project}${branchPrefix}/-/reports`,
-      label: "Reports",
-      hasPermission: $reports,
-    },
-    {
-      route: `/${organization}/${project}${branchPrefix}/-/alerts`,
-      label: "Alerts",
-      hasPermission: $alerts,
-    },
-    {
-      route: `/${organization}/${project}${branchPrefix}/-/status`,
-      label: "Status",
-      hasPermission: projectPermissions.manageProject,
-    },
-    {
-      route: `/${organization}/${project}${branchPrefix}/-/settings`,
-      label: "Settings",
-      hasPermission: projectPermissions.manageProject,
-    },
-  ];
+  // While "View As" is active, the project view is scoped to dashboards
+  // only — other tabs (Home, AI, Reports, Alerts, Status, Settings) are
+  // hidden and their routes redirect in the project layout.
+  $: tabs = $viewAsUserStore
+    ? [
+        {
+          route: `/${organization}/${project}${branchPrefix}/-/dashboards`,
+          label: "Dashboards",
+          hasPermission: true,
+        },
+      ]
+    : [
+        {
+          route: `/${organization}/${project}${branchPrefix}`,
+          label: "Home",
+          hasPermission: true,
+        },
+        {
+          route: `/${organization}/${project}${branchPrefix}/-/ai`,
+          label: "AI",
+          hasPermission: $chat,
+        },
+        {
+          route: `/${organization}/${project}${branchPrefix}/-/dashboards`,
+          label: "Dashboards",
+          hasPermission: true,
+        },
+        {
+          route: `/${organization}/${project}${branchPrefix}/-/query`,
+          label: "Query",
+          hasPermission: false,
+        },
+        {
+          route: `/${organization}/${project}${branchPrefix}/-/reports`,
+          label: "Reports",
+          hasPermission: $reports,
+        },
+        {
+          route: `/${organization}/${project}${branchPrefix}/-/alerts`,
+          label: "Alerts",
+          hasPermission: $alerts,
+        },
+        {
+          route: `/${organization}/${project}${branchPrefix}/-/status`,
+          label: "Status",
+          hasPermission: projectPermissions.manageProject,
+        },
+        {
+          route: `/${organization}/${project}${branchPrefix}/-/settings`,
+          label: "Settings",
+          hasPermission: projectPermissions.manageProject,
+        },
+      ];
 
   $: selectedIndex = tabs?.findLastIndex((t) => isSelected(t.route, pathname));
 

--- a/web-admin/src/routes/[organization]/[project]/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/+layout.svelte
@@ -18,6 +18,7 @@
     branchPathPrefix,
     extractBranchFromPath,
     handleBranchNavigation,
+    removeBranchFromPath,
   } from "@rilldata/web-admin/features/branches/branch-utils";
   import {
     V1DeploymentStatus,
@@ -107,6 +108,21 @@
     return () => {
       viewAsUserStore.clear();
     };
+  });
+
+  // While "View As" is active, scope the project view to dashboards only.
+  // Any other project page (Home, AI, Reports, Alerts, Status, Settings) is
+  // redirected — entering View As is a deliberate "see what they see" mode,
+  // and admin surfaces aren't part of that.
+  $effect(() => {
+    if (!$viewAsUserStore) return;
+    if (!onProjectPage) return;
+    const dashboardsPath = `/${organization}/${project}${branchPrefix}/-/dashboards`;
+    const normalizedPath = removeBranchFromPath(page.url.pathname);
+    const normalizedDashboards = removeBranchFromPath(dashboardsPath);
+    if (!normalizedPath.startsWith(normalizedDashboards)) {
+      void goto(dashboardsPath);
+    }
   });
 
   // --- Queries (three auth strategies; cookie and token are mutually exclusive,


### PR DESCRIPTION
While impersonating a user via "View As", scope the project view to the dashboards experience only. Other project tabs (Home, AI, Reports, Alerts, Status, Settings) are hidden, and direct URL access to those routes redirects to `/-/dashboards`.

- `ProjectTabs.svelte` collapses to a single `Dashboards` tab when `viewAsUserStore` is set.
- The project layout adds a redirect effect that bounces non-dashboard project pages to `/-/dashboards` while View As is active.
- Per-resource access policies on dashboards are already enforced via the impersonated user's runtime JWT — no change needed there.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*