### PR TITLE
fix : changing granularity to week causes data to disappear in time-series charts for Bigquery

### DIFF
--- a/runtime/drivers/bigquery/dialect.go
+++ b/runtime/drivers/bigquery/dialect.go
@@ -87,6 +87,11 @@ func (d *dialect) DateTruncExpr(dim *runtimev1.MetricsViewSpec_Dimension, grain 
 	}
 
 	specifier := d.ConvertToDateTruncSpecifier(grain)
+	// BigQuery's bare WEEK specifier truncates to Sunday-start weeks. Rill's firstDayOfWeek follows ISO 8601
+	// (1=Monday, 7=Sunday, default 1), so map it to BigQuery's WEEK(<WEEKDAY>) form to keep them aligned.
+	if grain == runtimev1.TimeGrain_TIME_GRAIN_WEEK {
+		specifier = weekSpecifier(firstDayOfWeek)
+	}
 
 	var expr string
 	if dim.Expression != "" {
@@ -101,10 +106,6 @@ func (d *dialect) DateTruncExpr(dim *runtimev1.MetricsViewSpec_Dimension, grain 
 		expr = fmt.Sprintf("TIMESTAMP(%s)", expr)
 	}
 	if tz == "" {
-		if grain == runtimev1.TimeGrain_TIME_GRAIN_WEEK && firstDayOfWeek > 1 {
-			offset := 8 - firstDayOfWeek
-			return fmt.Sprintf("TIMESTAMP_SUB(TIMESTAMP_TRUNC(TIMESTAMP_ADD(%s, INTERVAL %d DAY), %s), INTERVAL %d DAY)", expr, offset, specifier, offset), nil
-		}
 		if grain == runtimev1.TimeGrain_TIME_GRAIN_YEAR && firstMonthOfYear > 1 {
 			offset := 13 - firstMonthOfYear
 			// TIMESTAMP_ADD/TIMESTAMP_SUB don't support MONTH; wrap TIMESTAMP_TRUNC result in DATETIME() before DATETIME_SUB.
@@ -113,10 +114,6 @@ func (d *dialect) DateTruncExpr(dim *runtimev1.MetricsViewSpec_Dimension, grain 
 		return fmt.Sprintf("TIMESTAMP_TRUNC(%s, %s)", expr, specifier), nil
 	}
 	// TIMESTAMP_TRUNC natively accepts a timezone argument.
-	if grain == runtimev1.TimeGrain_TIME_GRAIN_WEEK && firstDayOfWeek > 1 {
-		offset := 8 - firstDayOfWeek
-		return fmt.Sprintf("TIMESTAMP_SUB(TIMESTAMP_TRUNC(TIMESTAMP_ADD(%s, INTERVAL %d DAY), %s, '%s'), INTERVAL %d DAY)", expr, offset, specifier, tz, offset), nil
-	}
 	if grain == runtimev1.TimeGrain_TIME_GRAIN_YEAR && firstMonthOfYear > 1 {
 		offset := 13 - firstMonthOfYear
 		// TIMESTAMP_ADD/TIMESTAMP_SUB don't support MONTH; wrap TIMESTAMP_TRUNC result in DATETIME() before DATETIME_SUB.
@@ -154,5 +151,24 @@ func (d *dialect) SelectTimeRangeBins(start, end time.Time, grain runtimev1.Time
 			"SELECT TIMESTAMP(d, '%s') AS %s FROM UNNEST(GENERATE_DATE_ARRAY(DATE(TIMESTAMP '%s', '%s'), DATE(TIMESTAMP '%s', '%s'), INTERVAL 1 %s)) AS d WHERE TIMESTAMP(d, '%s') < TIMESTAMP '%s'",
 			tzStr, d.EscapeAlias(alias), startStr, tzStr, endStr, tzStr, d.ConvertToDateTruncSpecifier(grain), tzStr, endStr,
 		), nil, nil
+	}
+}
+
+func weekSpecifier(firstDayOfWeek int) string {
+	switch firstDayOfWeek {
+	case 2:
+		return "WEEK(TUESDAY)"
+	case 3:
+		return "WEEK(WEDNESDAY)"
+	case 4:
+		return "WEEK(THURSDAY)"
+	case 5:
+		return "WEEK(FRIDAY)"
+	case 6:
+		return "WEEK(SATURDAY)"
+	case 7:
+		return "WEEK(SUNDAY)"
+	default:
+		return "WEEK(MONDAY)"
 	}
 }

--- a/runtime/queries/metricsview_timeseries_test.go
+++ b/runtime/queries/metricsview_timeseries_test.go
@@ -796,12 +796,16 @@ func testMetricsViewTimeSeries_DayLightSavingsBackwards_Continuous_WeeklyOnSatur
 	require.Len(t, rows, 4)
 	i := 0
 	require.Equal(t, parseTime(t, "2023-10-28T04:00:00Z").AsTime(), rows[i].Ts.AsTime())
+	require.Equal(t, float64(456), rows[i].Records.Fields["total_records"].GetNumberValue())
 	i++
 	require.Equal(t, parseTime(t, "2023-11-04T04:00:00Z").AsTime(), rows[i].Ts.AsTime())
+	require.Equal(t, float64(525), rows[i].Records.Fields["total_records"].GetNumberValue())
 	i++
 	require.Equal(t, parseTime(t, "2023-11-11T05:00:00Z").AsTime(), rows[i].Ts.AsTime())
+	require.Equal(t, float64(0), rows[i].Records.Fields["total_records"].GetNumberValue())
 	i++
 	require.Equal(t, parseTime(t, "2023-11-18T05:00:00Z").AsTime(), rows[i].Ts.AsTime())
+	require.Equal(t, float64(0), rows[i].Records.Fields["total_records"].GetNumberValue())
 }
 
 func testMetricsViewTimeSeries_DayLightSavingsBackwards_Continuous_Daily(t *testing.T, rt *runtime.Runtime, instanceID string) {


### PR DESCRIPTION
closes https://linear.app/rilldata/issue/PLAT-486/bigquery-changing-granularity-to-week-causes-data-to-disappear-in-time

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
