### PR TITLE
Add tags support for pivot tables

### DIFF
--- a/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
+++ b/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
@@ -197,10 +197,7 @@
         <!-- Right column: shown/hidden lists -->
         <div class="flex flex-col flex-1 min-w-0">
           {#if filterActive && selectedTag}
-            <TagFilterBanner
-              tagName={selectedTag}
-              onClear={clearTagFilter}
-            />
+            <TagFilterBanner tagName={selectedTag} onClear={clearTagFilter} />
           {/if}
 
           {#key selectedTag}

--- a/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
+++ b/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import DraggableList from "@rilldata/web-common/components/draggable-list";
   import CaretDownIcon from "@rilldata/web-common/components/icons/CaretDownIcon.svelte";
-  import CancelCircle from "@rilldata/web-common/components/icons/CancelCircle.svelte";
   import DragHandle from "@rilldata/web-common/components/icons/DragHandle.svelte";
   import EyeIcon from "@rilldata/web-common/components/icons/Eye.svelte";
   import EyeOffIcon from "@rilldata/web-common/components/icons/EyeInvisible.svelte";
@@ -14,18 +13,20 @@
   import { Button } from "../button";
   import Search from "../search/Search.svelte";
   import DashboardMetricsTagRow from "./DashboardMetricsTagRow.svelte";
+  import TagFilterBanner from "./TagFilterBanner.svelte";
   import {
     applyHideAllInTag,
     applyOnlyShowTag,
     applyShowAllInTag,
-    buildTagIndex,
     computeTagVisibility,
+    type TagIndex,
   } from "./tag-utils";
 
   type SelectableItem = MetricsViewSpecMeasure | MetricsViewSpecDimension;
 
   export let selectedItems: string[];
   export let allItems: SelectableItem[] = [];
+  export let tagIndex: TagIndex;
   export let type: "measure" | "dimension" = "measure";
   export let onSelectedChange: (items: string[]) => void;
 
@@ -44,7 +45,6 @@
   $: tooltipText = `Choose ${type === "measure" ? "measures" : "dimensions"} to display`;
   $: pluralLabel = type === "measure" ? "measures" : "dimensions";
 
-  $: tagIndex = buildTagIndex(allItems);
   $: tags = tagIndex.tags;
 
   $: hasTags = tags.length > 0;
@@ -196,23 +196,11 @@
 
         <!-- Right column: shown/hidden lists -->
         <div class="flex flex-col flex-1 min-w-0">
-          {#if filterActive}
-            <div
-              class="flex items-center justify-between gap-x-2 px-3 py-1.5 bg-popover-accent"
-            >
-              <div class="text-xs text-fg-secondary truncate">
-                Filtered by tag
-                <span class="text-fg-primary font-medium">{selectedTag}</span>
-              </div>
-              <button
-                type="button"
-                class="flex items-center gap-x-1 text-xs text-theme-500 hover:text-theme-600 font-medium"
-                onclick={clearTagFilter}
-              >
-                <CancelCircle size="12px" />
-                Clear
-              </button>
-            </div>
+          {#if filterActive && selectedTag}
+            <TagFilterBanner
+              tagName={selectedTag}
+              onClear={clearTagFilter}
+            />
           {/if}
 
           {#key selectedTag}

--- a/web-common/src/components/menu/TagFilterBanner.svelte
+++ b/web-common/src/components/menu/TagFilterBanner.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import * as Tooltip from "@rilldata/web-common/components/tooltip-v2";
+  import CancelCircle from "../icons/CancelCircle.svelte";
+
+  type Props = {
+    tagName: string;
+    onClear: () => void;
+  };
+
+  let { tagName, onClear }: Props = $props();
+</script>
+
+<div
+  class="flex items-center gap-x-1.5 px-3 py-1.5 bg-popover-accent border-b"
+>
+  <span class="text-xs text-fg-secondary flex-none">Filter:</span>
+  <span class="truncate text-xs text-fg-primary font-medium flex-1 min-w-0">
+    {tagName}
+  </span>
+  <Tooltip.Root delayDuration={200}>
+    <Tooltip.Trigger>
+      <button
+        type="button"
+        class="flex-none text-icon-muted hover:text-fg-primary transition-colors"
+        onclick={onClear}
+        aria-label="Clear tag filter"
+      >
+        <CancelCircle size="14px" />
+      </button>
+    </Tooltip.Trigger>
+    <Tooltip.Content
+      side="top"
+      class="bg-popover text-fg-primary z-popover text-xs px-2 py-1"
+    >
+      Clear filter
+    </Tooltip.Content>
+  </Tooltip.Root>
+</div>

--- a/web-common/src/components/menu/TagFilterBanner.svelte
+++ b/web-common/src/components/menu/TagFilterBanner.svelte
@@ -17,14 +17,17 @@
   </span>
   <Tooltip.Root delayDuration={200}>
     <Tooltip.Trigger>
-      <button
-        type="button"
-        class="flex-none text-icon-muted hover:text-fg-primary transition-colors"
-        onclick={onClear}
-        aria-label="Clear tag filter"
-      >
-        <CancelCircle size="14px" />
-      </button>
+      {#snippet child({ props })}
+        <button
+          {...props}
+          type="button"
+          class="flex-none text-icon-muted hover:text-fg-primary transition-colors"
+          onclick={onClear}
+          aria-label="Clear tag filter"
+        >
+          <CancelCircle size="14px" />
+        </button>
+      {/snippet}
     </Tooltip.Trigger>
     <Tooltip.Content
       side="top"

--- a/web-common/src/components/menu/TagFilterBanner.svelte
+++ b/web-common/src/components/menu/TagFilterBanner.svelte
@@ -10,9 +10,7 @@
   let { tagName, onClear }: Props = $props();
 </script>
 
-<div
-  class="flex items-center gap-x-1.5 px-3 py-1.5 bg-popover-accent border-b"
->
+<div class="flex items-center gap-x-1.5 px-3 py-1.5 bg-popover-accent border-b">
   <span class="text-xs text-fg-secondary flex-none">Filter:</span>
   <span class="truncate text-xs text-fg-primary font-medium flex-1 min-w-0">
     {tagName}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardControls.svelte
@@ -15,6 +15,7 @@
       measures: { getMeasureByName, visibleMeasures },
       leaderboard: { leaderboardSortByMeasureName, leaderboardMeasureNames },
       dimensions: { visibleDimensions, allDimensions },
+      tags: { dimensionTagIndex },
     },
     actions: {
       contextColumn: { setContextColumn },
@@ -78,6 +79,7 @@
     onSelectedChange={(items) =>
       setDimensionVisibility(items, allDimensionNames)}
     allItems={$allDimensions}
+    tagIndex={$dimensionTagIndex}
     selectedItems={visibleDimensionsNames}
   />
   <LeaderboardMeasureNamesDropdown

--- a/web-common/src/features/dashboards/pivot/AddField.svelte
+++ b/web-common/src/features/dashboards/pivot/AddField.svelte
@@ -18,7 +18,7 @@
 </script>
 
 <script lang="ts">
-  import { splitTagItems } from "./pivot-utils";
+  import { appendChipsToZone, splitTagItems } from "./pivot-utils";
 
   export let zone: "rows" | "columns" | null = null;
 
@@ -28,7 +28,7 @@
 
   const {
     selectors: {
-      pivot: { dimensions, measures },
+      pivot: { dimensions, measures, rows, originalColumns },
       tags: { combinedTagIndex, dimensionTagIndex, measureTagIndex },
     },
     exploreName,
@@ -120,6 +120,8 @@
   ];
 
   function handleSelectValue(name: string) {
+    let toAdd: PivotChipData[];
+
     if (name.startsWith(TAG_PREFIX)) {
       const tagName = name.slice(TAG_PREFIX.length);
       const { dimensions: dims, measures: meas } = splitTagItems(
@@ -127,22 +129,32 @@
         $dimensionTagIndex,
         $measureTagIndex,
       );
-      const toAdd = zone === "rows" ? dims : [...dims, ...meas];
-      for (const item of toAdd) {
-        metricsExplorerStore.addPivotField($exploreName, item, zone === "rows");
-      }
-      return;
+      toAdd = zone === "rows" ? dims : [...dims, ...meas];
+    } else {
+      const selectedItem = allDimensionsMeasures.find(
+        (item) => item.id === name,
+      ) as PivotChipData | undefined;
+      if (!selectedItem) return;
+      toAdd = [selectedItem];
     }
 
-    const selectedItem = allDimensionsMeasures.find(
-      (item) => item.id === name,
-    ) as PivotChipData;
+    if (toAdd.length === 0) return;
 
-    metricsExplorerStore.addPivotField(
-      $exploreName,
-      selectedItem,
-      zone === "rows",
-    );
+    // appendChipsToZone dedups against both zones so a dimension never lands
+    // in rows and columns at once. The dropdown sources already exclude
+    // placed dimensions/measures, but time grains and tag bulk-adds can
+    // include items already present elsewhere — this is the catch.
+    if (zone === "rows") {
+      const next = appendChipsToZone($rows, $originalColumns, toAdd);
+      if (next.length !== $rows.length) {
+        metricsExplorerStore.setPivotRows($exploreName, next);
+      }
+    } else {
+      const next = appendChipsToZone($originalColumns, $rows, toAdd);
+      if (next.length !== $originalColumns.length) {
+        metricsExplorerStore.setPivotColumns($exploreName, next);
+      }
+    }
   }
 </script>
 

--- a/web-common/src/features/dashboards/pivot/AddField.svelte
+++ b/web-common/src/features/dashboards/pivot/AddField.svelte
@@ -18,11 +18,18 @@
 </script>
 
 <script lang="ts">
+  import { splitTagItems } from "./pivot-utils";
+
   export let zone: "rows" | "columns" | null = null;
+
+  // Prefix used to identify tag rows in the dropdown's flat name space.
+  // Tag names can collide with dimension/measure ids otherwise.
+  const TAG_PREFIX = "__tag__:";
 
   const {
     selectors: {
       pivot: { dimensions, measures },
+      tags: { combinedTagIndex, dimensionTagIndex, measureTagIndex },
     },
     exploreName,
   } = getStateManagers();
@@ -48,7 +55,36 @@
       !isGrainBigger($timeControlsStore.minTimeGrain, tgo.id),
   );
 
+  // Tag rows count items that are routable for the current zone: rows can
+  // only accept dimensions, so a tag of pure measures has nothing to add
+  // there and is hidden.
+  $: tagGroupItems = $combinedTagIndex.tags
+    .map((t) => {
+      const dimCount = $dimensionTagIndex.itemsByTag.get(t.name)?.length ?? 0;
+      const measCount = $measureTagIndex.itemsByTag.get(t.name)?.length ?? 0;
+      const usable = zone === "rows" ? dimCount : dimCount + measCount;
+      return { tag: t, dimCount, measCount, usable };
+    })
+    .filter((t) => t.usable > 0)
+    .map(({ tag, dimCount, measCount }) => ({
+      name: `${TAG_PREFIX}${tag.name}`,
+      label:
+        dimCount > 0 && measCount > 0
+          ? `${tag.name} (${dimCount} dim · ${measCount} meas)`
+          : dimCount > 0
+            ? `${tag.name} (${dimCount} dim)`
+            : `${tag.name} (${measCount} meas)`,
+    }));
+
   $: selectableGroups = [
+    ...(tagGroupItems.length > 0
+      ? [
+          <SearchableFilterSelectableGroup>{
+            name: "TAGS",
+            items: tagGroupItems,
+          },
+        ]
+      : []),
     ...(zone === "columns"
       ? [
           <SearchableFilterSelectableGroup>{
@@ -83,7 +119,27 @@
     ...timeGrainOptions,
   ];
 
-  function handleSelectValue(name) {
+  function handleSelectValue(name: string) {
+    if (name.startsWith(TAG_PREFIX)) {
+      const tagName = name.slice(TAG_PREFIX.length);
+      const { dimensions: dims, measures: meas } = splitTagItems(
+        tagName,
+        $dimensionTagIndex,
+        $measureTagIndex,
+      );
+      if (zone === "rows") {
+        if (dims.length) {
+          metricsExplorerStore.addPivotFields($exploreName, dims, "rows");
+        }
+      } else {
+        const all = [...dims, ...meas];
+        if (all.length) {
+          metricsExplorerStore.addPivotFields($exploreName, all, "columns");
+        }
+      }
+      return;
+    }
+
     const selectedItem = allDimensionsMeasures.find(
       (item) => item.id === name,
     ) as PivotChipData;

--- a/web-common/src/features/dashboards/pivot/AddField.svelte
+++ b/web-common/src/features/dashboards/pivot/AddField.svelte
@@ -127,15 +127,9 @@
         $dimensionTagIndex,
         $measureTagIndex,
       );
-      if (zone === "rows") {
-        if (dims.length) {
-          metricsExplorerStore.addPivotFields($exploreName, dims, "rows");
-        }
-      } else {
-        const all = [...dims, ...meas];
-        if (all.length) {
-          metricsExplorerStore.addPivotFields($exploreName, all, "columns");
-        }
+      const toAdd = zone === "rows" ? dims : [...dims, ...meas];
+      for (const item of toAdd) {
+        metricsExplorerStore.addPivotField($exploreName, item, zone === "rows");
       }
       return;
     }

--- a/web-common/src/features/dashboards/pivot/DragList.svelte
+++ b/web-common/src/features/dashboards/pivot/DragList.svelte
@@ -182,11 +182,7 @@
           if (replace) {
             metricsExplorerStore.replacePivotColumns($exploreName, all);
           } else if (all.length > 0) {
-            metricsExplorerStore.addPivotFields(
-              $exploreName,
-              all,
-              "columns",
-            );
+            metricsExplorerStore.addPivotFields($exploreName, all, "columns");
           }
         }
       } else if (dragChip && ghostIndex !== null) {

--- a/web-common/src/features/dashboards/pivot/DragList.svelte
+++ b/web-common/src/features/dashboards/pivot/DragList.svelte
@@ -6,8 +6,6 @@
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { V1TimeGrain } from "@rilldata/web-common/runtime-client";
   import { writable } from "svelte/store";
-  import { getStateManagers } from "../state-managers/state-managers";
-  import { metricsExplorerStore } from "../stores/dashboard-stores";
   import AddField from "./AddField.svelte";
   import PivotChip from "./PivotChip.svelte";
   import PivotPortalItem from "./PivotPortalItem.svelte";
@@ -72,8 +70,6 @@
   let dragStart = { left: 0, top: 0 };
   let pendingDrag: PendingDragState | null = null;
   let dragActive = false;
-
-  const { exploreName } = getStateManagers();
 
   $: ghostIndex = $_ghostIndex;
   $: dragData = $dragDataStore;
@@ -165,25 +161,18 @@
     if (isValidDropZone) {
       if (dragData?.tagPayload) {
         // Bulk-add path for tag drops. Skips ghost-index positioning since
-        // we are inserting multiple chips, not a single one.
+        // we are inserting multiple chips, not a single one. Cross-zone
+        // cleanup on replace happens in the auto-arrange zone or the click
+        // affordances on the tag row — DragList only manages its own zone.
         const { dimensions, measures } = dragData.tagPayload;
-        if (zone === "rows") {
-          if (replace) {
-            metricsExplorerStore.replacePivotRows($exploreName, dimensions);
-          } else if (dimensions.length > 0) {
-            metricsExplorerStore.addPivotFields(
-              $exploreName,
-              dimensions,
-              "rows",
-            );
-          }
-        } else if (zone === "columns") {
-          const all = [...dimensions, ...measures];
-          if (replace) {
-            metricsExplorerStore.replacePivotColumns($exploreName, all);
-          } else if (all.length > 0) {
-            metricsExplorerStore.addPivotFields($exploreName, all, "columns");
-          }
+        const newItems =
+          zone === "rows" ? dimensions : [...dimensions, ...measures];
+        if (replace) {
+          onUpdate(newItems);
+        } else if (newItems.length > 0) {
+          const existing = new Set(items.map((c) => c.id));
+          const additions = newItems.filter((c) => !existing.has(c.id));
+          if (additions.length > 0) onUpdate([...items, ...additions]);
         }
       } else if (dragChip && ghostIndex !== null) {
         const temp = [...items];

--- a/web-common/src/features/dashboards/pivot/DragList.svelte
+++ b/web-common/src/features/dashboards/pivot/DragList.svelte
@@ -26,12 +26,28 @@
   } from "@rilldata/web-common/features/dashboards/pivot/time-pill-utils";
   import { timePillSelectors } from "./time-pill-store";
 
-  export type Zone = "rows" | "columns" | "Time" | "Measures" | "Dimensions";
+  export type Zone =
+    | "rows"
+    | "columns"
+    | "Time"
+    | "Measures"
+    | "Dimensions"
+    | "tags";
+
+  // When a tag chip is being dragged the drop receivers do a bulk-add instead
+  // of the per-chip splice path. The dimensions and measures arrays are
+  // precomputed at drag-start so each receiver does not have to re-split.
+  export type TagDragPayload = {
+    tagName: string;
+    dimensions: PivotChipData[];
+    measures: PivotChipData[];
+  };
 
   export type DragData = {
     source: Zone;
     width: number;
     chip: PivotChipData;
+    tagPayload?: TagDragPayload;
   };
 
   export const dragDataStore = writable<null | DragData>(null);
@@ -70,10 +86,14 @@
     (i) => i.type !== PivotChipType.Measure,
   );
 
+  $: isTagDrag = !!dragData?.tagPayload;
+
   $: isValidDropZone =
     isDropLocation &&
     dragData &&
-    (zone === "columns" || dragChip?.type !== PivotChipType.Measure);
+    (isTagDrag ||
+      zone === "columns" ||
+      dragChip?.type !== PivotChipType.Measure);
 
   // Get available grains from the store
   const availableGrainsStore = timePillSelectors.getAvailableGrains("time");
@@ -134,12 +154,42 @@
     window.removeEventListener("mousemove", detectDragStart);
   }
 
-  function handleDrop() {
+  function handleDrop(e: MouseEvent) {
     if (zoneStartedDrag)
       $controllerStore?.abort("Drag cancelled - item dropped");
 
+    // Holding CMD (mac) or Ctrl flips the tag drop from append to replace,
+    // matching the click-side affordance on the tag row.
+    const replace = e.metaKey || e.ctrlKey;
+
     if (isValidDropZone) {
-      if (dragChip && ghostIndex !== null) {
+      if (dragData?.tagPayload) {
+        // Bulk-add path for tag drops. Skips ghost-index positioning since
+        // we are inserting multiple chips, not a single one.
+        const { dimensions, measures } = dragData.tagPayload;
+        if (zone === "rows") {
+          if (replace) {
+            metricsExplorerStore.replacePivotRows($exploreName, dimensions);
+          } else if (dimensions.length > 0) {
+            metricsExplorerStore.addPivotFields(
+              $exploreName,
+              dimensions,
+              "rows",
+            );
+          }
+        } else if (zone === "columns") {
+          const all = [...dimensions, ...measures];
+          if (replace) {
+            metricsExplorerStore.replacePivotColumns($exploreName, all);
+          } else if (all.length > 0) {
+            metricsExplorerStore.addPivotFields(
+              $exploreName,
+              all,
+              "columns",
+            );
+          }
+        }
+      } else if (dragChip && ghostIndex !== null) {
         const temp = [...items];
 
         let chipToAdd = dragChip;

--- a/web-common/src/features/dashboards/pivot/DragList.svelte
+++ b/web-common/src/features/dashboards/pivot/DragList.svelte
@@ -171,9 +171,11 @@
         const { dimensions, measures } = dragData.tagPayload;
         const newItems =
           zone === "rows" ? dimensions : [...dimensions, ...measures];
-        if (replace) {
+        if (newItems.length === 0) {
+          // Pure-measure tag dropped on rows, for instance: nothing to do.
+        } else if (replace) {
           onUpdate(newItems);
-        } else if (newItems.length > 0) {
+        } else {
           const existing = new Set(items.map((c) => c.id));
           const additions = newItems.filter((c) => !existing.has(c.id));
           if (additions.length > 0) onUpdate([...items, ...additions]);

--- a/web-common/src/features/dashboards/pivot/DragList.svelte
+++ b/web-common/src/features/dashboards/pivot/DragList.svelte
@@ -6,6 +6,8 @@
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import { V1TimeGrain } from "@rilldata/web-common/runtime-client";
   import { writable } from "svelte/store";
+  import { getStateManagers } from "../state-managers/state-managers";
+  import { metricsExplorerStore } from "../stores/dashboard-stores";
   import AddField from "./AddField.svelte";
   import PivotChip from "./PivotChip.svelte";
   import PivotPortalItem from "./PivotPortalItem.svelte";
@@ -70,6 +72,8 @@
   let dragStart = { left: 0, top: 0 };
   let pendingDrag: PendingDragState | null = null;
   let dragActive = false;
+
+  const { exploreName } = getStateManagers();
 
   $: ghostIndex = $_ghostIndex;
   $: dragData = $dragDataStore;

--- a/web-common/src/features/dashboards/pivot/PivotAutoArrangeZone.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotAutoArrangeZone.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+  import Pivot from "@rilldata/web-common/components/icons/Pivot.svelte";
+  import { modifierHeld } from "@rilldata/web-common/lib/modifier-key";
+  import { slide } from "svelte/transition";
+  import { dragDataStore } from "./DragList.svelte";
+  import type { PivotChipData } from "./types";
+
+  export let rows: PivotChipData[];
+  export let columns: PivotChipData[];
+  export let setRows: (items: PivotChipData[]) => void;
+  export let setColumns: (items: PivotChipData[]) => void;
+
+  $: dragData = $dragDataStore;
+  // Auto-arrange only makes sense for mixed tags: a pure-dim or pure-measure
+  // tag has a single natural target so the user can drop on Rows or Columns
+  // directly.
+  $: visible =
+    !!dragData?.tagPayload &&
+    dragData.tagPayload.dimensions.length > 0 &&
+    dragData.tagPayload.measures.length > 0;
+
+  let hover = false;
+
+  function handleDrop(e: MouseEvent) {
+    if (!dragData?.tagPayload) return;
+    const replace = e.metaKey || e.ctrlKey;
+    const { dimensions, measures } = dragData.tagPayload;
+    if (replace) {
+      // Both zones are set to the natural slice of the tag; cross-zone
+      // cleanup happens implicitly since the zones don't overlap.
+      setRows(dimensions);
+      setColumns(measures);
+    } else {
+      if (dimensions.length > 0) {
+        const existingRows = new Set(rows.map((c) => c.id));
+        const dimAdds = dimensions.filter((d) => !existingRows.has(d.id));
+        if (dimAdds.length > 0) setRows([...rows, ...dimAdds]);
+      }
+      if (measures.length > 0) {
+        const existingCols = new Set(columns.map((c) => c.id));
+        const measAdds = measures.filter((m) => !existingCols.has(m.id));
+        if (measAdds.length > 0) setColumns([...columns, ...measAdds]);
+      }
+    }
+    dragDataStore.set(null);
+    hover = false;
+  }
+</script>
+
+{#if visible && dragData?.tagPayload}
+  <div class="header-row" transition:slide={{ duration: 160, axis: "y" }}>
+    <span class="row-label">
+      <Pivot size="16px" /> Auto
+    </span>
+    <div
+      role="presentation"
+      class="auto-arrange-zone"
+      class:hover
+      class:replace={$modifierHeld}
+      onmouseenter={() => (hover = true)}
+      onmouseleave={() => (hover = false)}
+      onmouseup={handleDrop}
+      aria-label={$modifierHeld
+        ? "Drop here to replace rows and columns with this tag"
+        : "Drop here to auto-arrange tag"}
+    >
+      {#if $modifierHeld}
+        Drop to <strong>replace</strong>:
+        <strong>{dragData.tagPayload.dimensions.length}</strong>
+        {dragData.tagPayload.dimensions.length === 1 ? "dim" : "dims"}
+        → rows,
+        <strong>{dragData.tagPayload.measures.length}</strong>
+        {dragData.tagPayload.measures.length === 1 ? "measure" : "measures"}
+        → columns
+      {:else}
+        Drop here to split:
+        <strong>{dragData.tagPayload.dimensions.length}</strong>
+        {dragData.tagPayload.dimensions.length === 1 ? "dim" : "dims"}
+        → rows,
+        <strong>{dragData.tagPayload.measures.length}</strong>
+        {dragData.tagPayload.measures.length === 1 ? "measure" : "measures"}
+        → columns (<span class="kbd">⌘</span> + Drop to replace)
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style lang="postcss">
+  .header-row {
+    @apply flex items-center gap-x-2 px-2;
+  }
+
+  .row-label {
+    @apply w-20 flex items-center gap-x-1 flex-shrink-0 text-fg-secondary;
+  }
+
+  .auto-arrange-zone {
+    @apply flex-1 flex items-center justify-center gap-x-1;
+    @apply rounded-sm border border-dashed border-blue-400;
+    @apply bg-blue-50/50 text-fg-secondary text-xs;
+    @apply py-2 px-3;
+  }
+
+  .auto-arrange-zone.hover {
+    @apply bg-blue-100 border-blue-500 text-fg-primary;
+  }
+
+  .auto-arrange-zone.replace {
+    @apply border-amber-500 bg-amber-50/50;
+  }
+
+  .auto-arrange-zone.replace.hover {
+    @apply bg-amber-100 border-amber-600;
+  }
+
+  .kbd {
+    @apply inline-block px-1 py-px ml-1 rounded-sm border;
+    @apply text-[10px] font-mono text-fg-secondary;
+  }
+</style>

--- a/web-common/src/features/dashboards/pivot/PivotDisplay.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotDisplay.svelte
@@ -26,6 +26,7 @@
     validSpecStore,
     selectors: {
       pivot: { columns, measures, dimensions },
+      tags: { combinedTagIndex, dimensionTagIndex, measureTagIndex },
     },
     timeRangeSummaryStore,
   } = stateManagers;
@@ -100,6 +101,10 @@
       pivotState={enrichedPivotState}
       measures={$measures}
       dimensions={$dimensions}
+      combinedTagIndex={$combinedTagIndex}
+      dimensionTagIndex={$dimensionTagIndex}
+      measureTagIndex={$measureTagIndex}
+      exploreName={$exploreName}
       {timeControlsForPillActions}
     />
   {/if}

--- a/web-common/src/features/dashboards/pivot/PivotDisplay.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotDisplay.svelte
@@ -104,7 +104,9 @@
       combinedTagIndex={$combinedTagIndex}
       dimensionTagIndex={$dimensionTagIndex}
       measureTagIndex={$measureTagIndex}
-      exploreName={$exploreName}
+      setRows={(rows) => metricsExplorerStore.setPivotRows($exploreName, rows)}
+      setColumns={(columns) =>
+        metricsExplorerStore.setPivotColumns($exploreName, columns)}
       {timeControlsForPillActions}
     />
   {/if}

--- a/web-common/src/features/dashboards/pivot/PivotHeader.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotHeader.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
   import Column from "@rilldata/web-common/components/icons/Column.svelte";
+  import Pivot from "@rilldata/web-common/components/icons/Pivot.svelte";
   import Row from "@rilldata/web-common/components/icons/Row.svelte";
   import { splitPivotChips } from "@rilldata/web-common/features/dashboards/pivot/pivot-utils.ts";
+  import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
+  import { modifierHeld } from "@rilldata/web-common/lib/modifier-key";
   import { slide } from "svelte/transition";
-  import DragList from "./DragList.svelte";
+  import { getStateManagers } from "../state-managers/state-managers";
+  import DragList, { dragDataStore } from "./DragList.svelte";
   import { lastNestState } from "./PivotToolbar.svelte";
   import { PivotChipType, type PivotChipData, type PivotState } from "./types";
 
@@ -11,10 +15,51 @@
   export let setRows: (items: PivotChipData[]) => void;
   export let setColumns: (items: PivotChipData[]) => void;
 
+  const { exploreName } = getStateManagers();
+
   $: ({ rows, columns, tableMode } = pivotState);
   $: splitColumns = splitPivotChips(columns);
   $: fullColumns = splitColumns.dimension.concat(splitColumns.measure);
   $: isFlat = tableMode === "flat";
+
+  $: dragData = $dragDataStore;
+  // Auto-arrange only makes sense for mixed tags. A pure-dimension or
+  // pure-measure tag has a single natural target — drop on Rows or
+  // Columns directly.
+  $: showAutoArrange =
+    !isFlat &&
+    !!dragData?.tagPayload &&
+    dragData.tagPayload.dimensions.length > 0 &&
+    dragData.tagPayload.measures.length > 0;
+
+  let autoArrangeHover = false;
+
+  function handleAutoArrangeDrop(e: MouseEvent) {
+    if (!dragData?.tagPayload) return;
+    const replace = e.metaKey || e.ctrlKey;
+    const { dimensions, measures } = dragData.tagPayload;
+    if (replace) {
+      metricsExplorerStore.replacePivotRows($exploreName, dimensions);
+      metricsExplorerStore.replacePivotColumns($exploreName, measures);
+    } else {
+      if (dimensions.length > 0) {
+        metricsExplorerStore.addPivotFields(
+          $exploreName,
+          dimensions,
+          "rows",
+        );
+      }
+      if (measures.length > 0) {
+        metricsExplorerStore.addPivotFields(
+          $exploreName,
+          measures,
+          "columns",
+        );
+      }
+    }
+    dragDataStore.set(null);
+    autoArrangeHover = false;
+  }
 
   function updateColumn(items: PivotChipData[]) {
     // Reset lastNestState when columns are updated
@@ -50,6 +95,47 @@
       />
     </div>
   {/if}
+  {#if showAutoArrange && dragData?.tagPayload}
+    <div
+      class="header-row"
+      transition:slide={{ duration: 160, axis: "y" }}
+    >
+      <span class="row-label">
+        <Pivot size="16px" /> Auto
+      </span>
+      <div
+        role="presentation"
+        class="auto-arrange-zone"
+        class:hover={autoArrangeHover}
+        class:replace={$modifierHeld}
+        onmouseenter={() => (autoArrangeHover = true)}
+        onmouseleave={() => (autoArrangeHover = false)}
+        onmouseup={handleAutoArrangeDrop}
+        aria-label={$modifierHeld
+          ? "Drop here to replace rows and columns with this tag"
+          : "Drop here to auto-arrange tag"}
+      >
+        {#if $modifierHeld}
+          Drop to <strong>replace</strong>:
+          <strong>{dragData.tagPayload.dimensions.length}</strong>
+          {dragData.tagPayload.dimensions.length === 1 ? "dim" : "dims"}
+          → rows,
+          <strong>{dragData.tagPayload.measures.length}</strong>
+          {dragData.tagPayload.measures.length === 1 ? "measure" : "measures"}
+          → columns
+        {:else}
+          Drop here to split:
+          <strong>{dragData.tagPayload.dimensions.length}</strong>
+          {dragData.tagPayload.dimensions.length === 1 ? "dim" : "dims"}
+          → rows,
+          <strong>{dragData.tagPayload.measures.length}</strong>
+          {dragData.tagPayload.measures.length === 1 ? "measure" : "measures"}
+          → columns
+          (<span class="kbd">⌘</span> + Drop to replace)
+        {/if}
+      </div>
+    </div>
+  {/if}
   <div class="header-row">
     <div class="row-label">
       <Column size="16px" /> Columns
@@ -81,5 +167,29 @@
   }
   .row-label {
     @apply w-20 flex items-center gap-x-1 flex-shrink-0 text-fg-secondary;
+  }
+
+  .auto-arrange-zone {
+    @apply flex-1 flex items-center justify-center gap-x-1;
+    @apply rounded-sm border border-dashed border-blue-400;
+    @apply bg-blue-50/50 text-fg-secondary text-xs;
+    @apply py-2 px-3;
+  }
+
+  .auto-arrange-zone.hover {
+    @apply bg-blue-100 border-blue-500 text-fg-primary;
+  }
+
+  .auto-arrange-zone.replace {
+    @apply border-amber-500 bg-amber-50/50;
+  }
+
+  .auto-arrange-zone.replace.hover {
+    @apply bg-amber-100 border-amber-600;
+  }
+
+  .kbd {
+    @apply inline-block px-1 py-px ml-1 rounded-sm border;
+    @apply text-[10px] font-mono text-fg-secondary;
   }
 </style>

--- a/web-common/src/features/dashboards/pivot/PivotHeader.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotHeader.svelte
@@ -1,13 +1,10 @@
 <script lang="ts">
   import Column from "@rilldata/web-common/components/icons/Column.svelte";
-  import Pivot from "@rilldata/web-common/components/icons/Pivot.svelte";
   import Row from "@rilldata/web-common/components/icons/Row.svelte";
   import { splitPivotChips } from "@rilldata/web-common/features/dashboards/pivot/pivot-utils.ts";
-  import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
-  import { modifierHeld } from "@rilldata/web-common/lib/modifier-key";
   import { slide } from "svelte/transition";
-  import { getStateManagers } from "../state-managers/state-managers";
-  import DragList, { dragDataStore } from "./DragList.svelte";
+  import DragList from "./DragList.svelte";
+  import PivotAutoArrangeZone from "./PivotAutoArrangeZone.svelte";
   import { lastNestState } from "./PivotToolbar.svelte";
   import { PivotChipType, type PivotChipData, type PivotState } from "./types";
 
@@ -15,43 +12,11 @@
   export let setRows: (items: PivotChipData[]) => void;
   export let setColumns: (items: PivotChipData[]) => void;
 
-  const { exploreName } = getStateManagers();
-
   $: ({ rows, columns, tableMode } = pivotState);
   $: splitColumns = splitPivotChips(columns);
   $: fullColumns = splitColumns.dimension.concat(splitColumns.measure);
   $: isFlat = tableMode === "flat";
-
-  $: dragData = $dragDataStore;
-  // Auto-arrange only makes sense for mixed tags. A pure-dimension or
-  // pure-measure tag has a single natural target — drop on Rows or
-  // Columns directly.
-  $: showAutoArrange =
-    !isFlat &&
-    !!dragData?.tagPayload &&
-    dragData.tagPayload.dimensions.length > 0 &&
-    dragData.tagPayload.measures.length > 0;
-
-  let autoArrangeHover = false;
-
-  function handleAutoArrangeDrop(e: MouseEvent) {
-    if (!dragData?.tagPayload) return;
-    const replace = e.metaKey || e.ctrlKey;
-    const { dimensions, measures } = dragData.tagPayload;
-    if (replace) {
-      metricsExplorerStore.replacePivotRows($exploreName, dimensions);
-      metricsExplorerStore.replacePivotColumns($exploreName, measures);
-    } else {
-      if (dimensions.length > 0) {
-        metricsExplorerStore.addPivotFields($exploreName, dimensions, "rows");
-      }
-      if (measures.length > 0) {
-        metricsExplorerStore.addPivotFields($exploreName, measures, "columns");
-      }
-    }
-    dragDataStore.set(null);
-    autoArrangeHover = false;
-  }
+  $: columnsForList = isFlat ? columns : fullColumns;
 
   function updateColumn(items: PivotChipData[]) {
     // Reset lastNestState when columns are updated
@@ -69,13 +34,7 @@
 
 <div class="header" transition:slide>
   {#if !isFlat}
-    <div
-      class="header-row"
-      transition:slide={{
-        duration: 200,
-        axis: "y",
-      }}
-    >
+    <div class="header-row" transition:slide={{ duration: 200, axis: "y" }}>
       <span class="row-label">
         <Row size="16px" /> Rows
       </span>
@@ -86,43 +45,12 @@
         onUpdate={updateRows}
       />
     </div>
-  {/if}
-  {#if showAutoArrange && dragData?.tagPayload}
-    <div class="header-row" transition:slide={{ duration: 160, axis: "y" }}>
-      <span class="row-label">
-        <Pivot size="16px" /> Auto
-      </span>
-      <div
-        role="presentation"
-        class="auto-arrange-zone"
-        class:hover={autoArrangeHover}
-        class:replace={$modifierHeld}
-        onmouseenter={() => (autoArrangeHover = true)}
-        onmouseleave={() => (autoArrangeHover = false)}
-        onmouseup={handleAutoArrangeDrop}
-        aria-label={$modifierHeld
-          ? "Drop here to replace rows and columns with this tag"
-          : "Drop here to auto-arrange tag"}
-      >
-        {#if $modifierHeld}
-          Drop to <strong>replace</strong>:
-          <strong>{dragData.tagPayload.dimensions.length}</strong>
-          {dragData.tagPayload.dimensions.length === 1 ? "dim" : "dims"}
-          → rows,
-          <strong>{dragData.tagPayload.measures.length}</strong>
-          {dragData.tagPayload.measures.length === 1 ? "measure" : "measures"}
-          → columns
-        {:else}
-          Drop here to split:
-          <strong>{dragData.tagPayload.dimensions.length}</strong>
-          {dragData.tagPayload.dimensions.length === 1 ? "dim" : "dims"}
-          → rows,
-          <strong>{dragData.tagPayload.measures.length}</strong>
-          {dragData.tagPayload.measures.length === 1 ? "measure" : "measures"}
-          → columns (<span class="kbd">⌘</span> + Drop to replace)
-        {/if}
-      </div>
-    </div>
+    <PivotAutoArrangeZone
+      {rows}
+      columns={columnsForList}
+      setRows={updateRows}
+      setColumns={updateColumn}
+    />
   {/if}
   <div class="header-row">
     <div class="row-label">
@@ -132,7 +60,7 @@
     <DragList
       zone="columns"
       {tableMode}
-      items={isFlat ? columns : fullColumns}
+      items={columnsForList}
       placeholder="Drag dimensions or measures here"
       onUpdate={updateColumn}
     />
@@ -155,29 +83,5 @@
   }
   .row-label {
     @apply w-20 flex items-center gap-x-1 flex-shrink-0 text-fg-secondary;
-  }
-
-  .auto-arrange-zone {
-    @apply flex-1 flex items-center justify-center gap-x-1;
-    @apply rounded-sm border border-dashed border-blue-400;
-    @apply bg-blue-50/50 text-fg-secondary text-xs;
-    @apply py-2 px-3;
-  }
-
-  .auto-arrange-zone.hover {
-    @apply bg-blue-100 border-blue-500 text-fg-primary;
-  }
-
-  .auto-arrange-zone.replace {
-    @apply border-amber-500 bg-amber-50/50;
-  }
-
-  .auto-arrange-zone.replace.hover {
-    @apply bg-amber-100 border-amber-600;
-  }
-
-  .kbd {
-    @apply inline-block px-1 py-px ml-1 rounded-sm border;
-    @apply text-[10px] font-mono text-fg-secondary;
   }
 </style>

--- a/web-common/src/features/dashboards/pivot/PivotHeader.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotHeader.svelte
@@ -43,18 +43,10 @@
       metricsExplorerStore.replacePivotColumns($exploreName, measures);
     } else {
       if (dimensions.length > 0) {
-        metricsExplorerStore.addPivotFields(
-          $exploreName,
-          dimensions,
-          "rows",
-        );
+        metricsExplorerStore.addPivotFields($exploreName, dimensions, "rows");
       }
       if (measures.length > 0) {
-        metricsExplorerStore.addPivotFields(
-          $exploreName,
-          measures,
-          "columns",
-        );
+        metricsExplorerStore.addPivotFields($exploreName, measures, "columns");
       }
     }
     dragDataStore.set(null);
@@ -96,10 +88,7 @@
     </div>
   {/if}
   {#if showAutoArrange && dragData?.tagPayload}
-    <div
-      class="header-row"
-      transition:slide={{ duration: 160, axis: "y" }}
-    >
+    <div class="header-row" transition:slide={{ duration: 160, axis: "y" }}>
       <span class="row-label">
         <Pivot size="16px" /> Auto
       </span>
@@ -130,8 +119,7 @@
           → rows,
           <strong>{dragData.tagPayload.measures.length}</strong>
           {dragData.tagPayload.measures.length === 1 ? "measure" : "measures"}
-          → columns
-          (<span class="kbd">⌘</span> + Drop to replace)
+          → columns (<span class="kbd">⌘</span> + Drop to replace)
         {/if}
       </div>
     </div>

--- a/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
@@ -1,11 +1,20 @@
 <script lang="ts">
-  import { slide } from "svelte/transition";
+  import TagFilterBanner from "@rilldata/web-common/components/menu/TagFilterBanner.svelte";
+  import type { TagIndex } from "@rilldata/web-common/components/menu/tag-utils";
   import { Search } from "@rilldata/web-common/components/search";
-  import { splitPivotChips } from "@rilldata/web-common/features/dashboards/pivot/pivot-utils.ts";
+  import {
+    splitPivotChips,
+    splitTagItems,
+  } from "@rilldata/web-common/features/dashboards/pivot/pivot-utils.ts";
+  import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
   import { type TimeControlState } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
   import { onMount } from "svelte";
+  import { slide } from "svelte/transition";
   import type { PivotState } from "web-common/src/features/dashboards/pivot/types.ts";
+  import { dragDataStore } from "./DragList.svelte";
   import PivotDrag from "./PivotDrag.svelte";
+  import PivotPortalItem from "./PivotPortalItem.svelte";
+  import PivotTagRow from "./PivotTagRow.svelte";
   import { timePillActions, timePillSelectors } from "./time-pill-store";
   import type { PivotChipData } from "./types";
   import { PivotChipType } from "./types";
@@ -13,6 +22,10 @@
   export let pivotState: PivotState;
   export let measures: PivotChipData[];
   export let dimensions: PivotChipData[];
+  export let combinedTagIndex: TagIndex;
+  export let dimensionTagIndex: TagIndex;
+  export let measureTagIndex: TagIndex;
+  export let exploreName: string;
   export let timeControlsForPillActions: Pick<
     TimeControlState,
     "timeStart" | "timeEnd" | "minTimeGrain"
@@ -23,6 +36,25 @@
 
   let sidebarHeight = 0;
   let searchText = "";
+  let selectedTag: string | null = null;
+
+  // Tag drag-and-drop state. Mirrors the chip-drag flow in DragList.svelte
+  // but coordinates from the sidebar level since tag rows are not chips.
+  const TAG_DRAG_THRESHOLD_PX = 4;
+  let tagPendingDrag: {
+    tagName: string;
+    dimensions: PivotChipData[];
+    measures: PivotChipData[];
+    rect: DOMRect;
+    startX: number;
+    startY: number;
+    offsetX: number;
+    offsetY: number;
+  } | null = null;
+  let tagDragActive = false;
+  let tagDragPosition = { left: 0, top: 0 };
+  let tagDragOffset = { x: 0, y: 0 };
+  let tagDragChip: PivotChipData | null = null;
 
   onMount(() => {
     timePillActions.initTimeDimension("time", "Time");
@@ -43,7 +75,6 @@
     timePillActions.updateUsedGrains("time", rows, splitColumns.dimension);
   }
 
-  // Get reactive values from the store
   $: shouldShowTimePill = timePillSelectors.getAllGrainsUsed("time");
 
   $: timeGrainOptions = !$shouldShowTimePill
@@ -56,18 +87,186 @@
       ]
     : [];
 
-  $: filteredMeasures = filterBasedOnSearch(measures, searchText);
-  $: filteredDimensions = filterBasedOnSearch(dimensions, searchText);
+  $: tags = combinedTagIndex.tags;
+  $: hasTags = tags.length > 0;
 
-  function filterBasedOnSearch(fullList: PivotChipData[], search: string) {
-    return fullList.filter((d) =>
-      d.title.toLowerCase().includes(search.toLowerCase()),
-    );
+  // Drop the selection if the active tag disappears from the spec
+  // (e.g. the user edits the metrics view).
+  $: if (selectedTag && !tags.some((t) => t.name === selectedTag)) {
+    selectedTag = null;
+  }
+
+  $: namesInSelectedTag = selectedTag
+    ? new Set(
+        (combinedTagIndex.itemsByTag.get(selectedTag) ?? [])
+          .map((item) => item.name)
+          .filter((n): n is string => !!n),
+      )
+    : null;
+
+  $: filteredTags = searchText.trim()
+    ? tags.filter((t) =>
+        t.name.toLowerCase().includes(searchText.trim().toLowerCase()),
+      )
+    : tags;
+
+  $: filteredMeasures = filterItems(measures, searchText, namesInSelectedTag);
+  $: filteredDimensions = filterItems(
+    dimensions,
+    searchText,
+    namesInSelectedTag,
+  );
+
+  function filterItems(
+    fullList: PivotChipData[],
+    search: string,
+    tagNames: Set<string> | null,
+  ) {
+    const lowerSearch = search.trim().toLowerCase();
+    return fullList.filter((chip) => {
+      if (tagNames && !tagNames.has(chip.id)) return false;
+      if (lowerSearch && !chip.title.toLowerCase().includes(lowerSearch))
+        return false;
+      return true;
+    });
+  }
+
+  function toggleTagFilter(tagName: string) {
+    selectedTag = selectedTag === tagName ? null : tagName;
+  }
+
+  function clearTagFilter() {
+    selectedTag = null;
+  }
+
+  function tagItemsFor(tagName: string) {
+    return splitTagItems(tagName, dimensionTagIndex, measureTagIndex);
+  }
+
+  function handleTagDragStart(
+    e: MouseEvent,
+    tagName: string,
+    items: { dimensions: PivotChipData[]; measures: PivotChipData[] },
+    rect: DOMRect,
+  ) {
+    tagPendingDrag = {
+      tagName,
+      dimensions: items.dimensions,
+      measures: items.measures,
+      rect,
+      startX: e.clientX,
+      startY: e.clientY,
+      offsetX: e.clientX - rect.left,
+      offsetY: e.clientY - rect.top,
+    };
+    window.addEventListener("mousemove", detectTagDragStart);
+    window.addEventListener("mouseup", handleTagGlobalMouseUp, { once: true });
+  }
+
+  function detectTagDragStart(e: MouseEvent) {
+    if (!tagPendingDrag || tagDragActive) return;
+    const moved =
+      Math.abs(e.clientX - tagPendingDrag.startX) >= TAG_DRAG_THRESHOLD_PX ||
+      Math.abs(e.clientY - tagPendingDrag.startY) >= TAG_DRAG_THRESHOLD_PX;
+    if (!moved) return;
+    beginTagDrag();
+  }
+
+  function beginTagDrag() {
+    if (!tagPendingDrag) return;
+    tagDragActive = true;
+    window.removeEventListener("mousemove", detectTagDragStart);
+
+    const { tagName, dimensions, measures, rect, offsetX, offsetY } =
+      tagPendingDrag;
+
+    tagDragPosition = { left: rect.left, top: rect.top };
+    tagDragOffset = { x: offsetX, y: offsetY };
+
+    // Synthetic chip used by PivotPortalItem to render the floating preview.
+    // Pure-measure tags render with the (rectangular) measure chip styling;
+    // mixed and pure-dimension tags render with the (rounded) dimension shape.
+    const chipType =
+      dimensions.length === 0 && measures.length > 0
+        ? PivotChipType.Measure
+        : PivotChipType.Dimension;
+    tagDragChip = {
+      id: `__tag__:${tagName}`,
+      title: tagName,
+      type: chipType,
+    };
+
+    dragDataStore.set({
+      source: "tags",
+      width: rect.width,
+      chip: tagDragChip,
+      tagPayload: { tagName, dimensions, measures },
+    });
+  }
+
+  function handleTagGlobalMouseUp() {
+    window.removeEventListener("mousemove", detectTagDragStart);
+    if (!tagDragActive) {
+      // Mousedown without movement: treat as a click on the tag row.
+      // Toggles the filter selection. This avoids needing a separate
+      // onclick handler that would race with the drag setup.
+      if (tagPendingDrag) {
+        toggleTagFilter(tagPendingDrag.tagName);
+      }
+      tagPendingDrag = null;
+      return;
+    }
+    resetTagDrag();
+  }
+
+  function resetTagDrag() {
+    tagDragActive = false;
+    tagDragChip = null;
+    tagPendingDrag = null;
+    dragDataStore.set(null);
+    window.removeEventListener("mousemove", detectTagDragStart);
+  }
+
+  function addTagToRows(tagName: string, replace: boolean) {
+    const { dimensions: dims } = tagItemsFor(tagName);
+    if (replace) {
+      metricsExplorerStore.replacePivotRows(exploreName, dims);
+      return;
+    }
+    if (dims.length === 0) return;
+    metricsExplorerStore.addPivotFields(exploreName, dims, "rows");
+  }
+
+  function addTagToColumns(tagName: string, replace: boolean) {
+    const { dimensions: dims, measures: meas } = tagItemsFor(tagName);
+    const all = [...dims, ...meas];
+    if (replace) {
+      metricsExplorerStore.replacePivotColumns(exploreName, all);
+      return;
+    }
+    if (all.length === 0) return;
+    metricsExplorerStore.addPivotFields(exploreName, all, "columns");
+  }
+
+  function autoArrangeTag(tagName: string, replace: boolean) {
+    const { dimensions: dims, measures: meas } = tagItemsFor(tagName);
+    if (replace) {
+      metricsExplorerStore.replacePivotRows(exploreName, dims);
+      metricsExplorerStore.replacePivotColumns(exploreName, meas);
+      return;
+    }
+    if (dims.length > 0) {
+      metricsExplorerStore.addPivotFields(exploreName, dims, "rows");
+    }
+    if (meas.length > 0) {
+      metricsExplorerStore.addPivotFields(exploreName, meas, "columns");
+    }
   }
 </script>
 
 <div
   class="sidebar"
+  class:has-tags={hasTags}
   bind:clientHeight={sidebarHeight}
   transition:slide={{ axis: "x" }}
 >
@@ -75,20 +274,64 @@
     <Search theme background bind:value={searchText} />
   </div>
 
-  <PivotDrag title="Time" items={timeGrainOptions} {tableMode} />
+  <div class="body">
+    {#if hasTags}
+      <div class="tags-column">
+        <h3 class="column-header">Tags</h3>
+        {#if filteredTags.length === 0}
+          <p class="text-fg-secondary my-1 px-2 text-xs">No matching tags</p>
+        {:else}
+          {#each filteredTags as tag (tag.name)}
+            {@const items = tagItemsFor(tag.name)}
+            <PivotTagRow
+              {tag}
+              dimensions={items.dimensions}
+              measures={items.measures}
+              selected={selectedTag === tag.name}
+              onAddRows={(replace) => addTagToRows(tag.name, replace)}
+              onAddColumns={(replace) => addTagToColumns(tag.name, replace)}
+              onAutoArrange={(replace) => autoArrangeTag(tag.name, replace)}
+              onDragStart={(e, rect) =>
+                handleTagDragStart(e, tag.name, items, rect)}
+            />
+          {/each}
+        {/if}
+      </div>
+    {/if}
 
-  <PivotDrag title="Measures" items={filteredMeasures} />
+    <div class="items-column">
+      {#if selectedTag}
+        <TagFilterBanner tagName={selectedTag} onClear={clearTagFilter} />
+      {/if}
 
-  <PivotDrag title="Dimensions" items={filteredDimensions} {tableMode} />
+      <PivotDrag title="Time" items={timeGrainOptions} {tableMode} />
+      <PivotDrag title="Measures" items={filteredMeasures} />
+      <PivotDrag title="Dimensions" items={filteredDimensions} {tableMode} />
+    </div>
+  </div>
 </div>
+
+{#if tagDragActive && tagDragChip}
+  <PivotPortalItem
+    item={tagDragChip}
+    offset={tagDragOffset}
+    position={tagDragPosition}
+    removable={false}
+    onRelease={resetTagDrag}
+  />
+{/if}
 
 <style lang="postcss">
   .sidebar {
-    @apply flex flex-col relative overflow-y-scroll;
+    @apply flex flex-col relative overflow-hidden;
     @apply h-full border-r z-0 w-60;
     transition-property: width;
     will-change: width;
     @apply select-none bg-surface-background;
+  }
+
+  .sidebar.has-tags {
+    width: 400px;
   }
 
   .input-wrapper {
@@ -96,4 +339,28 @@
     @apply border-b;
     @apply gap-x-2 p-2;
   }
+
+  .body {
+    @apply flex flex-row flex-1 min-h-0;
+  }
+
+  .has-tags .body {
+    @apply divide-x;
+  }
+
+  .tags-column {
+    @apply flex flex-col flex-none w-40 py-2 px-2;
+    @apply overflow-y-auto gap-y-0.5;
+  }
+
+  .items-column {
+    @apply flex flex-col flex-1 min-w-0;
+    @apply overflow-y-auto;
+  }
+
+  .column-header {
+    @apply uppercase font-semibold text-[10px];
+    @apply px-1.5 pt-1 pb-1 text-fg-secondary;
+  }
+
 </style>

--- a/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
@@ -6,14 +6,11 @@
     splitPivotChips,
     splitTagItems,
   } from "@rilldata/web-common/features/dashboards/pivot/pivot-utils.ts";
-  import { metricsExplorerStore } from "@rilldata/web-common/features/dashboards/stores/dashboard-stores";
   import { type TimeControlState } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
   import { onMount } from "svelte";
   import { slide } from "svelte/transition";
   import type { PivotState } from "web-common/src/features/dashboards/pivot/types.ts";
-  import { dragDataStore } from "./DragList.svelte";
   import PivotDrag from "./PivotDrag.svelte";
-  import PivotPortalItem from "./PivotPortalItem.svelte";
   import PivotTagRow from "./PivotTagRow.svelte";
   import { timePillActions, timePillSelectors } from "./time-pill-store";
   import type { PivotChipData } from "./types";
@@ -25,7 +22,8 @@
   export let combinedTagIndex: TagIndex;
   export let dimensionTagIndex: TagIndex;
   export let measureTagIndex: TagIndex;
-  export let exploreName: string;
+  export let setRows: (items: PivotChipData[]) => void;
+  export let setColumns: (items: PivotChipData[]) => void;
   export let timeControlsForPillActions: Pick<
     TimeControlState,
     "timeStart" | "timeEnd" | "minTimeGrain"
@@ -37,24 +35,6 @@
   let sidebarHeight = 0;
   let searchText = "";
   let selectedTag: string | null = null;
-
-  // Tag drag-and-drop state. Mirrors the chip-drag flow in DragList.svelte
-  // but coordinates from the sidebar level since tag rows are not chips.
-  const TAG_DRAG_THRESHOLD_PX = 4;
-  let tagPendingDrag: {
-    tagName: string;
-    dimensions: PivotChipData[];
-    measures: PivotChipData[];
-    rect: DOMRect;
-    startX: number;
-    startY: number;
-    offsetX: number;
-    offsetY: number;
-  } | null = null;
-  let tagDragActive = false;
-  let tagDragPosition = { left: 0, top: 0 };
-  let tagDragOffset = { x: 0, y: 0 };
-  let tagDragChip: PivotChipData | null = null;
 
   onMount(() => {
     timePillActions.initTimeDimension("time", "Time");
@@ -142,126 +122,6 @@
   function tagItemsFor(tagName: string) {
     return splitTagItems(tagName, dimensionTagIndex, measureTagIndex);
   }
-
-  function handleTagDragStart(
-    e: MouseEvent,
-    tagName: string,
-    items: { dimensions: PivotChipData[]; measures: PivotChipData[] },
-    rect: DOMRect,
-  ) {
-    tagPendingDrag = {
-      tagName,
-      dimensions: items.dimensions,
-      measures: items.measures,
-      rect,
-      startX: e.clientX,
-      startY: e.clientY,
-      offsetX: e.clientX - rect.left,
-      offsetY: e.clientY - rect.top,
-    };
-    window.addEventListener("mousemove", detectTagDragStart);
-    window.addEventListener("mouseup", handleTagGlobalMouseUp, { once: true });
-  }
-
-  function detectTagDragStart(e: MouseEvent) {
-    if (!tagPendingDrag || tagDragActive) return;
-    const moved =
-      Math.abs(e.clientX - tagPendingDrag.startX) >= TAG_DRAG_THRESHOLD_PX ||
-      Math.abs(e.clientY - tagPendingDrag.startY) >= TAG_DRAG_THRESHOLD_PX;
-    if (!moved) return;
-    beginTagDrag();
-  }
-
-  function beginTagDrag() {
-    if (!tagPendingDrag) return;
-    tagDragActive = true;
-    window.removeEventListener("mousemove", detectTagDragStart);
-
-    const { tagName, dimensions, measures, rect, offsetX, offsetY } =
-      tagPendingDrag;
-
-    tagDragPosition = { left: rect.left, top: rect.top };
-    tagDragOffset = { x: offsetX, y: offsetY };
-
-    // Synthetic chip used by PivotPortalItem to render the floating preview.
-    // Pure-measure tags render with the (rectangular) measure chip styling;
-    // mixed and pure-dimension tags render with the (rounded) dimension shape.
-    const chipType =
-      dimensions.length === 0 && measures.length > 0
-        ? PivotChipType.Measure
-        : PivotChipType.Dimension;
-    tagDragChip = {
-      id: `__tag__:${tagName}`,
-      title: tagName,
-      type: chipType,
-    };
-
-    dragDataStore.set({
-      source: "tags",
-      width: rect.width,
-      chip: tagDragChip,
-      tagPayload: { tagName, dimensions, measures },
-    });
-  }
-
-  function handleTagGlobalMouseUp() {
-    window.removeEventListener("mousemove", detectTagDragStart);
-    if (!tagDragActive) {
-      // Mousedown without movement: treat as a click on the tag row.
-      // Toggles the filter selection. This avoids needing a separate
-      // onclick handler that would race with the drag setup.
-      if (tagPendingDrag) {
-        toggleTagFilter(tagPendingDrag.tagName);
-      }
-      tagPendingDrag = null;
-      return;
-    }
-    resetTagDrag();
-  }
-
-  function resetTagDrag() {
-    tagDragActive = false;
-    tagDragChip = null;
-    tagPendingDrag = null;
-    dragDataStore.set(null);
-    window.removeEventListener("mousemove", detectTagDragStart);
-  }
-
-  function addTagToRows(tagName: string, replace: boolean) {
-    const { dimensions: dims } = tagItemsFor(tagName);
-    if (replace) {
-      metricsExplorerStore.replacePivotRows(exploreName, dims);
-      return;
-    }
-    if (dims.length === 0) return;
-    metricsExplorerStore.addPivotFields(exploreName, dims, "rows");
-  }
-
-  function addTagToColumns(tagName: string, replace: boolean) {
-    const { dimensions: dims, measures: meas } = tagItemsFor(tagName);
-    const all = [...dims, ...meas];
-    if (replace) {
-      metricsExplorerStore.replacePivotColumns(exploreName, all);
-      return;
-    }
-    if (all.length === 0) return;
-    metricsExplorerStore.addPivotFields(exploreName, all, "columns");
-  }
-
-  function autoArrangeTag(tagName: string, replace: boolean) {
-    const { dimensions: dims, measures: meas } = tagItemsFor(tagName);
-    if (replace) {
-      metricsExplorerStore.replacePivotRows(exploreName, dims);
-      metricsExplorerStore.replacePivotColumns(exploreName, meas);
-      return;
-    }
-    if (dims.length > 0) {
-      metricsExplorerStore.addPivotFields(exploreName, dims, "rows");
-    }
-    if (meas.length > 0) {
-      metricsExplorerStore.addPivotFields(exploreName, meas, "columns");
-    }
-  }
 </script>
 
 <div
@@ -287,12 +147,12 @@
               {tag}
               dimensions={items.dimensions}
               measures={items.measures}
+              {rows}
+              {columns}
               selected={selectedTag === tag.name}
-              onAddRows={(replace) => addTagToRows(tag.name, replace)}
-              onAddColumns={(replace) => addTagToColumns(tag.name, replace)}
-              onAutoArrange={(replace) => autoArrangeTag(tag.name, replace)}
-              onDragStart={(e, rect) =>
-                handleTagDragStart(e, tag.name, items, rect)}
+              {setRows}
+              {setColumns}
+              onSelect={() => toggleTagFilter(tag.name)}
             />
           {/each}
         {/if}
@@ -310,16 +170,6 @@
     </div>
   </div>
 </div>
-
-{#if tagDragActive && tagDragChip}
-  <PivotPortalItem
-    item={tagDragChip}
-    offset={tagDragOffset}
-    position={tagDragPosition}
-    removable={false}
-    onRelease={resetTagDrag}
-  />
-{/if}
 
 <style lang="postcss">
   .sidebar {

--- a/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
@@ -362,5 +362,4 @@
     @apply uppercase font-semibold text-[10px];
     @apply px-1.5 pt-1 pb-1 text-fg-secondary;
   }
-
 </style>

--- a/web-common/src/features/dashboards/pivot/PivotTagRow.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTagRow.svelte
@@ -46,7 +46,7 @@
   } | null = null;
   let dragActive = $state(false);
   let dragPosition = $state({ left: 0, top: 0 });
-  let dragOffset = { x: 0, y: 0 };
+  let dragOffset = $state({ x: 0, y: 0 });
   let dragChip: PivotChipData | null = $state(null);
 
   const dimensionCount = $derived(dimensions.length);

--- a/web-common/src/features/dashboards/pivot/PivotTagRow.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTagRow.svelte
@@ -46,10 +46,7 @@
     onDragStart(e, rowEl.getBoundingClientRect());
   }
 
-  function handleClick(
-    e: MouseEvent,
-    action: (replace: boolean) => void,
-  ) {
+  function handleClick(e: MouseEvent, action: (replace: boolean) => void) {
     // Read the modifier off the event itself so a click that happens before
     // the global keydown fires still picks up the held key.
     action(e.metaKey || e.ctrlKey);

--- a/web-common/src/features/dashboards/pivot/PivotTagRow.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTagRow.svelte
@@ -1,0 +1,215 @@
+<script lang="ts">
+  import type { DimensionTag } from "@rilldata/web-common/components/menu/tag-utils";
+  import Column from "@rilldata/web-common/components/icons/Column.svelte";
+  import Pivot from "@rilldata/web-common/components/icons/Pivot.svelte";
+  import Row from "@rilldata/web-common/components/icons/Row.svelte";
+  import * as Tooltip from "@rilldata/web-common/components/tooltip-v2";
+  import { modifierHeld } from "@rilldata/web-common/lib/modifier-key";
+  import type { PivotChipData } from "./types";
+
+  type Props = {
+    tag: DimensionTag;
+    dimensions: PivotChipData[];
+    measures: PivotChipData[];
+    selected: boolean;
+    onAddRows: (replace: boolean) => void;
+    onAddColumns: (replace: boolean) => void;
+    onAutoArrange: (replace: boolean) => void;
+    onDragStart: (event: MouseEvent, rect: DOMRect) => void;
+  };
+
+  let {
+    tag,
+    dimensions,
+    measures,
+    selected,
+    onAddRows,
+    onAddColumns,
+    onAutoArrange,
+    onDragStart,
+  }: Props = $props();
+
+  let rowEl: HTMLDivElement | undefined = $state();
+
+  const dimensionCount = $derived(dimensions.length);
+  const measureCount = $derived(measures.length);
+
+  const actionBtnClass =
+    "flex items-center justify-center h-[18px] w-[18px] rounded-sm text-icon-muted hover:text-fg-primary hover:bg-surface-background transition-colors";
+
+  function handleMouseDown(e: MouseEvent) {
+    if (e.button !== 0) return;
+    const target = e.target as HTMLElement | null;
+    if (target?.closest("button")) return;
+    if (!rowEl) return;
+    e.preventDefault();
+    onDragStart(e, rowEl.getBoundingClientRect());
+  }
+
+  function handleClick(
+    e: MouseEvent,
+    action: (replace: boolean) => void,
+  ) {
+    // Read the modifier off the event itself so a click that happens before
+    // the global keydown fires still picks up the held key.
+    action(e.metaKey || e.ctrlKey);
+  }
+</script>
+
+<div
+  bind:this={rowEl}
+  class="tag-row group"
+  class:selected
+  role="presentation"
+  onmousedown={handleMouseDown}
+>
+  <span class="truncate flex-1 min-w-0 text-fg-primary">
+    {tag.name}
+  </span>
+
+  <div class="flex items-center gap-x-1 flex-none group-hover:hidden">
+    {#if measureCount > 0}
+      <span class="count-tile meas-tile" title={`${measureCount} measures`}>
+        {measureCount}
+      </span>
+    {/if}
+    {#if dimensionCount > 0}
+      <span class="count-tile dim-tile" title={`${dimensionCount} dimensions`}>
+        {dimensionCount}
+      </span>
+    {/if}
+  </div>
+
+  <div class="hidden group-hover:flex items-center gap-x-0.5 flex-none">
+    {#if dimensionCount > 0}
+      <Tooltip.Root delayDuration={200}>
+        <Tooltip.Trigger>
+          <button
+            type="button"
+            class={actionBtnClass}
+            onclick={(e) => handleClick(e, onAddRows)}
+            aria-label={$modifierHeld
+              ? `Replace rows with dimensions in ${tag.name}`
+              : `Add all dimensions in ${tag.name} to rows`}
+          >
+            <Row size="14px" color="currentColor" />
+          </button>
+        </Tooltip.Trigger>
+        <Tooltip.Content
+          side="top"
+          class="bg-popover text-fg-primary z-popover text-xs px-2 py-1"
+        >
+          {#if $modifierHeld}
+            Replace rows with this tag's dimensions
+          {:else}
+            <div>Add all to rows</div>
+            <div class="hint">
+              <span class="kbd">⌘</span> + Click to replace
+            </div>
+          {/if}
+        </Tooltip.Content>
+      </Tooltip.Root>
+    {/if}
+
+    <Tooltip.Root delayDuration={200}>
+      <Tooltip.Trigger>
+        <button
+          type="button"
+          class={actionBtnClass}
+          onclick={(e) => handleClick(e, onAddColumns)}
+          aria-label={$modifierHeld
+            ? `Replace columns with items in ${tag.name}`
+            : `Add all in ${tag.name} to columns`}
+        >
+          <Column size="14px" color="currentColor" />
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Content
+        side="top"
+        class="bg-popover text-fg-primary z-popover text-xs px-2 py-1"
+      >
+        {#if $modifierHeld}
+          Replace columns with this tag's items
+        {:else}
+          <div>Add all to columns</div>
+          <div class="hint">
+            <span class="kbd">⌘</span> + Click to replace
+          </div>
+        {/if}
+      </Tooltip.Content>
+    </Tooltip.Root>
+
+    {#if dimensionCount > 0 && measureCount > 0}
+      <Tooltip.Root delayDuration={200}>
+        <Tooltip.Trigger>
+          <button
+            type="button"
+            class={actionBtnClass}
+            onclick={(e) => handleClick(e, onAutoArrange)}
+            aria-label={$modifierHeld
+              ? `Replace rows and columns with auto-arranged ${tag.name}`
+              : `Auto-arrange ${tag.name}: dimensions to rows, measures to columns`}
+          >
+            <Pivot size="14px" color="currentColor" />
+          </button>
+        </Tooltip.Trigger>
+        <Tooltip.Content
+          side="top"
+          class="bg-popover text-fg-primary z-popover text-xs px-2 py-1"
+        >
+          {#if $modifierHeld}
+            Replace rows and columns with this tag
+          {:else}
+            <div>Auto-arrange</div>
+            <div class="hint">
+              <span class="kbd">⌘</span> + Click to replace
+            </div>
+          {/if}
+        </Tooltip.Content>
+      </Tooltip.Root>
+    {/if}
+  </div>
+</div>
+
+<style lang="postcss">
+  .tag-row {
+    @apply w-full flex items-center gap-x-1 px-1.5 py-0.5 rounded-sm;
+    @apply cursor-grab select-none;
+    @apply hover:bg-surface-hover;
+  }
+
+  .tag-row.selected {
+    @apply bg-popover-accent;
+  }
+
+  .tag-row.selected:hover {
+    @apply bg-popover-accent;
+  }
+
+  .tag-row:active {
+    @apply cursor-grabbing;
+  }
+
+  .count-tile {
+    @apply inline-flex items-center justify-center;
+    @apply tabular-nums text-[10px] font-medium;
+    @apply min-w-[16px] h-[16px] px-1 rounded-sm border;
+  }
+
+  .dim-tile {
+    @apply bg-theme-50 border-theme-200 text-theme-800;
+  }
+
+  .meas-tile {
+    @apply bg-theme-secondary-50 border-theme-secondary-200 text-theme-secondary-800;
+  }
+
+  .kbd {
+    @apply inline-block px-1 py-px rounded-sm border;
+    @apply text-[10px] font-mono text-fg-secondary;
+  }
+
+  .hint {
+    @apply mt-0.5 text-[10px] text-fg-secondary;
+  }
+</style>

--- a/web-common/src/features/dashboards/pivot/PivotTagRow.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTagRow.svelte
@@ -5,31 +5,49 @@
   import Row from "@rilldata/web-common/components/icons/Row.svelte";
   import * as Tooltip from "@rilldata/web-common/components/tooltip-v2";
   import { modifierHeld } from "@rilldata/web-common/lib/modifier-key";
-  import type { PivotChipData } from "./types";
+  import { dragDataStore } from "./DragList.svelte";
+  import PivotPortalItem from "./PivotPortalItem.svelte";
+  import { appendChipsToZone, replaceZoneCleaningOther } from "./pivot-utils";
+  import { PivotChipType, type PivotChipData } from "./types";
 
   type Props = {
     tag: DimensionTag;
     dimensions: PivotChipData[];
     measures: PivotChipData[];
+    rows: PivotChipData[];
+    columns: PivotChipData[];
     selected: boolean;
-    onAddRows: (replace: boolean) => void;
-    onAddColumns: (replace: boolean) => void;
-    onAutoArrange: (replace: boolean) => void;
-    onDragStart: (event: MouseEvent, rect: DOMRect) => void;
+    setRows: (items: PivotChipData[]) => void;
+    setColumns: (items: PivotChipData[]) => void;
+    onSelect: () => void;
   };
 
   let {
     tag,
     dimensions,
     measures,
+    rows,
+    columns,
     selected,
-    onAddRows,
-    onAddColumns,
-    onAutoArrange,
-    onDragStart,
+    setRows,
+    setColumns,
+    onSelect,
   }: Props = $props();
 
+  const DRAG_THRESHOLD_PX = 4;
+
   let rowEl: HTMLDivElement | undefined = $state();
+  let pendingDrag: {
+    rect: DOMRect;
+    startX: number;
+    startY: number;
+    offsetX: number;
+    offsetY: number;
+  } | null = null;
+  let dragActive = $state(false);
+  let dragPosition = $state({ left: 0, top: 0 });
+  let dragOffset = { x: 0, y: 0 };
+  let dragChip: PivotChipData | null = $state(null);
 
   const dimensionCount = $derived(dimensions.length);
   const measureCount = $derived(measures.length);
@@ -37,18 +55,130 @@
   const actionBtnClass =
     "flex items-center justify-center h-[18px] w-[18px] rounded-sm text-icon-muted hover:text-fg-primary hover:bg-surface-background transition-colors";
 
+  // ---- mutation actions ---- //
+
+  function addToRows(replace: boolean) {
+    if (replace) {
+      const { zone, other } = replaceZoneCleaningOther(dimensions, columns);
+      setRows(zone);
+      if (other.length !== columns.length) setColumns(other);
+      return;
+    }
+    if (dimensions.length === 0) return;
+    setRows(appendChipsToZone(rows, columns, dimensions));
+  }
+
+  function addToColumns(replace: boolean) {
+    const all = [...dimensions, ...measures];
+    if (replace) {
+      const { zone, other } = replaceZoneCleaningOther(all, rows);
+      setColumns(zone);
+      if (other.length !== rows.length) setRows(other);
+      return;
+    }
+    if (all.length === 0) return;
+    setColumns(appendChipsToZone(columns, rows, all));
+  }
+
+  function autoArrange(replace: boolean) {
+    if (replace) {
+      // Replace both zones; cross-zone cleanup happens naturally since each
+      // zone gets exactly its slice of the tag.
+      setRows(dimensions);
+      setColumns(measures);
+      return;
+    }
+    if (dimensions.length > 0) {
+      setRows(appendChipsToZone(rows, columns, dimensions));
+    }
+    if (measures.length > 0) {
+      setColumns(appendChipsToZone(columns, rows, measures));
+    }
+  }
+
+  // ---- click vs drag ---- //
+
   function handleMouseDown(e: MouseEvent) {
     if (e.button !== 0) return;
     const target = e.target as HTMLElement | null;
     if (target?.closest("button")) return;
     if (!rowEl) return;
     e.preventDefault();
-    onDragStart(e, rowEl.getBoundingClientRect());
+    const rect = rowEl.getBoundingClientRect();
+    pendingDrag = {
+      rect,
+      startX: e.clientX,
+      startY: e.clientY,
+      offsetX: e.clientX - rect.left,
+      offsetY: e.clientY - rect.top,
+    };
+    window.addEventListener("mousemove", detectDragStart);
+    window.addEventListener("mouseup", handleGlobalMouseUp, { once: true });
   }
 
-  function handleClick(e: MouseEvent, action: (replace: boolean) => void) {
-    // Read the modifier off the event itself so a click that happens before
-    // the global keydown fires still picks up the held key.
+  function detectDragStart(e: MouseEvent) {
+    if (!pendingDrag || dragActive) return;
+    const moved =
+      Math.abs(e.clientX - pendingDrag.startX) >= DRAG_THRESHOLD_PX ||
+      Math.abs(e.clientY - pendingDrag.startY) >= DRAG_THRESHOLD_PX;
+    if (!moved) return;
+    beginDrag();
+  }
+
+  function beginDrag() {
+    if (!pendingDrag) return;
+    dragActive = true;
+    window.removeEventListener("mousemove", detectDragStart);
+
+    const { rect, offsetX, offsetY } = pendingDrag;
+    dragPosition = { left: rect.left, top: rect.top };
+    dragOffset = { x: offsetX, y: offsetY };
+
+    // Synthetic chip used by PivotPortalItem to render the floating preview.
+    // Pure-measure tags render with the rectangular measure chip; mixed and
+    // pure-dimension tags use the rounded dimension shape.
+    const chipType =
+      dimensions.length === 0 && measures.length > 0
+        ? PivotChipType.Measure
+        : PivotChipType.Dimension;
+    dragChip = {
+      id: `__tag__:${tag.name}`,
+      title: tag.name,
+      type: chipType,
+    };
+
+    dragDataStore.set({
+      source: "tags",
+      width: rect.width,
+      chip: dragChip,
+      tagPayload: { tagName: tag.name, dimensions, measures },
+    });
+  }
+
+  function handleGlobalMouseUp() {
+    window.removeEventListener("mousemove", detectDragStart);
+    if (!dragActive) {
+      // Mousedown without movement: treat as a click on the tag row body.
+      // Toggles the filter selection.
+      if (pendingDrag) onSelect();
+      pendingDrag = null;
+      return;
+    }
+    resetDrag();
+  }
+
+  function resetDrag() {
+    dragActive = false;
+    dragChip = null;
+    pendingDrag = null;
+    dragDataStore.set(null);
+    window.removeEventListener("mousemove", detectDragStart);
+  }
+
+  function handleActionClick(
+    e: MouseEvent,
+    action: (replace: boolean) => void,
+  ) {
     action(e.metaKey || e.ctrlKey);
   }
 </script>
@@ -81,16 +211,19 @@
     {#if dimensionCount > 0}
       <Tooltip.Root delayDuration={200}>
         <Tooltip.Trigger>
-          <button
-            type="button"
-            class={actionBtnClass}
-            onclick={(e) => handleClick(e, onAddRows)}
-            aria-label={$modifierHeld
-              ? `Replace rows with dimensions in ${tag.name}`
-              : `Add all dimensions in ${tag.name} to rows`}
-          >
-            <Row size="14px" color="currentColor" />
-          </button>
+          {#snippet child({ props })}
+            <button
+              {...props}
+              type="button"
+              class={actionBtnClass}
+              onclick={(e) => handleActionClick(e, addToRows)}
+              aria-label={$modifierHeld
+                ? `Replace rows with dimensions in ${tag.name}`
+                : `Add all dimensions in ${tag.name} to rows`}
+            >
+              <Row size="14px" color="currentColor" />
+            </button>
+          {/snippet}
         </Tooltip.Trigger>
         <Tooltip.Content
           side="top"
@@ -110,16 +243,19 @@
 
     <Tooltip.Root delayDuration={200}>
       <Tooltip.Trigger>
-        <button
-          type="button"
-          class={actionBtnClass}
-          onclick={(e) => handleClick(e, onAddColumns)}
-          aria-label={$modifierHeld
-            ? `Replace columns with items in ${tag.name}`
-            : `Add all in ${tag.name} to columns`}
-        >
-          <Column size="14px" color="currentColor" />
-        </button>
+        {#snippet child({ props })}
+          <button
+            {...props}
+            type="button"
+            class={actionBtnClass}
+            onclick={(e) => handleActionClick(e, addToColumns)}
+            aria-label={$modifierHeld
+              ? `Replace columns with items in ${tag.name}`
+              : `Add all in ${tag.name} to columns`}
+          >
+            <Column size="14px" color="currentColor" />
+          </button>
+        {/snippet}
       </Tooltip.Trigger>
       <Tooltip.Content
         side="top"
@@ -139,16 +275,19 @@
     {#if dimensionCount > 0 && measureCount > 0}
       <Tooltip.Root delayDuration={200}>
         <Tooltip.Trigger>
-          <button
-            type="button"
-            class={actionBtnClass}
-            onclick={(e) => handleClick(e, onAutoArrange)}
-            aria-label={$modifierHeld
-              ? `Replace rows and columns with auto-arranged ${tag.name}`
-              : `Auto-arrange ${tag.name}: dimensions to rows, measures to columns`}
-          >
-            <Pivot size="14px" color="currentColor" />
-          </button>
+          {#snippet child({ props })}
+            <button
+              {...props}
+              type="button"
+              class={actionBtnClass}
+              onclick={(e) => handleActionClick(e, autoArrange)}
+              aria-label={$modifierHeld
+                ? `Replace rows and columns with auto-arranged ${tag.name}`
+                : `Auto-arrange ${tag.name}: dimensions to rows, measures to columns`}
+            >
+              <Pivot size="14px" color="currentColor" />
+            </button>
+          {/snippet}
         </Tooltip.Trigger>
         <Tooltip.Content
           side="top"
@@ -167,6 +306,16 @@
     {/if}
   </div>
 </div>
+
+{#if dragActive && dragChip}
+  <PivotPortalItem
+    item={dragChip}
+    offset={dragOffset}
+    position={dragPosition}
+    removable={false}
+    onRelease={resetDrag}
+  />
+{/if}
 
 <style lang="postcss">
   .tag-row {

--- a/web-common/src/features/dashboards/pivot/pivot-tag-utils.spec.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-tag-utils.spec.ts
@@ -115,15 +115,8 @@ describe("splitTagItems", () => {
   });
 
   it("preserves spec order in output", () => {
-    const orderedDims = [
-      dim("a", ["T"]),
-      dim("b", ["T"]),
-      dim("c", ["T"]),
-    ];
-    const orderedMeas = [
-      meas("x", ["T"]),
-      meas("y", ["T"]),
-    ];
+    const orderedDims = [dim("a", ["T"]), dim("b", ["T"]), dim("c", ["T"])];
+    const orderedMeas = [meas("x", ["T"]), meas("y", ["T"])];
     const { dimensions: dims, measures: meas2 } = splitTagItems(
       "T",
       buildTagIndex(orderedDims),

--- a/web-common/src/features/dashboards/pivot/pivot-tag-utils.spec.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-tag-utils.spec.ts
@@ -1,0 +1,135 @@
+import { buildTagIndex } from "@rilldata/web-common/components/menu/tag-utils";
+import type {
+  MetricsViewSpecDimension,
+  MetricsViewSpecMeasure,
+} from "@rilldata/web-common/runtime-client";
+import { describe, expect, it } from "vitest";
+import {
+  dimensionToChipData,
+  measureToChipData,
+  splitTagItems,
+} from "./pivot-utils";
+import { PivotChipType } from "./types";
+
+const dim = (
+  name: string,
+  tags: string[] = [],
+  displayName?: string,
+): MetricsViewSpecDimension => ({
+  name,
+  displayName,
+  tags,
+});
+
+const meas = (
+  name: string,
+  tags: string[] = [],
+  displayName?: string,
+): MetricsViewSpecMeasure => ({
+  name,
+  displayName,
+  tags,
+});
+
+describe("dimensionToChipData", () => {
+  it("uses displayName when present", () => {
+    expect(dimensionToChipData(dim("country", [], "Country"))).toEqual({
+      id: "country",
+      title: "Country",
+      type: PivotChipType.Dimension,
+      description: undefined,
+    });
+  });
+
+  it("falls back to name when displayName is missing", () => {
+    expect(dimensionToChipData(dim("region"))).toEqual({
+      id: "region",
+      title: "region",
+      type: PivotChipType.Dimension,
+      description: undefined,
+    });
+  });
+});
+
+describe("measureToChipData", () => {
+  it("projects a measure spec", () => {
+    expect(measureToChipData(meas("revenue", [], "Revenue"))).toEqual({
+      id: "revenue",
+      title: "Revenue",
+      type: PivotChipType.Measure,
+      description: undefined,
+    });
+  });
+});
+
+describe("splitTagItems", () => {
+  const dimensions = [
+    dim("country", ["Geography", "Customer"], "Country"),
+    dim("region", ["Geography"], "Region"),
+    dim("segment", ["Customer"], "Segment"),
+  ];
+  const measures = [
+    meas("revenue", ["Geography", "Finance"], "Revenue"),
+    meas("profit", ["Finance"], "Profit"),
+  ];
+  const dimIndex = buildTagIndex(dimensions);
+  const measIndex = buildTagIndex(measures);
+
+  it("splits a mixed tag into dim chips and measure chips", () => {
+    const { dimensions: dims, measures: meas } = splitTagItems(
+      "Geography",
+      dimIndex,
+      measIndex,
+    );
+    expect(dims.map((c) => c.id)).toEqual(["country", "region"]);
+    expect(meas.map((c) => c.id)).toEqual(["revenue"]);
+    expect(dims.every((c) => c.type === PivotChipType.Dimension)).toBe(true);
+    expect(meas.every((c) => c.type === PivotChipType.Measure)).toBe(true);
+  });
+
+  it("returns only dimensions for a pure-dimension tag", () => {
+    const { dimensions: dims, measures: meas } = splitTagItems(
+      "Customer",
+      dimIndex,
+      measIndex,
+    );
+    expect(dims.map((c) => c.id)).toEqual(["country", "segment"]);
+    expect(meas).toEqual([]);
+  });
+
+  it("returns only measures for a pure-measure tag", () => {
+    const { dimensions: dims, measures: meas } = splitTagItems(
+      "Finance",
+      dimIndex,
+      measIndex,
+    );
+    expect(dims).toEqual([]);
+    expect(meas.map((c) => c.id)).toEqual(["revenue", "profit"]);
+  });
+
+  it("returns empty arrays for an unknown tag", () => {
+    expect(splitTagItems("Nope", dimIndex, measIndex)).toEqual({
+      dimensions: [],
+      measures: [],
+    });
+  });
+
+  it("preserves spec order in output", () => {
+    const orderedDims = [
+      dim("a", ["T"]),
+      dim("b", ["T"]),
+      dim("c", ["T"]),
+    ];
+    const orderedMeas = [
+      meas("x", ["T"]),
+      meas("y", ["T"]),
+    ];
+    const { dimensions: dims, measures: meas2 } = splitTagItems(
+      "T",
+      buildTagIndex(orderedDims),
+      buildTagIndex(orderedMeas),
+    );
+    expect(dims.map((c) => c.id)).toEqual(["a", "b", "c"]);
+    expect(meas2.map((c) => c.id)).toEqual(["x", "y"]);
+  });
+});

--- a/web-common/src/features/dashboards/pivot/pivot-utils.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-utils.ts
@@ -1,3 +1,4 @@
+import { itemsInTag, type TagIndex } from "@rilldata/web-common/components/menu/tag-utils";
 import { getValuesForExpandedKey } from "@rilldata/web-common/features/dashboards/pivot/pivot-expansion";
 import {
   createAndExpression,
@@ -12,6 +13,8 @@ import {
   type TimeRangeString,
 } from "@rilldata/web-common/lib/time/types";
 import type {
+  MetricsViewSpecDimension,
+  MetricsViewSpecMeasure,
   V1Expression,
   V1MetricsViewAggregationMeasure,
   V1MetricsViewAggregationResponse,
@@ -745,4 +748,48 @@ export function splitPivotChips(data: PivotChipData[]): {
 export function isShowMoreRow(row: Row<PivotDataRow>): boolean {
   const firstCell = row?.getVisibleCells()?.[0];
   return firstCell?.getValue() === SHOW_MORE_BUTTON;
+}
+
+/**
+ * Project a dimension or measure spec into the PivotChipData shape used by
+ * the sidebar and bulk-add paths. Mirrors the projection in
+ * state-managers/selectors/pivot.ts so chips look identical regardless of
+ * whether they came from drag-and-drop or a tag bulk-add.
+ */
+export function dimensionToChipData(
+  d: MetricsViewSpecDimension,
+): PivotChipData {
+  return {
+    id: d.name || d.column || "Unknown",
+    title: d.displayName || d.name || d.column || "Unknown",
+    type: PivotChipType.Dimension,
+    description: d.description,
+  };
+}
+
+export function measureToChipData(m: MetricsViewSpecMeasure): PivotChipData {
+  return {
+    id: m.name || "Unknown",
+    title: m.displayName || m.name || "Unknown",
+    type: PivotChipType.Measure,
+    description: m.description,
+  };
+}
+
+/**
+ * Split the items in a tag into dimension chips and measure chips, preserving
+ * spec order. Used by the pivot sidebar's bulk-add actions: "Add all to rows"
+ * consumes the dimensions output, "Add all to columns" concatenates both, and
+ * "Auto-arrange" routes each list to its natural zone.
+ */
+export function splitTagItems(
+  tagName: string,
+  dimensionTagIndex: TagIndex,
+  measureTagIndex: TagIndex,
+): { dimensions: PivotChipData[]; measures: PivotChipData[] } {
+  const dimensions = itemsInTag(dimensionTagIndex, tagName)
+    .map((d) => dimensionToChipData(d as MetricsViewSpecDimension));
+  const measures = itemsInTag(measureTagIndex, tagName)
+    .map((m) => measureToChipData(m as MetricsViewSpecMeasure));
+  return { dimensions, measures };
 }

--- a/web-common/src/features/dashboards/pivot/pivot-utils.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-utils.ts
@@ -798,3 +798,43 @@ export function splitTagItems(
   );
   return { dimensions, measures };
 }
+
+/**
+ * Append new chips to a zone, skipping any whose id already exists in the
+ * zone or in the opposite zone. Used for tag bulk-add when the caller has
+ * access to both zones (cross-zone dedup keeps a dimension from appearing
+ * in both rows and columns). Returns a new array; preserves the original
+ * order of the zone followed by the new items.
+ */
+export function appendChipsToZone(
+  zoneItems: PivotChipData[],
+  otherZoneItems: PivotChipData[],
+  newItems: PivotChipData[],
+): PivotChipData[] {
+  const existing = new Set([
+    ...zoneItems.map((c) => c.id),
+    ...otherZoneItems.map((c) => c.id),
+  ]);
+  const additions: PivotChipData[] = [];
+  for (const item of newItems) {
+    if (existing.has(item.id)) continue;
+    existing.add(item.id);
+    additions.push(item);
+  }
+  return [...zoneItems, ...additions];
+}
+
+/**
+ * Replace a zone's contents with new chips, removing those chips' ids from
+ * the opposite zone so a dimension never appears in both zones at once.
+ */
+export function replaceZoneCleaningOther(
+  newItems: PivotChipData[],
+  otherZoneItems: PivotChipData[],
+): { zone: PivotChipData[]; other: PivotChipData[] } {
+  const ids = new Set(newItems.map((v) => v.id));
+  return {
+    zone: newItems,
+    other: otherZoneItems.filter((c) => !ids.has(c.id)),
+  };
+}

--- a/web-common/src/features/dashboards/pivot/pivot-utils.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-utils.ts
@@ -1,4 +1,7 @@
-import { itemsInTag, type TagIndex } from "@rilldata/web-common/components/menu/tag-utils";
+import {
+  itemsInTag,
+  type TagIndex,
+} from "@rilldata/web-common/components/menu/tag-utils";
 import { getValuesForExpandedKey } from "@rilldata/web-common/features/dashboards/pivot/pivot-expansion";
 import {
   createAndExpression,
@@ -787,9 +790,11 @@ export function splitTagItems(
   dimensionTagIndex: TagIndex,
   measureTagIndex: TagIndex,
 ): { dimensions: PivotChipData[]; measures: PivotChipData[] } {
-  const dimensions = itemsInTag(dimensionTagIndex, tagName)
-    .map((d) => dimensionToChipData(d as MetricsViewSpecDimension));
-  const measures = itemsInTag(measureTagIndex, tagName)
-    .map((m) => measureToChipData(m as MetricsViewSpecMeasure));
+  const dimensions = itemsInTag(dimensionTagIndex, tagName).map((d) =>
+    dimensionToChipData(d as MetricsViewSpecDimension),
+  );
+  const measures = itemsInTag(measureTagIndex, tagName).map((m) =>
+    measureToChipData(m as MetricsViewSpecMeasure),
+  );
   return { dimensions, measures };
 }

--- a/web-common/src/features/dashboards/state-managers/selectors/index.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/index.ts
@@ -15,6 +15,7 @@ import { dimensionSelectors } from "./dimensions";
 import { measureSelectors } from "./measures";
 import { pivotSelectors } from "./pivot";
 import { sortingSelectors } from "./sorting";
+import { tagSelectors } from "./tags";
 import { timeRangeSelectors } from "./time-range";
 import type { ReadablesObj, SelectorFnsObj } from "./types";
 import { leaderboardSelectors } from "./leaderboard";
@@ -138,6 +139,13 @@ export const createStateManagerReadables = (
      * Readables related to pivot state
      */
     pivot: createReadablesFromSelectors(pivotSelectors, dashboardDataReadables),
+
+    /**
+     * Readables exposing shared tag indices over dimensions, measures, and
+     * their union. Consumed by tag-aware surfaces (dimension/measure dropdown,
+     * pivot sidebar) so the index is built once per spec change.
+     */
+    tags: createReadablesFromSelectors(tagSelectors, dashboardDataReadables),
 
     /**
      * Readables related to the chart interactions state

--- a/web-common/src/features/dashboards/state-managers/selectors/tags.ts
+++ b/web-common/src/features/dashboards/state-managers/selectors/tags.ts
@@ -1,0 +1,24 @@
+import {
+  buildTagIndex,
+  type TagIndex,
+} from "@rilldata/web-common/components/menu/tag-utils";
+import { allDimensions } from "./dimensions";
+import { allMeasures } from "./measures";
+import type { DashboardDataSources } from "./types";
+
+export const dimensionTagIndex = (dashData: DashboardDataSources): TagIndex =>
+  buildTagIndex(allDimensions(dashData));
+
+export const measureTagIndex = (dashData: DashboardDataSources): TagIndex =>
+  buildTagIndex(allMeasures(dashData));
+
+// Combined index over dimensions + measures, used by surfaces (e.g. the pivot
+// sidebar) where both kinds participate in a single tag-filtered list.
+export const combinedTagIndex = (dashData: DashboardDataSources): TagIndex =>
+  buildTagIndex([...allDimensions(dashData), ...allMeasures(dashData)]);
+
+export const tagSelectors = {
+  dimensionTagIndex,
+  measureTagIndex,
+  combinedTagIndex,
+};

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -303,79 +303,17 @@ const metricsViewReducers = {
   },
 
   addPivotField(name: string, value: PivotChipData, rows: boolean) {
-    metricsExplorerStore.addPivotFields(
-      name,
-      [value],
-      value.type === PivotChipType.Measure
-        ? "columns"
-        : rows
-          ? "rows"
-          : "columns",
-    );
-  },
-
-  // Replace the rows zone with the given values. Anything in the new rows
-  // that already lived in columns is removed from columns, so the same
-  // dimension never appears in both zones.
-  replacePivotRows(name: string, values: PivotChipData[]) {
-    updateMetricsExplorerByName(name, (exploreState) => {
-      exploreState.pivot.rowPage = 1;
-      exploreState.pivot.activeCell = null;
-      exploreState.pivot.expanded = {};
-      const ids = new Set(values.map((v) => v.id));
-      exploreState.pivot.rows = values.filter(
-        (v) => v.type !== PivotChipType.Measure,
-      );
-      exploreState.pivot.columns = exploreState.pivot.columns.filter(
-        (c) => !ids.has(c.id),
-      );
-    });
-  },
-
-  // Replace the columns zone with the given values, removing any of them
-  // from rows so a dimension never appears in both zones.
-  replacePivotColumns(name: string, values: PivotChipData[]) {
-    updateMetricsExplorerByName(name, (exploreState) => {
-      exploreState.pivot.rowPage = 1;
-      exploreState.pivot.activeCell = null;
-      exploreState.pivot.expanded = {};
-      const ids = new Set(values.map((v) => v.id));
-      exploreState.pivot.columns = values;
-      exploreState.pivot.rows = exploreState.pivot.rows.filter(
-        (r) => !ids.has(r.id),
-      );
-    });
-  },
-
-  // Bulk-add fields to either the rows or columns zone in a single
-  // store transaction. Measures targeted at "rows" are silently skipped
-  // because the rows zone does not accept measures. Items already present
-  // in either zone are skipped — a pivot dimension only makes sense in one
-  // axis at a time, and tag bulk-adds shouldn't create duplicates across
-  // rows and columns.
-  addPivotFields(
-    name: string,
-    values: PivotChipData[],
-    target: "rows" | "columns",
-  ) {
     updateMetricsExplorerByName(name, (exploreState) => {
       exploreState.pivot.rowPage = 1;
       exploreState.pivot.activeCell = null;
       exploreState.pivot.expanded = {};
 
-      const existingRows = new Set(exploreState.pivot.rows.map((c) => c.id));
-      const existingCols = new Set(exploreState.pivot.columns.map((c) => c.id));
-
-      for (const value of values) {
-        if (existingRows.has(value.id) || existingCols.has(value.id)) {
-          continue;
-        }
-        if (target === "rows") {
-          if (value.type === PivotChipType.Measure) continue;
-          existingRows.add(value.id);
+      if (value.type === PivotChipType.Measure) {
+        exploreState.pivot.columns.push(value);
+      } else {
+        if (rows) {
           exploreState.pivot.rows.push(value);
         } else {
-          existingCols.add(value.id);
           exploreState.pivot.columns.push(value);
         }
       }

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -303,17 +303,79 @@ const metricsViewReducers = {
   },
 
   addPivotField(name: string, value: PivotChipData, rows: boolean) {
+    metricsExplorerStore.addPivotFields(
+      name,
+      [value],
+      value.type === PivotChipType.Measure ? "columns" : rows ? "rows" : "columns",
+    );
+  },
+
+  // Replace the rows zone with the given values. Anything in the new rows
+  // that already lived in columns is removed from columns, so the same
+  // dimension never appears in both zones.
+  replacePivotRows(name: string, values: PivotChipData[]) {
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.pivot.rowPage = 1;
+      exploreState.pivot.activeCell = null;
+      exploreState.pivot.expanded = {};
+      const ids = new Set(values.map((v) => v.id));
+      exploreState.pivot.rows = values.filter(
+        (v) => v.type !== PivotChipType.Measure,
+      );
+      exploreState.pivot.columns = exploreState.pivot.columns.filter(
+        (c) => !ids.has(c.id),
+      );
+    });
+  },
+
+  // Replace the columns zone with the given values, removing any of them
+  // from rows so a dimension never appears in both zones.
+  replacePivotColumns(name: string, values: PivotChipData[]) {
+    updateMetricsExplorerByName(name, (exploreState) => {
+      exploreState.pivot.rowPage = 1;
+      exploreState.pivot.activeCell = null;
+      exploreState.pivot.expanded = {};
+      const ids = new Set(values.map((v) => v.id));
+      exploreState.pivot.columns = values;
+      exploreState.pivot.rows = exploreState.pivot.rows.filter(
+        (r) => !ids.has(r.id),
+      );
+    });
+  },
+
+  // Bulk-add fields to either the rows or columns zone in a single
+  // store transaction. Measures targeted at "rows" are silently skipped
+  // because the rows zone does not accept measures. Items already present
+  // in either zone are skipped — a pivot dimension only makes sense in one
+  // axis at a time, and tag bulk-adds shouldn't create duplicates across
+  // rows and columns.
+  addPivotFields(
+    name: string,
+    values: PivotChipData[],
+    target: "rows" | "columns",
+  ) {
     updateMetricsExplorerByName(name, (exploreState) => {
       exploreState.pivot.rowPage = 1;
       exploreState.pivot.activeCell = null;
       exploreState.pivot.expanded = {};
 
-      if (value.type === PivotChipType.Measure) {
-        exploreState.pivot.columns.push(value);
-      } else {
-        if (rows) {
+      const existingRows = new Set(
+        exploreState.pivot.rows.map((c) => c.id),
+      );
+      const existingCols = new Set(
+        exploreState.pivot.columns.map((c) => c.id),
+      );
+
+      for (const value of values) {
+        if (existingRows.has(value.id) || existingCols.has(value.id)) {
+          continue;
+        }
+        if (target === "rows") {
+          if (value.type === PivotChipType.Measure) continue;
+          existingRows.add(value.id);
           exploreState.pivot.rows.push(value);
         } else {
+          existingCols.add(value.id);
           exploreState.pivot.columns.push(value);
         }
       }

--- a/web-common/src/features/dashboards/stores/dashboard-stores.ts
+++ b/web-common/src/features/dashboards/stores/dashboard-stores.ts
@@ -306,7 +306,11 @@ const metricsViewReducers = {
     metricsExplorerStore.addPivotFields(
       name,
       [value],
-      value.type === PivotChipType.Measure ? "columns" : rows ? "rows" : "columns",
+      value.type === PivotChipType.Measure
+        ? "columns"
+        : rows
+          ? "rows"
+          : "columns",
     );
   },
 
@@ -359,12 +363,8 @@ const metricsViewReducers = {
       exploreState.pivot.activeCell = null;
       exploreState.pivot.expanded = {};
 
-      const existingRows = new Set(
-        exploreState.pivot.rows.map((c) => c.id),
-      );
-      const existingCols = new Set(
-        exploreState.pivot.columns.map((c) => c.id),
-      );
+      const existingRows = new Set(exploreState.pivot.rows.map((c) => c.id));
+      const existingCols = new Set(exploreState.pivot.columns.map((c) => c.id));
 
       for (const value of values) {
         if (existingRows.has(value.id) || existingCols.has(value.id)) {

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -62,6 +62,7 @@
       measures: { allMeasures, visibleMeasures, getMeasureByName },
       dimensionFilters: { includedDimensionValues },
       charts: { canPanLeft, canPanRight, getNewPanRange },
+      tags: { measureTagIndex },
     },
     actions: {
       measures: { setMeasureVisibility },
@@ -283,6 +284,7 @@
         onSelectedChange={(items) =>
           setMeasureVisibility(items, allMeasureNames)}
         allItems={$allMeasures}
+        tagIndex={$measureTagIndex}
         selectedItems={visibleMeasureNames}
       />
 

--- a/web-common/src/lib/modifier-key.ts
+++ b/web-common/src/lib/modifier-key.ts
@@ -1,4 +1,4 @@
-import { derived, writable, type Readable } from "svelte/store";
+import { writable, type Readable } from "svelte/store";
 
 // Tracks whether the platform's "modify" key (CMD on macOS, Ctrl elsewhere)
 // is currently held. Subscribe via `$modifierHeld` for reactive UI; read
@@ -17,7 +17,4 @@ if (typeof window !== "undefined") {
   window.addEventListener("blur", () => _modifierHeld.set(false));
 }
 
-export const modifierHeld: Readable<boolean> = derived(
-  _modifierHeld,
-  ($v) => $v,
-);
+export const modifierHeld = _modifierHeld as Readable<boolean>;

--- a/web-common/src/lib/modifier-key.ts
+++ b/web-common/src/lib/modifier-key.ts
@@ -1,0 +1,23 @@
+import { derived, writable, type Readable } from "svelte/store";
+
+// Tracks whether the platform's "modify" key (CMD on macOS, Ctrl elsewhere)
+// is currently held. Subscribe via `$modifierHeld` for reactive UI; read
+// the value at the moment of action from the original MouseEvent's
+// `metaKey || ctrlKey` so a fast click that arrives before the keydown
+// listener fires still picks up the held key.
+const _modifierHeld = writable(false);
+
+if (typeof window !== "undefined") {
+  window.addEventListener("keydown", (e) => {
+    if (e.metaKey || e.ctrlKey) _modifierHeld.set(true);
+  });
+  window.addEventListener("keyup", (e) => {
+    if (!e.metaKey && !e.ctrlKey) _modifierHeld.set(false);
+  });
+  window.addEventListener("blur", () => _modifierHeld.set(false));
+}
+
+export const modifierHeld: Readable<boolean> = derived(
+  _modifierHeld,
+  ($v) => $v,
+);


### PR DESCRIPTION
Brings the merged Explore tag feature into the pivot sidebar. When a metrics view defines tags on dimensions or measures, the sidebar shows a dedicated Tags column on the left (mirroring the Explore dropdown's two-column layout).

- Click a tag to filter the Measures and Dimensions lists. Click again or use the inline `×` to clear.
- Hover a tag for three icon actions: Add all to rows, Add all to columns, and Auto-arrange (dims to rows, measures to columns) when a tag has both kinds.
- Drag a tag onto a zone for the same bulk-add, plus a contextual Auto-arrange drop zone that appears between Rows and Columns when the tag has both kinds of items.
- `⌘` / Ctrl + Click or + Drop replaces the target zone instead of appending. Replace paths also clean the opposite zone, so the same dimension never lands in both rows and columns. Append paths skip items already placed in either zone.

The tag index is hoisted into a shared `state-managers/selectors/tags.ts` so the Explore dropdown and the pivot sidebar consume the same derived index. `DashboardMetricsDraggableList` now takes `tagIndex` as a prop; its two callers pass the new selector value. Shared `TagFilterBanner` and `modifier-key` modules deduplicate the banner UI and CMD/Ctrl tracking across surfaces.

Closes [APP-1234](https://linear.app)

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*