### PR TITLE
Explicit checkpoint for editable deployments

### DIFF
--- a/admin/deployments.go
+++ b/admin/deployments.go
@@ -340,7 +340,8 @@ func (s *Service) StopDeploymentInner(ctx context.Context, depl *database.Deploy
 		// The runtime does checkpoint on close but because DeleteInstance removes the storage directly, the checkpoint can fail.
 		if depl.Editable {
 			_, err = rt.GitPush(ctx, &runtimev1.GitPushRequest{
-				InstanceId: depl.RuntimeInstanceID,
+				InstanceId:    depl.RuntimeInstanceID,
+				CommitMessage: "Auto checkpoint",
 			})
 			if err != nil {
 				s.Logger.Error("failed to checkpoint repo changes", zap.String("deployment_id", depl.ID), zap.String("runtime_instance_id", depl.RuntimeInstanceID), zap.Error(err), observability.ZapCtx(ctx))

--- a/admin/deployments.go
+++ b/admin/deployments.go
@@ -337,7 +337,7 @@ func (s *Service) StopDeploymentInner(ctx context.Context, depl *database.Deploy
 		defer rt.Close()
 
 		// Checkpoint repo changes if this is an editable deployment.
-		// The runtime does checkpoint on close but because DeleteInstance removes the directly the checkpoint can fail.
+		// The runtime does checkpoint on close but because DeleteInstance removes the storage directly, the checkpoint can fail.
 		if depl.Editable {
 			_, err = rt.GitPush(ctx, &runtimev1.GitPushRequest{
 				InstanceId: depl.RuntimeInstanceID,

--- a/admin/deployments.go
+++ b/admin/deployments.go
@@ -335,6 +335,18 @@ func (s *Service) StopDeploymentInner(ctx context.Context, depl *database.Deploy
 		s.Logger.Error("failed to open runtime client", zap.String("deployment_id", depl.ID), zap.String("runtime_instance_id", depl.RuntimeInstanceID), zap.Error(err), observability.ZapCtx(ctx))
 	} else {
 		defer rt.Close()
+
+		// Checkpoint repo changes if this is an editable deployment.
+		// The runtime does checkpoint on close but because DeleteInstance removes the directly the checkpoint can fail.
+		if depl.Editable {
+			_, err = rt.GitPush(ctx, &runtimev1.GitPushRequest{
+				InstanceId: depl.RuntimeInstanceID,
+			})
+			if err != nil {
+				s.Logger.Error("failed to checkpoint repo changes", zap.String("deployment_id", depl.ID), zap.String("runtime_instance_id", depl.RuntimeInstanceID), zap.Error(err), observability.ZapCtx(ctx))
+			}
+		}
+
 		_, err = rt.DeleteInstance(ctx, &runtimev1.DeleteInstanceRequest{
 			InstanceId: depl.RuntimeInstanceID,
 		})


### PR DESCRIPTION
In the stop deployment, we do a `DeleteInstance` on the runtime. The DeleteInstance removes the instance from the catalog and wipes out the disk. This does not give chance for git push to complete to checkpoint dev changes.

While we can remove `DeleteInstance` for dynamic runtimes but we still need it for static runtimes which are used for local development. Also explicit checkpoint feels safer.

The subsequent checkpoint on `Close` will be ` no-op`.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
