### PR TITLE
test(e2e): enable retries and remove arbitrary `waitForTimeout` sleeps

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,17 @@ export default [
     ...playwright.configs["flat/playwright"],
     ...vitest.configs.recommended,
   },
+  {
+    // Block new arbitrary sleeps in e2e specs; they are both a speed and a
+    // flake tax. Use web-first assertions, expect.poll, waitForResponse, or
+    // waitForReconciliation instead. Justified exceptions must carry an inline
+    // `// eslint-disable-next-line playwright/no-wait-for-timeout -- <reason>`.
+    files: ["**/tests/**/*.spec.ts"],
+    plugins: { playwright },
+    rules: {
+      "playwright/no-wait-for-timeout": "error",
+    },
+  },
   ...eslintPluginSvelte.configs["flat/prettier"],
   {
     languageOptions: {

--- a/web-admin/playwright.config.ts
+++ b/web-admin/playwright.config.ts
@@ -8,8 +8,11 @@ const config: PlaywrightTestConfig = {
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
   },
-  retries: 0,
-  reporter: "html",
+  /* Retry on CI so genuine infra noise is absorbed and surfaced as "flaky" rather than failing the run. */
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI
+    ? [["github"], ["blob"], ["html", { open: "never" }]]
+    : [["html"]],
   use: {
     baseURL: "http://localhost:3000",
     ...devices["Desktop Chrome"],

--- a/web-admin/tests/embeds.spec.ts
+++ b/web-admin/tests/embeds.spec.ts
@@ -2,14 +2,34 @@ import { expect, type Page } from "@playwright/test";
 import { test } from "./setup/base";
 
 /**
+ * Polls the captured messages until one satisfies the predicate, or the timeout
+ * elapses. Returns whether a matching message was found, so callers can emit a
+ * detailed, debuggable failure rather than a bare timeout.
+ */
+async function waitForMessage(
+  messages: string[],
+  predicate: (msg: string) => boolean,
+  timeout = 5_000,
+) {
+  try {
+    await expect.poll(() => messages.some(predicate), { timeout }).toBe(true);
+  } catch {
+    // Timed out: fall through so the caller can report the captured messages.
+  }
+  return messages.some(predicate);
+}
+
+/**
  * Asserts that at least one message in the array contains the expected substring.
  * On failure, provides detailed output showing expected vs received messages.
  */
-function expectMessageContaining(
+async function expectMessageContaining(
   messages: string[],
   expectedSubstring: string,
 ) {
-  const found = messages.some((msg) => msg.includes(expectedSubstring));
+  const found = await waitForMessage(messages, (msg) =>
+    msg.includes(expectedSubstring),
+  );
   if (!found) {
     const formattedMessages =
       messages.length > 0
@@ -34,12 +54,12 @@ ${formattedMessages}`,
  * Asserts that at least one message in the array matches the predicate.
  * On failure, provides detailed output showing the expectation description and received messages.
  */
-function expectMessageMatching(
+async function expectMessageMatching(
   messages: string[],
   predicate: (msg: string) => boolean,
   description: string,
 ) {
-  const found = messages.some(predicate);
+  const found = await waitForMessage(messages, predicate);
   if (!found) {
     const formattedMessages =
       messages.length > 0
@@ -100,9 +120,8 @@ test.describe("Embeds", () => {
       const frame = embedPage.frameLocator("iframe");
 
       await frame.getByRole("row", { name: "Instacart $2.1k" }).click();
-      await embedPage.waitForTimeout(500);
 
-      expectMessageContaining(
+      await expectMessageContaining(
         logMessages,
         "tr=P7D&grain=day&f=advertiser_name+IN+%28%27Instacart%27%29",
       );
@@ -137,7 +156,11 @@ test.describe("Embeds", () => {
       const frame = embedPage.frameLocator("iframe");
 
       await frame.getByRole("row", { name: "Instacart $2.1k" }).click();
-      await embedPage.waitForTimeout(500);
+      // Wait for the click's state change to propagate before requesting it.
+      await expectMessageContaining(
+        logMessages,
+        "f=advertiser_name+IN+%28%27Instacart%27%29",
+      );
 
       await embedPage.evaluate(() => {
         const iframe = document.querySelector("iframe");
@@ -147,9 +170,7 @@ test.describe("Embeds", () => {
         );
       });
 
-      await embedPage.waitForTimeout(500);
-
-      expectMessageContaining(
+      await expectMessageContaining(
         logMessages,
         `{"id":1337,"result":{"state":"tr=P7D&grain=day&f=advertiser_name+IN+%28%27Instacart%27%29"}}`,
       );
@@ -175,7 +196,7 @@ test.describe("Embeds", () => {
       await expect(
         frame.getByRole("row", { name: "Instacart $2.1k" }),
       ).toBeVisible();
-      expectMessageContaining(logMessages, `{"id":1337,"result":true}`);
+      await expectMessageContaining(logMessages, `{"id":1337,"result":true}`);
 
       // Set new rill syntax that includes `+` in the syntax.
       await embedPage.evaluate(() => {
@@ -193,7 +214,7 @@ test.describe("Embeds", () => {
       await expect(
         frame.getByRole("row", { name: "Instacart $1.1k" }),
       ).toBeVisible();
-      expectMessageContaining(logMessages, `{"id":1338,"result":true}`);
+      await expectMessageContaining(logMessages, `{"id":1338,"result":true}`);
     });
 
     test("getThemeMode returns current theme mode", async ({ embedPage }) => {
@@ -208,9 +229,7 @@ test.describe("Embeds", () => {
         );
       });
 
-      await embedPage.waitForTimeout(500);
-
-      expectMessageMatching(
+      await expectMessageMatching(
         logMessages,
         (msg) =>
           msg.includes(`"method":"getThemeMode"`) ||
@@ -239,15 +258,9 @@ test.describe("Embeds", () => {
         );
       });
 
-      await embedPage.waitForTimeout(500);
-
       // Check that dark class is applied to the document
-      const hasDarkClass = await frame
-        .locator("html.dark")
-        .count()
-        .then((count) => count > 0);
-      expect(hasDarkClass).toBeTruthy();
-      expectMessageContaining(logMessages, `{"id":2002,"result":true}`);
+      await expect(frame.locator("html.dark")).toBeAttached();
+      await expectMessageContaining(logMessages, `{"id":2002,"result":true}`);
     });
 
     test("setThemeMode changes theme to light", async ({ embedPage }) => {
@@ -268,7 +281,7 @@ test.describe("Embeds", () => {
         );
       });
 
-      await embedPage.waitForTimeout(500);
+      await expect(frame.locator("html.dark")).toBeAttached();
 
       // Then set to light
       await embedPage.evaluate(() => {
@@ -283,15 +296,9 @@ test.describe("Embeds", () => {
         );
       });
 
-      await embedPage.waitForTimeout(500);
-
       // Check that dark class is not present
-      const hasDarkClass = await frame
-        .locator("html.dark")
-        .count()
-        .then((count) => count > 0);
-      expect(hasDarkClass).toBeFalsy();
-      expectMessageContaining(logMessages, `{"id":2004,"result":true}`);
+      await expect(frame.locator("html.dark")).not.toBeAttached();
+      await expectMessageContaining(logMessages, `{"id":2004,"result":true}`);
     });
 
     test("setThemeMode changes theme to system", async ({ embedPage }) => {
@@ -310,9 +317,7 @@ test.describe("Embeds", () => {
         );
       });
 
-      await embedPage.waitForTimeout(500);
-
-      expectMessageContaining(logMessages, `{"id":2005,"result":true}`);
+      await expectMessageContaining(logMessages, `{"id":2005,"result":true}`);
     });
 
     test("setThemeMode rejects invalid theme mode", async ({ embedPage }) => {
@@ -331,9 +336,7 @@ test.describe("Embeds", () => {
         );
       });
 
-      await embedPage.waitForTimeout(500);
-
-      expectMessageMatching(
+      await expectMessageMatching(
         logMessages,
         (msg) =>
           msg.includes(`"id":2006`) &&
@@ -361,9 +364,8 @@ test.describe("Embeds", () => {
         ).toContainText(
           /Advertising Spend Overall\s+\$252.33\s+-\$52.08\s+-17%/m,
         );
-        await embedPage.waitForTimeout(500);
 
-        expectMessageContaining(
+        await expectMessageContaining(
           logMessages,
           "tr=PT6H&compare_tr=rill-PP&grain=hour&f=advertiser_name+IN+%28%27Instacart%27%29",
         );
@@ -394,9 +396,8 @@ test.describe("Embeds", () => {
         .getByRole("row", { name: "Instacart $1.1k" })
         .scrollIntoViewIfNeeded();
       await frame.getByRole("row", { name: "Instacart $1.1k" }).click();
-      await embedPage.waitForTimeout(500);
 
-      expectMessageContaining(
+      await expectMessageContaining(
         logMessages,
         "tr=PT24H&compare_tr=rill-PP&f.bids_metrics=advertiser_name+IN+%28%27Instacart%27%29",
       );
@@ -411,7 +412,11 @@ test.describe("Embeds", () => {
         .getByRole("row", { name: "Instacart $1.1k" })
         .scrollIntoViewIfNeeded();
       await frame.getByRole("row", { name: "Instacart $1.1k" }).click();
-      await embedPage.waitForTimeout(500);
+      // Wait for the click's state change to propagate before requesting it.
+      await expectMessageContaining(
+        logMessages,
+        "f.bids_metrics=advertiser_name+IN+%28%27Instacart%27%29",
+      );
 
       await embedPage.evaluate(() => {
         const iframe = document.querySelector("iframe");
@@ -421,9 +426,7 @@ test.describe("Embeds", () => {
         );
       });
 
-      await embedPage.waitForTimeout(500);
-
-      expectMessageContaining(
+      await expectMessageContaining(
         logMessages,
         `{"id":1337,"result":{"state":"tr=PT24H&compare_tr=rill-PP&f.bids_metrics=advertiser_name+IN+%28%27Instacart%27%29"}}`,
       );
@@ -433,8 +436,6 @@ test.describe("Embeds", () => {
       const logMessages: string[] = [];
       await waitForReadyMessage(embedPage, logMessages);
       const frame = embedPage.frameLocator("iframe");
-
-      await embedPage.waitForTimeout(500);
 
       await embedPage.evaluate(() => {
         const iframe = document.querySelector("iframe");
@@ -451,7 +452,7 @@ test.describe("Embeds", () => {
       await expect(frame.getByLabel("overall_spend KPI data")).toContainText(
         /Advertising Spend Overall\s*\$2,066\s*\+\$1,926 \+1k%\s*vs previous week/,
       );
-      expectMessageContaining(logMessages, `{"id":1337,"result":true}`);
+      await expectMessageContaining(logMessages, `{"id":1337,"result":true}`);
 
       await embedPage.evaluate(() => {
         const iframe = document.querySelector("iframe");
@@ -468,7 +469,7 @@ test.describe("Embeds", () => {
       await expect(frame.getByLabel("overall_spend KPI data")).toContainText(
         /Advertising Spend Overall\s*\$1,128\s*\+\$1,075 \+2k%\s*vs previous period/,
       );
-      expectMessageContaining(logMessages, `{"id":1338,"result":true}`);
+      await expectMessageContaining(logMessages, `{"id":1338,"result":true}`);
     });
 
     test("getThemeMode returns current theme mode for canvas", async ({
@@ -485,9 +486,7 @@ test.describe("Embeds", () => {
         );
       });
 
-      await embedPage.waitForTimeout(500);
-
-      expectMessageMatching(
+      await expectMessageMatching(
         logMessages,
         (msg) =>
           msg.includes(`"id":3001`) &&
@@ -515,14 +514,8 @@ test.describe("Embeds", () => {
         );
       });
 
-      await embedPage.waitForTimeout(500);
-
-      const hasDarkClass = await frame
-        .locator("html.dark")
-        .count()
-        .then((count) => count > 0);
-      expect(hasDarkClass).toBeTruthy();
-      expectMessageContaining(logMessages, `{"id":3002,"result":true}`);
+      await expect(frame.locator("html.dark")).toBeAttached();
+      await expectMessageContaining(logMessages, `{"id":3002,"result":true}`);
     });
 
     test.describe("embedded canvas with initial state", () => {
@@ -539,9 +532,8 @@ test.describe("Embeds", () => {
         await expect(frame.getByLabel("overall_spend KPI data")).toContainText(
           /Advertising Spend Overall\s+\$252.33\s+-\$52.08 -17%\s+vs previous period/m,
         );
-        await embedPage.waitForTimeout(500);
 
-        expectMessageContaining(
+        await expectMessageContaining(
           logMessages,
           "tr=PT6H&compare_tr=rill-PP&f=advertiser_name+IN+%28%27Instacart%27%29",
         );
@@ -576,9 +568,7 @@ test.describe("Embeds", () => {
       })
       .click();
 
-    await embedPage.waitForTimeout(500);
-
-    expectMessageContaining(
+    await expectMessageContaining(
       logMessages,
       `{"method":"navigation","params":{"from":"bids_explore","to":"auction_explore"}}`,
     );
@@ -592,9 +582,7 @@ test.describe("Embeds", () => {
       .first()
       .click();
 
-    await embedPage.waitForTimeout(500);
-
-    expectMessageContaining(
+    await expectMessageContaining(
       logMessages,
       `{"method":"navigation","params":{"from":"auction_explore","to":"bids_canvas"}}`,
     );
@@ -617,9 +605,7 @@ test.describe("Embeds", () => {
       .getByRole("menuitemcheckbox", { name: "Programmatic Ads Bids" })
       .click();
 
-    await embedPage.waitForTimeout(500);
-
-    expectMessageContaining(
+    await expectMessageContaining(
       logMessages,
       `{"method":"navigation","params":{"from":"bids_canvas","to":"bids_explore"}}`,
     );
@@ -633,9 +619,7 @@ test.describe("Embeds", () => {
       .first()
       .click();
 
-    await embedPage.waitForTimeout(500);
-
-    expectMessageContaining(
+    await expectMessageContaining(
       logMessages,
       `{"method":"navigation","params":{"from":"bids_explore","to":"bids_canvas"}}`,
     );
@@ -645,9 +629,8 @@ test.describe("Embeds", () => {
 
     // Go to `Home` using the breadcrumbs
     await frame.getByText("Home").click();
-    await embedPage.waitForTimeout(500);
 
-    expectMessageContaining(
+    await expectMessageContaining(
       logMessages,
       `{"method":"navigation","params":{"from":"bids_canvas","to":"dashboardListing"}}`,
     );
@@ -661,9 +644,8 @@ test.describe("Embeds", () => {
 
     // Go to `Programmatic Ads Auction` using the links on home
     await frame.getByRole("link", { name: "Programmatic Ads Bids" }).click();
-    await embedPage.waitForTimeout(500);
 
-    expectMessageContaining(
+    await expectMessageContaining(
       logMessages,
       `{"method":"navigation","params":{"from":"dashboardListing","to":"bids_explore"}}`,
     );
@@ -672,9 +654,8 @@ test.describe("Embeds", () => {
 
     // Go to `Home` using the breadcrumbs
     await frame.getByText("Home").click();
-    await embedPage.waitForTimeout(500);
 
-    expectMessageContaining(
+    await expectMessageContaining(
       logMessages,
       `{"method":"navigation","params":{"from":"bids_explore","to":"dashboardListing"}}`,
     );
@@ -684,9 +665,7 @@ test.describe("Embeds", () => {
       .first()
       .click();
 
-    await embedPage.waitForTimeout(500);
-
-    expectMessageContaining(
+    await expectMessageContaining(
       logMessages,
       `{"method":"navigation","params":{"from":"dashboardListing","to":"bids_canvas"}}`,
     );

--- a/web-admin/tests/embeds.spec.ts
+++ b/web-admin/tests/embeds.spec.ts
@@ -2,104 +2,105 @@ import { expect, type Page } from "@playwright/test";
 import { test } from "./setup/base";
 
 /**
- * Polls the captured messages until one satisfies the predicate, or the timeout
- * elapses. Returns whether a matching message was found, so callers can emit a
- * detailed, debuggable failure rather than a bare timeout.
+ * Captures the embed's `console.log` messages (the postMessage protocol echoes
+ * its traffic to the console) and exposes web-first assertions over them. The
+ * captured messages are encapsulated here rather than passed around as a shared
+ * array, so it is clear that the listener owns and mutates them.
  */
-async function waitForMessage(
-  messages: string[],
-  predicate: (msg: string) => boolean,
-  timeout = 5_000,
-) {
-  try {
-    await expect.poll(() => messages.some(predicate), { timeout }).toBe(true);
-  } catch {
-    // Timed out: fall through so the caller can report the captured messages.
-  }
-  return messages.some(predicate);
-}
+class EmbedMessageRecorder {
+  private readonly messages: string[] = [];
+  private readonly ready: Promise<void>;
 
-/**
- * Asserts that at least one message in the array contains the expected substring.
- * On failure, provides detailed output showing expected vs received messages.
- */
-async function expectMessageContaining(
-  messages: string[],
-  expectedSubstring: string,
-) {
-  const found = await waitForMessage(messages, (msg) =>
-    msg.includes(expectedSubstring),
-  );
-  if (!found) {
-    const formattedMessages =
-      messages.length > 0
-        ? messages.map((m, i) => `  [${i}]: ${m}`).join("\n")
-        : "  (no messages captured)";
-    expect
-      .soft(
-        found,
-        `No message containing expected substring.
+  constructor(embedPage: Page) {
+    this.ready = new Promise<void>((resolve) => {
+      embedPage.on("console", async (msg) => {
+        if (msg.type() !== "log") return;
+
+        try {
+          const args = await Promise.all(
+            msg.args().map((arg) => arg.jsonValue()),
+          );
+          const logMessage = JSON.stringify(args);
+          this.messages.push(logMessage);
+          if (logMessage.includes(`{"method":"ready"}`)) {
+            resolve();
+          }
+        } catch {
+          // Ignore errors in parsing. Any rogue log shouldn't break the test.
+          // There is also a race condition when browser/page is closed while we
+          // are extracting the values in the await.
+        }
+      });
+    });
+  }
+
+  /** Resolves once the embed has posted its `ready` message. */
+  waitForReady() {
+    return this.ready;
+  }
+
+  /** Asserts that at least one captured message contains the substring. */
+  async expectContaining(expectedSubstring: string) {
+    const found = await this.poll((msg) => msg.includes(expectedSubstring));
+    if (!found) {
+      expect
+        .soft(
+          found,
+          `No message containing expected substring.
 
 Expected substring:
   ${expectedSubstring}
 
 Received messages:
-${formattedMessages}`,
-      )
-      .toBeTruthy();
+${this.formatMessages()}`,
+        )
+        .toBeTruthy();
+    }
   }
-}
 
-/**
- * Asserts that at least one message in the array matches the predicate.
- * On failure, provides detailed output showing the expectation description and received messages.
- */
-async function expectMessageMatching(
-  messages: string[],
-  predicate: (msg: string) => boolean,
-  description: string,
-) {
-  const found = await waitForMessage(messages, predicate);
-  if (!found) {
-    const formattedMessages =
-      messages.length > 0
-        ? messages.map((m, i) => `  [${i}]: ${m}`).join("\n")
-        : "  (no messages captured)";
-    expect
-      .soft(
-        found,
-        `No message matching expected condition.
+  /** Asserts that at least one captured message matches the predicate. */
+  async expectMatching(
+    predicate: (msg: string) => boolean,
+    description: string,
+  ) {
+    const found = await this.poll(predicate);
+    if (!found) {
+      expect
+        .soft(
+          found,
+          `No message matching expected condition.
 
 Expected:
   ${description}
 
 Received messages:
-${formattedMessages}`,
-      )
-      .toBeTruthy();
+${this.formatMessages()}`,
+        )
+        .toBeTruthy();
+    }
   }
-}
 
-async function waitForReadyMessage(embedPage: Page, logMessages: string[]) {
-  return new Promise<void>((resolve) => {
-    embedPage.on("console", async (msg) => {
-      if (msg.type() !== "log") return;
+  /**
+   * Polls the captured messages until one satisfies the predicate, or the
+   * timeout elapses. Returns whether a matching message was found, so callers
+   * can emit a detailed, debuggable failure rather than a bare timeout.
+   */
+  private async poll(predicate: (msg: string) => boolean, timeout = 5_000) {
+    try {
+      await expect
+        .poll(() => this.messages.some(predicate), { timeout })
+        .toBe(true);
+    } catch {
+      // Timed out: fall through so the caller can report the captured messages.
+    }
+    return this.messages.some(predicate);
+  }
 
-      try {
-        const args = await Promise.all(
-          msg.args().map((arg) => arg.jsonValue()),
-        );
-        const logMessage = JSON.stringify(args);
-        logMessages.push(logMessage);
-        if (logMessage.includes(`{"method":"ready"}`)) {
-          resolve();
-        }
-      } catch {
-        // Ignore errors in parsing. Any rogue log shouldn't break the test.
-        // There is also a race condition when browser/page is closed while we are extracting the values in the await.
-      }
-    });
-  });
+  private formatMessages() {
+    return this.messages.length > 0
+      ? this.messages.map((m, i) => `  [${i}]: ${m}`).join("\n")
+      : "  (no messages captured)";
+  }
 }
 
 test.describe("Embeds", () => {
@@ -115,14 +116,13 @@ test.describe("Embeds", () => {
     });
 
     test("state is emitted for embeds", async ({ embedPage }) => {
-      const logMessages: string[] = [];
-      await waitForReadyMessage(embedPage, logMessages);
+      const recorder = new EmbedMessageRecorder(embedPage);
+      await recorder.waitForReady();
       const frame = embedPage.frameLocator("iframe");
 
       await frame.getByRole("row", { name: "Instacart $2.1k" }).click();
 
-      await expectMessageContaining(
-        logMessages,
+      await recorder.expectContaining(
         "tr=P7D&grain=day&f=advertiser_name+IN+%28%27Instacart%27%29",
       );
     });
@@ -151,14 +151,13 @@ test.describe("Embeds", () => {
     });
 
     test("getState returns from embed", async ({ embedPage }) => {
-      const logMessages: string[] = [];
-      await waitForReadyMessage(embedPage, logMessages);
+      const recorder = new EmbedMessageRecorder(embedPage);
+      await recorder.waitForReady();
       const frame = embedPage.frameLocator("iframe");
 
       await frame.getByRole("row", { name: "Instacart $2.1k" }).click();
       // Wait for the click's state change to propagate before requesting it.
-      await expectMessageContaining(
-        logMessages,
+      await recorder.expectContaining(
         "f=advertiser_name+IN+%28%27Instacart%27%29",
       );
 
@@ -170,15 +169,14 @@ test.describe("Embeds", () => {
         );
       });
 
-      await expectMessageContaining(
-        logMessages,
+      await recorder.expectContaining(
         `{"id":1337,"result":{"state":"tr=P7D&grain=day&f=advertiser_name+IN+%28%27Instacart%27%29"}}`,
       );
     });
 
     test("setState changes embedded explore", async ({ embedPage }) => {
-      const logMessages: string[] = [];
-      await waitForReadyMessage(embedPage, logMessages);
+      const recorder = new EmbedMessageRecorder(embedPage);
+      await recorder.waitForReady();
       const frame = embedPage.frameLocator("iframe");
 
       await embedPage.evaluate(() => {
@@ -196,7 +194,7 @@ test.describe("Embeds", () => {
       await expect(
         frame.getByRole("row", { name: "Instacart $2.1k" }),
       ).toBeVisible();
-      await expectMessageContaining(logMessages, `{"id":1337,"result":true}`);
+      await recorder.expectContaining(`{"id":1337,"result":true}`);
 
       // Set new rill syntax that includes `+` in the syntax.
       await embedPage.evaluate(() => {
@@ -214,12 +212,12 @@ test.describe("Embeds", () => {
       await expect(
         frame.getByRole("row", { name: "Instacart $1.1k" }),
       ).toBeVisible();
-      await expectMessageContaining(logMessages, `{"id":1338,"result":true}`);
+      await recorder.expectContaining(`{"id":1338,"result":true}`);
     });
 
     test("getThemeMode returns current theme mode", async ({ embedPage }) => {
-      const logMessages: string[] = [];
-      await waitForReadyMessage(embedPage, logMessages);
+      const recorder = new EmbedMessageRecorder(embedPage);
+      await recorder.waitForReady();
 
       await embedPage.evaluate(() => {
         const iframe = document.querySelector("iframe");
@@ -229,8 +227,7 @@ test.describe("Embeds", () => {
         );
       });
 
-      await expectMessageMatching(
-        logMessages,
+      await recorder.expectMatching(
         (msg) =>
           msg.includes(`"method":"getThemeMode"`) ||
           (msg.includes(`"id":2001`) &&
@@ -242,8 +239,8 @@ test.describe("Embeds", () => {
     });
 
     test("setThemeMode changes theme to dark", async ({ embedPage }) => {
-      const logMessages: string[] = [];
-      await waitForReadyMessage(embedPage, logMessages);
+      const recorder = new EmbedMessageRecorder(embedPage);
+      await recorder.waitForReady();
       const frame = embedPage.frameLocator("iframe");
 
       await embedPage.evaluate(() => {
@@ -260,12 +257,12 @@ test.describe("Embeds", () => {
 
       // Check that dark class is applied to the document
       await expect(frame.locator("html.dark")).toBeAttached();
-      await expectMessageContaining(logMessages, `{"id":2002,"result":true}`);
+      await recorder.expectContaining(`{"id":2002,"result":true}`);
     });
 
     test("setThemeMode changes theme to light", async ({ embedPage }) => {
-      const logMessages: string[] = [];
-      await waitForReadyMessage(embedPage, logMessages);
+      const recorder = new EmbedMessageRecorder(embedPage);
+      await recorder.waitForReady();
       const frame = embedPage.frameLocator("iframe");
 
       // First set to dark
@@ -298,12 +295,12 @@ test.describe("Embeds", () => {
 
       // Check that dark class is not present
       await expect(frame.locator("html.dark")).not.toBeAttached();
-      await expectMessageContaining(logMessages, `{"id":2004,"result":true}`);
+      await recorder.expectContaining(`{"id":2004,"result":true}`);
     });
 
     test("setThemeMode changes theme to system", async ({ embedPage }) => {
-      const logMessages: string[] = [];
-      await waitForReadyMessage(embedPage, logMessages);
+      const recorder = new EmbedMessageRecorder(embedPage);
+      await recorder.waitForReady();
 
       await embedPage.evaluate(() => {
         const iframe = document.querySelector("iframe");
@@ -317,12 +314,12 @@ test.describe("Embeds", () => {
         );
       });
 
-      await expectMessageContaining(logMessages, `{"id":2005,"result":true}`);
+      await recorder.expectContaining(`{"id":2005,"result":true}`);
     });
 
     test("setThemeMode rejects invalid theme mode", async ({ embedPage }) => {
-      const logMessages: string[] = [];
-      await waitForReadyMessage(embedPage, logMessages);
+      const recorder = new EmbedMessageRecorder(embedPage);
+      await recorder.waitForReady();
 
       await embedPage.evaluate(() => {
         const iframe = document.querySelector("iframe");
@@ -336,8 +333,7 @@ test.describe("Embeds", () => {
         );
       });
 
-      await expectMessageMatching(
-        logMessages,
+      await recorder.expectMatching(
         (msg) =>
           msg.includes(`"id":2006`) &&
           msg.includes(`"error"`) &&
@@ -353,8 +349,8 @@ test.describe("Embeds", () => {
       });
 
       test("init state is applied to dashboard", async ({ embedPage }) => {
-        const logMessages: string[] = [];
-        await waitForReadyMessage(embedPage, logMessages);
+        const recorder = new EmbedMessageRecorder(embedPage);
+        await recorder.waitForReady();
         const frame = embedPage.frameLocator("iframe");
 
         await expect(
@@ -365,8 +361,7 @@ test.describe("Embeds", () => {
           /Advertising Spend Overall\s+\$252.33\s+-\$52.08\s+-17%/m,
         );
 
-        await expectMessageContaining(
-          logMessages,
+        await recorder.expectContaining(
           "tr=PT6H&compare_tr=rill-PP&grain=hour&f=advertiser_name+IN+%28%27Instacart%27%29",
         );
       });
@@ -388,8 +383,8 @@ test.describe("Embeds", () => {
     });
 
     test("state is emitted for embeds", async ({ embedPage }) => {
-      const logMessages: string[] = [];
-      await waitForReadyMessage(embedPage, logMessages);
+      const recorder = new EmbedMessageRecorder(embedPage);
+      await recorder.waitForReady();
       const frame = embedPage.frameLocator("iframe");
 
       await frame
@@ -397,15 +392,14 @@ test.describe("Embeds", () => {
         .scrollIntoViewIfNeeded();
       await frame.getByRole("row", { name: "Instacart $1.1k" }).click();
 
-      await expectMessageContaining(
-        logMessages,
+      await recorder.expectContaining(
         "tr=PT24H&compare_tr=rill-PP&f.bids_metrics=advertiser_name+IN+%28%27Instacart%27%29",
       );
     });
 
     test("getState returns from embed", async ({ embedPage }) => {
-      const logMessages: string[] = [];
-      await waitForReadyMessage(embedPage, logMessages);
+      const recorder = new EmbedMessageRecorder(embedPage);
+      await recorder.waitForReady();
       const frame = embedPage.frameLocator("iframe");
 
       await frame
@@ -413,8 +407,7 @@ test.describe("Embeds", () => {
         .scrollIntoViewIfNeeded();
       await frame.getByRole("row", { name: "Instacart $1.1k" }).click();
       // Wait for the click's state change to propagate before requesting it.
-      await expectMessageContaining(
-        logMessages,
+      await recorder.expectContaining(
         "f.bids_metrics=advertiser_name+IN+%28%27Instacart%27%29",
       );
 
@@ -426,15 +419,14 @@ test.describe("Embeds", () => {
         );
       });
 
-      await expectMessageContaining(
-        logMessages,
+      await recorder.expectContaining(
         `{"id":1337,"result":{"state":"tr=PT24H&compare_tr=rill-PP&f.bids_metrics=advertiser_name+IN+%28%27Instacart%27%29"}}`,
       );
     });
 
     test("setState changes embedded canvas", async ({ embedPage }) => {
-      const logMessages: string[] = [];
-      await waitForReadyMessage(embedPage, logMessages);
+      const recorder = new EmbedMessageRecorder(embedPage);
+      await recorder.waitForReady();
       const frame = embedPage.frameLocator("iframe");
 
       await embedPage.evaluate(() => {
@@ -452,7 +444,7 @@ test.describe("Embeds", () => {
       await expect(frame.getByLabel("overall_spend KPI data")).toContainText(
         /Advertising Spend Overall\s*\$2,066\s*\+\$1,926 \+1k%\s*vs previous week/,
       );
-      await expectMessageContaining(logMessages, `{"id":1337,"result":true}`);
+      await recorder.expectContaining(`{"id":1337,"result":true}`);
 
       await embedPage.evaluate(() => {
         const iframe = document.querySelector("iframe");
@@ -469,14 +461,14 @@ test.describe("Embeds", () => {
       await expect(frame.getByLabel("overall_spend KPI data")).toContainText(
         /Advertising Spend Overall\s*\$1,128\s*\+\$1,075 \+2k%\s*vs previous period/,
       );
-      await expectMessageContaining(logMessages, `{"id":1338,"result":true}`);
+      await recorder.expectContaining(`{"id":1338,"result":true}`);
     });
 
     test("getThemeMode returns current theme mode for canvas", async ({
       embedPage,
     }) => {
-      const logMessages: string[] = [];
-      await waitForReadyMessage(embedPage, logMessages);
+      const recorder = new EmbedMessageRecorder(embedPage);
+      await recorder.waitForReady();
 
       await embedPage.evaluate(() => {
         const iframe = document.querySelector("iframe");
@@ -486,8 +478,7 @@ test.describe("Embeds", () => {
         );
       });
 
-      await expectMessageMatching(
-        logMessages,
+      await recorder.expectMatching(
         (msg) =>
           msg.includes(`"id":3001`) &&
           (msg.includes(`"themeMode":"light"`) ||
@@ -498,8 +489,8 @@ test.describe("Embeds", () => {
     });
 
     test("setThemeMode works for canvas", async ({ embedPage }) => {
-      const logMessages: string[] = [];
-      await waitForReadyMessage(embedPage, logMessages);
+      const recorder = new EmbedMessageRecorder(embedPage);
+      await recorder.waitForReady();
       const frame = embedPage.frameLocator("iframe");
 
       await embedPage.evaluate(() => {
@@ -515,7 +506,7 @@ test.describe("Embeds", () => {
       });
 
       await expect(frame.locator("html.dark")).toBeAttached();
-      await expectMessageContaining(logMessages, `{"id":3002,"result":true}`);
+      await recorder.expectContaining(`{"id":3002,"result":true}`);
     });
 
     test.describe("embedded canvas with initial state", () => {
@@ -525,16 +516,15 @@ test.describe("Embeds", () => {
       });
 
       test("init state is applied to canvas", async ({ embedPage }) => {
-        const logMessages: string[] = [];
-        await waitForReadyMessage(embedPage, logMessages);
+        const recorder = new EmbedMessageRecorder(embedPage);
+        await recorder.waitForReady();
         const frame = embedPage.frameLocator("iframe");
 
         await expect(frame.getByLabel("overall_spend KPI data")).toContainText(
           /Advertising Spend Overall\s+\$252.33\s+-\$52.08 -17%\s+vs previous period/m,
         );
 
-        await expectMessageContaining(
-          logMessages,
+        await recorder.expectContaining(
           "tr=PT6H&compare_tr=rill-PP&f=advertiser_name+IN+%28%27Instacart%27%29",
         );
       });
@@ -542,8 +532,8 @@ test.describe("Embeds", () => {
   });
 
   test("navigation works as expected", async ({ embedPage }) => {
-    const logMessages: string[] = [];
-    await waitForReadyMessage(embedPage, logMessages);
+    const recorder = new EmbedMessageRecorder(embedPage);
+    await recorder.waitForReady();
     const frame = embedPage.frameLocator("iframe");
 
     // Time range is the default
@@ -568,8 +558,7 @@ test.describe("Embeds", () => {
       })
       .click();
 
-    await expectMessageContaining(
-      logMessages,
+    await recorder.expectContaining(
       `{"method":"navigation","params":{"from":"bids_explore","to":"auction_explore"}}`,
     );
     // Time range is still the default
@@ -582,8 +571,7 @@ test.describe("Embeds", () => {
       .first()
       .click();
 
-    await expectMessageContaining(
-      logMessages,
+    await recorder.expectContaining(
       `{"method":"navigation","params":{"from":"auction_explore","to":"bids_canvas"}}`,
     );
     // Time range is still the default
@@ -605,8 +593,7 @@ test.describe("Embeds", () => {
       .getByRole("menuitemcheckbox", { name: "Programmatic Ads Bids" })
       .click();
 
-    await expectMessageContaining(
-      logMessages,
+    await recorder.expectContaining(
       `{"method":"navigation","params":{"from":"bids_canvas","to":"bids_explore"}}`,
     );
     // Old selection has persisted
@@ -619,8 +606,7 @@ test.describe("Embeds", () => {
       .first()
       .click();
 
-    await expectMessageContaining(
-      logMessages,
+    await recorder.expectContaining(
       `{"method":"navigation","params":{"from":"bids_explore","to":"bids_canvas"}}`,
     );
 
@@ -630,8 +616,7 @@ test.describe("Embeds", () => {
     // Go to `Home` using the breadcrumbs
     await frame.getByText("Home").click();
 
-    await expectMessageContaining(
-      logMessages,
+    await recorder.expectContaining(
       `{"method":"navigation","params":{"from":"bids_canvas","to":"dashboardListing"}}`,
     );
     // Check that the dashboards are listed
@@ -645,8 +630,7 @@ test.describe("Embeds", () => {
     // Go to `Programmatic Ads Auction` using the links on home
     await frame.getByRole("link", { name: "Programmatic Ads Bids" }).click();
 
-    await expectMessageContaining(
-      logMessages,
+    await recorder.expectContaining(
       `{"method":"navigation","params":{"from":"dashboardListing","to":"bids_explore"}}`,
     );
     // Old selection has persisted
@@ -655,8 +639,7 @@ test.describe("Embeds", () => {
     // Go to `Home` using the breadcrumbs
     await frame.getByText("Home").click();
 
-    await expectMessageContaining(
-      logMessages,
+    await recorder.expectContaining(
       `{"method":"navigation","params":{"from":"bids_explore","to":"dashboardListing"}}`,
     );
     // Go to `Bids Canvas Dashboard` using the links on home
@@ -665,8 +648,7 @@ test.describe("Embeds", () => {
       .first()
       .click();
 
-    await expectMessageContaining(
-      logMessages,
+    await recorder.expectContaining(
       `{"method":"navigation","params":{"from":"dashboardListing","to":"bids_canvas"}}`,
     );
     // Old selection has persisted

--- a/web-integration/playwright.config.ts
+++ b/web-integration/playwright.config.ts
@@ -9,8 +9,11 @@ const config: PlaywrightTestConfig = {
     timeout: 120_000,
     cwd: "../web-admin",
   },
-  retries: 0,
-  reporter: "html",
+  /* Retry on CI so genuine infra noise is absorbed and surfaced as "flaky" rather than failing the run. */
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI
+    ? [["github"], ["blob"], ["html", { open: "never" }]]
+    : [["html"]],
   use: {
     baseURL: "http://localhost:3000",
     ...devices["Desktop Chrome"],

--- a/web-local/playwright.config.ts
+++ b/web-local/playwright.config.ts
@@ -9,11 +9,14 @@ export default defineConfig({
   fullyParallel: !process.env.CI,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  retries: 0,
+  /* Retry on CI so genuine infra noise is absorbed and surfaced as "flaky" rather than failing the run. */
+  retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel testing in CI */
   workers: process.env.CI ? 1 : 8,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
+  reporter: process.env.CI
+    ? [["github"], ["blob"], ["html", { open: "never" }]]
+    : [["html"]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/web-local/tests/canvas/charts.spec.ts
+++ b/web-local/tests/canvas/charts.spec.ts
@@ -13,16 +13,12 @@ test.describe("canvas charts", () => {
 
     await page.locator(".chart-icons").getByLabel("Heatmap").click();
 
-    await page.waitForTimeout(500);
-
     await page
       .getByLabel("A heatmap chart with embedded data")
       .locator("canvas")
       .click();
 
     await page.locator(".chart-icons").getByLabel("Donut").click();
-
-    await page.waitForTimeout(500);
 
     // Ensure the sidebar properties have updated
     await expect(page.getByText("Inner Radius (%)")).toBeVisible();

--- a/web-local/tests/canvas/default-filters.spec.ts
+++ b/web-local/tests/canvas/default-filters.spec.ts
@@ -83,7 +83,8 @@ test.describe("canvas time filters", () => {
 
     await page.goto(`${currentUrl}`);
 
-    await page.waitForTimeout(1000);
+    // The app redirects to a URL carrying the default-filter params after load.
+    await page.waitForURL("**/*f.AdBids_metrics=*");
     expect(page.url()).toContain(
       "?tr=PT24H&compare_tr=rill-PP&f.AdBids_metrics=domain+IN+%28%27facebook.com%27%2C%27google.com%27%2C%27msn.com%27%29",
     );

--- a/web-local/tests/canvas/filters.spec.ts
+++ b/web-local/tests/canvas/filters.spec.ts
@@ -26,6 +26,14 @@ test.describe("canvas time filters", () => {
       .click();
     await page.getByRole("menuitem", { name: "Last 7 days" }).click();
 
+    // Wait for the local time range to apply before enabling comparison,
+    // otherwise the comparison toggle can race the range change.
+    await expect(
+      page
+        .getByRole("complementary", { name: "Inspector Panel" })
+        .getByLabel("Select time range"),
+    ).toContainText("Last 7");
+
     await page
       .getByRole("complementary", { name: "Inspector Panel" })
       .getByLabel("Toggle time comparison")

--- a/web-local/tests/canvas/filters.spec.ts
+++ b/web-local/tests/canvas/filters.spec.ts
@@ -26,8 +26,6 @@ test.describe("canvas time filters", () => {
       .click();
     await page.getByRole("menuitem", { name: "Last 7 days" }).click();
 
-    await page.waitForTimeout(500);
-
     await page
       .getByRole("complementary", { name: "Inspector Panel" })
       .getByLabel("Toggle time comparison")

--- a/web-local/tests/canvas/global-dimension-filters.spec.ts
+++ b/web-local/tests/canvas/global-dimension-filters.spec.ts
@@ -12,8 +12,6 @@ test.describe("canvas global dimension filters", () => {
 
     await page.getByRole("button", { name: "Preview" }).click();
 
-    await page.waitForTimeout(1000);
-
     await expect(page.getByText("Total records 1,122")).toBeVisible();
 
     await page.getByRole("button", { name: "Add filter button" }).click();

--- a/web-local/tests/canvas/global-time-filters.spec.ts
+++ b/web-local/tests/canvas/global-time-filters.spec.ts
@@ -13,8 +13,6 @@ test.describe("canvas global time filters", () => {
 
     await page.getByRole("button", { name: "Preview" }).click();
 
-    await page.waitForTimeout(1000);
-
     // Change global time range
     await interactWithTimeRangeMenu(page, async () => {
       await page.getByRole("menuitem", { name: "Last 6 Hours" }).click();

--- a/web-local/tests/connectors/bigquery-connector.spec.ts
+++ b/web-local/tests/connectors/bigquery-connector.spec.ts
@@ -62,9 +62,6 @@ test.describe("BigQuery connector", () => {
 
       // Upload the file using FileChooser
       await fileChooser.setFiles([tempFilePath]);
-
-      // Wait a moment for the file to be processed
-      await page.waitForTimeout(500);
     } finally {
       // Clean up temp file
       if (existsSync(tempFilePath)) {
@@ -153,12 +150,16 @@ test.describe("BigQuery connector", () => {
     try {
       writeFileSync(tempFilePath, credentialsJson);
       await fileChooser1.setFiles([tempFilePath]);
-      await page.waitForTimeout(500);
     } finally {
       if (existsSync(tempFilePath)) {
         unlinkSync(tempFilePath);
       }
     }
+
+    // Wait for the uploaded credentials to be processed into the form.
+    await expect(page.getByRole("textbox", { name: "Project ID" })).toHaveValue(
+      credentials.project_id,
+    );
 
     await page.getByLabel("Save connector").click();
     await page.waitForURL(`**/files/connectors/bigquery.yaml`);
@@ -176,12 +177,16 @@ test.describe("BigQuery connector", () => {
     try {
       writeFileSync(tempFilePath, credentialsJson);
       await fileChooser2.setFiles([tempFilePath]);
-      await page.waitForTimeout(500);
     } finally {
       if (existsSync(tempFilePath)) {
         unlinkSync(tempFilePath);
       }
     }
+
+    // Wait for the uploaded credentials to be processed into the form.
+    await expect(page.getByRole("textbox", { name: "Project ID" })).toHaveValue(
+      credentials.project_id,
+    );
 
     await page.getByLabel("Save connector").click();
     // Second connector should get _1 suffix in filename

--- a/web-local/tests/connectors/gcs-connector.spec.ts
+++ b/web-local/tests/connectors/gcs-connector.spec.ts
@@ -116,7 +116,6 @@ test.describe("GCS connector", () => {
 
     // Switch to Public (no required fields) -> CTA should remain enabled and allow advancing.
     await page.getByRole("radio", { name: "Public" }).click();
-    await page.waitForTimeout(1000);
     await expect(
       page.getByRole("button", {
         name: "Continue",

--- a/web-local/tests/connectors/motherduck-connector.spec.ts
+++ b/web-local/tests/connectors/motherduck-connector.spec.ts
@@ -59,7 +59,6 @@ test.describe("MotherDuck welcome flow", () => {
     );
     await updateCodeEditor(page, updatedContent);
     await page.getByRole("button", { name: "Save" }).click();
-    await page.waitForTimeout(1000);
 
     // Verify the updated syntax is now in the file
     await expect(connectorEditor).toContainText(

--- a/web-local/tests/explores/annotations.spec.ts
+++ b/web-local/tests/explores/annotations.spec.ts
@@ -59,6 +59,9 @@ async function setupDashboard(page: Page, dashboardTZ: string) {
   // Wait for annotation query responses to arrive and the chart to
   // finish re-rendering. Without this, menu interactions race against
   // DOM element detachment from the annotation-triggered re-render.
+  // There is no stable DOM signal for the annotation re-render completing,
+  // so a fixed wait is required here.
+  // eslint-disable-next-line playwright/no-wait-for-timeout -- annotation re-render has no deterministic completion signal to await
   await page.waitForTimeout(2000);
 }
 
@@ -238,6 +241,9 @@ test.describe("annotations (rendering)", () => {
           if (!dBox) continue;
 
           await page.mouse.move(dBox.x + dBox.width / 2, hoverY);
+          // Give the hover-triggered popover a moment to render before
+          // probing for it; there is no element to await prior to the probe.
+          // eslint-disable-next-line playwright/no-wait-for-timeout -- hover popover render has no awaitable signal before the probe below
           await page.waitForTimeout(100);
 
           const popover = page

--- a/web-local/tests/explores/annotations.spec.ts
+++ b/web-local/tests/explores/annotations.spec.ts
@@ -56,13 +56,12 @@ async function setupDashboard(page: Page, dashboardTZ: string) {
     page.getByRole("button", { name: /Total records/ }).first(),
   ).toBeVisible({ timeout: 30_000 });
 
-  // Wait for annotation query responses to arrive and the chart to
-  // finish re-rendering. Without this, menu interactions race against
-  // DOM element detachment from the annotation-triggered re-render.
-  // There is no stable DOM signal for the annotation re-render completing,
-  // so a fixed wait is required here.
-  // eslint-disable-next-line playwright/no-wait-for-timeout -- annotation re-render has no deterministic completion signal to await
-  await page.waitForTimeout(2000);
+  // Wait for the annotation markers to render. Their presence signals the
+  // annotation queries returned and the chart finished re-rendering, so menu
+  // interactions no longer race the annotation-triggered re-render.
+  await expect(
+    page.locator('rect[aria-label="annotation marker"]').first(),
+  ).toBeVisible({ timeout: 30_000 });
 }
 
 async function selectGrain(page: Page, grain: string) {

--- a/web-local/tests/explores/banner.spec.ts
+++ b/web-local/tests/explores/banner.spec.ts
@@ -11,7 +11,6 @@ test.describe("banner in explore preview", () => {
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
 
     await page.getByRole("button", { name: "Preview" }).click();
-    await page.waitForTimeout(1000);
 
     const banner = page.locator(".app-banner");
     await expect(banner).toBeHidden();
@@ -34,7 +33,6 @@ test.describe("banner in explore preview", () => {
     await page.getByRole("button", { name: "switch to code editor" }).click();
     await watcher.updateAndWaitForDashboard(exploreWithBanner);
     await page.getByRole("button", { name: "Preview" }).click();
-    await page.waitForTimeout(500);
 
     const banner = page.locator(".app-banner");
     await expect(banner).toBeVisible();

--- a/web-local/tests/explores/custom-time-range.spec.ts
+++ b/web-local/tests/explores/custom-time-range.spec.ts
@@ -11,7 +11,6 @@ test.describe("custom timerange in Explore", () => {
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
 
     await page.getByRole("button", { name: "Preview" }).click();
-    await page.waitForTimeout(1000);
 
     await page.getByLabel("Select time range").click();
 
@@ -37,7 +36,6 @@ test.describe("custom timerange in Explore", () => {
     await page.getByRole("button", { name: "switch to code editor" }).click();
     await watcher.updateAndWaitForDashboard(exploreWithBanner);
     await page.getByRole("button", { name: "Preview" }).click();
-    await page.waitForTimeout(500);
 
     await page.getByLabel("Select time range").click();
     await expect(page.getByRole("menuitem", { name: "Custom" })).toBeHidden();

--- a/web-local/tests/explores/explores.spec.ts
+++ b/web-local/tests/explores/explores.spec.ts
@@ -24,8 +24,6 @@ test.describe("explores", () => {
   test("Autogenerate explore from source nav file", async ({ page }) => {
     await createSourceV2(page, "AdBids.csv", "/models/AdBids.yaml");
     await createExploreFromSource(page);
-    // Temporary timeout while the issue is looked into
-    await page.waitForTimeout(1000);
     await assertAdBidsDashboard(page);
   });
 
@@ -231,7 +229,6 @@ time_ranges:
 
     // Change filter to excluded
     await page.getByText("Publisher Facebook").click();
-    await page.waitForTimeout(500); // wait for the filter bar to update
     await page.getByLabel("Include exclude toggle").click();
     await page.keyboard.press("Escape"); // close the dimension filter dropdown
 

--- a/web-local/tests/explores/leaderboard-and-dim-table-sort.spec.ts
+++ b/web-local/tests/explores/leaderboard-and-dim-table-sort.spec.ts
@@ -4,14 +4,19 @@ import { gotoNavEntry } from "../utils/waitHelpers";
 import { test } from "../setup/base";
 
 async function assertAAboveB(locA: Locator, locB: Locator) {
-  const topA = await locA.boundingBox().then((box) => box?.y);
-  const topB = await locB.boundingBox().then((box) => box?.y);
+  await expect(locA).toBeVisible();
+  await expect(locB).toBeVisible();
 
-  expect(topA).toBeDefined();
-  expect(topB).toBeDefined();
-
-  // Safety: topB is defined
-  expect(topA).toBeLessThan(topB as number);
+  // Poll the layout so the assertion waits for rankings to settle rather than
+  // relying on a fixed sleep after the action that triggered the re-sort.
+  await expect
+    .poll(async () => {
+      const topA = (await locA.boundingBox())?.y;
+      const topB = (await locB.boundingBox())?.y;
+      if (topA === undefined || topB === undefined) return false;
+      return topA < topB;
+    })
+    .toBe(true);
 }
 
 test.describe("leaderboard and dimension table sorting", () => {
@@ -63,18 +68,12 @@ test.describe("leaderboard and dimension table sorting", () => {
     // add time comparison and select Pct change
     await page.getByLabel("Toggle time comparison").click();
 
-    // need a slight delay for the time range to update
-    // and the "Pct change" option to be available
-    // in the context column dropdown
-    await page.waitForTimeout(1000);
-
+    // The percent-change sort toggle only appears once time comparison is on;
+    // the click below auto-waits for it to become actionable.
     await page
       .getByLabel("publisher leaderboard")
       .getByLabel("Toggle sort leaderboards by percent change")
       .click();
-
-    // need a slight delay for the rankings to update
-    await page.waitForTimeout(1000);
 
     // Broader selectors using RegEx to account for some Playwright runs triggering the display
     // of the starting value on hover

--- a/web-local/tests/explores/open-query.spec.ts
+++ b/web-local/tests/explores/open-query.spec.ts
@@ -18,10 +18,11 @@ test.describe("Query-to-Explore routing", () => {
       `${baseUrl}/-/open-query?query=%7B%22dimensions%22%3A%5B%7B%22name%22%3A%22publisher%22%7D%5D%2C%22measures%22%3A%5B%7B%22name%22%3A%22bid_price_sum%22%7D%2C%7B%22name%22%3A%22total_records%22%7D%5D%2C%22metrics_view%22%3A%22AdBids_metrics%22%2C%22time_range%22%3A%7B%22end%22%3A%222022-03-30T23%3A59%3A54.56Z%22%2C%22start%22%3A%222022-01-01T00%3A02%3A39.041Z%22%7D%2C%22where%22%3A%7B%22cond%22%3A%7B%22exprs%22%3A%5B%7B%22name%22%3A%22publisher%22%7D%2C%7B%22val%22%3A%22Facebook%22%7D%5D%2C%22op%22%3A%22eq%22%7D%7D%7D`,
     );
 
-    // Wait a bit for any redirects to happen
-    await page.waitForTimeout(2000);
+    // Wait for the redirect to the explore page with a rich stateful URL.
+    await page.waitForURL(
+      "**/explore/AdBids_metrics_explore?tr=2022-01-01T00%3A02%3A39.041Z%2C2022-03-30T23%3A59%3A54.560Z&grain=day&f=publisher+IN+%28%27Facebook%27%29&measures=bid_price_sum%2Ctotal_records&dims=publisher&expand_dim=publisher",
+    );
 
-    // Expect to get redirected to the explore page with a rich stateful URL
     expect(page.url()).toContain(
       "explore/AdBids_metrics_explore?tr=2022-01-01T00%3A02%3A39.041Z%2C2022-03-30T23%3A59%3A54.560Z&grain=day&f=publisher+IN+%28%27Facebook%27%29&measures=bid_price_sum%2Ctotal_records&dims=publisher&expand_dim=publisher",
     );

--- a/web-local/tests/explores/open-query.spec.ts
+++ b/web-local/tests/explores/open-query.spec.ts
@@ -1,4 +1,3 @@
-import { expect } from "@playwright/test";
 import { test } from "../setup/base";
 import { waitForReconciliation } from "../utils/wait-for-reconciliation.ts";
 
@@ -21,10 +20,6 @@ test.describe("Query-to-Explore routing", () => {
     // Wait for the redirect to the explore page with a rich stateful URL.
     await page.waitForURL(
       "**/explore/AdBids_metrics_explore?tr=2022-01-01T00%3A02%3A39.041Z%2C2022-03-30T23%3A59%3A54.560Z&grain=day&f=publisher+IN+%28%27Facebook%27%29&measures=bid_price_sum%2Ctotal_records&dims=publisher&expand_dim=publisher",
-    );
-
-    expect(page.url()).toContain(
-      "explore/AdBids_metrics_explore?tr=2022-01-01T00%3A02%3A39.041Z%2C2022-03-30T23%3A59%3A54.560Z&grain=day&f=publisher+IN+%28%27Facebook%27%29&measures=bid_price_sum%2Ctotal_records&dims=publisher&expand_dim=publisher",
     );
   });
 

--- a/web-local/tests/explores/pivot.spec.ts
+++ b/web-local/tests/explores/pivot.spec.ts
@@ -667,6 +667,9 @@ test.describe("pivot run through", () => {
       await page.getByRole("menuitem", { name: "Last 4 weeks" }).click();
     });
 
+    // Wait for the time-range change to re-run queries before dragging chips.
+    await expect(page.locator(".status.running")).toHaveCount(0);
+
     // add measure and time week to column
     await dragPivotChip(page, totalRecords, columnZone);
 

--- a/web-local/tests/explores/pivot.spec.ts
+++ b/web-local/tests/explores/pivot.spec.ts
@@ -667,8 +667,6 @@ test.describe("pivot run through", () => {
       await page.getByRole("menuitem", { name: "Last 4 weeks" }).click();
     });
 
-    await page.waitForTimeout(100);
-
     // add measure and time week to column
     await dragPivotChip(page, totalRecords, columnZone);
 

--- a/web-local/tests/explores/pivot.spec.ts
+++ b/web-local/tests/explores/pivot.spec.ts
@@ -667,8 +667,12 @@ test.describe("pivot run through", () => {
       await page.getByRole("menuitem", { name: "Last 4 weeks" }).click();
     });
 
-    // Wait for the time-range change to re-run queries before dragging chips.
-    await expect(page.locator(".status.running")).toHaveCount(0);
+    // Wait for the new time range to apply before dragging chips. The running
+    // status can flip too quickly to observe reliably, so assert the applied
+    // range instead.
+    await expect(page.getByLabel("Select time range")).toContainText(
+      "Last 4 Weeks",
+    );
 
     // add measure and time week to column
     await dragPivotChip(page, totalRecords, columnZone);

--- a/web-local/tests/explores/scrub.spec.ts
+++ b/web-local/tests/explores/scrub.spec.ts
@@ -18,7 +18,6 @@ async function setupDashboard(page: Page) {
   await interactWithTimeRangeMenu(page, async () => {
     await page.getByRole("menuitem", { name: "All Time" }).click();
   });
-  await page.waitForTimeout(1000);
 
   const valueLocator = bigNumber.locator('div[role="button"]');
   await expect(valueLocator).toBeVisible({ timeout: 5000 });
@@ -46,7 +45,6 @@ async function scrub(
   await page.mouse.down();
   await page.mouse.move(endX, centerY, { steps: 15 });
   await page.mouse.up();
-  await page.waitForTimeout(1500);
 }
 
 test.describe("chart scrub and zoom", () => {
@@ -56,18 +54,18 @@ test.describe("chart scrub and zoom", () => {
     page,
   }) => {
     const { valueLocator, box } = await setupDashboard(page);
-    const initialValue = await valueLocator.textContent();
+    const initialValue = (await valueLocator.textContent()) ?? "";
 
     await scrub(page, box, 0.2, 0.6);
 
-    const scrubValue = await valueLocator.textContent();
+    // The big number recomputes for the scrubbed range.
+    await expect(valueLocator).not.toHaveText(initialValue);
+    const scrubValue = (await valueLocator.textContent()) ?? "";
     expect(scrubValue).toBeTruthy();
-    expect(scrubValue).not.toBe(initialValue);
 
     await expect(page.getByLabel("Zoom")).toBeVisible({ timeout: 3000 });
 
     await page.keyboard.press("z");
-    await page.waitForTimeout(1500);
 
     await expect(page.getByLabel("Undo zoom")).toBeVisible({ timeout: 3000 });
     const timeRangeText = await page
@@ -75,15 +73,17 @@ test.describe("chart scrub and zoom", () => {
       .textContent();
     expect(timeRangeText).toContain("Custom");
 
-    const zoomedValue = await valueLocator.textContent();
-    expect(zoomedValue).toBe(scrubValue);
+    // Zooming to the scrubbed range keeps the same value.
+    await expect(valueLocator).toHaveText(scrubValue);
   });
 
   test("move scrub range updates big number", async ({ page }) => {
     const { valueLocator, box } = await setupDashboard(page);
+    const initialValue = (await valueLocator.textContent()) ?? "";
 
     await scrub(page, box, 0.2, 0.5);
-    const scrubValue = await valueLocator.textContent();
+    await expect(valueLocator).not.toHaveText(initialValue);
+    const scrubValue = (await valueLocator.textContent()) ?? "";
     expect(scrubValue).toBeTruthy();
 
     // Grab center of selection (35%) and drag right to 65%
@@ -95,19 +95,18 @@ test.describe("chart scrub and zoom", () => {
     await page.mouse.down();
     await page.mouse.move(dropX, centerY, { steps: 15 });
     await page.mouse.up();
-    await page.waitForTimeout(1500);
 
-    const movedValue = await valueLocator.textContent();
-    expect(movedValue).toBeTruthy();
-    expect(movedValue).not.toBe(scrubValue);
+    await expect(valueLocator).not.toHaveText(scrubValue);
     await expect(page.getByLabel("Zoom")).toBeVisible({ timeout: 3000 });
   });
 
   test("resize scrub start edge updates big number", async ({ page }) => {
     const { valueLocator, box } = await setupDashboard(page);
+    const initialValue = (await valueLocator.textContent()) ?? "";
 
     await scrub(page, box, 0.3, 0.7);
-    const scrubValue = await valueLocator.textContent();
+    await expect(valueLocator).not.toHaveText(initialValue);
+    const scrubValue = (await valueLocator.textContent()) ?? "";
     expect(scrubValue).toBeTruthy();
 
     // Drag left edge from 30% to 10%
@@ -119,19 +118,18 @@ test.describe("chart scrub and zoom", () => {
     await page.mouse.down();
     await page.mouse.move(newEdgeX, centerY, { steps: 15 });
     await page.mouse.up();
-    await page.waitForTimeout(1500);
 
-    const resizedValue = await valueLocator.textContent();
-    expect(resizedValue).toBeTruthy();
-    expect(resizedValue).not.toBe(scrubValue);
+    await expect(valueLocator).not.toHaveText(scrubValue);
     await expect(page.getByLabel("Zoom")).toBeVisible({ timeout: 3000 });
   });
 
   test("resize scrub end edge updates big number", async ({ page }) => {
     const { valueLocator, box } = await setupDashboard(page);
+    const initialValue = (await valueLocator.textContent()) ?? "";
 
     await scrub(page, box, 0.2, 0.5);
-    const scrubValue = await valueLocator.textContent();
+    await expect(valueLocator).not.toHaveText(initialValue);
+    const scrubValue = (await valueLocator.textContent()) ?? "";
     expect(scrubValue).toBeTruthy();
 
     // Drag right edge from 50% to 80%
@@ -143,11 +141,8 @@ test.describe("chart scrub and zoom", () => {
     await page.mouse.down();
     await page.mouse.move(newEdgeX, centerY, { steps: 15 });
     await page.mouse.up();
-    await page.waitForTimeout(1500);
 
-    const resizedValue = await valueLocator.textContent();
-    expect(resizedValue).toBeTruthy();
-    expect(resizedValue).not.toBe(scrubValue);
+    await expect(valueLocator).not.toHaveText(scrubValue);
     await expect(page.getByLabel("Zoom")).toBeVisible({ timeout: 3000 });
   });
 });

--- a/web-local/tests/explores/time-dimension-selection.spec.ts
+++ b/web-local/tests/explores/time-dimension-selection.spec.ts
@@ -9,7 +9,6 @@ async function waitForDashboard(page: Page) {
   await expect(page.getByLabel("Select time range")).toBeVisible({
     timeout: 10000,
   });
-  await page.waitForTimeout(1000);
 }
 
 function getMetricsViewYaml(includeSecondTimeDimension = false) {
@@ -73,7 +72,6 @@ test.describe("time dimension selection", () => {
     await waitForDashboard(page);
 
     await page.getByLabel("Select time range").click();
-    await page.waitForTimeout(500);
 
     const timeZoneButton = page.getByRole("button", { name: /Time zone/ });
     await expect(timeZoneButton).toBeVisible({ timeout: 5000 });
@@ -92,8 +90,6 @@ test.describe("time dimension selection", () => {
     await interactWithTimeRangeMenu(page, async () => {
       await page.getByRole("menuitem", { name: "Last 7 days" }).click();
     });
-
-    await page.waitForTimeout(1000);
 
     await expect(page.getByText("Last 7 Days")).toBeVisible();
 
@@ -136,7 +132,6 @@ test.describe("time dimension selection", () => {
     await interactWithTimeRangeMenu(page, async () => {
       await page.getByRole("menuitem", { name: "All Time" }).click();
     });
-    await page.waitForTimeout(1000);
 
     await expect(page.getByText("Publisher")).toBeVisible();
     await expect(

--- a/web-local/tests/explores/timeseries.spec.ts
+++ b/web-local/tests/explores/timeseries.spec.ts
@@ -148,9 +148,6 @@ test.describe("timeseries charts (rendering)", () => {
           })
           .click();
 
-        // Wait for chart to update with new data
-        await page.waitForTimeout(500);
-
         const apiData = await timeseriesPromise;
         expect(apiData.data.length).toBe(testCase.expectedDataPoints);
 
@@ -212,8 +209,6 @@ test.describe("timeseries charts system TZ independence", () => {
           exact: true,
         })
         .click();
-
-      await page.waitForTimeout(500);
 
       const apiData = await timeseriesPromise;
       expect(apiData.data.length).toBe(testCase.expectedDataPoints);

--- a/web-local/tests/explores/visual-explore-editing.spec.ts
+++ b/web-local/tests/explores/visual-explore-editing.spec.ts
@@ -40,12 +40,12 @@ test.describe("visual explore editing", () => {
     await page.getByRole("button", { name: "Default" }).first().click();
     await page.getByRole("button", { name: "Presets" }).click();
 
-    text = await page
-      .getByRole("textbox", { name: "codemirror editor" })
-      .textContent();
-
-    expect(text).toEqual(
-      ' 45123456789101112131415161718192021222324252627282930313233343536373839404142434445# Explore YAML# Reference documentation: https://docs.rilldata.com/reference/project-files/explore-dashboardstype: exploretitle: "Adbids dashboard"metrics_view: AdBids_metricsdimensions:  expr: "*"measures:  expr: "*"time_ranges:  - PT6H  - PT24H  - P7D  - P14D  - P4W  - P3M  - P12M  - rill-TD  - rill-WTD  - rill-MTD  - rill-QTD  - rill-YTD  - rill-PDC  - rill-PWC  - rill-PMC  - rill-PQC  - rill-PYCtime_zones:  - UTC  - America/Los_Angeles  - America/Chicago  - America/New_York  - Europe/London  - Europe/Paris  - Asia/Jerusalem  - Europe/Moscow  - Asia/Kolkata  - Asia/Shanghai  - Asia/Tokyo  - Australia/Sydney',
-    );
+    await expect
+      .poll(() =>
+        page.getByRole("textbox", { name: "codemirror editor" }).textContent(),
+      )
+      .toEqual(
+        ' 45123456789101112131415161718192021222324252627282930313233343536373839404142434445# Explore YAML# Reference documentation: https://docs.rilldata.com/reference/project-files/explore-dashboardstype: exploretitle: "Adbids dashboard"metrics_view: AdBids_metricsdimensions:  expr: "*"measures:  expr: "*"time_ranges:  - PT6H  - PT24H  - P7D  - P14D  - P4W  - P3M  - P12M  - rill-TD  - rill-WTD  - rill-MTD  - rill-QTD  - rill-YTD  - rill-PDC  - rill-PWC  - rill-PMC  - rill-PQC  - rill-PYCtime_zones:  - UTC  - America/Los_Angeles  - America/Chicago  - America/New_York  - Europe/London  - Europe/Paris  - Asia/Jerusalem  - Europe/Moscow  - Asia/Kolkata  - Asia/Shanghai  - Asia/Tokyo  - Australia/Sydney',
+      );
   });
 });

--- a/web-local/tests/explores/visual-explore-editing.spec.ts
+++ b/web-local/tests/explores/visual-explore-editing.spec.ts
@@ -24,13 +24,15 @@ test.describe("visual explore editing", () => {
     await page.getByRole("button", { name: "Custom" }).nth(1).click();
     await page.getByRole("button", { name: "Custom" }).nth(2).click();
 
-    let text = await page
-      .getByRole("textbox", { name: "codemirror editor" })
-      .textContent();
-
-    expect(text).toEqual(
-      ' 561234567891011121314151617181920212223242526272829303132333435363738394041424344454647484950515253545556# Explore YAML# Reference documentation: https://docs.rilldata.com/reference/project-files/explore-dashboardstype: exploretitle: "Adbids dashboard"metrics_view: AdBids_metricsdimensions:  - publisher  - domain  - timestamp  - offset_timestampmeasures:  - total_records  - bid_price_sumtime_ranges:  - PT6H  - PT24H  - P7D  - P14D  - P4W  - P12M  - rill-TD  - rill-WTD  - rill-MTD  - rill-QTD  - rill-YTD  - rill-PDC  - rill-PWC  - rill-PMC  - rill-PQC  - rill-PYC  - inftime_zones:  - UTC  - America/Los_Angeles  - America/Chicago  - America/New_York  - Europe/London  - Europe/Paris  - Asia/Jerusalem  - Europe/Moscow  - Asia/Kolkata  - Asia/Shanghai  - Asia/Tokyo  - Australia/Sydneytheme:  light:    primary: hsl(180, 100%, 50%)    secondary: lightgreen  dark:    primary: hsl(180, 100%, 50%)    secondary: lightgreen',
-    );
+    // Poll the editor content so the assertion waits for the visual-editor
+    // edits to flush into the code editor rather than reading mid-update.
+    await expect
+      .poll(() =>
+        page.getByRole("textbox", { name: "codemirror editor" }).textContent(),
+      )
+      .toEqual(
+        ' 561234567891011121314151617181920212223242526272829303132333435363738394041424344454647484950515253545556# Explore YAML# Reference documentation: https://docs.rilldata.com/reference/project-files/explore-dashboardstype: exploretitle: "Adbids dashboard"metrics_view: AdBids_metricsdimensions:  - publisher  - domain  - timestamp  - offset_timestampmeasures:  - total_records  - bid_price_sumtime_ranges:  - PT6H  - PT24H  - P7D  - P14D  - P4W  - P12M  - rill-TD  - rill-WTD  - rill-MTD  - rill-QTD  - rill-YTD  - rill-PDC  - rill-PWC  - rill-PMC  - rill-PQC  - rill-PYC  - inftime_zones:  - UTC  - America/Los_Angeles  - America/Chicago  - America/New_York  - Europe/London  - Europe/Paris  - Asia/Jerusalem  - Europe/Moscow  - Asia/Kolkata  - Asia/Shanghai  - Asia/Tokyo  - Australia/Sydneytheme:  light:    primary: hsl(180, 100%, 50%)    secondary: lightgreen  dark:    primary: hsl(180, 100%, 50%)    secondary: lightgreen',
+      );
 
     await page.getByRole("button", { name: "Expression" }).first().click();
     await page.getByRole("button", { name: "Expression" }).nth(1).click();

--- a/web-local/tests/explores/visual-explore-editing.spec.ts
+++ b/web-local/tests/explores/visual-explore-editing.spec.ts
@@ -14,7 +14,6 @@ test.describe("visual explore editing", () => {
     await waitForReconciliation(page);
 
     await page.getByLabel("/dashboards").click();
-    await page.waitForTimeout(1000);
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
     await page.getByRole("button", { name: "switch to code editor" }).click();
 

--- a/web-local/tests/explores/visual-explore-editing.spec.ts
+++ b/web-local/tests/explores/visual-explore-editing.spec.ts
@@ -30,8 +30,8 @@ test.describe("visual explore editing", () => {
       .poll(() =>
         page.getByRole("textbox", { name: "codemirror editor" }).textContent(),
       )
-      .toEqual(
-        ' 561234567891011121314151617181920212223242526272829303132333435363738394041424344454647484950515253545556# Explore YAML# Reference documentation: https://docs.rilldata.com/reference/project-files/explore-dashboardstype: exploretitle: "Adbids dashboard"metrics_view: AdBids_metricsdimensions:  - publisher  - domain  - timestamp  - offset_timestampmeasures:  - total_records  - bid_price_sumtime_ranges:  - PT6H  - PT24H  - P7D  - P14D  - P4W  - P12M  - rill-TD  - rill-WTD  - rill-MTD  - rill-QTD  - rill-YTD  - rill-PDC  - rill-PWC  - rill-PMC  - rill-PQC  - rill-PYC  - inftime_zones:  - UTC  - America/Los_Angeles  - America/Chicago  - America/New_York  - Europe/London  - Europe/Paris  - Asia/Jerusalem  - Europe/Moscow  - Asia/Kolkata  - Asia/Shanghai  - Asia/Tokyo  - Australia/Sydneytheme:  light:    primary: hsl(180, 100%, 50%)    secondary: lightgreen  dark:    primary: hsl(180, 100%, 50%)    secondary: lightgreen',
+      .toContain(
+        '# Explore YAML# Reference documentation: https://docs.rilldata.com/reference/project-files/explore-dashboardstype: exploretitle: "Adbids dashboard"metrics_view: AdBids_metricsdimensions:  - publisher  - domain  - timestamp  - offset_timestampmeasures:  - total_records  - bid_price_sumtime_ranges:  - PT6H  - PT24H  - P7D  - P14D  - P4W  - P12M  - rill-TD  - rill-WTD  - rill-MTD  - rill-QTD  - rill-YTD  - rill-PDC  - rill-PWC  - rill-PMC  - rill-PQC  - rill-PYC  - inftime_zones:  - UTC  - America/Los_Angeles  - America/Chicago  - America/New_York  - Europe/London  - Europe/Paris  - Asia/Jerusalem  - Europe/Moscow  - Asia/Kolkata  - Asia/Shanghai  - Asia/Tokyo  - Australia/Sydneytheme:  light:    primary: hsl(180, 100%, 50%)    secondary: lightgreen  dark:    primary: hsl(180, 100%, 50%)    secondary: lightgreen',
       );
 
     await page.getByRole("button", { name: "Expression" }).first().click();
@@ -44,8 +44,8 @@ test.describe("visual explore editing", () => {
       .poll(() =>
         page.getByRole("textbox", { name: "codemirror editor" }).textContent(),
       )
-      .toEqual(
-        ' 45123456789101112131415161718192021222324252627282930313233343536373839404142434445# Explore YAML# Reference documentation: https://docs.rilldata.com/reference/project-files/explore-dashboardstype: exploretitle: "Adbids dashboard"metrics_view: AdBids_metricsdimensions:  expr: "*"measures:  expr: "*"time_ranges:  - PT6H  - PT24H  - P7D  - P14D  - P4W  - P3M  - P12M  - rill-TD  - rill-WTD  - rill-MTD  - rill-QTD  - rill-YTD  - rill-PDC  - rill-PWC  - rill-PMC  - rill-PQC  - rill-PYCtime_zones:  - UTC  - America/Los_Angeles  - America/Chicago  - America/New_York  - Europe/London  - Europe/Paris  - Asia/Jerusalem  - Europe/Moscow  - Asia/Kolkata  - Asia/Shanghai  - Asia/Tokyo  - Australia/Sydney',
+      .toContain(
+        '# Explore YAML# Reference documentation: https://docs.rilldata.com/reference/project-files/explore-dashboardstype: exploretitle: "Adbids dashboard"metrics_view: AdBids_metricsdimensions:  expr: "*"measures:  expr: "*"time_ranges:  - PT6H  - PT24H  - P7D  - P14D  - P4W  - P3M  - P12M  - rill-TD  - rill-WTD  - rill-MTD  - rill-QTD  - rill-YTD  - rill-PDC  - rill-PWC  - rill-PMC  - rill-PQC  - rill-PYCtime_zones:  - UTC  - America/Los_Angeles  - America/Chicago  - America/New_York  - Europe/London  - Europe/Paris  - Asia/Jerusalem  - Europe/Moscow  - Asia/Kolkata  - Asia/Shanghai  - Asia/Tokyo  - Australia/Sydney',
       );
   });
 });

--- a/web-local/tests/file-explorer.spec.ts
+++ b/web-local/tests/file-explorer.spec.ts
@@ -39,8 +39,6 @@ test.describe("File Explorer", () => {
       await page.getByRole("textbox").nth(1).click();
       await page.keyboard.type("Here's a README.md file for the e2e test!");
       await page.getByRole("button", { name: "Save" }).click();
-      // Wait half a second for the changes to be saved
-      await page.waitForTimeout(500);
       // Navigate away from the file and back to it to verify the changes
       await page.getByRole("link", { name: "rill.yaml" }).click();
       await page.getByRole("link", { name: "README.md" }).first().click();
@@ -90,9 +88,6 @@ test.describe("File Explorer", () => {
       await page.getByLabel("Folder name").fill("my-directory");
       await page.getByLabel("Folder name").press("Enter");
 
-      // Page reloads in test environment
-      await page.waitForTimeout(2000);
-
       // Add something to the folder
       await page.getByRole("directory", { name: "my-directory" }).hover();
       await page.getByLabel("my-directory actions menu").click();
@@ -115,7 +110,6 @@ test.describe("File Explorer", () => {
         }),
       ).toBeVisible();
 
-      await page.waitForTimeout(2000);
       // Delete the folder
       await page
         .getByRole("button", { name: "my-directory my-directory" })

--- a/web-local/tests/file-explorer.spec.ts
+++ b/web-local/tests/file-explorer.spec.ts
@@ -38,7 +38,11 @@ test.describe("File Explorer", () => {
       await page.getByLabel("Auto-save").click(); // Turn off auto-save
       await page.getByRole("textbox").nth(1).click();
       await page.keyboard.type("Here's a README.md file for the e2e test!");
-      await page.getByRole("button", { name: "Save" }).click();
+      // Wait for the file write to complete so navigating away doesn't race it.
+      await Promise.all([
+        page.waitForResponse("**/rill.runtime.v1.RuntimeService/PutFile"),
+        page.getByRole("button", { name: "Save" }).click(),
+      ]);
       // Navigate away from the file and back to it to verify the changes
       await page.getByRole("link", { name: "rill.yaml" }).click();
       await page.getByRole("link", { name: "README.md" }).first().click();
@@ -87,6 +91,12 @@ test.describe("File Explorer", () => {
       await page.getByLabel("Folder name").press("Meta+a");
       await page.getByLabel("Folder name").fill("my-directory");
       await page.getByLabel("Folder name").press("Enter");
+
+      // The rename triggers a reload in the test environment; wait for the
+      // renamed entry to render before interacting with it.
+      await expect(
+        page.getByRole("directory", { name: "my-directory" }),
+      ).toBeVisible();
 
       // Add something to the folder
       await page.getByRole("directory", { name: "my-directory" }).hover();

--- a/web-local/tests/file-explorer.spec.ts
+++ b/web-local/tests/file-explorer.spec.ts
@@ -38,11 +38,11 @@ test.describe("File Explorer", () => {
       await page.getByLabel("Auto-save").click(); // Turn off auto-save
       await page.getByRole("textbox").nth(1).click();
       await page.keyboard.type("Here's a README.md file for the e2e test!");
-      // Wait for the file write to complete so navigating away doesn't race it.
-      await Promise.all([
-        page.waitForResponse("**/rill.runtime.v1.RuntimeService/PutFile"),
-        page.getByRole("button", { name: "Save" }).click(),
-      ]);
+      const saveButton = page.getByRole("button", { name: "Save" });
+      await saveButton.click();
+      // The Save button disables once the write finishes; wait for that UI
+      // feedback so navigating away doesn't race the save.
+      await expect(saveButton).toBeDisabled();
       // Navigate away from the file and back to it to verify the changes
       await page.getByRole("link", { name: "rill.yaml" }).click();
       await page.getByRole("link", { name: "README.md" }).first().click();


### PR DESCRIPTION
Tier 1 of improving frontend e2e test performance & flakiness — quick wins, low risk.

- Enable Playwright retries in CI (`retries: process.env.CI ? 2 : 0`) with a flaky-aware reporter (`[["github"], ["blob"], ["html"]]`) in `web-local`, `web-admin`, and `web-integration` configs. Retries absorb genuine infra noise and surface pass-on-retry tests as *flaky* rather than hiding them; the `blob` report is the data source for later flaky tracking.
- Replace ~76 arbitrary `page.waitForTimeout()` sleeps with web-first waits — `expect.poll`, `expect().not.toHaveText()`, `toBeAttached()`, `waitForResponse`, `waitForURL`. Biggest cleanups: `embeds.spec.ts` (25 → 0, helpers now poll the message log), `scrub.spec.ts` (6), `time-dimension-selection.spec.ts` (4), and `leaderboard-and-dim-table-sort.spec.ts` (now polls layout, fixing the underlying one-shot-`boundingBox` flakiness). Only two genuinely non-awaitable sleeps remain in `annotations.spec.ts`, each with a justifying `eslint-disable` comment.
- Add a `playwright/no-wait-for-timeout` ESLint guard (error level) scoped to `**/tests/**/*.spec.ts` to prevent new sleeps; wired through the existing `npm run quality` gate.

Shared helper/fixture debounce waits are intentionally left for Tier 2 (runtime-reuse + shared readiness helper).

Verified: all touched files lint clean, `playwright test --list` loads all 73 (web-admin) + 105 (web-local) tests, Prettier passes, and the guard fires as an error on a new `waitForTimeout`.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*
