### PR TITLE
fix: org create flow triggering on embed

### DIFF
--- a/web-admin/src/features/welcome/utils.ts
+++ b/web-admin/src/features/welcome/utils.ts
@@ -10,6 +10,7 @@ import {
 } from "@rilldata/web-admin/client";
 import { isThemeSelectionNeeded } from "@rilldata/web-common/features/themes/theme-control.ts";
 import { redirect, type Page } from "@sveltejs/kit";
+import { isEmbedPage } from "@rilldata/web-common/layout/navigation/navigation-utils.ts";
 
 /**
  * Redirect users through the welcome flow when they have no organizations.
@@ -18,6 +19,7 @@ import { redirect, type Page } from "@sveltejs/kit";
 export async function maybeRedirectToWelcomePage(route: Page["route"]) {
   if (
     withinOrganization({ route }) ||
+    isEmbedPage({ route }) ||
     isAuthPage({ route }) ||
     isWelcomePage({ route })
   ) {

--- a/web-common/src/layout/navigation/navigation-utils.ts
+++ b/web-common/src/layout/navigation/navigation-utils.ts
@@ -28,7 +28,7 @@ export async function emitNavigationTelemetry(href: string, name: string) {
   );
 }
 
-export function isEmbedPage(page: Page): boolean {
-  if (!page.route.id) return false;
-  return page.route.id.startsWith("/-/embed");
+export function isEmbedPage({ route }: Pick<Page, "route">): boolean {
+  if (!route.id) return false;
+  return route.id.startsWith("/-/embed");
 }


### PR DESCRIPTION
Org create flow is triggered on embed if the user has no org. Fixing by adding it to the the skip in `maybeRedirectToWelcomePage`

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
