### PR TITLE
fix: change Projects List page header from org name to "Projects"

### DIFF
--- a/web-admin/src/routes/[organization]/+page.svelte
+++ b/web-admin/src/routes/[organization]/+page.svelte
@@ -23,18 +23,16 @@
     query: { enabled: !!$org.data?.organization },
   });
   $: allProjectsHibernating = areAllProjectsHibernating(orgName);
-
-  $: title = $org.data?.organization?.displayName || orgName;
 </script>
 
 <svelte:head>
-  <title>{title} overview - Rill</title>
+  <title>Projects - Rill</title>
 </svelte:head>
 
 <ContentContainer showTitle={false} maxWidth={1300}>
   {#if $org.data && $org.data.organization && $projs.data}
     {#if $projs.data.projects?.length === 0}
-      <OrganizationHero {title} />
+      <OrganizationHero title="Projects" />
       <span>
         This organization has no projects yet. <a
           href="https://docs.rilldata.com/"
@@ -56,7 +54,7 @@
       />
     {:else}
       <div class="flex flex-col gap-y-8">
-        <OrganizationHero {title} />
+        <OrganizationHero title="Projects" />
         <ProjectCards organization={orgName} />
       </div>
     {/if}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Change the Projects List page header from displaying the organization's display name to the static word "Projects".

Previously, the `OrganizationHero` component on the `/{organization}` page showed the org's `displayName` (or slug). This changes it to always show "Projects" as the `<h1>` header, and updates the browser tab title from `"{orgName} overview - Rill"` to `"Projects - Rill"`.

Closes APP-883

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [APP-883](https://linear.app/rilldata/issue/APP-883/modify-projects-list-page-so-that-header-isnt-name-of-org-but-just-the)

<div><a href="https://cursor.com/agents/bc-83bf12b8-bb3b-4836-8ec5-46ddd43c4faa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83bf12b8-bb3b-4836-8ec5-46ddd43c4faa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

