### PR TITLE
Fix: clone with mirror when connecting rill managed git repo to self hosted github repo

### DIFF
--- a/admin/server/github.go
+++ b/admin/server/github.go
@@ -434,7 +434,7 @@ func (s *Server) ConnectProjectToGithub(ctx context.Context, req *adminv1.Connec
 		if err != nil {
 			return nil, err
 		}
-		err = s.mirrorGitRepo(ctx, *proj.GitRemote, req.Remote, mgdRepoToken, token)
+		err = mirrorGitRepo(ctx, *proj.GitRemote, req.Remote, mgdRepoToken, token)
 		if err != nil {
 			return nil, err
 		}
@@ -1207,43 +1207,6 @@ func (s *Server) createRepo(ctx context.Context, remote, branch string, user *da
 	return token, nil
 }
 
-func (s *Server) mirrorGitRepo(ctx context.Context, srcGitRemote, destGitRemote, srcToken, destToken string) error {
-	gitPath, err := os.MkdirTemp(os.TempDir(), "projects")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(gitPath)
-
-	repo, err := git.PlainCloneContext(ctx, gitPath, false, &git.CloneOptions{
-		URL:  srcGitRemote,
-		Auth: &githttp.BasicAuth{Username: "x-access-token", Password: srcToken},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to clone git repo: %w", err)
-	}
-
-	_, err = repo.CreateRemote(&config.RemoteConfig{
-		Name: "dest",
-		URLs: []string{destGitRemote},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create remote: %w", err)
-	}
-
-	// Push everything (all refs, like git push --mirror)
-	err = repo.PushContext(ctx, &git.PushOptions{
-		Auth:       &githttp.BasicAuth{Username: "x-access-token", Password: destToken},
-		RemoteName: "dest",
-		RefSpecs: []config.RefSpec{
-			"+refs/*:refs/*", // force-push all refs
-		},
-	})
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 func (s *Server) pushAssetToGit(ctx context.Context, assetID, remote, branch, token string, author *object.Signature) error {
 	asset, err := s.admin.DB.FindAsset(ctx, assetID)
 	if err != nil {
@@ -1295,6 +1258,40 @@ func fromStringPtr(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+func mirrorGitRepo(ctx context.Context, srcGitRemote, destGitRemote, srcToken, destToken string) error {
+	gitPath, err := os.MkdirTemp(os.TempDir(), "projects")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(gitPath)
+
+	repo, err := git.PlainCloneContext(ctx, gitPath, false, &git.CloneOptions{
+		URL:    srcGitRemote,
+		Auth:   &githttp.BasicAuth{Username: "x-access-token", Password: srcToken},
+		Mirror: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to clone git repo: %w", err)
+	}
+
+	_, err = repo.CreateRemote(&config.RemoteConfig{
+		Name: "dest",
+		URLs: []string{destGitRemote},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create remote: %w", err)
+	}
+
+	// Push everything (all refs, like git push --mirror)
+	return repo.PushContext(ctx, &git.PushOptions{
+		Auth:       &githttp.BasicAuth{Username: "x-access-token", Password: destToken},
+		RemoteName: "dest",
+		RefSpecs: []config.RefSpec{
+			"+refs/*:refs/*", // force-push all refs
+		},
+	})
 }
 
 // normalizeGitRemote adds a .git suffix to the Git remote URL if it doesn't already have one.

--- a/admin/server/github_test.go
+++ b/admin/server/github_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMirrorGitRepo(t *testing.T) {
+	src := setupMirrorSourceRepo(t)
+	dest := t.TempDir()
+
+	runGitCommand(t, dest, "init", "--bare")
+	err := mirrorGitRepo(context.Background(), src, dest, "", "")
+	require.NoError(t, err)
+
+	refs := runGitCommand(t, dest, "show-ref")
+	require.Contains(t, refs, "refs/heads/main")
+	require.Contains(t, refs, "refs/heads/feature")
+	require.Contains(t, refs, "refs/tags/v1.0")
+}
+
+// setupMirrorSourceRepo creates a local git repository with commits on two branches and a tag.
+func setupMirrorSourceRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGitCommand(t, dir, "init")
+	runGitCommand(t, dir, "checkout", "-b", "main")
+	runGitCommand(t, dir, "config", "user.name", "Test User")
+	runGitCommand(t, dir, "config", "user.email", "test@example.com")
+
+	err := os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("hello"), 0644)
+	require.NoError(t, err)
+	runGitCommand(t, dir, "add", "readme.txt")
+	runGitCommand(t, dir, "commit", "-m", "initial commit")
+	runGitCommand(t, dir, "tag", "v1.0")
+
+	runGitCommand(t, dir, "checkout", "-b", "feature")
+	err = os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0644)
+	require.NoError(t, err)
+	runGitCommand(t, dir, "add", "feature.txt")
+	runGitCommand(t, dir, "commit", "-m", "add feature")
+	return dir
+}
+
+func runGitCommand(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v failed: %s", args, string(output))
+	return string(output)
+}


### PR DESCRIPTION
In default clone, while all data for every branch is pulled down to the machine, Git only creates one local branch by default.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
