### PR TITLE
fix: tool call error displaying full message

### DIFF
--- a/admin/server/server.go
+++ b/admin/server/server.go
@@ -411,7 +411,7 @@ func (s *Server) jwtAttributesForService(ctx context.Context, serviceID string, 
 
 func timeoutSelector(fullMethodName string) time.Duration {
 	if strings.HasPrefix(fullMethodName, "/rill.admin.v1.AIService") {
-		return time.Second * 2 // Temporary to test, should not be in PR
+		return time.Minute * 2
 	}
 	if fullMethodName == "/rill.admin.v1.AdminService/DeleteProject" {
 		return time.Minute * 4

--- a/admin/server/server.go
+++ b/admin/server/server.go
@@ -411,7 +411,7 @@ func (s *Server) jwtAttributesForService(ctx context.Context, serviceID string, 
 
 func timeoutSelector(fullMethodName string) time.Duration {
 	if strings.HasPrefix(fullMethodName, "/rill.admin.v1.AIService") {
-		return time.Minute * 2
+		return time.Second * 2 // Temporary to test, should not be in PR
 	}
 	if fullMethodName == "/rill.admin.v1.AdminService/DeleteProject" {
 		return time.Minute * 4

--- a/web-common/src/features/chat/core/conversation.ts
+++ b/web-common/src/features/chat/core/conversation.ts
@@ -37,6 +37,7 @@ import {
   invalidateConversationsList,
   NEW_CONVERSATION_ID,
 } from "./utils";
+import { formatTransportError } from "./errors";
 
 type ConversationEvents = {
   "conversation-created": string;
@@ -259,7 +260,7 @@ export class Conversation {
         userMessage,
         this.hasReceivedFirstMessage,
       );
-      this.events.emit("error", this.formatTransportError(error as Error));
+      this.events.emit("error", formatTransportError(error as Error));
     } finally {
       this.isStreaming.set(false);
     }
@@ -300,7 +301,7 @@ export class Conversation {
         error,
         conversationId: this.conversationId,
       });
-      this.streamError.set(this.formatTransportError(error as Error));
+      this.streamError.set(formatTransportError(error as Error));
     } finally {
       this.isStreaming.set(false);
     }
@@ -446,7 +447,7 @@ export class Conversation {
           error instanceof SSEHttpError ? error.statusText : undefined,
         name: error.name,
       });
-      this.streamError.set(this.formatTransportError(error));
+      this.streamError.set(formatTransportError(error));
     });
   }
 
@@ -693,54 +694,6 @@ export class Conversation {
   // ----- Transport Errors (Connection-level) -----
 
   /**
-   * Format transport error into user-friendly message
-   */
-  private formatTransportError(error: Error): string {
-    if (error.name === "AbortError") {
-      return "Message sending was cancelled";
-    }
-
-    // Extract status code from SSEHttpError
-    const status = error instanceof SSEHttpError ? error.status : null;
-
-    // Authentication errors - suggest refresh to get new JWT
-    if (status === 401 || status === 403) {
-      return "Authentication failed. Please refresh the page and try again.";
-    }
-
-    // Bad request errors
-    if (status === 400) {
-      return "Invalid request. Please try again.";
-    }
-
-    // Server errors (5xx)
-    if (status && status >= 500 && status < 600) {
-      return "Server is temporarily unavailable. Please try sending your message again.";
-    }
-
-    // Rate limiting
-    if (status === 429) {
-      return "Too many requests. Please wait a moment before trying again.";
-    }
-
-    // Network/connection errors (fetch() throws TypeError for network failures)
-    const lowerMessage = error.message?.toLowerCase() || "";
-    const isNetworkError =
-      (error.name === "TypeError" &&
-        (lowerMessage.includes("fetch") ||
-          lowerMessage.includes("network") ||
-          lowerMessage.includes("load failed"))) ||
-      (typeof navigator !== "undefined" && !navigator.onLine);
-
-    if (isNetworkError) {
-      return "Unable to connect to server. Please check your connection and try again.";
-    }
-
-    // Fallback error message
-    return "Failed to connect to server. Please try again or refresh the page.";
-  }
-
-  /**
    * Handle transport-level errors with conditional rollback
    *
    * Transport errors can occur at two stages:
@@ -755,7 +708,7 @@ export class Conversation {
     wasStreaming: boolean,
   ): void {
     // Set error message
-    this.streamError.set(this.formatTransportError(error as Error));
+    this.streamError.set(formatTransportError(error as Error));
 
     // Only rollback if we hadn't started streaming yet
     if (!wasStreaming) {

--- a/web-common/src/features/chat/core/errors.ts
+++ b/web-common/src/features/chat/core/errors.ts
@@ -1,0 +1,56 @@
+import { SSEHttpError } from "@rilldata/web-common/runtime-client/sse";
+
+/**
+ * Format transport error into user-friendly message
+ */
+export function formatTransportError(error: Error): string {
+  if (error.name === "AbortError") {
+    return "Message sending was cancelled";
+  }
+
+  // Extract status code from SSEHttpError
+  const status = error instanceof SSEHttpError ? error.status : null;
+
+  // Authentication errors - suggest refresh to get new JWT
+  if (status === 401 || status === 403) {
+    return "Authentication failed. Please refresh the page and try again.";
+  }
+
+  // Bad request errors
+  if (status === 400) {
+    return "Invalid request. Please try again.";
+  }
+
+  // Server errors (5xx)
+  if (status && status >= 500 && status < 600) {
+    return "Server is temporarily unavailable. Please try sending your message again.";
+  }
+
+  // Rate limiting
+  if (status === 429) {
+    return "Too many requests. Please wait a moment before trying again.";
+  }
+
+  // Network/connection errors (fetch() throws TypeError for network failures)
+  const lowerMessage = error.message?.toLowerCase() || "";
+  const isNetworkError =
+    (error.name === "TypeError" &&
+      (lowerMessage.includes("fetch") ||
+        lowerMessage.includes("network") ||
+        lowerMessage.includes("load failed"))) ||
+    (typeof navigator !== "undefined" && !navigator.onLine);
+
+  if (isNetworkError) {
+    return "Unable to connect to server. Please check your connection and try again.";
+  }
+
+  const isDeadlineExceeded =
+    lowerMessage.includes("context deadline exceeded") ||
+    lowerMessage.includes("agent timed out");
+  if (isDeadlineExceeded) {
+    return "Server took too long to respond. Please try again.";
+  }
+
+  // Fallback error message
+  return "Failed to connect to server. Please try again or refresh the page.";
+}

--- a/web-common/src/features/chat/core/messages/Messages.svelte
+++ b/web-common/src/features/chat/core/messages/Messages.svelte
@@ -15,6 +15,7 @@
   import ThinkingBlock from "./thinking/ThinkingBlock.svelte";
   import WorkingBlock from "./working/WorkingBlock.svelte";
   import SimpleToolCallBlock from "@rilldata/web-common/features/chat/core/messages/simple-tool-call/SimpleToolCallBlock.svelte";
+  import ErrorMessage from "@rilldata/web-common/features/chat/core/messages/error/ErrorMessage.svelte";
 
   export let conversationManager: ConversationManager;
   export let layout: "sidebar" | "fullpage";
@@ -129,14 +130,18 @@
     </div>
   {:else}
     {#each blocks as block (block.id)}
-      {#if block.type === "text" && block.message.role === "user"}
-        <UserMessage message={block.message} />
-      {:else if block.type === "text" && block.message.role === "assistant"}
-        <AssistantMessage
-          {block}
-          conversation={currentConversation}
-          onDownvote={handleDownvote}
-        />
+      {#if block.type === "text"}
+        {#if block.isError}
+          <ErrorMessage message={block.message} />
+        {:else if block.message.role === "user"}
+          <UserMessage message={block.message} />
+        {:else if block.message.role === "assistant"}
+          <AssistantMessage
+            {block}
+            conversation={currentConversation}
+            onDownvote={handleDownvote}
+          />
+        {/if}
       {:else if block.type === "thinking"}
         <ThinkingBlock {block} {tools} />
       {:else if block.type === "working"}

--- a/web-common/src/features/chat/core/messages/error/ErrorMessage.svelte
+++ b/web-common/src/features/chat/core/messages/error/ErrorMessage.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import type { V1Message } from "@rilldata/web-common/runtime-client";
+  import ErrorComponent from "@rilldata/web-common/features/chat/core/messages/Error.svelte";
+  import { extractMessageText } from "@rilldata/web-common/features/chat/core/utils.ts";
+  import { formatTransportError } from "@rilldata/web-common/features/chat/core/errors.ts";
+
+  let { message }: { message: V1Message } = $props();
+  let errorMessage = $derived(extractMessageText(message));
+  let headline = $derived(formatTransportError(new Error(errorMessage)));
+</script>
+
+<ErrorComponent {headline} error={errorMessage} />

--- a/web-common/src/features/chat/core/messages/text/text-block.ts
+++ b/web-common/src/features/chat/core/messages/text/text-block.ts
@@ -10,6 +10,7 @@ export type TextBlock = {
   id: string;
   message: V1Message;
   feedback?: FeedbackData;
+  isError: boolean;
 };
 
 /**
@@ -34,5 +35,6 @@ export function createTextBlock(
     id: message.id!,
     message,
     feedback,
+    isError: message.contentType === "error",
   };
 }


### PR DESCRIPTION
We treat tool call error as a assistant message and display the full error message. Handling `contentType=error` as a separate block. We will show a parsed error headline and full error message under "show details"

<img width="414" height="342" alt="Screenshot 2026-05-29 at 10 41 32 AM" src="https://github.com/user-attachments/assets/0272bb80-ee22-44ba-bca4-7b63f1947891" />


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
