### PR TITLE
fix: allow `rill devtool` to run inside a git worktree

### DIFF
--- a/cli/cmd/devtool/start.go
+++ b/cli/cmd/devtool/start.go
@@ -178,11 +178,13 @@ func checkRillRepo() error {
 		return fmt.Errorf("you must run `rill devtool` from the root of the rill repository")
 	}
 
-	remote, err := gitutil.ExtractGitRemote("", "", false)
+	// Shell out to `git` so this also works inside a linked worktree, where `.git` is
+	// a file and the remote config lives in the main repo (not reachable via go-git's PlainOpen).
+	out, err := exec.Command("git", "remote", "get-url", "origin").Output()
 	if err != nil {
 		return fmt.Errorf("error extracting git remote: %w", err)
 	}
-	githubRemote, _ := remote.Github()
+	githubRemote, _ := gitutil.NormalizeGithubRemote(strings.TrimSpace(string(out)))
 
 	if githubRemote != rillGitRemote {
 		return fmt.Errorf("you must run `rill devtool` from the rill repository (expected remote %q, got %q)", rillGitRemote, githubRemote)

--- a/cli/cmd/devtool/start.go
+++ b/cli/cmd/devtool/start.go
@@ -178,13 +178,11 @@ func checkRillRepo() error {
 		return fmt.Errorf("you must run `rill devtool` from the root of the rill repository")
 	}
 
-	// Shell out to `git` so this also works inside a linked worktree, where `.git` is
-	// a file and the remote config lives in the main repo (not reachable via go-git's PlainOpen).
-	out, err := exec.Command("git", "remote", "get-url", "origin").Output()
+	remote, err := gitutil.ExtractGitRemote("", "", false)
 	if err != nil {
 		return fmt.Errorf("error extracting git remote: %w", err)
 	}
-	githubRemote, _ := gitutil.NormalizeGithubRemote(strings.TrimSpace(string(out)))
+	githubRemote, _ := remote.Github()
 
 	if githubRemote != rillGitRemote {
 		return fmt.Errorf("you must run `rill devtool` from the rill repository (expected remote %q, got %q)", rillGitRemote, githubRemote)

--- a/cli/pkg/gitutil/gitutil.go
+++ b/cli/pkg/gitutil/gitutil.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/go-git/go-git/v5"
@@ -118,33 +119,47 @@ func ExtractGitRemote(projectPath, remoteName string, detectDotGit bool) (Remote
 }
 
 // ExtractRemotes extracts all Git remotes from the Git repository at projectPath.
-// The returned remotes are normalized with NormalizeGithubRemote.
 // If detectDotGit is true, it will look for a .git directory in parent directories.
+// Shells out to the `git` CLI so it works inside linked worktrees, where `.git` is a
+// file pointing to the main repo's worktree dir and the remote config is reachable
+// only via `commondir` (which go-git's PlainOpen does not resolve).
 func ExtractRemotes(projectPath string, detectDotGit bool) ([]Remote, error) {
-	repo, err := git.PlainOpenWithOptions(projectPath, &git.PlainOpenOptions{
-		DetectDotGit: detectDotGit,
-	})
+	if !detectDotGit {
+		// require a .git entry at exactly this path: a directory in a regular
+		// checkout, or a file in a linked worktree.
+		if _, err := os.Stat(filepath.Join(projectPath, ".git")); err != nil {
+			if os.IsNotExist(err) {
+				return nil, ErrNotAGitRepository
+			}
+			return nil, err
+		}
+	}
+
+	out, err := exec.Command("git", "-C", projectPath, "remote").Output()
 	if err != nil {
+		var execErr *exec.ExitError
+		if errors.As(err, &execErr) {
+			stderr := strings.TrimSpace(string(execErr.Stderr))
+			if strings.Contains(stderr, "not a git repository") {
+				return nil, ErrNotAGitRepository
+			}
+			return nil, fmt.Errorf("git remote: %s", stderr)
+		}
 		return nil, err
 	}
 
-	remotes, err := repo.Remotes()
-	if err != nil {
-		return nil, err
-	}
-
-	res := make([]Remote, len(remotes))
-	for idx, remote := range remotes {
-		if len(remote.Config().URLs) == 0 {
-			return nil, fmt.Errorf("no URL found for git remote %q", remote.Config().Name)
+	names := strings.Fields(string(out))
+	res := make([]Remote, 0, len(names))
+	for _, name := range names {
+		urlOut, err := exec.Command("git", "-C", projectPath, "remote", "get-url", name).Output()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get URL for git remote %q: %w", name, err)
 		}
-
-		res[idx] = Remote{
-			Name: remote.Config().Name,
-			// The first URL in the slice is the URL Git fetches from (main one).
-			// We'll make things easy for ourselves and only consider that.
-			URL: remote.Config().URLs[0],
+		u := strings.TrimSpace(string(urlOut))
+		if u == "" {
+			return nil, fmt.Errorf("no URL found for git remote %q", name)
 		}
+		res = append(res, Remote{Name: name, URL: u})
 	}
 
 	return res, nil

--- a/cli/pkg/local/server.go
+++ b/cli/pkg/local/server.go
@@ -143,7 +143,7 @@ func (s *Server) PushToGithub(ctx context.Context, r *connect.Request[localv1.Pu
 	initGit := false
 	remote, err := gitutil.ExtractGitRemote(s.app.ProjectPath, "", false)
 	if err != nil {
-		if errors.Is(err, git.ErrRepositoryNotExists) {
+		if errors.Is(err, gitutil.ErrNotAGitRepository) {
 			initGit = true
 		} else if !errors.Is(err, gitutil.ErrGitRemoteNotFound) {
 			return nil, err
@@ -396,7 +396,7 @@ func (s *Server) DeployProject(ctx context.Context, r *connect.Request[localv1.D
 		// check if project is a git repo
 		remote, err := gitutil.ExtractGitRemote(gitPath, "", false)
 		if err != nil {
-			if errors.Is(err, gitutil.ErrGitRemoteNotFound) || errors.Is(err, git.ErrRepositoryNotExists) {
+			if errors.Is(err, gitutil.ErrGitRemoteNotFound) || errors.Is(err, gitutil.ErrNotAGitRepository) {
 				return nil, errors.New("project is not a valid git repository or not connected to a remote")
 			}
 			return nil, err


### PR DESCRIPTION
- `checkRillRepo` used go-git's `PlainOpen` to read the origin remote, but in a linked worktree `.git` is a file pointing to `<main>/.git/worktrees/<name>`, which has no `config` file (the remote config lives in the main repo via `commondir`). go-git returned zero remotes, so `rill devtool start cloud` failed with `error extracting git remote: no git remotes found`.
- Shell out to `git remote get-url origin` instead, then reuse `gitutil.NormalizeGithubRemote` to compare against the expected rill remote. The `git` CLI transparently resolves `commondir`, so the check now works in both regular checkouts and worktrees.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*