### PR TITLE
design: Improve `TableToolbar` layout and styling

### DIFF
--- a/web-admin/src/features/branches/deployment-filter-utils.ts
+++ b/web-admin/src/features/branches/deployment-filter-utils.ts
@@ -1,0 +1,57 @@
+import {
+  type V1Deployment,
+  V1DeploymentStatus,
+} from "@rilldata/web-admin/client";
+import type { FilterGroup } from "@rilldata/web-common/components/table-toolbar";
+
+export function getDeploymentStatusFilterGroup(
+  statusFilter: string[],
+  includeUnpublished = false,
+) {
+  return {
+    label: "Status",
+    key: "status",
+    options: [
+      { label: "Ready", value: "running" },
+      { label: "Pending", value: "pending" },
+      { label: "Error", value: "errored" },
+      { label: "Stopped", value: "stopped" },
+      ...(includeUnpublished
+        ? [{ label: "Unpublished", value: "unpublished" }]
+        : []),
+    ],
+    selected: statusFilter,
+    defaultValue: [],
+    multiSelect: true,
+  } satisfies FilterGroup;
+}
+
+export function deploymentStatusFilterMatches(
+  statusFilter: string[],
+  d: V1Deployment | undefined,
+): boolean {
+  if (statusFilter.length === 0) return true;
+  const s = d?.status ?? V1DeploymentStatus.DEPLOYMENT_STATUS_UNSPECIFIED;
+  return statusFilter.some((sel) => {
+    switch (sel) {
+      case "running":
+        return s === V1DeploymentStatus.DEPLOYMENT_STATUS_RUNNING;
+      case "pending":
+        return (
+          s === V1DeploymentStatus.DEPLOYMENT_STATUS_PENDING ||
+          s === V1DeploymentStatus.DEPLOYMENT_STATUS_UPDATING
+        );
+      case "errored":
+        return s === V1DeploymentStatus.DEPLOYMENT_STATUS_ERRORED;
+      case "stopped":
+        return (
+          s === V1DeploymentStatus.DEPLOYMENT_STATUS_STOPPED ||
+          s === V1DeploymentStatus.DEPLOYMENT_STATUS_STOPPING
+        );
+      case "unpublished":
+        return s === V1DeploymentStatus.DEPLOYMENT_STATUS_UNSPECIFIED;
+      default:
+        return false;
+    }
+  });
+}

--- a/web-admin/src/features/projects/ProjectCards.svelte
+++ b/web-admin/src/features/projects/ProjectCards.svelte
@@ -84,7 +84,6 @@
     searchDisabled={!$projectsQuery.data?.projects?.length}
     showSort
     bind:sortDirection
-    showViewToggle
     {filterGroups}
     onFilterChange={onFilterChange}
     onClearAllFilters={() => {
@@ -93,7 +92,7 @@
     }}
   >
     {#if showNewProject}
-      <Button type="secondary" href="/{organization}/-/create-project">
+      <Button type="secondary" large href="/{organization}/-/create-project">
         + New project
       </Button>
     {/if}

--- a/web-admin/src/features/projects/ProjectCards.svelte
+++ b/web-admin/src/features/projects/ProjectCards.svelte
@@ -3,37 +3,111 @@
   import ProjectCard from "./ProjectCard.svelte";
   import { Button } from "@rilldata/web-common/components/button";
   import { projectWelcomeEnabled } from "@rilldata/web-admin/features/welcome/project/welcome-status.ts";
+  import {
+    type FilterGroup,
+    type SortDirection,
+    TableToolbar,
+  } from "@rilldata/web-common/components/table-toolbar";
+  import {
+    deploymentStatusFilterMatches,
+    getDeploymentStatusFilterGroup,
+  } from "@rilldata/web-admin/features/branches/deployment-filter-utils.ts";
+  import { createQueries } from "@tanstack/svelte-query";
+  import { getAdminServiceGetProjectQueryOptions } from "@rilldata/web-admin/client/index.ts";
 
-  export let organization: string;
+  let {
+    organization,
+    createProjectsPermission,
+  }: { organization: string; createProjectsPermission: boolean } = $props();
 
-  $: projs = createAdminServiceListProjectsForOrganization(organization, {
-    pageSize: 1000,
+  let projectsQuery = $derived(
+    createAdminServiceListProjectsForOrganization(organization, {
+      pageSize: 1000,
+    }),
+  );
+  let projectDetailsQuery = $derived(
+    createQueries({
+      queries:
+        $projectsQuery.data?.projects.map((p) =>
+          getAdminServiceGetProjectQueryOptions(organization, p.name, {}),
+        ) ?? [],
+      combine: (queries) => {
+        return queries.map((q) => q.data);
+      },
+    }),
+  );
+
+  let searchText = $state("");
+  let sortDirection = $state<SortDirection>("a-z");
+  let statusFilter = $state<string[]>([]);
+
+  let filterGroups = $derived([
+    getDeploymentStatusFilterGroup(statusFilter, true),
+  ] satisfies FilterGroup[]);
+
+  let resolvedProjects = $derived.by(() => {
+    const q = searchText.trim().toLowerCase();
+    const projects =
+      $projectsQuery.data?.projects?.filter((p) => {
+        if (!p.name?.toLowerCase().includes(q)) return false;
+        const deployment = $projectDetailsQuery.find(
+          (d) => d?.project?.name === p.name,
+        )?.deployment;
+        return deploymentStatusFilterMatches(statusFilter, deployment);
+      }) ?? [];
+    return projects.sort((a, b) => {
+      switch (sortDirection) {
+        case "a-z":
+          return (a.name ?? "").localeCompare(b.name ?? "");
+        case "z-a":
+          return (b.name ?? "").localeCompare(a.name ?? "");
+        case "newest":
+          return a.createdOn > b.createdOn ? -1 : 1;
+        case "oldest":
+          return a.createdOn > b.createdOn ? 1 : -1;
+      }
+    });
   });
+
+  let showNewProject = $derived(
+    projectWelcomeEnabled && createProjectsPermission,
+  );
+
+  function onFilterChange(key: string, selected: string | string[]) {
+    if (key === "status" && Array.isArray(selected)) statusFilter = selected;
+  }
 </script>
 
 <div class="flex flex-col gap-y-4">
-  <span
-    class="flex flex-row items-center text-fg-secondary text-base font-normal leading-normal"
+  <TableToolbar
+    bind:searchText
+    searchDisabled={!$projectsQuery.data?.projects?.length}
+    showSort
+    bind:sortDirection
+    showViewToggle
+    {filterGroups}
+    onFilterChange={onFilterChange}
+    onClearAllFilters={() => {
+      statusFilter = [];
+      searchText = "";
+    }}
   >
-    <span class="grow">Check out your projects below.</span>
-    {#if projectWelcomeEnabled}
-      <Button type="primary" href="/{organization}/-/create-project">
-        Create new
+    {#if showNewProject}
+      <Button type="secondary" href="/{organization}/-/create-project">
+        + New project
       </Button>
     {/if}
-  </span>
+  </TableToolbar>
 
-  {#if $projs.data && $projs.data.projects?.length === 0}
-    <p class="text-fg-secondary text-xs">
-      This organization has no projects yet.
-    </p>
-  {:else if $projs.data && $projs.data.projects?.length > 0}
-    <ol class="flex gap-6 flex-wrap">
-      {#each $projs.data.projects as proj}
-        <li>
-          <ProjectCard {organization} project={proj.name} />
-        </li>
-      {/each}
-    </ol>
-  {/if}
+  <ol class="flex gap-6 flex-wrap">
+    {#each resolvedProjects as proj (proj.name)}
+      <li>
+        <ProjectCard {organization} project={proj.name} />
+      </li>
+    {:else}
+      <p class="text-fg-secondary text-xs">
+        This organization has no projects yet.
+      </p>
+    {/each}
+  </ol>
 </div>

--- a/web-admin/src/features/projects/ProjectCards.svelte
+++ b/web-admin/src/features/projects/ProjectCards.svelte
@@ -85,7 +85,7 @@
     showSort
     bind:sortDirection
     {filterGroups}
-    onFilterChange={onFilterChange}
+    {onFilterChange}
     onClearAllFilters={() => {
       statusFilter = [];
       searchText = "";

--- a/web-admin/src/routes/[organization]/+page.svelte
+++ b/web-admin/src/routes/[organization]/+page.svelte
@@ -57,7 +57,10 @@
     {:else}
       <div class="flex flex-col gap-y-8">
         <OrganizationHero {title} />
-        <ProjectCards organization={orgName} />
+        <ProjectCards
+          organization={orgName}
+          createProjectsPermission={organizationPermissions.createProjects}
+        />
       </div>
     {/if}
   {/if}

--- a/web-common/src/components/table-toolbar/TableToolbar.svelte
+++ b/web-common/src/components/table-toolbar/TableToolbar.svelte
@@ -10,6 +10,7 @@
   let {
     searchText = $bindable(""),
     searchDisabled = false,
+    searchPlaceholder = "Search",
     filterGroups = [],
     onFilterChange,
     onClearAllFilters,
@@ -21,6 +22,7 @@
   }: {
     searchText?: string;
     searchDisabled?: boolean;
+    searchPlaceholder?: string;
     filterGroups?: FilterGroup[];
     onFilterChange?: (key: string, selected: string | string[]) => void;
     onClearAllFilters?: () => void;
@@ -32,19 +34,23 @@
   } = $props();
 </script>
 
-<section class="flex flex-col w-full">
-  <div class="flex flex-row items-center justify-between h-9 gap-x-4">
-    <div class="flex flex-row items-center">
+<section class="flex flex-col w-full gap-y-2">
+  <div class="flex flex-row items-center gap-x-2.5">
+    <div class="flex flex-row items-center gap-x-2.5 shrink-0">
       <TableToolbarFilterDropdown {filterGroups} {onFilterChange} />
-    </div>
-
-    <div class="flex flex-row items-center gap-x-3">
-      <TableToolbarSearch bind:searchText disabled={searchDisabled} />
 
       {#if showSort}
         <TableToolbarSort bind:sortDirection />
       {/if}
+    </div>
 
+    <TableToolbarSearch
+      bind:searchText
+      disabled={searchDisabled}
+      placeholder={searchPlaceholder}
+    />
+
+    <div class="flex flex-row items-center gap-x-2.5 shrink-0">
       {#if showViewToggle}
         <TableToolbarViewToggle bind:viewMode />
       {/if}

--- a/web-common/src/components/table-toolbar/TableToolbarAppliedFilters.svelte
+++ b/web-common/src/components/table-toolbar/TableToolbarAppliedFilters.svelte
@@ -64,12 +64,13 @@
 
 {#if hasFilters}
   <div class="overflow-hidden" in:slide out:slide>
-    <hr class="border-t mt-2" />
-    <div class="flex flex-row items-center justify-between gap-x-2 h-9">
-      <div class="flex flex-row items-center gap-2 flex-wrap">
+    <div
+      class="flex flex-row items-center justify-between gap-x-2.5 bg-surface-subtle rounded-b-sm p-2"
+    >
+      <div class="flex flex-row items-center gap-2.5 flex-1 min-w-0 flex-wrap">
         {#each appliedFilters as filter (`${filter.key}:${filter.value}`)}
           <span
-            class="inline-flex items-center gap-x-1 h-7 px-2 rounded-sm border bg-surface-background text-xs font-medium text-fg-primary"
+            class="inline-flex items-center gap-x-1 h-7 px-2.5 rounded-md border bg-surface-background shadow-xs text-sm font-medium text-fg-primary"
           >
             {filter.label}
             <button
@@ -85,7 +86,7 @@
       </div>
       <button
         type="button"
-        class="text-sm text-fg-secondary hover:text-fg-primary whitespace-nowrap cursor-pointer"
+        class="text-sm font-medium text-fg-accent hover:text-fg-primary whitespace-nowrap cursor-pointer px-4 py-2 shrink-0"
         onclick={onClearAllFilters}
       >
         Clear all

--- a/web-common/src/components/table-toolbar/TableToolbarFilterDropdown.svelte
+++ b/web-common/src/components/table-toolbar/TableToolbarFilterDropdown.svelte
@@ -11,6 +11,19 @@
     onFilterChange?: (key: string, selected: string | string[]) => void;
   } = $props();
 
+  let hasActiveFilters = $derived(
+    filterGroups.some((g) => {
+      if (g.multiSelect && Array.isArray(g.selected)) {
+        return g.selected.length > 0;
+      }
+      return (
+        typeof g.selected === "string" &&
+        g.selected !== "" &&
+        g.selected !== g.defaultValue
+      );
+    }),
+  );
+
   function handleClick(group: FilterGroup, value: string) {
     if (group.multiSelect) {
       const current = Array.isArray(group.selected) ? group.selected : [];
@@ -27,10 +40,12 @@
 {#if filterGroups.length > 0}
   <DropdownMenu.Root>
     <DropdownMenu.Trigger
-      class="flex flex-row items-center gap-x-1.5 h-9 px-2 text-sm font-medium text-fg-primary cursor-pointer"
+      class="flex flex-row items-center gap-x-2 h-9 px-4 border rounded-[2px] shadow-xs text-sm font-medium cursor-pointer {hasActiveFilters
+        ? 'bg-surface-hover border-border text-fg-accent'
+        : 'bg-white border-border text-fg-primary hover:bg-surface-hover'}"
       aria-label="Filter options"
     >
-      <FilterOutlined size="14" />
+      <FilterOutlined size="16" />
       <span>Filter</span>
     </DropdownMenu.Trigger>
     <DropdownMenu.Content align="start">

--- a/web-common/src/components/table-toolbar/TableToolbarSearch.svelte
+++ b/web-common/src/components/table-toolbar/TableToolbarSearch.svelte
@@ -1,69 +1,26 @@
 <script lang="ts">
   import SearchIcon from "@rilldata/web-common/components/icons/Search.svelte";
-  import { X } from "lucide-svelte";
-  import { tick } from "svelte";
 
   let {
     searchText = $bindable(""),
     disabled = false,
+    placeholder = "Search",
   }: {
     searchText?: string;
     disabled?: boolean;
+    placeholder?: string;
   } = $props();
-
-  let manualExpanded = $state(false);
-  let expanded = $derived(manualExpanded || searchText.length > 0);
-  let inputRef: HTMLInputElement | undefined = $state();
-
-  async function open() {
-    if (disabled) return;
-    manualExpanded = true;
-    await tick();
-    inputRef?.focus();
-  }
-
-  function close() {
-    searchText = "";
-    manualExpanded = false;
-  }
-
-  function handleKeyDown(e: KeyboardEvent) {
-    if (e.key === "Escape") {
-      close();
-    }
-  }
 </script>
 
-{#if expanded}
-  <div
-    class="flex flex-row items-center gap-x-1.5 h-9 border rounded-sm bg-input px-2 min-w-[200px]"
-  >
-    <SearchIcon size="16" className="text-fg-secondary shrink-0" />
-    <input
-      bind:this={inputRef}
-      bind:value={searchText}
-      type="text"
-      class="outline-none bg-transparent text-sm text-fg-primary placeholder-fg-secondary flex-1 min-w-0"
-      placeholder="Search..."
-      onkeydown={handleKeyDown}
-    />
-    <button
-      type="button"
-      class="text-fg-secondary hover:text-fg-primary shrink-0"
-      onclick={close}
-      aria-label="Close search"
-    >
-      <X size={14} />
-    </button>
-  </div>
-{:else}
-  <button
-    type="button"
-    class="flex items-center justify-center h-9 w-4 text-fg-primary hover:text-fg-secondary cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-    onclick={open}
-    aria-label="Search"
+<div
+  class="flex flex-row items-center gap-x-2 h-9 flex-1 min-w-0 border px-3 py-2.5"
+>
+  <SearchIcon size="16" className="text-fg-muted shrink-0" />
+  <input
+    bind:value={searchText}
+    type="text"
+    class="outline-none bg-transparent text-sm text-fg-primary placeholder-fg-muted flex-1 min-w-0"
+    {placeholder}
     {disabled}
-  >
-    <SearchIcon size="16" className="text-fg-secondary" />
-  </button>
-{/if}
+  />
+</div>

--- a/web-common/src/components/table-toolbar/TableToolbarSort.svelte
+++ b/web-common/src/components/table-toolbar/TableToolbarSort.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
-  import { ArrowDownAZ } from "lucide-svelte";
+  import { ArrowUpDown } from "lucide-svelte";
   import { SORT_OPTIONS, type SortDirection } from "./types";
 
   let {
@@ -19,7 +19,7 @@
     class="flex flex-row items-center gap-x-1.5 h-9 px-4 border rounded-[2px] shadow-xs bg-white text-sm font-medium text-fg-primary hover:bg-surface-hover cursor-pointer"
     aria-label="Sort order: {sortLabel}"
   >
-    <ArrowDownAZ size={16} />
+    <ArrowUpDown size={16} />
     <span>Sort by {sortLabel}</span>
   </DropdownMenu.Trigger>
   <DropdownMenu.Content align="start">

--- a/web-common/src/components/table-toolbar/TableToolbarSort.svelte
+++ b/web-common/src/components/table-toolbar/TableToolbarSort.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { ArrowUpDown } from "lucide-svelte";
-  import type { SortDirection } from "./types";
+  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
+  import { ArrowDownAZ } from "lucide-svelte";
+  import { SORT_OPTIONS, type SortDirection } from "./types";
 
   let {
     sortDirection = $bindable("newest"),
@@ -8,19 +9,28 @@
     sortDirection: SortDirection;
   } = $props();
 
-  const sortLabel = $derived(sortDirection === "newest" ? "Newest" : "Oldest");
-
-  function toggleSortDirection() {
-    sortDirection = sortDirection === "newest" ? "oldest" : "newest";
-  }
+  const sortLabel = $derived(
+    SORT_OPTIONS.find((o) => o.value === sortDirection)?.label ?? "Newest",
+  );
 </script>
 
-<button
-  type="button"
-  class="flex flex-row items-center gap-x-1.5 h-9 px-2 text-sm font-medium text-fg-primary hover:text-fg-secondary cursor-pointer"
-  onclick={toggleSortDirection}
-  aria-label="Sort order: {sortLabel}"
->
-  <span>{sortLabel}</span>
-  <ArrowUpDown size={14} />
-</button>
+<DropdownMenu.Root>
+  <DropdownMenu.Trigger
+    class="flex flex-row items-center gap-x-1.5 h-9 px-4 border rounded-[2px] shadow-xs bg-white text-sm font-medium text-fg-primary hover:bg-surface-hover cursor-pointer"
+    aria-label="Sort order: {sortLabel}"
+  >
+    <ArrowDownAZ size={16} />
+    <span>Sort by {sortLabel}</span>
+  </DropdownMenu.Trigger>
+  <DropdownMenu.Content align="start">
+    {#each SORT_OPTIONS as option (option.value)}
+      <DropdownMenu.CheckboxItem
+        closeOnSelect
+        checked={sortDirection === option.value}
+        onclick={() => (sortDirection = option.value)}
+      >
+        {option.label}
+      </DropdownMenu.CheckboxItem>
+    {/each}
+  </DropdownMenu.Content>
+</DropdownMenu.Root>

--- a/web-common/src/components/table-toolbar/TableToolbarSort.svelte
+++ b/web-common/src/components/table-toolbar/TableToolbarSort.svelte
@@ -22,7 +22,7 @@
     <ArrowUpDown size={16} />
     <span>Sort by {sortLabel}</span>
   </DropdownMenu.Trigger>
-  <DropdownMenu.Content align="start">
+  <DropdownMenu.Content align="start" sameWidth>
     {#each SORT_OPTIONS as option (option.value)}
       <DropdownMenu.CheckboxItem
         closeOnSelect

--- a/web-common/src/components/table-toolbar/TableToolbarViewToggle.svelte
+++ b/web-common/src/components/table-toolbar/TableToolbarViewToggle.svelte
@@ -1,4 +1,3 @@
-<!-- Used by dashboard list/grid view toggle -->
 <script lang="ts">
   import List from "@rilldata/web-common/components/icons/List.svelte";
   import { LayoutGrid } from "lucide-svelte";
@@ -11,12 +10,13 @@
   } = $props();
 </script>
 
-<div class="flex flex-row border rounded-sm overflow-hidden">
+<div class="flex flex-row border overflow-hidden">
   <button
     type="button"
-    class="flex items-center justify-center w-8 h-8 {viewMode === 'grid'
+    class="flex items-center justify-center w-9 h-9 border-r {viewMode ===
+    'grid'
       ? 'bg-surface-hover'
-      : 'bg-input hover:bg-surface-hover'}"
+      : 'bg-white hover:bg-surface-hover'} rounded-l-[2px]"
     onclick={() => (viewMode = "grid")}
     aria-label="Grid view"
     aria-pressed={viewMode === "grid"}
@@ -25,10 +25,9 @@
   </button>
   <button
     type="button"
-    class="flex items-center justify-center w-8 h-8 border-l {viewMode ===
-    'list'
+    class="flex items-center justify-center w-9 h-9 {viewMode === 'list'
       ? 'bg-surface-hover'
-      : 'bg-input hover:bg-surface-hover'}"
+      : 'bg-white hover:bg-surface-hover'} rounded-r-[2px]"
     onclick={() => (viewMode = "list")}
     aria-label="List view"
     aria-pressed={viewMode === "list"}

--- a/web-common/src/components/table-toolbar/index.ts
+++ b/web-common/src/components/table-toolbar/index.ts
@@ -1,3 +1,8 @@
 export { default as TableToolbar } from "./TableToolbar.svelte";
-export type { FilterGroup, FilterOption, SortDirection, ViewMode } from "./types";
+export type {
+  FilterGroup,
+  FilterOption,
+  SortDirection,
+  ViewMode,
+} from "./types";
 export { SORT_OPTIONS } from "./types";

--- a/web-common/src/components/table-toolbar/index.ts
+++ b/web-common/src/components/table-toolbar/index.ts
@@ -1,7 +1,3 @@
 export { default as TableToolbar } from "./TableToolbar.svelte";
-export type {
-  FilterGroup,
-  FilterOption,
-  SortDirection,
-  ViewMode,
-} from "./types";
+export type { FilterGroup, FilterOption, SortDirection, ViewMode } from "./types";
+export { SORT_OPTIONS } from "./types";

--- a/web-common/src/components/table-toolbar/types.ts
+++ b/web-common/src/components/table-toolbar/types.ts
@@ -1,8 +1,8 @@
 export type SortDirection = "newest" | "oldest" | "a-z" | "z-a";
 
 export const SORT_OPTIONS: { value: SortDirection; label: string }[] = [
-  { value: "a-z", label: "A-Z" },
-  { value: "z-a", label: "Z-A" },
+  { value: "a-z", label: "A → Z" },
+  { value: "z-a", label: "Z → A" },
   { value: "newest", label: "Newest" },
   { value: "oldest", label: "Oldest" },
 ];

--- a/web-common/src/components/table-toolbar/types.ts
+++ b/web-common/src/components/table-toolbar/types.ts
@@ -1,4 +1,11 @@
-export type SortDirection = "newest" | "oldest";
+export type SortDirection = "newest" | "oldest" | "a-z" | "z-a";
+
+export const SORT_OPTIONS: { value: SortDirection; label: string }[] = [
+  { value: "newest", label: "Newest" },
+  { value: "oldest", label: "Oldest" },
+  { value: "a-z", label: "A-Z" },
+  { value: "z-a", label: "Z-A" },
+];
 
 export type ViewMode = "list" | "grid";
 

--- a/web-common/src/components/table-toolbar/types.ts
+++ b/web-common/src/components/table-toolbar/types.ts
@@ -1,10 +1,10 @@
 export type SortDirection = "newest" | "oldest" | "a-z" | "z-a";
 
 export const SORT_OPTIONS: { value: SortDirection; label: string }[] = [
-  { value: "newest", label: "Newest" },
-  { value: "oldest", label: "Oldest" },
   { value: "a-z", label: "A-Z" },
   { value: "z-a", label: "Z-A" },
+  { value: "newest", label: "Newest" },
+  { value: "oldest", label: "Oldest" },
 ];
 
 export type ViewMode = "list" | "grid";


### PR DESCRIPTION
Improves the shared `TableToolbar` component and projects page to match the updated Figma design:

- Rearranges toolbar layout: Filter + Sort grouped on the left, always-visible Search (flex-1) in the center, view toggle + action buttons on the right
- Replaces the Sort toggle with a dropdown supporting Newest, Oldest, A-Z, and Z-A options
- Adds bordered button styling to Filter and Sort buttons with accent state when filters are active
- Styles the applied filters row with a subtle gray background (`bg-surface-subtle`) and rounded bottom corners
- Adds status filtering, A-Z/Z-A name sorting, view toggle, and "New project" button to the projects page toolbar

Follows up on [#9173](https://github.com/rilldata/rill/pull/9173)

Figma: https://www.figma.com/design/JtG3sbaopjO0xQlyeCjmho/RILL-WIP?node-id=7699-201332&m=dev

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---

*Developed in collaboration with Claude Code*