### PR TITLE
fix for direct file path is not working in rill

### DIFF
--- a/runtime/pkg/duckdbsql/ast_traversal.go
+++ b/runtime/pkg/duckdbsql/ast_traversal.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 // TODO: handle parameters in values
@@ -191,10 +192,21 @@ func (a *AST) traverseBaseTable(parent astNode, childKey string) {
 	if a.added[name] {
 		return
 	}
-	a.newFromNode(node, parent, childKey, &TableRef{
-		Name:       name,
-		LocalAlias: a.aliases[name],
-	})
+	var ref *TableRef
+	if fn, ok := fileToFunc(name); ok {
+		ref = &TableRef{
+			Function: fn,
+			Paths:    []string{name},
+		}
+	} else {
+		ref = &TableRef{
+			Name:       name,
+			LocalAlias: a.aliases[name],
+		}
+	}
+
+	a.newFromNode(node, parent, childKey, ref)
+	a.newFromNode(node, parent, childKey, ref)
 	a.added[name] = true
 	// TODO: add to local alias
 }
@@ -373,6 +385,20 @@ func forceConvertToNum[N int32 | int64 | uint32 | uint64 | float32 | float64](v 
 		return 0
 	}
 	return 0
+}
+
+func fileToFunc(name string) (string, bool) {
+	nameLower := strings.ToLower(name)
+	switch {
+	case strings.HasSuffix(nameLower, ".csv"):
+		return "read_csv", true
+	case strings.HasSuffix(nameLower, ".json"):
+		return "read_json", true
+	case strings.HasSuffix(nameLower, ".parquet"):
+		return "read_parquet", true
+	default:
+		return "", false
+	}
 }
 
 type PositionError struct {

--- a/runtime/pkg/duckdbsql/ast_traversal.go
+++ b/runtime/pkg/duckdbsql/ast_traversal.go
@@ -206,7 +206,6 @@ func (a *AST) traverseBaseTable(parent astNode, childKey string) {
 	}
 
 	a.newFromNode(node, parent, childKey, ref)
-	a.newFromNode(node, parent, childKey, ref)
 	a.added[name] = true
 	// TODO: add to local alias
 }

--- a/runtime/resolvers/testdata/metrics_sql_duckdb.yaml
+++ b/runtime/resolvers/testdata/metrics_sql_duckdb.yaml
@@ -6,8 +6,7 @@ project_files:
     connector: duckdb
     materialize: true
     sql: |
-      select id, timestamp, publisher, domain, volume, impressions, clicks
-      from read_csv('data/AdBids_mini.csv')
+      select id, timestamp, publisher, domain, volume, impressions, clicks from 'data/AdBids_mini.csv'
   metrics_with_policy.yaml:
     type: metrics_view
     model: ad_bids_mini


### PR DESCRIPTION
Fix for direct file path is not working in rill
example
```
select * from 'data/bids.csv'
```

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
