### PR TITLE
fix: shell out for git remotes when go-git can't read the repo

### DIFF
--- a/cli/pkg/gitutil/gitutil.go
+++ b/cli/pkg/gitutil/gitutil.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/go-git/go-git/v5"
@@ -125,7 +126,9 @@ func ExtractRemotes(projectPath string, detectDotGit bool) ([]Remote, error) {
 		DetectDotGit: detectDotGit,
 	})
 	if err != nil {
-		return nil, err
+		// go-git rejects some valid repos (e.g. those with extensions.worktreeConfig).
+		// Fall back to shell git, which has more complete feature support.
+		return extractRemotesShell(projectPath)
 	}
 
 	remotes, err := repo.Remotes()
@@ -147,7 +150,40 @@ func ExtractRemotes(projectPath string, detectDotGit bool) ([]Remote, error) {
 		}
 	}
 
+	// In a git worktree, go-git opens the worktree's gitdir successfully but sees no remotes,
+	// because remote config lives in the common gitdir. Fall back to shell git.
+	if len(res) == 0 {
+		if shellRes, shellErr := extractRemotesShell(projectPath); shellErr == nil && len(shellRes) > 0 {
+			return shellRes, nil
+		}
+	}
+
 	return res, nil
+}
+
+// extractRemotesShell lists remotes by shelling out to `git remote -v`.
+// Used as a fallback when go-git can't read the repository (e.g. git worktrees).
+func extractRemotesShell(projectPath string) ([]Remote, error) {
+	cmd := exec.Command("git", "remote", "-v")
+	if projectPath != "" {
+		cmd.Dir = projectPath
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git remote -v: %w", err)
+	}
+	seen := make(map[string]bool)
+	var remotes []Remote
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		// Format: "<name>\t<url> (fetch|push)"
+		fields := strings.Fields(line)
+		if len(fields) < 3 || fields[2] != "(fetch)" || seen[fields[0]] {
+			continue
+		}
+		seen[fields[0]] = true
+		remotes = append(remotes, Remote{Name: fields[0], URL: fields[1]})
+	}
+	return remotes, nil
 }
 
 func CommitAndPush(ctx context.Context, projectPath string, config *Config, commitMsg string, author *object.Signature) error {


### PR DESCRIPTION
`gitutil.ExtractRemotes` fails in two cases that come up when running the CLI from a git worktree:

- The repo has `extensions.worktreeConfig = true` (set automatically when any worktree gets a per-worktree config). go-git rejects this extension, so `PlainOpenWithOptions` errors out.
- Inside a git worktree, `.git` points to the worktree's gitdir but remote config lives in the common gitdir's config. go-git opens the worktree's gitdir and silently reports zero remotes.

`rill devtool start` is gated on this check and fails to start in both cases.

- Fall back to `git remote -v` (via shell) when go-git can't open the repo or returns no remotes.
- `git` is already a hard dependency for `gitutil.CloneRepo`, so this adds no new prerequisite.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*