### PR TITLE
fix: canvas component sub/unsub lifecycle

### DIFF
--- a/web-common/src/features/canvas/CanvasBuilder.svelte
+++ b/web-common/src/features/canvas/CanvasBuilder.svelte
@@ -63,7 +63,6 @@
       componentsStore,
       processRows,
       specStore,
-      unsubscribe,
       _rows,
       firstLoad,
     },
@@ -106,7 +105,7 @@
 
   $: maxWidth = canvasMaxWidth || DEFAULT_DASHBOARD_WIDTH;
 
-  $: specCanvasRows = structuredClone(rows) as V1CanvasRow[];
+  $: specCanvasRows = structuredClone(rows);
 
   $: rawYamlRows = rowsGuard(contents?.get("rows"));
   $: yamlCanvasRows = mapGuard(rawYamlRows);
@@ -433,8 +432,6 @@
     if (timeout) {
       clearTimeout(timeout);
     }
-
-    unsubscribe();
   });
 </script>
 

--- a/web-common/src/features/canvas/CanvasInitialization.svelte
+++ b/web-common/src/features/canvas/CanvasInitialization.svelte
@@ -173,6 +173,7 @@
     }
 
     existingStore?.canvasEntity?.resubscribe();
+    unsubscribe?.(); // cleanup old entities if any
     unsubscribe = existingStore?.canvasEntity?.unsubscribe;
 
     return existingStore;

--- a/web-common/src/features/canvas/CanvasInitialization.svelte
+++ b/web-common/src/features/canvas/CanvasInitialization.svelte
@@ -18,6 +18,7 @@
   } from "@rilldata/web-common/runtime-client";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
   import { createQueryServiceResolveCanvas } from "@rilldata/web-common/runtime-client";
+  import { onDestroy } from "svelte";
   const PollIntervalWhenDashboardFirstReconciling = 1000;
   const PollIntervalWhenDashboardErrored = 5000;
 
@@ -103,6 +104,8 @@
     });
   }
 
+  let unsubscribe: (() => void) | undefined = undefined;
+
   onNavigate(() => {
     if (hasBanner) {
       eventBus.emit("remove-banner", DashboardBannerID);
@@ -169,8 +172,15 @@
       }
     }
 
+    existingStore?.canvasEntity?.resubscribe();
+    unsubscribe = existingStore?.canvasEntity?.unsubscribe;
+
     return existingStore;
   }
+
+  onDestroy(() => {
+    unsubscribe?.();
+  });
 </script>
 
 <svelte:head>

--- a/web-common/src/features/canvas/stores/canvas-entity.ts
+++ b/web-common/src/features/canvas/stores/canvas-entity.ts
@@ -512,6 +512,8 @@ export class CanvasEntity {
     this.timeManager.state.onUrlChange(searchParams);
   };
 
+  // Resubscribes to the spec store. Internal call to processSpec will recreate the components.
+  // This ensures that cached canvas entities are not left in an error state.
   resubscribe = () => {
     this.unsubscriber = this.specStore.subscribe(({ data }) => {
       if (this.firstTimeLoad) {

--- a/web-common/src/features/canvas/stores/canvas-entity.ts
+++ b/web-common/src/features/canvas/stores/canvas-entity.ts
@@ -178,15 +178,7 @@ export class CanvasEntity {
       this._metricsViews,
     );
 
-    this.unsubscriber = this.specStore.subscribe(({ data }) => {
-      if (this.firstTimeLoad) {
-        this.firstTimeLoad = false;
-        return;
-      }
-      if (data) {
-        this.processSpec(data);
-      }
-    });
+    this.resubscribe();
 
     this.viewingDefaultsStore = derived(
       [
@@ -518,6 +510,18 @@ export class CanvasEntity {
     this.searchParams.set(searchParams);
     this.saveSnapshot(searchParams.toString());
     this.timeManager.state.onUrlChange(searchParams);
+  };
+
+  resubscribe = () => {
+    this.unsubscriber = this.specStore.subscribe(({ data }) => {
+      if (this.firstTimeLoad) {
+        this.firstTimeLoad = false;
+        return;
+      }
+      if (data) {
+        this.processSpec(data);
+      }
+    });
   };
 
   // Tears down the spec subscription opened in the constructor and disposes


### PR DESCRIPTION
Switching between code and no-code modes in canvas throws a no component found error. This is because we cleanup on unmount of no-code variant but do not re-init on mount.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
