### PR TITLE
feat: full env editor on cloud edit page

### DIFF
--- a/web-admin/src/features/projects/environment-variables/EnvironmentVariablesEditor.svelte
+++ b/web-admin/src/features/projects/environment-variables/EnvironmentVariablesEditor.svelte
@@ -1,0 +1,168 @@
+<script lang="ts">
+  import { page } from "$app/state";
+  import { createAdminServiceGetProjectVariables } from "@rilldata/web-admin/client";
+  import AddDialog from "@rilldata/web-admin/features/projects/environment-variables/AddDialog.svelte";
+  import EnvironmentVariablesTable from "@rilldata/web-admin/features/projects/environment-variables/EnvironmentVariablesTable.svelte";
+  import {
+    EnvironmentType,
+    type EnvironmentTypes,
+  } from "@rilldata/web-admin/features/projects/environment-variables/types";
+  import { getEnvironmentType } from "@rilldata/web-admin/features/projects/environment-variables/utils";
+  import Button from "@rilldata/web-common/components/button/Button.svelte";
+  import { TableToolbar } from "@rilldata/web-common/components/table-toolbar";
+  import RadixLarge from "@rilldata/web-common/components/typography/RadixLarge.svelte";
+  import DelayedSpinner from "@rilldata/web-common/features/entity-management/DelayedSpinner.svelte";
+  import { Plus } from "lucide-svelte";
+  import Callout from "web-common/src/components/callout/Callout.svelte";
+  import { extractBranchFromPath } from "@rilldata/web-admin/features/branches/branch-utils.ts";
+
+  let {
+    searchText = $bindable(""),
+    envFilter = $bindable<EnvironmentTypes[]>([]),
+  }: {
+    searchText?: string;
+    envFilter?: EnvironmentTypes[];
+  } = $props();
+
+  let open = $state(false);
+
+  let organization = $derived(page.params.organization);
+  let project = $derived(page.params.project);
+  let activeBranch = $derived(extractBranchFromPath(page.url.pathname));
+
+  let getProjectVariables = $derived(
+    createAdminServiceGetProjectVariables(organization, project, {
+      forAllEnvironments: true,
+    }),
+  );
+
+  let projectVariables = $derived($getProjectVariables.data?.variables || []);
+
+  let variableNames = $derived(
+    projectVariables.map((variable) => {
+      return {
+        environment: getEnvironmentType(variable.environment),
+        name: variable.name,
+      };
+    }),
+  );
+
+  let searchedVariables = $derived(
+    projectVariables.filter((variable) =>
+      variable.name.toLowerCase().includes(searchText.toLowerCase()),
+    ),
+  );
+
+  let filteredVariables = $derived(
+    searchedVariables.filter((variable) => {
+      if (envFilter.length === 0) return true;
+      return envFilter.some((sel) => {
+        if (sel === EnvironmentType.DEVELOPMENT) {
+          return (
+            variable.environment === EnvironmentType.DEVELOPMENT ||
+            variable.environment === EnvironmentType.UNDEFINED
+          );
+        }
+        if (sel === EnvironmentType.PRODUCTION) {
+          return (
+            variable.environment === EnvironmentType.PRODUCTION ||
+            variable.environment === EnvironmentType.UNDEFINED
+          );
+        }
+        return false;
+      });
+    }),
+  );
+
+  let sortedVariables = $derived(
+    [...filteredVariables].sort((a, b) => {
+      return new Date(b.updatedOn).getTime() - new Date(a.updatedOn).getTime();
+    }),
+  );
+
+  function handleFilterChange(_key: string, selected: string | string[]) {
+    envFilter = selected as EnvironmentTypes[];
+  }
+
+  function handleClearAllFilters() {
+    envFilter = [];
+    searchText = "";
+  }
+
+  let emptyTextWhenNoVariables = $derived(
+    envFilter.length === 0
+      ? "No environment variables"
+      : `No environment variables match the selected filters`,
+  );
+
+  let filterGroups = $derived([
+    {
+      label: "Environment",
+      key: "environment",
+      options: [
+        { value: EnvironmentType.PRODUCTION, label: "Production" },
+        { value: EnvironmentType.DEVELOPMENT, label: "Development" },
+      ],
+      selected: envFilter,
+      defaultValue: [],
+      multiSelect: true,
+    },
+  ]);
+</script>
+
+<div class="flex flex-col w-full overflow-hidden">
+  <div class="flex md:flex-row flex-col gap-6">
+    {#if $getProjectVariables.isLoading}
+      <DelayedSpinner isLoading={$getProjectVariables.isLoading} size="1rem" />
+    {:else if $getProjectVariables.isError}
+      <div class="text-red-500">
+        Error loading environment variables: {$getProjectVariables.error}
+      </div>
+    {:else if $getProjectVariables.isSuccess}
+      <div class="flex flex-col gap-3 w-full overflow-hidden">
+        <div class="flex flex-col">
+          <RadixLarge>Environment variables</RadixLarge>
+
+          <p class="text-sm text-fg-tertiary font-medium">
+            Manage your environment variables here. Note that these are project
+            wide. <a
+              href="https://docs.rilldata.com/guide/administration/project-settings/variables-and-credentials"
+              target="_blank"
+              class="text-primary-600 hover:text-primary-700 active:text-primary-800"
+            >
+              Learn more ->
+            </a>
+          </p>
+
+          {#if activeBranch}
+            <Callout level="info">
+              <span class="text-sm">
+                These settings apply to the entire project, not just this
+                branch.
+              </span>
+            </Callout>
+          {/if}
+        </div>
+        <TableToolbar
+          bind:searchText
+          searchDisabled={projectVariables.length === 0}
+          {filterGroups}
+          onFilterChange={handleFilterChange}
+          onClearAllFilters={handleClearAllFilters}
+          showSort={false}
+        >
+          <Button type="primary" large onClick={() => (open = true)}>
+            <Plus size="16px" /> New key
+          </Button>
+        </TableToolbar>
+        <EnvironmentVariablesTable
+          data={sortedVariables}
+          emptyText={emptyTextWhenNoVariables}
+          {variableNames}
+        />
+      </div>
+    {/if}
+  </div>
+</div>
+
+<AddDialog bind:open {variableNames} />

--- a/web-admin/src/routes/[organization]/[project]/-/edit/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/+layout.svelte
@@ -9,6 +9,7 @@
   import {
     branchPathPrefix,
     extractBranchFromPath,
+    injectBranchIntoPath,
   } from "@rilldata/web-admin/features/branches/branch-utils";
   import BranchDeploymentStopped from "@rilldata/web-admin/features/branches/BranchDeploymentStopped.svelte";
   import EditSessionLoading from "@rilldata/web-admin/features/edit-session/EditSessionLoading.svelte";
@@ -28,6 +29,7 @@
   import { isProjectWelcomePage } from "@rilldata/web-admin/features/navigation/nav-utils.ts";
   import WelcomeRedirector from "@rilldata/web-admin/features/welcome/project/WelcomeRedirector.svelte";
   import { InfoIcon } from "lucide-svelte";
+  import EnvironmentVariablesEditor from "@rilldata/web-admin/features/projects/environment-variables/EnvironmentVariablesEditor.svelte";
 
   $: organization = $page.params.organization;
   $: project = $page.params.project;
@@ -38,6 +40,11 @@
   // Keep the workspace route prefix in sync for cloud editing.
   $: editorRoutePrefix.set(
     `/${organization}/${project}${branchPathPrefix(branch)}/-/edit`,
+  );
+
+  $: settingsHref = injectBranchIntoPath(
+    `/${organization}/${project}/-/edit/env`,
+    branch,
   );
 
   // Root layout data: org permissions, plan display name, organization object
@@ -199,15 +206,8 @@
 </div>
 
 {#snippet envEditDisabled()}
-  <div class="flex flex-row gap-2 items-center w-fit text-sm">
-    <InfoIcon size={14} /> Manage environment variables in
-    <a
-      href="/{organization}/{project}/-/settings/environment-variables"
-      target="_blank"
-      rel="noopener"
-    >
-      Settings →
-    </a>
+  <div class="p-4 bg-surface-base h-full border">
+    <EnvironmentVariablesEditor />
   </div>
 {/snippet}
 

--- a/web-admin/src/routes/[organization]/[project]/-/settings/environment-variables/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/settings/environment-variables/+page.svelte
@@ -1,26 +1,13 @@
 <script lang="ts">
   import { page } from "$app/stores";
-  import { createAdminServiceGetProjectVariables } from "@rilldata/web-admin/client";
-  import AddDialog from "@rilldata/web-admin/features/projects/environment-variables/AddDialog.svelte";
-  import EnvironmentVariablesTable from "@rilldata/web-admin/features/projects/environment-variables/EnvironmentVariablesTable.svelte";
-  import {
-    EnvironmentType,
-    type EnvironmentTypes,
-  } from "@rilldata/web-admin/features/projects/environment-variables/types";
-  import { getEnvironmentType } from "@rilldata/web-admin/features/projects/environment-variables/utils";
-  import Button from "@rilldata/web-common/components/button/Button.svelte";
-  import { TableToolbar } from "@rilldata/web-common/components/table-toolbar";
-  import RadixLarge from "@rilldata/web-common/components/typography/RadixLarge.svelte";
-  import DelayedSpinner from "@rilldata/web-common/features/entity-management/DelayedSpinner.svelte";
+  import { type EnvironmentTypes } from "@rilldata/web-admin/features/projects/environment-variables/types";
   import {
     createUrlFilterSync,
     parseArrayParam,
     parseStringParam,
   } from "@rilldata/web-common/lib/url-filter-sync";
-  import { Plus } from "lucide-svelte";
   import { onMount } from "svelte";
-
-  let open = false;
+  import EnvironmentVariablesEditor from "@rilldata/web-admin/features/projects/environment-variables/EnvironmentVariablesEditor.svelte";
 
   // Filters — synced to URL params `q` and `env` (multi-select array)
   const filterSync = createUrlFilterSync([
@@ -52,125 +39,6 @@
   onMount(() => {
     mounted = true;
   });
-
-  $: organization = $page.params.organization;
-  $: project = $page.params.project;
-
-  $: getProjectVariables = createAdminServiceGetProjectVariables(
-    organization,
-    project,
-    {
-      forAllEnvironments: true,
-    },
-  );
-
-  $: projectVariables = $getProjectVariables.data?.variables || [];
-
-  $: variableNames = projectVariables.map((variable) => {
-    return {
-      environment: getEnvironmentType(variable.environment),
-      name: variable.name,
-    };
-  });
-
-  $: searchedVariables = projectVariables.filter((variable) =>
-    variable.name.toLowerCase().includes(searchText.toLowerCase()),
-  );
-
-  $: filteredVariables = searchedVariables.filter((variable) => {
-    if (envFilter.length === 0) return true;
-    return envFilter.some((sel) => {
-      if (sel === EnvironmentType.DEVELOPMENT) {
-        return (
-          variable.environment === EnvironmentType.DEVELOPMENT ||
-          variable.environment === EnvironmentType.UNDEFINED
-        );
-      }
-      if (sel === EnvironmentType.PRODUCTION) {
-        return (
-          variable.environment === EnvironmentType.PRODUCTION ||
-          variable.environment === EnvironmentType.UNDEFINED
-        );
-      }
-      return false;
-    });
-  });
-
-  $: sortedVariables = [...filteredVariables].sort((a, b) => {
-    return new Date(b.updatedOn).getTime() - new Date(a.updatedOn).getTime();
-  });
-
-  function handleFilterChange(_key: string, selected: string | string[]) {
-    envFilter = selected as EnvironmentTypes[];
-  }
-
-  function handleClearAllFilters() {
-    envFilter = [];
-    searchText = "";
-  }
-
-  $: emptyTextWhenNoVariables =
-    envFilter.length === 0
-      ? "No environment variables"
-      : `No environment variables match the selected filters`;
-
-  $: filterGroups = [
-    {
-      label: "Environment",
-      key: "environment",
-      options: [
-        { value: EnvironmentType.PRODUCTION, label: "Production" },
-        { value: EnvironmentType.DEVELOPMENT, label: "Development" },
-      ],
-      selected: envFilter,
-      defaultValue: [],
-      multiSelect: true,
-    },
-  ];
 </script>
 
-<div class="flex flex-col w-full overflow-hidden">
-  <div class="flex md:flex-row flex-col gap-6">
-    {#if $getProjectVariables.isLoading}
-      <DelayedSpinner isLoading={$getProjectVariables.isLoading} size="1rem" />
-    {:else if $getProjectVariables.isError}
-      <div class="text-red-500">
-        Error loading environment variables: {$getProjectVariables.error}
-      </div>
-    {:else if $getProjectVariables.isSuccess}
-      <div class="flex flex-col gap-3 w-full overflow-hidden">
-        <div class="flex flex-col">
-          <RadixLarge>Environment variables</RadixLarge>
-          <p class="text-sm text-fg-tertiary font-medium">
-            Manage your environment variables here. <a
-              href="https://docs.rilldata.com/guide/administration/project-settings/variables-and-credentials"
-              target="_blank"
-              class="text-primary-600 hover:text-primary-700 active:text-primary-800"
-            >
-              Learn more ->
-            </a>
-          </p>
-        </div>
-        <TableToolbar
-          bind:searchText
-          searchDisabled={projectVariables.length === 0}
-          {filterGroups}
-          onFilterChange={handleFilterChange}
-          onClearAllFilters={handleClearAllFilters}
-          showSort={false}
-        >
-          <Button type="primary" large onClick={() => (open = true)}>
-            <Plus size="16px" /> New key
-          </Button>
-        </TableToolbar>
-        <EnvironmentVariablesTable
-          data={sortedVariables}
-          emptyText={emptyTextWhenNoVariables}
-          {variableNames}
-        />
-      </div>
-    {/if}
-  </div>
-</div>
-
-<AddDialog bind:open {variableNames} />
+<EnvironmentVariablesEditor bind:searchText bind:envFilter />

--- a/web-common/src/features/workspaces/WorkspaceDispatcher.svelte
+++ b/web-common/src/features/workspaces/WorkspaceDispatcher.svelte
@@ -102,7 +102,7 @@
         />
         <svelte:fragment slot="body">
           {#if managed && notice}
-            <div class="flex flex-col size-full items-center justify-center">
+            <div class="flex flex-col size-full">
               {@render notice()}
             </div>
           {:else}


### PR DESCRIPTION
We show a link to settings page while editing `.env` on cloud. This wont be available when there is no prod deployment yet. So removing the link when the project is unpublished.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
