### PR TITLE
fix: cloud editing more qa items

### DIFF
--- a/web-admin/src/features/edit-session/MergePopover.svelte
+++ b/web-admin/src/features/edit-session/MergePopover.svelte
@@ -93,7 +93,7 @@
     const targetUrl = buildPostMergeUrl({
       organization,
       project,
-      pathname: $page.url.pathname,
+      page: $page,
       hadProdDeployment,
       preCommitSha: $parserShaQuery.data,
     });

--- a/web-admin/src/features/edit-session/PublishPopover.svelte
+++ b/web-admin/src/features/edit-session/PublishPopover.svelte
@@ -23,6 +23,7 @@
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
   import { Rocket } from "lucide-svelte";
   import { buildPostMergeUrl } from "./post-merge-url";
+  import { goto } from "$app/navigation";
 
   export let organization: string;
   export let project: string;
@@ -86,27 +87,6 @@
     const hadProdDeployment = !!prodDeployment;
     const needsRedeploy = !prodDeploymentActive;
 
-    // Open the new tab synchronously so the browser ties window.open() to
-    // the click gesture; otherwise pop-up blockers reject the open after
-    // the awaited mutations below. The destination pages handle their own
-    // loading state, so no placeholder is needed.
-    const targetUrl = buildPostMergeUrl({
-      organization,
-      project,
-      pathname: $page.url.pathname,
-      hadProdDeployment,
-      preCommitSha: $parserShaQuery.data,
-    });
-    const targetWindow = window.open(targetUrl, "_blank");
-    if (!targetWindow) {
-      eventBus.emit("notification", {
-        type: "error",
-        message: "Pop-up was blocked. Please allow pop-ups and try again.",
-      });
-      isPublishing = false;
-      return;
-    }
-
     // gitStatus tracks localChanges and currentBranch; the mutations below
     // change both, so refresh once the flow finishes (success or failure).
     const gitStatusQueryKey = getRuntimeServiceGitStatusQueryKey(
@@ -126,7 +106,6 @@
         force: false,
       });
     } catch (err) {
-      targetWindow.close();
       eventBus.emit("notification", {
         type: "error",
         message: extractErrorMessage(err) || "Failed to publish",
@@ -166,7 +145,6 @@
         // The merge succeeded but the prod deployment failed to (re)start.
         // Be explicit so the user knows their changes are on the primary
         // branch and that the deployment step is what needs retrying.
-        targetWindow.close();
         const detail = extractErrorMessage(err);
         eventBus.emit("notification", {
           type: "error",
@@ -177,6 +155,23 @@
         isPublishing = false;
         return;
       }
+    }
+
+    const targetUrl = buildPostMergeUrl({
+      organization,
+      project,
+      page: $page,
+      hadProdDeployment,
+      preCommitSha: $parserShaQuery.data,
+    });
+    const targetWindow = window.open(targetUrl, "_blank");
+    if (!targetWindow) {
+      // Go to target directly if popup is blocked.
+      void goto(targetUrl);
+      eventBus.emit("notification", {
+        type: "error",
+        message: "Pop-up was blocked.",
+      });
     }
 
     isPublishing = false;

--- a/web-admin/src/features/edit-session/post-merge-url.ts
+++ b/web-admin/src/features/edit-session/post-merge-url.ts
@@ -2,6 +2,10 @@ import {
   TargetDashboardUrlParam,
   PreCommitShaUrlParam,
 } from "@rilldata/web-common/features/project/deploy/utils";
+import type { Page } from "@sveltejs/kit";
+import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts.ts";
+import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors.ts";
+import { get } from "svelte/store";
 
 // /-/invite for the first deploy; /-/deploying when prod already exists.
 // If the user was editing a dashboard, pass its name through so the
@@ -12,30 +16,58 @@ import {
 export function buildPostMergeUrl({
   organization,
   project,
-  pathname,
+  page,
   hadProdDeployment,
   preCommitSha,
 }: {
   organization: string;
   project: string;
-  pathname: string;
+  page: Page;
   hadProdDeployment: boolean;
   preCommitSha?: string;
 }): string {
-  const dashboard = pathname.match(
-    /\/-\/edit\/(?:explore|canvas)\/([^/?#]+)/,
-  )?.[1];
-
   const path = hadProdDeployment ? "/-/deploying" : "/-/invite";
   const url = new URL(
     `/${organization}/${project}${path}`,
     window.location.origin,
   );
+
+  const dashboard = getDashboardFromUrl(page);
   if (dashboard) {
     url.searchParams.set(TargetDashboardUrlParam, dashboard);
   }
+
   if (preCommitSha) {
     url.searchParams.set(PreCommitShaUrlParam, preCommitSha);
   }
   return `${url.pathname}${url.search}`;
+}
+
+function getDashboardFromUrl(page: Page) {
+  if (isEditRoute(page)) {
+    const filePath = page.url.pathname.replace(/.*\/files/, "");
+    const curFile = fileArtifacts.getFileArtifact(filePath);
+    const curResource = get(curFile.resourceName);
+    const isDashboardResource =
+      curResource?.kind === ResourceKind.Explore ||
+      curResource?.kind === ResourceKind.Canvas;
+    return isDashboardResource ? curResource.name : undefined;
+  }
+
+  if (isDashboardVizRoute(page)) {
+    return page.params.name;
+  }
+}
+
+function isDashboardVizRoute(page: Page) {
+  return (
+    page.route.id === "/[organization]/[project]/-/edit/(viz)/explore/[name]" ||
+    page.route.id === "/[organization]/[project]/-/edit/(viz)/canvas/[name]"
+  );
+}
+
+function isEditRoute(page: Page) {
+  return page.route.id?.startsWith(
+    "/[organization]/[project]/-/edit/(workspace)/files",
+  );
 }

--- a/web-admin/src/routes/[organization]/[project]/-/edit/(workspace)/files/[...file]/+page.ts
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/(workspace)/files/[...file]/+page.ts
@@ -2,7 +2,8 @@ import { addLeadingSlash } from "@rilldata/web-common/features/entity-management
 import { fileArtifacts } from "@rilldata/web-common/features/entity-management/file-artifacts.js";
 import { error } from "@sveltejs/kit";
 
-export const load = async ({ params: { file } }) => {
+export const load = async ({ params: { file }, parent }) => {
+  await parent();
   const path = addLeadingSlash(file);
   const fileArtifact = fileArtifacts.getFileArtifact(path);
 


### PR DESCRIPTION
1. Fix "Project hibernating" message while publishing for the 1st time. This is because we open the page before calling redeploy in an attempt to beat popups disabled. Remove this check and open at the end, if popup is disabled then open in the same tab.
2. Deploy doesnt land the user on the dashboard when in edit mode. Update the logic similar to rill-dev.
3. Refreshing on an `.env` file will disable the edit protection. Ensuring cloud edit env is set and child routes wait for parent.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
