### PR TITLE
better handling pivot export failures

### DIFF
--- a/runtime/drivers/registry.go
+++ b/runtime/drivers/registry.go
@@ -110,6 +110,11 @@ type InstanceConfig struct {
 	// MetricsNullFillingImplementation switches between null-filling implementations for timeseries queries.
 	// Can be "", "none", "new", "pushdown".
 	MetricsNullFillingImplementation string `mapstructure:"rill.metrics.timeseries_null_filling_implementation"`
+	// MetricsPivotExportColumnLimit caps the number of columns a pivot export may produce.
+	// Pivots are executed in DuckDB, which materializes each output row in a single storage block,
+	// so a pivot producing too many columns fails with an opaque error. This is a conservative safety cap
+	// that lets us return a clear error first. If set to 0, there is no limit.
+	MetricsPivotExportColumnLimit int64 `mapstructure:"rill.metrics.pivot_export_column_limit"`
 	// AlertsDefaultStreamingRefreshCron sets a default cron expression for refreshing alerts with streaming refs.
 	// Namely, this is used to check alerts against external tables (e.g. in Druid) where new data may be added at any time (i.e. is considered "streaming").
 	AlertsDefaultStreamingRefreshCron string `mapstructure:"rill.alerts.default_streaming_refresh_cron"`
@@ -205,6 +210,7 @@ func (i *Instance) Config() (InstanceConfig, error) {
 		MetricsApproxComparisonTwoPhaseLimit: 250,
 		MetricsExactifyDruidTopN:             false,
 		MetricsNullFillingImplementation:     "pushdown",
+		MetricsPivotExportColumnLimit:        15000,
 		AlertsDefaultStreamingRefreshCron:    "0 0 * * *",    // Every 24 hours
 		AlertsFastStreamingRefreshCron:       "*/10 * * * *", // Every 10 minutes
 		AICompletionTimeoutSeconds:           60 * 10,        // 10 minutes

--- a/runtime/drivers/registry.go
+++ b/runtime/drivers/registry.go
@@ -111,7 +111,7 @@ type InstanceConfig struct {
 	// Can be "", "none", "new", "pushdown".
 	MetricsNullFillingImplementation string `mapstructure:"rill.metrics.timeseries_null_filling_implementation"`
 	// MetricsPivotExportColumnLimit caps the number of columns a pivot export may produce.
-	// Pivots are executed in DuckDB, which materializes each output row in a single storage block,
+	// Pivots are executed in DuckDB and produces one column per combination of the pivoted dimension values, times the number of measures.
 	// so a pivot producing too many columns fails with an opaque error. This is a conservative safety cap
 	// that lets us return a clear error first. If set to 0, there is no limit.
 	MetricsPivotExportColumnLimit int64 `mapstructure:"rill.metrics.pivot_export_column_limit"`

--- a/runtime/metricsview/executor/executor_pivot.go
+++ b/runtime/metricsview/executor/executor_pivot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -177,6 +178,14 @@ func (e *Executor) executePivotExport(ctx context.Context, ast *metricsview.AST,
 			}
 		}()
 
+		// Guard against pivots that would generate too many columns.
+		// A pivot produces one column per distinct combination of the pivoted dimension values, times the number of measures.
+		// Pivots are executed in DuckDB, which materializes each output row in a single storage block, so an overly
+		// wide pivot fails with an opaque error; we detect it up front to return a clear, actionable message instead.
+		if err := e.checkPivotColumns(wrappedCtx, olap, alias, pivot); err != nil {
+			return err
+		}
+
 		// Build the PIVOT query
 		pivotSQL, err := pivot.SQL(ast, alias)
 		if err != nil {
@@ -188,6 +197,11 @@ func (e *Executor) executePivotExport(ctx context.Context, ast *metricsview.AST,
 			"sql": pivotSQL,
 		}, headers)
 		if err != nil {
+			// Backstop for wide pivots that slip past checkPivotColumns (e.g. wide column types overflow the block size
+			// at a lower column count than the limit). DuckDB reports this as a "tuple width exceeds block size" error.
+			if strings.Contains(err.Error(), "tuple width exceeds block size") {
+				return fmt.Errorf("pivot produced too many columns to export; reduce the number of pivoted dimensions or filter the data to fewer values")
+			}
 			return fmt.Errorf("failed to execute pivot export: %w", err)
 		}
 
@@ -197,6 +211,53 @@ func (e *Executor) executePivotExport(ctx context.Context, ast *metricsview.AST,
 		return "", err
 	}
 	return path, nil
+}
+
+// checkPivotColumns returns an error if the pivot would produce more columns than the configured limit.
+// The staged data in tableName is queried for the number of distinct combinations of the pivoted dimensions,
+// which is multiplied by the number of measures to estimate the resulting column count.
+// The limit is a conservative safety cap (configurable via rill.metrics.pivot_export_column_limit); a limit of 0 disables the check.
+func (e *Executor) checkPivotColumns(ctx context.Context, olap drivers.OLAPStore, tableName string, pivot *pivotAST) error {
+	limit := e.instanceCfg.MetricsPivotExportColumnLimit
+	if limit <= 0 || len(pivot.on) == 0 {
+		return nil
+	}
+
+	var cols strings.Builder
+	for i, on := range pivot.on {
+		if i > 0 {
+			cols.WriteString(", ")
+		}
+		cols.WriteString(pivot.dialect.EscapeIdentifier(on))
+	}
+
+	res, err := olap.Query(ctx, &drivers.Statement{
+		Query:           fmt.Sprintf("SELECT count(*) FROM (SELECT DISTINCT %s FROM %s)", cols.String(), tableName),
+		QueryAttributes: e.queryAttributes,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to check pivot cardinality: %w", err)
+	}
+	defer res.Close()
+
+	if !res.Next() {
+		return errors.New("failed to check pivot cardinality: no rows returned")
+	}
+	var distinctCombinations int64
+	if err := res.Scan(&distinctCombinations); err != nil {
+		return fmt.Errorf("failed to check pivot cardinality: %w", err)
+	}
+
+	measures := int64(len(pivot.using))
+	if measures < 1 {
+		measures = 1
+	}
+	columns := distinctCombinations * measures
+	if columns > limit {
+		return fmt.Errorf("pivot would produce %d columns (%d distinct combinations of the pivoted dimensions times %d measures), which exceeds the limit of %d; reduce the number of pivoted dimensions or filter the data to fewer values", columns, distinctCombinations, measures, limit)
+	}
+
+	return nil
 }
 
 // pivotAST represents config for generating a PIVOT query.

--- a/runtime/metricsview/executor/executor_pivot.go
+++ b/runtime/metricsview/executor/executor_pivot.go
@@ -180,8 +180,7 @@ func (e *Executor) executePivotExport(ctx context.Context, ast *metricsview.AST,
 
 		// Guard against pivots that would generate too many columns.
 		// A pivot produces one column per distinct combination of the pivoted dimension values, times the number of measures.
-		// Pivots are executed in DuckDB, which materializes each output row in a single storage block, so an overly
-		// wide pivot fails with an opaque error; we detect it up front to return a clear, actionable message instead.
+		// Pivots are executed in DuckDB, an overly wide pivot fails with an opaque error; we detect it up front to return a clear, actionable message instead.
 		if err := e.checkPivotColumns(wrappedCtx, olap, alias, pivot); err != nil {
 			return err
 		}

--- a/runtime/queries/metricsview_aggregation_test.go
+++ b/runtime/queries/metricsview_aggregation_test.go
@@ -789,6 +789,38 @@ func TestMetricsViewsAggregation_pivot_export_labels_2_time_columns(t *testing.T
 	require.Equal(t, "Facebook", fieldsToString(rows[i], "Publisher"))
 }
 
+func TestMetricsViewsAggregation_pivot_export_column_limit_exceeded(t *testing.T) {
+	rt, instanceID := testruntime.NewInstanceForProjectWithConfigs(t, "ad_bids", map[string]string{
+		"rill.metrics.pivot_export_column_limit": "2",
+	})
+
+	limit := int64(1000)
+	q := &queries.MetricsViewAggregation{
+		MetricsViewName: "ad_bids_metrics",
+		Dimensions: []*runtimev1.MetricsViewAggregationDimension{
+			{Name: "pub"},
+			{
+				Name:      "timestamp",
+				TimeGrain: runtimev1.TimeGrain_TIME_GRAIN_MONTH,
+			},
+		},
+		Measures: []*runtimev1.MetricsViewAggregationMeasure{
+			{Name: "measure_1"},
+		},
+		Sort: []*runtimev1.MetricsViewAggregationSort{
+			{Name: "pub"},
+		},
+		PivotOn:        []string{"timestamp"},
+		Limit:          &limit,
+		Exporting:      true,
+		SecurityClaims: testClaims(),
+	}
+	// The pivot spans three months, which exceeds the configured limit of 2 columns.
+	err := q.Resolve(context.Background(), rt, instanceID, 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds the limit of 2")
+}
+
 func TestMetricsViewsAggregation_pivot_export_labels(t *testing.T) {
 	rt, instanceID := testruntime.NewInstanceForProject(t, "ad_bids")
 


### PR DESCRIPTION
To produce actionable error when pivot fails

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
