### PR TITLE
allow uri dimension in rollup selection

### DIFF
--- a/runtime/metricsview/executor/executor_rewrite_rollup.go
+++ b/runtime/metricsview/executor/executor_rewrite_rollup.go
@@ -404,7 +404,7 @@ func rollupEligible(rollup *runtimev1.MetricsViewSpec_Rollup, qry *metricsview.Q
 		if m.Compute != nil {
 			refName, ok := comparisonReferencedMeasure(m.Compute)
 			if !ok {
-				// Non-comparison compute (count, count_distinct, URI, percent_of_total, etc.)
+				// Non-comparison compute (count, count_distinct, percent_of_total, etc.)
 				return false, rejectComputedMeasure, nil
 			}
 			// refName == "" for ComparisonTime: pure date arithmetic, no measure dependency.
@@ -556,7 +556,7 @@ func checkEndAlignment(end, baseMax time.Time, grain runtimev1.TimeGrain, loc *t
 // comparisonReferencedMeasure returns the base measure referenced by a comparison-derived compute,
 // along with ok=true if the compute is a comparison type that's safe to evaluate against a rollup.
 // Returns ("", true) for ComparisonTime since it is pure date arithmetic with no measure dependency.
-// Returns ("", false) for non-comparison computes (count, count_distinct, percent_of_total, uri),
+// Returns ("", false) for non-comparison computes (count, count_distinct, percent_of_total),
 // which cannot be correctly re-aggregated from a pre-aggregated rollup table.
 func comparisonReferencedMeasure(c *metricsview.MeasureCompute) (string, bool) {
 	switch {
@@ -567,6 +567,8 @@ func comparisonReferencedMeasure(c *metricsview.MeasureCompute) (string, bool) {
 	case c.ComparisonRatio != nil:
 		return c.ComparisonRatio.Measure, true
 	case c.ComparisonTime != nil:
+		return "", true
+	case c.URI != nil:
 		return "", true
 	}
 	return "", false

--- a/runtime/metricsview/executor/executor_rewrite_rollup_test.go
+++ b/runtime/metricsview/executor/executor_rewrite_rollup_test.go
@@ -358,7 +358,7 @@ func TestRollupEligible_ComparisonDeltaMissingReferencedMeasure(t *testing.T) {
 }
 
 func TestRollupEligible_CountStillRejected(t *testing.T) {
-	// Non-comparison computed measures (count, count_distinct, percent_of_total, uri) remain rejected.
+	// Non-comparison computed measures (count, count_distinct, percent_of_total) remain rejected.
 	rollup := &runtimev1.MetricsViewSpec_Rollup{
 		Table:     "daily_rollup",
 		TimeGrain: runtimev1.TimeGrain_TIME_GRAIN_DAY,


### PR DESCRIPTION
Dimensions with URI are sent as computed measures by the UI and were getting rejected in rollup selection. 

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
