### PR TITLE
fix: resuming editable deployment hangs at 'Starting'

### DIFF
--- a/web-admin/src/features/branches/BranchDeploymentStopped.svelte
+++ b/web-admin/src/features/branches/BranchDeploymentStopped.svelte
@@ -20,52 +20,49 @@
   export let status: V1DeploymentStatus;
   export let canManage: boolean;
   export let branch: string | undefined;
-  export let onStarted: (() => void) | undefined = undefined;
+  export let starting: boolean = false;
 
   $: isStopping = status === V1DeploymentStatus.DEPLOYMENT_STATUS_STOPPING;
 
   const startMutation = createAdminServiceStartDeployment();
 
-  function handleStart() {
-    $startMutation.mutate(
-      { deploymentId, data: {} },
-      {
-        onSuccess: () => {
-          onStarted?.();
+  async function handleStart() {
+    starting = true;
 
-          const projectQueryKey = getAdminServiceGetProjectQueryKey(
-            organization,
-            project,
-            branch ? { branch } : undefined,
-          );
+    try {
+      await $startMutation.mutateAsync({ deploymentId, data: {} });
 
-          // Without this, the invalidation refetch may return the old STOPPED
-          // status (race condition), leaving the UI stuck on this page.
-          queryClient.setQueryData<V1GetProjectResponse>(
-            projectQueryKey,
-            (old) => {
-              if (!old?.deployment) return old;
-              return {
-                ...old,
-                deployment: {
-                  ...old.deployment,
-                  status: V1DeploymentStatus.DEPLOYMENT_STATUS_PENDING,
-                },
-              };
-            },
-          );
+      const projectQueryKey = getAdminServiceGetProjectQueryKey(
+        organization,
+        project,
+        branch ? { branch } : undefined,
+      );
 
-          // Mark stale without immediate refetch; PENDING triggers polling
-          // (1–2s) which picks up the real server status.
-          void queryClient.invalidateQueries({
-            queryKey: projectQueryKey,
-            refetchType: "none",
-          });
+      // Without this, the invalidation refetch may return the old STOPPED
+      // status (race condition), leaving the UI stuck on this page.
+      queryClient.setQueryData<V1GetProjectResponse>(projectQueryKey, (old) => {
+        if (!old?.deployment) return old;
+        return {
+          ...old,
+          deployment: {
+            ...old.deployment,
+            status: V1DeploymentStatus.DEPLOYMENT_STATUS_PENDING,
+          },
+        };
+      });
 
-          void invalidateDeployments(organization, project);
-        },
-      },
-    );
+      // Mark stale without immediate refetch; PENDING triggers polling
+      // (1–2s) which picks up the real server status.
+      void queryClient.invalidateQueries({
+        queryKey: projectQueryKey,
+        refetchType: "none",
+      });
+
+      void invalidateDeployments(organization, project);
+    } catch (e) {
+      console.error("Failed to start deployment", e);
+    }
+    starting = false;
   }
 </script>
 

--- a/web-admin/src/routes/[organization]/[project]/-/edit/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/+layout.svelte
@@ -156,7 +156,7 @@
       status={deploymentStatus}
       canManage={!!projectPermissions?.manageDev}
       {branch}
-      onStarted={() => (starting = true)}
+      bind:starting
     />
   {:else if isReady && deployment?.id && instanceId && runtimeHost && jwt}
     {#key `${runtimeHost}::${instanceId}`}


### PR DESCRIPTION
We were not tracking the `starting` variable correctly. This lead to resuming an editable deployment being stuck at `starting.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
