### PR TITLE
feat: add screenshot capture to measure charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19785,6 +19785,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
@@ -36113,6 +36120,7 @@
         "fflate": "^0.8.2",
         "globals": "^16.0.0",
         "gridstack": "^11.3.0",
+        "html-to-image": "^1.11.13",
         "jsdom": "^26.0.0",
         "json-schema": "^0.4.0",
         "lucide-svelte": "^0.298.0",

--- a/web-common/package.json
+++ b/web-common/package.json
@@ -73,6 +73,7 @@
     "fflate": "^0.8.2",
     "globals": "^16.0.0",
     "gridstack": "^11.3.0",
+    "html-to-image": "^1.11.13",
     "jsdom": "^26.0.0",
     "json-schema": "^0.4.0",
     "lucide-svelte": "^0.298.0",

--- a/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
+++ b/web-common/src/features/dashboards/big-number/MeasureBigNumber.svelte
@@ -40,6 +40,7 @@
   export let comparisonTimeEnd: string | undefined = undefined;
   export let showComparison = false;
   export let ready: boolean = true;
+  export let skipLink: boolean = false;
 
   const client = useRuntimeClient();
 
@@ -189,7 +190,7 @@
       isMeasureExpanded = true;
     }
   };
-  $: useDiv = isMeasureExpanded || !withTimeseries;
+  $: useDiv = isMeasureExpanded || !withTimeseries || skipLink;
 
   function handleMouseOver() {
     cellInspectorStore.updateValue(value, tooltipValue);
@@ -300,11 +301,10 @@
                   copyValue =
                     measureValueFormatterUnabridged(value) ?? "no data";
                 }}
-                class="w-fit {(
-                  lowerIsBetter ? isComparisonNegative : isComparisonPositive
-                )
-                  ? 'font-semibold'
-                  : ''} {comparisonDeltaColorClass}"
+                class="w-fit {comparisonDeltaColorClass}"
+                class:font-semibold={lowerIsBetter
+                  ? isComparisonNegative
+                  : isComparisonPositive}
               >
                 <WithTween
                   value={comparisonPercChange}

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -438,7 +438,7 @@
             />
 
             <DropdownMenu.Root>
-              <DropdownMenu.Trigger class="absolute right-2 top-0">
+              <DropdownMenu.Trigger class="absolute right-2 -top-2">
                 <ThreeDot />
               </DropdownMenu.Trigger>
               <DropdownMenu.Content align="end">

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -33,7 +33,7 @@
   import { type MetricsViewSpecMeasure } from "@rilldata/web-common/runtime-client/gen/index.schemas";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
   import { DateTime, Interval } from "luxon";
-  import { Button, IconButton } from "../../../components/button";
+  import { Button } from "../../../components/button";
   import Pivot from "../../../components/icons/Pivot.svelte";
   import { TIME_GRAIN } from "../../../lib/time/config";
   import { DashboardState_ActivePage } from "../../../proto/gen/rill/ui/v1/dashboard_pb";

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -33,7 +33,7 @@
   import { type MetricsViewSpecMeasure } from "@rilldata/web-common/runtime-client/gen/index.schemas";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
   import { DateTime, Interval } from "luxon";
-  import { Button } from "../../../components/button";
+  import { Button, IconButton } from "../../../components/button";
   import Pivot from "../../../components/icons/Pivot.svelte";
   import { TIME_GRAIN } from "../../../lib/time/config";
   import { DashboardState_ActivePage } from "../../../proto/gen/rill/ui/v1/dashboard_pb";
@@ -44,6 +44,8 @@
   import MeasureChart from "./measure-chart/MeasureChart.svelte";
   import MeasureChartXAxis from "./measure-chart/MeasureChartXAxis.svelte";
   import { ScrubController } from "./measure-chart/ScrubController";
+  import ThreeDot from "@rilldata/web-common/components/icons/ThreeDot.svelte";
+  import ScreenshotContainer from "@rilldata/web-common/features/dashboards/time-series/ScreenshotContainer.svelte";
 
   const { rillTime } = featureFlags;
 
@@ -179,6 +181,9 @@
   $: annotationsEnabled =
     !!$exploreValidSpec.data?.metricsView?.annotations?.length;
 
+  let screenshotDialogOpen = false;
+  let screenshotDialogMeasure: MetricsViewSpecMeasure | undefined = undefined;
+
   // Pan handler
   function handlePan(direction: "left" | "right") {
     const panRange = $getNewPanRange(direction);
@@ -252,6 +257,11 @@
     if (!measureSelection.isRangeSelection()) {
       measureSelection.clear();
     }
+  }
+
+  function openScreenshotDialog(measure: MetricsViewSpecMeasure) {
+    screenshotDialogMeasure = measure;
+    screenshotDialogOpen = true;
   }
 </script>
 
@@ -392,39 +402,54 @@
         />
 
         {#if activeTimeGrain}
-          <MeasureChart
-            {measure}
-            {scrubController}
-            {connectNulls}
-            tddChartType={tddChartType ?? TDDChart.DEFAULT}
-            metricsViewName={chartMetricsViewName}
-            where={chartWhere}
-            {timeDimension}
-            interval={chartInterval}
-            comparisonInterval={chartComparisonInterval}
-            timeGranularity={activeTimeGrain}
-            timeZone={selectedTimezone}
-            ready={chartReady}
-            {chartScrubInterval}
-            {comparisonDimension}
-            dimensionValues={chartDimensionValues}
-            dimensionWhere={whereFilter}
-            {annotationsEnabled}
-            canPanLeft={$canPanLeft}
-            canPanRight={$canPanRight}
-            onPanLeft={() => handlePan("left")}
-            onPanRight={() => handlePan("right")}
-            {showComparison}
-            {showTimeDimensionDetail}
-            dynamicYAxis={dynamicYAxisScale}
-            onScrub={handleScrub}
-            onScrubClear={() => {
-              metricsExplorerStore.setSelectedScrubRange(
-                exploreName,
-                undefined,
-              );
-            }}
-          />
+          <div class="relative">
+            <MeasureChart
+              {measure}
+              {scrubController}
+              {connectNulls}
+              tddChartType={tddChartType ?? TDDChart.DEFAULT}
+              metricsViewName={chartMetricsViewName}
+              where={chartWhere}
+              {timeDimension}
+              interval={chartInterval}
+              comparisonInterval={chartComparisonInterval}
+              timeGranularity={activeTimeGrain}
+              timeZone={selectedTimezone}
+              ready={chartReady}
+              {chartScrubInterval}
+              {comparisonDimension}
+              dimensionValues={chartDimensionValues}
+              dimensionWhere={whereFilter}
+              {annotationsEnabled}
+              canPanLeft={$canPanLeft}
+              canPanRight={$canPanRight}
+              onPanLeft={() => handlePan("left")}
+              onPanRight={() => handlePan("right")}
+              {showComparison}
+              {showTimeDimensionDetail}
+              dynamicYAxis={dynamicYAxisScale}
+              onScrub={handleScrub}
+              onScrubClear={() => {
+                metricsExplorerStore.setSelectedScrubRange(
+                  exploreName,
+                  undefined,
+                );
+              }}
+            />
+
+            <DropdownMenu.Root>
+              <DropdownMenu.Trigger class="absolute right-2 top-0">
+                <ThreeDot />
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Content align="end">
+                <DropdownMenu.Item
+                  onclick={() => openScreenshotDialog(measure)}
+                >
+                  Download as PNG
+                </DropdownMenu.Item>
+              </DropdownMenu.Content>
+            </DropdownMenu.Root>
+          </div>
         {:else}
           <div class="flex items-center justify-center w-24">
             <Spinner status={EntityStatus.Running} />
@@ -442,3 +467,23 @@
   }}
   onReplace={createPivot}
 />
+
+{#if screenshotDialogMeasure}
+  <ScreenshotContainer
+    bind:open={screenshotDialogOpen}
+    measure={screenshotDialogMeasure}
+    metricsViewName={chartMetricsViewName}
+    where={chartWhere}
+    {timeDimension}
+    {timeStart}
+    {timeEnd}
+    {comparisonTimeStart}
+    {comparisonTimeEnd}
+    interval={chartInterval}
+    comparisonInterval={chartComparisonInterval}
+    timeGranularity={activeTimeGrain}
+    timeZone={selectedTimezone}
+    {showComparison}
+    ready={chartReady}
+  />
+{/if}

--- a/web-common/src/features/dashboards/time-series/ScreenshotContainer.svelte
+++ b/web-common/src/features/dashboards/time-series/ScreenshotContainer.svelte
@@ -12,7 +12,6 @@
   import MeasureBigNumber from "../big-number/MeasureBigNumber.svelte";
   import MeasureChart from "./measure-chart/MeasureChart.svelte";
   import MeasureChartXAxis from "./measure-chart/MeasureChartXAxis.svelte";
-  import { ScrubController } from "./measure-chart/ScrubController";
   import { prettyFormatTimeRange } from "@rilldata/web-common/lib/time/ranges/formatter.ts";
   import ExploreFilterChipsReadOnly from "@rilldata/web-common/features/dashboards/filters/ExploreFilterChipsReadOnly.svelte";
   import ThemeProvider from "@rilldata/web-common/features/dashboards/ThemeProvider.svelte";
@@ -33,9 +32,6 @@
   export let timeZone: string = "UTC";
   export let showComparison = false;
   export let ready = true;
-
-  // Inert scrub controller — interactions are not needed for screenshots.
-  const scrubController = new ScrubController();
 
   let captureNode: HTMLDivElement;
   let downloading = false;
@@ -140,12 +136,12 @@
             {comparisonTimeEnd}
             {showComparison}
             {ready}
+            skipLink
           />
 
           {#if timeGranularity}
             <MeasureChart
               {measure}
-              {scrubController}
               tddChartType={TDDChart.DEFAULT}
               {metricsViewName}
               {where}

--- a/web-common/src/features/dashboards/time-series/ScreenshotContainer.svelte
+++ b/web-common/src/features/dashboards/time-series/ScreenshotContainer.svelte
@@ -7,12 +7,16 @@
     V1Expression,
     V1TimeGrain,
   } from "@rilldata/web-common/runtime-client";
-  import { getFontEmbedCSS, toPng } from "html-to-image";
-  import { Interval } from "luxon";
+  import { toPng } from "html-to-image";
+  import { DateTime, Interval } from "luxon";
   import MeasureBigNumber from "../big-number/MeasureBigNumber.svelte";
   import MeasureChart from "./measure-chart/MeasureChart.svelte";
   import MeasureChartXAxis from "./measure-chart/MeasureChartXAxis.svelte";
   import { ScrubController } from "./measure-chart/ScrubController";
+  import { prettyFormatTimeRange } from "@rilldata/web-common/lib/time/ranges/formatter.ts";
+  import ExploreFilterChipsReadOnly from "@rilldata/web-common/features/dashboards/filters/ExploreFilterChipsReadOnly.svelte";
+  import ThemeProvider from "@rilldata/web-common/features/dashboards/ThemeProvider.svelte";
+  import { activeDashboardTheme } from "@rilldata/web-common/features/themes/active-dashboard-theme.ts";
 
   export let open = false;
   export let measure: MetricsViewSpecMeasure;
@@ -35,7 +39,14 @@
 
   let captureNode: HTMLDivElement;
   let downloading = false;
-  let url = "";
+
+  $: formattedTimeRange = interval
+    ? prettyFormatTimeRange(interval, timeGranularity)
+    : "";
+  $: generatedTime = prettyFormatTimeRange(
+    Interval.fromDateTimes(DateTime.now(), DateTime.now()),
+    timeGranularity,
+  );
 
   const SVG_PROPS = [
     "fill",
@@ -68,97 +79,94 @@
     try {
       inlineSvgStyles(captureNode);
       await document.fonts.ready;
-      const fontEmbedCSS = await getFontEmbedCSS(captureNode);
-      url = await toPng(captureNode, { fontEmbedCSS, cacheBust: true });
-      // const link = document.createElement("a");
-      // link.download = `${measure.name ?? "chart"}.png`;
-      // link.href = url;
-      // link.click();
+      const url = await toPng(captureNode, { cacheBust: true });
+      const link = document.createElement("a");
+      link.download = `${measure.name ?? "chart"}_${formattedTimeRange || generatedTime}.png`;
+      link.href = url;
+      link.click();
     } finally {
       downloading = false;
     }
   }
 </script>
 
-<Dialog.Root
-  bind:open
-  onOpenChange={() => {
-    url = "";
-  }}
->
+<Dialog.Root bind:open>
   <Dialog.Content class="max-w-3xl flex flex-col gap-y-4">
     <Dialog.Header>
       <Dialog.Title>Export chart</Dialog.Title>
     </Dialog.Header>
 
-    <div
-      bind:this={captureNode}
-      class="flex flex-col gap-y-3 p-4 bg-surface-background border rounded-md"
-    >
-      <header class="flex flex-col gap-y-0.5">
-        <slot name="header">
-          <h2 class="text-base font-semibold text-fg-base">
-            {measure.displayName || measure.name}
-          </h2>
-          {#if measure.description}
-            <p class="text-xs text-fg-muted">{measure.description}</p>
-          {/if}
-        </slot>
-      </header>
-
-      <div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2">
-        {#if timeGranularity}
-          <div class="col-span-2 grid grid-cols-subgrid">
-            <div></div>
-            <MeasureChartXAxis {interval} {timeGranularity} />
+    <ThemeProvider theme={$activeDashboardTheme} applyLayout={false}>
+      <div
+        bind:this={captureNode}
+        class="flex flex-col gap-y-3 p-4 bg-surface-background border rounded-md"
+      >
+        <header class="flex flex-row gap-y-0.5">
+          <div class="flex flex-col">
+            <h2 class="text-base font-semibold text-fg-base">
+              {measure.displayName || measure.name}
+            </h2>
+            {#if measure.description}
+              <p class="text-xs text-fg-muted">{measure.description}</p>
+            {/if}
           </div>
-        {/if}
+          <div class="grow"></div>
+          <div>{formattedTimeRange}</div>
+        </header>
 
-        <MeasureBigNumber
-          {measure}
-          {metricsViewName}
-          {where}
-          {timeDimension}
-          {timeStart}
-          {timeEnd}
-          {comparisonTimeStart}
-          {comparisonTimeEnd}
-          {showComparison}
-          {ready}
+        <ExploreFilterChipsReadOnly
+          metricsViewNames={[metricsViewName]}
+          filters={where}
+          dimensionsWithInlistFilter={[]}
+          dimensionThresholdFilters={[]}
         />
 
-        {#if timeGranularity}
-          <MeasureChart
+        <div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2">
+          {#if timeGranularity}
+            <div class="col-span-2 grid grid-cols-subgrid">
+              <div></div>
+              <MeasureChartXAxis {interval} {timeGranularity} />
+            </div>
+          {/if}
+
+          <MeasureBigNumber
             {measure}
-            {scrubController}
-            tddChartType={TDDChart.DEFAULT}
             {metricsViewName}
             {where}
             {timeDimension}
-            {interval}
-            {comparisonInterval}
-            {timeGranularity}
-            {timeZone}
-            {ready}
+            {timeStart}
+            {timeEnd}
+            {comparisonTimeStart}
+            {comparisonTimeEnd}
             {showComparison}
-            connectNulls={true}
+            {ready}
           />
-        {/if}
-      </div>
 
-      <footer class="flex items-center justify-between text-xs text-fg-muted">
-        <slot name="footer">
-          <span>Generated {new Date().toLocaleString()}</span>
+          {#if timeGranularity}
+            <MeasureChart
+              {measure}
+              {scrubController}
+              tddChartType={TDDChart.DEFAULT}
+              {metricsViewName}
+              {where}
+              {timeDimension}
+              {interval}
+              {comparisonInterval}
+              {timeGranularity}
+              {timeZone}
+              {ready}
+              {showComparison}
+              connectNulls={true}
+            />
+          {/if}
+        </div>
+
+        <footer class="flex items-center justify-between text-xs text-fg-muted">
           <span>Rill</span>
-        </slot>
-      </footer>
-    </div>
-
-    {#if url}
-      <div>
-        <img src={url} alt="Screenshot" class="w-full h-auto" />
+          <span>Generated {generatedTime}</span>
+        </footer>
       </div>
-    {/if}
+    </ThemeProvider>
 
     <Dialog.Footer>
       <Button type="secondary" onClick={() => (open = false)}>Cancel</Button>

--- a/web-common/src/features/dashboards/time-series/ScreenshotContainer.svelte
+++ b/web-common/src/features/dashboards/time-series/ScreenshotContainer.svelte
@@ -1,0 +1,174 @@
+<script lang="ts">
+  import { Button } from "@rilldata/web-common/components/button";
+  import * as Dialog from "@rilldata/web-common/components/dialog";
+  import { TDDChart } from "@rilldata/web-common/features/dashboards/time-dimension-details/types";
+  import type {
+    MetricsViewSpecMeasure,
+    V1Expression,
+    V1TimeGrain,
+  } from "@rilldata/web-common/runtime-client";
+  import { getFontEmbedCSS, toPng } from "html-to-image";
+  import { Interval } from "luxon";
+  import MeasureBigNumber from "../big-number/MeasureBigNumber.svelte";
+  import MeasureChart from "./measure-chart/MeasureChart.svelte";
+  import MeasureChartXAxis from "./measure-chart/MeasureChartXAxis.svelte";
+  import { ScrubController } from "./measure-chart/ScrubController";
+
+  export let open = false;
+  export let measure: MetricsViewSpecMeasure;
+  export let metricsViewName: string;
+  export let where: V1Expression | undefined = undefined;
+  export let timeDimension: string | undefined = undefined;
+  export let timeStart: string | undefined = undefined;
+  export let timeEnd: string | undefined = undefined;
+  export let comparisonTimeStart: string | undefined = undefined;
+  export let comparisonTimeEnd: string | undefined = undefined;
+  export let interval: Interval<true> | undefined = undefined;
+  export let comparisonInterval: Interval<true> | undefined = undefined;
+  export let timeGranularity: V1TimeGrain | undefined = undefined;
+  export let timeZone: string = "UTC";
+  export let showComparison = false;
+  export let ready = true;
+
+  // Inert scrub controller — interactions are not needed for screenshots.
+  const scrubController = new ScrubController();
+
+  let captureNode: HTMLDivElement;
+  let downloading = false;
+  let url = "";
+
+  const SVG_PROPS = [
+    "fill",
+    "fill-opacity",
+    "stroke",
+    "stroke-width",
+    "stroke-opacity",
+    "stroke-dasharray",
+    "stroke-linecap",
+    "opacity",
+    "font-family",
+    "font-size",
+    "font-weight",
+    "color",
+  ];
+
+  function inlineSvgStyles(root: HTMLElement) {
+    root.querySelectorAll("svg, svg *").forEach((el) => {
+      const cs = getComputedStyle(el);
+      const inline = SVG_PROPS.map(
+        (p) => `${p}: ${cs.getPropertyValue(p)}`,
+      ).join("; ");
+      el.setAttribute("style", `${inline}; ${el.getAttribute("style") ?? ""}`);
+    });
+  }
+
+  async function downloadScreenshot() {
+    if (!captureNode) return;
+    downloading = true;
+    try {
+      inlineSvgStyles(captureNode);
+      await document.fonts.ready;
+      const fontEmbedCSS = await getFontEmbedCSS(captureNode);
+      url = await toPng(captureNode, { fontEmbedCSS, cacheBust: true });
+      // const link = document.createElement("a");
+      // link.download = `${measure.name ?? "chart"}.png`;
+      // link.href = url;
+      // link.click();
+    } finally {
+      downloading = false;
+    }
+  }
+</script>
+
+<Dialog.Root
+  bind:open
+  onOpenChange={() => {
+    url = "";
+  }}
+>
+  <Dialog.Content class="max-w-3xl flex flex-col gap-y-4">
+    <Dialog.Header>
+      <Dialog.Title>Export chart</Dialog.Title>
+    </Dialog.Header>
+
+    <div
+      bind:this={captureNode}
+      class="flex flex-col gap-y-3 p-4 bg-surface-background border rounded-md"
+    >
+      <header class="flex flex-col gap-y-0.5">
+        <slot name="header">
+          <h2 class="text-base font-semibold text-fg-base">
+            {measure.displayName || measure.name}
+          </h2>
+          {#if measure.description}
+            <p class="text-xs text-fg-muted">{measure.description}</p>
+          {/if}
+        </slot>
+      </header>
+
+      <div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2">
+        {#if timeGranularity}
+          <div class="col-span-2 grid grid-cols-subgrid">
+            <div></div>
+            <MeasureChartXAxis {interval} {timeGranularity} />
+          </div>
+        {/if}
+
+        <MeasureBigNumber
+          {measure}
+          {metricsViewName}
+          {where}
+          {timeDimension}
+          {timeStart}
+          {timeEnd}
+          {comparisonTimeStart}
+          {comparisonTimeEnd}
+          {showComparison}
+          {ready}
+        />
+
+        {#if timeGranularity}
+          <MeasureChart
+            {measure}
+            {scrubController}
+            tddChartType={TDDChart.DEFAULT}
+            {metricsViewName}
+            {where}
+            {timeDimension}
+            {interval}
+            {comparisonInterval}
+            {timeGranularity}
+            {timeZone}
+            {ready}
+            {showComparison}
+            connectNulls={true}
+          />
+        {/if}
+      </div>
+
+      <footer class="flex items-center justify-between text-xs text-fg-muted">
+        <slot name="footer">
+          <span>Generated {new Date().toLocaleString()}</span>
+          <span>Rill</span>
+        </slot>
+      </footer>
+    </div>
+
+    {#if url}
+      <div>
+        <img src={url} alt="Screenshot" class="w-full h-auto" />
+      </div>
+    {/if}
+
+    <Dialog.Footer>
+      <Button type="secondary" onClick={() => (open = false)}>Cancel</Button>
+      <Button
+        type="primary"
+        disabled={downloading}
+        onClick={downloadScreenshot}
+      >
+        {downloading ? "Generating…" : "Download PNG"}
+      </Button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>

--- a/web-common/src/features/dashboards/time-series/measure-chart/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/measure-chart/MeasureChart.svelte
@@ -61,7 +61,7 @@
   export let onScrubClear: (() => void) | undefined = undefined;
   export let onPanLeft: (() => void) | undefined = undefined;
   export let onPanRight: (() => void) | undefined = undefined;
-  export let scrubController: ScrubController;
+  export let scrubController: ScrubController | undefined = undefined;
   export let connectNulls: boolean = true;
   export let dynamicYAxis: boolean = false;
 

--- a/web-common/src/features/dashboards/time-series/measure-chart/MeasureChartBody.svelte
+++ b/web-common/src/features/dashboards/time-series/measure-chart/MeasureChartBody.svelte
@@ -76,7 +76,7 @@
       }) => void)
     | undefined;
   export let onScrubClear: (() => void) | undefined;
-  export let scrubController: ScrubController;
+  export let scrubController: ScrubController | undefined = undefined;
   export let metricsViewName: string;
   export let connectNulls: boolean = true;
   export let dynamicYAxis: boolean = false;
@@ -141,12 +141,12 @@
   $: xTickIndices = computeXTickIndices(mode, data.length);
 
   // Keep scrub controller in sync with data length
-  $: scrubController.setDataLength(data.length);
+  $: scrubController?.setDataLength(data.length);
 
   // Subscribe to scrub state from controller for rendering
-  $: scrubStateStore = scrubController.state;
+  $: scrubStateStore = scrubController?.state;
   $: currentScrubState = $scrubStateStore;
-  $: isScrubbing = currentScrubState.isScrubbing;
+  $: isScrubbing = Boolean(currentScrubState?.isScrubbing);
 
   // Scrub indices: use local (active) state while scrubbing, external (URL) state otherwise
   $: externalScrubStartIndex = chartScrubInterval
@@ -155,8 +155,8 @@
   $: externalScrubEndIndex = chartScrubInterval
     ? dateToIndex(data, chartScrubInterval.end.toMillis())
     : null;
-  $: scrubStartIndex = currentScrubState.startIndex ?? externalScrubStartIndex;
-  $: scrubEndIndex = currentScrubState.endIndex ?? externalScrubEndIndex;
+  $: scrubStartIndex = currentScrubState?.startIndex ?? externalScrubStartIndex;
+  $: scrubEndIndex = currentScrubState?.endIndex ?? externalScrubEndIndex;
   $: hasScrubSelection = scrubStartIndex !== null && scrubEndIndex !== null;
 
   // Hover state
@@ -178,7 +178,7 @@
 
   $: hoveredIndex = $hoverIndex?.start ?? -1;
   $: hoveredPoint = data[hoveredIndex] ?? null;
-  $: cursorStyle = scrubController.getCursorStyle(hoverState.screenX, xScale);
+  $: cursorStyle = scrubController?.getCursorStyle(hoverState.screenX, xScale);
 
   // Formatters
   $: measureFormatter = createMeasureValueFormatter(measure);
@@ -264,7 +264,7 @@
 
   function handleReset() {
     onScrubClear?.();
-    scrubController.reset();
+    scrubController?.reset();
   }
 
   function handleSvgMouseLeave() {
@@ -275,7 +275,7 @@
   }
 
   function handleMouseDown(e: MouseEvent) {
-    if (e.button !== 0) return;
+    if (!scrubController || e.button !== 0) return;
     mouseDownX = e.clientX;
     mouseDownY = e.clientY;
     const x = clampX(e.offsetX);
@@ -308,7 +308,7 @@
       const [start, end] = s < e ? [s, e] : [e, s];
       measureSelection.setRange(measureName, start, end);
     }
-    scrubController.reset();
+    scrubController?.reset();
   }
 
   function handlePointClick(offsetX: number) {
@@ -324,6 +324,8 @@
   }
 
   function handleMouseUp(e: MouseEvent) {
+    if (!scrubController) return;
+
     const wasClick =
       mouseDownX !== null &&
       mouseDownY !== null &&
@@ -383,7 +385,7 @@
 
     if (isOutside) {
       // Click outside selection clears it
-      scrubController.reset();
+      scrubController?.reset();
       onScrubClear?.();
       measureSelection.clear();
     } else if (measureName) {
@@ -421,7 +423,7 @@
       };
 
       // Update scrub if dragging
-      if (get(scrubController.state).isScrubbing) {
+      if (scrubController && get(scrubController.state).isScrubbing) {
         scrubController.update(x, xScale);
       }
 

--- a/web-common/src/features/themes/selectors.ts
+++ b/web-common/src/features/themes/selectors.ts
@@ -72,6 +72,7 @@ export function createResolvedThemeStore(
         queryClient,
       );
       return themeQuery.subscribe(($themeQuery) => {
+        console.log(name, $themeQuery.data);
         if ($themeQuery.data?.theme?.spec) {
           set(new Theme($themeQuery.data.theme.spec));
         } else {


### PR DESCRIPTION
Uses `html-to-image` to take a screenshot of charts. 
- [x] Open a dialog with preview of what the screenshot will be. Based on mocks: https://linear.app/rilldata/issue/ENG-1099/download-explore-chart-as-png-with-left-side-data-callout#clickable-mock-b5824f7d
- [x] Add a button to create the screenshot. For this this renders the image below the preview for quick testing, will be a download in the future.
- [x] Make the button download the screenshot with `<measure>_<from-time>_<to-time>.png` file name.
- [x] Match every elements of the mocks like add measure name, time range, comparison time range and filters.
- [x] Make sure custom themes are applied correctly.

Popup with preview,
<img width="1562" height="793" alt="Screenshot 2026-05-26 at 4 37 22 PM" src="https://github.com/user-attachments/assets/fb609871-9731-4832-8ee8-33e8653d2967" />

Downloaded screenshots,
<img width="1436" height="618" alt="total_records_Mar 24 – 30, 2022" src="https://github.com/user-attachments/assets/cabc2efb-f7ba-442e-a557-5cf06a97caba" />
<img width="1436" height="670" alt="total_records_Mar 30 – 31, 2022 (6PM-12AM)" src="https://github.com/user-attachments/assets/15cb94ab-95ad-4134-a9c8-532304f11752" />


Closes ENG-1099

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
