### PR TITLE
fix: dimension description tooltip not legible

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
@@ -83,7 +83,7 @@
               style:min-width="200px"
             >
               <div
-                class="text-fg-muted justify-self-start"
+                class="text-fg-inverse/70 justify-self-start"
                 style:max-width="280px"
                 aria-label="tooltip-name-description"
               >


### PR DESCRIPTION
Dimension description tooltip didnt have enough contrast unlike measure tooltip. Matching the dimension description tooltip color of measure tooltip.

New tooltips,
<img width="366" height="270" alt="Screenshot 2026-06-15 at 10 36 21 AM" src="https://github.com/user-attachments/assets/182b701e-875f-46f0-9c1e-9bc1c5986f1c" />
<img width="365" height="254" alt="Screenshot 2026-06-15 at 10 36 15 AM" src="https://github.com/user-attachments/assets/1322a54a-fde9-4ba1-9381-d5a5646c80bd" />

Closes APP-908


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
