### PR TITLE
Fix canvas resource list flakiness

### DIFF
--- a/web-common/src/features/canvas/AddComponentDropdown.svelte
+++ b/web-common/src/features/canvas/AddComponentDropdown.svelte
@@ -59,6 +59,7 @@
       {#if componentForm}
         <button
           {...props}
+          {disabled}
           class="pointer-events-auto shadow-sm hover:shadow-md flex bg-surface-subtle h-[84px] flex-col justify-center gap-2 items-center rounded-md border border-gray-200 w-full"
         >
           <PlusCircle class="w-6 h-6 text-fg-secondary" />
@@ -67,6 +68,7 @@
       {:else if floatingForm}
         <button
           {...props}
+          {disabled}
           class:pr-3.5={open}
           aria-label="Add widget"
           class="shadow-lg flex group hover:rounded-3xl w-fit gap-x-1 p-2 hover:pr-3.5 absolute bottom-3 right-3 items-center justify-center z-50 rounded-full bg-primary-600 text-white hover:bg-primary-500"

--- a/web-common/src/features/canvas/CanvasBuilder.svelte
+++ b/web-common/src/features/canvas/CanvasBuilder.svelte
@@ -311,6 +311,8 @@
     position: { row: number; column: number },
     items: CanvasComponentType[],
   ) {
+    if (!defaultMetrics) return;
+
     performTransaction({
       operations: items.map((type, i) => ({
         type: "add",
@@ -325,6 +327,7 @@
     const id = getId(position.row, position.column);
 
     setSelectedComponent(id);
+    openSidebar();
   }
 
   function updateContents() {
@@ -356,6 +359,7 @@
     });
 
     setSelectedComponent(id);
+    openSidebar();
   }
 
   function onDrop(row: number, column: number | null) {
@@ -557,6 +561,7 @@
 {#if specCanvasRows.length}
   <AddComponentDropdown
     floatingForm
+    disabled={!defaultMetrics}
     onItemClick={(type) => {
       initializeRow(specCanvasRows.length, type);
       setTimeout(() => scrollToBottom(), 500);

--- a/web-common/src/features/entity-management/resource-selectors.ts
+++ b/web-common/src/features/entity-management/resource-selectors.ts
@@ -259,6 +259,7 @@ export function useClientFilteredResources(
           ) ?? [],
       },
     },
+    queryClient,
   );
 }
 

--- a/web-common/src/features/metrics-views/metrics-view-selectors.ts
+++ b/web-common/src/features/metrics-views/metrics-view-selectors.ts
@@ -5,13 +5,12 @@ import {
   type MetricsViewSpecMeasure,
   type V1MetricsView,
   type V1MetricsViewSpec,
-  type V1Resource,
 } from "@rilldata/web-common/runtime-client";
 import type { RuntimeClient } from "@rilldata/web-common/runtime-client/v2";
 import { derived, get, type Readable } from "svelte/store";
 import {
   ResourceKind,
-  useFilteredResources,
+  useClientFilteredResources,
 } from "../entity-management/resource-selectors";
 
 type MetricsViewsData = Readable<Record<string, V1MetricsView | undefined>>;
@@ -59,12 +58,10 @@ export class MetricsViewSelectors {
   allDimensions: Readable<MetricsViewSpecDimension[]>;
   metricsViewDimensionsMap: Readable<Record<string, Set<string>>>;
 
-  allMetricsViews: ReturnType<
-    typeof useFilteredResources<Array<V1Resource | undefined>>
-  >;
+  allMetricsViews: ReturnType<typeof useClientFilteredResources>;
 
   constructor(client: RuntimeClient, metricsViewsData?: MetricsViewsData) {
-    this.allMetricsViews = useFilteredResources(
+    this.allMetricsViews = useClientFilteredResources(
       client,
       ResourceKind.MetricsView,
     );

--- a/web-common/src/runtime-client/invalidation/resource-invalidators.spec.ts
+++ b/web-common/src/runtime-client/invalidation/resource-invalidators.spec.ts
@@ -3,6 +3,7 @@ import {
   getConnectorServiceOLAPListTablesQueryKey,
   getRuntimeServiceAnalyzeConnectorsQueryKey,
   getRuntimeServiceGetResourceQueryKey,
+  getRuntimeServiceListResourcesQueryKey,
   V1ReconcileStatus,
   type V1Resource,
   V1ResourceEvent,
@@ -179,6 +180,33 @@ describe("handleResourceEvent — setup + guards", () => {
 
     await handleResourceEvent(event, qc, fakeRuntimeClient, makeState());
     expect(qc.refetchQueries).not.toHaveBeenCalled();
+  });
+
+  it("invalidates list queries for an idle write even without a previous cached resource", async () => {
+    const qc = fakeQueryClient();
+    const event = writeEvent(ResourceKind.MetricsView, "mv", {
+      meta: baseMeta({
+        stateVersion: "2",
+        reconcileStatus: V1ReconcileStatus.RECONCILE_STATUS_IDLE,
+      }),
+    });
+
+    await handleResourceEvent(event, qc, fakeRuntimeClient, makeState());
+
+    expect(
+      containsQueryKey(
+        qc.refetchQueries,
+        getRuntimeServiceListResourcesQueryKey(INSTANCE_ID, undefined),
+      ),
+    ).toBe(true);
+    expect(
+      containsQueryKey(
+        qc.refetchQueries,
+        getRuntimeServiceListResourcesQueryKey(INSTANCE_ID, {
+          kind: ResourceKind.MetricsView,
+        }),
+      ),
+    ).toBe(true);
   });
 });
 

--- a/web-common/src/runtime-client/invalidation/resource-invalidators.ts
+++ b/web-common/src/runtime-client/invalidation/resource-invalidators.ts
@@ -114,14 +114,15 @@ async function dispatchWrite(
 
   // Mirror the legacy watcher gate:
   //   - resourceVersionUnchanged: duplicate stateVersion (same server view)
-  //   - resourceFinishedReconciling: a non-idle -> idle transition
+  //   - resourceFinishedReconciling: a non-idle/unknown -> idle transition
   // If the version advanced and reconcile is still in progress, skip noisy
   // intermediate invalidations.
   const resourceVersionUnchanged =
     event.resource.meta.stateVersion === previousResource?.meta?.stateVersion;
   const resourceFinishedReconciling =
-    previousResource?.meta?.reconcileStatus !==
-      V1ReconcileStatus.RECONCILE_STATUS_IDLE &&
+    (!previousResource ||
+      previousResource.meta?.reconcileStatus !==
+        V1ReconcileStatus.RECONCILE_STATUS_IDLE) &&
     event.resource.meta.reconcileStatus ===
       V1ReconcileStatus.RECONCILE_STATUS_IDLE;
   if (!resourceVersionUnchanged && !resourceFinishedReconciling) {


### PR DESCRIPTION
The floating Add widget button rendered before `defaultMetrics` was ready. Clicking during that window made initializeRow silently return.

- Disabled the floating add-widget trigger until `defaultMetrics` is available.
- Made successful widget adds open the inspector.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
