### PR TITLE
fix: theme colors not applied to dimension dots in measure chart tooltip

### DIFF
--- a/web-common/src/features/dashboards/time-series/measure-chart/MeasureChartBody.svelte
+++ b/web-common/src/features/dashboards/time-series/measure-chart/MeasureChartBody.svelte
@@ -3,6 +3,7 @@
   import TimeSeriesChart from "@rilldata/web-common/components/time-series-chart/TimeSeriesChart.svelte";
   import { TDDChart } from "@rilldata/web-common/features/dashboards/time-dimension-details/types";
   import type { Annotation } from "@rilldata/web-common/features/dashboards/time-series/measure-chart/annotation-utils";
+  import { qualitativeColorsArray } from "@rilldata/web-common/features/themes/palette-store";
   import { createMeasureValueFormatter } from "@rilldata/web-common/lib/number-formatting/format-measure-value";
   import { formatGrainBucket } from "@rilldata/web-common/lib/time/ranges/formatter";
   import type {
@@ -205,10 +206,12 @@
   $: dimTooltipEntries =
     isComparingDimension && hoveredIndex >= 0
       ? dimensionData
-          .map((dim) => ({
+          .map((dim, i) => ({
             label: dim.dimensionValue ?? "null",
             value: dim.data[hoveredIndex]?.value ?? null,
-            color: dim.color,
+            color:
+              $qualitativeColorsArray[i % $qualitativeColorsArray.length] ||
+              dim.color,
           }))
           .filter((e) => e.value !== null)
           .sort((a, b) => (b.value ?? 0) - (a.value ?? 0))


### PR DESCRIPTION
- The floating tooltip is portaled to `document.body`, outside `.dashboard-theme-boundary`, so the `var(--color-qualitative-N)` CSS variables on each dimension dot resolved to the unscoped defaults instead of the theme overrides.
- Resolve dimension colors through `qualitativeColorsArray` (which reads from the theme boundary) when building `dimTooltipEntries`.

https://rilldata.slack.com/archives/C02T907FEUB/p1779210691324489

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
