### PR TITLE
refac: replace pivot/flat toggle with a two-segment control

### DIFF
--- a/web-common/src/features/dashboards/pivot/PivotToolbar.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotToolbar.svelte
@@ -59,6 +59,8 @@
    * dashboard store when toggling back from `flat` to `nest`
    */
   function togglePivotType(newJoinState: PivotTableMode) {
+    if (newJoinState === tableMode) return;
+
     if (newJoinState === "flat") {
       lastNestState.set(rows);
       setTableMode(
@@ -106,22 +108,48 @@
   </Tooltip>
 
   <div class="flex items-center gap-x-1">
-    <Tooltip location="bottom" alignment="start" distance={8}>
-      <Button
-        type="toolbar"
-        onClick={() => togglePivotType(isFlat ? "nest" : "flat")}
-      >
-        {#if isFlat}
-          <TableIcon size="16px" />
-        {:else}
+    <div
+      class="flex h-6 overflow-hidden rounded-sm border border-gray-200 bg-input pointer-events-auto"
+      role="group"
+      aria-label="Table mode"
+    >
+      <Tooltip location="bottom" alignment="start" distance={8}>
+        <button
+          type="button"
+          class="pivot-mode-button"
+          class:selected={!isFlat}
+          aria-pressed={!isFlat}
+          onclick={(e) => {
+            togglePivotType("nest");
+            blurCurrentTarget(e);
+          }}
+        >
           <Pivot size="16px" />
-        {/if}
-        <span>{isFlat ? "Flat table" : "Pivot table"}</span>
-      </Button>
-      <TooltipContent slot="tooltip-content">
-        {isFlat ? "Switch to a pivot table" : "Switch to a flat table"}
-      </TooltipContent>
-    </Tooltip>
+          <span>Pivot</span>
+        </button>
+        <TooltipContent slot="tooltip-content">
+          {!isFlat ? "Currently showing pivot view" : "Switch to pivot view"}
+        </TooltipContent>
+      </Tooltip>
+      <Tooltip location="bottom" alignment="start" distance={8}>
+        <button
+          type="button"
+          class="pivot-mode-button border-l border-gray-200"
+          class:selected={isFlat}
+          aria-pressed={isFlat}
+          onclick={(e) => {
+            togglePivotType("flat");
+            blurCurrentTarget(e);
+          }}
+        >
+          <TableIcon size="16px" color="currentColor" />
+          <span>Flat</span>
+        </button>
+        <TooltipContent slot="tooltip-content">
+          {isFlat ? "Currently showing flat view" : "Switch to flat view"}
+        </TooltipContent>
+      </Tooltip>
+    </div>
 
     <Button
       type="toolbar"
@@ -158,3 +186,14 @@
     {/if}
   </div>
 </div>
+
+<style lang="postcss">
+  .pivot-mode-button {
+    @apply flex h-full min-w-[64px] items-center justify-center gap-x-1.5 px-2;
+    @apply text-xs font-normal text-fg-secondary hover:bg-gray-600/15;
+  }
+
+  .pivot-mode-button.selected {
+    @apply bg-gray-600/15;
+  }
+</style>

--- a/web-local/tests/explores/pivot.spec.ts
+++ b/web-local/tests/explores/pivot.spec.ts
@@ -628,12 +628,12 @@ test.describe("pivot run through", () => {
     await validateTableContents(page, "table", expectedTwoMeasureRowDimColDim);
 
     // Flatten the table
-    await page.getByRole("button", { name: "Pivot table" }).click();
+    await page.getByRole("button", { name: "Flat", exact: true }).click();
     await expect(page.locator(".status.running")).toHaveCount(0);
     await validateTableContents(page, "table", expectedFlatTable);
 
     // Nest the table
-    await page.getByRole("button", { name: "Flat table" }).click();
+    await page.getByRole("button", { name: "Pivot", exact: true }).click();
     await expect(page.locator(".status.running")).toHaveCount(0);
 
     // Remove the row dimension and second measure


### PR DESCRIPTION
Replace the single Pivot/Flat toggle button with a two-segment control that always shows both modes and which one is active (default: Pivot)

https://linear.app/rilldata/issue/APP-348/flat-and-pivot-button-change

<img width="547" height="220" alt="image" src="https://github.com/user-attachments/assets/00c8c17f-60a2-4ab1-b5d1-6ea3277e01ea" />

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
