### PR TITLE
docs: update iframe embedding to use admin role for service tokens

### DIFF
--- a/docs/docs/developers/embed/iframe.md
+++ b/docs/docs/developers/embed/iframe.md
@@ -42,14 +42,18 @@ sequenceDiagram
 Use the Rill CLI to create a service token for your current organization using the following command:
 ```bash
 # Create with organization role
-rill service create <service_name> --org-role viewer
+rill service create <service_name> --org-role admin
 
 # Or create with project-specific role
-rill service create <service_name> --project <project_name> --project-role viewer
+rill service create <service_name> --project <project_name> --project-role admin
 ```
 
 :::info
 For comprehensive documentation on service tokens, including roles, custom attributes, and management, see [Service Tokens](/guide/administration/access-tokens/service-tokens). Also see the [CLI reference](/reference/cli/service) for command details.
+:::
+
+:::note Why is the admin role required?
+Service tokens used for iframe embedding require the `admin` role to access the deployment management APIs that generate iframe URLs. Using the `viewer` role will result in a 403 permission error.
 :::
 
 :::caution


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Users were getting 403 errors ("does not have permission to manage deployment") when using `viewer` role for service tokens in iframe embedding. The `admin` role is required to access deployment management APIs that generate iframe URLs.

## Changes
- Changed `--org-role` from `viewer` to `admin`
- Changed `--project-role` from `viewer` to `admin`
- Added an informational note explaining why the admin role is required

**Checklist:**
- [x] Covered by tests (N/A - documentation only change)
- [x] Ran it and it works as intended (N/A - documentation only change)
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes (PM-147)
- [x] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue (this PR is the docs update)
- [ ] Intend to cherry-pick into the release branch
- [x] I'm proud of this work!
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [PM-147](https://linear.app/rilldata/issue/PM-147/update-docs-for-embedded-iframe-to-use-role-admin)

<div><a href="https://cursor.com/agents/bc-d57bba93-e28b-4c0f-8f9c-90c25fc46f42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d57bba93-e28b-4c0f-8f9c-90c25fc46f42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

