### PR TITLE
fix: canvas editor applies property edits to the wrong component

### DIFF
--- a/web-common/src/features/canvas/components/charts/BaseChart.ts
+++ b/web-common/src/features/canvas/components/charts/BaseChart.ts
@@ -203,7 +203,7 @@ export abstract class BaseChart<
     );
 
     this.parent.componentsStore.set(newComponent.id, newComponent);
-    this.parent.selectedComponent.set(newComponent.id);
+    this.parent.setSelectedComponent(newComponent.id);
     this.parent._rows.refresh();
 
     // Preserve the width from the current chart

--- a/web-common/src/features/canvas/stores/canvas-entity.ts
+++ b/web-common/src/features/canvas/stores/canvas-entity.ts
@@ -752,6 +752,15 @@ export class CanvasEntity {
   };
 
   setSelectedComponent = (id: string | null) => {
+    // Inspector inputs commit their value on blur. Canvas component elements are
+    // not focusable, so clicking another component never blurs the focused input,
+    // which would otherwise apply the pending edit to the newly-selected component.
+    // Blur the active element first so the edit commits against the component that
+    // is still selected, before we switch.
+    if (id !== get(this.selectedComponent) && typeof document !== "undefined") {
+      const active = document.activeElement;
+      if (active instanceof HTMLElement) active.blur();
+    }
     this.selectedComponent.set(id);
   };
 


### PR DESCRIPTION
- Inspector property inputs (title, description, and other text/number/textarea fields) commit their value on **blur**, not on every keystroke.
- Canvas component elements are non-focusable (`role="presentation"`, no `tabindex`), so clicking another component never blurred the focused input. `setSelectedComponent` ran immediately and reactively re-pointed the inspector at the newly-clicked component, so the pending edit resolved against the **wrong** component (or was lost). Clicking outside worked only because it naturally blurred the input first.
- Fix: blur the active element in `setSelectedComponent` before switching selection, so the pending edit commits against the still-selected component first. This is a single, centralized commit point that covers every blur-committed input.
- Also routed `BaseChart`'s direct `selectedComponent.set(...)` through `setSelectedComponent` for consistency.

**Testing:** select a component, edit its title, then click a different component — the edit now applies to the first (edited) component, not the second. Verified deselect and Enter-to-commit still work.

---
*Developed in collaboration with Claude Code*