### PR TITLE
index on session_id, delete expired ai sessions async in batches

### DIFF
--- a/runtime/drivers/sqlite/ai_sessions_cleanup.go
+++ b/runtime/drivers/sqlite/ai_sessions_cleanup.go
@@ -1,0 +1,108 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// TTL for AI sessions; sessions with no messages newer than this are deleted by deleteExpiredAISessionsLoop.
+var aiSessionTTL = 90 * 24 * time.Hour // 3 months
+
+// aiSessionDeleteBatchSize bounds how many sessions are deleted per transaction.
+// Each batch holds the sqlite write lock briefly, so other registry operations can interleave.
+const aiSessionDeleteBatchSize = 200
+
+// deleteExpiredAISessionsLoop runs deleteExpiredAISessions once at startup and then daily.
+// It runs in the background so it doesn't block Migrate (and therefore runtime startup).
+func (c *connection) deleteExpiredAISessionsLoop() {
+	for {
+		if err := c.deleteExpiredAISessions(c.ctx); err != nil && c.ctx.Err() == nil {
+			c.logger.Error("sqlite: failed to delete expired AI sessions", zap.Error(err))
+		}
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-time.After(24 * time.Hour):
+		}
+	}
+}
+
+// deleteExpiredAISessions deletes AI sessions that have no messages newer than aiSessionTTL.
+// It snapshots expired session IDs first, then deletes messages and sessions in batched transactions to bound lock-hold time.
+func (c *connection) deleteExpiredAISessions(ctx context.Context) error {
+	cutoff := time.Now().UTC().Add(-aiSessionTTL)
+
+	ids, err := c.expiredAISessionIDs(ctx, cutoff)
+	if err != nil {
+		return err
+	}
+
+	// Delete in batches; each batch atomically deletes a session's messages and the session itself.
+	for start := 0; start < len(ids); start += aiSessionDeleteBatchSize {
+		end := start + aiSessionDeleteBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		if err := c.deleteAISessionBatch(ctx, ids[start:end]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// expiredAISessionIDs returns the IDs of AI sessions older than cutoff with no messages newer than cutoff.
+// It does a single full scan of ai_messages (filtered by created_on >= cutoff) and a single scan of ai_sessions.
+func (c *connection) expiredAISessionIDs(ctx context.Context, cutoff time.Time) ([]string, error) {
+	rows, err := c.db.QueryContext(ctx, `
+		SELECT id FROM ai_sessions
+		WHERE created_on < ?
+		  AND id NOT IN (SELECT session_id FROM ai_messages WHERE created_on >= ?)
+	`, cutoff, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query expired AI sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("failed to scan expired AI session id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read expired AI sessions: %w", err)
+	}
+	return ids, nil
+}
+
+func (c *connection) deleteAISessionBatch(ctx context.Context, ids []string) error {
+	placeholders := strings.Repeat("?,", len(ids)-1) + "?"
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin AI session cleanup transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM ai_messages WHERE session_id IN (%s)`, placeholders), args...); err != nil {
+		return fmt.Errorf("failed to delete expired AI messages: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM ai_sessions WHERE id IN (%s)`, placeholders), args...); err != nil {
+		return fmt.Errorf("failed to delete expired AI sessions: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit AI session cleanup: %w", err)
+	}
+	return nil
+}

--- a/runtime/drivers/sqlite/migrate.go
+++ b/runtime/drivers/sqlite/migrate.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 // Embed migrations directory in the binary
@@ -18,7 +20,7 @@ var migrationsFS embed.FS
 // Name of the table that tracks migrations.
 var migrationVersionTable = "runtime_migration_version"
 
-// TTL for AI sessions; sessions with no messages newer than this are deleted on startup.
+// TTL for AI sessions; sessions with no messages newer than this are deleted by deleteExpiredAISessionsLoop.
 var aiSessionTTL = 90 * 24 * time.Hour // 3 months
 
 // Migrate implements drivers.Connection.
@@ -74,13 +76,6 @@ func (c *connection) Migrate(_ context.Context) (err error) {
 		if err != nil {
 			return err
 		}
-	}
-
-	// Apply TTL to AI sessions: delete sessions with no messages newer than aiSessionTTL.
-	// Messages are deleted explicitly before sessions to avoid reliance on ON DELETE CASCADE.
-	err = c.deleteExpiredAISessions(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to delete expired AI sessions: %w", err)
 	}
 
 	return nil
@@ -146,13 +141,33 @@ func migrationFilenameToVersion(name string) (int, error) {
 	return strconv.Atoi(strings.TrimSuffix(name, ".sql"))
 }
 
+// deleteExpiredAISessionsLoop runs deleteExpiredAISessions once at startup and then daily.
+// It runs in the background so it doesn't block Migrate (and therefore runtime startup).
+func (c *connection) deleteExpiredAISessionsLoop() {
+	for {
+		if err := c.deleteExpiredAISessions(c.ctx); err != nil && c.ctx.Err() == nil {
+			c.logger.Error("sqlite: failed to delete expired AI sessions", zap.Error(err))
+		}
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-time.After(24 * time.Hour):
+		}
+	}
+}
+
+// aiSessionDeleteBatchSize bounds how many sessions are deleted per transaction.
+// Each batch holds the sqlite write lock briefly, so other registry operations can interleave.
+const aiSessionDeleteBatchSize = 500
+
 // deleteExpiredAISessions deletes AI sessions that have no messages newer than aiSessionTTL.
-// Messages are deleted explicitly before the sessions to avoid reliance on ON DELETE CASCADE.
+// It snapshots expired session IDs first, then deletes messages and sessions in batched transactions
+// to bound lock-hold time and to avoid a race where a resurrected session loses its old messages.
 func (c *connection) deleteExpiredAISessions(ctx context.Context) error {
 	cutoff := time.Now().UTC().Add(-aiSessionTTL)
 
-	// Identify expired sessions: those older than the cutoff with no messages newer than the cutoff.
-	expiredSessionsQuery := `
+	// Snapshot expired session IDs: sessions older than the cutoff with no messages newer than the cutoff.
+	rows, err := c.db.QueryContext(ctx, `
 		SELECT id FROM ai_sessions
 		WHERE ai_sessions.created_on < ?
 		  AND NOT EXISTS (
@@ -160,17 +175,61 @@ func (c *connection) deleteExpiredAISessions(ctx context.Context) error {
 			WHERE ai_messages.session_id = ai_sessions.id
 			  AND ai_messages.created_on >= ?
 		)
-	`
-
-	// Delete messages first, then sessions.
-	_, err := c.db.ExecContext(ctx, fmt.Sprintf(`DELETE FROM ai_messages WHERE session_id IN (%s)`, expiredSessionsQuery), cutoff, cutoff)
+	`, cutoff, cutoff)
 	if err != nil {
+		return fmt.Errorf("failed to query expired AI sessions: %w", err)
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return fmt.Errorf("failed to scan expired AI session id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return fmt.Errorf("failed to read expired AI sessions: %w", err)
+	}
+	rows.Close()
+
+	// Delete in batches; each batch atomically deletes a session's messages and the session itself,
+	// so a session resurrected between statements can't end up orphaned with its messages gone.
+	for start := 0; start < len(ids); start += aiSessionDeleteBatchSize {
+		end := start + aiSessionDeleteBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		if err := c.deleteAISessionBatch(ctx, ids[start:end]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *connection) deleteAISessionBatch(ctx context.Context, ids []string) error {
+	placeholders := strings.Repeat("?,", len(ids)-1) + "?"
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin AI session cleanup transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM ai_messages WHERE session_id IN (%s)`, placeholders), args...); err != nil {
 		return fmt.Errorf("failed to delete expired AI messages: %w", err)
 	}
-	_, err = c.db.ExecContext(ctx, fmt.Sprintf(`DELETE FROM ai_sessions WHERE id IN (%s)`, expiredSessionsQuery), cutoff, cutoff)
-	if err != nil {
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM ai_sessions WHERE id IN (%s)`, placeholders), args...); err != nil {
 		return fmt.Errorf("failed to delete expired AI sessions: %w", err)
 	}
-
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit AI session cleanup: %w", err)
+	}
 	return nil
 }

--- a/runtime/drivers/sqlite/migrate.go
+++ b/runtime/drivers/sqlite/migrate.go
@@ -7,9 +7,6 @@ import (
 	"path"
 	"strconv"
 	"strings"
-	"time"
-
-	"go.uber.org/zap"
 )
 
 // Embed migrations directory in the binary
@@ -19,13 +16,6 @@ var migrationsFS embed.FS
 
 // Name of the table that tracks migrations.
 var migrationVersionTable = "runtime_migration_version"
-
-// TTL for AI sessions; sessions with no messages newer than this are deleted by deleteExpiredAISessionsLoop.
-var aiSessionTTL = 90 * 24 * time.Hour // 3 months
-
-// aiSessionDeleteBatchSize bounds how many sessions are deleted per transaction.
-// Each batch holds the sqlite write lock briefly, so other registry operations can interleave.
-const aiSessionDeleteBatchSize = 200
 
 // Migrate implements drivers.Connection.
 // Migrate for SQLite may not be safe for concurrent use.
@@ -143,91 +133,4 @@ func (c *connection) MigrationStatus(_ context.Context) (current, desired int, e
 
 func migrationFilenameToVersion(name string) (int, error) {
 	return strconv.Atoi(strings.TrimSuffix(name, ".sql"))
-}
-
-// deleteExpiredAISessionsLoop runs deleteExpiredAISessions once at startup and then daily.
-// It runs in the background so it doesn't block Migrate (and therefore runtime startup).
-func (c *connection) deleteExpiredAISessionsLoop() {
-	for {
-		if err := c.deleteExpiredAISessions(c.ctx); err != nil && c.ctx.Err() == nil {
-			c.logger.Error("sqlite: failed to delete expired AI sessions", zap.Error(err))
-		}
-		select {
-		case <-c.ctx.Done():
-			return
-		case <-time.After(24 * time.Hour):
-		}
-	}
-}
-
-// deleteExpiredAISessions deletes AI sessions that have no messages newer than aiSessionTTL.
-// It snapshots expired session IDs first, then deletes messages and sessions in batched transactions to bound lock-hold time.
-func (c *connection) deleteExpiredAISessions(ctx context.Context) error {
-	cutoff := time.Now().UTC().Add(-aiSessionTTL)
-
-	// Snapshot expired session IDs: sessions older than the cutoff with no messages newer than the cutoff.
-	rows, err := c.db.QueryContext(ctx, `
-		SELECT id FROM ai_sessions
-		WHERE ai_sessions.created_on < ?
-		  AND NOT EXISTS (
-			SELECT 1 FROM ai_messages
-			WHERE ai_messages.session_id = ai_sessions.id
-			  AND ai_messages.created_on >= ?
-		)
-	`, cutoff, cutoff)
-	if err != nil {
-		return fmt.Errorf("failed to query expired AI sessions: %w", err)
-	}
-	var ids []string
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			rows.Close()
-			return fmt.Errorf("failed to scan expired AI session id: %w", err)
-		}
-		ids = append(ids, id)
-	}
-	if err := rows.Err(); err != nil {
-		rows.Close()
-		return fmt.Errorf("failed to read expired AI sessions: %w", err)
-	}
-	rows.Close()
-
-	// Delete in batches; each batch atomically deletes a session's messages and the session itself.
-	for start := 0; start < len(ids); start += aiSessionDeleteBatchSize {
-		end := start + aiSessionDeleteBatchSize
-		if end > len(ids) {
-			end = len(ids)
-		}
-		if err := c.deleteAISessionBatch(ctx, ids[start:end]); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (c *connection) deleteAISessionBatch(ctx context.Context, ids []string) error {
-	placeholders := strings.Repeat("?,", len(ids)-1) + "?"
-	args := make([]any, len(ids))
-	for i, id := range ids {
-		args[i] = id
-	}
-
-	tx, err := c.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin AI session cleanup transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM ai_messages WHERE session_id IN (%s)`, placeholders), args...); err != nil {
-		return fmt.Errorf("failed to delete expired AI messages: %w", err)
-	}
-	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`DELETE FROM ai_sessions WHERE id IN (%s)`, placeholders), args...); err != nil {
-		return fmt.Errorf("failed to delete expired AI sessions: %w", err)
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit AI session cleanup: %w", err)
-	}
-	return nil
 }

--- a/runtime/drivers/sqlite/migrate.go
+++ b/runtime/drivers/sqlite/migrate.go
@@ -25,7 +25,7 @@ var aiSessionTTL = 90 * 24 * time.Hour // 3 months
 
 // aiSessionDeleteBatchSize bounds how many sessions are deleted per transaction.
 // Each batch holds the sqlite write lock briefly, so other registry operations can interleave.
-const aiSessionDeleteBatchSize = 500
+const aiSessionDeleteBatchSize = 200
 
 // Migrate implements drivers.Connection.
 // Migrate for SQLite may not be safe for concurrent use.

--- a/runtime/drivers/sqlite/migrate.go
+++ b/runtime/drivers/sqlite/migrate.go
@@ -23,6 +23,10 @@ var migrationVersionTable = "runtime_migration_version"
 // TTL for AI sessions; sessions with no messages newer than this are deleted by deleteExpiredAISessionsLoop.
 var aiSessionTTL = 90 * 24 * time.Hour // 3 months
 
+// aiSessionDeleteBatchSize bounds how many sessions are deleted per transaction.
+// Each batch holds the sqlite write lock briefly, so other registry operations can interleave.
+const aiSessionDeleteBatchSize = 500
+
 // Migrate implements drivers.Connection.
 // Migrate for SQLite may not be safe for concurrent use.
 func (c *connection) Migrate(_ context.Context) (err error) {
@@ -156,13 +160,8 @@ func (c *connection) deleteExpiredAISessionsLoop() {
 	}
 }
 
-// aiSessionDeleteBatchSize bounds how many sessions are deleted per transaction.
-// Each batch holds the sqlite write lock briefly, so other registry operations can interleave.
-const aiSessionDeleteBatchSize = 500
-
 // deleteExpiredAISessions deletes AI sessions that have no messages newer than aiSessionTTL.
-// It snapshots expired session IDs first, then deletes messages and sessions in batched transactions
-// to bound lock-hold time and to avoid a race where a resurrected session loses its old messages.
+// It snapshots expired session IDs first, then deletes messages and sessions in batched transactions to bound lock-hold time.
 func (c *connection) deleteExpiredAISessions(ctx context.Context) error {
 	cutoff := time.Now().UTC().Add(-aiSessionTTL)
 
@@ -194,8 +193,7 @@ func (c *connection) deleteExpiredAISessions(ctx context.Context) error {
 	}
 	rows.Close()
 
-	// Delete in batches; each batch atomically deletes a session's messages and the session itself,
-	// so a session resurrected between statements can't end up orphaned with its messages gone.
+	// Delete in batches; each batch atomically deletes a session's messages and the session itself.
 	for start := 0; start < len(ids); start += aiSessionDeleteBatchSize {
 		end := start + aiSessionDeleteBatchSize
 		if end > len(ids) {

--- a/runtime/drivers/sqlite/migrations/0041.sql
+++ b/runtime/drivers/sqlite/migrations/0041.sql
@@ -1,1 +1,1 @@
-CREATE INDEX IF NOT EXISTS ai_messages_session_id_created_on_idx ON ai_messages (session_id, created_on);
+CREATE INDEX IF NOT EXISTS ai_messages_session_id_idx ON ai_messages (session_id);

--- a/runtime/drivers/sqlite/migrations/0041.sql
+++ b/runtime/drivers/sqlite/migrations/0041.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS ai_messages_session_id_created_on_idx ON ai_messages (session_id, created_on);

--- a/runtime/drivers/sqlite/sqlite.go
+++ b/runtime/drivers/sqlite/sqlite.go
@@ -77,6 +77,10 @@ func (d driver) Open(_, _ string, config map[string]any, st *storage.Client, ac 
 	// Start backups in the background (no-op if backups are not configured)
 	go h.startBackups()
 
+	// Apply TTL to AI sessions in the background.
+	// This can be slow on large databases, so it must not block Migrate (and therefore runtime startup).
+	go h.deleteExpiredAISessionsLoop()
+
 	return h, nil
 }
 


### PR DESCRIPTION
To prevent runtime start blocking

Took thread dump and found this hanging
```
goroutine 67 [runnable]:
modernc.org/sqlite/lib._sqlite3VdbeExec(...)
...
github.com/rilldata/rill/runtime/drivers/sqlite.(*connection).deleteExpiredAISessions(...)
    runtime/drivers/sqlite/migrate.go:166
github.com/rilldata/rill/runtime/drivers/sqlite.(*connection).Migrate(...)
    runtime/drivers/sqlite/migrate.go:81
github.com/rilldata/rill/runtime.(*Runtime).openAndMigrate(...)
    runtime/connection_cache.go:180
github.com/rilldata/rill/runtime/pkg/conncache.(*cacheImpl).beginOpen.func1()
```

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
