### PR TITLE
fix: misc cloud editing issues - delayed generate CTA and minor fixes

### DIFF
--- a/web-admin/src/routes/[organization]/[project]/-/edit/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/-/edit/+layout.svelte
@@ -28,6 +28,8 @@
   import { isProjectWelcomePage } from "@rilldata/web-admin/features/navigation/nav-utils.ts";
   import WelcomeRedirector from "@rilldata/web-admin/features/welcome/project/WelcomeRedirector.svelte";
   import { InfoIcon } from "lucide-svelte";
+  import { overlay } from "@rilldata/web-common/layout/overlay-store";
+  import BlockingOverlayContainer from "@rilldata/web-common/layout/BlockingOverlayContainer.svelte";
 
   $: organization = $page.params.organization;
   $: project = $page.params.project;
@@ -206,6 +208,24 @@
     />
   {/if}
 </div>
+
+{#if $overlay !== null}
+  <BlockingOverlayContainer
+    bg="linear-gradient(to right, rgba(0,0,0,.6), rgba(0,0,0,.8))"
+  >
+    <div slot="title" class="font-bold">
+      {$overlay?.title}
+    </div>
+    <svelte:fragment slot="detail">
+      {#if $overlay?.detail}
+        <svelte:component
+          this={$overlay.detail.component}
+          {...$overlay.detail.props}
+        />
+      {/if}
+    </svelte:fragment>
+  </BlockingOverlayContainer>
+{/if}
 
 {#snippet envEditDisabled()}
   <div class="flex flex-row gap-2 items-center w-fit text-sm">

--- a/web-common/src/features/add-data/manager/AddDataManager.svelte
+++ b/web-common/src/features/add-data/manager/AddDataManager.svelte
@@ -170,7 +170,8 @@
       {config}
       schemaName={schema}
       connectorName={connector}
-      onConnectorChange={(newConnector) => connectorSelected(newConnector, {})}
+      onConnectorChange={(newConnector) =>
+        connectorSelected(newConnector, newConnector, {})}
       onNewConnector={() => schemaSelected(schema)}
     />
   {/if}

--- a/web-common/src/features/add-data/manager/AddDataManager.svelte
+++ b/web-common/src/features/add-data/manager/AddDataManager.svelte
@@ -116,6 +116,7 @@
 
   async function connectorSelected(
     connector: string,
+    schema: string,
     connectorFormValues: Record<string, any>,
   ) {
     const analyzedConnector = await getConnectorDriverForConnector(
@@ -137,11 +138,11 @@
         connectorFormValues,
       });
     } else if (connectorFormValues["auth_method"] === "public") {
-      const driver = getConnectorDriverForSchema(connector);
+      const driver = getConnectorDriverForSchema(schema);
       if (!driver) return;
       stateManager.transition({
         type: TransitionEventType.ConnectorSelected,
-        schema: connector,
+        schema,
         driver,
         connector,
         connectorFormValues,
@@ -181,7 +182,11 @@
       {stateManager}
       step={stepState}
       onSubmit={(connectorName, connectorFormValues) =>
-        void connectorSelected(connectorName, connectorFormValues)}
+        void connectorSelected(
+          connectorName,
+          stepState.schema,
+          connectorFormValues,
+        )}
       {onBack}
       onClose={onDone}
     />

--- a/web-common/src/features/visual-editing/MeasureDimensionSelector.svelte
+++ b/web-common/src/features/visual-editing/MeasureDimensionSelector.svelte
@@ -82,6 +82,7 @@
     </a>
   {:else if mode === "subset"}
     <SelectionDropdown
+      id={type}
       excludable
       {excludeMode}
       allItems={new Set(items.map((m) => m.name ?? ""))}


### PR DESCRIPTION
1. Generate metrics/dashboard CTA had a delay. This was missing the overlay we have on rill-dev.
2. Adding public source can break if there is a connector already.
3. Measure/dimension selector dropdowns were broken after the svelte5 migration. Missing `id` param leading to unresponsive UI.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
