### PR TITLE
Explicit `ReloadConfig` when unhibernating deployments for static runtimes

### DIFF
--- a/admin/deployments.go
+++ b/admin/deployments.go
@@ -251,7 +251,11 @@ func (s *Service) StartDeploymentInner(ctx context.Context, depl *database.Deplo
 		return err
 	}
 	if err == nil {
-		// Instance already exists. We can return.
+		// Instance already exists (resumed from hibernation). Call ReloadConfig to pick up any variable or config changes that occurred while stopped.
+		_, err = rt.ReloadConfig(ctx, &runtimev1.ReloadConfigRequest{InstanceId: instanceID})
+		if err != nil {
+			return err
+		}
 		return nil
 	}
 


### PR DESCRIPTION
`ReloadConfig` gets triggered on runtime restart and periodically. For static runtimes need to call `ReloadConfig` explicitly when unhibernating.