### PR TITLE
fix: inaccessible env settings on un-published projects

### DIFF
--- a/web-admin/src/routes/[organization]/[project]/-/edit/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/+layout.svelte
@@ -61,6 +61,15 @@
   $: primaryBranch = $projectQuery.data?.project?.primaryBranch;
   $: devTtlSeconds = $projectQuery.data?.project?.devTtlSeconds;
 
+  $: primaryProjectQuery = createAdminServiceGetProject(
+    organization,
+    project,
+    undefined,
+    { query: baseGetProjectQueryOptions },
+  );
+  $: hasPrimaryDeployment =
+    !!$primaryProjectQuery.data?.project?.primaryDeploymentId;
+
   // Deployment data and credentials come from GetProject (no separate API needed)
   $: deployment = $projectQuery.data?.deployment;
   $: deploymentStatus = deployment?.status;
@@ -200,14 +209,19 @@
 
 {#snippet envEditDisabled()}
   <div class="flex flex-row gap-2 items-center w-fit text-sm">
-    <InfoIcon size={14} /> Manage environment variables in
-    <a
-      href="/{organization}/{project}/-/settings/environment-variables"
-      target="_blank"
-      rel="noopener"
-    >
-      Settings →
-    </a>
+    {#if hasPrimaryDeployment}
+      <InfoIcon size={14} /> Manage environment variables in
+      <a
+        href="/{organization}/{project}/-/settings/environment-variables"
+        target="_blank"
+        rel="noopener"
+      >
+        Settings →
+      </a>
+    {:else}
+      <InfoIcon size={14} /> You can manage environment variables from settings page
+      after the project has been published.
+    {/if}
   </div>
 {/snippet}
 


### PR DESCRIPTION
We show a link to settings page while editing .env on cloud. This wont be available when there is no prod deployment yet. So removing the link when the project is unpublished.

<img width="1485" height="866" alt="Screenshot 2026-05-14 at 10 59 12 AM" src="https://github.com/user-attachments/assets/c4a6e5e4-8ff0-4c2e-be24-0a2784697467" />

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
