### PR TITLE
fix: cloud editing missing edit button in preview

### DIFF
--- a/web-admin/src/features/edit-session/EditActions.svelte
+++ b/web-admin/src/features/edit-session/EditActions.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+  import { page } from "$app/stores";
   import { Button } from "@rilldata/web-common/components/button";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
+  import ExploreEditDropdown from "@rilldata/web-common/features/explores/ExploreEditDropdown.svelte";
   import { extractErrorMessage } from "@rilldata/web-common/lib/errors";
   import { createRuntimeServiceGitStatus } from "@rilldata/web-common/runtime-client";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
@@ -10,6 +12,7 @@
   import ExitButton from "./ExitButton.svelte";
   import MergePopover from "./MergePopover.svelte";
   import PublishPopover from "./PublishPopover.svelte";
+  import CanvasEditButton from "@rilldata/web-common/features/canvas/CanvasEditButton.svelte";
 
   export let organization: string;
   export let project: string;
@@ -27,7 +30,22 @@
     !gitStatusLoaded && $gitStatusQuery.isError
       ? extractErrorMessage($gitStatusQuery.error)
       : "";
+
+  $: onExplorePreview = !!$page.route.id?.startsWith(
+    "/[organization]/[project]/-/edit/(viz)/explore",
+  );
+  $: onCanvasPreview = !!$page.route.id?.startsWith(
+    "/[organization]/[project]/-/edit/(viz)/canvas",
+  );
+  $: dashboardName = $page.params.name ?? "";
 </script>
+
+{#if onExplorePreview && dashboardName}
+  <ExploreEditDropdown exploreName={dashboardName} />
+{/if}
+{#if onCanvasPreview && dashboardName}
+  <CanvasEditButton canvasName={dashboardName} />
+{/if}
 
 {#if gitStatusLoaded}
   {#if managedGit}

--- a/web-common/src/features/canvas/CanvasEditButton.svelte
+++ b/web-common/src/features/canvas/CanvasEditButton.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { getFileHref } from "@rilldata/web-common/layout/navigation/editor-routing.ts";
+  import { Button } from "@rilldata/web-common/components/button/index.ts";
+  import { useCanvas } from "@rilldata/web-common/features/canvas/selector.ts";
+  import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
+
+  let { canvasName }: { canvasName: string } = $props();
+
+  const runtimeClient = useRuntimeClient();
+
+  let canvasQuery = $derived(useCanvas(runtimeClient, canvasName));
+  let canvasFilePath = $derived($canvasQuery.data?.filePath ?? "");
+</script>
+
+<Button type="secondary" href={getFileHref(canvasFilePath)}>Edit</Button>

--- a/web-common/src/features/canvas/CanvasPreviewCTAs.svelte
+++ b/web-common/src/features/canvas/CanvasPreviewCTAs.svelte
@@ -14,6 +14,7 @@
     useDashboardPolicyCheck,
     useRillYamlPolicyCheck,
   } from "../dashboards/granular-access-policies/useSecurityPolicyCheck";
+  import CanvasEditButton from "@rilldata/web-common/features/canvas/CanvasEditButton.svelte";
 
   const client = useRuntimeClient();
 
@@ -49,7 +50,7 @@
       <ChatToggle open={dashboardChatOpen} actions={dashboardChatActions} />
     {/if}
     {#if !$readOnly}
-      <Button type="secondary" href={getFileHref(canvasFilePath)}>Edit</Button>
+      <CanvasEditButton {canvasName} />
     {/if}
   </div>
 {/if}

--- a/web-common/src/features/canvas/CanvasPreviewCTAs.svelte
+++ b/web-common/src/features/canvas/CanvasPreviewCTAs.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
   import { useCanvas } from "@rilldata/web-common/features/canvas/selector";
-  import { Button } from "../../components/button";
   import { useRuntimeClient } from "../../runtime-client/v2";
   import { featureFlags } from "../feature-flags";
-  import { getFileHref } from "../../layout/navigation/editor-routing";
   import ChatToggle from "@rilldata/web-common/features/chat/layouts/sidebar/ChatToggle.svelte";
   import {
     dashboardChatActions,

--- a/web-common/src/features/explore-mappers/generate-explore-link.ts
+++ b/web-common/src/features/explore-mappers/generate-explore-link.ts
@@ -4,6 +4,7 @@ import { ExploreLinkErrorType } from "@rilldata/web-common/features/explore-mapp
 import { getExplorePageUrlSearchParams } from "@rilldata/web-common/features/explore-mappers/utils";
 import type { RuntimeClient } from "@rilldata/web-common/runtime-client/v2";
 import { EmbedStore } from "@rilldata/web-common/features/embeds/embed-store.ts";
+import { withEditorPrefix } from "@rilldata/web-common/layout/navigation/editor-routing.ts";
 
 /**
  * Generates the explore page URL with proper search parameters
@@ -58,7 +59,7 @@ export function getUrlForExplore(
     );
   } else {
     url = new URL(
-      `/explore/${encodeURIComponent(exploreName)}`,
+      withEditorPrefix(`/explore/${encodeURIComponent(exploreName)}`),
       window.location.origin,
     );
   }

--- a/web-common/src/features/explores/ExploreEditDropdown.svelte
+++ b/web-common/src/features/explores/ExploreEditDropdown.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { Button } from "@rilldata/web-common/components/button";
+  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
+  import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
+  import ExploreIcon from "@rilldata/web-common/components/icons/ExploreIcon.svelte";
+  import MetricsViewIcon from "@rilldata/web-common/components/icons/MetricsViewIcon.svelte";
+  import { useExplore } from "@rilldata/web-common/features/explores/selectors";
+  import { getFileHref } from "@rilldata/web-common/layout/navigation/editor-routing";
+  import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
+
+  let { exploreName }: { exploreName: string } = $props();
+
+  const runtimeClient = useRuntimeClient();
+
+  let exploreQuery = $derived(useExplore(runtimeClient, exploreName));
+  let exploreFilePath = $derived(
+    $exploreQuery.data?.explore?.meta?.filePaths?.[0] ?? "",
+  );
+  let metricsViewFilePath = $derived(
+    $exploreQuery.data?.metricsView?.meta?.filePaths?.[0] ?? "",
+  );
+</script>
+
+<DropdownMenu.Root>
+  <DropdownMenu.Trigger>
+    {#snippet child({ props })}
+      <Button {...props} type="secondary">
+        Edit
+        <CaretDownIcon />
+      </Button>
+    {/snippet}
+  </DropdownMenu.Trigger>
+  <DropdownMenu.Content align="end">
+    <DropdownMenu.Item href={getFileHref(exploreFilePath)}>
+      <ExploreIcon size="16px" />
+      Explore dashboard
+    </DropdownMenu.Item>
+    <DropdownMenu.Item href={getFileHref(metricsViewFilePath)}>
+      <MetricsViewIcon size="16px" />
+      Metrics View
+    </DropdownMenu.Item>
+  </DropdownMenu.Content>
+</DropdownMenu.Root>

--- a/web-common/src/features/explores/ExplorePreviewCTAs.svelte
+++ b/web-common/src/features/explores/ExplorePreviewCTAs.svelte
@@ -1,11 +1,6 @@
 <script lang="ts">
-  import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
-  import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
-  import ExploreIcon from "@rilldata/web-common/components/icons/ExploreIcon.svelte";
-  import MetricsViewIcon from "@rilldata/web-common/components/icons/MetricsViewIcon.svelte";
   import GlobalDimensionSearch from "@rilldata/web-common/features/dashboards/dimension-search/GlobalDimensionSearch.svelte";
   import { useExplore } from "@rilldata/web-common/features/explores/selectors";
-  import { Button } from "../../components/button";
   import { useRuntimeClient } from "../../runtime-client/v2";
   import ChatToggle from "../chat/layouts/sidebar/ChatToggle.svelte";
   import {
@@ -19,7 +14,7 @@
   } from "../dashboards/granular-access-policies/useSecurityPolicyCheck";
   import StateManagersProvider from "../dashboards/state-managers/StateManagersProvider.svelte";
   import { featureFlags } from "../feature-flags";
-  import { getFileHref } from "../../layout/navigation/editor-routing";
+  import ExploreEditDropdown from "./ExploreEditDropdown.svelte";
 
   export let exploreName: string;
 
@@ -57,25 +52,6 @@
     {/if}
   </StateManagersProvider>
   {#if !$readOnly}
-    <DropdownMenu.Root>
-      <DropdownMenu.Trigger>
-        {#snippet child({ props })}
-          <Button {...props} type="secondary">
-            Edit
-            <CaretDownIcon />
-          </Button>
-        {/snippet}
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content align="end">
-        <DropdownMenu.Item href={getFileHref(exploreFilePath)}>
-          <ExploreIcon size="16px" />
-          Explore dashboard
-        </DropdownMenu.Item>
-        <DropdownMenu.Item href={getFileHref(metricsViewFilePath)}>
-          <MetricsViewIcon size="16px" />
-          Metrics View
-        </DropdownMenu.Item>
-      </DropdownMenu.Content>
-    </DropdownMenu.Root>
+    <ExploreEditDropdown {exploreName} />
   {/if}
 </div>

--- a/web-common/src/features/explores/explore-link/ExploreLink.svelte
+++ b/web-common/src/features/explores/explore-link/ExploreLink.svelte
@@ -15,7 +15,6 @@
   import { getErrorMessage } from "@rilldata/web-common/features/explore-mappers/utils";
   import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
-  import { get } from "svelte/store";
 
   const runtimeClient = useRuntimeClient();
 

--- a/web-common/src/features/explores/explore-link/ExploreLink.svelte
+++ b/web-common/src/features/explores/explore-link/ExploreLink.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { page } from "$app/stores";
   import { goto } from "$app/navigation";
   import IconButton from "@rilldata/web-common/components/button/IconButton.svelte";
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu/";
@@ -14,6 +15,7 @@
   import { getErrorMessage } from "@rilldata/web-common/features/explore-mappers/utils";
   import type { ExploreState } from "@rilldata/web-common/features/dashboards/stores/explore-state";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
+  import { get } from "svelte/store";
 
   const runtimeClient = useRuntimeClient();
 
@@ -28,6 +30,8 @@
   let isNavigating = false;
   let navigationError: ExploreLinkError | null = null;
 
+  $: onEditPage = $page.route?.id?.includes("/edit/(viz)/canvas");
+
   async function gotoExplorePage() {
     if (!exploreName || !exploreState || disabled) return;
 
@@ -39,8 +43,8 @@
         runtimeClient,
         exploreState,
         exploreName,
-        organization,
-        project,
+        onEditPage ? undefined : organization,
+        onEditPage ? undefined : project,
       );
       await goto(exploreURL);
     } catch (error) {


### PR DESCRIPTION
Previewing explore/canvas in cloud while editing is missing edit buttons. This lead to a dead end and no way to go back without using browser back buttons.

This PR mirrors the edit buttons from rill-dev. Note that we will need a better edit/preview design in the long term. Also fixing `go to explore` buttons in canvas.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
