### PR TITLE
Auto-create dev branch on first Edit; restrict modal to self-managed

### DIFF
--- a/web-admin/src/features/branches/branch-utils.spec.ts
+++ b/web-admin/src/features/branches/branch-utils.spec.ts
@@ -9,6 +9,7 @@ import {
   consumeSkipBranchInjection,
   getBranchRedirect,
   handleBranchNavigation,
+  deriveDefaultBranchName,
 } from "./branch-utils";
 
 // Shared test data: every entry exercises extract, inject, and remove together.
@@ -306,6 +307,56 @@ describe("branch-utils", () => {
       handleBranchNavigation(nav, branch, org, proj, navigateFn);
       expect(nav.cancel).not.toHaveBeenCalled();
       expect(navigateFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("deriveDefaultBranchName", () => {
+    it("returns the bare local part when there are no special characters", () => {
+      expect(deriveDefaultBranchName("adrian@rilldata.com")).toBe("adrian");
+    });
+
+    it("replaces periods in the local part with hyphens", () => {
+      expect(deriveDefaultBranchName("eric.green@rilldata.com")).toBe(
+        "eric-green",
+      );
+      expect(deriveDefaultBranchName("john.smith@company.com")).toBe(
+        "john-smith",
+      );
+    });
+
+    it("lowercases the result for cross-platform safety", () => {
+      expect(deriveDefaultBranchName("Eric.Green@rilldata.com")).toBe(
+        "eric-green",
+      );
+    });
+
+    it("replaces whitespace with hyphens", () => {
+      expect(deriveDefaultBranchName("eric green@rilldata.com")).toBe(
+        "eric-green",
+      );
+    });
+
+    it("drops ~ characters", () => {
+      expect(deriveDefaultBranchName("eric~green@rilldata.com")).toBe(
+        "ericgreen",
+      );
+    });
+
+    it("strips leading and trailing periods or slashes", () => {
+      // Local parts can't actually start with "." per RFC, but the sanitizer
+      // should defend against any path-like residue regardless.
+      expect(deriveDefaultBranchName(".eric.@rilldata.com")).toBe("eric");
+      expect(deriveDefaultBranchName("/eric/@rilldata.com")).toBe("eric");
+    });
+
+    it("returns empty string for missing input", () => {
+      expect(deriveDefaultBranchName(undefined)).toBe("");
+      expect(deriveDefaultBranchName("")).toBe("");
+    });
+
+    it("returns empty string when sanitization removes all characters", () => {
+      expect(deriveDefaultBranchName("...@rilldata.com")).toBe("");
+      expect(deriveDefaultBranchName("~~~@rilldata.com")).toBe("");
     });
   });
 

--- a/web-admin/src/features/branches/branch-utils.ts
+++ b/web-admin/src/features/branches/branch-utils.ts
@@ -109,6 +109,29 @@ export function handleBranchNavigation(
 }
 
 /**
+ * Derive a default dev-branch name from an email's local part.
+ *
+ * Lowercased so the same email always produces the same branch name across
+ * platforms (git is case-sensitive on Linux, case-insensitive on macOS/Windows
+ * filesystems — preserving case here invites cross-platform collisions).
+ *
+ * Periods are valid in git branch names but read awkwardly as a separator,
+ * so they're replaced with "-". Whitespace is also replaced with "-" and
+ * "~" is dropped (reserved by `encodeBranch` as the path-segment "/" replacement).
+ * Returns "" if the input is missing or sanitization yields no usable name.
+ */
+export function deriveDefaultBranchName(email: string | undefined): string {
+  if (!email) return "";
+  const local = email.split("@")[0] ?? "";
+  const sanitized = local
+    .toLowerCase()
+    .replace(/\./g, "-")
+    .replace(/\s+/g, "-")
+    .replace(/~/g, "");
+  return sanitized.replace(/^[-./]+|[-./]+$/g, "");
+}
+
+/**
  * Shared flag: when set, the next `beforeNavigate` call in the project layout
  * will skip `@branch` injection. Callers set this before navigating to a URL
  * that intentionally lacks a branch segment, to prevent the layout from

--- a/web-admin/src/features/edit-session/EditBranchDialog.svelte
+++ b/web-admin/src/features/edit-session/EditBranchDialog.svelte
@@ -1,10 +1,6 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
-  import {
-    createAdminServiceCreateDeployment,
-    createAdminServiceGetCurrentUser,
-    V1DeploymentStatus,
-  } from "@rilldata/web-admin/client";
+  import { createAdminServiceCreateDeployment } from "@rilldata/web-admin/client";
   import { getRpcErrorMessage } from "@rilldata/web-admin/components/errors/error-utils";
   import {
     injectBranchIntoPath,
@@ -22,7 +18,11 @@
   } from "@rilldata/web-common/components/tabs";
   import { Select as SelectPrimitive } from "bits-ui";
   import { GitBranchIcon, GitBranchPlusIcon } from "lucide-svelte";
-  import { useDevDeployments, invalidateDeployments } from "./use-edit-session";
+  import {
+    invalidateDeployments,
+    useDevDeployments,
+    useOwnDevDeployments,
+  } from "./use-edit-session";
 
   export let open = false;
   export let organization: string;
@@ -31,8 +31,14 @@
   export let activeBranch: string | undefined = undefined;
   /** The project's primary branch, used as the source for new branches. */
   export let primaryBranch: string | undefined = undefined;
+  /**
+   * Pre-fills the "new branch" tab with this name. Used by EditButton when an
+   * auto-create attempt collides with an existing branch and we fall back to
+   * letting the user pick a different name.
+   */
+  export let initialBranchName: string | undefined = undefined;
 
-  const user = createAdminServiceGetCurrentUser();
+  const ownQuery = useOwnDevDeployments(organization, project);
   const devDeployments = useDevDeployments(organization, project);
   const createMutation = createAdminServiceCreateDeployment();
 
@@ -41,31 +47,19 @@
   let selectedBranchId = "";
   let createError = "";
 
-  $: currentUserId = $user.data?.user?.id;
-  $: deployments = $devDeployments.data?.deployments ?? [];
+  $: ({ ownDeployments, currentUserId } = $ownQuery);
   $: sourceBranch = primaryBranch || "main";
-
-  // Editable deployments owned by the current user, sorted by most recently
-  // updated. Stopped/errored branches show so the user can resume or retry.
-  $: ownDeployments = deployments
-    .filter(
-      (d) =>
-        d.ownerUserId === currentUserId &&
-        d.editable &&
-        d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETING &&
-        d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETED,
-    )
-    .sort((a, b) => (b.updatedOn ?? "").localeCompare(a.updatedOn ?? ""));
 
   $: latestBranchId = ownDeployments[0]?.id ?? "";
   $: hasOwnSessions = ownDeployments.length > 0;
   $: isStarting = $createMutation.isPending;
 
-  // Banner condition: active branch is owned but not editable
+  // Banner condition: active branch is owned but not editable. `ownDeployments`
+  // already excludes the non-editable case, so we read the unfiltered dev list.
   $: activeBranchIsNonEditable =
     !!activeBranch &&
     !!currentUserId &&
-    deployments.some(
+    ($devDeployments.data?.deployments ?? []).some(
       (d) =>
         d.branch === activeBranch &&
         d.ownerUserId === currentUserId &&
@@ -80,9 +74,11 @@
   $: selectedDeployment = ownDeployments.find((d) => d.id === selectedBranchId);
 
   function resetState() {
-    branchName = "";
+    // initialBranchName seeds the "new" tab when the caller is recovering from
+    // a name collision (e.g. EditButton's auto-create returned AlreadyExists).
+    branchName = initialBranchName ?? "";
     selectedBranchId = latestBranchId;
-    currentTab = hasOwnSessions ? "existing" : "new";
+    currentTab = initialBranchName || !hasOwnSessions ? "new" : "existing";
     createError = "";
   }
 

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -1,16 +1,25 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import {
+    createAdminServiceCreateDeployment,
     createAdminServiceGetCurrentUser,
-    V1DeploymentStatus,
+    createAdminServiceGetProject,
+    type RpcStatus,
   } from "@rilldata/web-admin/client";
+  import { getRpcErrorMessage } from "@rilldata/web-admin/components/errors/error-utils";
   import {
+    deriveDefaultBranchName,
     injectBranchIntoPath,
     requestSkipBranchInjection,
   } from "@rilldata/web-admin/features/branches/branch-utils";
   import { Button } from "@rilldata/web-common/components/button";
-  import { useDevDeployments } from "./use-edit-session";
+  import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
+  import type { AxiosError } from "axios";
   import EditBranchDialog from "./EditBranchDialog.svelte";
+  import {
+    invalidateDeployments,
+    useOwnDevDeployments,
+  } from "./use-edit-session";
 
   export let organization: string;
   export let project: string;
@@ -19,28 +28,28 @@
   /** The project's primary branch, used as the source for new branches. */
   export let primaryBranch: string | undefined = undefined;
 
-  const user = createAdminServiceGetCurrentUser();
-  const devDeployments = useDevDeployments(organization, project);
+  const userQuery = createAdminServiceGetCurrentUser();
+  const projectQuery = createAdminServiceGetProject(organization, project);
+  const ownQuery = useOwnDevDeployments(organization, project);
+  const createMutation = createAdminServiceCreateDeployment();
 
   let dialogOpen = false;
+  let dialogInitialBranchName: string | undefined = undefined;
 
-  $: currentUserId = $user.data?.user?.id;
-  $: deployments = $devDeployments.data?.deployments ?? [];
-  $: isLoading = $devDeployments.isLoading;
+  $: email = $userQuery.data?.user?.email;
+  $: ({ ownDeployments } = $ownQuery);
+  $: isManagedGit = !!$projectQuery.data?.project?.managedGitId;
 
-  // If viewing a branch the user owns, clicking the button should go straight
-  // there — no dialog.
-  $: activeBranchDeployment =
-    activeBranch && currentUserId
-      ? deployments.find(
-          (d) =>
-            d.branch === activeBranch &&
-            d.ownerUserId === currentUserId &&
-            d.editable &&
-            d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETING &&
-            d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETED,
-        )
-      : undefined;
+  $: isLoading =
+    $userQuery.isLoading || $ownQuery.isLoading || $projectQuery.isLoading;
+  $: isStarting = $createMutation.isPending;
+
+  // Direct-edit shortcut: the user is viewing a branch they own and it's
+  // editable. Skip all the branching logic and link straight to it. Preserved
+  // as an `href` so middle-click / cmd-click open in a new tab.
+  $: activeBranchDeployment = activeBranch
+    ? ownDeployments.find((d) => d.branch === activeBranch)
+    : undefined;
 
   $: directEditHref = activeBranchDeployment?.branch
     ? injectBranchIntoPath(
@@ -53,6 +62,77 @@
     e.preventDefault();
     requestSkipBranchInjection();
     void goto(directEditHref!);
+  }
+
+  function gotoBranch(branch: string) {
+    requestSkipBranchInjection();
+    void goto(
+      injectBranchIntoPath(`/${organization}/${project}/-/edit`, branch),
+    );
+  }
+
+  function openDialog(initialName?: string) {
+    dialogInitialBranchName = initialName;
+    dialogOpen = true;
+  }
+
+  async function autoCreateAndEdit(branchName: string) {
+    try {
+      const resp = await $createMutation.mutateAsync({
+        org: organization,
+        project,
+        data: {
+          environment: "dev",
+          editable: true,
+          branch: branchName,
+        },
+      });
+      // Await invalidation so the destination edit page reads a fresh
+      // deployment list — the create response isn't auto-inserted into the
+      // ListDeployments cache.
+      await invalidateDeployments(organization, project);
+      const newBranch = resp.deployment?.branch ?? branchName;
+      gotoBranch(newBranch);
+    } catch (err) {
+      // Cross-user collision: someone else's branch already occupies this name.
+      // Hand off to the dialog with the name pre-filled so the user can pick
+      // a different one.
+      const code = (err as AxiosError<RpcStatus>)?.response?.data?.code;
+      if (code === 6 /* ALREADY_EXISTS */) {
+        openDialog(branchName);
+        return;
+      }
+      const message =
+        getRpcErrorMessage(err as RpcStatus) ?? "Failed to start edit session.";
+      eventBus.emit("notification", { type: "error", message });
+    }
+  }
+
+  async function handleEditClick() {
+    if (isLoading || isStarting) return;
+
+    // Rill-managed users are limited to one dev branch each (UI convention).
+    // If they already have one, route directly to it — never show the modal.
+    if (ownDeployments.length > 0 && isManagedGit) {
+      gotoBranch(ownDeployments[0].branch ?? primaryBranch ?? "main");
+      return;
+    }
+
+    // Self-managed with at least one branch: existing modal flow.
+    if (ownDeployments.length > 0) {
+      openDialog();
+      return;
+    }
+
+    // Zero owned dev branches: auto-create one named after the email's local
+    // part. If the email is missing or sanitization yields nothing usable,
+    // fall back to the modal so the user can name the branch themselves.
+    const branchName = deriveDefaultBranchName(email);
+    if (!branchName) {
+      openDialog();
+      return;
+    }
+    await autoCreateAndEdit(branchName);
   }
 </script>
 
@@ -68,8 +148,10 @@
 {:else}
   <Button
     type="secondary"
-    disabled={isLoading}
-    onClick={() => (dialogOpen = true)}
+    disabled={isLoading || isStarting}
+    loading={isStarting}
+    loadingCopy="Starting..."
+    onClick={handleEditClick}
   >
     Edit
   </Button>
@@ -79,5 +161,6 @@
     {project}
     {activeBranch}
     {primaryBranch}
+    initialBranchName={dialogInitialBranchName}
   />
 {/if}

--- a/web-admin/src/features/edit-session/use-edit-session.ts
+++ b/web-admin/src/features/edit-session/use-edit-session.ts
@@ -1,8 +1,13 @@
 import {
   createAdminServiceListDeployments,
+  getAdminServiceGetCurrentUserQueryOptions,
   getAdminServiceListDeploymentsQueryKey,
+  getAdminServiceListDeploymentsQueryOptions,
+  V1DeploymentStatus,
+  type V1Deployment,
 } from "@rilldata/web-admin/client";
 import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
+import { createQueries } from "@tanstack/svelte-query";
 import { derived } from "svelte/store";
 
 /**
@@ -37,6 +42,42 @@ export function useDevDeployments(org: string, project: string) {
         }
       : $query.data,
   }));
+}
+
+/**
+ * Lists the current user's editable dev deployments for a project. Combines
+ * the deployment list and current-user queries so callers get a single store
+ * with the filtered, sorted slice plus the current user's id.
+ *
+ * Stopped/errored deployments are included so the user can resume or retry;
+ * deleting/deleted deployments are filtered out.
+ */
+export function useOwnDevDeployments(org: string, project: string) {
+  return createQueries({
+    queries: [
+      getAdminServiceListDeploymentsQueryOptions(org, project, {}),
+      getAdminServiceGetCurrentUserQueryOptions(),
+    ],
+    combine: ([deploymentsQuery, userQuery]) => {
+      const currentUserId = userQuery.data?.user?.id;
+      const all = deploymentsQuery.data?.deployments ?? [];
+      const ownDeployments: V1Deployment[] = all
+        .filter(
+          (d) =>
+            d.environment === "dev" &&
+            d.ownerUserId === currentUserId &&
+            d.editable &&
+            d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETING &&
+            d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETED,
+        )
+        .sort((a, b) => (b.updatedOn ?? "").localeCompare(a.updatedOn ?? ""));
+      return {
+        ownDeployments,
+        currentUserId,
+        isLoading: deploymentsQuery.isLoading || userQuery.isLoading,
+      };
+    },
+  });
 }
 
 /**


### PR DESCRIPTION
- For **Rill-managed** projects, `EditBranchDialog` never opens. With zero owned dev branches, the Edit button auto-creates one named after the email's local part and routes into the edit session. With one or more, it routes to the user's most-recently-updated owned branch.
- For **self-managed** projects, the same zero-branch auto-create kicks in. With one or more, the existing modal opens (status quo).
- Adds `useOwnDevDeployments` (TanStack `combine`) so `EditButton` and `EditBranchDialog` share one source of truth for the user's editable dev deployments.
- Adds `deriveDefaultBranchName(email)` in `branch-utils.ts` — lowercased for cross-platform safety, periods replaced with hyphens, leading/trailing `-./` trimmed.
- Cross-user branch-name collisions (gRPC `AlreadyExists`) fall back to opening the dialog with the name pre-filled rather than silently appending a suffix.

Preemptive polish on cloud editing while it's still flagged behind `cloudEditing`.

Closes [GEN-728](https://www.notion.so/rilldata/Restrict-edit-create-branch-modal-to-self-managed-Git-case-only-Rill-managed-auto-created-branches-51bd408612bb47a8b98baf96e9643be5).

Note: the "one dev branch per user on Rill-managed" rule is a UI convention, not a server constraint — `rill project deployment create` will still let a CLI user create multiple. The UI defensively picks the most-recently-updated owned branch when multiple exist; backend enforcement is intentionally out of scope here.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*