### PR TITLE
fix: external_user_id not ignored for embed dashboards

### DIFF
--- a/web-admin/src/features/embeds/init-embed-public-api.ts
+++ b/web-admin/src/features/embeds/init-embed-public-api.ts
@@ -174,6 +174,7 @@ const EmbedParams = [
   "navigation",
   "theme",
   "theme_mode",
+  "external_user_id",
 ];
 export function removeEmbedParams(searchParams: URLSearchParams) {
   const cleanedParams = new URLSearchParams(searchParams);


### PR DESCRIPTION
Fixing https://rilldata.slack.com/archives/C095LTR6RQB/p1778518212093599?thread_ts=1776690181.002049&cid=C095LTR6RQB
When we recently added `external_user_id` we missed ignoring it for explore url params.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
