### PR TITLE
fix: canvas chat context loading forever

### DIFF
--- a/web-common/src/features/chat/core/context/picker/ExpandableOption.svelte
+++ b/web-common/src/features/chat/core/context/picker/ExpandableOption.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import * as Collapsible from "@rilldata/web-common/components/collapsible";
   import { ChevronDownIcon, ChevronRightIcon } from "lucide-svelte";
-  import type { Readable } from "svelte/store";
+  import { readable, type Readable } from "svelte/store";
   import type { PickerTreeNode } from "@rilldata/web-common/features/chat/core/context/picker/picker-tree.ts";
   import type { KeyboardNavigationManager } from "@rilldata/web-common/features/chat/core/context/picker/keyboard-navigation.ts";
   import {
@@ -24,13 +24,13 @@
   export let onSelect: (ctx: InlineContext) => void;
   export let focusEditor: () => void;
 
-  const item = node.item;
-  const context = item.context;
+  $: item = node.item;
+  $: ({ id, context, recentlyUsed, currentlyActive } = item);
 
   const runtimeClient = useRuntimeClient();
 
-  const typeConfig = InlineContextConfig[context.type];
-  const typeLabel = typeConfig.typeLabel;
+  $: typeConfig = InlineContextConfig[context.type];
+  $: typeLabel = typeConfig.typeLabel;
   const contextMetadataStore = getInlineChatContextMetadata(runtimeClient);
   $: icon = typeConfig?.getIcon?.(context, $contextMetadataStore);
   const selectedItemId = selectedChatContext
@@ -39,23 +39,24 @@
 
   const { focusedItemStore, enhancePickerNode } = keyboardNavigationManager;
   $: focusedItem = $focusedItemStore;
-  $: focused = focusedItem?.id === item.id;
-  $: selected = item.id === selectedItemId;
+  $: focused = focusedItem?.id === id;
+  $: selected = id === selectedItemId;
 
   $: childSelected =
     selectedChatContext !== null &&
     inlineContextIsWithin(context, selectedChatContext);
   $: shouldForceOpen =
     childSelected ||
-    item.recentlyUsed ||
-    item.currentlyActive ||
+    recentlyUsed ||
+    currentlyActive ||
     $searchTextStore.length > 0;
-  $: if (shouldForceOpen) uiState.expand(item.id);
+  $: if (shouldForceOpen) uiState.expand(id);
 
-  const openStore = uiState.getExpandedStore(item.id);
+  let openStore = readable(false);
+  $: openStore = id ? uiState.getExpandedStore(id) : openStore;
 
   function onClick() {
-    uiState.toggle(item.id);
+    uiState.toggle(id);
     focusEditor();
   }
 </script>


### PR DESCRIPTION
We were missing some reactivity in chat context. This lead to canvas context items stuck in loading state for fetching components.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
