### PR TITLE
fix: hourly canvas chart date labels

### DIFF
--- a/web-common/src/features/components/charts/builder.ts
+++ b/web-common/src/features/components/charts/builder.ts
@@ -83,6 +83,10 @@ export function createPositionEncoding(
 ): PositionFieldDef<Field> {
   if (!field || field.type === "value") return {};
   const metaData = data.fields[field.field];
+  const temporalAxisLabelExpr =
+    field.type === "temporal" && metaData && "format" in metaData
+      ? getTemporalAxisLabelExpr(metaData.format)
+      : undefined;
   return {
     field: sanitizeValueForVega(field.field),
     title: metaData?.displayName || field.field,
@@ -115,9 +119,22 @@ export function createPositionEncoding(
               "format" in metaData && {
                 format: metaData.format,
               }),
+            ...(temporalAxisLabelExpr && {
+              labelExpr: temporalAxisLabelExpr,
+            }),
             ...(!field.showAxisTitle && { title: null }),
           },
   };
+}
+
+export function getTemporalAxisLabelExpr(format: string | undefined) {
+  if (format !== "%H:%M") return undefined;
+
+  return [
+    "timeFormat(datum.value, '%H:%M') === '00:00'",
+    "? timeFormat(datum.value, '%b %d')",
+    ": timeFormat(datum.value, '%H:%M')",
+  ].join(" ");
 }
 
 export function createSizeEncoding(


### PR DESCRIPTION
Fixes temporal X-axis labels for canvas charts using hourly grain over wider time ranges.

Previously, hourly axes used `%H:%M` for every tick. For ranges like 14 days, Vega-Lite often chooses midnight ticks, which made labels repeat as `00:00`. This updates hourly temporal axis labeling so midnight ticks render as dates and other ticks still render as times.

- Adds a temporal axis `labelExpr` for hourly grain formatting.
- Shows day-boundary ticks as `%b %d`.
- Keeps non-midnight ticks as `%H:%M`.

Examples

<img width="892" height="330" alt="image" src="https://github.com/user-attachments/assets/e9234f01-30f0-4216-84db-3fc5da87e94f" />

<img width="901" height="330" alt="image" src="https://github.com/user-attachments/assets/00915d8d-e5a5-4868-9461-52d6e0038e62" />

<img width="912" height="331" alt="image" src="https://github.com/user-attachments/assets/b5d1a8be-ad62-4d36-853f-b0b0dae0cc86" />




**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
