### PR TITLE
Hide cloud edit entries without access

### DIFF
--- a/web-admin/src/features/branches/BranchesSection.svelte
+++ b/web-admin/src/features/branches/BranchesSection.svelte
@@ -51,6 +51,7 @@
   } from "lucide-svelte";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
   import { onMount } from "svelte";
+  import { featureFlags } from "@rilldata/web-common/features/feature-flags";
 
   let { organization, project }: { organization: string; project: string } =
     $props();
@@ -70,7 +71,13 @@
         query: {
           refetchInterval: (query) => {
             const deployments = query.state.data?.deployments;
-            if (deployments?.some((d) => isTransitoryStatus(d.status))) {
+            if (
+              deployments?.some((d) =>
+                isTransitoryStatus(
+                  d.status ?? V1DeploymentStatus.DEPLOYMENT_STATUS_UNSPECIFIED,
+                ),
+              )
+            ) {
               return 2000;
             }
             return false;
@@ -82,12 +89,16 @@
   let projectQuery = $derived(
     createAdminServiceGetProject(organization, project),
   );
+  const { cloudEditing } = featureFlags;
   const startMutation = createAdminServiceStartDeployment();
   const stopMutation = createAdminServiceStopDeployment();
   const deleteMutation = createAdminServiceDeleteDeployment();
 
   let primaryBranch = $derived($projectQuery.data?.project?.primaryBranch);
   let activeBranch = $derived(extractBranchFromPath(page.url.pathname));
+  let canEditProject = $derived(
+    $cloudEditing && !!$projectQuery.data?.projectPermissions?.manageDev,
+  );
 
   let userNameMap = $derived(
     new Map(
@@ -424,7 +435,7 @@
                   </IconButton>
                 </DropdownMenu.Trigger>
                 <DropdownMenu.Content align="start">
-                  {#if deployment.editable}
+                  {#if canEditProject && deployment.editable}
                     <DropdownMenu.Item
                       class="font-normal flex items-center"
                       href={editUrl(deployment.branch)}

--- a/web-admin/src/features/projects/ProjectCard.svelte
+++ b/web-admin/src/features/projects/ProjectCard.svelte
@@ -11,9 +11,9 @@
   import GuardedDeleteProjectConfirmation from "@rilldata/web-admin/features/projects/settings/GuardedDeleteProjectConfirmation.svelte";
   import ProjectRenameDialog from "@rilldata/web-admin/features/projects/settings/ProjectRenameDialog.svelte";
   import EditBranchDialog from "@rilldata/web-admin/features/edit-session/EditBranchDialog.svelte";
-  import { getFeatureFlags } from "@rilldata/web-common/features/feature-flags";
+  import { createRuntimeServiceGetInstance } from "@rilldata/web-common/runtime-client";
   import { getRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
-  import { createQuery } from "@tanstack/svelte-query";
+  import { readable } from "svelte/store";
 
   let { organization, project }: { organization: string; project: string } =
     $props();
@@ -27,6 +27,7 @@
   let editProjectOpen = $state(false);
   let renameProjectOpen = $state(false);
   let deleteProjectOpen = $state(false);
+  const disabledCloudEditingQuery = readable({ data: false });
 
   function doesProjectNameIncludeUnderscores(project: string) {
     return project.includes("_");
@@ -45,23 +46,19 @@
     };
   });
 
-  let cloudEditingQuery = $derived(
-    createQuery({
-      queryKey: [
-        "project-card-cloud-editing",
-        organization,
-        project,
-        runtimeConfig?.host,
-        runtimeConfig?.instanceId,
-      ],
-      enabled: !!runtimeConfig,
-      queryFn: async () => {
-        if (!runtimeConfig) return false;
-        const flags = await getFeatureFlags(getRuntimeClient(runtimeConfig));
-        return !!flags.cloudEditing;
+  let cloudEditingQuery = $derived.by(() => {
+    if (!runtimeConfig) return disabledCloudEditingQuery;
+    const runtimeClient = getRuntimeClient(runtimeConfig);
+    return createRuntimeServiceGetInstance(
+      runtimeClient,
+      {},
+      {
+        query: {
+          select: (data) => !!data.instance?.featureFlags?.cloudEditing,
+        },
       },
-    }),
-  );
+    );
+  });
 
   let canEditProject = $derived(
     !!$cloudEditingQuery.data && !!$proj.data?.projectPermissions?.manageDev,

--- a/web-admin/src/features/projects/ProjectCard.svelte
+++ b/web-admin/src/features/projects/ProjectCard.svelte
@@ -11,6 +11,9 @@
   import GuardedDeleteProjectConfirmation from "@rilldata/web-admin/features/projects/settings/GuardedDeleteProjectConfirmation.svelte";
   import ProjectRenameDialog from "@rilldata/web-admin/features/projects/settings/ProjectRenameDialog.svelte";
   import EditBranchDialog from "@rilldata/web-admin/features/edit-session/EditBranchDialog.svelte";
+  import { getFeatureFlags } from "@rilldata/web-common/features/feature-flags";
+  import { getRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
+  import { createQuery } from "@tanstack/svelte-query";
 
   let { organization, project }: { organization: string; project: string } =
     $props();
@@ -28,9 +31,49 @@
   function doesProjectNameIncludeUnderscores(project: string) {
     return project.includes("_");
   }
+
+  let runtimeConfig = $derived.by(() => {
+    const deployment = $proj.data?.deployment;
+    if (!deployment?.runtimeHost || !deployment.runtimeInstanceId) {
+      return undefined;
+    }
+
+    return {
+      host: deployment.runtimeHost,
+      instanceId: deployment.runtimeInstanceId,
+      jwt: $proj.data?.jwt,
+    };
+  });
+
+  let cloudEditingQuery = $derived(
+    createQuery({
+      queryKey: [
+        "project-card-cloud-editing",
+        organization,
+        project,
+        runtimeConfig?.host,
+        runtimeConfig?.instanceId,
+      ],
+      enabled: !!runtimeConfig,
+      queryFn: async () => {
+        if (!runtimeConfig) return false;
+        const flags = await getFeatureFlags(getRuntimeClient(runtimeConfig));
+        return !!flags.cloudEditing;
+      },
+    }),
+  );
+
+  let canEditProject = $derived(
+    !!$cloudEditingQuery.data && !!$proj.data?.projectPermissions?.manageDev,
+  );
+
+  $effect(() => {
+    if (!canEditProject) editProjectOpen = false;
+  });
 </script>
 
-{#if $proj.data}
+{#if $proj.data?.project}
+  {@const projectData = $proj.data.project}
   <Card href="/{organization}/{project}" bind:hovering>
     <!-- Project name -->
     <h2
@@ -49,6 +92,7 @@
           {organization}
           {project}
           bind:open={actionsOpen}
+          canEdit={canEditProject}
           onEdit={() => (editProjectOpen = true)}
           onRename={() => (renameProjectOpen = true)}
           onDelete={() => (deleteProjectOpen = true)}
@@ -65,7 +109,7 @@
     <!-- Public vs Private indicator -->
     <div class="absolute bottom-2.5 right-2.5 text-fg-secondary">
       <Tooltip distance={10}>
-        {#if $proj.data.project.public}
+        {#if projectData.public}
           <Globe size="16px" />
         {:else}
           <Lock size="16px" />
@@ -73,7 +117,7 @@
         <TooltipContent slot="tooltip-content">
           <span class="text-xs"
             >This project is
-            {#if $proj.data.project.public}
+            {#if projectData.public}
               <span class="font-medium"> public</span>
             {:else}
               <span class="font-medium"> private</span>
@@ -94,9 +138,11 @@
   button={false}
 />
 
-<EditBranchDialog
-  bind:open={editProjectOpen}
-  {organization}
-  {project}
-  {primaryBranch}
-/>
+{#if canEditProject}
+  <EditBranchDialog
+    bind:open={editProjectOpen}
+    {organization}
+    {project}
+    {primaryBranch}
+  />
+{/if}

--- a/web-admin/src/features/projects/ProjectCardActions.svelte
+++ b/web-admin/src/features/projects/ProjectCardActions.svelte
@@ -10,6 +10,7 @@
     organization,
     project,
     open = $bindable(false),
+    canEdit = false,
     onEdit,
     onRename,
     onDelete,
@@ -17,7 +18,8 @@
     organization: string;
     project: string;
     open?: boolean;
-    onEdit: () => void;
+    canEdit?: boolean;
+    onEdit?: () => void;
     onRename: () => void;
     onDelete: () => void;
   } = $props();
@@ -28,9 +30,11 @@
     <ThreeDot size="16px" />
   </Dropdown.Trigger>
   <Dropdown.Content class="w-48" align="start" side="right">
-    <Dropdown.Item class="text-sm" onclick={onEdit}>
-      <FeatherEditIcon /> Edit
-    </Dropdown.Item>
+    {#if canEdit}
+      <Dropdown.Item class="text-sm" onclick={() => onEdit?.()}>
+        <FeatherEditIcon /> Edit
+      </Dropdown.Item>
+    {/if}
     <Dropdown.Item class="text-sm" onclick={onRename}>
       <PencilIcon /> Rename
     </Dropdown.Item>


### PR DESCRIPTION
## Summary
- Hide the org-home project card Edit action unless cloud editing is enabled for that project and the user can manage dev deployments
- Avoid mounting the edit branch dialog when editing is unavailable
- Hide branch Open editor actions without the same cloud-editing/manage-dev access

## Testing
- npx prettier --check web-admin/src/features/projects/ProjectCard.svelte web-admin/src/features/projects/ProjectCardActions.svelte web-admin/src/features/branches/BranchesSection.svelte
- git diff --check
- npx svelte-check --workspace web-admin --tsconfig ./tsconfig.json --output machine 2>&1 | rg 'ProjectCard\\.svelte|ProjectCardActions\\.svelte|BranchesSection\\.svelte'\n- npm run check -w web-admin (fails on existing repo-wide diagnostics unrelated to these files: 594 errors in 151 files)