### PR TITLE
Remove stale `rill-examples` gitlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ saved-state.json
 last-query-output.json
 staging-databases
 /rilldata
+/rill-examples/
 docs/dist/
 coverage
 # locally deployed test projects can generate this


### PR DESCRIPTION
- The `rill-examples` directory was accidentally committed as a submodule reference in #8214: a gitlink with no `.gitmodules` entry, pointing to a commit that doesn't exist upstream. This made the folder render as an unclickable `rill-examples @ 28a09f2` entry on GitHub.
- Removes the gitlink and adds `/rill-examples/` to `.gitignore` so a nested clone can't be re-committed by accident.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*