### PR TITLE
fix: file upload error not surfacing in the form

### DIFF
--- a/web-common/src/features/add-data/form/SourceForm.svelte
+++ b/web-common/src/features/add-data/form/SourceForm.svelte
@@ -21,7 +21,10 @@
   } from "@rilldata/web-common/features/add-data/manager/steps/types.ts";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
   import { getLabelsForSource } from "@rilldata/web-common/features/add-data/form/form-labels.ts";
-  import { uploadFile } from "@rilldata/web-common/features/sources/modal/file-upload.ts";
+  import {
+    FileTooLargeError,
+    uploadFile,
+  } from "@rilldata/web-common/features/sources/modal/file-upload.ts";
   import { splitFolderFileNameAndExtension } from "@rilldata/web-common/features/entity-management/file-path-utils.ts";
   import { getName } from "@rilldata/web-common/features/entity-management/name-utils.ts";
   import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors.ts";
@@ -33,8 +36,12 @@
     getImportStepsForSource,
   } from "@rilldata/web-common/features/add-data/manager/steps/utils.ts";
   import { maybeInitProject } from "@rilldata/web-common/features/add-data/manager/steps/connector.ts";
+  import { setSubmitError } from "@rilldata/web-common/features/add-data/form/errors.ts";
+  import type { AddDataStateManager } from "@rilldata/web-common/features/add-data/manager/AddDataStateManager.svelte.ts";
+  import { setError, type SuperValidated } from "sveltekit-superforms";
 
   export let config: AddDataConfig;
+  export let stateManager: AddDataStateManager;
   export let step: CreateModelStep;
   export let onSubmit: (importConfig: ImportStepConfig) => void;
   export let onBack: () => void;
@@ -85,7 +92,12 @@
     formType: "source",
     onUpdate: async ({ form }) => {
       if (!form.valid) return;
-      return submitImportConfig(form.data);
+      try {
+        await submitImportConfig(form);
+      } catch (e) {
+        stateManager.fireErrorEvent(e.message);
+        setSubmitError(form, e);
+      }
     },
     additionalDefaults: step.connectorFormValues,
   });
@@ -106,10 +118,13 @@
 
   $: sourceFormLabels = getLabelsForSource(importSteps);
 
-  async function submitImportConfig(formValues: any) {
+  async function submitImportConfig(
+    form: SuperValidated<Record<string, unknown>>,
+  ) {
     if (!connectorDriver) {
       throw new Error("Connector driver not found for: " + step.connector);
     }
+    const formValues = form.data;
 
     await maybeInitProject(runtimeClient);
 
@@ -137,14 +152,17 @@
     if (formValues.file) {
       // TODO: support multiple files upload
       const firstFile = formValues.file[0];
-      const filePath = await uploadFile(runtimeClient, firstFile);
-      if (filePath) {
+      try {
+        const filePath = await uploadFile(runtimeClient, firstFile);
         formValues.path = filePath;
         const [, fileName] = splitFolderFileNameAndExtension(filePath);
         formValues.name = getName(
           fileName,
           fileArtifacts.getNamesForKind(ResourceKind.Model),
         );
+      } catch (e) {
+        setError(form, "file", e.message); // set error on the file field
+        throw e; // rethrow so that global error handler is triggered
       }
     }
     const yaml = getSourceYamlPreview({

--- a/web-common/src/features/add-data/form/SourceForm.svelte
+++ b/web-common/src/features/add-data/form/SourceForm.svelte
@@ -21,10 +21,7 @@
   } from "@rilldata/web-common/features/add-data/manager/steps/types.ts";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
   import { getLabelsForSource } from "@rilldata/web-common/features/add-data/form/form-labels.ts";
-  import {
-    FileTooLargeError,
-    uploadFile,
-  } from "@rilldata/web-common/features/sources/modal/file-upload.ts";
+  import { uploadFile } from "@rilldata/web-common/features/sources/modal/file-upload.ts";
   import { splitFolderFileNameAndExtension } from "@rilldata/web-common/features/entity-management/file-path-utils.ts";
   import { getName } from "@rilldata/web-common/features/entity-management/name-utils.ts";
   import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors.ts";
@@ -183,7 +180,10 @@
       importSteps,
       connector: rewrittenConnector.name!,
       importFrom,
-      importTo: generateImportToConfig(importFrom, formValues.name),
+      importTo: generateImportToConfig(
+        importFrom,
+        formValues.name as string | undefined,
+      ),
       envBlob: newBlob,
     } satisfies ImportStepConfig;
 

--- a/web-common/src/features/add-data/form/errors.ts
+++ b/web-common/src/features/add-data/form/errors.ts
@@ -14,8 +14,15 @@ export function setSubmitError(
   form: SuperValidated<Record<string, unknown>>,
   error: Error,
 ) {
-  setError(form, SubmitErrorKey + ".message", error.message);
-  setError(form, SubmitErrorKey + ".details", (error as any).details);
+  setError(form, SubmitErrorKey + ".message", error.message, {
+    removeFiles: false,
+  });
+  const details = (error as any).details;
+  if (details) {
+    setError(form, SubmitErrorKey + ".details", details, {
+      removeFiles: false,
+    });
+  }
 }
 
 export function getSubmitError(errors: Record<string, any>): SubmitError {

--- a/web-common/src/features/add-data/manager/AddDataManager.svelte
+++ b/web-common/src/features/add-data/manager/AddDataManager.svelte
@@ -193,6 +193,7 @@
     {#key stepState.connector}
       <SourceForm
         {config}
+        {stateManager}
         step={stepState}
         onSubmit={importConfigured}
         {onBack}

--- a/web-common/src/features/entity-management/edit-environment.ts
+++ b/web-common/src/features/entity-management/edit-environment.ts
@@ -3,12 +3,17 @@
 // The flag is set once at the surface's entry point and read by code that needs to
 // vary behavior per editEnvironment (e.g. `.env` is readonly on cloud but editable locally).
 
+import { updateLocalFileSchemaForCloud } from "@rilldata/web-common/features/templates/schemas/local_file.ts";
+
 export type RuntimeEditEnvironment = "local" | "cloud";
 
 let editEnvironment: RuntimeEditEnvironment = "local";
 
 export function setRuntimeEditEnvironment(env: RuntimeEditEnvironment) {
   editEnvironment = env;
+  if (env === "cloud") {
+    updateLocalFileSchemaForCloud();
+  }
 }
 
 export function getRuntimeEditEnvironment(): RuntimeEditEnvironment {

--- a/web-common/src/features/sources/modal/FormValidation.ts
+++ b/web-common/src/features/sources/modal/FormValidation.ts
@@ -1,6 +1,5 @@
 import type { ValidationAdapter } from "sveltekit-superforms/adapters";
 import { superForm, defaults, type SuperValidated } from "sveltekit-superforms";
-
 import { createSchemasafeValidator } from "./jsonSchemaValidator";
 import { getConnectorSchema } from "./connector-schemas";
 import type { AddDataFormType } from "./types";
@@ -78,9 +77,6 @@ export function createConnectorForm(args: {
     SPA: true,
     validators: adapter,
     onUpdate,
-    onError: ({ result }) => {
-      form.message.set((result.error as any).details || result.error.message);
-    },
     resetForm: false,
     validationMethod: "onsubmit",
   });

--- a/web-common/src/features/sources/modal/file-upload.ts
+++ b/web-common/src/features/sources/modal/file-upload.ts
@@ -4,10 +4,14 @@ import {
 } from "@rilldata/web-common/features/sources/modal/possible-file-extensions";
 import type { RuntimeClient } from "@rilldata/web-common/runtime-client/v2";
 
+export const FileTooLargeError = new Error(
+  "File exceeds the maximum size. Please choose a smaller file to continue.",
+);
+
 export async function uploadFile(
   client: RuntimeClient,
   file: File,
-): Promise<string | undefined> {
+): Promise<string> {
   const formData = new FormData();
   formData.append("file", file);
 
@@ -22,10 +26,11 @@ export async function uploadFile(
     if (!resp.ok) throw new Error(`Upload failed: ${resp.status}`);
     return filePath;
   } catch (err) {
-    console.error(err);
+    if (err.message.includes("413")) {
+      throw FileTooLargeError;
+    }
+    throw err;
   }
-
-  return undefined;
 }
 
 export function openFileUploadDialog(multiple = true) {

--- a/web-common/src/features/sources/modal/jsonSchemaValidator.ts
+++ b/web-common/src/features/sources/modal/jsonSchemaValidator.ts
@@ -4,13 +4,14 @@ import { schemasafe } from "sveltekit-superforms/adapters";
 import type { ValidationAdapter } from "sveltekit-superforms/adapters";
 
 import { getFieldLabel, isStepMatch } from "../../templates/schema-utils";
-import { formatMemorySize } from "@rilldata/web-common/lib/number-formatting/memory-size.ts";
 import { validateDuckLakeAttach } from "../../templates/schemas/ducklake-utils";
 import type {
   JSONSchemaConditional,
   JSONSchemaConstraint,
+  JSONSchemaField,
   MultiStepFormSchema,
 } from "../../templates/schemas/types";
+import { validateFileSize } from "@rilldata/web-common/features/sources/upload-utils.ts";
 
 /**
  * Registry of named validators referenced via `"x-custom-validator"` on a
@@ -18,8 +19,12 @@ import type {
  * a list of user-facing error messages; an empty list means the value is
  * structurally valid.
  */
-const CUSTOM_VALIDATORS: Record<string, (value: unknown) => string[]> = {
+const CUSTOM_VALIDATORS: Record<
+  string,
+  (value: unknown, prop: JSONSchemaField) => string[]
+> = {
   "ducklake-attach": validateDuckLakeAttach,
+  "file-upload": validateFileSize,
 };
 
 const DEFAULT_SCHEMASAFE_OPTIONS: ValidatorOptions = {
@@ -103,10 +108,9 @@ export function createSchemasafeValidator(
       const pruned = pruneEmptyFields(data);
       const isValid = validator(pruned as any);
 
-      const fileSizeIssues = checkFileSizeLimits(stepSchema, data);
       const customIssues = checkCustomValidators(stepSchema, data);
 
-      if (isValid && fileSizeIssues.length === 0 && customIssues.length === 0) {
+      if (isValid && customIssues.length === 0) {
         return { data: pruned, success: true };
       }
 
@@ -115,7 +119,7 @@ export function createSchemasafeValidator(
       );
       return {
         success: false,
-        issues: [...schemaIssues, ...fileSizeIssues, ...customIssues],
+        issues: [...schemaIssues, ...customIssues],
       };
     },
   };
@@ -131,33 +135,9 @@ function checkCustomValidators(
     if (!validatorKey) continue;
     const validator = CUSTOM_VALIDATORS[validatorKey];
     if (!validator) continue;
-    const messages = validator(data[key]);
+    const messages = validator(data[key], prop);
     for (const message of messages) {
       issues.push({ path: [key], message });
-    }
-  }
-  return issues;
-}
-
-function checkFileSizeLimits(
-  schema: MultiStepFormSchema,
-  data: Record<string, unknown>,
-): Array<{ path: string[]; message: string }> {
-  const issues: Array<{ path: string[]; message: string }> = [];
-  for (const [key, prop] of Object.entries(schema.properties ?? {})) {
-    if (prop["x-file-size-soft-limit"] === true) continue;
-    const limit = prop["x-file-size-limit"];
-    if (!limit) continue;
-    const files = data[key];
-    if (!(files instanceof FileList)) continue;
-    for (const file of Array.from(files)) {
-      if (file.size > limit) {
-        issues.push({
-          path: [key],
-          message: `File exceeds the maximum size of ${formatMemorySize(limit)}. Please choose a smaller file to continue.`,
-        });
-        break; // one error per field is enough
-      }
     }
   }
   return issues;

--- a/web-common/src/features/sources/upload-utils.ts
+++ b/web-common/src/features/sources/upload-utils.ts
@@ -1,3 +1,23 @@
 // TODO: Use this to block deploy
+import type { JSONSchemaField } from "@rilldata/web-common/features/templates/schemas/types.ts";
+import { formatMemorySize } from "@rilldata/web-common/lib/number-formatting/memory-size.ts";
+
 export const UploadFileSizeLimitInBytes = 100 * 1024 * 1024; // 100MB limit
-export const UploadSizeExceededIsWarning = true; // TODO: set to false on cloud
+
+export function validateFileSize(
+  files: unknown,
+  prop: JSONSchemaField,
+): string[] {
+  if (prop["x-file-size-soft-limit"] === true) return [];
+  const limit = prop["x-file-size-limit"];
+  if (!limit) return [];
+  if (!(files instanceof FileList)) return [];
+  return Array.from(files)
+    .map((file) => {
+      if (file.size > limit) {
+        return `File exceeds the maximum size of ${formatMemorySize(limit)}. Please choose a smaller file to continue.`;
+      }
+      return "";
+    })
+    .filter(Boolean);
+}

--- a/web-common/src/features/templates/schemas/local_file.ts
+++ b/web-common/src/features/templates/schemas/local_file.ts
@@ -3,10 +3,7 @@ import {
   PossibleFileExtensions,
   PossibleZipExtensions,
 } from "@rilldata/web-common/features/sources/modal/possible-file-extensions.ts";
-import {
-  UploadFileSizeLimitInBytes,
-  UploadSizeExceededIsWarning,
-} from "@rilldata/web-common/features/sources/upload-utils.ts";
+import { UploadFileSizeLimitInBytes } from "@rilldata/web-common/features/sources/upload-utils.ts";
 
 export const localFileSchema: MultiStepFormSchema = {
   $schema: "http://json-schema.org/draft-07/schema#",
@@ -24,11 +21,16 @@ export const localFileSchema: MultiStepFormSchema = {
       ].join(","),
       "x-step": "source",
       "x-hint": "CSV, TSV, Parquet, TXT or JSON",
+      "x-custom-validator": "file-upload",
       "x-file-size-limit": UploadFileSizeLimitInBytes,
-      "x-file-size-soft-limit": UploadSizeExceededIsWarning,
+      "x-file-size-soft-limit": true,
       "x-file-size-limit-warning-message":
         "Files over 100MB can be used locally but deployment to Rill Cloud is not allowed. Consider storing the data externally (e.g. S3) if you plan to deploy this project",
     },
   },
   required: ["file"],
 };
+
+export function updateLocalFileSchemaForCloud() {
+  (localFileSchema.properties!.file as any)["x-file-size-soft-limit"] = false;
+}


### PR DESCRIPTION
File upload errors were silently ignored leading to unexpected errors downstream. Consuming file upload errors and surfacing to the upload form. Also updating the size warning to error on cloud editing.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
