### PR TITLE
Allow editor roles to "view as" other users and to load the prod status page

### DIFF
--- a/admin/server/deployment.go
+++ b/admin/server/deployment.go
@@ -178,9 +178,15 @@ func (s *Server) GetDeployment(ctx context.Context, req *adminv1.GetDeploymentRe
 			if !permissions.ReadDev {
 				return nil, status.Error(codes.PermissionDenied, "does not have permission to read dev deployment")
 			}
+			if !permissions.ReadDevStatus {
+				depl.StatusMessage = ""
+			}
 		} else {
 			if !permissions.ReadProd {
 				return nil, status.Error(codes.PermissionDenied, "does not have permission to read prod deployment")
+			}
+			if !permissions.ReadProdStatus {
+				depl.StatusMessage = ""
 			}
 		}
 

--- a/admin/server/deployment.go
+++ b/admin/server/deployment.go
@@ -192,11 +192,11 @@ func (s *Server) GetDeployment(ctx context.Context, req *adminv1.GetDeploymentRe
 
 		if req.For != nil || req.ExternalUserId != "" {
 			if depl.Environment == "dev" {
-				if !permissions.ManageDev {
+				if !permissions.ReadDevStatus {
 					return nil, status.Error(codes.PermissionDenied, "does not have permission to manage dev deployment")
 				}
 			} else {
-				if !permissions.ManageProd {
+				if !permissions.ReadProdStatus {
 					return nil, status.Error(codes.PermissionDenied, "does not have permission to manage prod deployment")
 				}
 			}

--- a/admin/server/projects.go
+++ b/admin/server/projects.go
@@ -300,13 +300,6 @@ func (s *Server) GetProject(ctx context.Context, req *adminv1.GetProjectRequest)
 
 	var depl *database.Deployment
 	if req.Branch != "" {
-		if !permissions.ReadDev {
-			return &adminv1.GetProjectResponse{
-				Project:            s.projToDTO(proj, org.Name),
-				ProjectPermissions: permissions,
-			}, nil
-		}
-
 		depls, err := s.admin.DB.FindDeploymentsForProject(ctx, proj.ID, "", req.Branch)
 		if err != nil {
 			return nil, err
@@ -317,12 +310,8 @@ func (s *Server) GetProject(ctx context.Context, req *adminv1.GetProjectRequest)
 			return nil, status.Errorf(codes.FailedPrecondition, "multiple deployments found for branch %q. Recreate deployments to resolve", req.Branch)
 		}
 		depl = depls[0]
-
-		if !permissions.ReadDevStatus {
-			depl.StatusMessage = ""
-		}
 	} else {
-		if proj.PrimaryDeploymentID == nil || !permissions.ReadProd {
+		if proj.PrimaryDeploymentID == nil {
 			return &adminv1.GetProjectResponse{
 				Project:            s.projToDTO(proj, org.Name),
 				ProjectPermissions: permissions,
@@ -333,7 +322,19 @@ func (s *Server) GetProject(ctx context.Context, req *adminv1.GetProjectRequest)
 		if err != nil {
 			return nil, err
 		}
+	}
 
+	if depl.Environment == "dev" {
+		if !permissions.ReadDev {
+			return nil, status.Error(codes.PermissionDenied, "does not have permission to read dev deployment")
+		}
+		if !permissions.ReadDevStatus {
+			depl.StatusMessage = ""
+		}
+	} else {
+		if !permissions.ReadProd {
+			return nil, status.Error(codes.PermissionDenied, "does not have permission to read prod deployment")
+		}
 		if !permissions.ReadProdStatus {
 			depl.StatusMessage = ""
 		}

--- a/admin/server/runtime_jwt.go
+++ b/admin/server/runtime_jwt.go
@@ -173,14 +173,16 @@ func (s *Server) issueRuntimeToken(ctx context.Context, opts *issueRuntimeTokenO
 		}
 	}
 
-	// Check if allowed to manage the deployment's environment.
+	// Check if has elevated permissions for the deployment's environment.
 	// NOTE: Only applicable for tokens issued for the claims owner (not possible to delegate to other end users).
-	var manageDepl bool
+	var canReadStatus, canManage bool
 	if opts.forOwner {
-		if opts.deployment.Environment == "prod" {
-			manageDepl = opts.projectPermissions.ManageProd
+		if opts.deployment.Environment == "dev" {
+			canReadStatus = opts.projectPermissions.ReadDevStatus
+			canManage = opts.projectPermissions.ManageDev
 		} else {
-			manageDepl = opts.projectPermissions.ManageDev
+			canReadStatus = opts.projectPermissions.ReadProdStatus
+			canManage = opts.projectPermissions.ManageProd
 		}
 	}
 
@@ -191,22 +193,28 @@ func (s *Server) issueRuntimeToken(ctx context.Context, opts *issueRuntimeTokenO
 		runtime.ReadObjects,
 		runtime.UseAI,
 	}
-	if manageDepl {
+	if canReadStatus || canManage {
 		instancePermissions = append(
 			instancePermissions,
 			runtime.ReadInstance,
 			runtime.ReadResolvers,
-			runtime.EditTrigger,
 		)
 		if opts.deployment.Editable {
-			instancePermissions = append(
-				instancePermissions,
-				runtime.ManageInstance,
+			instancePermissions = append(instancePermissions,
 				runtime.ReadOLAP,
 				runtime.ReadProfiling,
 				runtime.ReadRepo,
-				runtime.EditRepo,
 			)
+		}
+		if canManage {
+			instancePermissions = append(instancePermissions, runtime.EditTrigger)
+			if opts.deployment.Editable {
+				instancePermissions = append(
+					instancePermissions,
+					runtime.EditRepo,
+					runtime.ManageInstance,
+				)
+			}
 		}
 	}
 

--- a/runtime/server/controller.go
+++ b/runtime/server/controller.go
@@ -62,7 +62,7 @@ func (s *Server) ListResources(ctx context.Context, req *runtimev1.ListResources
 	})
 
 	if req.SkipSecurityChecks {
-		if !claims.Admin() {
+		if !claims.Can(runtime.ReadInstance) {
 			return nil, ErrForbidden
 		}
 		return &runtimev1.ListResourcesResponse{Resources: rs}, nil
@@ -182,7 +182,7 @@ func (s *Server) GetResource(ctx context.Context, req *runtimev1.GetResourceRequ
 	}
 
 	if req.SkipSecurityChecks {
-		if !claims.Admin() {
+		if !claims.Can(runtime.ReadInstance) {
 			return nil, ErrForbidden
 		}
 		return &runtimev1.GetResourceResponse{Resource: r}, nil


### PR DESCRIPTION
- Allow passing `for` in `GetDeployment` when you have `read_<env>_status` permission (instead of `manage_<env>`)
- Grant editors `ReadInstance` and `ReadResolvers` so they can load the prod status page (editors currently have `ReadProdStatus`, but not `ManageProd` permission)
    - Modifies `ListResources`/`GetResource` such that `SkipSecurityChecks` requires `ReadInstance` instead of an `admin` attribute
- Modifies the access checks in `GetDeployment` and `GetProject` for consistency

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!