### PR TITLE
refac: better sparse data ux for time series charts

### DIFF
--- a/web-common/src/components/time-series-chart/Chart.svelte
+++ b/web-common/src/components/time-series-chart/Chart.svelte
@@ -14,11 +14,18 @@
   import { onDestroy } from "svelte";
   import Line from "./Line.svelte";
   import Point from "./Point.svelte";
-  import { bridgeGaps } from "./sparse-data-utils";
+  import { bridgeGaps, snapToNearestNonNull } from "./sparse-data-utils";
   import type { ChartDataPoint } from "./types";
 
   const THROTTLE_MS = 16;
   const chartId = Math.random().toString(36).slice(2, 11);
+
+  // Hover snaps to the nearest non-null point within this distance (in index
+  // units), so sparse points are easy to land on without snapping across wide
+  // gaps. A fraction of the data length keeps the snap radius a roughly
+  // constant pixel distance regardless of point count.
+  const SNAP_FRACTION = 0.05;
+  const MIN_SNAP_INDICES = 3;
 
   const pointValueAccessor = (d: ChartDataPoint) => d.value ?? null;
   const pointCloneWithValue = (
@@ -100,11 +107,22 @@
       .map((s) => s.startIndex),
   );
 
+  $: maxSnapDistance = Math.max(
+    MIN_SNAP_INDICES,
+    maxDataLength * SNAP_FRACTION,
+  );
+
   $: hoverIndex = (() => {
     if (offsetPosition === null) return null;
     if (maxDataLength === 0) return null;
     if (maxDataLength === 1) return 0;
-    return Math.round((offsetPosition.x / width) * (maxDataLength - 1));
+    const fractionalIndex = (offsetPosition.x / width) * (maxDataLength - 1);
+    return snapToNearestNonNull(
+      fractionalIndex,
+      mappedData,
+      pointValueAccessor,
+      maxSnapDistance,
+    );
   })();
 
   $: hoveredPoints = getPoints(hoverIndex);

--- a/web-common/src/components/time-series-chart/Chart.svelte
+++ b/web-common/src/components/time-series-chart/Chart.svelte
@@ -14,7 +14,7 @@
   import { onDestroy } from "svelte";
   import Line from "./Line.svelte";
   import Point from "./Point.svelte";
-  import { bridgeSmallGaps } from "./sparse-data-utils";
+  import { bridgeGaps } from "./sparse-data-utils";
   import type { ChartDataPoint } from "./types";
 
   const THROTTLE_MS = 16;
@@ -87,21 +87,9 @@
   $: yExtents = [Math.min(0, min(mins) ?? 0), max(maxes) ?? 0];
   $: yScale = scaleLinear().domain(yExtents).range([100, 0]);
 
-  // Convert viewBox x to pixel x for gap-bridging threshold
-  $: xPixel = (index: number) => {
-    if (width === 0) return index;
-    return xScale(index) * (width / 10000);
-  };
-
-  // Bridge small gaps in the data for smoother rendering
+  // Bridge gaps in the data, treating missing data as zero
   $: bridgeResults = mappedData.map((line) =>
-    bridgeSmallGaps(
-      line,
-      pointValueAccessor,
-      pointCloneWithValue,
-      xPixel,
-      connectNulls,
-    ),
+    bridgeGaps(line, pointValueAccessor, pointCloneWithValue, connectNulls),
   );
   $: bridgedData = bridgeResults.map((r) => r.values);
 

--- a/web-common/src/components/time-series-chart/TimeSeriesChart.svelte
+++ b/web-common/src/components/time-series-chart/TimeSeriesChart.svelte
@@ -7,7 +7,7 @@
     ChartScales,
     ChartSeries,
   } from "@rilldata/web-common/features/dashboards/time-series/measure-chart/types";
-  import { bridgeSmallGaps } from "./sparse-data-utils";
+  import { bridgeGaps } from "./sparse-data-utils";
 
   const numAccessor = (d: number | null) => d;
   const numClone = (_d: number | null, v: number): number | null => v;
@@ -37,13 +37,7 @@
   $: primarySeries = series[0];
 
   $: primaryBridgeResult = primarySeries
-    ? bridgeSmallGaps(
-        primarySeries.values,
-        numAccessor,
-        numClone,
-        scales.x,
-        connectNulls,
-      )
+    ? bridgeGaps(primarySeries.values, numAccessor, numClone, connectNulls)
     : {
         values: [] as (number | null)[],
         inputSegments: [],
@@ -63,13 +57,7 @@
     : [];
 
   $: secondarySeries = series.slice(1).map((s) => {
-    const bridged = bridgeSmallGaps(
-      s.values,
-      numAccessor,
-      numClone,
-      scales.x,
-      connectNulls,
-    );
+    const bridged = bridgeGaps(s.values, numAccessor, numClone, connectNulls);
     const singletons = bridged.bridgedSegments
       .filter((seg) => seg.startIndex === seg.endIndex)
       .map((seg) => seg.startIndex);

--- a/web-common/src/components/time-series-chart/sparse-data-utils.spec.ts
+++ b/web-common/src/components/time-series-chart/sparse-data-utils.spec.ts
@@ -79,9 +79,9 @@ describe("snapToNearestNonNull", () => {
       const primary = [10, null, null, null, null];
       const secondary = [null, null, null, 20, null];
       // Cursor near index 3: primary null there, secondary has a value
-      expect(
-        snapToNearestNonNull(3, [primary, secondary], identity, big),
-      ).toBe(3);
+      expect(snapToNearestNonNull(3, [primary, secondary], identity, big)).toBe(
+        3,
+      );
     });
 
     it("snaps to whichever line's point is closest to the cursor", () => {
@@ -100,9 +100,9 @@ describe("snapToNearestNonNull", () => {
     it("handles series of different lengths", () => {
       const primary = [10];
       const secondary = [null, null, 20];
-      expect(
-        snapToNearestNonNull(2, [primary, secondary], identity, big),
-      ).toBe(2);
+      expect(snapToNearestNonNull(2, [primary, secondary], identity, big)).toBe(
+        2,
+      );
     });
   });
 });

--- a/web-common/src/components/time-series-chart/sparse-data-utils.spec.ts
+++ b/web-common/src/components/time-series-chart/sparse-data-utils.spec.ts
@@ -1,10 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { computeSegments, bridgeSmallGaps } from "./sparse-data-utils";
+import { computeSegments, bridgeGaps } from "./sparse-data-utils";
 
 const identity = (d: number | null) => d;
 const cloneWith = (_d: number | null, v: number): number | null => v;
-// 1:1 pixel mapping so gap width = index difference
-const xPixel = (i: number) => i;
 
 describe("computeSegments", () => {
   it("finds contiguous non-null segments", () => {
@@ -27,18 +25,17 @@ describe("computeSegments", () => {
   });
 });
 
-describe("bridgeSmallGaps", () => {
-  it("bridges small gaps when connectNulls is true", () => {
-    // Gap of 2 indices (< default 36px threshold with 1:1 pixel mapping)
+describe("bridgeGaps", () => {
+  it("bridges gaps when connectNulls is true", () => {
     const data: (number | null)[] = [10, null, 20];
-    const result = bridgeSmallGaps(data, identity, cloneWith, xPixel, true);
+    const result = bridgeGaps(data, identity, cloneWith, true);
     expect(result.values[1]).toBe(0); // filled with zero
     expect(result.bridgedSegments).toEqual([{ startIndex: 0, endIndex: 2 }]);
   });
 
   it("fills multiple consecutive nulls with zeros", () => {
     const data: (number | null)[] = [3, null, null, null, 7];
-    const result = bridgeSmallGaps(data, identity, cloneWith, xPixel, true);
+    const result = bridgeGaps(data, identity, cloneWith, true);
     expect(result.values[1]).toBe(0);
     expect(result.values[2]).toBe(0);
     expect(result.values[3]).toBe(0);
@@ -47,7 +44,7 @@ describe("bridgeSmallGaps", () => {
 
   it("does not bridge when connectNulls is false", () => {
     const data: (number | null)[] = [10, null, 20];
-    const result = bridgeSmallGaps(data, identity, cloneWith, xPixel, false);
+    const result = bridgeGaps(data, identity, cloneWith, false);
     expect(result.values[1]).toBeNull();
     expect(result.bridgedSegments).toEqual([
       { startIndex: 0, endIndex: 0 },
@@ -55,21 +52,15 @@ describe("bridgeSmallGaps", () => {
     ]);
   });
 
-  it("does not bridge gaps wider than maxGapPx", () => {
-    // With 1:1 pixel mapping and maxGapPx=2, a gap of 3 indices won't bridge
-    const data: (number | null)[] = [10, null, null, 20];
-    const result = bridgeSmallGaps(data, identity, cloneWith, xPixel, true, 2);
-    expect(result.values[1]).toBeNull();
-    expect(result.values[2]).toBeNull();
-    expect(result.bridgedSegments).toEqual([
-      { startIndex: 0, endIndex: 0 },
-      { startIndex: 3, endIndex: 3 },
-    ]);
+  it("bridges wide gaps regardless of width", () => {
+    const data: (number | null)[] = [10, null, null, null, null, 20];
+    const result = bridgeGaps(data, identity, cloneWith, true);
+    expect(result.values).toEqual([10, 0, 0, 0, 0, 20]);
+    expect(result.bridgedSegments).toEqual([{ startIndex: 0, endIndex: 5 }]);
   });
 
   describe("singleton detection with connectNulls on", () => {
-    it("singleton surrounded by wide gaps remains a singleton in bridgedSegments", () => {
-      // Gap too wide to bridge (> maxGapPx=2): singleton at index 5 stays isolated
+    it("merges all interior singletons into one continuous segment", () => {
       const data: (number | null)[] = [
         10,
         null,
@@ -83,31 +74,21 @@ describe("bridgeSmallGaps", () => {
         null,
         100,
       ];
-      const result = bridgeSmallGaps(
-        data,
-        identity,
-        cloneWith,
-        xPixel,
-        true,
-        2,
-      );
+      const result = bridgeGaps(data, identity, cloneWith, true);
 
-      // The singleton at index 5 should still appear as a singleton segment
+      // Every gap bridged: one continuous segment, no singletons.
+      expect(result.bridgedSegments).toEqual([{ startIndex: 0, endIndex: 10 }]);
+
       const singletons = result.bridgedSegments
         .filter((s) => s.startIndex === s.endIndex)
         .map((s) => s.startIndex);
-
-      expect(singletons).toContain(0);
-      expect(singletons).toContain(5);
-      expect(singletons).toContain(10);
+      expect(singletons).toEqual([]);
     });
 
-    it("singleton gets merged when gap is small enough to bridge", () => {
-      // Gap of 2 (within maxGapPx=36): singleton should get bridged into neighbors
+    it("merges singletons separated by single-null gaps", () => {
       const data: (number | null)[] = [10, null, 20, null, 30];
-      const result = bridgeSmallGaps(data, identity, cloneWith, xPixel, true);
+      const result = bridgeGaps(data, identity, cloneWith, true);
 
-      // All gaps bridged: single continuous segment
       expect(result.bridgedSegments).toEqual([{ startIndex: 0, endIndex: 4 }]);
 
       const singletons = result.bridgedSegments

--- a/web-common/src/components/time-series-chart/sparse-data-utils.spec.ts
+++ b/web-common/src/components/time-series-chart/sparse-data-utils.spec.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { computeSegments, bridgeGaps } from "./sparse-data-utils";
+import {
+  computeSegments,
+  bridgeGaps,
+  snapToNearestNonNull,
+} from "./sparse-data-utils";
 
 const identity = (d: number | null) => d;
 const cloneWith = (_d: number | null, v: number): number | null => v;
@@ -22,6 +26,84 @@ describe("computeSegments", () => {
     expect(computeSegments([1, 2, 3], identity)).toEqual([
       { startIndex: 0, endIndex: 2 },
     ]);
+  });
+});
+
+describe("snapToNearestNonNull", () => {
+  const big = 1000; // effectively unbounded snap distance
+
+  it("snaps to the closer of two non-null points", () => {
+    const data = [10, null, null, null, 20];
+    // 1.4 is closer to index 0 than to index 4
+    expect(snapToNearestNonNull(1.4, [data], identity, big)).toBe(0);
+    // 3.0 is closer to index 4
+    expect(snapToNearestNonNull(3.0, [data], identity, big)).toBe(4);
+  });
+
+  it("snaps off a null directly under the cursor to the nearest non-null", () => {
+    const data = [10, null, null, null, 20];
+    // Exactly on a null (index 2), equidistant: prefers the right (index 4
+    // is reached before index 0 by the outward scan at equal distance)
+    expect(snapToNearestNonNull(2, [data], identity, big)).toBe(4);
+  });
+
+  it("returns null when the nearest non-null is beyond maxDistance", () => {
+    const data = [10, null, null, null, null, null, 20];
+    // Cursor at index 3 is 3 away from both ends; maxDistance 2 excludes them
+    expect(snapToNearestNonNull(3, [data], identity, 2)).toBeNull();
+  });
+
+  it("returns null for all-null data", () => {
+    expect(snapToNearestNonNull(1, [[null, null, null]], identity, big)).toBe(
+      null,
+    );
+  });
+
+  it("returns null for empty data", () => {
+    expect(snapToNearestNonNull(0, [[]], identity, big)).toBeNull();
+  });
+
+  it("snaps to a single non-null point within distance", () => {
+    const data = [null, null, 42, null, null];
+    expect(snapToNearestNonNull(1, [data], identity, big)).toBe(2);
+    expect(snapToNearestNonNull(1, [data], identity, 0.5)).toBeNull();
+  });
+
+  it("clamps a fractional index outside the data range", () => {
+    const data = [5, null, null];
+    expect(snapToNearestNonNull(-3, [data], identity, big)).toBe(0);
+  });
+
+  describe("comparison (multiple series)", () => {
+    it("snaps to an index where only the secondary series is non-null", () => {
+      const primary = [10, null, null, null, null];
+      const secondary = [null, null, null, 20, null];
+      // Cursor near index 3: primary null there, secondary has a value
+      expect(
+        snapToNearestNonNull(3, [primary, secondary], identity, big),
+      ).toBe(3);
+    });
+
+    it("snaps to whichever line's point is closest to the cursor", () => {
+      const primary = [10, null, null, null, null];
+      const secondary = [null, null, null, null, 20];
+      // Cursor at 1.4 is closest to primary's index 0
+      expect(
+        snapToNearestNonNull(1.4, [primary, secondary], identity, big),
+      ).toBe(0);
+      // Cursor at 3.6 is closest to secondary's index 4
+      expect(
+        snapToNearestNonNull(3.6, [primary, secondary], identity, big),
+      ).toBe(4);
+    });
+
+    it("handles series of different lengths", () => {
+      const primary = [10];
+      const secondary = [null, null, 20];
+      expect(
+        snapToNearestNonNull(2, [primary, secondary], identity, big),
+      ).toBe(2);
+    });
   });
 });
 

--- a/web-common/src/components/time-series-chart/sparse-data-utils.ts
+++ b/web-common/src/components/time-series-chart/sparse-data-utils.ts
@@ -60,6 +60,48 @@ export function computeSegments<T>(
 }
 
 /**
+ * Snap a fractional index to the nearest index that is non-null in any of
+ * the given series. Returns null when the closest such point is farther than
+ * maxDistance (in index units), so the cursor in a large gap snaps to nothing
+ * rather than jumping to a far-away point.
+ *
+ * Passing multiple series handles the comparison case: hovering near either
+ * line's point snaps to it, even when the two series have nulls at different
+ * indices. Single-series callers pass a one-element array.
+ */
+export function snapToNearestNonNull<T>(
+  fractionalIndex: number,
+  series: T[][],
+  valueAccessor: (d: T) => number | null | undefined,
+  maxDistance: number,
+): number | null {
+  const length = Math.max(0, ...series.map((s) => s.length));
+  if (length === 0) return null;
+
+  const hasValue = (i: number) =>
+    series.some((s) => {
+      const v = s[i] !== undefined ? valueAccessor(s[i]) : null;
+      return v !== null && v !== undefined;
+    });
+
+  const clamped = Math.max(0, Math.min(length - 1, fractionalIndex));
+  const center = Math.round(clamped);
+
+  for (let offset = 0; offset < length; offset++) {
+    const right = center + offset;
+    if (right < length && hasValue(right)) {
+      return Math.abs(right - fractionalIndex) <= maxDistance ? right : null;
+    }
+    const left = center - offset;
+    if (offset > 0 && left >= 0 && hasValue(left)) {
+      return Math.abs(left - fractionalIndex) <= maxDistance ? left : null;
+    }
+  }
+
+  return null;
+}
+
+/**
  * Fill all gaps with zeros, treating missing data as zero so adjacent
  * segments connect through zero.
  * Returns a new array with gap values filled, plus segment metadata.

--- a/web-common/src/components/time-series-chart/sparse-data-utils.ts
+++ b/web-common/src/components/time-series-chart/sparse-data-utils.ts
@@ -1,10 +1,10 @@
 /**
  * Rendering sparse data with null gaps
  *
- * 1. Null bridging: `bridgeSmallGaps` fills small gaps (< MAX_BRIDGE_GAP_PX)
- *    with zeros when `connectNulls` is on, so lines route through zero
- *    rather than connecting directly across the gap. Large gaps remain as
- *    nulls and produce natural line breaks.
+ * 1. Null bridging: `bridgeGaps` fills all gaps with zeros when
+ *    `connectNulls` is on, treating missing data as zero, so lines route
+ *    through zero rather than breaking. With `connectNulls` off, gaps
+ *    remain as nulls and produce natural line breaks.
  *
  * 2. Clip paths: The primary series needs clip paths because its area
  *    fill gradient would otherwise render across gaps (`defined` only
@@ -36,9 +36,6 @@ export interface BridgeResult<T> {
   bridgedSegments: Segment[];
 }
 
-/** Default maximum gap width in pixels to bridge with zeros */
-export const MAX_BRIDGE_GAP_PX = 36;
-
 /**
  * Find contiguous non-null segments in a values array.
  */
@@ -63,8 +60,8 @@ export function computeSegments<T>(
 }
 
 /**
- * Fill small pixel-width gaps with zeros, connecting adjacent segments
- * through zero
+ * Fill all gaps with zeros, treating missing data as zero so adjacent
+ * segments connect through zero.
  * Returns a new array with gap values filled, plus segment metadata.
  *
  * When `connectNulls` is false, no bridging is performed; the result
@@ -73,17 +70,13 @@ export function computeSegments<T>(
  * @param data           The data array
  * @param valueAccessor  Extracts the numeric value (or null) from a data point
  * @param cloneWithValue Creates a new data point with the interpolated value
- * @param xPixel         Maps an index to pixel-space x coordinate
- * @param connectNulls   Whether to bridge small gaps (default true)
- * @param maxGapPx       Maximum gap width (in pixels) to bridge
+ * @param connectNulls   Whether to bridge gaps (default true)
  */
-export function bridgeSmallGaps<T>(
+export function bridgeGaps<T>(
   data: T[],
   valueAccessor: (d: T) => number | null | undefined,
   cloneWithValue: (d: T, value: number) => T,
-  xPixel: (index: number) => number,
   connectNulls: boolean = true,
-  maxGapPx: number = MAX_BRIDGE_GAP_PX,
 ): BridgeResult<T> {
   const inputSegments = computeSegments(data, valueAccessor);
 
@@ -100,12 +93,8 @@ export function bridgeSmallGaps<T>(
   for (let i = 0; i < inputSegments.length - 1; i++) {
     const prev = inputSegments[i];
     const next = inputSegments[i + 1];
-    const gapPx = xPixel(next.startIndex) - xPixel(prev.endIndex);
-
-    if (gapPx <= maxGapPx) {
-      for (let j = prev.endIndex + 1; j < next.startIndex; j++) {
-        result[j] = cloneWithValue(data[j], 0);
-      }
+    for (let j = prev.endIndex + 1; j < next.startIndex; j++) {
+      result[j] = cloneWithValue(data[j], 0);
     }
   }
 

--- a/web-common/src/features/dashboards/time-series/measure-chart/MeasureChartBody.svelte
+++ b/web-common/src/features/dashboards/time-series/measure-chart/MeasureChartBody.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import BarChart from "@rilldata/web-common/components/time-series-chart/BarChart.svelte";
+  import { snapToNearestNonNull } from "@rilldata/web-common/components/time-series-chart/sparse-data-utils";
   import TimeSeriesChart from "@rilldata/web-common/components/time-series-chart/TimeSeriesChart.svelte";
   import { TDDChart } from "@rilldata/web-common/features/dashboards/time-dimension-details/types";
   import type { Annotation } from "@rilldata/web-common/features/dashboards/time-series/measure-chart/annotation-utils";
@@ -52,6 +53,13 @@
 
   const chartId = Math.random().toString(36).slice(2, 11);
   const CLICK_THRESHOLD_PX = 4;
+
+  // Hover snaps to the nearest non-null point within this distance (in index
+  // units), so sparse points are easy to land on without snapping across wide
+  // gaps. A fraction of the data length keeps the snap radius a roughly
+  // constant pixel distance regardless of point count.
+  const SNAP_FRACTION = 0.05;
+  const MIN_SNAP_INDICES = 3;
 
   export let measure: MetricsViewSpecMeasure;
   export let measureName: string;
@@ -161,10 +169,28 @@
 
   // Hover state
   $: hoverIndex.registerScale(xScale);
+  $: maxSnapDistance = Math.max(MIN_SNAP_INDICES, data.length * SNAP_FRACTION);
   $: isLocallyHovered =
     hoverState.isHovered && hoverState.index !== null && data.length > 0;
-  $: if (isLocallyHovered) {
-    hoverIndex.set(snapIndex(hoverState.index!, data.length), chartId);
+  // All series the cursor can snap to: the primary measure, its time
+  // comparison, and any dimension comparison series.
+  $: snapSeries = [
+    data.map((d) => d.value),
+    ...(showComparison ? [data.map((d) => d.comparisonValue ?? null)] : []),
+    ...dimensionData.map((dim) => dim.data.map((d) => d.value)),
+  ];
+  // Snap to the nearest non-null point so sparse data is easy to hover; null
+  // when the cursor is in a gap wider than maxSnapDistance.
+  $: snappedHoverIndex = isLocallyHovered
+    ? snapToNearestNonNull(
+        hoverState.index!,
+        snapSeries,
+        (v) => v,
+        maxSnapDistance,
+      )
+    : null;
+  $: if (snappedHoverIndex !== null) {
+    hoverIndex.set(snappedHoverIndex, chartId);
   } else if (
     hasScrubSelection &&
     scrubStartIndex !== null &&


### PR DESCRIPTION
- Remove pixel threshold for bridging null gaps
- Snap cursor to nearest data point on hover skipping nulls

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
