### PR TITLE
use arrayJoin for CH unnests

### DIFF
--- a/runtime/drivers/clickhouse/dialect.go
+++ b/runtime/drivers/clickhouse/dialect.go
@@ -68,13 +68,16 @@ func (d *dialect) MetricsViewDimensionExpression(dimension *runtimev1.MetricsVie
 	return d.EscapeIdentifier(dimension.Name), nil
 }
 
-func (d *dialect) LateralUnnest(expr, _, colName string) (tbl string, tupleStyle, auto bool, err error) {
-	// using LEFT ARRAY JOIN instead of ARRAY JOIN to include empty arrays with zero values
-	return fmt.Sprintf("LEFT ARRAY JOIN %s AS %s", expr, d.EscapeIdentifier(colName)), false, false, nil
+func (d *dialect) LateralUnnest(_, _, _ string) (tbl string, tupleStyle, auto bool, err error) {
+	return "", false, true, nil
 }
 
-func (d *dialect) UnnestSQLSuffix(tbl string) string {
-	return fmt.Sprintf(" %s", tbl)
+func (d *dialect) UnnestSQLSuffix(_ string) string {
+	panic("ClickHouse auto unnests")
+}
+
+func (d *dialect) AutoUnnest(expr string) string {
+	return fmt.Sprintf("arrayJoin(%s)", expr)
 }
 
 func (d *dialect) RequiresArrayContainsForInOperator() bool { return true }

--- a/runtime/drivers/dialect.go
+++ b/runtime/drivers/dialect.go
@@ -52,6 +52,8 @@ type Dialect interface {
 	DimensionSelect(escapeTable string, dim *runtimev1.MetricsViewSpec_Dimension) (dimSelect, unnestClause string, err error)
 	LateralUnnest(expr, tableAlias, colName string) (tbl string, tupleStyle, auto bool, err error)
 	UnnestSQLSuffix(tbl string) string
+	// AutoUnnest wraps an expression so the dialect unnests it automatically (used when LateralUnnest reports auto == true).
+	AutoUnnest(expr string) string
 	MetricsViewDimensionExpression(dimension *runtimev1.MetricsViewSpec_Dimension) (string, error)
 	AnyValueExpression(expr string) string
 	MinDimensionExpression(expr string) string
@@ -218,6 +220,10 @@ func (b *BaseDialect) LateralUnnest(expr, tableAlias, colName string) (tbl strin
 
 func (b *BaseDialect) UnnestSQLSuffix(tbl string) string {
 	return fmt.Sprintf(", %s", tbl)
+}
+
+func (b *BaseDialect) AutoUnnest(expr string) string {
+	return expr
 }
 
 func (b *BaseDialect) RequiresArrayContainsForInOperator() bool {

--- a/runtime/metricsview/ast.go
+++ b/runtime/metricsview/ast.go
@@ -260,7 +260,10 @@ func NewAST(mv *runtimev1.MetricsViewSpec, sec MetricsViewSecurity, qry *Query, 
 				return nil, fmt.Errorf("failed to unnest field %q: %w", f.Name, err)
 			}
 
-			if !auto {
+			if auto {
+				// The dialect unnests automatically, so we just wrap the expression.
+				f.Expr = ast.Dialect.AutoUnnest(f.Expr)
+			} else {
 				ast.unnests = append(ast.unnests, tblWithAlias)
 				if tupleStyle {
 					f.Expr = ast.Dialect.EscapeMember(unnestAlias, f.Name)

--- a/runtime/metricsview/astexpr.go
+++ b/runtime/metricsview/astexpr.go
@@ -291,6 +291,7 @@ func (b *sqlExprBuilder) writeBinaryCondition(exprs []*Expression, op Operator) 
 		}
 		if auto {
 			// Means the DB automatically unnests, so we can treat it as a normal value
+			leftExpr = b.ast.Dialect.AutoUnnest(leftExpr)
 			return b.writeBinaryConditionInner(nil, right, leftExpr, op)
 		}
 		var unnestColAlias string


### PR DESCRIPTION
Now that we will update to Clickhouse 26.x and the arrayJoin [bug](https://github.com/ClickHouse/ClickHouse/issues/80703) will be resolved and using `LEFT ARRAY JOIN` creates unoptimized query plans

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
