### PR TITLE
don't raise sub cancel issue on credit depletion

### DIFF
--- a/admin/jobs/river/credit_balance_event_handlers.go
+++ b/admin/jobs/river/credit_balance_event_handlers.go
@@ -96,7 +96,7 @@ type CreditBalanceDepletedWorker struct {
 }
 
 // Work handles a credit_balance_depleted Orb webhook. We re-fetch the balance, on a confirmed zero balance for an org that is on the credit trial,
-// we cancel the trial subscription, hibernate every project, raise BillingIssueTypeTrialCreditsDepleted (blocks API operations) and BillingIssueTypeSubscriptionCancelled.
+// we cancel the trial subscription, hibernate every project, raise BillingIssueTypeTrialCreditsDepleted (blocks API operations).
 func (w *CreditBalanceDepletedWorker) Work(ctx context.Context, job *river.Job[CreditBalanceDepletedArgs]) error {
 	org, err := w.admin.DB.FindOrganizationForBillingCustomerID(ctx, job.Args.BillingCustomerID)
 	if err != nil {
@@ -130,12 +130,9 @@ func (w *CreditBalanceDepletedWorker) Work(ctx context.Context, job *river.Job[C
 		planID = m.PlanID
 	}
 
-	subEndDate, err := w.admin.Biller.CancelSubscriptionsForCustomer(ctx, org.BillingCustomerID, billing.SubscriptionCancellationOptionImmediate)
+	_, err = w.admin.Biller.CancelSubscriptionsForCustomer(ctx, org.BillingCustomerID, billing.SubscriptionCancellationOptionImmediate)
 	if err != nil {
 		return fmt.Errorf("failed to cancel trial subscription for org %q: %w", org.Name, err)
-	}
-	if subEndDate.IsZero() {
-		subEndDate = time.Now().UTC()
 	}
 
 	txCtx, tx, err := w.admin.DB.NewTx(ctx, false)
@@ -159,17 +156,6 @@ func (w *CreditBalanceDepletedWorker) Work(ctx context.Context, job *river.Job[C
 		EventTime: time.Now().UTC(),
 	}); err != nil {
 		return fmt.Errorf("failed to raise trial-credits-depleted issue: %w", err)
-	}
-
-	if _, err := w.admin.DB.UpsertBillingIssue(txCtx, &database.UpsertBillingIssueOptions{
-		OrgID: org.ID,
-		Type:  database.BillingIssueTypeSubscriptionCancelled,
-		Metadata: &database.BillingIssueMetadataSubscriptionCancelled{
-			EndDate: subEndDate,
-		},
-		EventTime: time.Now().UTC(),
-	}); err != nil {
-		return fmt.Errorf("failed to raise subscription-cancelled issue: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {


### PR DESCRIPTION
Keeping this issue only for when customer explicitly cancels the subscription. Keep the upgrade path same for both before and after trial expires through `UpdateBillingSubscription` API as earlier with time based trial.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
