### PR TITLE
fix: billing banners showing up on welcome pages

### DIFF
--- a/web-admin/src/features/navigation/nav-utils.ts
+++ b/web-admin/src/features/navigation/nav-utils.ts
@@ -129,6 +129,20 @@ export function isAuthPage({ route }: Pick<Page, "route">): boolean {
   return !!route.id?.startsWith("/-/auth");
 }
 
+/**
+ * Returns true if the page is a page that is part of the onboarding flow.
+ * Project invite page, org/project welcome page, and project create page are all onboarding pages as of now.
+ * @param page
+ */
+export function isOnboardingPage(page: Page): boolean {
+  return (
+    isProjectInvitePage(page) ||
+    isProjectInvitePage(page) ||
+    isWelcomePage(page) ||
+    isProjectWelcomePage(page)
+  );
+}
+
 export function getScreenNameFromPage(page: Page): MetricsEventScreenName {
   switch (true) {
     case isOrganizationPage(page):

--- a/web-admin/src/features/navigation/nav-utils.ts
+++ b/web-admin/src/features/navigation/nav-utils.ts
@@ -137,9 +137,9 @@ export function isAuthPage({ route }: Pick<Page, "route">): boolean {
 export function isOnboardingPage(page: Page): boolean {
   return (
     isProjectInvitePage(page) ||
-    isProjectInvitePage(page) ||
     isWelcomePage(page) ||
-    isProjectWelcomePage(page)
+    isProjectWelcomePage(page) ||
+    isProjectCreatePage(page)
   );
 }
 

--- a/web-admin/src/routes/+layout.svelte
+++ b/web-admin/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
   import BillingBannerManager from "@rilldata/web-admin/features/billing/banner/BillingBannerManager.svelte";
   import {
     isBillingUpgradePage,
+    isOnboardingPage,
     isProjectCreatePage,
     isProjectInvitePage,
     isProjectWelcomePage,
@@ -95,24 +96,18 @@
 
   $: isEmbed = isEmbedPage($page);
 
+  // Onboarding pages like the project invite page, org/project welcome page, and project create page should hide the top bar and billing manager
+  $: onOnboardingPage = isOnboardingPage($page);
+
   $: hideTopBar =
-    // invite page shouldn't show the top bar because it is considered an onboard step
-    isProjectInvitePage($page) ||
     // upgrade callback landing page shouldn't show any rill identifications
     isBillingUpgradePage($page) ||
     // public reports are shared to external users who shouldn't be shown any rill related stuff
     isPublicReportPage($page) ||
-    // Welcome page should be a full screen experience
-    isWelcomePage($page) ||
-    // Project welcome page should not show the banner to avoid breaking the UX.
-    isProjectWelcomePage($page) ||
-    // Project create page should be a full page experience as well.
-    isProjectCreatePage($page);
+    onOnboardingPage;
   $: hideBillingManager =
     // billing manager needs organization
-    !organization ||
-    // invite page shouldn't show the banner since the illusion is that the user is not on cloud yet.
-    isProjectInvitePage($page);
+    !organization || onOnboardingPage;
 
   $: withinOnlyOrg = withinOrganization($page) && !withinProject($page);
 

--- a/web-admin/src/routes/+layout.svelte
+++ b/web-admin/src/routes/+layout.svelte
@@ -8,11 +8,7 @@
   import {
     isBillingUpgradePage,
     isOnboardingPage,
-    isProjectCreatePage,
-    isProjectInvitePage,
-    isProjectWelcomePage,
     isPublicReportPage,
-    isWelcomePage,
     withinOrganization,
     withinProject,
   } from "@rilldata/web-admin/features/navigation/nav-utils";


### PR DESCRIPTION
Refactoring to add `onOnboardingPage` boolean while deciding whether top bar or billing banners are shown. Invite page, org/project welcome page and create org page are added to this right now.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
