### PR TITLE
fix: hide measure chart info box when cursor moves onto y-axis

### DIFF
--- a/web-common/src/features/dashboards/time-series/measure-chart/MeasureChartBody.svelte
+++ b/web-common/src/features/dashboards/time-series/measure-chart/MeasureChartBody.svelte
@@ -406,19 +406,33 @@
     height="{height}px"
     onmousemove={(e) => {
       const x = clampX(e.offsetX);
-      const fractionalIndex = xScale.invert(x);
+      const isScrubbingNow = get(scrubController.state).isScrubbing;
 
+      // Keep scrub tracking even if the drag strays into the margins.
+      if (isScrubbingNow) {
+        scrubController.update(x, xScale);
+      }
+
+      // The SVG extends into the y-axis margin (and top/bottom margins),
+      // so onmouseleave doesn't fire when the cursor moves onto axis labels.
+      // Treat anything outside the plot bounds as a leave so the tooltip hides.
+      const isInPlot =
+        e.offsetX >= pb.left &&
+        e.offsetX <= pb.left + pb.width &&
+        e.offsetY >= pb.top &&
+        e.offsetY <= pb.top + pb.height;
+      if (!isInPlot) {
+        handleSvgMouseLeave();
+        return;
+      }
+
+      const fractionalIndex = xScale.invert(x);
       hoverState = {
         index: fractionalIndex,
         screenX: x,
         screenY: e.offsetY,
         isHovered: true,
       };
-
-      // Update scrub if dragging
-      if (get(scrubController.state).isScrubbing) {
-        scrubController.update(x, xScale);
-      }
 
       annotationPopover.checkHover(e, annotationGroups, isScrubbing);
       mousePageX = e.pageX;


### PR DESCRIPTION
The measure chart's `<svg>` extends into the right margin where y-axis labels render, so `onmouseleave` never fires when the cursor crosses from the plot onto a label. The mousemove handler kept `hoverState.isHovered` true (with `clampX` pinning the index to the plot edge) and the floating tooltip stayed visible.

- Treat any mousemove outside the plot bounds as a leave; clears the floating tooltip, the inline `MeasureChartTooltip`, and the top-left date readout.
- Run scrub updates first so a drag that strays into the margins keeps tracking.

Closes [APP-890](https://linear.app/rilldata/issue/APP-890/info-box-stays-visible-after-cursor-moves-off-chart-onto-y-axis)

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
*Developed in collaboration with Claude Code*