### PR TITLE
docs: release notes for 0.87

### DIFF
--- a/docs/blog/0.87.md
+++ b/docs/blog/0.87.md
@@ -4,15 +4,13 @@ image: https://github.com/rilldata/rill/assets/5587788/b30486f6-002a-445d-8a1b-9
 description: Rill is the world's first AI-native business intelligence tool. Trusted by thousands of developers and analysts around the globe, Rill accelerates the creation of dashboards and data applications using BI-as-code.
 ---
 
-# Rill 0.87 - Databricks Connector, Metrics View Rollups, Cloud Editing
+# Rill 0.87 - Databricks Connector, Metrics View Rollups, Tag based grouping of Dimensions and Measures and Cloud Editing
 
 :::note
 ⚡ **Rill Developer** lets you transform datasets with SQL and build fast, exploratory dashboards. **Rill Cloud** enables collaboration at scale.
 
 👉 [Install Rill Developer](/developers/get-started/install) • [Join our Discord](https://discord.gg/2ubRfjC7Rh) • [Deploy to Rill Cloud](/developers/deploy/deploy-dashboard)
 :::
-
-release-0.87
 
 ## Databricks Connector
 

--- a/docs/blog/0.87.md
+++ b/docs/blog/0.87.md
@@ -4,17 +4,17 @@ image: https://github.com/rilldata/rill/assets/5587788/b30486f6-002a-445d-8a1b-9
 description: Rill is the world's first AI-native business intelligence tool. Trusted by thousands of developers and analysts around the globe, Rill accelerates the creation of dashboards and data applications using BI-as-code.
 ---
 
-# Rill 0.87 - Databricks Connector, Metrics View Rollups, Tag based grouping of Dimensions and Measures and Cloud Editing
+# Rill 0.87 - Databricks Connector, Metrics View Rollups, Tag-based Grouping of Dimensions and Measures, and Cloud Editing
 
 :::note
-⚡ **Rill Developer** lets you transform datasets with SQL and build fast, exploratory dashboards. **Rill Cloud** enables collaboration at scale.
+⚡ Rill's BI-as-code powers fast dashboards, embedded analytics, and an agent-ready semantic layer — all running on top of the warehouses you already use.
 
-👉 [Install Rill Developer](/developers/get-started/install) • [Join our Discord](https://discord.gg/2ubRfjC7Rh) • [Deploy to Rill Cloud](/developers/deploy/deploy-dashboard)
+👉 [Get Started](https://ui.rilldata.com) • [Join our Discord](https://discord.gg/2ubRfjC7Rh)
 :::
 
 ## Databricks Connector
 
-Rill now supports Databricks in two modes. As a [**live OLAP connector**](/developers/build/connectors/olap/databricks), metrics views and dashboards can be built on top of existing tables with no data copy. As a [**data source connector**](/developers/build/connectors/data-source/databricks), Rill ingests Databricks data into its the OLAP engine for modeling and transformation. Both are available from the "Add Data" flow in the UI.
+Rill now supports Databricks in two modes. As a [**live OLAP connector**](/developers/build/connectors/olap/databricks), metrics views and dashboards can be built on top of existing tables with no data copy. As a [**data source connector**](/developers/build/connectors/data-source/databricks), Rill ingests Databricks data into the OLAP engine for modeling and transformation. Both are available from the "Add Data" flow in the UI.
 
 ## Metrics View Rollups and Intelligent Query Routing
 
@@ -30,7 +30,7 @@ Dimensions and measures can be annotated with [`tags`](/reference/project-files/
 
 ## Cloud Editing (Beta)
 
-Projects can now be edited directly in Rill Cloud without leaving the browser. An edit session provisions a dedicated dev deployment on a branch where you can make changes to project files, preview the results live, and then **Publish** or **Merge to production** through UI. Cloud Editing ships in this release as an beta behind a feature flag `cloud_editing`.
+Projects can now be edited directly in Rill Cloud without leaving the browser. An edit session provisions a dedicated dev deployment on a branch where you can make changes to project files, preview the results live, and then **Publish** or **Merge to production** through the UI. Cloud Editing ships in this release as a beta behind the `cloud_editing` feature flag.
 
 ## Bug Fixes and Improvements
 
@@ -71,7 +71,7 @@ Projects can now be edited directly in Rill Cloud without leaving the browser. A
 
 ### Metrics Views
 
-- Allow querying metrics resolvers with the `ReadMetrics` permission
+- Allowed querying metrics resolvers with the `ReadMetrics` permission
 - Added validation to reject comparison queries with no base time range
 - Fixed handling of alert explore names containing spaces, hyphens, and other characters
 - Fixed metrics views on distributed tables

--- a/docs/blog/0.87.md
+++ b/docs/blog/0.87.md
@@ -4,7 +4,7 @@ image: https://github.com/rilldata/rill/assets/5587788/b30486f6-002a-445d-8a1b-9
 description: Rill is the world's first AI-native business intelligence tool. Trusted by thousands of developers and analysts around the globe, Rill accelerates the creation of dashboards and data applications using BI-as-code.
 ---
 
-# Rill 0.87 - Cloud Editing, Databricks Connector, Metrics View Rollups
+# Rill 0.87 - Databricks Connector, Metrics View Rollups, Cloud Editing
 
 :::note
 ⚡ **Rill Developer** lets you transform datasets with SQL and build fast, exploratory dashboards. **Rill Cloud** enables collaboration at scale.
@@ -13,10 +13,6 @@ description: Rill is the world's first AI-native business intelligence tool. Tru
 :::
 
 release-0.87
-
-## Cloud Editing (Beta)
-
-Projects can now be edited directly in Rill Cloud without leaving the browser. An edit session provisions a dedicated dev deployment on a branch where you can make changes to project files, preview the results live, and then **Publish** or **Merge to production** through UI. Cloud Editing ships in this release as an beta behind a feature flag `cloud_editing`.
 
 ## Databricks Connector
 
@@ -33,6 +29,10 @@ You can now mark a dashboard filter as **required** using the new `*` toggle nex
 ## Tags for Dimensions and Measures
 
 Dimensions and measures can be annotated with `tags` in the metrics view. The dimension and measure dropdowns support **tag-based filtering** to narrow a long list to a relevant group, and tags are carried through to pivot tables. This makes large metrics views considerably easier to navigate.
+
+## Cloud Editing (Beta)
+
+Projects can now be edited directly in Rill Cloud without leaving the browser. An edit session provisions a dedicated dev deployment on a branch where you can make changes to project files, preview the results live, and then **Publish** or **Merge to production** through UI. Cloud Editing ships in this release as an beta behind a feature flag `cloud_editing`.
 
 ## Bug Fixes and Improvements
 

--- a/docs/blog/0.87.md
+++ b/docs/blog/0.87.md
@@ -16,11 +16,11 @@ release-0.87
 
 ## Databricks Connector
 
-Rill now supports Databricks in two modes. As a **live OLAP connector**, metrics views and dashboards can be built on top of existing tables with no data copy. As a **data source connector**, Rill ingests Databricks data into its the OLAP engine for modeling and transformation. Both are available from the "Add Data" flow in the UI.
+Rill now supports Databricks in two modes. As a [**live OLAP connector**](/developers/build/connectors/olap/databricks), metrics views and dashboards can be built on top of existing tables with no data copy. As a [**data source connector**](/developers/build/connectors/data-source/databricks), Rill ingests Databricks data into its the OLAP engine for modeling and transformation. Both are available from the "Add Data" flow in the UI.
 
 ## Metrics View Rollups and Intelligent Query Routing
 
-Rollups let a metrics view be backed by one or more pre-aggregated tables in addition to the base table. When a query's time grain, dimensions, measures, time range, and filters all match a rollup, Rill transparently rewrites the query to read from the smaller rollup table for faster results, falling back to the base table otherwise. This release adds support for static data ranges, rollup priorities, and comparison queries against rollups.
+[Rollups](/developers/build/metrics-view/rollups) let a metrics view be backed by one or more pre-aggregated tables in addition to the base table. When a query's time grain, dimensions, measures, time range, and filters all match a rollup, Rill transparently rewrites the query to read from the smaller rollup table for faster results, falling back to the base table otherwise. This release adds support for static data ranges, rollup priorities, and comparison queries against rollups.
 
 ## Required Filters
 
@@ -28,7 +28,7 @@ You can now mark a dashboard filter as **required** using the new `*` toggle nex
 
 ## Tags for Dimensions and Measures
 
-Dimensions and measures can be annotated with `tags` in the metrics view. The dimension and measure dropdowns support **tag-based filtering** to narrow a long list to a relevant group, and tags are carried through to pivot tables. This makes large metrics views considerably easier to navigate.
+Dimensions and measures can be annotated with [`tags`](/reference/project-files/metrics-views) in the metrics view. The dimension and measure dropdowns support **tag-based filtering** to narrow a long list to a relevant group, and tags are carried through to pivot tables. This makes large metrics views considerably easier to navigate.
 
 ## Cloud Editing (Beta)
 
@@ -78,7 +78,7 @@ Projects can now be edited directly in Rill Cloud without leaving the browser. A
 - Fixed handling of alert explore names containing spaces, hyphens, and other characters
 - Fixed metrics views on distributed tables
 - Refined the Metrics View modal flows
-- Added metrics view query result caching for live connectors
+- Added [metrics view query result caching](/reference/project-files/metrics-views#cache) for live connectors
 
 ### AI / LLM
 
@@ -105,7 +105,7 @@ Projects can now be edited directly in Rill Cloud without leaving the browser. A
 
 - Restored interactive prompts in the `devtool seed` command
 - Allowed `rill devtool` to run inside a git worktree
-- Documented reserved `rill.*` env keys in `rill.yaml`
+- Documented [reserved `rill.*` env keys](/reference/project-files/rill-yaml#env) in `rill.yaml`
 - Fixed env file settings icon not showing for all variations
 - Fixed inaccessible env settings on unpublished projects
 
@@ -125,7 +125,7 @@ Projects can now be edited directly in Rill Cloud without leaving the browser. A
 ### Embedding
 
 - Persisted AI conversations in embeds via `external_user_id`
-- Refactored embedding docs and links to use the admin role for service tokens
+- Refactored [embedding docs](/developers/embed) and links to use the admin role for service tokens
 
 ### Infrastructure
 

--- a/docs/blog/0.87.md
+++ b/docs/blog/0.87.md
@@ -1,0 +1,138 @@
+---
+date: 2026-06-16
+image: https://github.com/rilldata/rill/assets/5587788/b30486f6-002a-445d-8a1b-955b6ec0066d
+description: Rill is the world's first AI-native business intelligence tool. Trusted by thousands of developers and analysts around the globe, Rill accelerates the creation of dashboards and data applications using BI-as-code.
+---
+
+# Rill 0.87 - Cloud Editing, Databricks Connector, Metrics View Rollups
+
+:::note
+⚡ **Rill Developer** lets you transform datasets with SQL and build fast, exploratory dashboards. **Rill Cloud** enables collaboration at scale.
+
+👉 [Install Rill Developer](/developers/get-started/install) • [Join our Discord](https://discord.gg/2ubRfjC7Rh) • [Deploy to Rill Cloud](/developers/deploy/deploy-dashboard)
+:::
+
+release-0.87
+
+## Cloud Editing (Beta)
+
+Projects can now be edited directly in Rill Cloud without leaving the browser. An edit session provisions a dedicated dev deployment on a branch where you can make changes to project files, preview the results live, and then **Publish** or **Merge to production** through UI. Cloud Editing ships in this release as an beta behind a feature flag `cloud_editing`.
+
+## Databricks Connector
+
+Rill now supports Databricks in two modes. As a **live OLAP connector**, metrics views and dashboards can be built on top of existing tables with no data copy. As a **data source connector**, Rill ingests Databricks data into its the OLAP engine for modeling and transformation. Both are available from the "Add Data" flow in the UI.
+
+## Metrics View Rollups and Intelligent Query Routing
+
+Rollups let a metrics view be backed by one or more pre-aggregated tables in addition to the base table. When a query's time grain, dimensions, measures, time range, and filters all match a rollup, Rill transparently rewrites the query to read from the smaller rollup table for faster results, falling back to the base table otherwise. This release adds support for static data ranges, rollup priorities, and comparison queries against rollups.
+
+## Required Filters
+
+You can now mark a dashboard filter as **required** using the new `*` toggle next to the pin button in the dimension and measure filter dropdowns.
+
+## Tags for Dimensions and Measures
+
+Dimensions and measures can be annotated with `tags` in the metrics view. The dimension and measure dropdowns support **tag-based filtering** to narrow a long list to a relevant group, and tags are carried through to pivot tables. This makes large metrics views considerably easier to navigate.
+
+## Bug Fixes and Improvements
+
+### Explore / Dashboards
+
+- Introduced a redesigned Filter Bar component
+- Added configurable pivot totals for Explore and Canvas
+- Restored tooltip and shift-click copy on nested pivot row dimension cells
+- Fixed dimension description tooltip legibility
+- Fixed pivot row dimension width reset
+- Fixed visual explore editing dropping pivot columns on refresh
+- Improved handling of pivot export failures
+- Fixed nav tab underline stale position after sibling tabs mount
+- Fixed user avatar flickering on scroll in the Rill Cloud user list
+- Simplified the table toolbar
+
+### Charts
+
+- Added data labels to donut charts
+- Added an "Other" bucket and percent-of-total tooltip for circular charts
+- Added a `percentMode` config and improved percentage formatting for funnel charts
+- Added screenshot (PNG) capture for measure charts
+- Fixed PNG export not supporting different chart types
+- Defaulted new donut charts to summable measures
+
+### Canvas
+
+- Added pivot click-to-filter in Canvas
+- Added backend validation for all canvas component types
+- Fixed canvas pivot rejecting time-grain row and column dimensions
+- Fixed canvas editor applying property edits to the wrong component
+- Fixed canvas chat context loading forever
+- Fixed canvas parse error missing from the editor preview
+- Fixed hourly canvas chart date labels
+- Fixed transient canvas query errors when adding new components
+- Fixed Canvas dashboards not respecting the custom time range setting
+- Fixed a race reading canvas YAML after async work in `saveDefaultFilters`
+
+### Metrics Views
+
+- Allow querying metrics resolvers with the `ReadMetrics` permission
+- Added validation to reject comparison queries with no base time range
+- Fixed handling of alert explore names containing spaces, hyphens, and other characters
+- Fixed metrics views on distributed tables
+- Refined the Metrics View modal flows
+- Added metrics view query result caching for live connectors
+
+### AI / LLM
+
+- Improved AI timeout handling and error messages
+- Added on-brand theme guidance to the theme AI skill
+- Fixed tool call errors displaying the full message
+- Created the working file immediately when sending an AI prompt
+- Fixed AI chat sidebar rendering and hydration in the cloud editor
+- Showed the connector icon at the bottom of the collapsed AI chat sidebar
+- Added glob pattern support to the `list_bucket_objects` tool
+- Indexed AI sessions on `session_id` and deleted expired sessions asynchronously in batches
+
+### Connectors
+
+- Added Databricks as a source connector in the UI
+- Implemented the OLAP interface for the Databricks driver
+- Added a raw type to the runtime type system
+- Handled ClickHouse "access denied" errors gracefully while estimating size
+- Fixed direct file path imports not working
+- Fixed public connector model import failure leading to a dead back button
+- Fixed file upload error not surfacing in the form
+
+### Rill Developer
+
+- Restored interactive prompts in the `devtool seed` command
+- Allowed `rill devtool` to run inside a git worktree
+- Documented reserved `rill.*` env keys in `rill.yaml`
+- Fixed env file settings icon not showing for all variations
+- Fixed inaccessible env settings on unpublished projects
+
+### Cloud
+
+- Added hibernation for idle dev deployments, preserving disks for 30 days
+- Made stopped deployment retention configurable and lowered the dev TTL
+- Added a project-level disk size override and prod/dev slot edit flags to `rill project edit`
+- Allowed editing `dev-ttl-seconds` via `rill project edit`
+- Increased the SQLite backup max size to 5 GB
+- Added "Manage in Stripe" for enterprise customers
+- Fixed the unhibernate project CTA getting stuck in a loading state
+- Guarded project and org admin routes against direct URL access
+- Fixed billing banners showing up on welcome pages
+- Added an org-level setting for billing-related banners
+
+### Embedding
+
+- Persisted AI conversations in embeds via `external_user_id`
+- Refactored embedding docs and links to use the admin role for service tokens
+
+### Infrastructure
+
+- Refactored the SSE client with tighter boundaries and a new lifecycle, then migrated all consumers and dropped the singleton
+- Consolidated runtime JWT issuance
+- Audited and standardized server error codes
+- Disallowed SVG asset uploads to prevent stored XSS
+- Hardened redirect handling against malicious hosts
+- Removed `go-git` from the file and admin drivers in favor of runtime git APIs
+- Updated dependencies to patch vulnerabilities


### PR DESCRIPTION
- Adds release notes for Rill 0.87 (`docs/blog/0.87.md`), covering changes between `release-0.86` and `release-0.87`.
- Headline features: Cloud Editing (beta), Databricks connector, metrics view rollups with query routing, required filters, and tags for dimensions and measures.
- Categorized Bug Fixes and Improvements following the structure of prior release notes.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*
