### PR TITLE
fix: canvas pivot rejects time-grain row/column dimensions

### DIFF
--- a/runtime/canvas/component.go
+++ b/runtime/canvas/component.go
@@ -339,12 +339,12 @@ func validatePivot(props map[string]any, metricsViews map[string]*runtimev1.Metr
 		}
 	}
 	for _, d := range rowDims {
-		if !metricsViewHasDimension(mv, d) {
+		if !metricsViewHasDimension(mv, d) && !isPivotTimeDimension(mv, d) {
 			return fmt.Errorf("referenced row_dimensions value %q is not a dimension in metrics view %q", d, mvn)
 		}
 	}
 	for _, d := range colDims {
-		if !metricsViewHasDimension(mv, d) {
+		if !metricsViewHasDimension(mv, d) && !isPivotTimeDimension(mv, d) {
 			return fmt.Errorf("referenced col_dimensions value %q is not a dimension in metrics view %q", d, mvn)
 		}
 	}
@@ -517,6 +517,22 @@ func metricsViewHasDimension(mv *runtimev1.MetricsViewSpec, fieldName string) bo
 		}
 	}
 	return false
+}
+
+// isPivotTimeDimension reports whether fieldName is an encoded time-grain pivot dimension
+// of the form "{timeDimension}_rill_{GRAIN}" (e.g. "ts_rill_TIME_GRAIN_MONTH"). The canvas
+// pivot frontend encodes a time dimension at a chosen grain this way; it is decoded back into
+// a proper aggregation dimension at query time on the client.
+func isPivotTimeDimension(mv *runtimev1.MetricsViewSpec, fieldName string) bool {
+	if mv.TimeDimension == "" {
+		return false
+	}
+	grain, ok := strings.CutPrefix(fieldName, mv.TimeDimension+"_rill_")
+	if !ok {
+		return false
+	}
+	v, ok := runtimev1.TimeGrain_value[grain]
+	return ok && v != int32(runtimev1.TimeGrain_TIME_GRAIN_UNSPECIFIED)
 }
 
 // metricsViewHasMeasure returns true if the metrics view has a measure with the given name.

--- a/runtime/canvas/component.go
+++ b/runtime/canvas/component.go
@@ -301,7 +301,7 @@ func validateTable(props map[string]any, metricsViews map[string]*runtimev1.Metr
 		return errors.New("renderer properties for table must include a non-empty 'columns' array of strings")
 	}
 	for _, col := range columns {
-		if !metricsViewHasDimension(mv, col) && !metricsViewHasMeasure(mv, col) {
+		if !metricsViewHasDimension(mv, col) && !metricsViewHasMeasure(mv, col) && !isEncodedTimeDimension(mv, col) {
 			return fmt.Errorf("referenced columns value %q is not a dimension or measure in metrics view %q", col, mvn)
 		}
 	}
@@ -339,12 +339,12 @@ func validatePivot(props map[string]any, metricsViews map[string]*runtimev1.Metr
 		}
 	}
 	for _, d := range rowDims {
-		if !metricsViewHasDimension(mv, d) && !isPivotTimeDimension(mv, d) {
+		if !metricsViewHasDimension(mv, d) && !isEncodedTimeDimension(mv, d) {
 			return fmt.Errorf("referenced row_dimensions value %q is not a dimension in metrics view %q", d, mvn)
 		}
 	}
 	for _, d := range colDims {
-		if !metricsViewHasDimension(mv, d) && !isPivotTimeDimension(mv, d) {
+		if !metricsViewHasDimension(mv, d) && !isEncodedTimeDimension(mv, d) {
 			return fmt.Errorf("referenced col_dimensions value %q is not a dimension in metrics view %q", d, mvn)
 		}
 	}
@@ -519,11 +519,16 @@ func metricsViewHasDimension(mv *runtimev1.MetricsViewSpec, fieldName string) bo
 	return false
 }
 
-// isPivotTimeDimension reports whether fieldName is an encoded time-grain pivot dimension
-// of the form "{timeDimension}_rill_{GRAIN}" (e.g. "ts_rill_TIME_GRAIN_MONTH"). The canvas
-// pivot frontend encodes a time dimension at a chosen grain this way; it is decoded back into
+// isEncodedTimeDimension reports whether fieldName is an encoded time-grain dimension of the
+// form "{timeDimension}_rill_{GRAIN}" (e.g. "ts_rill_TIME_GRAIN_MONTH"). The canvas pivot and
+// table frontends encode a time dimension at a chosen grain this way; it is decoded back into
 // a proper aggregation dimension at query time on the client.
-func isPivotTimeDimension(mv *runtimev1.MetricsViewSpec, fieldName string) bool {
+//
+// Note: this only recognizes the metrics view's primary time dimension, matching the frontend,
+// which currently only encodes the primary one. If pivots/tables start allowing secondary time
+// dimensions (time-type dimensions declared in the dimension list), this check must be extended
+// to recognize those prefixes as well.
+func isEncodedTimeDimension(mv *runtimev1.MetricsViewSpec, fieldName string) bool {
 	if mv.TimeDimension == "" {
 		return false
 	}

--- a/runtime/canvas/component_test.go
+++ b/runtime/canvas/component_test.go
@@ -769,6 +769,20 @@ table:
 	testruntime.ReconcileParserAndWait(t, rt, id)
 	testruntime.RequireReconcileState(t, rt, id, 4, 1, 0)
 	testruntime.RequireReconcileErrorContains(t, rt, id, runtime.ResourceKindComponent, "c1", "is not a dimension or measure")
+
+	// Valid: encoded time-grain column (the flat table frontend encodes a time dimension at a
+	// chosen grain as "{timeDimension}_rill_{GRAIN}").
+	testruntime.PutFiles(t, rt, id, map[string]string{
+		"c1.yaml": `
+type: component
+table:
+  metrics_view: mv1
+  columns:
+  - ts_rill_TIME_GRAIN_MONTH
+  - y
+`})
+	testruntime.ReconcileParserAndWait(t, rt, id)
+	testruntime.RequireReconcileState(t, rt, id, 4, 0, 0)
 }
 
 func TestValidatePivot(t *testing.T) {

--- a/runtime/canvas/component_test.go
+++ b/runtime/canvas/component_test.go
@@ -852,6 +852,36 @@ pivot:
 	testruntime.ReconcileParserAndWait(t, rt, id)
 	testruntime.RequireReconcileState(t, rt, id, 4, 1, 0)
 	testruntime.RequireReconcileErrorContains(t, rt, id, runtime.ResourceKindComponent, "c1", "is not a dimension")
+
+	// Valid: encoded time-grain dimensions (the canvas pivot frontend encodes a time
+	// dimension at a chosen grain as "{timeDimension}_rill_{GRAIN}").
+	testruntime.PutFiles(t, rt, id, map[string]string{
+		"c1.yaml": `
+type: component
+pivot:
+  metrics_view: mv1
+  measures:
+  - y
+  row_dimensions:
+  - ts_rill_TIME_GRAIN_DAY
+  col_dimensions:
+  - ts_rill_TIME_GRAIN_MONTH
+`})
+	testruntime.ReconcileParserAndWait(t, rt, id)
+	testruntime.RequireReconcileState(t, rt, id, 4, 0, 0)
+
+	// Invalid: encoded time dimension with an unknown grain.
+	testruntime.PutFiles(t, rt, id, map[string]string{
+		"c1.yaml": `
+type: component
+pivot:
+  metrics_view: mv1
+  col_dimensions:
+  - ts_rill_TIME_GRAIN_BOGUS
+`})
+	testruntime.ReconcileParserAndWait(t, rt, id)
+	testruntime.RequireReconcileState(t, rt, id, 4, 1, 0)
+	testruntime.RequireReconcileErrorContains(t, rt, id, runtime.ResourceKindComponent, "c1", "is not a dimension")
 }
 
 func TestValidateLeaderboard(t *testing.T) {


### PR DESCRIPTION
Selecting a time grain (Time month, Time day, Time week, …) as a row or column dimension in a canvas **pivot table** component broke reconciliation with `referenced col_dimensions value "..._rill_TIME_GRAIN_MONTH" is not a dimension in metrics view "..."`. The same selection works in the explore pivot.

- The canvas pivot frontend encodes a time-grain dimension as `"{timeDimension}_rill_{GRAIN}"`, but the backend validator (`runtime/canvas/component.go`) only accepted literal metrics-view dimension names, so it rejected the encoded value and the component never reconciled.
- Taught `validatePivot` to recognize the encoding via a new `isPivotTimeDimension` helper, which validates the grain suffix against the real `TimeGrain` enum (bogus grains still error).
- The runtime query path was already correct: these dimensions are read on the backend only by this validator; the client decodes them into a proper `{ name, timeGrain }` aggregation at query time.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*
