### PR TITLE
Allow querying metrics resolvers with ReadMetrics permission

### DIFF
--- a/runtime/server/query_resolver.go
+++ b/runtime/server/query_resolver.go
@@ -16,10 +16,19 @@ import (
 
 // QueryResolver enables superusers and project admins to query a resolver within a project
 func (s *Server) QueryResolver(ctx context.Context, req *runtimev1.QueryResolverRequest) (*runtimev1.QueryResolverResponse, error) {
-	// Validate the caller has the ReadResolvers permission
+	// Validate permissions
 	claims := auth.GetClaims(ctx, req.InstanceId)
-	if !claims.Can(runtime.ReadResolvers) {
-		return nil, status.Error(codes.PermissionDenied, "only project admins can query resolvers")
+	switch req.Resolver {
+	case "metrics", "metrics_sql":
+		// As a special case, we allow metrics resolvers for users with ReadMetrics permission (i.e. all users)
+		if !claims.Can(runtime.ReadMetrics) {
+			return nil, status.Error(codes.PermissionDenied, "not allowed to query metrics")
+		}
+	default:
+		// Other resolvers require ReadResolvers permission (i.e. project admin)
+		if !claims.Can(runtime.ReadResolvers) {
+			return nil, status.Error(codes.PermissionDenied, "only project admins can query resolvers")
+		}
 	}
 
 	// Resolver should exist


### PR DESCRIPTION
Lets non-admin users query the `metrics` and `metrics_sql` resolvers via `QueryResolver`, which previously required `ReadResolvers` (project admin).
