### PR TITLE
fix: contain Big Number and Time Series Chart error states

### DIFF
--- a/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
@@ -2,6 +2,7 @@
   import WithTween from "@rilldata/web-common/components/data-graphic/functional-components/WithTween.svelte";
   import PercentageChange from "@rilldata/web-common/components/data-types/PercentageChange.svelte";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
+  import InlineErrorIndicator from "@rilldata/web-common/features/dashboards/errors/InlineErrorIndicator.svelte";
   import { ExploreStateURLParams } from "@rilldata/web-common/features/dashboards/url-state/url-params";
   import DelayedSpinner from "@rilldata/web-common/features/entity-management/DelayedSpinner.svelte";
   import { EntityStatus } from "@rilldata/web-common/features/entity-management/types";
@@ -12,20 +13,20 @@
   import { formatMeasurePercentageDifference } from "@rilldata/web-common/lib/number-formatting/percentage-formatter";
   import { numberPartsToString } from "@rilldata/web-common/lib/number-formatting/utils/number-parts-utils";
   import {
-    type MetricsViewSpecMeasure,
     createQueryServiceMetricsViewAggregation,
+    type MetricsViewSpecMeasure,
     type V1Expression,
   } from "@rilldata/web-common/runtime-client";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
-  import { cellInspectorStore } from "../stores/cell-inspector-store";
+  import { keepPreviousData } from "@tanstack/svelte-query";
   import {
     crossfade,
     fly,
     type CrossfadeParams,
     type FlyParams,
   } from "svelte/transition";
+  import { cellInspectorStore } from "../stores/cell-inspector-store";
   import BigNumberTooltipContent from "./BigNumberTooltipContent.svelte";
-  import { keepPreviousData } from "@tanstack/svelte-query";
 
   export let measure: MetricsViewSpecMeasure;
   export let withTimeseries = true;
@@ -200,7 +201,7 @@
 </script>
 
 <Tooltip
-  suppress={suppressTooltip}
+  suppress={suppressTooltip || isError}
   distance={8}
   location="right"
   alignment="start"
@@ -321,12 +322,8 @@
           </div>
         {/if}
       {:else if status === EntityStatus.Error}
-        <div class="text-xs pt-1">
-          {#if errorMessage}
-            Error: {errorMessage}
-          {:else}
-            Error fetching totals data
-          {/if}
+        <div class="pt-1">
+          <InlineErrorIndicator message={errorMessage} />
         </div>
       {:else if status === EntityStatus.Running}
         <div

--- a/web-common/src/features/dashboards/errors/InlineErrorIndicator.svelte
+++ b/web-common/src/features/dashboards/errors/InlineErrorIndicator.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import * as Tooltip from "@rilldata/web-common/components/tooltip-v2";
+  import { copyToClipboard } from "@rilldata/web-common/lib/actions/copy-to-clipboard";
+  import { AlertTriangleIcon, Copy } from "lucide-svelte";
+
+  export let message: string | undefined;
+  export let compact = false;
+</script>
+
+<Tooltip.Root>
+  <Tooltip.Trigger>
+    {#snippet child({ props })}
+      <button
+        {...props}
+        type="button"
+        class="inline-flex items-center gap-1 text-fg-secondary text-xs"
+        aria-label="An error occurred. Hover for details."
+      >
+        <AlertTriangleIcon class="text-red-500" size="16px" />
+        {#if !compact}
+          <span>An error occurred</span>
+        {/if}
+      </button>
+    {/snippet}
+  </Tooltip.Trigger>
+
+  <Tooltip.Content side="top" sideOffset={6} class="max-w-md p-0">
+    <div class="flex items-start gap-2 p-2">
+      <div
+        class="text-fg-inverse whitespace-pre-wrap break-words max-h-60 overflow-auto text-xs font-mono"
+      >
+        {message || "No additional details available."}
+      </div>
+      {#if message}
+        <button
+          type="button"
+          class="shrink-0 p-1 rounded hover:bg-white/10 transition-colors text-fg-inverse"
+          on:click={() => copyToClipboard(message, "Copied error to clipboard")}
+          title="Copy error to clipboard"
+          aria-label="Copy error to clipboard"
+        >
+          <Copy size="14px" />
+        </button>
+      {/if}
+    </div>
+  </Tooltip.Content>
+</Tooltip.Root>

--- a/web-common/src/features/dashboards/time-series/measure-chart/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/measure-chart/MeasureChart.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import InlineErrorIndicator from "@rilldata/web-common/features/dashboards/errors/InlineErrorIndicator.svelte";
   import TDDMeasureChart from "@rilldata/web-common/features/dashboards/time-dimension-details/charts/TDDChart.svelte";
   import { TDDChart } from "@rilldata/web-common/features/dashboards/time-dimension-details/types";
   import Spinner from "@rilldata/web-common/features/entity-management/Spinner.svelte";
@@ -323,10 +324,10 @@
     </div>
   {:else if isError}
     <div
-      class="flex items-center justify-center text-red-500 text-xs h-[145px]"
+      class="flex items-center justify-center h-[145px]"
       class:h-[245px]={showTimeDimensionDetail}
     >
-      {error ?? "Error loading data"}
+      <InlineErrorIndicator message={error} />
     </div>
   {:else if usesVegaChart && data.length > 0}
     <div class="w-full" style:height="{height}px">


### PR DESCRIPTION
- Replaces inline raw error output in Big Number and Measure chart components with a warning icon + "An error occurred" label.
- Full error message and a copy-to-clipboard button are revealed on hover via a new shared InlineErrorIndicator component.

Closes https://linear.app/rilldata/issue/APP-887/contain-the-big-number-and-time-series-chart-error-states-to-be-behind

<img width="598" height="235" alt="Screenshot 2026-05-21 at 3 20 09 PM" src="https://github.com/user-attachments/assets/664ea122-4109-455a-b195-c6485936aac0" />

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
