### PR TITLE
fix: misc issues for cloud editing

### DIFF
--- a/web-admin/src/features/edit-session/PublishPopover.svelte
+++ b/web-admin/src/features/edit-session/PublishPopover.svelte
@@ -51,12 +51,12 @@
     !!prodDeployment && isActiveDeployment(prodDeployment);
   $: alreadyOnPrimary =
     !!primaryBranch && !!currentBranch && currentBranch === primaryBranch;
+  // TODO: this should also check currentBranch vs primaryBranch once that API is available.
   $: disabled =
     !primaryBranch ||
     !currentBranch ||
     !projectLoaded ||
     alreadyOnPrimary ||
-    !hasLocalChanges ||
     isPublishing;
 
   // Prefetch prod's project parser commit SHA so the deploying page can

--- a/web-admin/src/features/projects/selectors.ts
+++ b/web-admin/src/features/projects/selectors.ts
@@ -140,6 +140,7 @@ export async function fetchProjectDeploymentDetails(
   const projResp = await queryClient.fetchQuery({
     queryKey,
     queryFn,
+    staleTime: 1000 * 60,
   });
 
   return {

--- a/web-admin/src/features/projects/selectors.ts
+++ b/web-admin/src/features/projects/selectors.ts
@@ -140,6 +140,8 @@ export async function fetchProjectDeploymentDetails(
   const projResp = await queryClient.fetchQuery({
     queryKey,
     queryFn,
+    // We dont want to fire this for every page transition, only hit this once a minute.
+    // TODO: perhaps we can bump this further or not have it at all
     staleTime: 1000 * 60,
   });
 

--- a/web-admin/src/routes/[organization]/[project]/-/edit/welcome/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/welcome/+layout.svelte
@@ -1,8 +1,21 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
+  import { createRuntimeServiceAnalyzeConnectors } from "@rilldata/web-common/runtime-client";
+  import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
 
   let { children }: { children: Snippet } = $props();
+
+  const runtimeClient = useRuntimeClient();
+
+  // Prefetch connectors and load into cache. We will show a spinner while this is fetching.
+  const connectorsQuery = createRuntimeServiceAnalyzeConnectors(
+    runtimeClient,
+    {},
+  );
 </script>
+
+<!-- preload connectors list but dont show a spinner -->
+<div class="hidden">${$connectorsQuery.data}</div>
 
 <div class="flex size-full overflow-hidden">
   <div class="scroll">

--- a/web-admin/src/routes/[organization]/[project]/-/edit/welcome/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/welcome/+layout.svelte
@@ -7,14 +7,15 @@
 
   const runtimeClient = useRuntimeClient();
 
-  // Prefetch connectors and load into cache. We will show a spinner while this is fetching.
+  // Prefetch connectors and load into cache, but do not show a spinner,
+  // it can be a bit jarring to see a lot of spinners
   const connectorsQuery = createRuntimeServiceAnalyzeConnectors(
     runtimeClient,
     {},
   );
 </script>
 
-<!-- preload connectors list but dont show a spinner -->
+<!-- Trigger load with hidden div so query is fired -->
 <div class="hidden">${$connectorsQuery.data}</div>
 
 <div class="flex size-full overflow-hidden">

--- a/web-admin/src/routes/[organization]/[project]/-/edit/welcome/add-data/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/welcome/add-data/+page.svelte
@@ -5,9 +5,6 @@
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
   import { projectWelcomeStatus } from "@rilldata/web-admin/features/welcome/project/welcome-status.ts";
   import { checkpointProject } from "@rilldata/web-admin/features/projects/publish-project.ts";
-  import { createRuntimeServiceAnalyzeConnectors } from "@rilldata/web-common/runtime-client";
-  import { EntityStatus } from "@rilldata/web-common/features/entity-management/types.ts";
-  import Spinner from "@rilldata/web-common/features/entity-management/Spinner.svelte";
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
@@ -19,12 +16,6 @@
   let isImportStep = $derived(addDataStep === AddDataStep.Import);
 
   let project = $derived(page.params.project);
-
-  // Prefetch connectors and load into cache. We will show a spinner while this is fetching.
-  const connectorsQuery = createRuntimeServiceAnalyzeConnectors(
-    runtimeClient,
-    {},
-  );
 
   async function handleDone() {
     projectWelcomeStatus.setProjectWelcomeStep(project, false);
@@ -38,21 +29,17 @@
     <div class="text-3xl font-bold text-fg-accent">Connect your data</div>
   {/if}
   <div class="w-fit h-fit mt-4">
-    {#if $connectorsQuery.isPending}
-      <Spinner status={EntityStatus.Running} size="3rem" duration={725} />
-    {:else}
-      <!-- TODO: add error state when connectors query errors -->
-      {#key data.schema}
-        <AddDataManager
-          config={{
-            welcomeScreen: true,
-          }}
-          initSchema={data.schema}
-          onStepChange={(step) => (addDataStep = step)}
-          onClose={() => window.history.back()}
-          onDone={handleDone}
-        />
-      {/key}
-    {/if}
+    <!-- TODO: add error state when connectors query errors -->
+    {#key data.schema}
+      <AddDataManager
+        config={{
+          welcomeScreen: true,
+        }}
+        initSchema={data.schema}
+        onStepChange={(step) => (addDataStep = step)}
+        onClose={() => window.history.back()}
+        onDone={handleDone}
+      />
+    {/key}
   </div>
 </div>

--- a/web-common/src/features/add-data/form/SourceForm.svelte
+++ b/web-common/src/features/add-data/form/SourceForm.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { createConnectorForm } from "@rilldata/web-common/features/sources/modal/FormValidation.ts";
   import {
-    runtimeServiceGetFile,
     runtimeServiceGetInstance,
     getRuntimeServiceGetInstanceQueryKey,
   } from "@rilldata/web-common/runtime-client";
@@ -31,6 +30,7 @@
   import {
     getConnectorDriverForSchema,
     getImportStepsForSource,
+    maybeGetEnvContent,
   } from "@rilldata/web-common/features/add-data/manager/steps/utils.ts";
   import { maybeInitProject } from "@rilldata/web-common/features/add-data/manager/steps/connector.ts";
 
@@ -56,15 +56,7 @@
   let existingEnvBlob: string | null = null;
   let defaultOLAP = "duckdb";
   onMount(async () => {
-    try {
-      const envFile = await runtimeServiceGetFile(runtimeClient, {
-        path: ".env",
-      });
-      existingEnvBlob = envFile.blob ?? "";
-    } catch {
-      // .env doesn't exist yet
-      existingEnvBlob = "";
-    }
+    existingEnvBlob = await maybeGetEnvContent();
     try {
       const runtimeInstance = await queryClient.fetchQuery({
         queryKey: getRuntimeServiceGetInstanceQueryKey(

--- a/web-common/src/features/add-data/manager/AddDataManager.svelte
+++ b/web-common/src/features/add-data/manager/AddDataManager.svelte
@@ -23,7 +23,6 @@
     getConnectorDriverForSchema,
   } from "@rilldata/web-common/features/add-data/manager/steps/utils.ts";
   import type { V1ConnectorDriver } from "@rilldata/web-common/runtime-client";
-  import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts.ts";
   import ConnectorFormWrapper from "@rilldata/web-common/features/add-data/form/ConnectorFormWrapper.svelte";
   import { getAddDataClass } from "@rilldata/web-common/features/add-data/class-utils.ts";
   import { inferSchemaForConnector } from "@rilldata/web-common/features/entity-management/add/selectors.ts";
@@ -84,9 +83,6 @@
   );
 
   async function init(connector?: string, schema?: string) {
-    // Load .env file to make sure it's available to the state manager.
-    await fileArtifacts.getFileArtifact(".env").fetchContent(false);
-
     let driver: V1ConnectorDriver | undefined = undefined;
     if (connector) {
       const analyzedConnector = await getConnectorDriverForConnector(

--- a/web-common/src/features/add-data/manager/steps/connector.ts
+++ b/web-common/src/features/add-data/manager/steps/connector.ts
@@ -51,7 +51,8 @@ import {
   getProjectParserVersion,
   waitForProjectParserVersion,
 } from "@rilldata/web-common/features/entity-management/project-parser.ts";
-import { getRuntimeEditEnvironment } from "@rilldata/web-common/features/entity-management/edit-environment.ts";
+import { isCloudRuntimeEditEnvironment } from "@rilldata/web-common/features/entity-management/edit-environment.ts";
+import { maybeGetEnvContent } from "@rilldata/web-common/features/add-data/manager/steps/utils.ts";
 
 export async function createConnector({
   runtimeClient,
@@ -159,7 +160,7 @@ export async function createConnector({
         create: true,
         createOnly: false,
       });
-      if (getRuntimeEditEnvironment() === "cloud") {
+      if (isCloudRuntimeEditEnvironment()) {
         // Only push env on cloud for now. We will revisit this for rill-dev.
         await runtimeServicePushEnv(runtimeClient, {});
       }
@@ -240,7 +241,7 @@ export async function maybeDeleteConnector(
   if (!connectorYaml) return;
 
   // Get the existing env and remove the connector's env vars
-  const envBlob = await unsetResourceEnvVars(
+  const [envBlob, envBlobChanged] = await unsetResourceEnvVars(
     runtimeClient,
     queryClient,
     connectorYaml,
@@ -251,11 +252,17 @@ export async function maybeDeleteConnector(
     path: connectorFilePath,
   });
 
-  // Update the .env file with the removed env vars
-  await runtimeServicePutFile(runtimeClient, {
-    path: ".env",
-    blob: envBlob,
-  });
+  if (envBlobChanged) {
+    // Update the .env file with the removed env vars
+    await runtimeServicePutFile(runtimeClient, {
+      path: ".env",
+      blob: envBlob,
+    });
+    if (isCloudRuntimeEditEnvironment()) {
+      // Only push env on cloud for now. We will revisit this for rill-dev.
+      await runtimeServicePushEnv(runtimeClient, {});
+    }
+  }
 
   // Update the rill.yaml file to remove the connector as the OLAP connector.
   await unsetOlapConnectorInRillYAML(runtimeClient, queryClient, connectorName);
@@ -392,8 +399,7 @@ export class ConnectorFormCache {
       fileArtifacts.getNamesForKind(ResourceKind.Connector),
     );
 
-    const envFile = fileArtifacts.getFileArtifact(".env");
-    const envBlob = (await envFile.fetchContent(false)) ?? "";
+    const envBlob = await maybeGetEnvContent();
 
     const entry = {
       name,

--- a/web-common/src/features/add-data/manager/steps/import.ts
+++ b/web-common/src/features/add-data/manager/steps/import.ts
@@ -38,7 +38,7 @@ import { unsetResourceEnvVars } from "@rilldata/web-common/features/connectors/c
 import { maybeGetConnectorDriver } from "@rilldata/web-common/features/add-data/manager/steps/utils.ts";
 import { behaviourEvent } from "@rilldata/web-common/metrics/initMetrics.ts";
 import { BehaviourEventAction } from "@rilldata/web-common/metrics/service/BehaviourEventTypes.ts";
-import { getRuntimeEditEnvironment } from "@rilldata/web-common/features/entity-management/edit-environment.ts";
+import { isCloudRuntimeEditEnvironment } from "@rilldata/web-common/features/entity-management/edit-environment.ts";
 
 export async function runImportSteps(
   runtimeClient: RuntimeClient,
@@ -125,6 +125,7 @@ export async function cleanupImportStep(
   const importToConfig = config.importTo;
 
   let envBlob: string | null = null;
+  let envBlobChanged = false;
   if (
     importToConfig.modelPath &&
     fileArtifacts.hasFileArtifact(importToConfig.modelPath)
@@ -135,7 +136,7 @@ export async function cleanupImportStep(
     const modelYaml = await modelArtifact.fetchContent();
 
     // Get the existing env and remove the connector's env vars
-    envBlob = await unsetResourceEnvVars(
+    [envBlob, envBlobChanged] = await unsetResourceEnvVars(
       runtimeClient,
       queryClient,
       modelYaml ?? "",
@@ -156,12 +157,16 @@ export async function cleanupImportStep(
     }),
   );
 
-  if (envBlob) {
+  if (envBlob && envBlobChanged) {
     // Update the .env file with the removed env vars
     await runtimeServicePutFile(runtimeClient, {
       path: ".env",
       blob: envBlob,
     });
+    if (isCloudRuntimeEditEnvironment()) {
+      // Only push env on cloud for now. We will revisit this for rill-dev.
+      await runtimeServicePushEnv(runtimeClient, {});
+    }
   }
 }
 
@@ -250,7 +255,7 @@ async function runCreateModelStep(
       create: true,
       createOnly: false,
     });
-    if (getRuntimeEditEnvironment() === "cloud") {
+    if (isCloudRuntimeEditEnvironment()) {
       // Only push env on cloud for now. We will revisit this for rill-dev.
       await runtimeServicePushEnv(runtimeClient, {});
     }

--- a/web-common/src/features/add-data/manager/steps/utils.ts
+++ b/web-common/src/features/add-data/manager/steps/utils.ts
@@ -121,10 +121,7 @@ export function getImportStepsForSource(config: AddDataConfig) {
 }
 
 export async function maybeGetEnvContent() {
-  if (!fileArtifacts.hasFileArtifact("/.env")) {
-    console.log("No /.env file artifact found");
-    return "";
-  }
+  if (!fileArtifacts.hasFileArtifact("/.env")) return "";
   const envFile = fileArtifacts.getFileArtifact("/.env");
   return (await envFile.fetchContent(false)) ?? "";
 }

--- a/web-common/src/features/add-data/manager/steps/utils.ts
+++ b/web-common/src/features/add-data/manager/steps/utils.ts
@@ -12,6 +12,7 @@ import {
   ImportDataStep,
 } from "@rilldata/web-common/features/add-data/manager/steps/types.ts";
 import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors.ts";
+import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts.ts";
 
 export function getConnectorDriverForSchema(
   schemaName: string,
@@ -117,4 +118,13 @@ export function getImportStepsForConnector(
 
 export function getImportStepsForSource(config: AddDataConfig) {
   return config.importOnly ? [ImportDataStep.CreateModel] : FullListOfSteps;
+}
+
+export async function maybeGetEnvContent() {
+  if (!fileArtifacts.hasFileArtifact("/.env")) {
+    console.log("No /.env file artifact found");
+    return "";
+  }
+  const envFile = fileArtifacts.getFileArtifact("/.env");
+  return (await envFile.fetchContent(false)) ?? "";
 }

--- a/web-common/src/features/connectors/code-utils.ts
+++ b/web-common/src/features/connectors/code-utils.ts
@@ -330,7 +330,7 @@ export async function unsetResourceEnvVars(
   runtimeClient: RuntimeClient,
   queryClient: QueryClient,
   yaml: string,
-) {
+): Promise<[string, boolean]> {
   let envBlob: V1GetFileResponse | undefined = undefined;
   try {
     envBlob = await queryClient.fetchQuery({
@@ -341,7 +341,7 @@ export async function unsetResourceEnvVars(
     });
   } catch (error) {
     if (error.message?.includes("no such file or directory")) {
-      return "";
+      return ["", false];
     }
     throw error;
   }
@@ -353,7 +353,7 @@ export async function unsetResourceEnvVars(
     blob = deleteEnvVariable(blob, envVar);
   });
 
-  return blob;
+  return [blob, envVars.length > 0];
 }
 
 export async function updateDotEnvWithSecrets(

--- a/web-common/src/features/entity-management/actions/protected-files.ts
+++ b/web-common/src/features/entity-management/actions/protected-files.ts
@@ -1,6 +1,6 @@
 import picomatch from "picomatch";
 import type { Snippet } from "svelte";
-import { getRuntimeEditEnvironment } from "../edit-environment.ts";
+import { isCloudRuntimeEditEnvironment } from "../edit-environment.ts";
 
 // Two distinct kinds of path protections:
 //
@@ -38,7 +38,7 @@ export function setCloudReadonlyNotice(notice: Snippet | undefined) {
 }
 
 export function isManaged(path: string): boolean {
-  if (getRuntimeEditEnvironment() === "cloud") {
+  if (isCloudRuntimeEditEnvironment()) {
     return CLOUD_READONLY.some((m) => m(path));
   }
   return false;
@@ -49,10 +49,7 @@ export function isPinned(path: string): boolean {
 }
 
 export function getReadonlyNotice(path: string): Snippet | undefined {
-  if (
-    getRuntimeEditEnvironment() === "cloud" &&
-    CLOUD_READONLY.some((m) => m(path))
-  ) {
+  if (isCloudRuntimeEditEnvironment() && CLOUD_READONLY.some((m) => m(path))) {
     return cloudReadonlyNotice;
   }
   return undefined;

--- a/web-common/src/features/entity-management/edit-environment.ts
+++ b/web-common/src/features/entity-management/edit-environment.ts
@@ -11,6 +11,6 @@ export function setRuntimeEditEnvironment(env: RuntimeEditEnvironment) {
   editEnvironment = env;
 }
 
-export function getRuntimeEditEnvironment(): RuntimeEditEnvironment {
-  return editEnvironment;
+export function isCloudRuntimeEditEnvironment() {
+  return editEnvironment === "cloud";
 }


### PR DESCRIPTION
1. Publish button disabled when there are no local changes but current branch is different. We will need the API that gets the diff between 2 branches before we disable this.
2. Additional spinner on connector selector. We can offload this in welcome page so that it is loaded in the background.
3. `.env` fetch is attempted even if it doesnt exist. Because of file watcher we should already know if it exists or not.
4. PushEnv when we delete env entries during connector/source deletion.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
