### PR TITLE
refac: make admin network errors recoverable when cached data exists

### DIFF
--- a/web-admin/src/client/utils.ts
+++ b/web-admin/src/client/utils.ts
@@ -4,7 +4,9 @@ import type { AxiosError } from "axios";
 import { derived, type Readable } from "svelte/store";
 
 export function isAdminServerQuery(query: Query): boolean {
-  const [apiPath] = query.queryKey as string[];
+  const [apiPath] = query.queryKey as unknown[];
+  if (typeof apiPath !== "string") return false;
+
   const adminApiEndpoints = [
     "/v1/deployments",
     "/v1/github",

--- a/web-admin/src/components/errors/admin-network-errors.spec.ts
+++ b/web-admin/src/components/errors/admin-network-errors.spec.ts
@@ -1,0 +1,129 @@
+import { isAdminServerQuery } from "@rilldata/web-admin/client/utils";
+import {
+  clearAdminNetworkErrorState,
+  handleAdminServerNetworkError,
+  handleAdminServerQuerySuccess,
+  recoverFromAdminNetworkError,
+} from "@rilldata/web-admin/components/errors/admin-network-errors";
+import { errorStore } from "@rilldata/web-admin/components/errors/error-store";
+import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
+import type { Query, QueryClient } from "@tanstack/svelte-query";
+import { get } from "svelte/store";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type TestQueryClient = Pick<QueryClient, "refetchQueries">;
+
+function makeQuery(queryKey: unknown[], data?: unknown): Query {
+  return {
+    queryKey,
+    state: { data },
+  } as unknown as Query;
+}
+
+function makeQueryClient(): TestQueryClient {
+  return {
+    refetchQueries: vi.fn(() => Promise.resolve()),
+  } as unknown as TestQueryClient;
+}
+
+describe("admin network errors", () => {
+  beforeEach(() => {
+    errorStore.reset();
+    vi.spyOn(eventBus, "emit");
+  });
+
+  afterEach(() => {
+    clearAdminNetworkErrorState();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps cached data visible and shows a banner for admin network errors", () => {
+    const queryClient = makeQueryClient();
+    const handled = handleAdminServerNetworkError(
+      new Error("Network Error"),
+      makeQuery(["/v1/projects/org/proj"], { project: { name: "proj" } }),
+      queryClient,
+    );
+
+    expect(handled).toBe(true);
+    expect(get(errorStore).header).toBe("");
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      "add-banner",
+      expect.objectContaining({
+        id: "admin-network",
+        message: expect.objectContaining({
+          message: expect.stringContaining("Showing cached data"),
+          type: "warning",
+        }),
+      }),
+    );
+  });
+
+  it("uses the full-page error only when there is no cached data", () => {
+    const handled = handleAdminServerNetworkError(
+      new Error("Network Error"),
+      makeQuery(["/v1/projects/org/proj"]),
+      makeQueryClient(),
+    );
+
+    expect(handled).toBe(true);
+    expect(get(errorStore).header).toBe("Network Error");
+    expect(eventBus.emit).not.toHaveBeenCalledWith(
+      "add-banner",
+      expect.anything(),
+    );
+  });
+
+  it("ignores non-admin query network errors", () => {
+    const handled = handleAdminServerNetworkError(
+      new Error("Network Error"),
+      makeQuery(["/v1/instances/runtime/api/query"], { rows: [] }),
+      makeQueryClient(),
+    );
+
+    expect(handled).toBe(false);
+    expect(get(errorStore).header).toBe("");
+    expect(eventBus.emit).not.toHaveBeenCalledWith(
+      "add-banner",
+      expect.anything(),
+    );
+  });
+
+  it("clears the banner after a successful admin query", () => {
+    handleAdminServerNetworkError(
+      new Error("Network Error"),
+      makeQuery(["/v1/projects/org/proj"], { project: { name: "proj" } }),
+      makeQueryClient(),
+    );
+    vi.mocked(eventBus.emit).mockClear();
+
+    handleAdminServerQuerySuccess(makeQuery(["/v1/users/me"], { user: {} }));
+
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      "remove-banner",
+      "admin-network",
+    );
+  });
+
+  it("refetches active admin queries during recovery", async () => {
+    const queryClient = makeQueryClient();
+    handleAdminServerNetworkError(
+      new Error("Network Error"),
+      makeQuery(["/v1/projects/org/proj"], { project: { name: "proj" } }),
+      queryClient,
+    );
+
+    await recoverFromAdminNetworkError(queryClient);
+
+    expect(queryClient.refetchQueries).toHaveBeenCalledWith({
+      type: "active",
+      predicate: isAdminServerQuery,
+    });
+  });
+
+  it("treats non-string query keys as non-admin queries", () => {
+    expect(isAdminServerQuery(makeQuery([{ path: "/v1/projects" }]))).toBe(
+      false,
+    );
+  });
+});

--- a/web-admin/src/components/errors/admin-network-errors.ts
+++ b/web-admin/src/components/errors/admin-network-errors.ts
@@ -1,0 +1,110 @@
+import { isAdminServerQuery } from "@rilldata/web-admin/client/utils";
+import { errorStore } from "@rilldata/web-admin/components/errors/error-store";
+import { createUserFacingError } from "@rilldata/web-admin/components/errors/user-facing-errors";
+import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
+import type { Query, QueryClient } from "@tanstack/svelte-query";
+
+export const AdminNetworkErrorMessage = "Network Error";
+
+const AdminNetworkBannerID = "admin-network";
+const AdminNetworkBannerPriority = 0;
+
+type QueryRefetcher = Pick<QueryClient, "refetchQueries">;
+
+let adminNetworkErrorActive = false;
+
+export function isNetworkError(error: unknown): boolean {
+  return error instanceof Error && error.message === AdminNetworkErrorMessage;
+}
+
+export function handleAdminServerNetworkError(
+  error: unknown,
+  query: Query,
+  queryClient: QueryRefetcher,
+): boolean {
+  if (!isNetworkError(error) || !isAdminServerQuery(query)) return false;
+
+  adminNetworkErrorActive = true;
+
+  if (queryHasCachedData(query)) {
+    showAdminNetworkBanner(queryClient);
+  } else {
+    showAdminNetworkErrorPage();
+  }
+
+  return true;
+}
+
+export function handleAdminServerQuerySuccess(query: Query): void {
+  if (!adminNetworkErrorActive || !isAdminServerQuery(query)) return;
+  clearAdminNetworkErrorState();
+}
+
+export function recoverFromAdminNetworkError(
+  queryClient: QueryRefetcher,
+): Promise<unknown> {
+  if (!adminNetworkErrorActive) return Promise.resolve();
+
+  clearAdminNetworkErrorState();
+  return queryClient.refetchQueries({
+    type: "active",
+    predicate: isAdminServerQuery,
+  });
+}
+
+export function registerAdminNetworkRecoveryListeners(
+  queryClient: QueryRefetcher,
+): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  const recover = () => {
+    void recoverFromAdminNetworkError(queryClient);
+  };
+  const recoverWhenVisible = () => {
+    if (document.visibilityState !== "hidden") recover();
+  };
+
+  window.addEventListener("online", recover);
+  window.addEventListener("focus", recoverWhenVisible);
+  document.addEventListener("visibilitychange", recoverWhenVisible);
+
+  return () => {
+    window.removeEventListener("online", recover);
+    window.removeEventListener("focus", recoverWhenVisible);
+    document.removeEventListener("visibilitychange", recoverWhenVisible);
+  };
+}
+
+export function clearAdminNetworkErrorState(): void {
+  adminNetworkErrorActive = false;
+  errorStore.reset();
+  eventBus.emit("remove-banner", AdminNetworkBannerID);
+}
+
+function queryHasCachedData(query: Query): boolean {
+  return query.state.data !== undefined;
+}
+
+function showAdminNetworkErrorPage(): void {
+  errorStore.set(createUserFacingError(null, AdminNetworkErrorMessage));
+}
+
+function showAdminNetworkBanner(queryClient: QueryRefetcher): void {
+  eventBus.emit("add-banner", {
+    id: AdminNetworkBannerID,
+    priority: AdminNetworkBannerPriority,
+    message: {
+      type: "warning",
+      iconType: "alert",
+      message:
+        "Connection to Rill Cloud was interrupted. Showing cached data while we reconnect.",
+      cta: {
+        type: "button",
+        text: "Retry now",
+        async onClick() {
+          await recoverFromAdminNetworkError(queryClient);
+        },
+      },
+    },
+  });
+}

--- a/web-admin/src/components/errors/admin-network-errors.ts
+++ b/web-admin/src/components/errors/admin-network-errors.ts
@@ -2,6 +2,7 @@ import { isAdminServerQuery } from "@rilldata/web-admin/client/utils";
 import { errorStore } from "@rilldata/web-admin/components/errors/error-store";
 import { createUserFacingError } from "@rilldata/web-admin/components/errors/user-facing-errors";
 import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
+import { isNetworkError } from "@rilldata/web-common/lib/errors";
 import type { Query, QueryClient } from "@tanstack/svelte-query";
 
 export const AdminNetworkErrorMessage = "Network Error";
@@ -12,10 +13,6 @@ const AdminNetworkBannerPriority = 0;
 type QueryRefetcher = Pick<QueryClient, "refetchQueries">;
 
 let adminNetworkErrorActive = false;
-
-export function isNetworkError(error: unknown): boolean {
-  return error instanceof Error && error.message === AdminNetworkErrorMessage;
-}
 
 export function handleAdminServerNetworkError(
   error: unknown,

--- a/web-admin/src/routes/+layout.svelte
+++ b/web-admin/src/routes/+layout.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import { page } from "$app/stores";
-  import { isAdminServerQuery } from "@rilldata/web-admin/client/utils";
-  import { errorStore } from "@rilldata/web-admin/components/errors/error-store";
-  import { createUserFacingError } from "@rilldata/web-admin/components/errors/user-facing-errors";
+  import {
+    handleAdminServerNetworkError,
+    handleAdminServerQuerySuccess,
+    registerAdminNetworkRecoveryListeners,
+  } from "@rilldata/web-admin/components/errors/admin-network-errors";
   import { dynamicHeight } from "@rilldata/web-common/layout/layout-settings.ts";
   import BillingBannerManager from "@rilldata/web-admin/features/billing/banner/BillingBannerManager.svelte";
   import {
@@ -63,13 +65,14 @@
     // Add TanStack Query errors to telemetry
     errorEventHandler?.requestErrorEventHandler(error, query);
 
-    // Handle network errors
-    // Note: ideally, we'd throw this in the root `+layout.ts` file, but we're blocked by
-    // https://github.com/sveltejs/kit/issues/10201
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    if (isAdminServerQuery(query) && errorMessage === "Network Error") {
-      errorStore.set(createUserFacingError(null, errorMessage));
-    }
+    handleAdminServerNetworkError(error, query, queryClient);
+  };
+
+  queryClient.getQueryCache().config.onSuccess = (
+    _data: unknown,
+    query: Query,
+  ) => {
+    handleAdminServerQuerySuccess(query);
   };
 
   // The admin server enables some dashboard features like scheduled reports and alerts
@@ -87,7 +90,13 @@
   initPylonWidget();
 
   onMount(() => {
-    return () => removeJavascriptListeners?.();
+    const removeNetworkRecoveryListeners =
+      registerAdminNetworkRecoveryListeners(queryClient);
+
+    return () => {
+      removeJavascriptListeners?.();
+      removeNetworkRecoveryListeners();
+    };
   });
 
   $: isEmbed = isEmbedPage($page);

--- a/web-common/src/lib/errors.spec.ts
+++ b/web-common/src/lib/errors.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isNetworkError } from "./errors";
+
+describe("isNetworkError", () => {
+  it("matches Axios network errors", () => {
+    expect(isNetworkError(new Error("Network Error"))).toBe(true);
+    expect(isNetworkError({ code: "ERR_NETWORK" })).toBe(true);
+  });
+
+  it("matches browser fetch transport failures", () => {
+    expect(isNetworkError(new TypeError("Failed to fetch"))).toBe(true);
+    expect(isNetworkError(new TypeError("Load failed"))).toBe(true);
+    expect(isNetworkError(new Error("fetch failed"))).toBe(true);
+  });
+
+  it("matches Connect unavailable errors that wrap fetch failures", () => {
+    expect(isNetworkError({ code: 14, rawMessage: "fetch failed" })).toBe(true);
+  });
+
+  it("does not treat HTTP responses as network errors", () => {
+    expect(
+      isNetworkError({
+        response: {
+          status: 503,
+          data: { message: "Network Error" },
+        },
+      }),
+    ).toBe(false);
+    expect(
+      isNetworkError({ status: 503, message: "Service unavailable" }),
+    ).toBe(false);
+    expect(isNetworkError({ code: 14, rawMessage: "unavailable" })).toBe(false);
+  });
+});

--- a/web-common/src/lib/errors.ts
+++ b/web-common/src/lib/errors.ts
@@ -10,6 +10,39 @@ export interface HTTPError {
   traceId?: string;
 }
 
+const NetworkErrorMessages = [
+  "network error",
+  "failed to fetch",
+  "fetch failed",
+  "load failed",
+  "networkerror when attempting to fetch resource",
+];
+
+/**
+ * Returns true if the error looks like a client-side transport failure.
+ * Handles Axios network errors, fetch/TypeError failures, and ConnectRPC
+ * Unavailable errors that wrap browser fetch failures.
+ */
+export function isNetworkError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  const e = error as Record<string, unknown>;
+
+  // Axios uses this code for transport failures with no HTTP response.
+  if (e.code === "ERR_NETWORK" && !e.response) return true;
+
+  // If the server responded, this is an HTTP/application error, not a browser
+  // transport failure.
+  if (e.response || typeof e.status === "number") return false;
+
+  // extractErrorMessage reads ConnectRPC rawMessage first, so a ConnectRPC
+  // Unavailable (code 14) that wraps a fetch failure is caught here too. We
+  // match on the fetch/network shaped message rather than code 14 itself so
+  // that normal server 503s are not treated as browser offline.
+  const message = extractErrorMessage(error).toLowerCase();
+  return NetworkErrorMessages.some((value) => message.includes(value));
+}
+
 export function isHTTPError(error: unknown): error is HTTPError {
   return (
     typeof error === "object" &&

--- a/web-common/src/lib/svelte-query/globalQueryClient.ts
+++ b/web-common/src/lib/svelte-query/globalQueryClient.ts
@@ -1,5 +1,11 @@
 import { QueryClient } from "@tanstack/svelte-query";
 
+const MaxNetworkErrorRetries = 2;
+
+function isNetworkError(error: unknown): boolean {
+  return error instanceof Error && error.message === "Network Error";
+}
+
 export function createQueryClient() {
   return new QueryClient({
     defaultOptions: {
@@ -7,7 +13,9 @@ export function createQueryClient() {
         refetchOnMount: false,
         refetchOnReconnect: false,
         refetchOnWindowFocus: false,
-        retry: false,
+        retry: (failureCount, error) =>
+          isNetworkError(error) && failureCount < MaxNetworkErrorRetries,
+        retryDelay: (failureCount) => Math.min(1000 * 2 ** failureCount, 4000),
         networkMode: "always",
       },
       mutations: {

--- a/web-common/src/lib/svelte-query/globalQueryClient.ts
+++ b/web-common/src/lib/svelte-query/globalQueryClient.ts
@@ -1,10 +1,7 @@
 import { QueryClient } from "@tanstack/svelte-query";
+import { isNetworkError } from "../errors";
 
 const MaxNetworkErrorRetries = 2;
-
-function isNetworkError(error: unknown): boolean {
-  return error instanceof Error && error.message === "Network Error";
-}
 
 export function createQueryClient() {
   return new QueryClient({


### PR DESCRIPTION
Returning to an already-open dashboard tab frequently shows a full-page “Network Error” instead of either preserving the last view or retrying the load.

Root cause: any admin API query failing with Axios’ `Network Error` was treated as a global fatal error. This could happen from background or peripheral admin queries, even when the dashboard already had usable cached data. Once set, the global error page only cleared on navigation, so the tab could remain stuck on the network error.

This change:
- Keeps the current page visible when an admin API `Network Error` occurs but the query already has cached data
- Shows a recoverable warning banner with a retry action instead of replacing the app with the full-page Network Error
- Keeps the full-page Network Error for true initial-load failures with no cached data
- Clears the network error state after a successful admin query
- Refetches active admin queries on browser `online`, focus, and tab visibility recovery
- Adds limited retry/backoff for transient `Network Error` query failures
- Adds unit coverage for cached-data, initial-load, recovery, and non-admin query behavior
