### PR TITLE
fix: prevent canvas component loss when saving default filter

### DIFF
--- a/web-common/src/features/canvas/stores/canvas-entity.ts
+++ b/web-common/src/features/canvas/stores/canvas-entity.ts
@@ -355,14 +355,47 @@ export class CanvasEntity {
       setTimeout(resolve, 100);
     });
 
-    const yaml = get(this.parsedContent);
-    const filterMap = new YAMLMap();
-
     const pinnedFilters = get(this.filterManager.pinnedFilterKeysStore);
-
     const genericPinnedKeys = Array.from(pinnedFilters).map(
       (f) => f.split("::")[1],
     );
+    const timeRange = get(this.timeManager.state.rangeStore);
+    const comparisonOn = get(this.timeManager.state.showTimeComparisonStore);
+
+    const metricsViewFilters = get(this.filterManager.metricsViewFilters);
+    const filterNames = Array.from(metricsViewFilters.keys());
+    const promises = Array.from(metricsViewFilters.values()).map((filters) => {
+      const parsed = get(filters.parsed);
+      return queryClient.fetchQuery({
+        queryKey: [
+          "resolve-metrics-view-filter-expression",
+          this.instanceId,
+          parsed.where,
+        ],
+        queryFn: () =>
+          queryServiceConvertExpressionToMetricsSQL(this.client, {
+            expression: parsed.where as any,
+          }),
+      });
+    });
+
+    const responses = await Promise.all(promises);
+
+    const filterMap = new YAMLMap();
+    responses.forEach((response, index) => {
+      if (!response.sql) return;
+      filterMap.add({
+        key: filterNames[index],
+        value: response.sql,
+      });
+    });
+
+    // Read the YAML document AFTER the async work so any component edits
+    // that landed in editorContent during the await are preserved. Reading
+    // before the await captures a stale Document whose round-trip back to
+    // disk would drop those components. The mutate-and-write below runs
+    // synchronously to keep the read-modify-write atomic.
+    const yaml = get(this.parsedContent);
 
     if (genericPinnedKeys.length > 0) {
       yaml.setIn(["filters", "pinned"], genericPinnedKeys);
@@ -385,9 +418,6 @@ export class CanvasEntity {
       }
     }
 
-    const timeRange = get(this.timeManager.state.rangeStore);
-    const comparisonOn = get(this.timeManager.state.showTimeComparisonStore);
-
     if (timeRange) {
       yaml.setIn(["defaults", "time_range"], timeRange);
     }
@@ -401,37 +431,6 @@ export class CanvasEntity {
         // no-op
       }
     }
-
-    const promises = get(this.filterManager.metricsViewFilters)
-      .entries()
-      .map(([_, filters]) => {
-        const parsed = get(filters.parsed);
-
-        return queryClient.fetchQuery({
-          queryKey: [
-            "resolve-metrics-view-filter-expression",
-            this.instanceId,
-            parsed.where,
-          ],
-          queryFn: () =>
-            queryServiceConvertExpressionToMetricsSQL(this.client, {
-              expression: parsed.where as any,
-            }),
-        });
-      });
-
-    const responses = await Promise.all(promises);
-
-    responses.forEach((response, index) => {
-      const name = Array.from(
-        get(this.filterManager.metricsViewFilters).keys(),
-      )[index];
-      if (!response.sql) return;
-      filterMap.add({
-        key: name,
-        value: response.sql,
-      });
-    });
 
     yaml.setIn(["defaults", "filters"], filterMap);
 


### PR DESCRIPTION
### Root cause

`CanvasEntity.saveDefaultFilters` (`web-common/src/features/canvas/stores/canvas-entity.ts`) did a **read → await → mutate → write** on the canvas YAML, capturing the `Document` reference before the await:

1. `const yaml = get(this.parsedContent)` — `parsedContent` is a `derived` store over `editorContent`; each `editorContent` change emits a fresh parsed `Document`. The local `yaml` only points at one snapshot.
2. `await Promise.all(...)` — one `queryServiceConvertExpressionToMetricsSQL` round-trip per metrics view in scope (100–500 ms typical).
3. `yaml.setIn(["defaults", "filters"], filterMap)` then `yaml.toString()` then `updateEditorContent(newContent, false, true)` — writes the **pre-await** document back, immediately, via `runtimeServicePutFile`.

Anything that mutated `editorContent` during the await window was stranded on a newer `Document` that the saver never saw:

- **Grid edits.** `CanvasBuilder.updateContents` → `updateEditorContent(..., false, true)` runs `saveContent` immediately, not debounced. A drag/drop or resize finishing right around the click writes a newer YAML to disk.
- **File-watch echo.** Each save triggers `FILE_EVENT_WRITE` from the runtime; `file-invalidators.ts` re-fetches the file and, when `fileUntouched`, pushes the fresh blob into `editorContent`, re-deriving `parsedContent`.

When the stale YAML hit disk, the runtime reconciled a truncated canvas spec. `specStore.subscribe` → `processSpec` → `processRows` then deleted every component name no longer present in `rows[].items[].component` from the in-memory `componentsStore` — which is what the user perceived as "components disappeared."

The pre-existing `setTimeout(100)` at the top of the method is unrelated (it waits for filter-input blur) and does nothing to make the read-modify-write atomic.

### Fix

- Collect pinned/time/comparison inputs and kick off `Promise.all` first.
- Read `parsedContent` **after** the await, then apply all mutations and write in a single synchronous block.
- `clearDefaultFilters` was already synchronous and is unchanged.
- Behavior on disk is unchanged for the no-concurrent-edit case: only `filters.pinned` and `defaults.*` are touched; `rows`/`items` stay byte-identical.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*