### PR TITLE
docs: fix typo "agains" → "against" in `place-element.ts` comment

### DIFF
--- a/web-common/src/lib/place-element.ts
+++ b/web-common/src/lib/place-element.ts
@@ -58,7 +58,7 @@ export function placeElement({
   const parentWidth = parentPosition.width;
   const parentHeight = parentPosition.height;
 
-  // Task 1: check if we need to reflect agains the location axis.
+  // Task 1: check if we need to reflect against the location axis.
   if (location === "bottom") {
     if (
       overflowFlipY &&


### PR DESCRIPTION
Comment-only typo fix in `web-common/src/lib/place-element.ts:61` on the location-axis reflect logic. No behavior change.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*