### PR TITLE
fix: pivot row dimension width reset

### DIFF
--- a/web-common/src/features/canvas/components/pivot/CanvasPivotDisplay.svelte
+++ b/web-common/src/features/canvas/components/pivot/CanvasPivotDisplay.svelte
@@ -38,6 +38,7 @@
   $: metricsViewSpec = $_metricViewSpec.metricsView;
 
   $: schema = validateTableSchema(metricsViewSpec, tableSpec);
+  $: widthScopeKey = `canvas:${component.parent.name}:${component.id}`;
 
   $: if ("columns" in tableSpec && schema.isValid) {
     const columns = tableSpec?.columns || [];
@@ -78,4 +79,5 @@
   {pivotDataStore}
   pivotConfig={config}
   {pivotState}
+  {widthScopeKey}
 />

--- a/web-common/src/features/canvas/components/pivot/CanvasPivotRenderer.svelte
+++ b/web-common/src/features/canvas/components/pivot/CanvasPivotRenderer.svelte
@@ -19,6 +19,7 @@
   export let pivotDataStore: PivotDataStore | undefined;
   export let pivotConfig: Readable<PivotDataStoreConfig> | undefined;
   export let pivotState: Writable<PivotState>;
+  export let widthScopeKey: string;
   export let hasHeader = false;
 
   $: pivotColumns = splitPivotChips($pivotState.columns);
@@ -46,6 +47,7 @@
       />
     {:else}
       <PivotTable
+        {widthScopeKey}
         border={hasHeader}
         rounded={hasHeader}
         {pivotDataStore}

--- a/web-common/src/features/dashboards/pivot/NestedTable.svelte
+++ b/web-common/src/features/dashboards/pivot/NestedTable.svelte
@@ -1,6 +1,7 @@
 <script lang="ts" context="module">
   import { writable } from "svelte/store";
   const measureLengths = writable(new Map<string, number>());
+  const rowDimensionLengths = writable(new Map<string, number>());
 </script>
 
 <script lang="ts">
@@ -19,6 +20,7 @@
     calculateMeasureWidth,
     calculateRowDimensionWidth,
     COLUMN_WIDTH_CONSTANTS as WIDTHS,
+    getNestedRowDimensionWidthKey,
   } from "./pivot-column-width-utils";
   import { isShowMoreRow } from "./pivot-utils";
   import type { PivotDataRow } from "./types";
@@ -61,11 +63,28 @@
   $: hasMeasures = measures.length > 0;
   $: rowDimensionLabel = getRowNestedLabel(rowDimensions);
   $: rowDimensionName = rowDimensionLabel ? rowDimensionLabel : null;
+  $: rowDimensionWidthKey = getNestedRowDimensionWidthKey(rowDimensions);
+
+  $: if (
+    hasRowDimension &&
+    rowDimensionName &&
+    rowDimensionWidthKey &&
+    !$rowDimensionLengths.has(rowDimensionWidthKey)
+  ) {
+    const estimatedWidth = calculateRowDimensionWidth(
+      rowDimensionName,
+      timeDimension,
+      dataRows,
+    );
+
+    rowDimensionLengths.update((rowDimensionLengths) => {
+      return rowDimensionLengths.set(rowDimensionWidthKey, estimatedWidth);
+    });
+  }
 
   $: rowDimensionWidth =
-    hasRowDimension && rowDimensionName
-      ? calculateRowDimensionWidth(rowDimensionName, timeDimension, dataRows)
-      : 0;
+    (rowDimensionWidthKey && $rowDimensionLengths.get(rowDimensionWidthKey)) ||
+    0;
 
   $: {
     // Get the longest column dimension header to ensure proper width calculation
@@ -209,7 +228,13 @@
       min={WIDTHS.MIN_COL_WIDTH}
       max={WIDTHS.MAX_COL_WIDTH}
       dimension={rowDimensionWidth}
-      onUpdate={(d) => (rowDimensionWidth = d)}
+      onUpdate={(d) => {
+        if (!rowDimensionWidthKey) return;
+
+        rowDimensionLengths.update((rowDimensionLengths) => {
+          return rowDimensionLengths.set(rowDimensionWidthKey, d);
+        });
+      }}
       onMouseDown={(e) => {
         resizingMeasure = false;
         onResizeStart(e);

--- a/web-common/src/features/dashboards/pivot/NestedTable.svelte
+++ b/web-common/src/features/dashboards/pivot/NestedTable.svelte
@@ -27,6 +27,7 @@
 
   // State props
   export let hasColumnDimension: boolean;
+  export let widthScopeKey: string;
   export let timeDimension: string;
   export let assembled: boolean;
   export let rowDimensions: DimensionColumnProps;
@@ -63,7 +64,10 @@
   $: hasMeasures = measures.length > 0;
   $: rowDimensionLabel = getRowNestedLabel(rowDimensions);
   $: rowDimensionName = rowDimensionLabel ? rowDimensionLabel : null;
-  $: rowDimensionWidthKey = getNestedRowDimensionWidthKey(rowDimensions);
+  $: rowDimensionWidthKey = getNestedRowDimensionWidthKey(
+    widthScopeKey,
+    rowDimensions,
+  );
 
   $: if (
     hasRowDimension &&

--- a/web-common/src/features/dashboards/pivot/PivotDisplay.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotDisplay.svelte
@@ -90,6 +90,8 @@
     if (!$dashboardStore.pivot.activeCell) return;
     metricsExplorerStore.removePivotActiveCell($exploreName);
   }
+
+  $: widthScopeKey = `explore:${$exploreName}`;
 </script>
 
 <div class="layout" class:h-full={!$dynamicHeight}>
@@ -163,6 +165,7 @@
         />
       {:else}
         <PivotTable
+          {widthScopeKey}
           {pivotDataStore}
           overscan={60}
           config={pivotConfig}

--- a/web-common/src/features/dashboards/pivot/PivotTable.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTable.svelte
@@ -44,6 +44,7 @@
   const HEADER_HEIGHT = 30;
 
   export let pivotDataStore: PivotDataStore;
+  export let widthScopeKey: string;
   export let config: Readable<PivotDataStoreConfig>;
   export let pivotState: Readable<PivotState>;
   export let canShowDataViewer = false;
@@ -334,6 +335,7 @@
       {headerGroups}
       {rows}
       {virtualRows}
+      {widthScopeKey}
       {before}
       {after}
       {timeDimension}

--- a/web-common/src/features/dashboards/pivot/pivot-column-width-utils.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-column-width-utils.ts
@@ -124,3 +124,9 @@ export function calculateRowDimensionWidth(
     COLUMN_WIDTH_CONSTANTS.MAX_INIT_COL_WIDTH,
   );
 }
+
+export function getNestedRowDimensionWidthKey(
+  rowDimensions: Array<{ name: string }>,
+) {
+  return rowDimensions[0]?.name;
+}

--- a/web-common/src/features/dashboards/pivot/pivot-column-width-utils.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-column-width-utils.ts
@@ -126,7 +126,11 @@ export function calculateRowDimensionWidth(
 }
 
 export function getNestedRowDimensionWidthKey(
+  widthScopeKey: string,
   rowDimensions: Array<{ name: string }>,
 ) {
-  return rowDimensions[0]?.name;
+  const rowDimensionName = rowDimensions[0]?.name;
+  if (!widthScopeKey || !rowDimensionName) return undefined;
+
+  return `${widthScopeKey}:${rowDimensionName}`;
 }

--- a/web-common/src/features/dashboards/pivot/tests/pivot-column-width-utils.test.ts
+++ b/web-common/src/features/dashboards/pivot/tests/pivot-column-width-utils.test.ts
@@ -1,0 +1,26 @@
+import { getNestedRowDimensionWidthKey } from "@rilldata/web-common/features/dashboards/pivot/pivot-column-width-utils";
+import { describe, expect, it } from "vitest";
+
+describe("getNestedRowDimensionWidthKey", () => {
+  it("uses the first row dimension as the stable nested row column key", () => {
+    const initialKey = getNestedRowDimensionWidthKey([
+      { name: "country" },
+      { name: "city" },
+    ]);
+
+    expect(initialKey).toBe(
+      getNestedRowDimensionWidthKey([
+        { name: "country" },
+        { name: "city" },
+        { name: "postal_code" },
+      ]),
+    );
+  });
+
+  it("changes when the adjusted row dimension is removed", () => {
+    expect(getNestedRowDimensionWidthKey([{ name: "country" }])).toBe(
+      "country",
+    );
+    expect(getNestedRowDimensionWidthKey([{ name: "city" }])).toBe("city");
+  });
+});

--- a/web-common/src/features/dashboards/pivot/tests/pivot-column-width-utils.test.ts
+++ b/web-common/src/features/dashboards/pivot/tests/pivot-column-width-utils.test.ts
@@ -3,13 +3,13 @@ import { describe, expect, it } from "vitest";
 
 describe("getNestedRowDimensionWidthKey", () => {
   it("uses the first row dimension as the stable nested row column key", () => {
-    const initialKey = getNestedRowDimensionWidthKey([
+    const initialKey = getNestedRowDimensionWidthKey("explore:Sales Explore", [
       { name: "country" },
       { name: "city" },
     ]);
 
     expect(initialKey).toBe(
-      getNestedRowDimensionWidthKey([
+      getNestedRowDimensionWidthKey("explore:Sales Explore", [
         { name: "country" },
         { name: "city" },
         { name: "postal_code" },
@@ -18,9 +18,27 @@ describe("getNestedRowDimensionWidthKey", () => {
   });
 
   it("changes when the adjusted row dimension is removed", () => {
-    expect(getNestedRowDimensionWidthKey([{ name: "country" }])).toBe(
-      "country",
+    expect(
+      getNestedRowDimensionWidthKey("explore:Sales Explore", [
+        { name: "country" },
+      ]),
+    ).toBe("explore:Sales Explore:country");
+    expect(
+      getNestedRowDimensionWidthKey("explore:Sales Explore", [
+        { name: "city" },
+      ]),
+    ).toBe("explore:Sales Explore:city");
+  });
+
+  it("scopes row dimension widths by pivot table instance", () => {
+    expect(
+      getNestedRowDimensionWidthKey("canvas:sales:component-1", [
+        { name: "country" },
+      ]),
+    ).not.toBe(
+      getNestedRowDimensionWidthKey("canvas:sales:component-2", [
+        { name: "country" },
+      ]),
     );
-    expect(getNestedRowDimensionWidthKey([{ name: "city" }])).toBe("city");
   });
 });


### PR DESCRIPTION
Fixes pivot table row dimension column widths resetting unexpectedly after table state changes.

https://linear.app/rilldata/issue/APP-802/pivot-table-columns-widths-reset-unexpectedly-when-switching-tabs-or

## Changes

- Persist nested pivot row dimension widths in the same way measure widths are persisted.
- Key the persisted row dimension width by the first row dimension, so width survives:
  - switching tabs
  - expanding or collapsing nested pivot rows
  - adding or removing unrelated pivot columns
- Add unit coverage for stable nested row dimension width key behavior.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
