### PR TITLE
fix: hide Discord link in embedded canvas pivot tables

### DIFF
--- a/web-common/src/features/canvas/components/pivot/CanvasPivotRenderer.svelte
+++ b/web-common/src/features/canvas/components/pivot/CanvasPivotRenderer.svelte
@@ -4,6 +4,7 @@
   import PivotEmpty from "@rilldata/web-common/features/dashboards/pivot/PivotEmpty.svelte";
   import PivotError from "@rilldata/web-common/features/dashboards/pivot/PivotError.svelte";
   import PivotTable from "@rilldata/web-common/features/dashboards/pivot/PivotTable.svelte";
+  import { EmbedStore } from "@rilldata/web-common/features/embeds/embed-store";
   import type {
     PivotDataStore,
     PivotDataStoreConfig,
@@ -101,6 +102,7 @@
         assembled={$pivotDataStore.assembled}
         isFetching={$pivotDataStore.isFetching}
         {hasColumnAndNoMeasure}
+        isEmbedded={EmbedStore.isEmbedded()}
       />
     {:else}
       <PivotTable


### PR DESCRIPTION
Hide the Discord/docs links in embedded **canvas** pivot tables.

- The v0.85.0 fix (#9135) guarded these links behind `PivotEmpty`'s `isEmbedded` prop, which only the explore path threaded through. `CanvasPivotRenderer` never passed it, so Discord still showed in embedded canvas pivot components.
- Pass `isEmbedded={EmbedStore.isEmbedded()}` from `CanvasPivotRenderer`, matching the explore path.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*
