### PR TITLE
fix: canvas sub/unsub race condition

### DIFF
--- a/web-common/src/features/canvas/CanvasInitialization.svelte
+++ b/web-common/src/features/canvas/CanvasInitialization.svelte
@@ -108,7 +108,7 @@
     });
   }
 
-  let unsubscribe: (() => void) | undefined = undefined;
+  let release: (() => void) | undefined = undefined;
 
   onNavigate(() => {
     if (hasBanner) {
@@ -166,25 +166,29 @@
           filePath: fetchedCanvas?.canvas?.meta?.filePaths?.[0],
         };
 
-        return setCanvasStore(
+        const newStore = setCanvasStore(
           canvasName,
           instanceId,
           processed,
           client,
           allowUnvalidatedSpec,
         );
+        newStore.canvasEntity.acquire();
+        release?.(); // release our reference to the previous entity, if any
+        release = newStore.canvasEntity.release;
+        return newStore;
       }
     }
 
-    existingStore?.canvasEntity?.resubscribe();
-    unsubscribe?.(); // cleanup old entities if any
-    unsubscribe = existingStore?.canvasEntity?.unsubscribe;
+    existingStore?.canvasEntity?.acquire();
+    release?.(); // release our reference to the previous entity, if any
+    release = existingStore?.canvasEntity?.release;
 
     return existingStore;
   }
 
   onDestroy(() => {
-    unsubscribe?.();
+    release?.();
   });
 </script>
 

--- a/web-common/src/features/canvas/state-managers/state-managers.ts
+++ b/web-common/src/features/canvas/state-managers/state-managers.ts
@@ -31,7 +31,7 @@ export function getCanvasStoreUnguarded(
     allowUnvalidatedSpec !== undefined &&
     store.canvasEntity.allowUnvalidatedSpec !== allowUnvalidatedSpec
   ) {
-    store.canvasEntity.unsubscribe();
+    store.canvasEntity.dispose();
     canvasRegistry.delete(id);
     return undefined;
   }
@@ -64,10 +64,13 @@ export function removeCanvasStore(
   // Tear down the entity's subscriptions before dropping it from the registry,
   // otherwise the orphaned entity keeps reacting to spec emissions and races
   // the entity created on the next visit.
-  canvasRegistry.get(id)?.canvasEntity.unsubscribe();
+  canvasRegistry.get(id)?.canvasEntity.dispose();
   canvasRegistry.delete(id);
 }
 
+// The returned entity does not subscribe to its spec store until a consumer
+// calls `canvasEntity.acquire()`; callers are responsible for acquiring and
+// releasing their reference (see CanvasInitialization).
 export function setCanvasStore(
   canvasName: string,
   instanceId: string,
@@ -82,7 +85,7 @@ export function setCanvasStore(
     existingStore &&
     existingStore.canvasEntity.allowUnvalidatedSpec !== allowUnvalidatedSpec
   ) {
-    existingStore.canvasEntity.unsubscribe();
+    existingStore.canvasEntity.dispose();
     canvasRegistry.delete(id);
   } else if (existingStore) {
     console.warn(

--- a/web-common/src/features/canvas/stores/canvas-entity.ts
+++ b/web-common/src/features/canvas/stores/canvas-entity.ts
@@ -109,7 +109,7 @@ export class CanvasEntity {
   firstLoad = writable(true);
   themeName = writable<string | undefined>(undefined);
   theme: Readable<Theme | undefined>;
-  unsubscriber: Unsubscriber;
+  unsubscriber: Unsubscriber | undefined;
   private searchParams = writable<URLSearchParams>(new URLSearchParams());
   // This may sometimes be false due to discrepancy between two different ways
   // of storing the same state in the URL namely dimension IN (['value']) vs  dimension IN ('value')
@@ -125,6 +125,8 @@ export class CanvasEntity {
   // This is to skip processing the spec the first time the store updates with a value
   // We've already called it as part of the constructor
   firstTimeLoad = true;
+
+  private subscribers = 0;
 
   constructor(
     public name: string,
@@ -198,8 +200,6 @@ export class CanvasEntity {
       this.client,
       this._metricsViews,
     );
-
-    this.resubscribe();
 
     this.viewingDefaultsStore = derived(
       [
@@ -534,9 +534,15 @@ export class CanvasEntity {
     this.applyTabsFromURL();
   };
 
-  // Resubscribes to the spec store. Internal call to processSpec will recreate the components.
-  // This ensures that cached canvas entities are not left in an error state.
-  resubscribe = () => {
+  // Acquires a reference to the entity. The cached entity is shared across
+  // consumers (e.g. an unmounting editor and a mounting preview overlap during
+  // navigation), so its spec subscription must survive as long as any consumer
+  // needs it. Subscribes on the first consumer; idempotent thereafter. The
+  // subscription's processSpec call recreates the components, ensuring a cached
+  // entity that was previously disposed is not left in an error state.
+  acquire = () => {
+    this.subscribers++;
+    if (this.unsubscriber) return; // already subscribed
     this.unsubscriber = this.specStore.subscribe(({ data }) => {
       if (this.firstTimeLoad) {
         this.firstTimeLoad = false;
@@ -548,12 +554,25 @@ export class CanvasEntity {
     });
   };
 
-  // Tears down the spec subscription opened in the constructor and disposes
-  // every child component. Without this, a stale entity left over from a
-  // "reset to defaults" save keeps reacting to spec emissions and races the
-  // live entity over URL and YAML writes.
-  unsubscribe = () => {
-    this.unsubscriber();
+  // Releases a consumer's reference. Tears down only once the last consumer
+  // releases; balanced against acquire. Without this, a stale entity left over
+  // from a "reset to defaults" save keeps reacting to spec emissions and races
+  // the live entity over URL and YAML writes.
+  release = () => {
+    if (this.subscribers === 0) return; // guard against unbalanced release
+    this.subscribers--;
+    if (this.subscribers > 0) return;
+    this.dispose();
+  };
+
+  // Unconditionally tears down the spec subscription and disposes every child
+  // component, regardless of the reference count. Used when the entity is
+  // evicted from the registry (mode switch or removeCanvasStore) and is being
+  // discarded; a subsequent release on the disposed entity is a safe no-op.
+  dispose = () => {
+    this.subscribers = 0;
+    this.unsubscriber?.();
+    this.unsubscriber = undefined; // so a later acquire re-subscribes
     this.componentsStore.read().forEach((component) => component.destroy());
     this.componentsStore.reset();
   };


### PR DESCRIPTION
In https://github.com/rilldata/rill/pull/9606 we fixed canvas sub/unsub issues when moving from a canvas route to non-canvas route or a different canvas route. But going from canvas to same canvas route, (the preview button in rill dev) still has the old issue of components being unmounted.

Improving the checks to have a count of subsriptions per canvas. This way mounting and unmounting the same canvas doesnt leave the stores in unsubbed state.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
