### PR TITLE
fix: show full value in cell inspector for expanded dimension tables

### DIFF
--- a/web-common/src/components/virtualized-table/core/Cell.svelte
+++ b/web-common/src/components/virtualized-table/core/Cell.svelte
@@ -53,7 +53,7 @@
   function onFocus() {
     onInspect(row.index);
     cellActive = true;
-    cellInspectorStore.updateValue(value, tooltipValue);
+    cellInspectorStore.updateValue(value, inspectorValue);
   }
 
   function onSelect(e: MouseEvent) {
@@ -112,6 +112,11 @@
       : value && STRING_LIKES.has(type) && value.length >= TOOLTIP_STRING_LIMIT
         ? value?.slice(0, TOOLTIP_STRING_LIMIT) + "..."
         : value;
+
+  // The tooltip truncates long strings, but the cell inspector should show the
+  // full value, so feed it an untruncated version.
+  $: inspectorValue =
+    tooltipFormatter && value != null ? tooltipFormatter(value) : value;
 
   $: formattedDataTypeStyle = excluded
     ? "font-normal text-fg-muted"


### PR DESCRIPTION
- The expanded dimension table fed the cell inspector its hover-tooltip value, which is deliberately truncated to `TOOLTIP_STRING_LIMIT` (60 chars), so long string cells (e.g. call transcripts) showed up cut off in the inspector.
- The leaderboard was unaffected because its dimension cell passes the full, untruncated value.
- Fix: feed the cell inspector an untruncated `inspectorValue` in `core/Cell.svelte`; the tooltip keeps its truncation.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*
