### PR TITLE
fix: tear down leaked spec subscriptions on entity and component

### DIFF
--- a/web-common/src/features/canvas/components/BaseCanvasComponent.ts
+++ b/web-common/src/features/canvas/components/BaseCanvasComponent.ts
@@ -15,7 +15,7 @@ import type {
   V1TimeRange,
 } from "@rilldata/web-common/runtime-client";
 import type { ComponentType, SvelteComponent } from "svelte";
-import type { Readable } from "svelte/store";
+import type { Readable, Unsubscriber } from "svelte/store";
 import { derived, get, writable, type Writable } from "svelte/store";
 import { mergeFilters } from "../../dashboards/pivot/pivot-merge-filters";
 import {
@@ -50,6 +50,11 @@ export abstract class BaseCanvasComponent<T = ComponentSpec> {
   localTimeControls: TimeState;
 
   visible = writable(false);
+
+  // Tears down the spec subscription opened in the constructor. Without this,
+  // a component replaced in CanvasEntity.processRows keeps reacting to spec
+  // emissions and mutates the shared filter/time state of a deleted widget.
+  private unsubscribeSpec: Unsubscriber;
 
   abstract type: CanvasComponentType;
   // Component responsible for DOM rendering
@@ -137,7 +142,7 @@ export abstract class BaseCanvasComponent<T = ComponentSpec> {
       this.metricsViewName,
     );
 
-    this.specStore.subscribe((spec) => {
+    this.unsubscribeSpec = this.specStore.subscribe((spec) => {
       this.localFilters.onFilterStringChange(
         spec["dimension_filters"] as string,
       );
@@ -146,6 +151,10 @@ export abstract class BaseCanvasComponent<T = ComponentSpec> {
         new URLSearchParams(spec?.["time_filters"] ?? ""),
       );
     });
+  }
+
+  destroy() {
+    this.unsubscribeSpec?.();
   }
 
   update(resource: V1Resource, path: ComponentPath) {

--- a/web-common/src/features/canvas/state-managers/state-managers.ts
+++ b/web-common/src/features/canvas/state-managers/state-managers.ts
@@ -49,6 +49,10 @@ export function removeCanvasStore(
   instanceId: string,
 ): void {
   const id = makeCanvasId(canvasName, instanceId);
+  // Tear down the entity's subscriptions before dropping it from the registry,
+  // otherwise the orphaned entity keeps reacting to spec emissions and races
+  // the entity created on the next visit.
+  canvasRegistry.get(id)?.canvasEntity.unsubscribe();
   canvasRegistry.delete(id);
 }
 

--- a/web-common/src/features/canvas/stores/canvas-entity.ts
+++ b/web-common/src/features/canvas/stores/canvas-entity.ts
@@ -520,9 +520,14 @@ export class CanvasEntity {
     this.timeManager.state.onUrlChange(searchParams);
   };
 
-  // Not currently being used
+  // Tears down the spec subscription opened in the constructor and disposes
+  // every child component. Without this, a stale entity left over from a
+  // "reset to defaults" save keeps reacting to spec emissions and races the
+  // live entity over URL and YAML writes.
   unsubscribe = () => {
-    // this.unsubscriber();
+    this.unsubscriber();
+    this.componentsStore.read().forEach((component) => component.destroy());
+    this.componentsStore.reset();
   };
 
   handleCanvasRedirect = async ({
@@ -679,6 +684,10 @@ export class CanvasEntity {
           existingClass.update(newResource, path);
         } else {
           createdNewComponent = true;
+          // Tear down the replaced instance's spec subscription before
+          // overwriting it, otherwise the orphan keeps mutating shared
+          // filter/time state.
+          existingClass?.destroy();
           this.componentsStore.set(
             componentName,
             createComponent(newResource, this, path),
@@ -692,6 +701,7 @@ export class CanvasEntity {
     existingKeys.difference(set).forEach((componentName) => {
       const component = this.componentsStore.getNonReactive(componentName);
       if (component) {
+        component.destroy();
         this.componentsStore.delete(componentName);
       }
     });
@@ -773,6 +783,7 @@ export class CanvasEntity {
   };
 
   removeComponent = (componentName: string) => {
+    this.componentsStore.getNonReactive(componentName)?.destroy();
     this.componentsStore.delete(componentName);
   };
 }


### PR DESCRIPTION
`CanvasEntity` and every `BaseCanvasComponent` opened a `specStore` subscription in their constructor and discarded the unsubscriber, so stale instances kept reacting to spec emissions and raced the live instance over URL and YAML writes.

- `BaseCanvasComponent`: store the spec-subscription unsubscriber and expose `destroy()` to tear it down.
- `CanvasEntity.processRows`: call `destroy()` on a component before replacing it, in the deletion loop, and in `removeComponent`.
- `CanvasEntity.unsubscribe`: restore its body to call the spec unsubscriber, dispose all child components, and reset the components store.
- `removeCanvasStore`: call `canvasEntity.unsubscribe()` before dropping the registry entry, so the "reset to defaults" save path no longer leaves an orphan entity racing the next one.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
