### PR TITLE
move credit alerts to trial start time

### DIFF
--- a/admin/billing.go
+++ b/admin/billing.go
@@ -45,11 +45,6 @@ func (s *Service) InitOrganizationBilling(ctx context.Context, org *database.Org
 
 	org.BillingCustomerID = bc.ID
 
-	// Register credit-balance alerts on the customer; safe to call before any subscription / credit grant exists.
-	if err := s.Biller.CreateCustomerCreditAlerts(ctx, org.BillingCustomerID, billing.CreditsCurrency, billing.CreditTrialLowBalanceThreshold); err != nil {
-		return nil, fmt.Errorf("failed to register credit balance alerts: %w", err)
-	}
-
 	org, err = s.DB.UpdateOrganization(ctx, org.ID, &database.UpdateOrganizationOptions{
 		Name:                                org.Name,
 		DisplayName:                         org.DisplayName,
@@ -157,10 +152,6 @@ func (s *Service) RepairOrganizationBilling(ctx context.Context, org *database.O
 		}
 	}
 
-	if err := s.Biller.CreateCustomerCreditAlerts(ctx, org.BillingCustomerID, billing.CreditsCurrency, billing.CreditTrialLowBalanceThreshold); err != nil {
-		return nil, nil, fmt.Errorf("failed to register credit balance alerts: %w", err)
-	}
-
 	// update billing and payment customer id
 	org, err = s.DB.UpdateOrganization(ctx, org.ID, &database.UpdateOrganizationOptions{
 		Name:                                org.Name,
@@ -263,6 +254,11 @@ func (s *Service) StartCreditTrial(ctx context.Context, org *database.Organizati
 	plan, err := s.Biller.GetPlanByType(ctx, billing.FreePlanType)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get credit trial plan: %w", err)
+	}
+
+	// Register the credit-balance alerts on the customer.
+	if err := s.Biller.CreateCustomerCreditAlerts(ctx, org.BillingCustomerID, billing.CreditsCurrency, billing.CreditTrialLowBalanceThreshold); err != nil {
+		return nil, nil, fmt.Errorf("failed to register customer credit alerts: %w", err)
 	}
 
 	sub, err := s.Biller.GetActiveSubscription(ctx, org.BillingCustomerID)

--- a/admin/billing/orb.go
+++ b/admin/billing/orb.go
@@ -223,24 +223,43 @@ func (o *Orb) DeleteCustomer(ctx context.Context, customerID string) error {
 }
 
 // CreateCustomerCreditAlerts registers a credit_balance_dropped alert at the given threshold and a credit_balance_depleted alert for the customer in Orb. Required for Orb to deliver the corresponding webhook events.
+// Idempotent: if the alerts already exist for the customer/currency they are not re-created (Orb throws an error if the alert already exits).
 func (o *Orb) CreateCustomerCreditAlerts(ctx context.Context, customerID, currency string, lowThreshold float64) error {
-	_, err := o.client.Alerts.NewForExternalCustomer(ctx, customerID, orb.AlertNewForExternalCustomerParams{
-		Currency: orb.String(currency),
-		Type:     orb.F(orb.AlertNewForExternalCustomerParamsTypeCreditBalanceDropped),
-		Thresholds: orb.F([]orb.ThresholdParam{
-			{Value: orb.F(lowThreshold)},
-		}),
+	existing := make(map[orb.AlertType]bool)
+	iter := o.client.Alerts.ListAutoPaging(ctx, orb.AlertListParams{
+		ExternalCustomerID: orb.String(customerID),
 	})
-	if err != nil {
-		return fmt.Errorf("creating credit_balance_dropped alert: %w", err)
+	for iter.Next() {
+		a := iter.Current()
+		if a.Currency == currency {
+			existing[a.Type] = true
+		}
+	}
+	if err := iter.Err(); err != nil {
+		return fmt.Errorf("listing customer alerts: %w", err)
 	}
 
-	_, err = o.client.Alerts.NewForExternalCustomer(ctx, customerID, orb.AlertNewForExternalCustomerParams{
-		Currency: orb.String(currency),
-		Type:     orb.F(orb.AlertNewForExternalCustomerParamsTypeCreditBalanceDepleted),
-	})
-	if err != nil {
-		return fmt.Errorf("creating credit_balance_depleted alert: %w", err)
+	if !existing[orb.AlertTypeCreditBalanceDropped] {
+		_, err := o.client.Alerts.NewForExternalCustomer(ctx, customerID, orb.AlertNewForExternalCustomerParams{
+			Currency: orb.String(currency),
+			Type:     orb.F(orb.AlertNewForExternalCustomerParamsTypeCreditBalanceDropped),
+			Thresholds: orb.F([]orb.ThresholdParam{
+				{Value: orb.F(lowThreshold)},
+			}),
+		})
+		if err != nil {
+			return fmt.Errorf("creating credit_balance_dropped alert: %w", err)
+		}
+	}
+
+	if !existing[orb.AlertTypeCreditBalanceDepleted] {
+		_, err := o.client.Alerts.NewForExternalCustomer(ctx, customerID, orb.AlertNewForExternalCustomerParams{
+			Currency: orb.String(currency),
+			Type:     orb.F(orb.AlertNewForExternalCustomerParamsTypeCreditBalanceDepleted),
+		})
+		if err != nil {
+			return fmt.Errorf("creating credit_balance_depleted alert: %w", err)
+		}
 	}
 
 	return nil

--- a/admin/server/billing.go
+++ b/admin/server/billing.go
@@ -706,26 +706,22 @@ func (s *Server) SudoGrantTrialCredits(ctx context.Context, req *adminv1.SudoGra
 		return &adminv1.SudoGrantTrialCreditsResponse{GrantedUsd: req.AmountUsd}, nil
 	}
 
-	// Post-depletion: trial sub was cancelled at depletion. Recreate it so usage reports resume and decrement the newly-granted balance.
-	subCancelled, err := s.admin.DB.FindBillingIssueByTypeForOrg(ctx, org.ID, database.BillingIssueTypeSubscriptionCancelled)
-	if err != nil && !errors.Is(err, database.ErrNotFound) {
-		return nil, err
-	}
-
 	plan, err := s.admin.Biller.GetPlanByType(ctx, billing.FreePlanType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get credit trial plan: %w", err)
 	}
 
+	// there should not be any active subscription
 	sub, err := s.admin.Biller.GetActiveSubscription(ctx, org.BillingCustomerID)
 	if err != nil && !errors.Is(err, billing.ErrNotFound) {
 		return nil, fmt.Errorf("failed to get active subscription: %w", err)
 	}
-	if sub == nil {
-		sub, err = s.admin.Biller.CreateSubscription(ctx, org.BillingCustomerID, plan)
-		if err != nil {
-			return nil, fmt.Errorf("failed to recreate trial subscription: %w", err)
-		}
+	if sub != nil {
+		return nil, fmt.Errorf("unexpected active subscription found for org on depleted trial")
+	}
+	sub, err = s.admin.Biller.CreateSubscription(ctx, org.BillingCustomerID, plan)
+	if err != nil {
+		return nil, fmt.Errorf("failed to recreate trial subscription: %w", err)
 	}
 
 	txCtx, tx, err := s.admin.DB.NewTx(ctx, false)
@@ -734,13 +730,13 @@ func (s *Server) SudoGrantTrialCredits(ctx context.Context, req *adminv1.SudoGra
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	if err := s.admin.DB.DeleteBillingIssue(txCtx, depleted.ID); err != nil {
-		return nil, fmt.Errorf("failed to delete trial-credits-depleted issue: %w", err)
+	err = s.admin.CleanupSubscriptionBillingIssues(txCtx, org.ID)
+	if err != nil {
+		return nil, err
 	}
-	if subCancelled != nil {
-		if err := s.admin.DB.DeleteBillingIssue(txCtx, subCancelled.ID); err != nil {
-			return nil, fmt.Errorf("failed to delete subscription-cancelled issue: %w", err)
-		}
+	err = s.admin.CleanupTrialBillingIssues(txCtx, org.ID)
+	if err != nil {
+		return nil, err
 	}
 
 	if _, err := s.admin.DB.UpsertBillingIssue(txCtx, &database.UpsertBillingIssueOptions{


### PR DESCRIPTION
This ensures that alert creation is not missed on existing orgs whose trial not started yet but org has already been created.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
