### PR TITLE
fix: respect custom time range setting in Canvas dashboards

### DIFF
--- a/web-common/src/features/canvas/filters/CanvasFilters.svelte
+++ b/web-common/src/features/canvas/filters/CanvasFilters.svelte
@@ -199,6 +199,7 @@
             {activeTimeZone}
             {minTimeGrain}
             {showTimeComparison}
+            {allowCustomTimeRange}
             onDisplayTimeComparison={set.comparison}
             onSetSelectedComparisonRange={(range) => {
               if (range.name === "CUSTOM_COMPARISON_RANGE") {

--- a/web-common/src/features/canvas/stores/time-manager.ts
+++ b/web-common/src/features/canvas/stores/time-manager.ts
@@ -80,6 +80,7 @@ export class TimeManager {
     const ranges = this.checkAndSetTimeRangeOptions(spec);
     this.checkAndSetDefaultTimeRange(spec, ranges);
     this.checkAndSetAvailableTimeZones(spec);
+    this.checkAndSetAllowCustomRange(spec);
     this.checkIfHasTimeSeries(spec);
     this.checkAndSetFirstDayOfWeek(spec);
     this.checkAndSetMaxQueryTimeRange(spec);


### PR DESCRIPTION
- Applies `allow_custom_time_range` from the resolved Canvas spec to the Canvas time manager
- Passes the setting through to the Canvas comparison pill so custom comparison ranges are also hidden when disabled

Canvas dashboards parsed `allow_custom_time_range: false` correctly, but the frontend time manager never loaded that value from the Canvas spec. As a result, Canvas time controls kept using the default `true` behavior and still showed custom range options.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
