### PR TITLE
credit based trial as default

### DIFF
--- a/admin/billing.go
+++ b/admin/billing.go
@@ -198,21 +198,21 @@ func (s *Service) RepairOrganizationBilling(ctx context.Context, org *database.O
 
 	var updatedOrg *database.Organization
 	if sub == nil {
-		updatedOrg, sub, err = s.StartTrial(ctx, org)
+		updatedOrg, sub, err = s.StartCreditTrial(ctx, org)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to start trial: %w", err)
+			return nil, nil, fmt.Errorf("failed to start credit trial: %w", err)
 		}
 
-		// send trial started email
-		err = s.Email.SendTrialStarted(&email.TrialStarted{
-			ToEmail:      org.BillingEmail,
-			ToName:       org.Name,
-			OrgName:      org.Name,
-			FrontendURL:  s.URLs.Frontend(),
-			TrialEndDate: sub.TrialEndDate,
+		// send credit trial started email
+		err = s.Email.SendCreditTrialStarted(&email.CreditTrialStarted{
+			ToEmail:          org.BillingEmail,
+			ToName:           org.Name,
+			OrgName:          org.Name,
+			FrontendURL:      s.URLs.Frontend(),
+			CreditAllocation: CreditTrialAllocation,
 		})
 		if err != nil {
-			s.Logger.Named("billing").Error("failed to send trial started email", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.String("billing_email", org.BillingEmail), zap.Error(err))
+			s.Logger.Named("billing").Error("failed to send credit trial started email", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.String("billing_email", org.BillingEmail), zap.Error(err))
 		}
 	} else {
 		s.Logger.Named("billing").Warn("subscription already exists for org", zap.String("org_id", org.ID), zap.String("org_name", org.Name))

--- a/admin/server/billing.go
+++ b/admin/server/billing.go
@@ -125,7 +125,7 @@ func (s *Server) UpdateBillingSubscription(ctx context.Context, req *adminv1.Upd
 		}
 		return nil, err
 	}
-	// for the trial plan start the time-based trial, for the free plan start the credit trial
+	// for both free and legacy trial plan, start the credit trial
 	if plan.PlanType == billing.FreePlanType || plan.PlanType == billing.TrailPlanType {
 		bi, err := s.admin.DB.FindBillingIssueByTypeForOrg(ctx, org.ID, database.BillingIssueTypeNeverSubscribed)
 		if err != nil {
@@ -146,36 +146,18 @@ func (s *Server) UpdateBillingSubscription(ctx context.Context, req *adminv1.Upd
 				}
 			}
 
-			var updatedOrg *database.Organization
-			var sub *billing.Subscription
-			if plan.PlanType == billing.TrailPlanType {
-				updatedOrg, sub, err = s.admin.StartTrial(ctx, org)
-				if err != nil {
-					return nil, err
-				}
-				if err := s.admin.Email.SendTrialStarted(&email.TrialStarted{
-					ToEmail:      org.BillingEmail,
-					ToName:       org.Name,
-					OrgName:      org.Name,
-					FrontendURL:  s.admin.URLs.Frontend(),
-					TrialEndDate: sub.TrialEndDate,
-				}); err != nil {
-					s.logger.Named("billing").Error("failed to send trial started email", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.String("billing_email", org.BillingEmail), zap.Error(err))
-				}
-			} else {
-				updatedOrg, sub, err = s.admin.StartCreditTrial(ctx, org)
-				if err != nil {
-					return nil, err
-				}
-				if err := s.admin.Email.SendCreditTrialStarted(&email.CreditTrialStarted{
-					ToEmail:          org.BillingEmail,
-					ToName:           org.Name,
-					OrgName:          org.Name,
-					FrontendURL:      s.admin.URLs.Frontend(),
-					CreditAllocation: admin.CreditTrialAllocation,
-				}); err != nil {
-					s.logger.Named("billing").Error("failed to send credit trial started email", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.String("billing_email", org.BillingEmail), zap.Error(err))
-				}
+			updatedOrg, sub, err := s.admin.StartCreditTrial(ctx, org)
+			if err != nil {
+				return nil, err
+			}
+			if err := s.admin.Email.SendCreditTrialStarted(&email.CreditTrialStarted{
+				ToEmail:          org.BillingEmail,
+				ToName:           org.Name,
+				OrgName:          org.Name,
+				FrontendURL:      s.admin.URLs.Frontend(),
+				CreditAllocation: admin.CreditTrialAllocation,
+			}); err != nil {
+				s.logger.Named("billing").Error("failed to send credit trial started email", zap.String("org_name", org.Name), zap.String("org_id", org.ID), zap.String("billing_email", org.BillingEmail), zap.Error(err))
 			}
 
 			return &adminv1.UpdateBillingSubscriptionResponse{

--- a/admin/server/projects.go
+++ b/admin/server/projects.go
@@ -589,8 +589,8 @@ func (s *Server) CreateProject(ctx context.Context, req *adminv1.CreateProjectRe
 				return nil, status.Errorf(codes.FailedPrecondition, "trial orgs quota exceeded for user %s", u.Email)
 			}
 		}
-		if _, err = s.admin.Jobs.StartOrgTrial(ctx, org.ID); err != nil {
-			s.logger.Named("billing").Error("failed to submit job to start trial for org, please do it manually", zap.String("org_id", org.ID), zap.Error(err))
+		if _, err = s.admin.Jobs.StartOrgCreditTrial(ctx, org.ID); err != nil {
+			s.logger.Named("billing").Error("failed to submit job to start credit trial for org, please do it manually", zap.String("org_id", org.ID), zap.Error(err))
 			// continue creating the project
 		}
 	}


### PR DESCRIPTION
Revert the behavioral change from #9544 so new orgs and trial-plan subscriptions start on the credit-based trial again. The time-based trial machinery (StartTrial, StartOrgTrial, StartTrialWorker, SendTrialStarted) is left in place for manual/legacy use.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
