### PR TITLE
feat: add measure and dimension name tooltips to pivot view

### DIFF
--- a/web-common/src/components/table/tanstack-table-column-meta.ts
+++ b/web-common/src/components/table/tanstack-table-column-meta.ts
@@ -9,6 +9,8 @@ declare module "tanstack-table-8-svelte-5" {
     icon?: ComponentType<SvelteComponent>;
     /** Full path of dimension name/value pairs from root to this header */
     dimensionPath?: Record<string, string>;
+    /** Description shown in the header name tooltip */
+    description?: string;
     tooltipFormatter?: (value: unknown) => string | null | undefined;
   }
 }

--- a/web-common/src/features/dashboards/pivot/FlatTable.svelte
+++ b/web-common/src/features/dashboards/pivot/FlatTable.svelte
@@ -26,6 +26,7 @@
     dimKeyFromRow,
   } from "./pivot-click-selection";
   import type { PivotRowSelectionState } from "./pivot-row-selection";
+  import PivotHeaderLabel from "./PivotHeaderLabel.svelte";
   import type { PivotDataRow, PivotDataStoreConfig } from "./types";
 
   // State props
@@ -174,9 +175,10 @@
                 {#if icon}
                   <svelte:component this={icon} />
                 {:else}
-                  <p class="truncate">
-                    {header.column.columnDef.header}
-                  </p>
+                  <PivotHeaderLabel
+                    label={String(header.column.columnDef.header)}
+                    description={header.column.columnDef.meta?.description}
+                  />
                 {/if}
                 {#if sortDirection}
                   <span

--- a/web-common/src/features/dashboards/pivot/NestedTable.svelte
+++ b/web-common/src/features/dashboards/pivot/NestedTable.svelte
@@ -45,6 +45,7 @@
     isInSelectedColRange,
   } from "./pivot-selection-indices";
   import { isShowMoreRow } from "./pivot-utils";
+  import PivotHeaderLabel from "./PivotHeaderLabel.svelte";
   import type { PivotDataRow } from "./types";
 
   // State props
@@ -454,6 +455,11 @@
               {#if !header.isPlaceholder}
                 {#if icon}
                   <svelte:component this={icon} />
+                {:else if !dimMeta?.dimensionPath && header.column.columnDef.header}
+                  <PivotHeaderLabel
+                    label={String(header.column.columnDef.header)}
+                    description={dimMeta?.description}
+                  />
                 {:else}
                   <p class="truncate">
                     {header.column.columnDef.header}

--- a/web-common/src/features/dashboards/pivot/PivotHeaderLabel.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotHeaderLabel.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
+  import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
+
+  export let label: string;
+  export let description: string | undefined = undefined;
+</script>
+
+<Tooltip location="top" distance={8} activeDelay={200}>
+  <p class="truncate">{label}</p>
+  <TooltipContent slot="tooltip-content" maxWidth="280px">
+    <div class="pointer-events-none items-baseline" aria-label="tooltip-name">
+      {label}
+    </div>
+    {#if description}
+      <div
+        class="text-fg-inverse/70 pointer-events-none pt-1"
+        style:max-width="280px"
+        aria-label="tooltip-name-description"
+      >
+        {description}
+      </div>
+    {/if}
+  </TooltipContent>
+</Tooltip>

--- a/web-common/src/features/dashboards/pivot/pivot-column-definition.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-column-definition.ts
@@ -204,6 +204,7 @@ export type MeasureColumnProps = Array<{
   name: string;
   type: MeasureType;
   lowerIsBetter: boolean;
+  description?: string;
 }>;
 export function getMeasureColumnProps(
   config: PivotDataStoreConfig,
@@ -255,6 +256,7 @@ export function getMeasureColumnProps(
       type,
       icon,
       lowerIsBetter: measure?.lowerIsBetter ?? false,
+      description: measure?.description,
     };
   });
 }
@@ -262,25 +264,29 @@ export function getMeasureColumnProps(
 export type DimensionColumnProps = Array<{
   label: string;
   name: string;
+  description?: string;
 }>;
 
 export function getDimensionColumnProps(
   dimensionNames: string[],
   config: PivotDataStoreConfig,
-) {
+): DimensionColumnProps {
   return dimensionNames.map((d) => {
-    let label =
-      config.allDimensions.find(
-        (dimension) => dimension.name === d || dimension.column === d,
-      )?.displayName || d;
+    const dimension = config.allDimensions.find(
+      (dimension) => dimension.name === d || dimension.column === d,
+    );
+    let label = dimension?.displayName || d;
+    let description = dimension?.description;
     if (isTimeDimension(d, config.time.timeDimension)) {
       const timeGrain = getTimeGrainFromDimension(d);
       const grainLabel = TIME_GRAIN[timeGrain]?.label || d;
       label = `Time ${grainLabel}`;
+      description = undefined;
     }
     return {
       label,
       name: d,
+      description,
     };
   });
 }
@@ -316,7 +322,7 @@ export function getColumnDefForPivot(
 function getFlatColumnDef(
   config: PivotDataStoreConfig,
   measures: MeasureColumnProps,
-  rowDimensions: Array<{ label: string; name: string }>,
+  rowDimensions: DimensionColumnProps,
   rowDimensionNames: string[],
 ): ColumnDef<PivotDataRow>[] {
   const rowDefinitions: ColumnDef<PivotDataRow>[] = rowDimensions.map(
@@ -325,6 +331,9 @@ function getFlatColumnDef(
         id: d.name,
         accessorFn: (row) => row[d.name],
         header: d.label || d.name,
+        meta: {
+          description: d.description,
+        },
         cell: ({ getValue }) => {
           const value = formatDimensionValue(
             getValue() as string,
@@ -347,6 +356,7 @@ function getFlatColumnDef(
       meta: {
         icon: m.icon,
         tooltipFormatter: m.tooltipFormatter,
+        description: m.description,
       },
       cell: (info) => {
         const measureValue = info.getValue() as number | null | undefined;
@@ -446,8 +456,8 @@ export function getRowNestedLabel(
 function getNestedColumnDef(
   config: PivotDataStoreConfig,
   measures: MeasureColumnProps,
-  rowDimensions: Array<{ label: string; name: string }>,
-  colDimensions: Array<{ label: string; name: string }>,
+  rowDimensions: DimensionColumnProps,
+  colDimensions: DimensionColumnProps,
   columnDimensionAxes: Record<string, string[]> | undefined,
   totals: PivotDataRow,
   rowDimensionNames: string[],
@@ -466,6 +476,11 @@ function getNestedColumnDef(
         id: d.name,
         accessorFn: (row) => row[d.name],
         header: nestedLabel,
+        meta: {
+          // The header collapses multiple row dimensions into one label, so a
+          // single description only makes sense when there is one row dimension.
+          description: rowDimensions.length === 1 ? d.description : undefined,
+        },
         cell: ({ row, getValue }) => {
           const value = getValue() as string;
 
@@ -503,11 +518,14 @@ function getNestedColumnDef(
   let firstDimensionColumns: ColumnDef<PivotDataRow>[] = rowDefinitions;
   if (config.rowDimensionNames.length && config.colDimensionNames.length) {
     firstDimensionColumns = colDimensions.reverse().reduce((acc, dimension) => {
-      const { label, name } = dimension;
+      const { label, name, description } = dimension;
 
       const headColumn = {
         id: name,
         header: label || name,
+        meta: {
+          description,
+        },
         columns: acc,
       };
 
@@ -525,6 +543,7 @@ function getNestedColumnDef(
         meta: {
           icon: m.icon,
           tooltipFormatter: m.tooltipFormatter,
+          description: m.description,
         },
         cell: (info) => {
           const measureValue = info.getValue() as number | null | undefined;


### PR DESCRIPTION
- Adds header name tooltips to the pivot table for measure and dimension names, consistent with the explore dashboard (reuses the same `Tooltip` component used by the leaderboard header and pivot chips).
- Hovering a measure name, row-dimension name, or column-dimension grouping header shows the full display name plus its description from the metrics view spec. The tooltip shows even when there is no description, so truncated names remain readable.
- Threads the spec `description` through the tanstack column definitions' `meta`; renders it via a new shared `PivotHeaderLabel.svelte` used by both `NestedTable` and `FlatTable`.
- Dimension value headers (e.g. "USA") and the `Δ` / `Δ %` comparison icon columns are intentionally left without a name tooltip. The existing data-cell `VirtualTooltip` system is untouched.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*
