### PR TITLE
Tweak `EditSessionLoading`

### DIFF
--- a/web-admin/src/features/edit-session/EditSessionLoading.svelte
+++ b/web-admin/src/features/edit-session/EditSessionLoading.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
   import { V1DeploymentStatus } from "@rilldata/web-admin/client";
   import { Button } from "@rilldata/web-common/components/button";
+  import CtaNeedHelp from "@rilldata/web-common/components/calls-to-action/CTANeedHelp.svelte";
   import LoadingSpinner from "@rilldata/web-common/components/LoadingSpinner.svelte";
+  import { onDestroy, onMount } from "svelte";
 
   export let status: V1DeploymentStatus | undefined;
-  export let cancelHref: string;
+  export let href: string;
+
+  const SLOW_NOTICE_DELAY_MS = 30_000;
+
+  let showSlowNotice = false;
+  let slowNoticeTimer: ReturnType<typeof setTimeout> | undefined;
 
   function getHeading(s: V1DeploymentStatus | undefined): string {
     switch (s) {
@@ -17,19 +24,26 @@
     }
   }
 
-  function handleCancel() {
-    // Full page navigation bypasses the branch injection hook in the
-    // parent layout, which would otherwise re-inject @branch into the URL.
-    window.location.href = cancelHref;
-  }
+  onMount(() => {
+    slowNoticeTimer = setTimeout(() => {
+      showSlowNotice = true;
+    }, SLOW_NOTICE_DELAY_MS);
+  });
+
+  onDestroy(() => {
+    if (slowNoticeTimer) clearTimeout(slowNoticeTimer);
+  });
 </script>
 
 <div class="loading-container">
   <div class="loading-content">
     <LoadingSpinner />
     <h2 class="text-lg font-semibold">{getHeading(status)}</h2>
+    {#if showSlowNotice}
+      <CtaNeedHelp leading="This is taking longer than usual." />
+    {/if}
   </div>
-  <Button type="secondary" onClick={handleCancel}>Cancel</Button>
+  <Button type="secondary" {href}>Back to projects</Button>
 </div>
 
 <style lang="postcss">

--- a/web-admin/src/routes/[organization]/[project]/-/edit/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/+layout.svelte
@@ -158,6 +158,39 @@
         </CtaButton>
       </CtaContentContainer>
     </CtaLayoutContainer>
+  {:else if isLoading}
+    <EditSessionLoading status={deploymentStatus} href={`/${organization}`} />
+  {:else if isErrored}
+    <SlimProjectHeader
+      {organization}
+      {project}
+      readProjects={organizationPermissions?.readProjects}
+      {planDisplayName}
+      {organizationLogoUrl}
+    />
+    <ErrorPage
+      statusCode={500}
+      header="Edit session failed"
+      body={deployment?.statusMessage ||
+        "The editing environment encountered an error. Please try again."}
+    />
+  {:else if isStopped && deployment?.id}
+    <SlimProjectHeader
+      {organization}
+      {project}
+      readProjects={organizationPermissions?.readProjects}
+      {planDisplayName}
+      {organizationLogoUrl}
+    />
+    <BranchDeploymentStopped
+      {organization}
+      {project}
+      deploymentId={deployment.id}
+      status={deploymentStatus}
+      canManage={!!projectPermissions?.manageDev}
+      {branch}
+      onStarted={() => (starting = true)}
+    />
   {:else if isReady && deployment?.id && instanceId && runtimeHost && jwt}
     {#key `${runtimeHost}::${instanceId}`}
       <RuntimeProvider host={runtimeHost} {instanceId} {jwt}>
@@ -199,39 +232,6 @@
         </FileAndResourceWatcher>
       </RuntimeProvider>
     {/key}
-  {:else if isErrored}
-    <SlimProjectHeader
-      {organization}
-      {project}
-      readProjects={organizationPermissions?.readProjects}
-      {planDisplayName}
-      {organizationLogoUrl}
-    />
-    <ErrorPage
-      statusCode={500}
-      header="Edit session failed"
-      body={deployment?.statusMessage ||
-        "The editing environment encountered an error. Please try again."}
-    />
-  {:else if isStopped && deployment?.id}
-    <SlimProjectHeader
-      {organization}
-      {project}
-      readProjects={organizationPermissions?.readProjects}
-      {planDisplayName}
-      {organizationLogoUrl}
-    />
-    <BranchDeploymentStopped
-      {organization}
-      {project}
-      deploymentId={deployment.id}
-      status={deploymentStatus}
-      canManage={!!projectPermissions?.manageDev}
-      {branch}
-      onStarted={() => (starting = true)}
-    />
-  {:else if isLoading}
-    <EditSessionLoading status={deploymentStatus} href={`/${organization}`} />
   {:else}
     <SlimProjectHeader
       {organization}

--- a/web-admin/src/routes/[organization]/[project]/-/edit/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/+layout.svelte
@@ -108,7 +108,6 @@
     jwt !== null &&
     !isOtherOwner;
 
-  $: projectUrl = `/${organization}/${project}`;
   $: branchUrl = `/${organization}/${project}${branchPathPrefix(branch)}`;
 
   $: inProjectWelcomePage = isProjectWelcomePage($page);
@@ -232,7 +231,7 @@
       onStarted={() => (starting = true)}
     />
   {:else if isLoading}
-    <EditSessionLoading status={deploymentStatus} cancelHref={projectUrl} />
+    <EditSessionLoading status={deploymentStatus} href={`/${organization}`} />
   {:else}
     <SlimProjectHeader
       {organization}

--- a/web-common/src/components/calls-to-action/CTANeedHelp.svelte
+++ b/web-common/src/components/calls-to-action/CTANeedHelp.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
   import { EmbedStore } from "@rilldata/web-common/features/embeds/embed-store";
 
+  export let leading: string | undefined = undefined;
+
   $: isEmbedded = EmbedStore.isEmbedded();
 </script>
 
 {#if !isEmbedded}
   <p class="text-sm text-fg-secondary text-center">
-    Need help? Reach out to us on <a
+    {#if leading}{leading}{" "}{/if}Need help? Reach out to us on <a
       href="https://discord.gg/2ubRfjC7Rh"
       target="_blank">Discord</a
     >

--- a/web-common/src/components/calls-to-action/CTANeedHelp.svelte
+++ b/web-common/src/components/calls-to-action/CTANeedHelp.svelte
@@ -8,9 +8,7 @@
 
 {#if !isEmbedded}
   <p class="text-sm text-fg-secondary text-center">
-    {#if leading}{leading}{" "}{/if}Need help? Reach out to us on <a
-      href="https://discord.gg/2ubRfjC7Rh"
-      target="_blank">Discord</a
-    >
+    {#if leading}{leading}{" "}{/if}Need help? Reach out to us on
+    <a href="https://discord.gg/2ubRfjC7Rh" target="_blank">Discord</a>
   </p>
 {/if}


### PR DESCRIPTION
<img width="1383" height="1010" alt="image" src="https://github.com/user-attachments/assets/4da11264-ecee-481c-8971-4ba81cf9bd60" />

- Cancel is a real anchor now and lands on the org page; relabeled "Back to projects" since the click does not abort the deployment.
- After 30s, surface a "taking longer than usual" notice via `CtaNeedHelp` (extended with an optional `leading` prop).
- Reordered the edit layout's state branches for readability: guard → loading → error → stopped → ready.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*