### PR TITLE
fix: redirect to project home when user already has access on request-access page

### DIFF
--- a/web-admin/src/routes/-/request-project-access/+page.svelte
+++ b/web-admin/src/routes/-/request-project-access/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { goto } from "$app/navigation";
   import { page } from "$app/stores";
   import {
     createAdminServiceRequestProjectAccess,
@@ -25,8 +26,13 @@
     const rpcError = ($requestAccess.error as unknown as AxiosError<RpcStatus>)
       .response.data;
     if (rpcError) {
-      // do not show error if already requested invite
-      if (rpcError.code !== 6) errorMessage = rpcError.message;
+      if (rpcError.code === 9) {
+        // FailedPrecondition: the user already has access, so send them to the project.
+        void goto(`/${organization}/${project}`);
+      } else if (rpcError.code !== 6) {
+        // do not show error if already requested invite (AlreadyExists)
+        errorMessage = rpcError.message;
+      }
     } else {
       errorMessage = $requestAccess.error.toString();
     }


### PR DESCRIPTION
- The request-access page returns a `FailedPrecondition` (gRPC code 9) error when a user requests access to a project they already have access to. Previously this raw error message was displayed, leaving the user stuck on the request-access page.
- Now the page redirects the user to the project home page (`/{organization}/{project}`) instead of showing the message.
- Covers the `auto_request=true` entry path, which auto-fires the same request and now redirects through the same branch. The code-6 (already-requested) behavior is unchanged.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*