### PR TITLE
chore: selectively install browsers for playwright tests

### DIFF
--- a/.github/workflows/web-test-e2e.yml
+++ b/.github/workflows/web-test-e2e.yml
@@ -110,7 +110,22 @@ jobs:
       - name: Install browser for UI tests
         run: |
           npx playwright@^1.50.1 install
-          npx playwright install-deps
+          # For pull requests, always use chrome
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            npx playwright install-deps chrome
+          # For manual workflow runs, use the selected browser
+          elif [ "${{ github.event.inputs.browser }}" == "all" ]; then
+            npx playwright install-deps
+          elif [ "${{ github.event.inputs.browser }}" == "chrome" ]; then
+            npx playwright install-deps chrome
+          elif [ "${{ github.event.inputs.browser }}" == "safari" ]; then
+            npx playwright install-deps safari
+          elif [ "${{ github.event.inputs.browser }}" == "firefox" ]; then
+            npx playwright install-deps firefox
+          else
+            echo "Invalid browser choice: ${{ github.event.inputs.browser }}"
+            exit 1
+          fi
 
       - name: Authenticate GCloud
         uses: google-github-actions/auth@v2


### PR DESCRIPTION
We are installing all browsers every time when running e2e tests, but only use chrome most of the time. We can get throttled when multiple jobs run in quick succession. Improving this to a degree by only installing the relevant browser.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
