### PR TITLE
fix: broken citation link with time dimension sorting

### DIFF
--- a/web-common/src/features/dashboards/stores/test-data/data.ts
+++ b/web-common/src/features/dashboards/stores/test-data/data.ts
@@ -237,6 +237,10 @@ export const AD_BIDS_METRICS_3_MEASURES_DIMENSIONS: V1MetricsViewSpec = {
 export const AD_BIDS_METRICS_3_MEASURES_DIMENSIONS_WITH_TIME: V1MetricsViewSpec =
   {
     ...AD_BIDS_METRICS_3_MEASURES_DIMENSIONS,
+    dimensions: [...AD_BIDS_THREE_DIMENSIONS].concat({
+      name: AD_BIDS_TIMESTAMP_DIMENSION,
+      type: MetricsViewSpecDimensionType.DIMENSION_TYPE_TIME,
+    }),
     timeDimension: AD_BIDS_TIMESTAMP_DIMENSION,
   };
 
@@ -294,6 +298,15 @@ export const AD_BIDS_EXPLORE_WITH_3_MEASURES_DIMENSIONS: V1ExploreSpec = {
   measures: AD_BIDS_THREE_MEASURES.map((m) => m.name!),
   dimensions: AD_BIDS_THREE_DIMENSIONS.map((d) => d.name!),
 };
+export const AD_BIDS_EXPLORE_WITH_3_MEASURES_DIMENSIONS_TIME_DIMENSION: V1ExploreSpec =
+  {
+    displayName: AD_BIDS_EXPLORE_NAME,
+    metricsView: AD_BIDS_METRICS_NAME,
+    measures: AD_BIDS_THREE_MEASURES.map((m) => m.name!),
+    dimensions: AD_BIDS_THREE_DIMENSIONS.map((d) => d.name!).concat(
+      AD_BIDS_TIMESTAMP_DIMENSION,
+    ),
+  };
 
 // Exhaustive metrics view. TODO: replace usage of partial metrics view
 export const AD_BIDS_EXPLORE: V1ExploreSpec = {

--- a/web-common/src/features/explore-mappers/map-metrics-resolver-query-to-dashboard.spec.ts
+++ b/web-common/src/features/explore-mappers/map-metrics-resolver-query-to-dashboard.spec.ts
@@ -6,7 +6,7 @@ import {
 } from "@rilldata/web-common/features/dashboards/stores/filter-utils.ts";
 import {
   AD_BIDS_DOMAIN_DIMENSION,
-  AD_BIDS_EXPLORE_WITH_3_MEASURES_DIMENSIONS,
+  AD_BIDS_EXPLORE_WITH_3_MEASURES_DIMENSIONS_TIME_DIMENSION,
   AD_BIDS_IMPRESSIONS_MEASURE,
   AD_BIDS_METRICS_3_MEASURES_DIMENSIONS_WITH_TIME,
   AD_BIDS_PUBLISHER_DIMENSION,
@@ -182,6 +182,79 @@ describe("mapMetricsResolverQueryToDashboard", () => {
         },
       },
     },
+    {
+      title: "single measure and 2 dimensions one time dimension",
+      query: {
+        measures: [{ name: AD_BIDS_IMPRESSIONS_MEASURE }],
+        dimensions: [
+          { name: AD_BIDS_PUBLISHER_DIMENSION },
+          { name: AD_BIDS_DOMAIN_DIMENSION },
+          {
+            name: AD_BIDS_TIMESTAMP_DIMENSION,
+            compute: {
+              time_floor: {
+                dimension: AD_BIDS_TIMESTAMP_DIMENSION,
+                grain: "day",
+              },
+            },
+          },
+        ],
+        sort: [
+          { desc: true, name: AD_BIDS_TIMESTAMP_DIMENSION },
+          { name: AD_BIDS_IMPRESSIONS_MEASURE },
+        ],
+      },
+      expectedPartialExplore: {
+        activePage: DashboardState_ActivePage.PIVOT,
+        selectedTimeRange: {
+          name: TimeRangePreset.ALL_TIME,
+        } as DashboardTimeControls,
+
+        visibleMeasures: [AD_BIDS_IMPRESSIONS_MEASURE],
+        allMeasuresVisible: false,
+        visibleDimensions: [
+          AD_BIDS_PUBLISHER_DIMENSION,
+          AD_BIDS_DOMAIN_DIMENSION,
+        ],
+        allDimensionsVisible: false,
+
+        pivot: {
+          rows: [],
+          columns: [
+            {
+              id: "TIME_GRAIN_DAY",
+              title: "day",
+              type: PivotChipType.Time,
+            },
+            {
+              id: AD_BIDS_PUBLISHER_DIMENSION,
+              title: AD_BIDS_PUBLISHER_DIMENSION,
+              type: PivotChipType.Dimension,
+            },
+            {
+              id: AD_BIDS_DOMAIN_DIMENSION,
+              title: AD_BIDS_DOMAIN_DIMENSION,
+              type: PivotChipType.Dimension,
+            },
+            {
+              id: AD_BIDS_IMPRESSIONS_MEASURE,
+              title: AD_BIDS_IMPRESSIONS_MEASURE,
+              type: PivotChipType.Measure,
+            },
+          ],
+          sorting: [
+            { desc: true, id: "timestamp_rill_TIME_GRAIN_DAY" },
+            { desc: false, id: AD_BIDS_IMPRESSIONS_MEASURE },
+          ],
+          expanded: {},
+          columnPage: 0,
+          rowPage: 0,
+          enableComparison: false,
+          tableMode: "flat",
+          activeCell: null,
+        },
+      },
+    },
 
     {
       title: "time dimension filter",
@@ -248,7 +321,7 @@ describe("mapMetricsResolverQueryToDashboard", () => {
       expect(
         mapMetricsResolverQueryToDashboard(
           AD_BIDS_METRICS_3_MEASURES_DIMENSIONS_WITH_TIME,
-          AD_BIDS_EXPLORE_WITH_3_MEASURES_DIMENSIONS,
+          AD_BIDS_EXPLORE_WITH_3_MEASURES_DIMENSIONS_TIME_DIMENSION,
           query,
         ),
       ).toEqual(expectedPartialExplore);

--- a/web-common/src/features/explore-mappers/map-metrics-resolver-query-to-dashboard.ts
+++ b/web-common/src/features/explore-mappers/map-metrics-resolver-query-to-dashboard.ts
@@ -26,6 +26,7 @@ import {
   type V1Expression,
   type V1MetricsViewSpec,
   V1Operation,
+  V1TimeGrain,
 } from "@rilldata/web-common/runtime-client";
 import type {
   Dimension,
@@ -170,13 +171,15 @@ function getValidDimensions(
   const mvDimensions = new Set<string>(
     metricsViewSpec.dimensions?.map((d) => d.name!) ?? [],
   );
+  // TODO: handle multiple timestamp metrics views
   const exploreDimensions = dimensions
     .filter(
       (d) =>
-        mvDimensions.has(d.name) && exploreSpec.dimensions?.includes(d.name),
+        mvDimensions.has(d.name) &&
+        exploreSpec.dimensions?.includes(d.name) &&
+        d.compute?.time_floor?.dimension !== metricsViewSpec.timeDimension,
     )
     .map((d) => d.name);
-  // TODO: handle multiple timestamp metrics views
   const timeDimensions = dimensions.filter(
     (d) => d.compute?.time_floor?.dimension === metricsViewSpec.timeDimension,
   );
@@ -348,11 +351,13 @@ function mapPivot(
 
   if (partialExploreState.visibleDimensions) {
     columns.push(
-      ...partialExploreState.visibleDimensions.map((d) => ({
-        id: d,
-        title: d,
-        type: PivotChipType.Dimension,
-      })),
+      ...partialExploreState.visibleDimensions
+        .filter((d) => !timeDimensions.find((td) => td.name === d))
+        .map((d) => ({
+          id: d,
+          title: d,
+          type: PivotChipType.Dimension,
+        })),
     );
   }
 
@@ -367,7 +372,19 @@ function mapPivot(
   }
 
   const sorting: SortingState =
-    query.sort?.map((s) => ({ id: s.name, desc: !!s.desc })) ?? [];
+    query.sort?.map((s) => {
+      const td = timeDimensions.find((td) => td.name === s.name);
+      if (!td?.compute?.time_floor?.grain)
+        return { id: s.name, desc: !!s.desc };
+
+      const grain =
+        DateTimeUnitToV1TimeGrain[td.compute.time_floor.grain] ??
+        V1TimeGrain.TIME_GRAIN_SECOND;
+      const id = td?.compute?.time_floor?.grain
+        ? `${td.name}_rill_${grain}`
+        : s.name;
+      return { id, desc: !!s.desc };
+    }) ?? [];
 
   return {
     rows: [],


### PR DESCRIPTION
Citation links with time dimension sorting is breaking the pivot. Incorrect field name is being mapped.

Updating to handle sorting on time dimension. Adding a test for this to ensure it doesnt break.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
