### PR TITLE
Make stopped deployment retention configurable and lower dev TTL

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"cloud.google.com/go/storage"
 	lru "github.com/hashicorp/golang-lru"
@@ -20,44 +21,46 @@ import (
 )
 
 type Options struct {
-	DatabaseDriver            string
-	DatabaseDSN               string
-	DatabaseEncryptionKeyring string
-	ExternalURL               string
-	FrontendURL               string
-	ProvisionerSetJSON        string
-	ProvisionerMaxConcurrency int
-	DefaultProvisioner        string
-	Version                   version.Version
-	MetricsProjectOrg         string
-	MetricsProjectName        string
-	AutoscalerCron            string
-	ScaleDownConstraint       int
-	AllowMockBilling          bool
+	DatabaseDriver             string
+	DatabaseDSN                string
+	DatabaseEncryptionKeyring  string
+	ExternalURL                string
+	FrontendURL                string
+	ProvisionerSetJSON         string
+	ProvisionerMaxConcurrency  int
+	DefaultProvisioner         string
+	Version                    version.Version
+	MetricsProjectOrg          string
+	MetricsProjectName         string
+	AutoscalerCron             string
+	ScaleDownConstraint        int
+	AllowMockBilling           bool
+	StoppedDeploymentRetention time.Duration
 }
 
 type Service struct {
-	DB                        database.DB
-	Jobs                      jobs.Client
-	URLs                      *URLs
-	ProvisionerSet            map[string]provisioner.Provisioner
-	ProvisionerMaxConcurrency int
-	Email                     *email.Client
-	Github                    Github
-	AI                        drivers.AIService
-	Assets                    *storage.BucketHandle
-	Used                      *usedFlusher
-	Logger                    *zap.Logger
-	opts                      *Options
-	issuer                    *auth.Issuer
-	authCache                 *lru.Cache
-	Version                   version.Version
-	MetricsProjectID          string
-	AutoscalerCron            string
-	ScaleDownConstraint       int
-	AllowMockBilling          bool
-	Biller                    billing.Biller
-	PaymentProvider           payment.Provider
+	DB                         database.DB
+	Jobs                       jobs.Client
+	URLs                       *URLs
+	ProvisionerSet             map[string]provisioner.Provisioner
+	ProvisionerMaxConcurrency  int
+	Email                      *email.Client
+	Github                     Github
+	AI                         drivers.AIService
+	Assets                     *storage.BucketHandle
+	Used                       *usedFlusher
+	Logger                     *zap.Logger
+	opts                       *Options
+	issuer                     *auth.Issuer
+	authCache                  *lru.Cache
+	Version                    version.Version
+	MetricsProjectID           string
+	AutoscalerCron             string
+	ScaleDownConstraint        int
+	AllowMockBilling           bool
+	StoppedDeploymentRetention time.Duration
+	Biller                     billing.Biller
+	PaymentProvider            payment.Provider
 }
 
 func New(ctx context.Context, opts *Options, logger *zap.Logger, issuer *auth.Issuer, emailClient *email.Client, github Github, aiService drivers.AIService, assets *storage.BucketHandle, biller billing.Biller, p payment.Provider) (*Service, error) {
@@ -123,26 +126,27 @@ func New(ctx context.Context, opts *Options, logger *zap.Logger, issuer *auth.Is
 	}
 
 	return &Service{
-		DB:                        db,
-		URLs:                      urls,
-		ProvisionerSet:            provSet,
-		ProvisionerMaxConcurrency: opts.ProvisionerMaxConcurrency,
-		Email:                     emailClient,
-		Github:                    github,
-		AI:                        aiService,
-		Assets:                    assets,
-		Used:                      newUsedFlusher(logger, db),
-		Logger:                    logger,
-		opts:                      opts,
-		issuer:                    issuer,
-		authCache:                 authCache,
-		Version:                   opts.Version,
-		MetricsProjectID:          metricsProjectID,
-		AutoscalerCron:            opts.AutoscalerCron,
-		ScaleDownConstraint:       opts.ScaleDownConstraint,
-		AllowMockBilling:          opts.AllowMockBilling,
-		Biller:                    biller,
-		PaymentProvider:           p,
+		DB:                         db,
+		URLs:                       urls,
+		ProvisionerSet:             provSet,
+		ProvisionerMaxConcurrency:  opts.ProvisionerMaxConcurrency,
+		Email:                      emailClient,
+		Github:                     github,
+		AI:                         aiService,
+		Assets:                     assets,
+		Used:                       newUsedFlusher(logger, db),
+		Logger:                     logger,
+		opts:                       opts,
+		issuer:                     issuer,
+		authCache:                  authCache,
+		Version:                    opts.Version,
+		MetricsProjectID:           metricsProjectID,
+		AutoscalerCron:             opts.AutoscalerCron,
+		ScaleDownConstraint:        opts.ScaleDownConstraint,
+		AllowMockBilling:           opts.AllowMockBilling,
+		StoppedDeploymentRetention: opts.StoppedDeploymentRetention,
+		Biller:                     biller,
+		PaymentProvider:            p,
 	}, nil
 }
 

--- a/admin/jobs/river/hibernate_expired_deployments.go
+++ b/admin/jobs/river/hibernate_expired_deployments.go
@@ -2,7 +2,6 @@ package river
 
 import (
 	"context"
-	"time"
 
 	"github.com/rilldata/rill/admin"
 	"github.com/rilldata/rill/admin/database"
@@ -10,10 +9,6 @@ import (
 	"github.com/riverqueue/river"
 	"go.uber.org/zap"
 )
-
-// stoppedDeploymentRetention is how long after a deployment is stopped that we keep it around before fully deleting it.
-// (This ensures that we eventually delete persistent state like PVCs for stopped deployments.)
-const stoppedDeploymentRetention = 30 * 24 * time.Hour
 
 type HibernateExpiredDeploymentsArgs struct{}
 
@@ -43,8 +38,8 @@ func (w *HibernateExpiredDeploymentsWorker) Work(ctx context.Context, job *river
 	}
 	w.logger.Info("hibernate: completed running deployments check", zap.Int("deployments", len(running)))
 
-	// Delete deployments that have been stopped for a long time.
-	stopped, err := w.admin.DB.FindDeploymentsToDelete(ctx, stoppedDeploymentRetention)
+	// Delete deployments that have been stopped for longer than the configured retention.
+	stopped, err := w.admin.DB.FindDeploymentsToDelete(ctx, w.admin.StoppedDeploymentRetention)
 	if err != nil {
 		return err
 	}

--- a/admin/server/projects.go
+++ b/admin/server/projects.go
@@ -26,7 +26,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const devDeplTTL = 6 * time.Hour
+const devDeplTTL = time.Hour
 
 const prodDeplTTL = 14 * 24 * time.Hour
 

--- a/cli/cmd/admin/start.go
+++ b/cli/cmd/admin/start.go
@@ -104,13 +104,15 @@ type Config struct {
 	MetricsProject                    string `default:"" split_words:"true"`
 	AutoscalerCron                    string `default:"CRON_TZ=America/Los_Angeles 0 0 * * 1" split_words:"true"`
 	ScaleDownConstraint               int    `default:"0" split_words:"true"`
-	OrbAPIKey                         string `split_words:"true"`
-	OrbWebhookSecret                  string `split_words:"true"`
-	OrbIntegratedTaxProvider          string `default:"anrok" split_words:"true"`
-	StripeAPIKey                      string `split_words:"true"`
-	StripeWebhookSecret               string `split_words:"true"`
-	PylonIdentitySecret               string `split_words:"true"`
-	AllowMockBilling                  bool   `default:"false" split_words:"true"` // set to allow sending mock usage for billing, should be false in prod env
+	// StoppedDeploymentRetention is how long a stopped (hibernated) deployment is kept around before its persistent state is fully deleted.
+	StoppedDeploymentRetention time.Duration `default:"168h" split_words:"true"`
+	OrbAPIKey                  string        `split_words:"true"`
+	OrbWebhookSecret           string        `split_words:"true"`
+	OrbIntegratedTaxProvider   string        `default:"anrok" split_words:"true"`
+	StripeAPIKey               string        `split_words:"true"`
+	StripeWebhookSecret        string        `split_words:"true"`
+	PylonIdentitySecret        string        `split_words:"true"`
+	AllowMockBilling           bool          `default:"false" split_words:"true"` // set to allow sending mock usage for billing, should be false in prod env
 }
 
 // StartCmd starts an admin server. It only allows configuration using environment variables.
@@ -319,20 +321,21 @@ func StartCmd(ch *cmdutil.Helper) *cobra.Command {
 
 			// Init admin service
 			admOpts := &admin.Options{
-				DatabaseDriver:            conf.DatabaseDriver,
-				DatabaseDSN:               conf.DatabaseURL,
-				DatabaseEncryptionKeyring: conf.DatabaseEncryptionKeyring,
-				ExternalURL:               conf.ExternalGRPCURL, // NOTE: using gRPC url
-				FrontendURL:               conf.FrontendURL,
-				ProvisionerSetJSON:        conf.ProvisionerSetJSON,
-				ProvisionerMaxConcurrency: conf.ProvisionerMaxConcurrency,
-				DefaultProvisioner:        conf.DefaultProvisioner,
-				Version:                   ch.Version,
-				MetricsProjectOrg:         metricsProjectOrg,
-				MetricsProjectName:        metricsProjectName,
-				AutoscalerCron:            conf.AutoscalerCron,
-				ScaleDownConstraint:       conf.ScaleDownConstraint,
-				AllowMockBilling:          conf.AllowMockBilling,
+				DatabaseDriver:             conf.DatabaseDriver,
+				DatabaseDSN:                conf.DatabaseURL,
+				DatabaseEncryptionKeyring:  conf.DatabaseEncryptionKeyring,
+				ExternalURL:                conf.ExternalGRPCURL, // NOTE: using gRPC url
+				FrontendURL:                conf.FrontendURL,
+				ProvisionerSetJSON:         conf.ProvisionerSetJSON,
+				ProvisionerMaxConcurrency:  conf.ProvisionerMaxConcurrency,
+				DefaultProvisioner:         conf.DefaultProvisioner,
+				Version:                    ch.Version,
+				MetricsProjectOrg:          metricsProjectOrg,
+				MetricsProjectName:         metricsProjectName,
+				AutoscalerCron:             conf.AutoscalerCron,
+				ScaleDownConstraint:        conf.ScaleDownConstraint,
+				AllowMockBilling:           conf.AllowMockBilling,
+				StoppedDeploymentRetention: conf.StoppedDeploymentRetention,
 			}
 			adm, err := admin.New(cmd.Context(), admOpts, logger, issuer, emailClient, gh, aiService, assetsBucket, biller, p)
 			if err != nil {


### PR DESCRIPTION
- Lowers the default dev deployment TTL from 6h to 1h.
- Lowers stopped deployment retention to 7d from 30d.
- Makes stopped deployment retention configurable with an environment variable `RILL_ADMIN_STOPPED_DEPLOYMENT_RETENTION`.

Follow up on https://github.com/rilldata/rill/pull/9422.

Contributes to https://linear.app/rilldata/issue/PLAT-479/improve-dev-deployment-hibernation

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!