### PR TITLE
refac: pivot tables fill container in canvas

### DIFF
--- a/web-common/src/features/canvas/components/pivot/CanvasPivotRenderer.svelte
+++ b/web-common/src/features/canvas/components/pivot/CanvasPivotRenderer.svelte
@@ -112,6 +112,7 @@
         {pivotState}
         {rowSelectionState}
         {clickSelection}
+        fillWidth
         enableClickToFilter
         setPivotExpanded={(expanded) => {
           pivotState.update((state) => ({

--- a/web-common/src/features/dashboards/pivot/FlatTable.svelte
+++ b/web-common/src/features/dashboards/pivot/FlatTable.svelte
@@ -10,6 +10,7 @@
     calculateColumnWidth,
     calculateMeasureWidth,
     COLUMN_WIDTH_CONSTANTS as WIDTHS,
+    distributeColumnWidthsToFillContainer,
   } from "@rilldata/web-common/features/dashboards/pivot/pivot-column-width-utils";
   import Resizer from "@rilldata/web-common/layout/Resizer.svelte";
   import { modified } from "@rilldata/web-common/lib/actions/modified-click";
@@ -40,6 +41,8 @@
   export let clickSelection: PivotClickSelectionState | undefined = undefined;
   export let activeCell: { rowId: string; columnId: string } | null | undefined;
   export let config: PivotDataStoreConfig | undefined = undefined;
+  export let fillWidth = false;
+  export let containerWidth = 0;
 
   // Table props
   export let headerGroups: HeaderGroup<PivotDataRow>[];
@@ -85,10 +88,21 @@
     }
   });
 
-  $: totalLength = headers.reduce((acc, header) => {
-    return (
-      acc + ($columnLengths.get(header.column.id) ?? WIDTHS.INIT_MEASURE_WIDTH)
-    );
+  $: baseColumnWidths = headers.map(
+    (header) =>
+      $columnLengths.get(header.column.id) ?? WIDTHS.INIT_MEASURE_WIDTH,
+  );
+  $: displayColumnWidths = fillWidth
+    ? distributeColumnWidthsToFillContainer(
+        headers.map((header, i) => ({
+          width: baseColumnWidths[i],
+          role: getMeasureColumn(header.column) ? "measure" : "dimension",
+        })),
+        containerWidth,
+      )
+    : baseColumnWidths;
+  $: totalLength = displayColumnWidths.reduce((acc, width) => {
+    return acc + width;
   }, 0);
 
   function getMeasureColumn(headerColumn: Column<PivotDataRow>) {
@@ -117,8 +131,9 @@
   style:height="{totalRowSize + HEADER_HEIGHT + headerGroups.length}px"
 >
   {#each headers as header, i (header.id)}
-    {@const length =
+    {@const baseLength =
       $columnLengths.get(header.column.id) ?? WIDTHS.INIT_MEASURE_WIDTH}
+    {@const length = displayColumnWidths[i] ?? baseLength}
     {@const last = i === headers.length - 1}
     <div style:width="{length}px" class="h-full relative">
       <Resizer
@@ -126,10 +141,10 @@
         direction="EW"
         min={WIDTHS.MIN_MEASURE_WIDTH}
         max={WIDTHS.MAX_MEASURE_WIDTH}
-        dimension={length}
+        dimension={baseLength}
         justify={last ? "end" : "center"}
         hang={!last}
-        onUpdate={(d) =>
+        onUpdate={(d: number) =>
           columnLengths.update((lengths) => {
             return lengths.set(header.column.id, d);
           })}
@@ -149,9 +164,10 @@
   onmouseleave={onTableLeave}
 >
   <colgroup>
-    {#each headers as header (header.id)}
-      {@const length =
+    {#each headers as header, i (header.id)}
+      {@const baseLength =
         $columnLengths.get(header.column.id) ?? WIDTHS.INIT_MEASURE_WIDTH}
+      {@const length = displayColumnWidths[i] ?? baseLength}
       <col style:width="{length}px" style:max-width="{length}px" />
     {/each}
   </colgroup>

--- a/web-common/src/features/dashboards/pivot/FlatTable.svelte
+++ b/web-common/src/features/dashboards/pivot/FlatTable.svelte
@@ -1,19 +1,15 @@
-<script lang="ts" context="module">
-  import { writable } from "svelte/store";
-  const columnLengths = writable(new Map<string, number>());
-</script>
-
 <script lang="ts">
   import ArrowDown from "@rilldata/web-common/components/icons/ArrowDown.svelte";
   import type { MeasureColumnProps } from "@rilldata/web-common/features/dashboards/pivot/pivot-column-definition";
   import {
+    COLUMN_WIDTH_CONSTANTS as WIDTHS,
     calculateColumnWidth,
     calculateMeasureWidth,
-    COLUMN_WIDTH_CONSTANTS as WIDTHS,
     distributeColumnWidthsToFillContainer,
   } from "@rilldata/web-common/features/dashboards/pivot/pivot-column-width-utils";
   import Resizer from "@rilldata/web-common/layout/Resizer.svelte";
   import { modified } from "@rilldata/web-common/lib/actions/modified-click";
+  import { writable } from "svelte/store";
   import type { Column, HeaderGroup, Row } from "tanstack-table-8-svelte-5";
   import { flexRender } from "tanstack-table-8-svelte-5";
   import { cellInspectorStore } from "../stores/cell-inspector-store";
@@ -58,6 +54,8 @@
   export let onMouseMove: (e: MouseEvent) => void;
   export let onTableLeave: () => void;
   export let onCellCopy: (e: MouseEvent) => void;
+
+  const columnLengths = writable(new Map<string, number>());
 
   const HEADER_HEIGHT = 30;
 

--- a/web-common/src/features/dashboards/pivot/NestedTable.svelte
+++ b/web-common/src/features/dashboards/pivot/NestedTable.svelte
@@ -30,6 +30,7 @@
     calculateMeasureWidth,
     calculateRowDimensionWidth,
     COLUMN_WIDTH_CONSTANTS as WIDTHS,
+    distributeColumnWidthsToFillContainer,
     getNestedRowDimensionWidthKey,
   } from "./pivot-column-width-utils";
   import type { PivotRowSelectionState } from "./pivot-row-selection";
@@ -62,6 +63,8 @@
   export let rowSelectionState: PivotRowSelectionState | undefined = undefined;
   export let clickSelection: PivotClickSelectionState | undefined = undefined;
   export let activeCell: { rowId: string; columnId: string } | null | undefined;
+  export let fillWidth = false;
+  export let containerWidth = 0;
 
   // Table props
   export let headerGroups: HeaderGroup<PivotDataRow>[];
@@ -139,7 +142,7 @@
     });
   }
 
-  $: rowDimensionWidth =
+  $: baseRowDimensionWidth =
     (rowDimensionWidthKey && $rowDimensionLengths.get(rowDimensionWidthKey)) ||
     0;
 
@@ -196,8 +199,54 @@
     ) ?? subHeaders;
 
   $: measureGroupsLength = measureGroups.length;
+  $: visibleMeasureColumns = measureGroups.flatMap(({ subHeaders }) =>
+    subHeaders.map(
+      ({
+        column: {
+          columnDef: { name },
+        },
+      }) => ({ name }),
+    ),
+  );
+  $: displayColumnWidths = fillWidth
+    ? distributeColumnWidthsToFillContainer(
+        [
+          ...(hasRowDimension
+            ? [{ width: baseRowDimensionWidth, role: "dimension" as const }]
+            : []),
+          ...visibleMeasureColumns.map(({ name }) => ({
+            width: $measureLengths.get(name) ?? WIDTHS.INIT_MEASURE_WIDTH,
+            role: "measure" as const,
+          })),
+        ],
+        containerWidth,
+      )
+    : [
+        ...(hasRowDimension ? [baseRowDimensionWidth] : []),
+        ...visibleMeasureColumns.map(
+          ({ name }) => $measureLengths.get(name) ?? WIDTHS.INIT_MEASURE_WIDTH,
+        ),
+      ];
+  $: displayRowDimensionWidth = hasRowDimension
+    ? (displayColumnWidths[0] ?? baseRowDimensionWidth)
+    : 0;
+  $: displayMeasureWidths = new Map(
+    visibleMeasureColumns.map(({ name }, i) => {
+      const offset = hasRowDimension ? 1 : 0;
+      return [
+        name,
+        displayColumnWidths[i + offset] ??
+          $measureLengths.get(name) ??
+          WIDTHS.INIT_MEASURE_WIDTH,
+      ];
+    }),
+  );
   $: totalMeasureWidth = measures.reduce(
-    (acc, { name }) => acc + ($measureLengths.get(name) ?? 0),
+    (acc, { name }) =>
+      acc +
+      (displayMeasureWidths.get(name) ??
+        $measureLengths.get(name) ??
+        WIDTHS.INIT_MEASURE_WIDTH),
     0,
   );
   $: totalLength = measureGroupsLength * totalMeasureWidth;
@@ -218,10 +267,11 @@
     const offset =
       e.clientX -
       containerRefElement.getBoundingClientRect().left -
-      rowDimensionWidth -
+      displayRowDimensionWidth -
       measures.reduce((rollingSum, { name }, i) => {
         return i <= initialMeasureIndexOnResize
-          ? rollingSum + ($measureLengths.get(name) ?? 0)
+          ? rollingSum +
+              (displayMeasureWidths.get(name) ?? $measureLengths.get(name) ?? 0)
           : rollingSum;
       }, 0) +
       4;
@@ -272,24 +322,27 @@
 
 <div
   class="w-full absolute top-0 z-50 flex pointer-events-none"
-  style:width="{totalLength + rowDimensionWidth}px"
+  style:width="{totalLength + displayRowDimensionWidth}px"
   style:height="{totalRowSize + totalHeaderHeight + headerGroups.length}px"
 >
-  <div style:width="{rowDimensionWidth}px" class="sticky left-0 flex-none flex">
+  <div
+    style:width="{displayRowDimensionWidth}px"
+    class="sticky left-0 flex-none flex"
+  >
     <Resizer
       side="right"
       direction="EW"
       min={WIDTHS.MIN_COL_WIDTH}
       max={WIDTHS.MAX_COL_WIDTH}
-      dimension={rowDimensionWidth}
-      onUpdate={(d) => {
+      dimension={baseRowDimensionWidth}
+      onUpdate={(d: number) => {
         if (!rowDimensionWidthKey) return;
 
         rowDimensionLengths.update((rowDimensionLengths) => {
           return rowDimensionLengths.set(rowDimensionWidthKey, d);
         });
       }}
-      onMouseDown={(e) => {
+      onMouseDown={(e: MouseEvent) => {
         resizingMeasure = false;
         onResizeStart(e);
       }}
@@ -304,7 +357,9 @@
   {#each measureGroups as { subHeaders }, groupIndex (groupIndex)}
     <div class="h-full z-50 flex" style:width="{totalMeasureWidth}px">
       {#each subHeaders as { column: { columnDef: { name } } }, i (name)}
-        {@const length = $measureLengths.get(name) ?? WIDTHS.INIT_MEASURE_WIDTH}
+        {@const baseLength =
+          $measureLengths.get(name) ?? WIDTHS.INIT_MEASURE_WIDTH}
+        {@const length = displayMeasureWidths.get(name) ?? baseLength}
         {@const last =
           i === subHeaders.length - 1 &&
           groupIndex === measureGroups.length - 1}
@@ -314,14 +369,14 @@
             direction="EW"
             min={WIDTHS.MIN_MEASURE_WIDTH}
             max={WIDTHS.MAX_MEASURE_WIDTH}
-            dimension={length}
+            dimension={baseLength}
             justify={last ? "end" : "center"}
             hang={!last}
-            onUpdate={(d) =>
+            onUpdate={(d: number) =>
               measureLengths.update((measureLengths) => {
                 return measureLengths.set(name, d);
               })}
-            onMouseDown={(e) => {
+            onMouseDown={(e: MouseEvent) => {
               resizingMeasure = true;
               onResizeStart(e);
             }}
@@ -344,7 +399,7 @@
   class:with-totals-row={!!totalsRow}
   class:with-measures={hasMeasures}
   role="presentation"
-  style:width="{totalLength + rowDimensionWidth}px"
+  style:width="{totalLength + displayRowDimensionWidth}px"
   onclick={modified({ shift: onCellCopy, click: onCellClick })}
   onmousemove={onMouseMove}
   onmouseleave={() => {
@@ -353,16 +408,19 @@
   }}
 >
   <colgroup>
-    {#if rowDimensionName && rowDimensionWidth}
+    {#if rowDimensionName && displayRowDimensionWidth}
       <col
-        style:width="{rowDimensionWidth}px"
-        style:max-width="{rowDimensionWidth}px"
+        style:width="{displayRowDimensionWidth}px"
+        style:max-width="{displayRowDimensionWidth}px"
       />
     {/if}
 
     {#each measureGroups as { subHeaders }, i (i)}
       {#each subHeaders as { column: { columnDef: { name } } } (name)}
-        {@const length = $measureLengths.get(name)}
+        {@const length =
+          displayMeasureWidths.get(name) ??
+          $measureLengths.get(name) ??
+          WIDTHS.INIT_MEASURE_WIDTH}
         <col style:width="{length}px" style:max-width="{length}px" />
       {/each}
     {/each}

--- a/web-common/src/features/dashboards/pivot/NestedTable.svelte
+++ b/web-common/src/features/dashboards/pivot/NestedTable.svelte
@@ -1,13 +1,8 @@
-<script lang="ts" context="module">
-  import { writable } from "svelte/store";
-  const measureLengths = writable(new Map<string, number>());
-  const rowDimensionLengths = writable(new Map<string, number>());
-</script>
-
 <script lang="ts">
   import ArrowDown from "@rilldata/web-common/components/icons/ArrowDown.svelte";
   import Resizer from "@rilldata/web-common/layout/Resizer.svelte";
   import { modified } from "@rilldata/web-common/lib/actions/modified-click";
+  import { writable } from "svelte/store";
   import type { HeaderGroup, Row } from "tanstack-table-8-svelte-5";
   import { flexRender } from "tanstack-table-8-svelte-5";
   import { cellInspectorStore } from "../stores/cell-inspector-store";
@@ -17,9 +12,9 @@
     nestedRowState,
   } from "./pivot-cell-classes";
   import {
-    type PivotClickSelectionState,
     dimKeyFromRow,
     nestedDimKeyFromRow,
+    type PivotClickSelectionState,
   } from "./pivot-click-selection";
   import {
     getRowNestedLabel,
@@ -29,9 +24,9 @@
   import {
     calculateMeasureWidth,
     calculateRowDimensionWidth,
-    COLUMN_WIDTH_CONSTANTS as WIDTHS,
     distributeColumnWidthsToFillContainer,
     getNestedRowDimensionWidthKey,
+    COLUMN_WIDTH_CONSTANTS as WIDTHS,
   } from "./pivot-column-width-utils";
   import type { PivotRowSelectionState } from "./pivot-row-selection";
   import {
@@ -39,11 +34,11 @@
     computeCellSelectedColDimGroupIndices,
     computeCellSelectedColIndices,
     computeSelectedColIndices,
-    type HoveredColRange,
     isHeaderInHoveredRange,
     isHoveredHeader,
     isInCellSelectedColRange,
     isInSelectedColRange,
+    type HoveredColRange,
   } from "./pivot-selection-indices";
   import { isShowMoreRow } from "./pivot-utils";
   import PivotHeaderLabel from "./PivotHeaderLabel.svelte";
@@ -82,6 +77,9 @@
   export let onColumnHeaderClick:
     | ((dimensionPath: Record<string, string>) => void)
     | undefined = undefined;
+
+  const measureLengths = writable(new Map<string, number>());
+  const rowDimensionLengths = writable(new Map<string, number>());
 
   const HEADER_HEIGHT = 30;
 

--- a/web-common/src/features/dashboards/pivot/PivotTable.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTable.svelte
@@ -53,6 +53,7 @@
   export let border = true;
   export let overscan = 20;
   export let rounded = true;
+  export let fillWidth = false;
   export let setPivotExpanded: (expanded: ExpandedState) => void;
   export let setPivotSort: (sorting: SortingState) => void;
   export let setPivotRowPage: (page: number) => void;
@@ -115,6 +116,7 @@
   $: table = createSvelteTable(options);
 
   let containerRefElement: HTMLDivElement;
+  let containerWidth = 0;
   let stickyRows: number[] = [];
   let rowScrollOffset = 0;
   let scrollLeft = 0;
@@ -355,6 +357,9 @@
   style:--header-height="{HEADER_HEIGHT}px"
   style:--total-header-height="{totalHeaderHeight + 1}px"
   bind:this={containerRefElement}
+  bind:clientWidth={containerWidth}
+  class:w-full={fillWidth}
+  class:w-fit={!fillWidth}
   onscroll={() => handleScroll(containerRefElement)}
 >
   {#if isFlat}
@@ -379,6 +384,8 @@
       {onMouseMove}
       {onCellClick}
       {onTableLeave}
+      {fillWidth}
+      {containerWidth}
       onCellCopy={handleClick}
     />
   {:else}
@@ -408,6 +415,8 @@
       {onMouseMove}
       {onCellClick}
       {onTableLeave}
+      {fillWidth}
+      {containerWidth}
       onCellCopy={handleClick}
     />
   {/if}
@@ -425,7 +434,7 @@
 
 <style lang="postcss">
   .table-wrapper {
-    @apply overflow-auto h-fit max-h-full w-fit max-w-full;
+    @apply overflow-auto h-fit max-h-full max-w-full;
     @apply z-40 select-none;
   }
 </style>

--- a/web-common/src/features/dashboards/pivot/pivot-column-width-utils.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-column-width-utils.ts
@@ -18,6 +18,40 @@ export const COLUMN_WIDTH_CONSTANTS = {
   MAX_COL_DIMENSION_HEADER_LENGTH: 18,
 };
 
+type ColumnWidthRole = "dimension" | "measure";
+
+export type FillWidthColumn = {
+  width: number;
+  role: ColumnWidthRole;
+};
+
+const DIMENSION_FILL_WEIGHT = 1.4;
+const MEASURE_FILL_WEIGHT = 1;
+
+export function distributeColumnWidthsToFillContainer(
+  columns: FillWidthColumn[],
+  containerWidth: number,
+) {
+  const baseWidths = columns.map(({ width }) => width);
+  const totalWidth = baseWidths.reduce((sum, width) => sum + width, 0);
+  const extraWidth = containerWidth - totalWidth;
+
+  if (!columns.length || extraWidth <= 0) return baseWidths;
+
+  const hasDimensions = columns.some(({ role }) => role === "dimension");
+  const hasMeasures = columns.some(({ role }) => role === "measure");
+  const weights = columns.map(({ role }) =>
+    hasDimensions && hasMeasures && role === "dimension"
+      ? DIMENSION_FILL_WEIGHT
+      : MEASURE_FILL_WEIGHT,
+  );
+  const totalWeight = weights.reduce((sum, weight) => sum + weight, 0);
+
+  return baseWidths.map(
+    (width, i) => width + (extraWidth * weights[i]) / totalWeight,
+  );
+}
+
 export function calculateColumnWidth(
   columnName: string,
   timeDimension: string,

--- a/web-common/src/features/dashboards/pivot/tests/pivot-column-width-utils.test.ts
+++ b/web-common/src/features/dashboards/pivot/tests/pivot-column-width-utils.test.ts
@@ -1,4 +1,7 @@
-import { getNestedRowDimensionWidthKey } from "@rilldata/web-common/features/dashboards/pivot/pivot-column-width-utils";
+import {
+  distributeColumnWidthsToFillContainer,
+  getNestedRowDimensionWidthKey,
+} from "@rilldata/web-common/features/dashboards/pivot/pivot-column-width-utils";
 import { describe, expect, it } from "vitest";
 
 describe("getNestedRowDimensionWidthKey", () => {
@@ -40,5 +43,46 @@ describe("getNestedRowDimensionWidthKey", () => {
         { name: "country" },
       ]),
     );
+  });
+});
+
+describe("distributeColumnWidthsToFillContainer", () => {
+  it("leaves widths unchanged when the columns already fill the container", () => {
+    expect(
+      distributeColumnWidthsToFillContainer(
+        [
+          { width: 160, role: "dimension" },
+          { width: 100, role: "measure" },
+        ],
+        200,
+      ),
+    ).toEqual([160, 100]);
+  });
+
+  it("gives dimension columns more of the extra width than measure columns", () => {
+    const widths = distributeColumnWidthsToFillContainer(
+      [
+        { width: 160, role: "dimension" },
+        { width: 100, role: "measure" },
+        { width: 100, role: "measure" },
+      ],
+      530,
+    );
+
+    expect(widths.reduce((sum, width) => sum + width, 0)).toBeCloseTo(530);
+    expect(widths[0] - 160).toBeGreaterThan(widths[1] - 100);
+    expect(widths[1]).toBeCloseTo(widths[2]);
+  });
+
+  it("spreads extra width evenly when there are no measure columns", () => {
+    expect(
+      distributeColumnWidthsToFillContainer(
+        [
+          { width: 160, role: "dimension" },
+          { width: 120, role: "dimension" },
+        ],
+        380,
+      ),
+    ).toEqual([210, 170]);
   });
 });


### PR DESCRIPTION
Adds full width support to pivot tables. Enable it for all canvas tables.

Related: https://github.com/rilldata/rill/pull/9157

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
