### PR TITLE
refac: remap D3 SI prefix in measure formatting

### DIFF
--- a/web-common/src/lib/number-formatting/format-measure-value-locale.spec.ts
+++ b/web-common/src/lib/number-formatting/format-measure-value-locale.spec.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "vitest";
-import { createMeasureValueFormatter } from "./format-measure-value";
 import type { MetricsViewSpecMeasure } from "@rilldata/web-common/runtime-client";
+import { describe, expect, it } from "vitest";
+import { createMeasureValueFormatter } from "./format-measure-value";
 
 describe("format-measure-value with d3_locale", () => {
   it("should apply custom thousand separators for big numbers", () => {
@@ -136,5 +136,68 @@ describe("format-measure-value with d3_locale", () => {
     // Should have Euro as suffix
     expect(result).toContain("€");
     expect(result).toMatch(/\d+k?€/);
+  });
+});
+
+describe("format-measure-value SI prefix remap (G -> B)", () => {
+  const measureWithSI: MetricsViewSpecMeasure = {
+    name: "si_measure",
+    expression: "SUM(amount)",
+    formatD3: ",.3s",
+  };
+
+  it("should remap G to B for billions in table context", () => {
+    const formatter = createMeasureValueFormatter(measureWithSI, "table");
+    expect(formatter(1.5e9)).toBe("1.50B");
+  });
+
+  it("should remap G to B for negative billions", () => {
+    const formatter = createMeasureValueFormatter(measureWithSI, "table");
+    // D3 uses U+2212 (minus sign), not ASCII hyphen, for negatives.
+    expect(formatter(-2.5e9)).toBe("−2.50B");
+  });
+
+  it("should leave other SI prefixes untouched (M, k, T)", () => {
+    const formatter = createMeasureValueFormatter(measureWithSI, "table");
+    expect(formatter(1.5e6)).toBe("1.50M");
+    expect(formatter(1.5e3)).toBe("1.50k");
+    expect(formatter(1.5e12)).toBe("1.50T");
+  });
+
+  it("should remap G to B with a currency prefix", () => {
+    const measure: MetricsViewSpecMeasure = {
+      name: "currency_si",
+      expression: "SUM(amount)",
+      formatD3: "$,.3s",
+    };
+    const formatter = createMeasureValueFormatter(measure, "table");
+    expect(formatter(1.5e9)).toBe("$1.50B");
+  });
+
+  it("should remap G to B with a custom currency from locale", () => {
+    const measure: MetricsViewSpecMeasure = {
+      name: "rupee_si",
+      expression: "SUM(amount)",
+      formatD3: "$,.3s",
+      formatD3Locale: {
+        thousands: ",",
+        decimal: ".",
+        grouping: [3, 2, 2],
+        currency: ["₹", ""],
+      },
+    };
+    const formatter = createMeasureValueFormatter(measure, "table");
+    expect(formatter(1.5e9)).toBe("₹1.50B");
+  });
+
+  it("should not affect non-SI formats", () => {
+    // ",.3f" produces fixed-point output with no SI suffix.
+    const measure: MetricsViewSpecMeasure = {
+      name: "fixed_measure",
+      expression: "SUM(amount)",
+      formatD3: ",.3f",
+    };
+    const formatter = createMeasureValueFormatter(measure, "table");
+    expect(formatter(1500000000)).toBe("1,500,000,000.000");
   });
 });

--- a/web-common/src/lib/number-formatting/format-measure-value.ts
+++ b/web-common/src/lib/number-formatting/format-measure-value.ts
@@ -45,6 +45,15 @@ import {
   tooltipPercentOptions,
 } from "./strategies/per-range-tooltip-options";
 
+// D3's SI prefix for 10^9 is "G" (giga), which is correct in scientific/engineering
+// contexts but confusing in BI. Business users expect "B" for billions. Rill's own
+// humanizer already uses "B" — this aligns the D3 path with that convention.
+const SI_PREFIX_REMAP: Record<string, string> = { G: "B" };
+const SI_PREFIX_RE = /([yzafpnµmkMGTPEZY])$/;
+function remapSIPrefix(formatted: string): string {
+  return formatted.replace(SI_PREFIX_RE, (p) => SI_PREFIX_REMAP[p] ?? p);
+}
+
 /**
  * Coerce a value to a number for formatting.
  * INT256 and other large integer types from Snowflake arrive as strings;
@@ -287,7 +296,7 @@ export function createMeasureValueFormatter<T extends null | undefined = never>(
             return humanizer(coerced, FormatPreset.HUMANIZE);
           }
         }
-        return d3formatter(coerced);
+        return remapSIPrefix(d3formatter(coerced));
       };
     } catch (error) {
       console.warn("Invalid d3 format:", error);


### PR DESCRIPTION
Post-process D3's output in `createMeasureValueFormatter` to swap a trailing `G` for `B`, leaving all other prefixes untouched.

https://rilldata.slack.com/archives/C02T907FEUB/p1778598372475779

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
