### PR TITLE
chore: standardise billing langauge for slots

### DIFF
--- a/web-admin/src/features/billing/plans/FreePlan.svelte
+++ b/web-admin/src/features/billing/plans/FreePlan.svelte
@@ -3,6 +3,7 @@
   import { formatCredit } from "@rilldata/web-admin/features/billing/plans/utils.ts";
   import { getPlanCredits } from "@rilldata/web-admin/features/billing/plans/selectors.ts";
   import { useCategorisedOrganizationBillingIssues } from "@rilldata/web-admin/features/billing/selectors.ts";
+  import { PricingDetailsCompact } from "@rilldata/web-common/features/billing/pricing-details.ts";
 
   let {
     organization,
@@ -24,7 +25,7 @@
 <PlanContainer badge="Pro Trial" description="$250 free credit">
   {#snippet info()}
     No time limit, use it until it's gone.<br />
-    $0.15/unit/hr · $1/GB storage/mo<br />
+    {PricingDetailsCompact}<br />
     1 unit = 4GiB RAM, 1vGPU
   {/snippet}
 

--- a/web-admin/src/features/billing/plans/ProPlan.svelte
+++ b/web-admin/src/features/billing/plans/ProPlan.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
   import PlanContainer from "@rilldata/web-admin/features/billing/plans/PlanContainer.svelte";
+  import {
+    PricingDetails,
+    PricingDetailsCompact,
+  } from "@rilldata/web-common/features/billing/pricing-details.ts";
 
   let {
     billingPortalUrl,
@@ -32,12 +36,11 @@
   {/snippet}
 
   {#snippet info()}
-    $0.15/unit/hr · $1/GB storage/mo. Cancel anytime.
+    {PricingDetailsCompact} Cancel anytime.
   {/snippet}
 
   <div class="text-sm text-fg-tertiary mt-4 pb-4">
-    You'll be billed monthly based on usage at $0.15/compute unit/hr and $1/GB
-    storage/mo.
+    {PricingDetails}
   </div>
 </PlanContainer>
 

--- a/web-admin/src/features/billing/plans/dialog/StartTeamPlanDialog.svelte
+++ b/web-admin/src/features/billing/plans/dialog/StartTeamPlanDialog.svelte
@@ -15,6 +15,7 @@
   import { Button } from "@rilldata/web-common/components/button";
   import { upgradeToPro } from "@rilldata/web-admin/features/billing/plans/upgrade-to-pro.ts";
   import { extractErrorMessage } from "@rilldata/web-common/lib/errors.ts";
+  import { PricingDetails } from "@rilldata/web-common/features/billing/pricing-details.ts";
 
   let {
     open = $bindable(false),
@@ -29,10 +30,9 @@
   } = $props();
 
   let title: string = $state("");
-  let description =
-    $state(`Your subscription will start today using the payment method on file.
-    You'll be billed monthly based on usage at $0.15/compute unit/hr and $1/GB storage/mo.
-    Cancel anytime.`);
+  let description = $state(
+    `Your subscription will start today using the payment method on file. ${PricingDetails} Cancel anytime.`,
+  );
   let buttonText = $state("Upgrade to Pro");
   function setCopyBasedOnType(t: TeamPlanDialogTypes) {
     switch (t) {

--- a/web-common/src/features/billing/PricingDetails.svelte
+++ b/web-common/src/features/billing/PricingDetails.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
+  import { PricingDetails } from "@rilldata/web-common/features/billing/pricing-details.ts";
+
   export let extraText = "";
 </script>
 
 <div>
-  {extraText} Pricing is based on amount of data ingested (and compressed) into Rill.
+  {extraText} Pricing is based on compute and amount of data ingested (and compressed)
+  into Rill.
   <a
     href="https://www.rilldata.com/pricing"
     target="_blank"
@@ -13,7 +16,7 @@
   </a>
 
   <ul class="mt-5 ml-5 list-disc">
-    <li>Starts at $250/month with 10 GB included, $25/GB thereafter</li>
+    <li>{PricingDetails}</li>
     <li>Unlimited projects, limited to 50 GB each</li>
   </ul>
 </div>

--- a/web-common/src/features/billing/pricing-details.ts
+++ b/web-common/src/features/billing/pricing-details.ts
@@ -1,0 +1,2 @@
+export const PricingDetails = `You'll be billed monthly based on usage at $0.15/compute unit/hr and $1/GB storage/mo.`;
+export const PricingDetailsCompact = `$0.15/compute unit/hr · $1/GB storage/mo.`;


### PR DESCRIPTION
We have different laguage for slots based pricing. Standardising to `$0.15/compute unit/hr · $1/GB storage/mo.`

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
