### PR TITLE
Align edit-session `GetProject` polling for proactive JWT refresh

### DIFF
--- a/web-admin/src/features/projects/project-query-options.ts
+++ b/web-admin/src/features/projects/project-query-options.ts
@@ -33,4 +33,8 @@ export const baseGetProjectQueryOptions: Partial<
   refetchOnMount: true,
   refetchOnReconnect: true,
   refetchOnWindowFocus: true,
+  // Align staleness with the RUNNING poll cadence so near-simultaneous observer
+  // mounts (e.g. project + edit layouts) dedupe instead of each firing its own
+  // refetch. Focus/reconnect refetch still kicks in once data exceeds this window.
+  staleTime: PollTimeWhenProjectDeploymentOk,
 };

--- a/web-admin/src/routes/[organization]/[project]/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/+layout.svelte
@@ -120,16 +120,13 @@
    * `GetProject` with default cookie-based auth.
    * When `activeBranch` is set, the branch param is passed so the API
    * returns the branch deployment instead of production.
-   *
-   * On the edit page, the edit layout manages its own readiness detection,
-   * so we skip aggressive polling here to avoid unnecessary requests.
    */
   let cookieProjectQuery = $derived(
     createAdminServiceGetProject(
       organization,
       project,
       activeBranch ? { branch: activeBranch } : undefined,
-      { query: onEditPage ? {} : baseGetProjectQueryOptions },
+      { query: baseGetProjectQueryOptions },
     ),
   );
 

--- a/web-admin/src/routes/[organization]/[project]/-/edit/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/+layout.svelte
@@ -15,6 +15,7 @@
   import EditSessionLoading from "@rilldata/web-admin/features/edit-session/EditSessionLoading.svelte";
   import EditSessionTimeoutBanner from "@rilldata/web-admin/features/edit-session/EditSessionTimeoutBanner.svelte";
   import ProjectHeader from "@rilldata/web-admin/features/projects/ProjectHeader.svelte";
+  import { baseGetProjectQueryOptions } from "@rilldata/web-admin/features/projects/project-query-options";
   import SlimProjectHeader from "@rilldata/web-admin/features/projects/SlimProjectHeader.svelte";
   import { getThemedLogoUrl } from "@rilldata/web-admin/features/themes/organization-logo";
   import CtaButton from "@rilldata/web-common/components/calls-to-action/CTAButton.svelte";
@@ -53,31 +54,13 @@
     pageData?.organization as V1Organization | undefined,
   );
 
-  // GetProject({branch}): returns deployment status, credentials (runtimeHost,
-  // runtimeInstanceId, jwt), and project permissions. Polls at 2s while the
-  // deployment is provisioning or updating; stops once it reaches a terminal
-  // state (RUNNING, ERRORED, etc.). The parent layout skips its own polling
-  // on the edit page to avoid duplicate requests.
+  // Polling and JWT-refresh cadence are governed by `baseGetProjectQueryOptions`,
+  // shared with the parent project layout so both observers stay in sync.
   $: projectQuery = createAdminServiceGetProject(
     organization,
     project,
     branch ? { branch } : undefined,
-    {
-      query: {
-        refetchInterval: (query) => {
-          const status = query.state.data?.deployment?.status;
-          if (
-            status === V1DeploymentStatus.DEPLOYMENT_STATUS_PENDING ||
-            status === V1DeploymentStatus.DEPLOYMENT_STATUS_UPDATING ||
-            status === V1DeploymentStatus.DEPLOYMENT_STATUS_STOPPED ||
-            status === V1DeploymentStatus.DEPLOYMENT_STATUS_STOPPING
-          ) {
-            return 2000;
-          }
-          return false;
-        },
-      },
-    },
+    { query: baseGetProjectQueryOptions },
   );
   $: projectPermissions = $projectQuery.data?.projectPermissions ?? {};
   $: primaryBranch = $projectQuery.data?.project?.primaryBranch;


### PR DESCRIPTION
Long-lived edit sessions could end up with an expired JWT. The runtime JWT served from `GetProject` has a 30-minute TTL, and on non-edit pages the project layout already polls every 15 minutes to refresh it before expiry. The edit layout, however, had its own `GetProject` observer that stopped polling once the deployment reached RUNNING — so a tab left open past the TTL would silently lose its token, only recovering on the next SSE reconnect.

This PR aligns the edit layout's polling with the project layout's so both surfaces refresh the JWT on the same cadence.

**Implementation notes:**
- Edit layout reuses `baseGetProjectQueryOptions` instead of its own hand-rolled `refetchInterval`.
- Project layout drops the `onEditPage ? {} : baseGetProjectQueryOptions` ternary; both observers share a query key, so TanStack dedupes the network request.
- Adds `staleTime` to `baseGetProjectQueryOptions` so near-simultaneous mounts (the project and edit layout observers on initial load) dedupe instead of each firing its own refetch on mount.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
*Developed in collaboration with Claude Code*