### PR TITLE
fix: measure charts when measure name has special characters

### DIFF
--- a/web-common/src/features/components/charts/cartesian/area/spec.ts
+++ b/web-common/src/features/components/charts/cartesian/area/spec.ts
@@ -24,7 +24,7 @@ export function generateVLAreaChartSpec(
 
   const colorField =
     typeof config.color === "object" ? config.color.field : undefined;
-  const xField = sanitizeValueForVega(config.x?.field);
+  const sanitizedXField = sanitizeValueForVega(config.x?.field);
   const yField = config.y?.field;
   const sanitizedYField = sanitizeValueForVega(yField);
 
@@ -56,7 +56,7 @@ export function generateVLAreaChartSpec(
       layer: inner,
     },
     buildHoverRuleLayer({
-      xField,
+      xField: sanitizedXField,
       domainValues: data.domainValues,
       defaultTooltip: defaultTooltipChannel,
       multiValueTooltipChannel,
@@ -65,11 +65,11 @@ export function generateVLAreaChartSpec(
       isDarkMode: data.isDarkMode,
       isInteractive: config.isInteractive,
       pivot:
-        xField &&
+        sanitizedXField &&
         sanitizedYField &&
         colorField &&
         multiValueTooltipChannel?.length
-          ? { field: colorField, value: sanitizedYField, groupby: [xField] }
+          ? { field: colorField, value: sanitizedYField, groupby: [sanitizedXField] }
           : undefined,
     }),
   ];
@@ -79,8 +79,8 @@ export function generateVLAreaChartSpec(
   return {
     ...spec,
     ...(vegaConfig && { config: vegaConfig }),
-    ...(config.isInteractive && xField
-      ? { usermeta: { brushTemporalField: xField } }
+    ...(config.isInteractive && sanitizedXField
+      ? { usermeta: { brushTemporalField: sanitizedXField } }
       : {}),
   };
 }

--- a/web-common/src/features/components/charts/cartesian/area/spec.ts
+++ b/web-common/src/features/components/charts/cartesian/area/spec.ts
@@ -69,7 +69,11 @@ export function generateVLAreaChartSpec(
         sanitizedYField &&
         colorField &&
         multiValueTooltipChannel?.length
-          ? { field: colorField, value: sanitizedYField, groupby: [sanitizedXField] }
+          ? {
+              field: colorField,
+              value: sanitizedYField,
+              groupby: [sanitizedXField],
+            }
           : undefined,
     }),
   ];

--- a/web-common/src/features/components/charts/cartesian/area/spec.ts
+++ b/web-common/src/features/components/charts/cartesian/area/spec.ts
@@ -25,7 +25,8 @@ export function generateVLAreaChartSpec(
   const colorField =
     typeof config.color === "object" ? config.color.field : undefined;
   const xField = sanitizeValueForVega(config.x?.field);
-  const yField = sanitizeValueForVega(config.y?.field);
+  const yField = config.y?.field;
+  const sanitizedYField = sanitizeValueForVega(yField);
 
   const defaultTooltipChannel = createDefaultTooltipEncoding(
     [config.x, config.y, config.color],
@@ -64,8 +65,11 @@ export function generateVLAreaChartSpec(
       isDarkMode: data.isDarkMode,
       isInteractive: config.isInteractive,
       pivot:
-        xField && yField && colorField && multiValueTooltipChannel?.length
-          ? { field: colorField, value: yField, groupby: [xField] }
+        xField &&
+        sanitizedYField &&
+        colorField &&
+        multiValueTooltipChannel?.length
+          ? { field: colorField, value: sanitizedYField, groupby: [xField] }
           : undefined,
     }),
   ];

--- a/web-common/src/features/components/charts/cartesian/bar-chart/spec.ts
+++ b/web-common/src/features/components/charts/cartesian/bar-chart/spec.ts
@@ -32,7 +32,8 @@ export function generateVLBarChartSpec(
   const colorField =
     typeof config.color === "object" ? config.color.field : undefined;
   const xField = sanitizeValueForVega(config.x?.field);
-  const yField = sanitizeValueForVega(config.y?.field);
+  const yField = config.y?.field;
+  const sanitizedYField = sanitizeValueForVega(yField);
 
   const defaultTooltipChannel = createDefaultTooltipEncoding(
     [config.x, config.y, config.color],
@@ -62,7 +63,7 @@ export function generateVLBarChartSpec(
     isInteractive: config.isInteractive,
     pivot: createVegaTransformPivotConfig(
       xField,
-      yField,
+      sanitizedYField,
       colorField,
       !!hasComparison,
       !!multiValueTooltipChannel?.length,

--- a/web-common/src/features/components/charts/cartesian/bar-chart/spec.ts
+++ b/web-common/src/features/components/charts/cartesian/bar-chart/spec.ts
@@ -31,7 +31,7 @@ export function generateVLBarChartSpec(
 
   const colorField =
     typeof config.color === "object" ? config.color.field : undefined;
-  const xField = sanitizeValueForVega(config.x?.field);
+  const sanitizedXField = sanitizeValueForVega(config.x?.field);
   const yField = config.y?.field;
   const sanitizedYField = sanitizeValueForVega(yField);
 
@@ -52,7 +52,7 @@ export function generateVLBarChartSpec(
   const hasComparison = data.hasComparison;
 
   const hoverRuleLayer = buildHoverRuleLayer({
-    xField,
+    xField: sanitizedXField,
     domainValues: data.domainValues,
     isBarMark: true,
     defaultTooltip: defaultTooltipChannel,
@@ -62,7 +62,7 @@ export function generateVLBarChartSpec(
     isDarkMode: data.isDarkMode,
     isInteractive: config.isInteractive,
     pivot: createVegaTransformPivotConfig(
-      xField,
+      sanitizedXField,
       sanitizedYField,
       colorField,
       !!hasComparison,
@@ -125,8 +125,8 @@ export function generateVLBarChartSpec(
   return {
     ...spec,
     ...(vegaConfig && { config: vegaConfig }),
-    ...(config.isInteractive && xField
-      ? { usermeta: { brushTemporalField: xField } }
+    ...(config.isInteractive && sanitizedXField
+      ? { usermeta: { brushTemporalField: sanitizedXField } }
       : {}),
   };
 }

--- a/web-common/src/features/components/charts/cartesian/line-chart/spec.ts
+++ b/web-common/src/features/components/charts/cartesian/line-chart/spec.ts
@@ -31,7 +31,7 @@ export function generateVLLineChartSpec(
 
   const colorField =
     typeof config.color === "object" ? config.color.field : undefined;
-  const xField = sanitizeValueForVega(config.x?.field);
+  const sanitizedXField = sanitizeValueForVega(config.x?.field);
   const yField = config.y?.field;
   const sanitizedYField = sanitizeValueForVega(yField);
 
@@ -52,7 +52,7 @@ export function generateVLLineChartSpec(
   const hasComparison = data.hasComparison;
 
   const hoverRuleLayer = buildHoverRuleLayer({
-    xField,
+    xField: sanitizedXField,
     domainValues: data.domainValues,
     defaultTooltip: defaultTooltipChannel,
     multiValueTooltipChannel,
@@ -61,7 +61,7 @@ export function generateVLLineChartSpec(
     isDarkMode: data.isDarkMode,
     isInteractive: config.isInteractive,
     pivot: createVegaTransformPivotConfig(
-      xField,
+      sanitizedXField,
       sanitizedYField,
       colorField,
       !!hasComparison,
@@ -115,8 +115,8 @@ export function generateVLLineChartSpec(
   return {
     ...spec,
     ...(vegaConfig && { config: vegaConfig }),
-    ...(config.isInteractive && xField
-      ? { usermeta: { brushTemporalField: xField } }
+    ...(config.isInteractive && sanitizedXField
+      ? { usermeta: { brushTemporalField: sanitizedXField } }
       : {}),
   };
 }

--- a/web-common/src/features/components/charts/cartesian/line-chart/spec.ts
+++ b/web-common/src/features/components/charts/cartesian/line-chart/spec.ts
@@ -32,7 +32,8 @@ export function generateVLLineChartSpec(
   const colorField =
     typeof config.color === "object" ? config.color.field : undefined;
   const xField = sanitizeValueForVega(config.x?.field);
-  const yField = sanitizeValueForVega(config.y?.field);
+  const yField = config.y?.field;
+  const sanitizedYField = sanitizeValueForVega(yField);
 
   const defaultTooltipChannel = createDefaultTooltipEncoding(
     [config.x, config.y, config.color],
@@ -61,7 +62,7 @@ export function generateVLLineChartSpec(
     isInteractive: config.isInteractive,
     pivot: createVegaTransformPivotConfig(
       xField,
-      yField,
+      sanitizedYField,
       colorField,
       !!hasComparison,
       !!multiValueTooltipChannel?.length,

--- a/web-common/src/features/components/charts/cartesian/stacked-bar/default.ts
+++ b/web-common/src/features/components/charts/cartesian/stacked-bar/default.ts
@@ -30,7 +30,8 @@ export function generateVLStackedBarChartSpec(
   const colorField =
     typeof config.color === "object" ? config.color.field : undefined;
   const xField = sanitizeValueForVega(config.x?.field);
-  const yField = sanitizeValueForVega(config.y?.field);
+  const yField = config.y?.field;
+  const sanitizedYField = sanitizeValueForVega(yField);
 
   const defaultTooltipChannel = createDefaultTooltipEncoding(
     [config.x, config.y, config.color],
@@ -59,7 +60,7 @@ export function generateVLStackedBarChartSpec(
     isInteractive: config.isInteractive,
     pivot: createVegaTransformPivotConfig(
       xField,
-      yField,
+      sanitizedYField,
       colorField,
       !!hasComparison,
       !!multiValueTooltipChannel?.length,

--- a/web-common/src/features/components/charts/cartesian/stacked-bar/default.ts
+++ b/web-common/src/features/components/charts/cartesian/stacked-bar/default.ts
@@ -29,7 +29,7 @@ export function generateVLStackedBarChartSpec(
 
   const colorField =
     typeof config.color === "object" ? config.color.field : undefined;
-  const xField = sanitizeValueForVega(config.x?.field);
+  const sanitizedXField = sanitizeValueForVega(config.x?.field);
   const yField = config.y?.field;
   const sanitizedYField = sanitizeValueForVega(yField);
 
@@ -49,7 +49,7 @@ export function generateVLStackedBarChartSpec(
   const hasComparison = data.hasComparison;
 
   const hoverRuleLayer = buildHoverRuleLayer({
-    xField,
+    xField: sanitizedXField,
     domainValues: data.domainValues,
     isBarMark: true,
     defaultTooltip: defaultTooltipChannel,
@@ -59,7 +59,7 @@ export function generateVLStackedBarChartSpec(
     isDarkMode: data.isDarkMode,
     isInteractive: config.isInteractive,
     pivot: createVegaTransformPivotConfig(
-      xField,
+      sanitizedXField,
       sanitizedYField,
       colorField,
       !!hasComparison,
@@ -103,8 +103,8 @@ export function generateVLStackedBarChartSpec(
   return {
     ...spec,
     ...(vegaConfig && { config: vegaConfig }),
-    ...(config.isInteractive && xField
-      ? { usermeta: { brushTemporalField: xField } }
+    ...(config.isInteractive && sanitizedXField
+      ? { usermeta: { brushTemporalField: sanitizedXField } }
       : {}),
   };
 }

--- a/web-common/src/features/components/charts/cartesian/stacked-bar/normalized.ts
+++ b/web-common/src/features/components/charts/cartesian/stacked-bar/normalized.ts
@@ -36,14 +36,13 @@ export function generateVLStackedBarNormalizedSpec(
   const colorField =
     typeof config.color === "object" ? config.color.field : undefined;
   const xField = sanitizeValueForVega(config.x?.field);
-  const yField = sanitizeValueForVega(config.y?.field);
+  const yField = config.y?.field;
+  const sanitizedYField = sanitizeValueForVega(yField);
 
   // Check if comparison mode is enabled
   const hasComparison = data.hasComparison;
 
-  if (baseEncoding.y && config.y?.field) {
-    const yFieldRaw = config.y.field;
-
+  if (baseEncoding.y && yField) {
     baseEncoding.y = {
       ...baseEncoding.y,
       stack: "normalize",
@@ -53,7 +52,7 @@ export function generateVLStackedBarNormalizedSpec(
         domainMax: 1.1,
       },
       axis: {
-        ...(!config.y.showAxisTitle && { title: null }),
+        ...(!config.y?.showAxisTitle && { title: null }),
         format: ".0%",
       },
     };
@@ -71,14 +70,14 @@ export function generateVLStackedBarNormalizedSpec(
         joinaggregate: [
           {
             op: "sum",
-            field: yFieldRaw,
+            field: yField,
             as: "total",
           },
         ],
         groupby: groupbyFields,
       },
       {
-        calculate: `datum['${yFieldRaw}'] / datum.total`,
+        calculate: `datum['${yField}'] / datum.total`,
         as: "percentage",
       },
     ];
@@ -108,7 +107,7 @@ export function generateVLStackedBarNormalizedSpec(
     );
     baseEncoding.tooltip = tooltipValues
       .map((t: TooltipValue) => {
-        if (t.field === yField) {
+        if (t.field === sanitizedYField) {
           return [
             {
               ...t,
@@ -147,7 +146,7 @@ export function generateVLStackedBarNormalizedSpec(
     isDarkMode: data.isDarkMode,
     pivot: createVegaTransformPivotConfig(
       xField,
-      yField,
+      sanitizedYField,
       colorField,
       !!hasComparison,
       !!multiValueTooltipChannel?.length,

--- a/web-common/src/features/components/charts/cartesian/stacked-bar/normalized.ts
+++ b/web-common/src/features/components/charts/cartesian/stacked-bar/normalized.ts
@@ -35,7 +35,7 @@ export function generateVLStackedBarNormalizedSpec(
 
   const colorField =
     typeof config.color === "object" ? config.color.field : undefined;
-  const xField = sanitizeValueForVega(config.x?.field);
+  const sanitizedXField = sanitizeValueForVega(config.x?.field);
   const yField = config.y?.field;
   const sanitizedYField = sanitizeValueForVega(yField);
 
@@ -136,7 +136,7 @@ export function generateVLStackedBarNormalizedSpec(
   };
 
   const hoverRuleLayer = buildHoverRuleLayer({
-    xField,
+    xField: sanitizedXField,
     domainValues: data.domainValues,
     isBarMark: true,
     defaultTooltip: baseEncoding.tooltip as TooltipValue[],
@@ -145,7 +145,7 @@ export function generateVLStackedBarNormalizedSpec(
     primaryColor: data.theme.primary,
     isDarkMode: data.isDarkMode,
     pivot: createVegaTransformPivotConfig(
-      xField,
+      sanitizedXField,
       sanitizedYField,
       colorField,
       !!hasComparison,

--- a/web-common/src/features/components/charts/comparison-builder.ts
+++ b/web-common/src/features/components/charts/comparison-builder.ts
@@ -1,4 +1,3 @@
-import { sanitizeValueForVega } from "@rilldata/web-common/components/vega/util";
 import { ComparisonDeltaPreviousSuffix } from "@rilldata/web-common/features/dashboards/filters/measure-filters/measure-filter-entry";
 import type {
   Field,
@@ -17,7 +16,13 @@ export const SortOrderField = "sortOrder";
  * display current and comparison data side-by-side.
  *
  * The data structure has current and previous values as separate measure fields:
- * e.g., "total_bids" (current) and "total_bids_prev" (comparison)
+ * e.g., "total_bids" (current) and "total_bids_prev" (comparison).
+ *
+ * Field names are passed raw (not pre-escaped) on purpose. `fold.as` stores
+ * its second element as a literal field name, while downstream consumers
+ * such as `pivot.value` resolve field-path escapes — pre-escaping here makes
+ * those two views of the same field disagree (e.g. `"x \\| y"` vs `"x | y"`).
+ * Embedded Vega expression literals escape `\` and `'` via `escapeVegaString`.
  */
 export function createComparisonTransforms(
   xField: string | undefined,
@@ -26,38 +31,33 @@ export function createComparisonTransforms(
 ): Transform[] {
   if (!xField || !measureField) return [];
 
-  const sanitizedMeasure = sanitizeValueForVega(measureField);
-  const sanitizedComparisonMeasure = sanitizeValueForVega(
-    measureField + ComparisonDeltaPreviousSuffix,
-  );
+  const previousMeasureField = measureField + ComparisonDeltaPreviousSuffix;
+  const previousLiteral = escapeVegaString(previousMeasureField);
   const transforms: Transform[] = [];
 
-  // Fold the current and previous measure fields
-  // This creates two rows per original row: one for current, one for previous
+  // Fold the current and previous measure fields into the original measure
+  // column, with a `measure_key` flag indicating which period each row is.
   transforms.push({
-    fold: [sanitizedMeasure, sanitizedComparisonMeasure],
-    as: [MeasureKeyField, sanitizedMeasure],
+    fold: [measureField, previousMeasureField],
+    as: [MeasureKeyField, measureField],
   });
 
-  // If there's a color field, create a synthetic nominal field for grouping
-  // This combines the color dimension with the comparison key for proper stacking
   if (colorField) {
-    const sanitizedColor = sanitizeValueForVega(colorField);
+    const colorLiteral = escapeVegaString(colorField);
+    // Synthetic nominal field for grouping current and previous together.
     transforms.push({
-      calculate: `datum['${sanitizedColor}'] + (datum['${MeasureKeyField}'] === '${sanitizedComparisonMeasure}' ? '${ComparisonDeltaPreviousSuffix}' : '')`,
+      calculate: `datum['${colorLiteral}'] + (datum['${MeasureKeyField}'] === '${previousLiteral}' ? '${ComparisonDeltaPreviousSuffix}' : '')`,
       as: ColorWithComparisonField,
     });
 
-    // Add a sort order field that groups by color first, then by period
-    // This ensures the order is: A_current, A_previous, B_current, B_previous
+    // Sort order groups by color first, then by period (current before previous).
     transforms.push({
-      calculate: `datum['${sanitizedColor}'] + '_' + (datum['${MeasureKeyField}']=== '${sanitizedComparisonMeasure}' ? '1' : '0')`,
+      calculate: `datum['${colorLiteral}'] + '_' + (datum['${MeasureKeyField}'] === '${previousLiteral}' ? '1' : '0')`,
       as: SortOrderField,
     });
   } else {
-    // Add a sort order field to ensure current appears before comparison
     transforms.push({
-      calculate: `datum['${MeasureKeyField}'] === '${sanitizedComparisonMeasure}' ? 1 : 0`,
+      calculate: `datum['${MeasureKeyField}'] === '${previousLiteral}' ? 1 : 0`,
       as: SortOrderField,
     });
   }
@@ -67,22 +67,34 @@ export function createComparisonTransforms(
 
 /**
  * Creates an opacity encoding for comparison mode.
+ *
+ * `measureField` must be the raw measure name; the comparison-period key
+ * compared against here is derived the same way as in
+ * `createComparisonTransforms` so the test stays in sync.
  */
 export function createComparisonOpacityEncoding(
-  measureField: string,
+  measureField: string | undefined,
 ): NumericMarkPropDef<Field> {
-  const sanitizedComparisonMeasure = sanitizeValueForVega(
+  if (!measureField) return { value: 1 };
+
+  const previousLiteral = escapeVegaString(
     measureField + ComparisonDeltaPreviousSuffix,
   );
   return {
     condition: [
       {
-        test: `datum['${MeasureKeyField}'] === '${sanitizedComparisonMeasure}'`,
+        test: `datum['${MeasureKeyField}'] === '${previousLiteral}'`,
         value: 0.4,
       },
     ],
     value: 1,
   };
+}
+
+// Escape `\` and `'` for safe embedding inside a Vega expression
+// single-quoted string literal.
+function escapeVegaString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
 }
 
 /**


### PR DESCRIPTION
The Vega comparison-mode pipeline pre-escaped the measure name and then handed that escaped string to multiple layers that each interpreted escaped differently. 

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
