### PR TITLE
validation for bounded range for data time range

### DIFF
--- a/docs/docs/developers/build/metrics-view/rollups.md
+++ b/docs/docs/developers/build/metrics-view/rollups.md
@@ -96,7 +96,7 @@ You can declare coverage on the metrics view itself the same way — this skips 
 data_time_range: -5Y to now
 ```
 
-When `data_time_range` is set, the rilltime expression is resolved against fixed anchors at query time: `now`/`latest`/`watermark` all resolve to the current wallclock, and `earliest` resolves to the zero epoch. So `inf` (a shorthand for `earliest to latest`) declares "all time from zero epoch to now." Mixing declared and undeclared rollups in the same metrics view is fine — each table independently decides whether to probe or to use its declaration.
+When `data_time_range` is set, the rilltime expression is resolved against fixed anchors: `now`/`latest`/`watermark` all resolve to the current wallclock. The start must be bounded — `inf` and `earliest` are rejected, because they resolve start time to the zero time value, which the system treats as "no data". To declare full historical coverage, either omit `data_time_range` so the bounds are probed from the table, or use a concrete early bound such as `-100Y to now`. Mixing declared and undeclared rollups in the same metrics view is fine — each table independently decides whether to probe or to use its declaration.
 
 ### Selection Priority and Definition Order
 

--- a/docs/docs/reference/project-files/metrics-views.md
+++ b/docs/docs/reference/project-files/metrics-views.md
@@ -62,7 +62,7 @@ _[string]_ - A SQL expression that tells us the max timestamp that the measures 
 
 ### `data_time_range`
 
-_[string]_ - Optional [rilltime](https://docs.rilldata.com/reference/time-syntax) expression describing the base table's time coverage (e.g. `-5Y to now`, `inf`). When set, Rill skips the `min`/`max` OLAP probe for the base table and uses the declared bounds for coverage checks. 
+_[string]_ - Optional [rilltime](https://docs.rilldata.com/reference/time-syntax) expression describing the base table's time coverage (e.g. `-5Y to now`). When set, Rill skips the `min`/`max` OLAP probe for the base table and uses the declared bounds for coverage checks. The start must be bounded; `inf` and `earliest` are rejected. To declare full history, use a concrete early bound such as `-100Y to now` or omit this field to probe the table. 
 
 ### `smallest_time_grain`
 
@@ -316,7 +316,7 @@ _[array of object]_ - Pre-aggregated rollup tables that can be used to accelerat
 
       - **`exclude`** - _[object]_ - Select all fields except those listed here 
 
-  - **`data_time_range`** - _[string]_ - Optional [rilltime](https://docs.rilldata.com/reference/time-syntax) expression describing the rollup's time coverage (e.g. `-1Y to now`, `-5Y to -1Y`, `inf`). When set, Rill skips the `min`/`max` OLAP probe for this rollup and uses the declared bounds for coverage checks. 
+  - **`data_time_range`** - _[string]_ - Optional [rilltime](https://docs.rilldata.com/reference/time-syntax) expression describing the rollup's time coverage (e.g. `-1Y to now`, `-5Y to -1Y`). When set, Rill skips the `min`/`max` OLAP probe for this rollup and uses the declared bounds for coverage checks. The start must be bounded; `inf` and `earliest` are rejected. To declare full history, use a concrete early bound such as `-100Y to now` or omit this field to probe the table. 
 
 ### `security`
 

--- a/proto/gen/rill/runtime/v1/resources.pb.go
+++ b/proto/gen/rill/runtime/v1/resources.pb.go
@@ -1992,7 +1992,6 @@ type MetricsViewSpec struct {
 	WatermarkExpression string `protobuf:"bytes,20,opt,name=watermark_expression,json=watermarkExpression,proto3" json:"watermark_expression,omitempty"`
 	// Optional rilltime expression describing the time range covered by the base table.
 	// When set, the base table's coverage is resolved from this expression instead of probing the OLAP for min/max timestamps.
-	// Evaluated with `now` = current time, `earliest` = zero time, `latest`/`watermark` = current time.
 	DataTimeRange string `protobuf:"bytes,37,opt,name=data_time_range,json=dataTimeRange,proto3" json:"data_time_range,omitempty"`
 	// Dimensions in the metrics view
 	Dimensions []*MetricsViewSpec_Dimension `protobuf:"bytes,6,rep,name=dimensions,proto3" json:"dimensions,omitempty"`
@@ -7532,7 +7531,6 @@ type MetricsViewSpec_Rollup struct {
 	Model          string `protobuf:"bytes,4,opt,name=model,proto3" json:"model,omitempty"`
 	// Optional rilltime expression describing the time range covered by the rollup.
 	// When set, the rollup's coverage is resolved from this expression instead of probing the OLAP for min/max timestamps.
-	// Evaluated with `now` = current time, `earliest` = zero time, `latest`/`watermark` = current time.
 	DataTimeRange string `protobuf:"bytes,11,opt,name=data_time_range,json=dataTimeRange,proto3" json:"data_time_range,omitempty"`
 	// Time grain of the rollup.
 	TimeGrain TimeGrain `protobuf:"varint,5,opt,name=time_grain,json=timeGrain,proto3,enum=rill.runtime.v1.TimeGrain" json:"time_grain,omitempty"`

--- a/proto/gen/rill/runtime/v1/runtime.swagger.yaml
+++ b/proto/gen/rill/runtime/v1/runtime.swagger.yaml
@@ -3904,7 +3904,6 @@ definitions:
         description: |-
           Optional rilltime expression describing the time range covered by the rollup.
           When set, the rollup's coverage is resolved from this expression instead of probing the OLAP for min/max timestamps.
-          Evaluated with `now` = current time, `earliest` = zero time, `latest`/`watermark` = current time.
       timeGrain:
         $ref: '#/definitions/v1TimeGrain'
         description: Time grain of the rollup.
@@ -6532,7 +6531,6 @@ definitions:
         description: |-
           Optional rilltime expression describing the time range covered by the base table.
           When set, the base table's coverage is resolved from this expression instead of probing the OLAP for min/max timestamps.
-          Evaluated with `now` = current time, `earliest` = zero time, `latest`/`watermark` = current time.
       dimensions:
         type: array
         items:

--- a/proto/rill/runtime/v1/resources.proto
+++ b/proto/rill/runtime/v1/resources.proto
@@ -310,7 +310,6 @@ message MetricsViewSpec {
     string model = 4;
     // Optional rilltime expression describing the time range covered by the rollup.
     // When set, the rollup's coverage is resolved from this expression instead of probing the OLAP for min/max timestamps.
-    // Evaluated with `now` = current time, `earliest` = zero time, `latest`/`watermark` = current time.
     string data_time_range = 11;
     // Time grain of the rollup.
     TimeGrain time_grain = 5;
@@ -350,7 +349,6 @@ message MetricsViewSpec {
   string watermark_expression = 20;
   // Optional rilltime expression describing the time range covered by the base table.
   // When set, the base table's coverage is resolved from this expression instead of probing the OLAP for min/max timestamps.
-  // Evaluated with `now` = current time, `earliest` = zero time, `latest`/`watermark` = current time.
   string data_time_range = 37;
   // Dimensions in the metrics view
   repeated Dimension dimensions = 6;

--- a/runtime/metricsview/executor/executor.go
+++ b/runtime/metricsview/executor/executor.go
@@ -175,7 +175,7 @@ func (e *Executor) Timestamps(ctx context.Context, timeDim string) (metricsview.
 		timeDim = e.metricsView.TimeDimension
 	}
 
-	if res, ok := e.timestamps[timeDim]; ok && !res.Min.IsZero() {
+	if res, ok := e.timestamps[timeDim]; ok {
 		return res, nil
 	}
 

--- a/runtime/parser/parse_metrics_view.go
+++ b/runtime/parser/parse_metrics_view.go
@@ -314,8 +314,7 @@ func (p *Parser) parseMetricsView(node *Node) error {
 	}
 
 	if tmp.DataTimeRange != "" {
-		_, err := rilltime.Parse(tmp.DataTimeRange, rilltime.ParseOptions{})
-		if err != nil {
+		if err := validateDataTimeRange(tmp.DataTimeRange); err != nil {
 			return fmt.Errorf(`invalid "data_time_range": %w`, err)
 		}
 	}
@@ -801,7 +800,7 @@ func (p *Parser) parseMetricsView(node *Node) error {
 			}
 		}
 		if rollup.DataTimeRange != "" {
-			if _, err := rilltime.Parse(rollup.DataTimeRange, rilltime.ParseOptions{}); err != nil {
+			if err := validateDataTimeRange(rollup.DataTimeRange); err != nil {
 				return fmt.Errorf(`rollup[%d]: invalid "data_time_range": %w`, i, err)
 			}
 		}
@@ -1266,6 +1265,24 @@ func inferRefsFromSecurityRules(rules []*runtimev1.SecurityRule) ([]ResourceName
 	}
 	// No need to deduplicate because that's done upstream when the resource is inserted.
 	return refs, nil
+}
+
+// validateDataTimeRange parses a data_time_range expression and rejects it if it resolves to an
+// unbounded lower bound (e.g. "inf" or "earliest to now"). A zero start is the system-wide assumption
+// for "no time data present" (see valOrNullTime in the server and the metrics_time_range resolver),
+// so a declared range must have a concrete start; otherwise omit data_time_range to probe the table.
+func validateDataTimeRange(expr string) error {
+	rt, err := rilltime.Parse(expr, rilltime.ParseOptions{})
+	if err != nil {
+		return err
+	}
+	// Evaluate against the same synthetic anchors used when resolving declared ranges.
+	now := time.Now()
+	start, _, _ := rt.Eval(rilltime.EvalOptions{Now: now, MinTime: time.Time{}, MaxTime: now, Watermark: now})
+	if start.IsZero() {
+		return errors.New("must have a bounded start; \"inf\" and \"earliest\" resolve to an unbounded lower bound which the system treats as no data (use a concrete range like \"-90d to now\", or omit data_time_range to detect bounds from the table)")
+	}
+	return nil
 }
 
 // validateQueryAttributes validates query attribute keys

--- a/runtime/parser/parse_metrics_view_test.go
+++ b/runtime/parser/parse_metrics_view_test.go
@@ -853,6 +853,62 @@ measures:
 `,
 			wantErr: `invalid "data_time_range"`,
 		},
+		{
+			name: "unbounded metrics view data_time_range (inf)",
+			yaml: `
+type: metrics_view
+version: 1
+model: m1
+timeseries: id
+data_time_range: "inf"
+dimensions:
+- name: publisher
+  column: publisher
+measures:
+- name: count
+  expression: "COUNT(*)"
+`,
+			wantErr: `must have a bounded start`,
+		},
+		{
+			name: "unbounded metrics view data_time_range (earliest to now)",
+			yaml: `
+type: metrics_view
+version: 1
+model: m1
+timeseries: id
+data_time_range: "earliest to now"
+dimensions:
+- name: publisher
+  column: publisher
+measures:
+- name: count
+  expression: "COUNT(*)"
+`,
+			wantErr: `must have a bounded start`,
+		},
+		{
+			name: "unbounded rollup data_time_range (inf)",
+			yaml: `
+type: metrics_view
+version: 1
+model: m1
+timeseries: id
+dimensions:
+- name: publisher
+  column: publisher
+measures:
+- name: count
+  expression: "COUNT(*)"
+rollups:
+  - model: r1
+    time_grain: day
+    measures:
+      - count
+    data_time_range: "inf"
+`,
+			wantErr: `must have a bounded start`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -868,6 +924,42 @@ measures:
 			require.NoError(t, err)
 			require.NotEmpty(t, p.Errors)
 			require.Contains(t, p.Errors[0].Message, tt.wantErr)
+		})
+	}
+}
+
+func TestMetricsViewDataTimeRangeBounded(t *testing.T) {
+	// Bounded ranges (relative and absolute) must pass validation; only an unbounded start is rejected.
+	for _, expr := range []string{"-90d to now", "-1Y to now", "2020-01-01 to now", "-3M to -1M"} {
+		t.Run(expr, func(t *testing.T) {
+			yaml := `
+type: metrics_view
+version: 1
+model: m1
+timeseries: id
+data_time_range: "` + expr + `"
+dimensions:
+- name: publisher
+  column: publisher
+measures:
+- name: count
+  expression: "COUNT(*)"
+rollups:
+  - model: r1
+    time_grain: day
+    measures:
+      - count
+    data_time_range: "` + expr + `"
+`
+			files := map[string]string{
+				`rill.yaml`:              ``,
+				`models/m1.sql`:          `SELECT 1 AS id`,
+				`models/r1.sql`:          `SELECT 1 AS id`,
+				`metrics_views/mv1.yaml`: yaml,
+			}
+			p, err := Parse(context.Background(), makeRepo(t, files), "", "", "duckdb", true)
+			require.NoError(t, err)
+			require.Empty(t, p.Errors)
 		})
 	}
 }

--- a/runtime/parser/schema/project.schema.yaml
+++ b/runtime/parser/schema/project.schema.yaml
@@ -2078,7 +2078,7 @@ definitions:
             description: A SQL expression that tells us the max timestamp that the measures are considered valid for. Usually does not need to be overwritten
           data_time_range:
             type: string
-            description: 'Optional [rilltime](https://docs.rilldata.com/reference/time-syntax) expression describing the base table''s time coverage (e.g. `-5Y to now`, `inf`). When set, Rill skips the `min`/`max` OLAP probe for the base table and uses the declared bounds for coverage checks.'
+            description: 'Optional [rilltime](https://docs.rilldata.com/reference/time-syntax) expression describing the base table''s time coverage (e.g. `-5Y to now`). When set, Rill skips the `min`/`max` OLAP probe for the base table and uses the declared bounds for coverage checks. The start must be bounded; `inf` and `earliest` are rejected. To declare full history, use a concrete early bound such as `-100Y to now` or omit this field to probe the table.'
           smallest_time_grain:
             type: string
             description: 'Refers to the smallest time granularity the user is allowed to view. The valid values are: millisecond, second, minute, hour, day, week, month, quarter, year'
@@ -2311,7 +2311,7 @@ definitions:
                   description: Optional field selectors for measures to include in the rollup from the base metrics view. If not specified, all measures are included.
                 data_time_range:
                   type: string
-                  description: 'Optional [rilltime](https://docs.rilldata.com/reference/time-syntax) expression describing the rollup''s time coverage (e.g. `-1Y to now`, `-5Y to -1Y`, `inf`). When set, Rill skips the `min`/`max` OLAP probe for this rollup and uses the declared bounds for coverage checks.'
+                  description: 'Optional [rilltime](https://docs.rilldata.com/reference/time-syntax) expression describing the rollup''s time coverage (e.g. `-1Y to now`, `-5Y to -1Y`). When set, Rill skips the `min`/`max` OLAP probe for this rollup and uses the declared bounds for coverage checks. The start must be bounded; `inf` and `earliest` are rejected. To declare full history, use a concrete early bound such as `-100Y to now` or omit this field to probe the table.'
               required:
                 - model
                 - time_grain

--- a/web-common/src/proto/gen/rill/runtime/v1/resources_pb.ts
+++ b/web-common/src/proto/gen/rill/runtime/v1/resources_pb.ts
@@ -1452,7 +1452,6 @@ export class MetricsViewSpec extends Message<MetricsViewSpec> {
   /**
    * Optional rilltime expression describing the time range covered by the base table.
    * When set, the base table's coverage is resolved from this expression instead of probing the OLAP for min/max timestamps.
-   * Evaluated with `now` = current time, `earliest` = zero time, `latest`/`watermark` = current time.
    *
    * @generated from field: string data_time_range = 37;
    */
@@ -2213,7 +2212,6 @@ export class MetricsViewSpec_Rollup extends Message<MetricsViewSpec_Rollup> {
   /**
    * Optional rilltime expression describing the time range covered by the rollup.
    * When set, the rollup's coverage is resolved from this expression instead of probing the OLAP for min/max timestamps.
-   * Evaluated with `now` = current time, `earliest` = zero time, `latest`/`watermark` = current time.
    *
    * @generated from field: string data_time_range = 11;
    */


### PR DESCRIPTION
In [metrics time range resolver](https://github.com/rilldata/rill/blob/c23db2523748a8fdfa2fa69d5e8ced170d2c17af/runtime/resolvers/metricsview_time_range.go#L151) and other places we treat zero time as no data. When rill time like `inf` is used then returns start as zero time and that gets converted to nil values for all min/max timestamps so disallow such unbonded time ranges when defining static data time ranges.

I thought of changing the behaviour but if `min` is zero time that means 0001 year in golang, does that even mean anything? also `MetricsViewTimeRange` API converts zero time to `nil` and UI currently does not do queries if min time in `nil`. So we are already assuming at various places that zero time means no data.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
