### PR TITLE
feat: configurable AI chat and LLM request timeouts via `rill.yaml`

### DIFF
--- a/runtime/ai/ai.go
+++ b/runtime/ai/ai.go
@@ -1134,7 +1134,7 @@ func (s *Session) Complete(ctx context.Context, name string, out any, opts *Comp
 	if err != nil {
 		return fmt.Errorf("failed to get instance config: %w", err)
 	}
-	llmRequestTimeout := time.Duration(cfg.AILLMRequestTimeoutSeconds) * time.Second
+	llmRequestTimeout := time.Duration(cfg.AILLMTimeoutSeconds) * time.Second
 
 	// Prepare tool definitions.
 	tools := make([]*aiv1.Tool, 0, len(opts.Tools))

--- a/runtime/ai/ai.go
+++ b/runtime/ai/ai.go
@@ -1102,8 +1102,6 @@ func (s *Session) CallTool(ctx context.Context, role Role, toolName string, out,
 	})
 }
 
-const llmRequestTimeout = 3 * time.Minute
-
 // CompleteOptions provides options for Session.Complete.
 type CompleteOptions struct {
 	Messages      []*aiv1.CompletionMessage
@@ -1130,6 +1128,13 @@ func (s *Session) Complete(ctx context.Context, name string, out any, opts *Comp
 	if opts.MaxIterations == 1 && len(opts.Tools) > 0 {
 		return errors.New("max iterations must be greater than 1 when using tools")
 	}
+
+	// Resolve the configured LLM request timeout.
+	cfg, err := s.runner.Runtime.InstanceConfig(ctx, s.instanceID)
+	if err != nil {
+		return fmt.Errorf("failed to get instance config: %w", err)
+	}
+	llmRequestTimeout := time.Duration(cfg.AILLMRequestTimeoutSeconds) * time.Second
 
 	// Prepare tool definitions.
 	tools := make([]*aiv1.Tool, 0, len(opts.Tools))
@@ -1361,7 +1366,7 @@ func (s *Session) Complete(ctx context.Context, name string, out any, opts *Comp
 		return outVal, nil
 	}
 
-	_, err := s.Call(ctx, &CallOptions{
+	_, err = s.Call(ctx, &CallOptions{
 		Role:    RoleAssistant,
 		Name:    name,
 		Unwrap:  opts.UnwrapCall,

--- a/runtime/ai/ai_test.go
+++ b/runtime/ai/ai_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	aiv1 "github.com/rilldata/rill/proto/gen/rill/ai/v1"
@@ -15,11 +17,51 @@ import (
 	"github.com/rilldata/rill/runtime/ai"
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/pkg/activity"
+	"github.com/rilldata/rill/runtime/testruntime"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
 	_ "github.com/rilldata/rill/runtime/resolvers"
 )
+
+type deadlineRecordingAIService struct {
+	deadline time.Time
+}
+
+func (d *deadlineRecordingAIService) Complete(ctx context.Context, opts *drivers.CompleteOptions) (*drivers.CompleteResult, error) {
+	var ok bool
+	d.deadline, ok = ctx.Deadline()
+	if !ok {
+		return nil, errors.New("expected deadline")
+	}
+	return &drivers.CompleteResult{
+		Message: ai.NewTextCompletionMessage(ai.RoleAssistant, "done"),
+	}, nil
+}
+
+func TestCompleteUsesConfiguredLLMRequestTimeout(t *testing.T) {
+	rt, instanceID := testruntime.NewInstanceWithOptions(t, testruntime.InstanceOptions{
+		Variables: map[string]string{
+			"rill.ai.llm_request_timeout_seconds": "2",
+		},
+	})
+
+	s := newSession(t, rt, instanceID)
+	rec := &deadlineRecordingAIService{}
+	s.SetLLM(func(ctx context.Context) (drivers.AIService, func(), error) {
+		return rec, func() {}, nil
+	})
+
+	start := time.Now()
+	var out string
+	err := s.Complete(t.Context(), "test_completion", &out, &ai.CompleteOptions{
+		Messages: []*aiv1.CompletionMessage{
+			ai.NewTextCompletionMessage(ai.RoleUser, "hello"),
+		},
+	})
+	require.NoError(t, err)
+	require.WithinDuration(t, start.Add(2*time.Second), rec.deadline, time.Second)
+}
 
 // newSession sets up a new AI session for testing.
 // It is suitable for testing tool calls that do not require LLM completions.

--- a/runtime/ai/ai_test.go
+++ b/runtime/ai/ai_test.go
@@ -4,12 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	aiv1 "github.com/rilldata/rill/proto/gen/rill/ai/v1"
@@ -17,51 +15,11 @@ import (
 	"github.com/rilldata/rill/runtime/ai"
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/pkg/activity"
-	"github.com/rilldata/rill/runtime/testruntime"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
 	_ "github.com/rilldata/rill/runtime/resolvers"
 )
-
-type deadlineRecordingAIService struct {
-	deadline time.Time
-}
-
-func (d *deadlineRecordingAIService) Complete(ctx context.Context, opts *drivers.CompleteOptions) (*drivers.CompleteResult, error) {
-	var ok bool
-	d.deadline, ok = ctx.Deadline()
-	if !ok {
-		return nil, errors.New("expected deadline")
-	}
-	return &drivers.CompleteResult{
-		Message: ai.NewTextCompletionMessage(ai.RoleAssistant, "done"),
-	}, nil
-}
-
-func TestCompleteUsesConfiguredLLMRequestTimeout(t *testing.T) {
-	rt, instanceID := testruntime.NewInstanceWithOptions(t, testruntime.InstanceOptions{
-		Variables: map[string]string{
-			"rill.ai.llm_request_timeout_seconds": "2",
-		},
-	})
-
-	s := newSession(t, rt, instanceID)
-	rec := &deadlineRecordingAIService{}
-	s.SetLLM(func(ctx context.Context) (drivers.AIService, func(), error) {
-		return rec, func() {}, nil
-	})
-
-	start := time.Now()
-	var out string
-	err := s.Complete(t.Context(), "test_completion", &out, &ai.CompleteOptions{
-		Messages: []*aiv1.CompletionMessage{
-			ai.NewTextCompletionMessage(ai.RoleUser, "hello"),
-		},
-	})
-	require.NoError(t, err)
-	require.WithinDuration(t, start.Add(2*time.Second), rec.deadline, time.Second)
-}
 
 // newSession sets up a new AI session for testing.
 // It is suitable for testing tool calls that do not require LLM completions.

--- a/runtime/drivers/registry.go
+++ b/runtime/drivers/registry.go
@@ -117,6 +117,10 @@ type InstanceConfig struct {
 	AlertsFastStreamingRefreshCron string `mapstructure:"rill.alerts.fast_streaming_refresh_cron"`
 	// ParserSkipUpdatesIfParseErrors short-circuits project parser reconciliation when parse errors exist.
 	ParserSkipUpdatesIfParseErrors bool `mapstructure:"rill.parser.skip_updates_if_parse_errors"`
+	// AICompletionTimeoutSeconds is the maximum duration of a full AI completion request, which may include multiple LLM requests and tool calls.
+	AICompletionTimeoutSeconds uint32 `mapstructure:"rill.ai.completion_timeout_seconds"`
+	// AILLMTimeoutSeconds is the maximum duration of a single LLM completion request.
+	AILLMTimeoutSeconds uint32 `mapstructure:"rill.ai.llm_timeout_seconds"`
 	// AIDefaultQueryLimit is the default row limit applied to AI tool queries when no limit is specified.
 	AIDefaultQueryLimit int64 `mapstructure:"rill.ai.default_query_limit"`
 	// AIMaxQueryLimit is the maximum row limit allowed for AI tool queries.
@@ -125,10 +129,6 @@ type InstanceConfig struct {
 	AIRequireTimeRange bool `mapstructure:"rill.ai.require_time_range"`
 	// AIMaxTimeRangeDays is the maximum time range allowed for AI tool queries, in days. If set to 0, there is no limit.
 	AIMaxTimeRangeDays int64 `mapstructure:"rill.ai.max_time_range_days"`
-	// AILLMRequestTimeoutSeconds is the maximum duration of a single LLM completion request.
-	AILLMRequestTimeoutSeconds uint32 `mapstructure:"rill.ai.llm_request_timeout_seconds"`
-	// AIChatTimeoutSeconds is the maximum duration of an end-to-end AI chat request.
-	AIChatTimeoutSeconds uint32 `mapstructure:"rill.ai.chat_timeout_seconds"`
 	// StrictResolverProps indicates whether to return an error when a resolver contains properties that are not recognized by the resolver implementation.
 	StrictResolverProps bool `mapstructure:"rill.strict_resolver_properties"`
 	// StrictModelProps indicates whether to return an error when a model contains unmapped properties.
@@ -206,11 +206,11 @@ func (i *Instance) Config() (InstanceConfig, error) {
 		MetricsNullFillingImplementation:     "pushdown",
 		AlertsDefaultStreamingRefreshCron:    "0 0 * * *",    // Every 24 hours
 		AlertsFastStreamingRefreshCron:       "*/10 * * * *", // Every 10 minutes
+		AILLMTimeoutSeconds:                  180,
+		AICompletionTimeoutSeconds:           300,
 		AIDefaultQueryLimit:                  25,
 		AIMaxQueryLimit:                      250,
 		AIRequireTimeRange:                   true,
-		AILLMRequestTimeoutSeconds:           180,
-		AIChatTimeoutSeconds:                 300,
 		ModelPartitionsWarnOnFailure:         i.Environment == "prod",
 		ModelTestsWarnOnFailure:              i.Environment == "prod",
 	}

--- a/runtime/drivers/registry.go
+++ b/runtime/drivers/registry.go
@@ -125,6 +125,10 @@ type InstanceConfig struct {
 	AIRequireTimeRange bool `mapstructure:"rill.ai.require_time_range"`
 	// AIMaxTimeRangeDays is the maximum time range allowed for AI tool queries, in days. If set to 0, there is no limit.
 	AIMaxTimeRangeDays int64 `mapstructure:"rill.ai.max_time_range_days"`
+	// AILLMRequestTimeoutSeconds is the maximum duration of a single LLM completion request.
+	AILLMRequestTimeoutSeconds uint32 `mapstructure:"rill.ai.llm_request_timeout_seconds"`
+	// AIChatTimeoutSeconds is the maximum duration of an end-to-end AI chat request.
+	AIChatTimeoutSeconds uint32 `mapstructure:"rill.ai.chat_timeout_seconds"`
 	// StrictResolverProps indicates whether to return an error when a resolver contains properties that are not recognized by the resolver implementation.
 	StrictResolverProps bool `mapstructure:"rill.strict_resolver_properties"`
 	// StrictModelProps indicates whether to return an error when a model contains unmapped properties.
@@ -205,6 +209,8 @@ func (i *Instance) Config() (InstanceConfig, error) {
 		AIDefaultQueryLimit:                  25,
 		AIMaxQueryLimit:                      250,
 		AIRequireTimeRange:                   true,
+		AILLMRequestTimeoutSeconds:           180,
+		AIChatTimeoutSeconds:                 300,
 		ModelPartitionsWarnOnFailure:         i.Environment == "prod",
 		ModelTestsWarnOnFailure:              i.Environment == "prod",
 	}

--- a/runtime/drivers/registry_test.go
+++ b/runtime/drivers/registry_test.go
@@ -80,3 +80,27 @@ func testRegistry(t *testing.T, reg drivers.RegistryStore) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(insts))
 }
+
+func TestInstanceConfigAITimeouts(t *testing.T) {
+	inst := &drivers.Instance{
+		Environment: "prod",
+		Variables: map[string]string{
+			"rill.ai.llm_request_timeout_seconds": "600",
+			"rill.ai.chat_timeout_seconds":        "600",
+		},
+	}
+
+	cfg, err := inst.Config()
+	require.NoError(t, err)
+	require.Equal(t, uint32(600), cfg.AILLMRequestTimeoutSeconds)
+	require.Equal(t, uint32(600), cfg.AIChatTimeoutSeconds)
+}
+
+func TestInstanceConfigAITimeoutDefaults(t *testing.T) {
+	inst := &drivers.Instance{Environment: "prod"}
+
+	cfg, err := inst.Config()
+	require.NoError(t, err)
+	require.Equal(t, uint32(180), cfg.AILLMRequestTimeoutSeconds)
+	require.Equal(t, uint32(300), cfg.AIChatTimeoutSeconds)
+}

--- a/runtime/drivers/registry_test.go
+++ b/runtime/drivers/registry_test.go
@@ -85,22 +85,13 @@ func TestInstanceConfigAITimeouts(t *testing.T) {
 	inst := &drivers.Instance{
 		Environment: "prod",
 		Variables: map[string]string{
-			"rill.ai.llm_request_timeout_seconds": "600",
-			"rill.ai.chat_timeout_seconds":        "600",
+			"rill.ai.completion_timeout_seconds": "600",
+			"rill.ai.llm_timeout_seconds":        "600",
 		},
 	}
 
 	cfg, err := inst.Config()
 	require.NoError(t, err)
-	require.Equal(t, uint32(600), cfg.AILLMRequestTimeoutSeconds)
-	require.Equal(t, uint32(600), cfg.AIChatTimeoutSeconds)
-}
-
-func TestInstanceConfigAITimeoutDefaults(t *testing.T) {
-	inst := &drivers.Instance{Environment: "prod"}
-
-	cfg, err := inst.Config()
-	require.NoError(t, err)
-	require.Equal(t, uint32(180), cfg.AILLMRequestTimeoutSeconds)
-	require.Equal(t, uint32(300), cfg.AIChatTimeoutSeconds)
+	require.Equal(t, uint32(600), cfg.AICompletionTimeoutSeconds)
+	require.Equal(t, uint32(600), cfg.AILLMTimeoutSeconds)
 }

--- a/runtime/server/chat.go
+++ b/runtime/server/chat.go
@@ -210,6 +210,14 @@ func (s *Server) Complete(ctx context.Context, req *runtimev1.CompleteRequest) (
 		return nil, ErrForbidden
 	}
 
+	// Apply configured timeout for AI completions
+	cfg, err := s.runtime.InstanceConfig(ctx, req.InstanceId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load instance config: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(cfg.AICompletionTimeoutSeconds)*time.Second)
+	defer cancel()
+
 	// Validate request - either prompt or feedback context must be provided
 	if req.Prompt == "" && req.FeedbackAgentContext == nil {
 		return nil, status.Error(codes.InvalidArgument, "prompt or feedback_agent_context must be provided")
@@ -238,10 +246,6 @@ func (s *Server) Complete(ctx context.Context, req *runtimev1.CompleteRequest) (
 			resErr = errors.Join(resErr, err)
 		}
 	}()
-
-	// Context
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 
 	// Prepare agent args if provided
 	var analystAgentArgs *ai.AnalystAgentArgs
@@ -321,6 +325,14 @@ func (s *Server) CompleteStreaming(req *runtimev1.CompleteStreamingRequest, stre
 		return ErrForbidden
 	}
 
+	// Apply configured timeout for AI completions
+	cfg, err := s.runtime.InstanceConfig(stream.Context(), req.InstanceId)
+	if err != nil {
+		return fmt.Errorf("failed to load instance config: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(stream.Context(), time.Duration(cfg.AICompletionTimeoutSeconds)*time.Second)
+	defer cancel()
+
 	// Validate request - either prompt or feedback context must be provided
 	if req.Prompt == "" && req.FeedbackAgentContext == nil {
 		return status.Error(codes.InvalidArgument, "prompt or feedback_agent_context must be provided")
@@ -334,7 +346,7 @@ func (s *Server) CompleteStreaming(req *runtimev1.CompleteStreamingRequest, stre
 	userAgent := fmt.Sprintf("rill/%s", version)
 
 	// Open the AI session
-	session, err := s.ai.Session(stream.Context(), &ai.SessionOptions{
+	session, err := s.ai.Session(ctx, &ai.SessionOptions{
 		InstanceID: req.InstanceId,
 		SessionID:  req.ConversationId,
 		Claims:     claims,
@@ -344,15 +356,11 @@ func (s *Server) CompleteStreaming(req *runtimev1.CompleteStreamingRequest, stre
 		return err
 	}
 	defer func() {
-		err := session.Flush(stream.Context())
+		err := session.Flush(ctx)
 		if err != nil {
 			resErr = errors.Join(resErr, err)
 		}
 	}()
-
-	// Context
-	ctx, cancel := context.WithCancel(stream.Context())
-	defer cancel()
 
 	// Open subscription for session messages and stream them to the client in the background
 	subCh := session.Subscribe()
@@ -447,8 +455,8 @@ func (s *Server) CompleteStreaming(req *runtimev1.CompleteStreamingRequest, stre
 // This is required as vanguard doesn't currently map streaming RPCs to SSE, so we register this handler manually override the behavior
 func (s *Server) CompleteStreamingHandler(w http.ResponseWriter, req *http.Request) {
 	// Observability
-	instanceID := req.PathValue("instance_id")
 	ctx := req.Context()
+	instanceID := req.PathValue("instance_id")
 	observability.AddRequestAttributes(ctx,
 		attribute.String("args.instance_id", instanceID),
 	)
@@ -462,10 +470,10 @@ func (s *Server) CompleteStreamingHandler(w http.ResponseWriter, req *http.Reque
 	// Apply configured timeout for AI chat
 	cfg, err := s.runtime.InstanceConfig(ctx, instanceID)
 	if err != nil {
-		http.Error(w, "failed to load instance config", http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("failed to load instance config: %v", err), http.StatusBadRequest)
 		return
 	}
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(cfg.AIChatTimeoutSeconds)*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(cfg.AICompletionTimeoutSeconds)*time.Second)
 	defer cancel()
 	req = req.WithContext(ctx)
 

--- a/runtime/server/chat.go
+++ b/runtime/server/chat.go
@@ -446,13 +446,9 @@ func (s *Server) CompleteStreaming(req *runtimev1.CompleteStreamingRequest, stre
 // CompleteStreamingHandler is a HTTP handler that wraps CompleteStreaming and maps it to SSE.
 // This is required as vanguard doesn't currently map streaming RPCs to SSE, so we register this handler manually override the behavior
 func (s *Server) CompleteStreamingHandler(w http.ResponseWriter, req *http.Request) {
-	// Add timeout for AI completion
-	ctx, cancel := context.WithTimeout(req.Context(), time.Minute*5)
-	defer cancel()
-	req = req.WithContext(ctx) // Replace request context with the timed context
-
 	// Observability
 	instanceID := req.PathValue("instance_id")
+	ctx := req.Context()
 	observability.AddRequestAttributes(ctx,
 		attribute.String("args.instance_id", instanceID),
 	)
@@ -462,6 +458,16 @@ func (s *Server) CompleteStreamingHandler(w http.ResponseWriter, req *http.Reque
 		http.Error(w, "action not allowed", http.StatusUnauthorized)
 		return
 	}
+
+	// Apply configured timeout for AI chat
+	cfg, err := s.runtime.InstanceConfig(ctx, instanceID)
+	if err != nil {
+		http.Error(w, "failed to load instance config", http.StatusInternalServerError)
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(cfg.AIChatTimeoutSeconds)*time.Second)
+	defer cancel()
+	req = req.WithContext(ctx)
 
 	// Build request. Note we try to support both GET and POST.
 	completeReq := &runtimev1.CompleteStreamingRequest{}

--- a/runtime/server/server.go
+++ b/runtime/server/server.go
@@ -298,7 +298,7 @@ func timeoutSelector(fullMethodName string) time.Duration {
 	}
 
 	if fullMethodName == runtimev1.RuntimeService_Complete_FullMethodName || fullMethodName == runtimev1.RuntimeService_CompleteStreaming_FullMethodName {
-		return time.Minute * 10
+		return time.Minute * 59 // Hard cap. Actual timeout is configured using config variable rill.ai.completion_timeout_seconds.
 	}
 
 	if fullMethodName == runtimev1.RuntimeService_Health_FullMethodName || fullMethodName == runtimev1.RuntimeService_InstanceHealth_FullMethodName {


### PR DESCRIPTION
Adds new config variables for AI timeouts:
```
# Full tool call loop
rill.ai.completion_timeout_seconds

# Single LLM call
rill.ai.llm_timeout_seconds
```

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!