### PR TITLE
feat: support wider tags in dimension/measure selectors and pivot tables

### DIFF
--- a/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
+++ b/web-common/src/components/menu/DashboardMetricsDraggableList.svelte
@@ -10,10 +10,15 @@
     MetricsViewSpecMeasure,
   } from "@rilldata/web-common/runtime-client";
   import * as Tooltip from "@rilldata/web-common/components/tooltip-v2";
+  import Resizer from "@rilldata/web-common/layout/Resizer.svelte";
   import { Button } from "../button";
   import Search from "../search/Search.svelte";
   import DashboardMetricsTagRow from "./DashboardMetricsTagRow.svelte";
   import TagFilterBanner from "./TagFilterBanner.svelte";
+  import {
+    exploreTagColumnWidth,
+    TAG_COLUMN,
+  } from "@rilldata/web-common/features/dashboards/workspace/dashboard-layout-store";
   import {
     applyHideAllInTag,
     applyOnlyShowTag,
@@ -33,6 +38,9 @@
   let searchText = "";
   let active = false;
   let selectedTag: string | null = null;
+  // Rendered width of the auto-sized tags column; seeds the resizer until the
+  // user drags it to an explicit width.
+  let tagsColMeasured: number = TAG_COLUMN.explore.MIN;
 
   const toggleButtonBaseClass =
     "flex h-[26px] w-[42px] items-center justify-center rounded-sm text-icon-muted transition-colors hover:bg-surface-hover hover:text-fg-primary active:bg-gray-300 disabled:text-gray-300 disabled:cursor-not-allowed";
@@ -160,11 +168,28 @@
 
       <div class="flex flex-row" class:divide-x={hasTags}>
         {#if hasTags}
-          <!-- Left column: tags -->
+          <!-- Left column: tags. Auto-fits to content (capped) until the user
+               drags the divider to an explicit width. -->
           <div
-            class="flex flex-col flex-none w-[240px] p-1.5"
+            class="flex flex-col flex-none p-1.5 relative"
             data-testid="tags-section"
+            bind:clientWidth={tagsColMeasured}
+            style="width: {$exploreTagColumnWidth !== null
+              ? `${$exploreTagColumnWidth}px`
+              : 'fit-content'}; min-width: {TAG_COLUMN.explore
+              .MIN}px; max-width: {$exploreTagColumnWidth !== null
+              ? TAG_COLUMN.explore.DRAG_MAX
+              : TAG_COLUMN.explore.CAP}px;"
           >
+            <Resizer
+              direction="EW"
+              side="right"
+              min={TAG_COLUMN.explore.MIN}
+              max={TAG_COLUMN.explore.DRAG_MAX}
+              basis={0}
+              dimension={$exploreTagColumnWidth ?? tagsColMeasured}
+              onUpdate={(d) => exploreTagColumnWidth.set(d === 0 ? null : d)}
+            />
             <h3
               class="uppercase font-semibold text-[11px] text-fg-secondary px-2 pt-1 pb-1"
             >
@@ -194,8 +219,11 @@
           </div>
         {/if}
 
-        <!-- Right column: shown/hidden lists -->
-        <div class="flex flex-col flex-1 min-w-0">
+        <!-- Right column: shown/hidden lists. A min width keeps the list usable
+             as the tags column is dragged wider within the fixed-width popover. -->
+        <div
+          class="flex flex-col flex-1 {hasTags ? 'min-w-[240px]' : 'min-w-0'}"
+        >
           {#if filterActive && selectedTag}
             <TagFilterBanner tagName={selectedTag} onClear={clearTagFilter} />
           {/if}

--- a/web-common/src/components/menu/DashboardMetricsTagRow.svelte
+++ b/web-common/src/components/menu/DashboardMetricsTagRow.svelte
@@ -2,6 +2,7 @@
   import EyeIcon from "@rilldata/web-common/components/icons/Eye.svelte";
   import EyeOffIcon from "@rilldata/web-common/components/icons/EyeInvisible.svelte";
   import * as Tooltip from "@rilldata/web-common/components/tooltip-v2";
+  import { detectOverflow } from "@rilldata/web-common/lib/actions/detect-overflow";
   import type { DimensionTag, TagVisibilityState } from "./tag-utils";
 
   type Props = {
@@ -26,6 +27,8 @@
 
   const actionBtnClass =
     "flex items-center justify-center h-[22px] w-[22px] rounded-sm text-icon-muted hover:text-fg-primary hover:bg-surface-background transition-colors";
+
+  let isTruncated = $state(false);
 </script>
 
 <div
@@ -62,7 +65,11 @@
         />
       {/if}
     </svg>
-    <span class="truncate flex-1 min-w-0 text-fg-primary">
+    <span
+      class="truncate flex-1 min-w-0 text-left text-fg-primary"
+      use:detectOverflow={(v) => (isTruncated = v)}
+      title={isTruncated ? tag.name : undefined}
+    >
       {tag.name}
     </span>
     <span

--- a/web-common/src/components/menu/DashboardMetricsTagRow.svelte
+++ b/web-common/src/components/menu/DashboardMetricsTagRow.svelte
@@ -65,13 +65,25 @@
         />
       {/if}
     </svg>
-    <span
-      class="truncate flex-1 min-w-0 text-left text-fg-primary"
-      use:detectOverflow={(v) => (isTruncated = v)}
-      title={isTruncated ? tag.name : undefined}
-    >
-      {tag.name}
-    </span>
+    <Tooltip.Root delayDuration={200} disabled={!isTruncated}>
+      <Tooltip.Trigger>
+        {#snippet child({ props })}
+          <span
+            {...props}
+            class="truncate flex-1 min-w-0 text-left text-fg-primary"
+            use:detectOverflow={(v) => (isTruncated = v)}
+          >
+            {tag.name}
+          </span>
+        {/snippet}
+      </Tooltip.Trigger>
+      <Tooltip.Content
+        side="top"
+        class="bg-popover text-fg-primary z-popover text-xs px-2 py-1"
+      >
+        {tag.name}
+      </Tooltip.Content>
+    </Tooltip.Root>
     <span
       class="tabular-nums text-xs text-fg-secondary flex-none"
       aria-label={`${visibility.visibleCount} of ${visibility.totalCount} shown`}

--- a/web-common/src/features/dashboards/pivot/PivotChip.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotChip.svelte
@@ -78,9 +78,9 @@
     {#if item.type === PivotChipType.Time}
       {item.description}
     {:else}
-      <span class="font-semibold">{item.title}</span>
+      <div class="font-bold">{item.title}</div>
       {#if item.description}
-        <div class="text-fg-secondary">{item.description}</div>
+        <div class="text-fg-inverse/70 mt-0.5">{item.description}</div>
       {/if}
     {/if}
   </TooltipContent>

--- a/web-common/src/features/dashboards/pivot/PivotChip.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotChip.svelte
@@ -2,6 +2,7 @@
   import { Chip } from "@rilldata/web-common/components/chip";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
+  import { detectOverflow } from "@rilldata/web-common/lib/actions/detect-overflow";
   import { TIME_GRAIN } from "@rilldata/web-common/lib/time/config";
   import type { AvailableTimeGrain } from "@rilldata/web-common/lib/time/types";
   import type { PivotChipData } from "./types";
@@ -30,14 +31,14 @@
       return word.charAt(0).toUpperCase() + word.slice(1);
     })
     .join(" ");
+
+  let isTruncated = false;
+  // Show the tooltip whenever the label is clipped, even without a description,
+  // so the full measure/dimension name is always discoverable.
+  $: showTooltip = !!item.description || isTruncated;
 </script>
 
-<Tooltip
-  distance={8}
-  location="top"
-  suppress={!item.description}
-  activeDelay={200}
->
+<Tooltip distance={8} location="top" suppress={!showTooltip} activeDelay={200}>
   <Chip
     theme
     type={item.type}
@@ -63,12 +64,24 @@
           <p class="grain-label truncate">{capitalizedLabel}</p>
         {/if}
       {:else}
-        <p class="font-semibold truncate">{item.title}</p>
+        <p
+          class="font-semibold truncate"
+          use:detectOverflow={(v) => (isTruncated = v)}
+        >
+          {item.title}
+        </p>
       {/if}
       <slot name="body" />
     </div>
   </Chip>
   <TooltipContent slot="tooltip-content">
-    {item.description}
+    {#if item.type === PivotChipType.Time}
+      {item.description}
+    {:else}
+      <span class="font-semibold">{item.title}</span>
+      {#if item.description}
+        <div class="text-fg-secondary">{item.description}</div>
+      {/if}
+    {/if}
   </TooltipContent>
 </Tooltip>

--- a/web-common/src/features/dashboards/pivot/PivotChip.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotChip.svelte
@@ -2,7 +2,6 @@
   import { Chip } from "@rilldata/web-common/components/chip";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
-  import { detectOverflow } from "@rilldata/web-common/lib/actions/detect-overflow";
   import { TIME_GRAIN } from "@rilldata/web-common/lib/time/config";
   import type { AvailableTimeGrain } from "@rilldata/web-common/lib/time/types";
   import type { PivotChipData } from "./types";
@@ -32,10 +31,10 @@
     })
     .join(" ");
 
-  let isTruncated = false;
-  // Show the tooltip whenever the label is clipped, even without a description,
-  // so the full measure/dimension name is always discoverable.
-  $: showTooltip = !!item.description || isTruncated;
+  // Measure/dimension chips always show a tooltip (display name, plus the
+  // description when present). Time chips only have something worth showing
+  // when a description is set.
+  $: showTooltip = item.type === PivotChipType.Time ? !!item.description : true;
 </script>
 
 <Tooltip distance={8} location="top" suppress={!showTooltip} activeDelay={200}>
@@ -64,12 +63,7 @@
           <p class="grain-label truncate">{capitalizedLabel}</p>
         {/if}
       {:else}
-        <p
-          class="font-semibold truncate"
-          use:detectOverflow={(v) => (isTruncated = v)}
-        >
-          {item.title}
-        </p>
+        <p class="font-semibold truncate">{item.title}</p>
       {/if}
       <slot name="body" />
     </div>

--- a/web-common/src/features/dashboards/pivot/PivotDisplay.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotDisplay.svelte
@@ -6,7 +6,16 @@
   import ExportMenu from "@rilldata/web-common/features/exports/ExportMenu.svelte";
   import { featureFlags } from "@rilldata/web-common/features/feature-flags";
   import { dynamicHeight } from "@rilldata/web-common/layout/layout-settings.ts";
+  import Resizer from "@rilldata/web-common/layout/Resizer.svelte";
+  import {
+    DEFAULT_PIVOT_SIDEBAR_WIDTH,
+    DEFAULT_PIVOT_SIDEBAR_WIDTH_NO_TAGS,
+    MAX_PIVOT_SIDEBAR_WIDTH,
+    MIN_PIVOT_SIDEBAR_WIDTH,
+    pivotSidebarWidth,
+  } from "@rilldata/web-common/features/dashboards/workspace/dashboard-layout-store";
   import { derived } from "svelte/store";
+  import { slide } from "svelte/transition";
   import { useTimeControlStore } from "web-common/src/features/dashboards/time-controls/time-control-store.ts";
   import { getPivotConfig } from "./pivot-data-config";
   import { usePivotForExplore } from "./pivot-data-store";
@@ -93,22 +102,47 @@
   }
 
   $: widthScopeKey = `explore:${$exploreName}`;
+
+  // Until the user explicitly drags the divider (stored width is null), fall
+  // back to the legacy tag-aware default (240px without tags, 400px with).
+  $: pivotHasTags = ($combinedTagIndex?.tags?.length ?? 0) > 0;
+  $: sidebarWidth =
+    $pivotSidebarWidth ??
+    (pivotHasTags
+      ? DEFAULT_PIVOT_SIDEBAR_WIDTH
+      : DEFAULT_PIVOT_SIDEBAR_WIDTH_NO_TAGS);
 </script>
 
 <div class="layout" class:h-full={!$dynamicHeight}>
   {#if showPanels}
-    <PivotSidebar
-      pivotState={enrichedPivotState}
-      measures={$measures}
-      dimensions={$dimensions}
-      combinedTagIndex={$combinedTagIndex}
-      dimensionTagIndex={$dimensionTagIndex}
-      measureTagIndex={$measureTagIndex}
-      setRows={(rows) => metricsExplorerStore.setPivotRows($exploreName, rows)}
-      setColumns={(columns) =>
-        metricsExplorerStore.setPivotColumns($exploreName, columns)}
-      {timeControlsForPillActions}
-    />
+    <div
+      class="sidebar-pane"
+      style="width: {sidebarWidth}px"
+      transition:slide={{ axis: "x" }}
+    >
+      <Resizer
+        direction="EW"
+        side="right"
+        min={MIN_PIVOT_SIDEBAR_WIDTH}
+        max={MAX_PIVOT_SIDEBAR_WIDTH}
+        basis={0}
+        dimension={sidebarWidth}
+        onUpdate={(d) => pivotSidebarWidth.set(d === 0 ? null : d)}
+      />
+      <PivotSidebar
+        pivotState={enrichedPivotState}
+        measures={$measures}
+        dimensions={$dimensions}
+        combinedTagIndex={$combinedTagIndex}
+        dimensionTagIndex={$dimensionTagIndex}
+        measureTagIndex={$measureTagIndex}
+        setRows={(rows) =>
+          metricsExplorerStore.setPivotRows($exploreName, rows)}
+        setColumns={(columns) =>
+          metricsExplorerStore.setPivotColumns($exploreName, columns)}
+        {timeControlsForPillActions}
+      />
+    </div>
   {/if}
   <div
     class="flex flex-col overflow-hidden"
@@ -213,6 +247,10 @@
 <style lang="postcss">
   .layout {
     @apply flex box-border overflow-hidden size-full;
+  }
+
+  .sidebar-pane {
+    @apply relative flex-none h-full;
   }
 
   .content {

--- a/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotSidebar.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
   import TagFilterBanner from "@rilldata/web-common/components/menu/TagFilterBanner.svelte";
   import type { TagIndex } from "@rilldata/web-common/components/menu/tag-utils";
+  import {
+    pivotTagColumnWidth,
+    TAG_COLUMN,
+  } from "@rilldata/web-common/features/dashboards/workspace/dashboard-layout-store";
   import { Search } from "@rilldata/web-common/components/search";
+  import Resizer from "@rilldata/web-common/layout/Resizer.svelte";
   import {
     splitPivotChips,
     splitTagItems,
   } from "@rilldata/web-common/features/dashboards/pivot/pivot-utils.ts";
   import { type TimeControlState } from "@rilldata/web-common/features/dashboards/time-controls/time-control-store";
   import { onMount } from "svelte";
-  import { slide } from "svelte/transition";
   import type { PivotState } from "web-common/src/features/dashboards/pivot/types.ts";
   import PivotDrag from "./PivotDrag.svelte";
   import PivotTagRow from "./PivotTagRow.svelte";
@@ -35,6 +39,9 @@
   let sidebarHeight = 0;
   let searchText = "";
   let selectedTag: string | null = null;
+  // Rendered width of the auto-sized tags column; seeds the resizer until the
+  // user drags it to an explicit width.
+  let tagsColMeasured: number = TAG_COLUMN.pivot.MIN;
 
   onMount(() => {
     timePillActions.initTimeDimension("time", "Time");
@@ -124,38 +131,57 @@
   }
 </script>
 
-<div
-  class="sidebar"
-  class:has-tags={hasTags}
-  bind:clientHeight={sidebarHeight}
-  transition:slide={{ axis: "x" }}
->
+<div class="sidebar" class:has-tags={hasTags} bind:clientHeight={sidebarHeight}>
   <div class="input-wrapper sticky top-0 z-10 bg-surface-background">
     <Search theme background bind:value={searchText} />
   </div>
 
   <div class="body">
     {#if hasTags}
-      <div class="tags-column">
-        <h3 class="column-header">Tags</h3>
-        {#if filteredTags.length === 0}
-          <p class="text-fg-secondary my-1 px-2 text-xs">No matching tags</p>
-        {:else}
-          {#each filteredTags as tag (tag.name)}
-            {@const items = tagItemsFor(tag.name)}
-            <PivotTagRow
-              {tag}
-              dimensions={items.dimensions}
-              measures={items.measures}
-              {rows}
-              {columns}
-              selected={selectedTag === tag.name}
-              {setRows}
-              {setColumns}
-              onSelect={() => toggleTagFilter(tag.name)}
-            />
-          {/each}
-        {/if}
+      <!-- Tags pane: auto-fits to content (capped) until the user drags the
+           divider to an explicit width. -->
+      <div
+        class="tags-pane"
+        bind:clientWidth={tagsColMeasured}
+        style="width: {$pivotTagColumnWidth !== null
+          ? `${$pivotTagColumnWidth}px`
+          : 'fit-content'}; min-width: {TAG_COLUMN.pivot
+          .MIN}px; max-width: min({$pivotTagColumnWidth !== null
+          ? TAG_COLUMN.pivot.DRAG_MAX
+          : TAG_COLUMN.pivot.CAP}px, {TAG_COLUMN.pivot.PCT_CAP}%);"
+      >
+        <!-- Resizer lives in the pane (not the scroll area) so it stays
+             centered on the separator and never induces a scrollbar. -->
+        <Resizer
+          direction="EW"
+          side="right"
+          min={TAG_COLUMN.pivot.MIN}
+          max={TAG_COLUMN.pivot.DRAG_MAX}
+          basis={0}
+          dimension={$pivotTagColumnWidth ?? tagsColMeasured}
+          onUpdate={(d) => pivotTagColumnWidth.set(d === 0 ? null : d)}
+        />
+        <div class="tags-scroll">
+          <h3 class="column-header">Tags</h3>
+          {#if filteredTags.length === 0}
+            <p class="text-fg-secondary my-1 px-2 text-xs">No matching tags</p>
+          {:else}
+            {#each filteredTags as tag (tag.name)}
+              {@const items = tagItemsFor(tag.name)}
+              <PivotTagRow
+                {tag}
+                dimensions={items.dimensions}
+                measures={items.measures}
+                {rows}
+                {columns}
+                selected={selectedTag === tag.name}
+                {setRows}
+                {setColumns}
+                onSelect={() => toggleTagFilter(tag.name)}
+              />
+            {/each}
+          {/if}
+        </div>
       </div>
     {/if}
 
@@ -173,15 +199,10 @@
 
 <style lang="postcss">
   .sidebar {
+    /* Outer width is owned by the resizable wrapper in PivotDisplay. */
     @apply flex flex-col relative overflow-hidden;
-    @apply h-full border-r z-0 w-60;
-    transition-property: width;
-    will-change: width;
+    @apply h-full w-full border-r z-0;
     @apply select-none bg-surface-background;
-  }
-
-  .sidebar.has-tags {
-    width: 400px;
   }
 
   .input-wrapper {
@@ -198,14 +219,19 @@
     @apply divide-x;
   }
 
-  .tags-column {
-    @apply flex flex-col flex-none w-40 py-2 px-2;
-    @apply overflow-y-auto gap-y-0.5;
+  .tags-pane {
+    @apply relative flex-none h-full;
+  }
+
+  .tags-scroll {
+    @apply flex flex-col h-full w-full py-2 px-2 gap-y-0.5;
+    /* Vertical scroll only when the list overflows; never horizontal. */
+    @apply overflow-y-auto overflow-x-hidden;
   }
 
   .items-column {
     @apply flex flex-col flex-1 min-w-0;
-    @apply overflow-y-auto;
+    @apply overflow-y-auto overflow-x-hidden;
   }
 
   .column-header {

--- a/web-common/src/features/dashboards/pivot/PivotTagRow.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTagRow.svelte
@@ -193,13 +193,25 @@
   role="presentation"
   onmousedown={handleMouseDown}
 >
-  <span
-    class="truncate flex-1 min-w-0 text-left text-fg-primary"
-    use:detectOverflow={(v) => (isTruncated = v)}
-    title={isTruncated ? tag.name : undefined}
-  >
-    {tag.name}
-  </span>
+  <Tooltip.Root delayDuration={200} disabled={!isTruncated}>
+    <Tooltip.Trigger>
+      {#snippet child({ props })}
+        <span
+          {...props}
+          class="truncate flex-1 min-w-0 text-left text-fg-primary"
+          use:detectOverflow={(v) => (isTruncated = v)}
+        >
+          {tag.name}
+        </span>
+      {/snippet}
+    </Tooltip.Trigger>
+    <Tooltip.Content
+      side="top"
+      class="bg-popover text-fg-primary z-popover text-xs px-2 py-1"
+    >
+      {tag.name}
+    </Tooltip.Content>
+  </Tooltip.Root>
 
   <div class="flex items-center gap-x-1 flex-none group-hover:hidden">
     {#if measureCount > 0}

--- a/web-common/src/features/dashboards/pivot/PivotTagRow.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTagRow.svelte
@@ -4,6 +4,7 @@
   import Pivot from "@rilldata/web-common/components/icons/Pivot.svelte";
   import Row from "@rilldata/web-common/components/icons/Row.svelte";
   import * as Tooltip from "@rilldata/web-common/components/tooltip-v2";
+  import { detectOverflow } from "@rilldata/web-common/lib/actions/detect-overflow";
   import { modifierHeld } from "@rilldata/web-common/lib/modifier-key";
   import { dragDataStore } from "./DragList.svelte";
   import PivotPortalItem from "./PivotPortalItem.svelte";
@@ -51,6 +52,8 @@
 
   const dimensionCount = $derived(dimensions.length);
   const measureCount = $derived(measures.length);
+
+  let isTruncated = $state(false);
 
   const actionBtnClass =
     "flex items-center justify-center h-[18px] w-[18px] rounded-sm text-icon-muted hover:text-fg-primary hover:bg-surface-background transition-colors";
@@ -190,7 +193,11 @@
   role="presentation"
   onmousedown={handleMouseDown}
 >
-  <span class="truncate flex-1 min-w-0 text-fg-primary">
+  <span
+    class="truncate flex-1 min-w-0 text-left text-fg-primary"
+    use:detectOverflow={(v) => (isTruncated = v)}
+    title={isTruncated ? tag.name : undefined}
+  >
     {tag.name}
   </span>
 

--- a/web-common/src/features/dashboards/workspace/dashboard-layout-store.ts
+++ b/web-common/src/features/dashboards/workspace/dashboard-layout-store.ts
@@ -9,6 +9,24 @@ export const MIN_TIMESERIES_WIDTH = 440;
 export const DEFAULT_TDD_CHART_HEIGHT = 245;
 export const MIN_TDD_CHART_HEIGHT = 145;
 
+// Pivot view: width (px) of the sidebar (tags + items columns) beside the table.
+// The auto width depends on whether the metrics view has tags, matching the
+// legacy fixed widths (240px without tags, 400px with tags).
+export const DEFAULT_PIVOT_SIDEBAR_WIDTH = 400;
+export const DEFAULT_PIVOT_SIDEBAR_WIDTH_NO_TAGS = 240;
+export const MIN_PIVOT_SIDEBAR_WIDTH = 240;
+export const MAX_PIVOT_SIDEBAR_WIDTH = 900;
+
+// Width bounds for the tags column shared by the dimension/measure selector
+// dropdown (explore) and the pivot sidebar. In auto mode the column sizes to
+// its content between MIN and CAP; dragging the divider can widen it up to
+// DRAG_MAX. Pivot is additionally capped to PCT_CAP percent of the sidebar so
+// the items list stays usable.
+export const TAG_COLUMN = {
+  explore: { MIN: 200, CAP: 340, DRAG_MAX: 360 },
+  pivot: { MIN: 140, CAP: 240, DRAG_MAX: 600, PCT_CAP: 65 },
+} as const;
+
 /**
  * Width of the timeseries charts in the explore view, controlled by the
  * resizable divider between the charts and the leaderboards. Persisted so the
@@ -27,4 +45,35 @@ export const exploreTimeseriesWidth = localStorageStore<number>(
 export const tddChartHeight = localStorageStore<number>(
   "tdd-chart-height",
   DEFAULT_TDD_CHART_HEIGHT,
+);
+
+/**
+ * Width of the pivot sidebar, controlled by the resizable divider between the
+ * sidebar and the pivot table. `null` means use the tag-aware auto width; a
+ * number is an explicit user-chosen width set by dragging the divider.
+ * Persisted so the split is preserved as the user navigates back and forth.
+ */
+export const pivotSidebarWidth = localStorageStore<number | null>(
+  "pivot-sidebar-width",
+  null,
+);
+
+/**
+ * Width of the tags column in the explore dimension/measure selector. `null`
+ * means auto-fit to content (capped); a number is an explicit user-chosen width
+ * set by dragging the divider. Persisted across sessions.
+ */
+export const exploreTagColumnWidth = localStorageStore<number | null>(
+  "explore-tag-column-width",
+  null,
+);
+
+/**
+ * Width of the tags column in the pivot sidebar. `null` means auto-fit to
+ * content (capped); a number is an explicit user-chosen width set by dragging
+ * the divider. Persisted across sessions.
+ */
+export const pivotTagColumnWidth = localStorageStore<number | null>(
+  "pivot-tag-column-width",
+  null,
 );

--- a/web-common/src/features/dashboards/workspace/dashboard-layout-store.ts
+++ b/web-common/src/features/dashboards/workspace/dashboard-layout-store.ts
@@ -21,10 +21,11 @@ export const MAX_PIVOT_SIDEBAR_WIDTH = 900;
 // dropdown (explore) and the pivot sidebar. In auto mode the column sizes to
 // its content between MIN and CAP; dragging the divider can widen it up to
 // DRAG_MAX. Pivot is additionally capped to PCT_CAP percent of the sidebar so
-// the items list stays usable.
+// the items list stays usable. The minimums are deliberately generous: a
+// narrower column clips most tag names down to a few characters.
 export const TAG_COLUMN = {
-  explore: { MIN: 200, CAP: 340, DRAG_MAX: 360 },
-  pivot: { MIN: 140, CAP: 240, DRAG_MAX: 600, PCT_CAP: 65 },
+  explore: { MIN: 220, CAP: 340, DRAG_MAX: 360 },
+  pivot: { MIN: 180, CAP: 280, DRAG_MAX: 600, PCT_CAP: 65 },
 } as const;
 
 /**

--- a/web-common/src/lib/actions/detect-overflow.ts
+++ b/web-common/src/lib/actions/detect-overflow.ts
@@ -1,0 +1,32 @@
+/**
+ * Svelte action that reports whether a node's content is horizontally
+ * truncated (`scrollWidth > clientWidth`). Useful for showing a tooltip only
+ * when text is actually clipped. Re-checks on element resize and whenever the
+ * action parameter changes (e.g. the rendered text updates).
+ */
+export type OverflowCallback = (isOverflowing: boolean) => void;
+
+export function detectOverflow(node: HTMLElement, callback: OverflowCallback) {
+  let current = callback;
+
+  function check() {
+    current(node.scrollWidth > node.clientWidth);
+  }
+
+  let observer: ResizeObserver | undefined;
+  if (typeof ResizeObserver !== "undefined") {
+    observer = new ResizeObserver(check);
+    observer.observe(node);
+  }
+  check();
+
+  return {
+    update(next: OverflowCallback) {
+      current = next;
+      check();
+    },
+    destroy() {
+      observer?.disconnect();
+    },
+  };
+}

--- a/web-common/src/lib/store-utils/local-storage.ts
+++ b/web-common/src/lib/store-utils/local-storage.ts
@@ -9,21 +9,27 @@ export function localStorageStore<T>(itemKey: string, defaultValue: T) {
   const store = writable<T>(defaultValue);
 
   if (browser) {
-    const stored = localStorage.getItem(itemKey);
-    if (stored !== null) {
-      try {
+    try {
+      // Accessing localStorage can throw, not just return null: a sandboxed or
+      // storage-partitioned iframe (embed mode) raises a SecurityError. Keep the
+      // read inside the try so initialization degrades to in-memory only.
+      const stored = localStorage.getItem(itemKey);
+      if (stored !== null) {
         const parsed = JSON.parse(stored);
         if (parsed !== undefined) {
           store.set(parsed);
         }
-      } catch {
-        // ignore
       }
+    } catch {
+      // ignore: localStorage unavailable or unreadable
     }
   }
   const debouncer = debounce((v: T) => {
-    if (typeof localStorage === "undefined") return;
-    localStorage.setItem(itemKey, JSON.stringify(v));
+    try {
+      localStorage.setItem(itemKey, JSON.stringify(v));
+    } catch {
+      // ignore: localStorage unavailable or over quota (e.g. embed iframe)
+    }
   }, 300);
   store.subscribe(debouncer);
 
@@ -31,7 +37,11 @@ export function localStorageStore<T>(itemKey: string, defaultValue: T) {
     ...store,
     reset() {
       store.set(defaultValue);
-      localStorage.setItem(itemKey, JSON.stringify(defaultValue));
+      try {
+        localStorage.setItem(itemKey, JSON.stringify(defaultValue));
+      } catch {
+        // ignore: localStorage unavailable
+      }
     },
   };
 }


### PR DESCRIPTION
Adds resizable, content-aware tag columns to the dimension/measure selector (explore) and the pivot sidebar, so long tag names are readable instead of being clipped at a fixed width.

- Tags column now auto-fits its content (within min/cap bounds) and exposes a draggable divider to set an explicit width; the choice is persisted to `localStorage`.
- Pivot sidebar is wrapped in a resizable pane with its own draggable divider; width persists and falls back to the legacy tag-aware default (240px without tags, 400px with) until dragged.
- New `detectOverflow` action shows a tooltip with the full tag name only when the label is actually truncated.
- `localStorageStore` now guards reads and writes in `try/catch` so it degrades to in-memory state when `localStorage` is unavailable (e.g. sandboxed/storage-partitioned embed iframes raising `SecurityError`).

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*
