### PR TITLE
move ai session cleanup after migration

### DIFF
--- a/runtime/drivers/sqlite/migrate.go
+++ b/runtime/drivers/sqlite/migrate.go
@@ -72,6 +72,13 @@ func (c *connection) Migrate(_ context.Context) (err error) {
 		}
 	}
 
+	// Apply TTL to AI sessions in the background.
+	// This can be slow on large databases, so it must not block Migrate (and therefore runtime startup).
+	// Using aiSessionCleanupOnce defensively to make sure cleanup started only once.
+	c.aiSessionCleanupOnce.Do(func() {
+		go c.deleteExpiredAISessionsLoop()
+	})
+
 	return nil
 }
 

--- a/runtime/drivers/sqlite/migrate_test.go
+++ b/runtime/drivers/sqlite/migrate_test.go
@@ -24,6 +24,7 @@ func TestDeleteExpiredAISessions(t *testing.T) {
 	// Open the database, run migrations, and seed test data.
 	h, err := driver{}.Open("", "", cfg, storage.MustNew(storageDir, nil), activity.NewNoopClient(), zap.NewNop())
 	require.NoError(t, err)
+	defer h.Close()
 	require.NoError(t, h.Migrate(t.Context()))
 
 	catalog, ok := h.AsCatalogStore("inst")
@@ -43,12 +44,7 @@ func TestDeleteExpiredAISessions(t *testing.T) {
 	// Session 4: new session with no messages (should be kept).
 	require.NoError(t, catalog.InsertAISession(t.Context(), &drivers.AISession{ID: "s4", CreatedOn: now, UpdatedOn: now}))
 
-	// Close the handle, then re-open and migrate to trigger the TTL cleanup.
-	require.NoError(t, h.Close())
-	h, err = driver{}.Open("", "", cfg, storage.MustNew(storageDir, nil), activity.NewNoopClient(), zap.NewNop())
-	require.NoError(t, err)
-	defer h.Close()
-	require.NoError(t, h.Migrate(t.Context()))
+	require.NoError(t, h.(*connection).deleteExpiredAISessions(t.Context()))
 
 	// Query the database directly to verify results.
 	db := h.(*connection).db

--- a/runtime/drivers/sqlite/sqlite.go
+++ b/runtime/drivers/sqlite/sqlite.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"sync"
 
 	"github.com/XSAM/otelsql"
 	"github.com/jmoiron/sqlx"
@@ -77,10 +78,6 @@ func (d driver) Open(_, _ string, config map[string]any, st *storage.Client, ac 
 	// Start backups in the background (no-op if backups are not configured)
 	go h.startBackups()
 
-	// Apply TTL to AI sessions in the background.
-	// This can be slow on large databases, so it must not block Migrate (and therefore runtime startup).
-	go h.deleteExpiredAISessionsLoop()
-
 	return h, nil
 }
 
@@ -133,6 +130,9 @@ type connection struct {
 	db     *sqlx.DB
 	logger *zap.Logger
 	config map[string]any
+
+	// Ensures the AI session cleanup loop is started at most once.
+	aiSessionCleanupOnce sync.Once
 
 	// Backup management.
 	// See c.startBackups() for details.


### PR DESCRIPTION
After https://github.com/rilldata/rill/pull/9500 `rill start` is throwing error like because the cleanup starts in `open` method before migration has run which creates these tables.
```
ERROR    sqlite: failed to delete expired AI sessions    {"error": "failed to query expired AI sessions: SQL logic error: no such table: ai_sessions (1)"}
```
Although its harmless but still move clean up after catalog migration has run.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
