### PR TITLE
Increase default AI timeouts

### DIFF
--- a/runtime/drivers/registry.go
+++ b/runtime/drivers/registry.go
@@ -206,8 +206,8 @@ func (i *Instance) Config() (InstanceConfig, error) {
 		MetricsNullFillingImplementation:     "pushdown",
 		AlertsDefaultStreamingRefreshCron:    "0 0 * * *",    // Every 24 hours
 		AlertsFastStreamingRefreshCron:       "*/10 * * * *", // Every 10 minutes
-		AILLMTimeoutSeconds:                  180,
-		AICompletionTimeoutSeconds:           300,
+		AICompletionTimeoutSeconds:           60 * 10,        // 10 minutes
+		AILLMTimeoutSeconds:                  60 * 4,         // 4 minutes
 		AIDefaultQueryLimit:                  25,
 		AIMaxQueryLimit:                      250,
 		AIRequireTimeRange:                   true,


### PR DESCRIPTION
- Bumps `AICompletionTimeoutSeconds` from 5 to 10 minutes and `AILLMTimeoutSeconds` from 3 to 4 minutes to reduce premature timeouts on long-running AI requests.
