### PR TITLE
fix: refresh `ListProjects` cache after project creation

### DIFF
--- a/web-admin/src/features/billing/plans/PlanQuotas.svelte
+++ b/web-admin/src/features/billing/plans/PlanQuotas.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
-  import {
-    createAdminServiceGetOrganization,
-    createAdminServiceListProjectsForOrganization,
-  } from "@rilldata/web-admin/client";
+  import { createAdminServiceGetOrganization } from "@rilldata/web-admin/client";
+  import { listProjectsForOrgQueryOptions } from "@rilldata/web-admin/features/projects/list-projects-query-options";
+  import { createQuery } from "@tanstack/svelte-query";
   import { getOrganizationUsageMetrics } from "@rilldata/web-admin/features/billing/plans/selectors";
   import { formatUsageVsQuota } from "@rilldata/web-admin/features/billing/plans/utils";
   import { Progress } from "@rilldata/web-common/components/progress";
 
   export let organization: string;
 
-  $: projects = createAdminServiceListProjectsForOrganization(organization);
+  $: projects = createQuery(listProjectsForOrgQueryOptions(organization));
   $: organizationQuotas = createAdminServiceGetOrganization(
     organization,
     undefined,

--- a/web-admin/src/features/navigation/breadcrumb-selectors.ts
+++ b/web-admin/src/features/navigation/breadcrumb-selectors.ts
@@ -1,9 +1,10 @@
 import type { PathOption } from "@rilldata/web-common/components/navigation/breadcrumbs/types";
 import {
   createAdminServiceListOrganizations,
-  createAdminServiceListProjectsForOrganization,
   type V1Organization,
 } from "../../client";
+import { listProjectsForOrgQueryOptions } from "@rilldata/web-admin/features/projects/list-projects-query-options";
+import { createQuery } from "@tanstack/svelte-query";
 
 /**
  * Query selector for organization breadcrumb paths.
@@ -43,19 +44,13 @@ export function useBreadcrumbProjectPaths(
   organization: string | undefined,
   readProjects: boolean,
 ) {
-  return createAdminServiceListProjectsForOrganization(
-    organization ?? "",
-    { pageSize: 100 },
-    {
-      query: {
-        enabled: !!organization && readProjects,
-        retry: 2,
-        refetchOnMount: true,
-        placeholderData: {},
-        select: (data) => buildProjectPathMap(data.projects ?? []),
-      },
-    },
-  );
+  return createQuery({
+    ...listProjectsForOrgQueryOptions(organization ?? ""),
+    enabled: !!organization && readProjects,
+    retry: 2,
+    placeholderData: {},
+    select: (data) => buildProjectPathMap(data.projects ?? []),
+  });
 }
 
 /**

--- a/web-admin/src/features/organizations/selectors.ts
+++ b/web-admin/src/features/organizations/selectors.ts
@@ -6,13 +6,12 @@ import {
 } from "@rilldata/web-admin/client";
 import { listProjectsForOrgQueryOptions } from "@rilldata/web-admin/features/projects/list-projects-query-options";
 import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
-import { createQuery } from "@tanstack/svelte-query";
 import type { FetchQueryOptions } from "@tanstack/query-core";
+import { createQuery } from "@tanstack/svelte-query";
 
 export function areAllProjectsHibernating(organization: string) {
   return createQuery({
     ...listProjectsForOrgQueryOptions(organization),
-    enabled: !!organization,
     select: (data) =>
       data.projects?.length &&
       data.projects.every((p) => !p.primaryDeploymentId),

--- a/web-admin/src/features/organizations/selectors.ts
+++ b/web-admin/src/features/organizations/selectors.ts
@@ -1,36 +1,28 @@
 import {
   adminServiceGetOrganization,
-  adminServiceListProjectsForOrganization,
-  createAdminServiceListProjectsForOrganization,
   getAdminServiceGetOrganizationQueryKey,
-  getAdminServiceListProjectsForOrganizationQueryKey,
   type V1GetOrganizationResponse,
   type V1Organization,
 } from "@rilldata/web-admin/client";
+import { listProjectsForOrgQueryOptions } from "@rilldata/web-admin/features/projects/list-projects-query-options";
 import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
+import { createQuery } from "@tanstack/svelte-query";
 import type { FetchQueryOptions } from "@tanstack/query-core";
 
 export function areAllProjectsHibernating(organization: string) {
-  return createAdminServiceListProjectsForOrganization(
-    organization,
-    undefined,
-    {
-      query: {
-        enabled: !!organization,
-        select: (data) =>
-          data.projects?.length &&
-          data.projects.every((p) => !p.primaryDeploymentId),
-      },
-    },
-  );
+  return createQuery({
+    ...listProjectsForOrgQueryOptions(organization),
+    enabled: !!organization,
+    select: (data) =>
+      data.projects?.length &&
+      data.projects.every((p) => !p.primaryDeploymentId),
+  });
 }
 
 export async function fetchAllProjectsHibernating(organization: string) {
-  const projectsResp = await queryClient.fetchQuery({
-    queryKey: getAdminServiceListProjectsForOrganizationQueryKey(organization),
-    queryFn: () => adminServiceListProjectsForOrganization(organization),
-    staleTime: Infinity,
-  });
+  const projectsResp = await queryClient.fetchQuery(
+    listProjectsForOrgQueryOptions(organization),
+  );
   return projectsResp.projects?.every((p) => !p.primaryDeploymentId) ?? false;
 }
 

--- a/web-admin/src/features/organizations/user-management/dialogs/AddGuestsDialog.svelte
+++ b/web-admin/src/features/organizations/user-management/dialogs/AddGuestsDialog.svelte
@@ -6,6 +6,8 @@
     getAdminServiceListOrganizationMemberUsersQueryKey,
     type V1Project,
   } from "@rilldata/web-admin/client";
+  import { getRpcErrorMessage } from "@rilldata/web-admin/components/errors/error-utils";
+  import { ORG_ROLES_OPTIONS } from "@rilldata/web-admin/features/organizations/constants";
   import { listProjectsForOrgQueryOptions } from "@rilldata/web-admin/features/projects/list-projects-query-options";
   import { Button } from "@rilldata/web-common/components/button";
   import {
@@ -17,16 +19,14 @@
     DialogTitle,
     DialogTrigger,
   } from "@rilldata/web-common/components/dialog";
+  import * as Dropdown from "@rilldata/web-common/components/dropdown-menu";
   import MultiInput from "@rilldata/web-common/components/forms/MultiInput.svelte";
   import { RFC5322EmailRegex } from "@rilldata/web-common/components/forms/validation";
-  import * as Dropdown from "@rilldata/web-common/components/dropdown-menu";
-  import CaretUpIcon from "@rilldata/web-common/components/icons/CaretUpIcon.svelte";
   import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
+  import CaretUpIcon from "@rilldata/web-common/components/icons/CaretUpIcon.svelte";
   import DelayedSpinner from "@rilldata/web-common/features/entity-management/DelayedSpinner.svelte";
-  import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
-  import { getRpcErrorMessage } from "@rilldata/web-admin/components/errors/error-utils";
-  import { ORG_ROLES_OPTIONS } from "@rilldata/web-admin/features/organizations/constants";
   import { OrgUserRoles } from "@rilldata/web-common/features/users/roles";
+  import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
   import { createQuery, useQueryClient } from "@tanstack/svelte-query";
   import { defaults, superForm } from "sveltekit-superforms";
   import { yup } from "sveltekit-superforms/adapters";
@@ -58,7 +58,6 @@
   // Projects list
   $: projectsQuery = createQuery({
     ...listProjectsForOrgQueryOptions(organization),
-    enabled: !!organization,
     refetchOnWindowFocus: true,
   });
   $: projects = $projectsQuery?.data?.projects ?? ([] as V1Project[]);

--- a/web-admin/src/features/organizations/user-management/dialogs/AddGuestsDialog.svelte
+++ b/web-admin/src/features/organizations/user-management/dialogs/AddGuestsDialog.svelte
@@ -2,11 +2,11 @@
   import { page } from "$app/stores";
   import {
     createAdminServiceAddProjectMemberUser,
-    createAdminServiceListProjectsForOrganization,
     getAdminServiceListOrganizationInvitesQueryKey,
     getAdminServiceListOrganizationMemberUsersQueryKey,
     type V1Project,
   } from "@rilldata/web-admin/client";
+  import { listProjectsForOrgQueryOptions } from "@rilldata/web-admin/features/projects/list-projects-query-options";
   import { Button } from "@rilldata/web-common/components/button";
   import {
     Dialog,
@@ -27,7 +27,7 @@
   import { getRpcErrorMessage } from "@rilldata/web-admin/components/errors/error-utils";
   import { ORG_ROLES_OPTIONS } from "@rilldata/web-admin/features/organizations/constants";
   import { OrgUserRoles } from "@rilldata/web-common/features/users/roles";
-  import { useQueryClient } from "@tanstack/svelte-query";
+  import { createQuery, useQueryClient } from "@tanstack/svelte-query";
   import { defaults, superForm } from "sveltekit-superforms";
   import { yup } from "sveltekit-superforms/adapters";
   import { array, object, string } from "yup";
@@ -56,17 +56,11 @@
   }
 
   // Projects list
-  $: projectsQuery = createAdminServiceListProjectsForOrganization(
-    organization,
-    undefined,
-    {
-      query: {
-        enabled: !!organization,
-        refetchOnMount: true,
-        refetchOnWindowFocus: true,
-      },
-    },
-  );
+  $: projectsQuery = createQuery({
+    ...listProjectsForOrgQueryOptions(organization),
+    enabled: !!organization,
+    refetchOnWindowFocus: true,
+  });
   $: projects = $projectsQuery?.data?.projects ?? ([] as V1Project[]);
   $: projectsErrorMessage =
     getRpcErrorMessage($projectsQuery?.error) ?? $projectsQuery?.error?.message;

--- a/web-admin/src/features/projects/ProjectCards.svelte
+++ b/web-admin/src/features/projects/ProjectCards.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
-  import { createAdminServiceListProjectsForOrganization } from "../../client";
   import ProjectCard from "./ProjectCard.svelte";
   import { Button } from "@rilldata/web-common/components/button";
   import { projectWelcomeEnabled } from "@rilldata/web-admin/features/welcome/project/welcome-status.ts";
+  import { listProjectsForOrgQueryOptions } from "@rilldata/web-admin/features/projects/list-projects-query-options";
+  import { createQuery } from "@tanstack/svelte-query";
 
   export let organization: string;
 
-  $: projs = createAdminServiceListProjectsForOrganization(organization, {
-    pageSize: 1000,
-  });
+  $: projs = createQuery(listProjectsForOrgQueryOptions(organization));
 </script>
 
 <div class="flex flex-col gap-y-4">

--- a/web-admin/src/features/projects/list-projects-query-options.ts
+++ b/web-admin/src/features/projects/list-projects-query-options.ts
@@ -1,0 +1,11 @@
+import { getAdminServiceListProjectsForOrganizationQueryOptions } from "@rilldata/web-admin/client";
+
+const PAGE_SIZE = 1000;
+
+export function listProjectsForOrgQueryOptions(org: string) {
+  return getAdminServiceListProjectsForOrganizationQueryOptions(
+    org,
+    { pageSize: PAGE_SIZE },
+    { query: { refetchOnMount: true, staleTime: Infinity } },
+  );
+}

--- a/web-admin/src/routes/[organization]/+page.svelte
+++ b/web-admin/src/routes/[organization]/+page.svelte
@@ -3,10 +3,9 @@
   import ContentContainer from "@rilldata/web-common/components/layout/ContentContainer.svelte";
   import OrganizationHibernating from "@rilldata/web-admin/features/organizations/hibernating/OrganizationHibernating.svelte";
   import { areAllProjectsHibernating } from "@rilldata/web-admin/features/organizations/selectors";
-  import {
-    createAdminServiceGetOrganization,
-    createAdminServiceListProjectsForOrganization,
-  } from "../../client";
+  import { createAdminServiceGetOrganization } from "../../client";
+  import { listProjectsForOrgQueryOptions } from "@rilldata/web-admin/features/projects/list-projects-query-options";
+  import { createQuery } from "@tanstack/svelte-query";
   import OrganizationHero from "../../features/organizations/OrganizationHero.svelte";
   import ProjectCards from "../../features/projects/ProjectCards.svelte";
   import { Button } from "@rilldata/web-common/components/button";
@@ -19,8 +18,9 @@
   } = $page);
 
   $: org = createAdminServiceGetOrganization(orgName);
-  $: projs = createAdminServiceListProjectsForOrganization(orgName, undefined, {
-    query: { enabled: !!$org.data?.organization },
+  $: projs = createQuery({
+    ...listProjectsForOrgQueryOptions(orgName),
+    enabled: !!$org.data?.organization,
   });
   $: allProjectsHibernating = areAllProjectsHibernating(orgName);
 

--- a/web-admin/src/routes/[organization]/-/create-project/+page.svelte
+++ b/web-admin/src/routes/[organization]/-/create-project/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
-  import { createAdminServiceListProjectsForOrganization } from "@rilldata/web-admin/client";
+  import { listProjectsForOrgQueryOptions } from "@rilldata/web-admin/features/projects/list-projects-query-options";
+  import { createQuery } from "@tanstack/svelte-query";
   import CreateProjectForm from "@rilldata/web-admin/features/projects/CreateProjectForm.svelte";
   import { getName } from "@rilldata/web-common/features/entity-management/name-utils.ts";
   import { EntityStatus } from "@rilldata/web-common/features/entity-management/types.ts";
@@ -22,7 +23,7 @@
   let organization = $derived(page.params.organization);
 
   let projectsQuery = $derived(
-    createAdminServiceListProjectsForOrganization(organization, undefined),
+    createQuery(listProjectsForOrgQueryOptions(organization)),
   );
   let hasProjects = $derived($projectsQuery.data?.projects?.length > 0);
 


### PR DESCRIPTION
- Fixes a bug where newly created projects didn't appear on the org overview until manual refresh. Root cause: with the global `refetchOnMount: false` default, `invalidateQueries` against an unobserved query just marks it stale; nothing refetches on remount.
- Adopts `refetchOnMount: true` + `staleTime: Infinity` on the `ListProjects` observers — refetches only after invalidation, otherwise reads cache.
- Consolidates three cache keys (`projects`, `projects?pageSize=100`, `projects?pageSize=1000`) to one by standardizing all eight callers on `pageSize: 1000`. Also fixes a latent 20-cap bug at sites that passed no `pageSize` (server default `_defaultPageSize = 20` in `admin/server/page_token.go`).
- Extracts `listProjectsForOrgQueryOptions(org)` as a single source of truth for params + policy, delegating `queryKey`/`queryFn` to Orval's generated `getAdminServiceListProjectsForOrganizationQueryOptions`.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
*Developed in collaboration with Claude Code*