### PR TITLE
fix: navigate by relative path after project create

### DIFF
--- a/web-admin/src/features/projects/CreateProjectForm.svelte
+++ b/web-admin/src/features/projects/CreateProjectForm.svelte
@@ -33,7 +33,7 @@
   }: {
     organization: string;
     defaultName?: string;
-    onCreate: (projectName: string, frontendUrl: string) => void;
+    onCreate: (projectName: string) => void;
     onDeployError?: (deployError: DeployError) => void;
   } = $props();
 
@@ -117,7 +117,7 @@
           ),
         });
 
-        onCreate(project, resp.project?.frontendUrl ?? "/");
+        onCreate(project);
       },
       onError({ result }) {
         const error =

--- a/web-admin/src/routes/[organization]/-/create-project/+page.svelte
+++ b/web-admin/src/routes/[organization]/-/create-project/+page.svelte
@@ -37,11 +37,13 @@
   let showStartTeamPlanDialog = $state(false);
   let startTeamPlanType: TeamPlanDialogTypes = $state("base");
 
-  function handleCreate(projectName: string, frontendUrl: string) {
+  function handleCreate(projectName: string) {
     projectWelcomeStatus.setProjectWelcomeStep(projectName, true);
     setTimeout(
       () =>
-        void goto(`${frontendUrl}/@${CreateProjectBranchName}/-/edit/welcome`),
+        void goto(
+          `/${organization}/${projectName}/@${CreateProjectBranchName}/-/edit/welcome`,
+        ),
     );
   }
 </script>
@@ -65,7 +67,7 @@
     {:else}
       <RillLogoSquareNegative size="36px" />
       <div class="text-2xl font-extrabold text-fg-accent text-center">
-        Create {hasProjects ? "your first" : "a new"} project
+        Create {hasProjects ? "a new" : "your first"} project
       </div>
 
       <div
@@ -73,7 +75,7 @@
       >
         <div>
           <div class="text-base font-semibold">
-            Name your {hasProjects ? "first " : ""}project
+            Name your {hasProjects ? "" : "first "}project
           </div>
           <div class="text-sm text-fg-muted">
             You can rename anytime from project settings.


### PR DESCRIPTION
- After creating a project, the post-create redirect used the project's `frontendUrl` from the API, which is an absolute URL built from the admin server's configured frontend host. On hosts that don't match (e.g. `ui.rilldata.in`), `goto` silently failed because SvelteKit refuses cross-origin client-side navigation, leaving the user stranded on the create-project page. Switched to a relative path built from the route params.
- Fixed an inverted ternary: \"Create your first project\" / \"Name your first project\" was only shown when projects already existed.

Closes [GEN-724](https://www.notion.so/rilldata/Weird-interstitial-page-appears-after-entering-project-name-356ba33c8f578061b77aca11b9152f43)

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*