### PR TITLE
Rename `deploying_dashboard` URL param to `target_dashboard`

### DIFF
--- a/web-admin/src/features/dashboards/listing/deploying-dashboards.ts
+++ b/web-admin/src/features/dashboards/listing/deploying-dashboards.ts
@@ -18,7 +18,7 @@ export function useDeployingDashboards(
   client: RuntimeClient,
   orgName: string,
   projName: string,
-  deployingDashboard: string | null,
+  targetDashboard: string | null,
   preCommitSha: string | null,
 ): CreateQueryResult<{
   redirectPath: string | null;
@@ -47,7 +47,7 @@ export function useDeployingDashboards(
 
           const reconciling = getDashboardsReconciling(
             dashboards,
-            deployingDashboard,
+            targetDashboard,
           );
           if (reconciling) {
             return {
@@ -58,7 +58,7 @@ export function useDeployingDashboards(
 
           const dashboardsErrored = getDashboardsErrored(
             dashboards,
-            deployingDashboard,
+            targetDashboard,
           );
           if (dashboardsErrored) {
             return {
@@ -69,11 +69,11 @@ export function useDeployingDashboards(
           }
 
           const dashboard = dashboards.find(
-            (res) => res.meta?.name?.name === deployingDashboard,
+            (res) => res.meta?.name?.name === targetDashboard,
           );
 
           // Redirect to home page if no specific dashboard was deployed
-          if (!deployingDashboard || !dashboard?.meta?.name) {
+          if (!targetDashboard || !dashboard?.meta?.name) {
             return {
               redirectPath: `/${orgName}/${projName}`,
               dashboardsErrored: false,

--- a/web-admin/src/features/edit-session/post-merge-url.ts
+++ b/web-admin/src/features/edit-session/post-merge-url.ts
@@ -1,5 +1,5 @@
 import {
-  DeployingDashboardUrlParam,
+  TargetDashboardUrlParam,
   PreCommitShaUrlParam,
 } from "@rilldata/web-common/features/project/deploy/utils";
 
@@ -32,7 +32,7 @@ export function buildPostMergeUrl({
     window.location.origin,
   );
   if (dashboard) {
-    url.searchParams.set(DeployingDashboardUrlParam, dashboard);
+    url.searchParams.set(TargetDashboardUrlParam, dashboard);
   }
   if (preCommitSha) {
     url.searchParams.set(PreCommitShaUrlParam, preCommitSha);

--- a/web-admin/src/routes/[organization]/[project]/-/deploying/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/deploying/+page.svelte
@@ -7,7 +7,7 @@
   import type { PageData } from "./$types";
 
   export let data: PageData;
-  const { organization, project, deployingDashboard, preCommitSha } = data;
+  const { organization, project, targetDashboard, preCommitSha } = data;
 
   const runtimeClient = useRuntimeClient();
 
@@ -17,7 +17,7 @@
     runtimeClient,
     organization.name,
     project.name,
-    deployingDashboard,
+    targetDashboard,
     preCommitSha,
   );
 

--- a/web-admin/src/routes/[organization]/[project]/-/deploying/+page.ts
+++ b/web-admin/src/routes/[organization]/[project]/-/deploying/+page.ts
@@ -1,14 +1,14 @@
 import {
-  DeployingDashboardUrlParam,
+  TargetDashboardUrlParam,
   PreCommitShaUrlParam,
 } from "@rilldata/web-common/features/project/deploy/utils.ts";
 
 export const load = ({ url: { searchParams } }) => {
-  const deployingDashboard = searchParams.get(DeployingDashboardUrlParam);
+  const targetDashboard = searchParams.get(TargetDashboardUrlParam);
   const preCommitSha = searchParams.get(PreCommitShaUrlParam);
 
   return {
-    deployingDashboard,
+    targetDashboard,
     preCommitSha,
   };
 };

--- a/web-common/src/features/project/deploy/route-utils.ts
+++ b/web-common/src/features/project/deploy/route-utils.ts
@@ -1,8 +1,8 @@
 import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts.ts";
 import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors.ts";
 import {
-  DeployingDashboardUrlParam,
-  getDeployingDashboard,
+  TargetDashboardUrlParam,
+  getTargetDashboard,
 } from "@rilldata/web-common/features/project/deploy/utils.ts";
 import { addPosthogSessionIdToUrl } from "@rilldata/web-common/lib/analytics/posthog.ts";
 import { createLocalServiceGitStatus } from "@rilldata/web-common/runtime-client/local-service";
@@ -16,7 +16,7 @@ import type { V1ResourceName } from "@rilldata/web-common/runtime-client";
 /**
  * Returns a {@link Readable} with a route to deploy.
  *
- * Adds a "deploying_dashboard" param based on the active page.
+ * Adds a "target_dashboard" param based on the active page.
  * 1. If the user is on the editor page, gets the dashboard name from resourceName defined in {@link FileArtifact}. Since this is async we need a store derived from resourceName.
  * 2. If the user is on the visualization page, sets the dashboard name from route param.
  */
@@ -30,7 +30,7 @@ export function getDeployRoute(page: Page) {
   }
 
   if (isDashboardVizRoute(page)) {
-    deployUrl.searchParams.set(DeployingDashboardUrlParam, page.params.name);
+    deployUrl.searchParams.set(TargetDashboardUrlParam, page.params.name);
   }
 
   return readable(deployUrl.toString());
@@ -62,12 +62,9 @@ export function getUpdateProjectRoute(
     currentResource?.kind === ResourceKind.Explore ||
     currentResource?.kind === ResourceKind.Canvas
   ) {
-    deployUrl.searchParams.set(
-      DeployingDashboardUrlParam,
-      currentResource.name!,
-    );
+    deployUrl.searchParams.set(TargetDashboardUrlParam, currentResource.name!);
   } else if (isDashboardVizRoute(page)) {
-    deployUrl.searchParams.set(DeployingDashboardUrlParam, page.params.name);
+    deployUrl.searchParams.set(TargetDashboardUrlParam, page.params.name);
   }
 
   return deployUrl.toString();
@@ -91,9 +88,9 @@ export function getSelectOrganizationRoute() {
 
 export function getDeployingPageUrl(frontendUrl: string, isInvite: boolean) {
   const url = new URL(frontendUrl);
-  const deployingDashboard = getDeployingDashboard();
-  if (deployingDashboard) {
-    url.searchParams.set(DeployingDashboardUrlParam, deployingDashboard);
+  const targetDashboard = getTargetDashboard();
+  if (targetDashboard) {
+    url.searchParams.set(TargetDashboardUrlParam, targetDashboard);
   }
   if (isInvite) {
     url.pathname += "/-/invite";
@@ -184,7 +181,7 @@ function getDeployRouteFromEditor(page: Page, deployUrl: URL) {
       curResource?.kind === ResourceKind.Explore ||
       curResource?.kind === ResourceKind.Canvas;
     if (isDashboardResource && curResource.name) {
-      deployUrl.searchParams.set(DeployingDashboardUrlParam, curResource.name);
+      deployUrl.searchParams.set(TargetDashboardUrlParam, curResource.name);
     }
 
     return deployUrl.toString();

--- a/web-common/src/features/project/deploy/utils.ts
+++ b/web-common/src/features/project/deploy/utils.ts
@@ -1,25 +1,25 @@
-const deployingDashboardKey = "rill:app:deployingDashboard";
-export const DeployingDashboardUrlParam = "deploying_dashboard";
+const targetDashboardKey = "rill:app:targetDashboard";
+export const TargetDashboardUrlParam = "target_dashboard";
 export const PreCommitShaUrlParam = "pre_commit_sha";
 
 /**
- * Sets the deploying dashboard name from url to session storage if present.
+ * Sets the target dashboard name from url to session storage if present.
  * This prevents having to pass through the param during deploy flow. We could be going through different routes there.
  */
-export function maybeSetDeployingDashboard(url: URL) {
-  const deployingDashboard = url.searchParams.get(DeployingDashboardUrlParam);
-  if (!deployingDashboard) {
+export function maybeSetTargetDashboard(url: URL) {
+  const targetDashboard = url.searchParams.get(TargetDashboardUrlParam);
+  if (!targetDashboard) {
     // Remove item to ensure a stale dashboard name is not used.
-    sessionStorage.removeItem(deployingDashboardKey);
+    sessionStorage.removeItem(targetDashboardKey);
   } else {
-    sessionStorage.setItem(deployingDashboardKey, deployingDashboard);
+    sessionStorage.setItem(targetDashboardKey, targetDashboard);
   }
 }
 
-export function getDeployingDashboard() {
+export function getTargetDashboard() {
   const url = new URL(window.location.href);
   return (
-    sessionStorage.getItem(deployingDashboardKey) ||
-    url.searchParams.get(DeployingDashboardUrlParam)
+    sessionStorage.getItem(targetDashboardKey) ||
+    url.searchParams.get(TargetDashboardUrlParam)
   );
 }

--- a/web-integration/tests/deploy.spec.ts
+++ b/web-integration/tests/deploy.spec.ts
@@ -85,7 +85,7 @@ test.describe("Deploy journey", () => {
               .getAttribute("href"),
           { intervals: Array(15).fill(1_000), timeout: 15_000 },
         )
-        .toMatch(/deploying_dashboard/);
+        .toMatch(/target_dashboard/);
       await rillDevPage.getByRole("button", { name: "Continue" }).click();
 
       // Await for the popped up deploy page after hitting deploy

--- a/web-local/src/routes/(misc)/deploy/+page.svelte
+++ b/web-local/src/routes/(misc)/deploy/+page.svelte
@@ -10,7 +10,7 @@
     getSelectProjectRoute,
     getUpdateProjectRoute,
   } from "@rilldata/web-common/features/project/deploy/route-utils.ts";
-  import { maybeSetDeployingDashboard } from "@rilldata/web-common/features/project/deploy/utils.ts";
+  import { maybeSetTargetDashboard } from "@rilldata/web-common/features/project/deploy/utils.ts";
   import { waitUntil } from "@rilldata/web-common/lib/waitUtils.ts";
   import { behaviourEvent } from "@rilldata/web-common/metrics/initMetrics";
   import { BehaviourEventAction } from "@rilldata/web-common/metrics/service/BehaviourEventTypes";
@@ -58,7 +58,7 @@
 
     void behaviourEvent?.fireDeployEvent(BehaviourEventAction.LoginSuccess);
 
-    maybeSetDeployingDashboard(get(page).url);
+    maybeSetTargetDashboard(get(page).url);
 
     // Cloud project doest exist.
     const projectExists = !!$matchingProjects.data?.projects?.length;


### PR DESCRIPTION
- Renames the deploy/post-merge URL param `deploying_dashboard` → `target_dashboard`. The param identifies the dashboard the user wants to land on once reconciliation completes; the old name described state, the new one describes intent (and reads better on the post-merge flow, where nothing is technically "deploying").
- Pure rename. Constant `DeployingDashboardUrlParam` → `TargetDashboardUrlParam`, sessionStorage key `rill:app:deployingDashboard` → `rill:app:targetDashboard`, helpers `maybeSet*` / `get*` follow suit, local variables updated, e2e regex updated.
- `useDeployingDashboards` hook name is intentionally kept — it watches the deploying state of dashboards, which is distinct from the target. Only its parameter is renamed.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!

---
*Developed in collaboration with Claude Code*