### PR TITLE
fix: don't lock the UI during AI canvas generation

### DIFF
--- a/web-admin/src/routes/[organization]/[project]/-/edit/(workspace)/+page.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/(workspace)/+page.svelte
@@ -1,15 +1,12 @@
 <script lang="ts">
   import { GeneratingMessage } from "@rilldata/web-common/components/generating-message";
   import { generatingSampleData } from "@rilldata/web-common/features/sample-data/generate-sample-data.ts";
-  import { generatingCanvas } from "@rilldata/web-common/features/canvas/ai-generation/generateCanvas";
   import OnboardingWorkspace from "@rilldata/web-common/features/onboarding/OnboardingWorkspace.svelte";
 </script>
 
 <div class="flex size-full overflow-hidden bg-surface-subtle">
   {#if $generatingSampleData}
     <GeneratingMessage title="Generating your sample data..." />
-  {:else if $generatingCanvas}
-    <GeneratingMessage title="Generating your Canvas dashboard..." />
   {:else}
     <OnboardingWorkspace />
   {/if}

--- a/web-common/src/features/canvas/ai-generation/generateCanvas.ts
+++ b/web-common/src/features/canvas/ai-generation/generateCanvas.ts
@@ -12,6 +12,7 @@ import type { V1Resource } from "@rilldata/web-common/runtime-client";
 import {
   runtimeServiceGenerateCanvasFile,
   runtimeServiceGenerateMetricsViewFile,
+  runtimeServicePutFile,
 } from "@rilldata/web-common/runtime-client";
 import type { RuntimeClient } from "@rilldata/web-common/runtime-client/v2";
 import { get, writable } from "svelte/store";
@@ -21,7 +22,7 @@ import { getName } from "../../entity-management/name-utils";
 import { featureFlags } from "../../feature-flags";
 import OptionToCancelAIGeneration from "../../metrics-views/ai-generation/OptionToCancelAIGeneration.svelte";
 
-export const generatingCanvas = writable(false);
+export const generatingCanvasFilePath = writable<string | null>(null);
 
 /**
  * Creates a metrics view from a table.
@@ -173,6 +174,16 @@ export async function createCanvasDashboardFromMetricsViewWithAgent(
   const prompt = `Create a canvas dashboard at ${canvasFilePath} based on the "${metricsViewName}" metrics view. Include appropriate visualizations like KPI grids, charts, and leaderboards based on the available measures and dimensions.`;
 
   try {
+    // Set generating state and create a placeholder file so it appears in the
+    // left nav with a loading spinner before the agent has written anything.
+    generatingCanvasFilePath.set(canvasFilePath);
+    await runtimeServicePutFile(client, {
+      path: canvasFilePath,
+      blob: "type: canvas\n",
+      create: true,
+      createOnly: true,
+    });
+
     // 3. Set up file creation detection
     // Get conversation manager and start a new conversation
     const conversationManager = getConversationManager(client, {
@@ -187,9 +198,6 @@ export async function createCanvasDashboardFromMetricsViewWithAgent(
     const currentConversation = get(
       conversationManager.getCurrentConversation(),
     );
-
-    // Set generating state
-    generatingCanvas.set(true);
 
     // 4. Start the chat with the generation prompt
     developerChatActions.startChat(prompt);
@@ -206,7 +214,7 @@ export async function createCanvasDashboardFromMetricsViewWithAgent(
       detail: err instanceof Error ? err.message : String(err),
     });
   } finally {
-    generatingCanvas.set(false);
+    generatingCanvasFilePath.set(null);
   }
 }
 

--- a/web-common/src/features/file-explorer/NavFile.svelte
+++ b/web-common/src/features/file-explorer/NavFile.svelte
@@ -36,6 +36,7 @@
   import SourceMenuItems from "../sources/navigation/SourceMenuItems.svelte";
   import { isProtectedDirectory } from "@rilldata/web-common/features/entity-management/actions/protected-files.ts";
   import { getTopLevelFolder } from "@rilldata/web-common/features/entity-management/file-path-utils.ts";
+  import { generatingCanvasFilePath } from "@rilldata/web-common/features/canvas/ai-generation/generateCanvas";
 
   export let filePath: string;
   export let onRename: (filePath: string, isDir: boolean) => void;
@@ -71,6 +72,7 @@
 
   $: hasErrors = fileArtifact.getHasErrors(queryClient);
   $: hasWarnings = fileArtifact.getHasWarnings(queryClient);
+  $: isGenerating = $generatingCanvasFilePath === filePath;
 
   function fireTelemetry() {
     const previousScreenName = getScreenNameFromPage();
@@ -95,7 +97,7 @@
   aria-label="{filePath} Nav Entry"
   class="w-full text-left pr-2 h-6 group flex justify-between gap-x-1 items-center hover:bg-surface-hover"
   class:bg-surface-active={isCurrentFile}
-  class:opacity-50={$hasUnsavedChanges || $saving}
+  class:opacity-50={$hasUnsavedChanges || $saving || isGenerating}
 >
   <a
     class="w-full truncate flex items-center gap-x-1 font-medium {protectedDirectory ||
@@ -104,13 +106,13 @@
       : 'text-fg-primary hover:text-fg-primary'}"
     href={getFileHref(filePath)}
     {id}
-    class:italic={$hasUnsavedChanges || $saving}
+    class:italic={$hasUnsavedChanges || $saving || isGenerating}
     onclick={fireTelemetry}
     onmousedown={handleMouseDown}
     style:padding-left="{padding}px"
   >
     <div class="flex-none">
-      {#if $saving}
+      {#if $saving || isGenerating}
         <LoadingSpinner size="14px" />
       {:else if $error}
         <Alert size="14px" color="red" />

--- a/web-common/src/features/workspaces/WorkspaceDispatcher.svelte
+++ b/web-common/src/features/workspaces/WorkspaceDispatcher.svelte
@@ -3,7 +3,7 @@
   import type { EditorView } from "@codemirror/view";
   import { customYAMLwithJSONandSQL } from "@rilldata/web-common/components/editor/presets/yamlWithJsonAndSql";
   import { GeneratingMessage } from "@rilldata/web-common/components/generating-message";
-  import { generatingCanvas } from "@rilldata/web-common/features/canvas/ai-generation/generateCanvas";
+  import { generatingCanvasFilePath } from "@rilldata/web-common/features/canvas/ai-generation/generateCanvas";
   import Editor from "@rilldata/web-common/features/editor/Editor.svelte";
   import FileWorkspaceHeader from "@rilldata/web-common/features/editor/FileWorkspaceHeader.svelte";
   import { getExtensionsForFile } from "@rilldata/web-common/features/editor/getExtensionsForFile";
@@ -67,6 +67,8 @@
   let parseErrorQuery = $derived(getParseError(queryClient));
   let parseError = $derived($parseErrorQuery);
 
+  let isGeneratingThisFile = $derived($generatingCanvasFilePath === path);
+
   onMount(() => {
     expandDirectory(path);
   });
@@ -87,7 +89,7 @@
 
 <div class="flex h-full overflow-hidden">
   <div class="flex-1 overflow-hidden">
-    {#if $generatingCanvas}
+    {#if isGeneratingThisFile}
       <GeneratingMessage title="Generating your Canvas dashboard..." />
     {:else if WorkspaceComponent}
       <WorkspaceComponent {fileArtifact} />

--- a/web-local/src/routes/(application)/(workspace)/+page.svelte
+++ b/web-local/src/routes/(application)/(workspace)/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { GeneratingMessage } from "@rilldata/web-common/components/generating-message";
   import { generatingSampleData } from "@rilldata/web-common/features/sample-data/generate-sample-data.ts";
-  import { generatingCanvas } from "@rilldata/web-common/features/canvas/ai-generation/generateCanvas";
   import OnboardingWorkspace from "@rilldata/web-common/features/onboarding/OnboardingWorkspace.svelte";
   import type { LayoutData } from "../$types";
 
@@ -16,8 +15,6 @@
   {#if data.initialized}
     {#if $generatingSampleData}
       <GeneratingMessage title="Generating your sample data..." />
-    {:else if $generatingCanvas}
-      <GeneratingMessage title="Generating your Canvas dashboard..." />
     {:else}
       <OnboardingWorkspace />
     {/if}


### PR DESCRIPTION
- Replace the global `generatingCanvas` boolean with a `generatingCanvasFilePath` store so we can target the specific in-progress canvas instead of blocking every workspace.
- Show a `LoadingSpinner` next to the canvas file entry in the left nav while generation is in flight.
- Pre-create the canvas file with a minimal `type: canvas` placeholder so the nav entry appears immediately on click, before the agent runs `develop_file`.
- Scope `GeneratingMessage` to render only when the user is viewing the file being generated. All other workspaces remain interactive.
- Remove the canvas-generating branch from the empty-workspace routes in `web-local` and `web-admin` (sample-data branch is untouched).

https://rilldata.slack.com/archives/C08RDR9Q26P/p1774983767296659?thread_ts=1774879648.536779&cid=C08RDR9Q26P

Closes [APP-831](https://linear.app/rilldata/issue/APP-831/migrate-generate-metrics-view-and-explore-to-use-the-developer-agent)


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
