### PR TITLE
Surface time dimensions in time pickers

### DIFF
--- a/web-common/src/components/forms/Input.svelte
+++ b/web-common/src/components/forms/Input.svelte
@@ -47,7 +47,15 @@
   export let leadingIcon: ComponentType<SvelteComponent> | undefined =
     undefined;
   export let options:
-    | { value: string; label: string; type?: string }[]
+    | {
+        value: string;
+        label: string;
+        type?: string;
+        description?: string;
+        tooltip?: string;
+        icon?: ComponentType<SvelteComponent>;
+        group?: string;
+      }[]
     | undefined = undefined;
   export let additionalClass = "";
   export let onInput: (

--- a/web-common/src/components/forms/Select.svelte
+++ b/web-common/src/components/forms/Select.svelte
@@ -23,6 +23,9 @@
     disabled?: boolean;
     tooltip?: string;
     icon?: ComponentType<SvelteComponent>;
+    /** Optional section heading; a heading is rendered above the first
+     * option of each consecutive group. */
+    group?: string;
   }[];
   export let optionsLoading: boolean = false;
   export let onAddNew: (() => void) | null = null;
@@ -182,7 +185,14 @@
             </div>
           </div>
         {:else}
-          {#each filteredOptions as { type, value, label, description, disabled, tooltip, icon } (value)}
+          {#each filteredOptions as { type, value, label, description, disabled, tooltip, icon, group }, i (value)}
+            {#if group && group !== filteredOptions[i - 1]?.group}
+              <div
+                class="px-2 pt-2 pb-1 text-fg-secondary text-[11px] font-semibold uppercase tracking-wide"
+              >
+                {group}
+              </div>
+            {/if}
             <Select.Item
               {value}
               {label}
@@ -192,7 +202,9 @@
             >
               {#if tooltip}
                 <Tooltip.Root>
-                  <Tooltip.Trigger class="select-tooltip cursor-default">
+                  <Tooltip.Trigger
+                    class="inline-flex items-center gap-x-2 cursor-default text-left"
+                  >
                     {#if icon}
                       <svelte:component this={icon} size="16px" />
                     {:else if type}

--- a/web-common/src/features/dashboards/filters/Filters.svelte
+++ b/web-common/src/features/dashboards/filters/Filters.svelte
@@ -200,7 +200,8 @@
   $: timeDimensionOptions = $timeDimensions.map((timeDim) => {
     return {
       value: timeDim.name!,
-      label: timeDim.name!,
+      label: timeDim.displayName || timeDim.name!,
+      description: timeDim.description,
     };
   });
 

--- a/web-common/src/features/dashboards/time-controls/super-pill/SuperPill.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/SuperPill.svelte
@@ -45,7 +45,11 @@
   export let side: "top" | "right" | "bottom" | "left" = "bottom";
   export let primaryTimeDimension: string | undefined = undefined;
   export let selectedTimeDimension: string | undefined = undefined;
-  export let timeDimensions: { value: string; label: string }[] = [];
+  export let timeDimensions: {
+    value: string;
+    label: string;
+    description?: string;
+  }[] = [];
   export let onSelectRange: (range: NamedRange | ISODurationString) => void;
   export let onPan: (direction: "left" | "right") => void;
   export let onTimeGrainSelect: (timeGrain: V1TimeGrain) => void;

--- a/web-common/src/features/dashboards/time-controls/super-pill/new-time-dropdown/PrimaryRangeTooltip.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/new-time-dropdown/PrimaryRangeTooltip.svelte
@@ -4,9 +4,22 @@
 
   export let timeString: string | undefined;
   export let interval: Interval<true>;
+  // Set only when the active time axis is a time dimension (not a raw column).
+  export let timeDimensionLabel: string | undefined = undefined;
+  export let timeDimensionDescription: string | undefined = undefined;
 </script>
 
 <TooltipContent class="flex-col flex items-center gap-y-0 p-3">
+  {#if timeDimensionLabel}
+    <div class="flex flex-col items-center mb-1">
+      <span class="font-bold text-fg-inverse">{timeDimensionLabel}</span>
+      {#if timeDimensionDescription}
+        <span class="text-fg-inverse/70 text-center max-w-64">
+          {timeDimensionDescription}
+        </span>
+      {/if}
+    </div>
+  {/if}
   <span class="font-semibold italic mb-1">{timeString}</span>
   {#if interval.isValid}
     <span

--- a/web-common/src/features/dashboards/time-controls/super-pill/new-time-dropdown/RangePickerV2.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/new-time-dropdown/RangePickerV2.svelte
@@ -62,7 +62,11 @@
   export let availableTimeZones: string[];
   export let lockTimeZone = false;
   export let showFullRange = true;
-  export let timeDimensions: { value: string; label: string }[];
+  export let timeDimensions: {
+    value: string;
+    label: string;
+    description?: string;
+  }[];
   export let primaryTimeDimension: string | undefined;
   export let selectedTimeDimension: string | undefined;
   export let onTimeDimensionSelect: ((dimension: string) => void) | undefined =
@@ -108,6 +112,13 @@
   $: dateTimeAnchor = returnAnchor(ref, zone);
 
   $: selectedLabel = getRangeLabel(timeString);
+
+  // Resolve the active time axis to a defined time dimension, if any. When the
+  // timeseries points at a raw column this is undefined and the tooltip omits
+  // the dimension name and description.
+  $: activeTimeDimension = timeDimensions.find(
+    ({ value }) => value === (selectedTimeDimension || primaryTimeDimension),
+  );
 
   $: zoneAbbreviation = getAbbreviationForIANA(maxDate ?? DateTime.now(), zone);
 
@@ -269,7 +280,12 @@
 
     <Tooltip.Content side="bottom" sideOffset={8} class="z-50">
       {#if interval}
-        <PrimaryRangeTooltip {timeString} {interval} />
+        <PrimaryRangeTooltip
+          {timeString}
+          {interval}
+          timeDimensionLabel={activeTimeDimension?.label}
+          timeDimensionDescription={activeTimeDimension?.description}
+        />
       {/if}
     </Tooltip.Content>
   </Tooltip.Root>
@@ -429,7 +445,7 @@
           </div>
         {/if}
 
-        {#if timeDimensions.length && onTimeDimensionSelect}
+        {#if timeDimensions.length > 1 && onTimeDimensionSelect}
           <div class="w-full h-fit px-1">
             <div class="h-px w-full bg-gray-200 my-1"></div>
 
@@ -460,21 +476,41 @@
                 sideOffset={12}
                 class="p-1 z-50"
               >
-                {#each timeDimensions as { value, label } (value)}
-                  <button
-                    class="item"
-                    aria-label="Select {label} time dimension"
-                    onclick={() => {
-                      onTimeDimensionSelect(value);
-                      closeMenu();
-                      timeAxisPickerOpen = false;
-                    }}
-                  >
-                    {label}
-                    {#if value === (selectedTimeDimension || primaryTimeDimension)}
-                      <Check class="size-4" color="var(--color-gray-800)" />
+                {#each timeDimensions as { value, label, description } (value)}
+                  <Tooltip.Root>
+                    <Tooltip.Trigger>
+                      {#snippet child({ props })}
+                        <button
+                          {...props}
+                          class="item"
+                          aria-label="Select {label} time dimension"
+                          onclick={() => {
+                            onTimeDimensionSelect(value);
+                            closeMenu();
+                            timeAxisPickerOpen = false;
+                          }}
+                        >
+                          {label}
+                          {#if value === (selectedTimeDimension || primaryTimeDimension)}
+                            <Check
+                              class="size-4"
+                              color="var(--color-gray-800)"
+                            />
+                          {/if}
+                        </button>
+                      {/snippet}
+                    </Tooltip.Trigger>
+                    {#if description}
+                      <Tooltip.Content
+                        side="right"
+                        sideOffset={8}
+                        class="max-w-64"
+                      >
+                        <div class="font-bold text-fg-inverse">{label}</div>
+                        <div class="text-fg-inverse/70">{description}</div>
+                      </Tooltip.Content>
                     {/if}
-                  </button>
+                  </Tooltip.Root>
                 {/each}
               </Popover.Content>
             </Popover.Root>

--- a/web-common/src/features/dashboards/time-controls/super-pill/new-time-dropdown/RangePickerV2.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/new-time-dropdown/RangePickerV2.svelte
@@ -462,11 +462,11 @@
                   <Clock size="14px" />
                 </div>
                 <div class="mr-auto">Time axis</div>
-                <div class="sr-only group-hover:not-sr-only">
-                  <SyntaxElement
-                    range={selectedTimeDimension || primaryTimeDimension}
-                  />
-                </div>
+                {#if activeTimeDimension}
+                  <div class="sr-only group-hover:not-sr-only">
+                    <SyntaxElement range={activeTimeDimension.label} />
+                  </div>
+                {/if}
                 <CaretDownIcon className="-rotate-90" size="14px" />
               </Popover.Trigger>
 

--- a/web-common/src/features/workspaces/VisualMetrics.svelte
+++ b/web-common/src/features/workspaces/VisualMetrics.svelte
@@ -23,7 +23,7 @@
     type V1Resource,
   } from "@rilldata/web-common/runtime-client/gen/index.schemas";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
-  import { PlusIcon } from "lucide-svelte";
+  import { Clock, PlusIcon } from "lucide-svelte";
   import { tick } from "svelte";
   import { parseDocument, Scalar, YAMLMap, YAMLSeq } from "yaml";
   import ConnectorExplorer from "../connectors/explorer/ConnectorExplorer.svelte";
@@ -216,9 +216,7 @@
 
   $: columns = columnsResponse?.profileColumns ?? [];
 
-  $: timeOptions = columns
-    .filter(({ type }) => type && TIMESTAMPS.has(type))
-    .map(({ name }) => ({ value: name ?? "", label: name ?? "" }));
+  $: timeColumns = columns.filter(({ type }) => type && TIMESTAMPS.has(type));
 
   $: typeOfSelectedTimeDimension = columns.find(
     ({ name }) => name === timeDimension,
@@ -248,6 +246,39 @@
         ? createDimensions(raw.dimensions, dimensions)
         : [],
   };
+
+  // Time dimensions defined in the metrics view can be selected as the primary
+  // time dimension in addition to raw timestamp columns.
+  $: timeDimensionOptions = itemGroups.dimensions
+    .filter((d) => d.type === "time")
+    .map((d) => {
+      const value = d.name || d.resourceName;
+      return {
+        value,
+        label: d.display_name || value,
+        tooltip: d.description || undefined,
+        icon: Clock,
+        group: "Time dimensions",
+      };
+    })
+    .filter(({ value }) => value);
+
+  $: timeDimensionValues = new Set(
+    timeDimensionOptions.map(({ value }) => value),
+  );
+
+  $: timeOptions = [
+    ...timeDimensionOptions,
+    ...timeColumns
+      .filter(({ name }) => !timeDimensionValues.has(name ?? ""))
+      .map(({ name, type }) => ({
+        value: name ?? "",
+        label: name ?? "",
+        type,
+        // Only label the columns section when time dimensions are also listed.
+        group: timeDimensionOptions.length ? "Columns" : undefined,
+      })),
+  ];
 
   $: dimensionNamesAndLabels = itemGroups.dimensions.reduce(
     (acc, { name, display_name, resourceName }) => {
@@ -685,7 +716,7 @@
         disabledMessage={!hasValidModelOrSourceSelection
           ? "No model selected"
           : "No timestamp columns in model"}
-        hint="Column from model that will be used as primary time dimension in dashboards"
+        hint="Time dimension or timestamp column used as the primary time dimension in dashboards"
         onChange={async (value) => {
           await updateProperties({ timeseries: value });
         }}


### PR DESCRIPTION
Improvements to how time dimensions are surfaced now that metrics views support them:

- **Visual metrics editor:** the "Time column" picker now lists defined time dimensions (using their display name, with the description on hover) under a `TIME DIMENSIONS` section, above raw timestamp `COLUMNS`. Selecting a time dimension writes its name to `timeseries`; the section headers only appear when time dimensions exist, so the column-only case is unchanged.
- **Explore / Canvas time picker tooltip:** the primary range pill tooltip now shows the active time dimension's name and description, but only when the time axis resolves to a defined `type: time` dimension (a raw column shows just the range, as before). Tooltip text uses the standard `text-fg-inverse` tokens so it is readable in both light and dark themes.
- **Time axis switcher:** hidden when there is only one time dimension, since there is nothing to switch to.
- Added optional section-header (`group`) support to the shared `Select` component and widened the `Input`/`Select` option types to carry `description`/`tooltip`/`icon`/`group` (backward compatible). Also fixed a dead `select-tooltip` class so tooltip options render icon + label on a single line, consistent with non-tooltip options.
### Selector 
<img width="927" height="559" alt="Screenshot 2026-06-25 at 2 24 29 PM" src="https://github.com/user-attachments/assets/187bfbb0-1606-494d-b1a6-d8763d87a5b2" />

### Tooltip 
<img width="548" height="307" alt="Screenshot 2026-06-25 at 2 25 00 PM" src="https://github.com/user-attachments/assets/df2f3454-1146-4f19-b368-6719334b7a96" />

### Time axis switcher

<img width="927" height="788" alt="Screenshot 2026-06-25 at 2 25 37 PM" src="https://github.com/user-attachments/assets/29a6f0a8-b785-47ff-9ac2-0b3cb228555f" />

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*
