### PR TITLE
fix: canvas parse error missing from editor preview

### DIFF
--- a/web-common/src/features/workspaces/CanvasWorkspace.svelte
+++ b/web-common/src/features/workspaces/CanvasWorkspace.svelte
@@ -143,7 +143,7 @@
                   {ready}
                   {isReconciling}
                   {isLoading}
-                  errorMessage={rootCauseReconcileError}
+                  errorMessage={rootCauseReconcileError ?? parseError?.message}
                   {filePath}
                 >
                   <CanvasBuilder


### PR DESCRIPTION
In visual edit mode we do not display the yaml parse error. While this shouldnt happen when only using editor showing a perpetual spinner also doesnt make sense.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
