### PR TITLE
fix: ui create project setting its own slots

### DIFF
--- a/admin/server/projects.go
+++ b/admin/server/projects.go
@@ -30,6 +30,12 @@ const devDeplTTL = time.Hour
 
 const prodDeplTTL = 14 * 24 * time.Hour
 
+// defaultProdSlots and defaultDevSlots are the slot counts applied when a CreateProject
+// request omits them (e.g. the UI, or older CLIs that don't pass these fields).
+const defaultProdSlots = 4
+
+const defaultDevSlots = 4
+
 // runtimeAccessTokenTTL is the validity duration of JWTs issued for runtime access when calling GetProject.
 // This TTL is not used for tokens created for internal communication between the admin and runtime services.
 const runtimeAccessTokenDefaultTTL = 30 * time.Minute
@@ -482,6 +488,16 @@ func (s *Server) CreateProject(ctx context.Context, req *adminv1.CreateProjectRe
 		return nil, err
 	}
 
+	// Apply defaults when slots are omitted (e.g. the UI, or older CLIs that don't pass these fields).
+	prodSlots := int(req.ProdSlots)
+	if prodSlots == 0 {
+		prodSlots = defaultProdSlots
+	}
+	devSlots := int(req.DevSlots)
+	if devSlots == 0 {
+		devSlots = defaultDevSlots
+	}
+
 	// Check projects quota
 	usage, err := s.admin.DB.CountProjectsQuotaUsage(ctx, org.ID)
 	if err != nil {
@@ -490,13 +506,13 @@ func (s *Server) CreateProject(ctx context.Context, req *adminv1.CreateProjectRe
 	if org.QuotaProjects >= 0 && usage.Projects >= org.QuotaProjects {
 		return nil, status.Errorf(codes.FailedPrecondition, "quota exceeded: org %q is limited to %d projects", org.Name, org.QuotaProjects)
 	}
-	if org.QuotaSlotsPerDeployment >= 0 && int(req.ProdSlots) > org.QuotaSlotsPerDeployment {
+	if org.QuotaSlotsPerDeployment >= 0 && prodSlots > org.QuotaSlotsPerDeployment {
 		return nil, status.Errorf(codes.FailedPrecondition, "quota exceeded: org can't provision more than %d slots per deployment; contact support for larger deployments", org.QuotaSlotsPerDeployment)
 	}
-	if org.QuotaSlotsPerDeployment >= 0 && int(req.DevSlots) > org.QuotaSlotsPerDeployment {
+	if org.QuotaSlotsPerDeployment >= 0 && devSlots > org.QuotaSlotsPerDeployment {
 		return nil, status.Errorf(codes.FailedPrecondition, "quota exceeded: org can't provision more than %d slots per deployment; contact support for larger deployments", org.QuotaSlotsPerDeployment)
 	}
-	if org.QuotaSlotsTotal >= 0 && usage.Slots+int(req.ProdSlots) > org.QuotaSlotsTotal {
+	if org.QuotaSlotsTotal >= 0 && usage.Slots+prodSlots > org.QuotaSlotsTotal {
 		return nil, status.Errorf(codes.FailedPrecondition, "quota exceeded: org %q is limited to %d total slots", org.Name, org.QuotaSlotsTotal)
 	}
 	if org.QuotaDeployments >= 0 && usage.Deployments >= org.QuotaDeployments {
@@ -525,11 +541,6 @@ func (s *Server) CreateProject(ctx context.Context, req *adminv1.CreateProjectRe
 		userID = &tmp
 	}
 
-	devSlots := 4 // default value for older CLIs which will not pass this field
-	if req.DevSlots != 0 {
-		devSlots = int(req.DevSlots)
-	}
-
 	// Prepare the project options
 	opts := &database.InsertProjectOptions{
 		OrganizationID:       org.ID,
@@ -547,7 +558,7 @@ func (s *Server) CreateProject(ctx context.Context, req *adminv1.CreateProjectRe
 		PrimaryBranch:        "",          // Populated below
 		Subpath:              req.Subpath, // Populated below
 		ProdVersion:          req.ProdVersion,
-		ProdSlots:            int(req.ProdSlots),
+		ProdSlots:            prodSlots,
 		ProdTTLSeconds:       prodTTL,
 		DevSlots:             devSlots,
 		DevTTLSeconds:        devTTL,

--- a/cli/pkg/local/slots.go
+++ b/cli/pkg/local/slots.go
@@ -2,7 +2,10 @@ package local
 
 import "github.com/rilldata/rill/cli/pkg/cmdutil"
 
-// DefaultProdSlots returns the default number of slots for production environments.
+// DefaultProdSlots returns the prod slot count to request from the admin API.
+//
+// Returns 0 for released builds, which signals the admin server to apply its own default.
+// Dev builds request a single slot to keep local deployments small.
 //
 // A slot represents the following resources:
 //   - 1 CPU core
@@ -12,10 +15,13 @@ func DefaultProdSlots(ch *cmdutil.Helper) int {
 	if ch.IsDev() {
 		return 1
 	}
-	return 4
+	return 0
 }
 
-// DefaultDevSlots returns the default number of slots for dev environments.
+// DefaultDevSlots returns the dev slot count to request from the admin API.
+//
+// Returns 0 for released builds, which signals the admin server to apply its own default.
+// Dev builds request a single slot to keep local deployments small.
 //
 // A slot represents the following resources:
 //   - 1 CPU core
@@ -25,5 +31,5 @@ func DefaultDevSlots(ch *cmdutil.Helper) int {
 	if ch.IsDev() {
 		return 1
 	}
-	return 4
+	return 0
 }

--- a/web-admin/src/features/projects/CreateProjectForm.svelte
+++ b/web-admin/src/features/projects/CreateProjectForm.svelte
@@ -95,8 +95,6 @@
           data: {
             project,
             gitRemote: createdGitRepo,
-            prodSlots: "4",
-            devSlots: "8",
             skipDeploy: true,
           },
         });


### PR DESCRIPTION
We have default slots defined in 3 places. UI's Create Project button, cli's deploy commands and `CreateProject` API. This PR moves these defaults to `CreateProject` when slots are set to 0.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
