### PR TITLE
fix: edit blocked for deployment owened by others

### DIFF
--- a/web-admin/src/features/branches/BranchesSection.svelte
+++ b/web-admin/src/features/branches/BranchesSection.svelte
@@ -420,7 +420,7 @@
                   </IconButton>
                 </DropdownMenu.Trigger>
                 <DropdownMenu.Content align="start">
-                  {#if !!currentUserId && deployment.ownerUserId === currentUserId && deployment.editable}
+                  {#if !!currentUserId && deployment.editable}
                     <DropdownMenu.Item
                       class="font-normal flex items-center"
                       href={editUrl(deployment.branch)}

--- a/web-admin/src/features/branches/BranchesSection.svelte
+++ b/web-admin/src/features/branches/BranchesSection.svelte
@@ -4,7 +4,6 @@
   import {
     V1DeploymentStatus,
     createAdminServiceDeleteDeployment,
-    createAdminServiceGetCurrentUser,
     createAdminServiceGetProject,
     createAdminServiceListDeployments,
     createAdminServiceListOrganizationMemberUsers,
@@ -56,8 +55,6 @@
   let { organization, project }: { organization: string; project: string } =
     $props();
 
-  const user = createAdminServiceGetCurrentUser();
-
   let orgMembers = $derived(
     createAdminServiceListOrganizationMemberUsers(organization, {
       pageSize: 1000,
@@ -91,7 +88,6 @@
 
   let primaryBranch = $derived($projectQuery.data?.project?.primaryBranch);
   let activeBranch = $derived(extractBranchFromPath(page.url.pathname));
-  let currentUserId = $derived($user.data?.user?.id);
 
   let userNameMap = $derived(
     new Map(
@@ -420,7 +416,7 @@
                   </IconButton>
                 </DropdownMenu.Trigger>
                 <DropdownMenu.Content align="start">
-                  {#if !!currentUserId && deployment.editable}
+                  {#if deployment.editable}
                     <DropdownMenu.Item
                       class="font-normal flex items-center"
                       href={editUrl(deployment.branch)}

--- a/web-admin/src/features/edit-session/EditBranchDialog.svelte
+++ b/web-admin/src/features/edit-session/EditBranchDialog.svelte
@@ -45,12 +45,11 @@
   $: deployments = $devDeployments.data?.deployments ?? [];
   $: sourceBranch = primaryBranch || "main";
 
-  // Editable deployments owned by the current user, sorted by most recently
+  // Editable deployments sorted by most recently
   // updated. Stopped/errored branches show so the user can resume or retry.
   $: ownDeployments = deployments
     .filter(
       (d) =>
-        d.ownerUserId === currentUserId &&
         d.editable &&
         d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETING &&
         d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETED,
@@ -61,16 +60,11 @@
   $: hasOwnSessions = ownDeployments.length > 0;
   $: isStarting = $createMutation.isPending;
 
-  // Banner condition: active branch is owned but not editable
+  // Banner condition: active branch not editable
   $: activeBranchIsNonEditable =
     !!activeBranch &&
     !!currentUserId &&
-    deployments.some(
-      (d) =>
-        d.branch === activeBranch &&
-        d.ownerUserId === currentUserId &&
-        !d.editable,
-    );
+    deployments.some((d) => d.branch === activeBranch && !d.editable);
 
   // Reset all state every time the dialog opens.
   $: if (open) {
@@ -145,8 +139,7 @@
       requestSkipBranchInjection();
       await goto(editUrl(resp.deployment?.branch));
     } catch (err) {
-      createError =
-        getRpcErrorMessage(err as any) ?? "Failed to start edit session.";
+      createError = getRpcErrorMessage(err) ?? "Failed to start edit session.";
     }
   }
 

--- a/web-admin/src/features/edit-session/EditBranchDialog.svelte
+++ b/web-admin/src/features/edit-session/EditBranchDialog.svelte
@@ -2,7 +2,6 @@
   import { goto } from "$app/navigation";
   import {
     createAdminServiceCreateDeployment,
-    createAdminServiceGetCurrentUser,
     V1DeploymentStatus,
   } from "@rilldata/web-admin/client";
   import { getRpcErrorMessage } from "@rilldata/web-admin/components/errors/error-utils";
@@ -32,7 +31,6 @@
   /** The project's primary branch, used as the source for new branches. */
   export let primaryBranch: string | undefined = undefined;
 
-  const user = createAdminServiceGetCurrentUser();
   const devDeployments = useDevDeployments(organization, project);
   const createMutation = createAdminServiceCreateDeployment();
 
@@ -41,12 +39,11 @@
   let selectedBranchId = "";
   let createError = "";
 
-  $: currentUserId = $user.data?.user?.id;
   $: deployments = $devDeployments.data?.deployments ?? [];
   $: sourceBranch = primaryBranch || "main";
 
-  // Editable deployments sorted by most recently
-  // updated. Stopped/errored branches show so the user can resume or retry.
+  // Editable deployments sorted by most recently updated.
+  // Stopped/errored branches show so the user can resume or retry.
   $: ownDeployments = deployments
     .filter(
       (d) =>
@@ -63,7 +60,6 @@
   // Banner condition: active branch not editable
   $: activeBranchIsNonEditable =
     !!activeBranch &&
-    !!currentUserId &&
     deployments.some((d) => d.branch === activeBranch && !d.editable);
 
   // Reset all state every time the dialog opens.

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -28,14 +28,13 @@
   $: deployments = $devDeployments.data?.deployments ?? [];
   $: isLoading = $devDeployments.isLoading;
 
-  // If viewing a branch the user owns, clicking the button should go straight
+  // If viewing an editable branch, clicking the button should go straight
   // there — no dialog.
   $: activeBranchDeployment =
     activeBranch && currentUserId
       ? deployments.find(
           (d) =>
             d.branch === activeBranch &&
-            d.ownerUserId === currentUserId &&
             d.editable &&
             d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETING &&
             d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETED,
@@ -52,7 +51,7 @@
   function handleDirectEdit(e: MouseEvent) {
     e.preventDefault();
     requestSkipBranchInjection();
-    void goto(directEditHref!);
+    void goto(directEditHref);
   }
 </script>
 

--- a/web-admin/src/features/edit-session/EditButton.svelte
+++ b/web-admin/src/features/edit-session/EditButton.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
-  import {
-    createAdminServiceGetCurrentUser,
-    V1DeploymentStatus,
-  } from "@rilldata/web-admin/client";
+  import { V1DeploymentStatus } from "@rilldata/web-admin/client";
   import {
     injectBranchIntoPath,
     requestSkipBranchInjection,
@@ -19,27 +16,24 @@
   /** The project's primary branch, used as the source for new branches. */
   export let primaryBranch: string | undefined = undefined;
 
-  const user = createAdminServiceGetCurrentUser();
   const devDeployments = useDevDeployments(organization, project);
 
   let dialogOpen = false;
 
-  $: currentUserId = $user.data?.user?.id;
   $: deployments = $devDeployments.data?.deployments ?? [];
   $: isLoading = $devDeployments.isLoading;
 
   // If viewing an editable branch, clicking the button should go straight
   // there — no dialog.
-  $: activeBranchDeployment =
-    activeBranch && currentUserId
-      ? deployments.find(
-          (d) =>
-            d.branch === activeBranch &&
-            d.editable &&
-            d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETING &&
-            d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETED,
-        )
-      : undefined;
+  $: activeBranchDeployment = activeBranch
+    ? deployments.find(
+        (d) =>
+          d.branch === activeBranch &&
+          d.editable &&
+          d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETING &&
+          d.status !== V1DeploymentStatus.DEPLOYMENT_STATUS_DELETED,
+      )
+    : undefined;
 
   $: directEditHref = activeBranchDeployment?.branch
     ? injectBranchIntoPath(

--- a/web-admin/src/routes/[organization]/[project]/-/edit/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/+layout.svelte
@@ -75,11 +75,6 @@
 
   const user = createAdminServiceGetCurrentUser();
 
-  $: currentUserId = $user.data?.user?.id;
-
-  $: isOtherOwner =
-    !!deployment && !!currentUserId && deployment.ownerUserId !== currentUserId;
-
   // Flipped when the user clicks "Start deployment" on a stopped deployment;
   // keeps the UI in loading state while the backend transitions STOPPED → PENDING → RUNNING.
   let starting = false;
@@ -103,8 +98,7 @@
       deploymentStatus === V1DeploymentStatus.DEPLOYMENT_STATUS_UPDATING) &&
     runtimeHost !== null &&
     instanceId !== null &&
-    jwt !== null &&
-    !isOtherOwner;
+    jwt !== null;
 
   $: branchUrl = `/${organization}/${project}${branchPathPrefix(branch)}`;
 
@@ -132,31 +126,7 @@
 </script>
 
 <div class="edit-session">
-  {#if isOtherOwner}
-    <SlimProjectHeader
-      {organization}
-      {project}
-      readProjects={organizationPermissions?.readProjects}
-      {planDisplayName}
-      {organizationLogoUrl}
-    />
-    <CtaLayoutContainer>
-      <CtaContentContainer>
-        <h1
-          class="text-8xl font-extrabold bg-gradient-to-b from-[#CBD5E1] to-[#E2E8F0] text-transparent bg-clip-text"
-        >
-          403
-        </h1>
-        <h2 class="text-lg font-semibold">
-          This editing session belongs to another user
-        </h2>
-        <CtaMessage>You can preview this branch in read-only mode.</CtaMessage>
-        <CtaButton variant="secondary" href={branchUrl}>
-          Preview this branch
-        </CtaButton>
-      </CtaContentContainer>
-    </CtaLayoutContainer>
-  {:else if isLoading}
+  {#if isLoading}
     <EditSessionLoading status={deploymentStatus} href={`/${organization}`} />
   {:else if isErrored}
     <SlimProjectHeader

--- a/web-admin/src/routes/[organization]/[project]/-/edit/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/+layout.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { page } from "$app/stores";
   import {
-    createAdminServiceGetCurrentUser,
     createAdminServiceGetProject,
     getAdminServiceGetProjectQueryKey,
     V1DeploymentStatus,
@@ -18,10 +17,6 @@
   import { baseGetProjectQueryOptions } from "@rilldata/web-admin/features/projects/project-query-options";
   import SlimProjectHeader from "@rilldata/web-admin/features/projects/SlimProjectHeader.svelte";
   import { getThemedLogoUrl } from "@rilldata/web-admin/features/themes/organization-logo";
-  import CtaButton from "@rilldata/web-common/components/calls-to-action/CTAButton.svelte";
-  import CtaContentContainer from "@rilldata/web-common/components/calls-to-action/CTAContentContainer.svelte";
-  import CtaLayoutContainer from "@rilldata/web-common/components/calls-to-action/CTALayoutContainer.svelte";
-  import CtaMessage from "@rilldata/web-common/components/calls-to-action/CTAMessage.svelte";
   import ErrorPage from "@rilldata/web-common/components/ErrorPage.svelte";
   import FileAndResourceWatcher from "@rilldata/web-common/features/entity-management/FileAndResourceWatcher.svelte";
   import { themeControl } from "@rilldata/web-common/features/themes/theme-control";
@@ -73,15 +68,12 @@
   $: instanceId = deployment?.runtimeInstanceId ?? null;
   $: jwt = $projectQuery.data?.jwt ?? null;
 
-  const user = createAdminServiceGetCurrentUser();
-
   // Flipped when the user clicks "Start deployment" on a stopped deployment;
   // keeps the UI in loading state while the backend transitions STOPPED → PENDING → RUNNING.
   let starting = false;
 
   $: isLoading =
     $projectQuery.isPending ||
-    $user.isPending ||
     starting ||
     deploymentStatus === V1DeploymentStatus.DEPLOYMENT_STATUS_PENDING;
 
@@ -99,8 +91,6 @@
     runtimeHost !== null &&
     instanceId !== null &&
     jwt !== null;
-
-  $: branchUrl = `/${organization}/${project}${branchPathPrefix(branch)}`;
 
   $: inProjectWelcomePage = isProjectWelcomePage($page);
 


### PR DESCRIPTION
We are blocking users from editing deployments owned by others. This was for protection against parallel editing. We are forgoing this since parllel edits should be taken care of by sse watch clients.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
