### PR TITLE
Make glob resolver `last` parameter a hard limit on returned partitions

### DIFF
--- a/docs/docs/developers/build/models/partitioned-models.md
+++ b/docs/docs/developers/build/models/partitioned-models.md
@@ -230,7 +230,7 @@ Use `start` and `end` to filter which partitions are processed based on their pa
 
 - **`start`** — lower bound (inclusive): only partitions with paths ≥ this value are included.
 - **`end`** — upper bound (exclusive): only partitions with paths < this value are included.
-- **`last`** — process only the last N successfully ingested partitions (by lexicographic path order). Useful for rolling windows.
+- **`last`** — limit to the last N partitions (by lexicographic path order). This hard limit always applies, including on the first run when no partitions have been ingested yet. Once partitions have been ingested, it also raises the lower bound to the Nth-from-last successfully ingested partition, forming a rolling window that re-lists recent partitions.
 
 ```yaml
 # Fixed window: only process a specific month

--- a/docs/docs/reference/project-files/alerts.md
+++ b/docs/docs/reference/project-files/alerts.md
@@ -94,7 +94,7 @@ _[oneOf]_ - Data source for the alert _(required)_
 
         - **`end`** - _[string]_ - Defines the upper bound (exclusive) for partition filtering. Only partitions with paths less than this value are considered.
 
-        - **`last`** - _[integer]_ - Sets a lower bound based on the Nth partition from the end of the lexicographically sorted, successfully processed partitions. Only partitions after this point are included.
+        - **`last`** - _[integer]_ - Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that re-lists recent partitions.
 
         - **`partition`** - _[string]_ - Controls how matched files are grouped: - "file" (default) : Each matched path is returned as a row. Use the glob pattern to match files or directories at the level you want (for example, file-level or directory-level). - "directory": This mode is deprecated. Instead, use "file" with a glob that directly matches the directory level you want. - "hive": groups files by directory and extracts Hive-style partition values from the path as columns.
 

--- a/docs/docs/reference/project-files/alerts.md
+++ b/docs/docs/reference/project-files/alerts.md
@@ -94,7 +94,7 @@ _[oneOf]_ - Data source for the alert _(required)_
 
         - **`end`** - _[string]_ - Defines the upper bound (exclusive) for partition filtering. Only partitions with paths less than this value are considered.
 
-        - **`last`** - _[integer]_ - Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that re-lists recent partitions.
+        - **`last`** - _[integer]_ - Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that prevents full re-listings each time.
 
         - **`partition`** - _[string]_ - Controls how matched files are grouped: - "file" (default) : Each matched path is returned as a row. Use the glob pattern to match files or directories at the level you want (for example, file-level or directory-level). - "directory": This mode is deprecated. Instead, use "file" with a glob that directly matches the directory level you want. - "hive": groups files by directory and extracts Hive-style partition values from the path as columns.
 

--- a/docs/docs/reference/project-files/apis.md
+++ b/docs/docs/reference/project-files/apis.md
@@ -152,7 +152,7 @@ _[oneOf]_ - Simple path/glob pattern or path/glob patternwith advanced options .
 
     - **`end`** - _[string]_ - Defines the upper bound (exclusive) for partition filtering. Only partitions with paths less than this value are considered.
 
-    - **`last`** - _[integer]_ - Sets a lower bound based on the Nth partition from the end of the lexicographically sorted, successfully processed partitions. Only partitions after this point are included.
+    - **`last`** - _[integer]_ - Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that re-lists recent partitions.
 
     - **`partition`** - _[string]_ - Controls how matched files are grouped: - "file" (default) : Each matched path is returned as a row. Use the glob pattern to match files or directories at the level you want (for example, file-level or directory-level). - "directory": This mode is deprecated. Instead, use "file" with a glob that directly matches the directory level you want. - "hive": groups files by directory and extracts Hive-style partition values from the path as columns.
 

--- a/docs/docs/reference/project-files/apis.md
+++ b/docs/docs/reference/project-files/apis.md
@@ -152,7 +152,7 @@ _[oneOf]_ - Simple path/glob pattern or path/glob patternwith advanced options .
 
     - **`end`** - _[string]_ - Defines the upper bound (exclusive) for partition filtering. Only partitions with paths less than this value are considered.
 
-    - **`last`** - _[integer]_ - Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that re-lists recent partitions.
+    - **`last`** - _[integer]_ - Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that prevents full re-listings each time.
 
     - **`partition`** - _[string]_ - Controls how matched files are grouped: - "file" (default) : Each matched path is returned as a row. Use the glob pattern to match files or directories at the level you want (for example, file-level or directory-level). - "directory": This mode is deprecated. Instead, use "file" with a glob that directly matches the directory level you want. - "hive": groups files by directory and extracts Hive-style partition values from the path as columns.
 

--- a/docs/docs/reference/project-files/models.md
+++ b/docs/docs/reference/project-files/models.md
@@ -157,7 +157,7 @@ _[oneOf]_ - Refers to the explicitly defined state of your model, cannot be used
 
         - **`end`** - _[string]_ - Defines the upper bound (exclusive) for partition filtering. Only partitions with paths less than this value are considered.
 
-        - **`last`** - _[integer]_ - Sets a lower bound based on the Nth partition from the end of the lexicographically sorted, successfully processed partitions. Only partitions after this point are included.
+        - **`last`** - _[integer]_ - Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that re-lists recent partitions.
 
         - **`partition`** - _[string]_ - Controls how matched files are grouped: - "file" (default) : Each matched path is returned as a row. Use the glob pattern to match files or directories at the level you want (for example, file-level or directory-level). - "directory": This mode is deprecated. Instead, use "file" with a glob that directly matches the directory level you want. - "hive": groups files by directory and extracts Hive-style partition values from the path as columns.
 
@@ -255,7 +255,7 @@ _[oneOf]_ - Refers to the how your data is partitioned, cannot be used with stat
 
         - **`end`** - _[string]_ - Defines the upper bound (exclusive) for partition filtering. Only partitions with paths less than this value are considered.
 
-        - **`last`** - _[integer]_ - Sets a lower bound based on the Nth partition from the end of the lexicographically sorted, successfully processed partitions. Only partitions after this point are included.
+        - **`last`** - _[integer]_ - Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that re-lists recent partitions.
 
         - **`partition`** - _[string]_ - Controls how matched files are grouped: - "file" (default) : Each matched path is returned as a row. Use the glob pattern to match files or directories at the level you want (for example, file-level or directory-level). - "directory": This mode is deprecated. Instead, use "file" with a glob that directly matches the directory level you want. - "hive": groups files by directory and extracts Hive-style partition values from the path as columns.
 

--- a/docs/docs/reference/project-files/models.md
+++ b/docs/docs/reference/project-files/models.md
@@ -157,7 +157,7 @@ _[oneOf]_ - Refers to the explicitly defined state of your model, cannot be used
 
         - **`end`** - _[string]_ - Defines the upper bound (exclusive) for partition filtering. Only partitions with paths less than this value are considered.
 
-        - **`last`** - _[integer]_ - Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that re-lists recent partitions.
+        - **`last`** - _[integer]_ - Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that prevents full re-listings each time.
 
         - **`partition`** - _[string]_ - Controls how matched files are grouped: - "file" (default) : Each matched path is returned as a row. Use the glob pattern to match files or directories at the level you want (for example, file-level or directory-level). - "directory": This mode is deprecated. Instead, use "file" with a glob that directly matches the directory level you want. - "hive": groups files by directory and extracts Hive-style partition values from the path as columns.
 
@@ -255,7 +255,7 @@ _[oneOf]_ - Refers to the how your data is partitioned, cannot be used with stat
 
         - **`end`** - _[string]_ - Defines the upper bound (exclusive) for partition filtering. Only partitions with paths less than this value are considered.
 
-        - **`last`** - _[integer]_ - Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that re-lists recent partitions.
+        - **`last`** - _[integer]_ - Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that prevents full re-listings each time.
 
         - **`partition`** - _[string]_ - Controls how matched files are grouped: - "file" (default) : Each matched path is returned as a row. Use the glob pattern to match files or directories at the level you want (for example, file-level or directory-level). - "directory": This mode is deprecated. Instead, use "file" with a glob that directly matches the directory level you want. - "hive": groups files by directory and extracts Hive-style partition values from the path as columns.
 

--- a/docs/docs/reference/project-files/reports.md
+++ b/docs/docs/reference/project-files/reports.md
@@ -96,7 +96,7 @@ Supports ai resolvers only as of now.
 
         - **`end`** - _[string]_ - Defines the upper bound (exclusive) for partition filtering. Only partitions with paths less than this value are considered.
 
-        - **`last`** - _[integer]_ - Sets a lower bound based on the Nth partition from the end of the lexicographically sorted, successfully processed partitions. Only partitions after this point are included.
+        - **`last`** - _[integer]_ - Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that re-lists recent partitions.
 
         - **`partition`** - _[string]_ - Controls how matched files are grouped: - "file" (default) : Each matched path is returned as a row. Use the glob pattern to match files or directories at the level you want (for example, file-level or directory-level). - "directory": This mode is deprecated. Instead, use "file" with a glob that directly matches the directory level you want. - "hive": groups files by directory and extracts Hive-style partition values from the path as columns.
 

--- a/docs/docs/reference/project-files/reports.md
+++ b/docs/docs/reference/project-files/reports.md
@@ -96,7 +96,7 @@ Supports ai resolvers only as of now.
 
         - **`end`** - _[string]_ - Defines the upper bound (exclusive) for partition filtering. Only partitions with paths less than this value are considered.
 
-        - **`last`** - _[integer]_ - Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that re-lists recent partitions.
+        - **`last`** - _[integer]_ - Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that prevents full re-listings each time.
 
         - **`partition`** - _[string]_ - Controls how matched files are grouped: - "file" (default) : Each matched path is returned as a row. Use the glob pattern to match files or directories at the level you want (for example, file-level or directory-level). - "directory": This mode is deprecated. Instead, use "file" with a glob that directly matches the directory level you want. - "hive": groups files by directory and extracts Hive-style partition values from the path as columns.
 

--- a/runtime/parser/schema/project.schema.yaml
+++ b/runtime/parser/schema/project.schema.yaml
@@ -3549,7 +3549,7 @@ definitions:
                     description: Defines the upper bound (exclusive) for partition filtering. Only partitions with paths less than this value are considered.
                   last:
                     type: integer
-                    description: Sets a lower bound based on the Nth partition from the end of the lexicographically sorted, successfully processed partitions. Only partitions after this point are included.
+                    description: Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that re-lists recent partitions.
                   partition:
                     type: string
                     enum: [ "file", "directory", "hive"]
@@ -3676,7 +3676,7 @@ definitions:
                     description: Defines the upper bound (exclusive) for partition filtering. Only partitions with paths less than this value are considered.
                   last:
                     type: integer
-                    description: Sets a lower bound based on the Nth partition from the end of the lexicographically sorted, successfully processed partitions. Only partitions after this point are included.
+                    description: Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that re-lists recent partitions.
                   partition:
                     type: string
                     enum: [ "file", "directory", "hive"]

--- a/runtime/parser/schema/project.schema.yaml
+++ b/runtime/parser/schema/project.schema.yaml
@@ -3549,7 +3549,7 @@ definitions:
                     description: Defines the upper bound (exclusive) for partition filtering. Only partitions with paths less than this value are considered.
                   last:
                     type: integer
-                    description: Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that re-lists recent partitions.
+                    description: Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that prevents full re-listings each time.
                   partition:
                     type: string
                     enum: [ "file", "directory", "hive"]
@@ -3676,7 +3676,7 @@ definitions:
                     description: Defines the upper bound (exclusive) for partition filtering. Only partitions with paths less than this value are considered.
                   last:
                     type: integer
-                    description: Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that re-lists recent partitions.
+                    description: Limits the result to the last N partitions (the N highest paths in lexicographic order). This hard limit always applies, including on the first run when there is no existing data. Additionally, when previously processed partitions exist, it raises the lower bound to the Nth partition from the end of those successfully processed partitions, forming a rolling window that prevents full re-listings each time.
                   partition:
                     type: string
                     enum: [ "file", "directory", "hive"]

--- a/runtime/resolvers/glob.go
+++ b/runtime/resolvers/glob.go
@@ -75,9 +75,12 @@ type globProps struct {
 	// End defines the upper bound (exclusive) for partition filtering.
 	// Only partitions with paths less than this value are considered.
 	End string `mapstructure:"end"`
-	// Last sets a lower bound based on the Nth partition from the end of the
-	// lexicographically sorted, successfully processed partitions. Only partitions
-	// after this point are included.
+	// Last limits the result to the last N partitions (the N highest paths in
+	// lexicographic order). It always applies as a hard limit, including on the
+	// first run when there is no existing data. Additionally, when previously
+	// processed partitions exist, it raises the lower bound to the Nth partition
+	// from the end of those successfully processed partitions, forming a rolling
+	// window that re-lists recent partitions.
 	Last int `mapstructure:"last"`
 	// Partition defines if and how to group the files that match the glob into partitions.
 	Partition globPartitionType `mapstructure:"partition"`
@@ -167,7 +170,7 @@ func newGlob(ctx context.Context, opts *runtime.ResolverOptions) (runtime.Resolv
 			return nil, err
 		}
 
-		paths := make([]string, len(partitions))
+		paths := make([]string, 0, len(partitions))
 		for _, p := range partitions {
 			var data map[string]any
 
@@ -290,6 +293,14 @@ func (r *globResolver) ResolveInteractive(ctx context.Context) (runtime.Resolver
 		rows = r.buildPartitionedResult(entries, true)
 	default:
 		return nil, fmt.Errorf("unknown glob partition type %q", r.props.Partition)
+	}
+
+	// If `last` is set, return only the last N rows (the N highest paths).
+	// Combined with the lookback window applied via partitionStart in newGlob,
+	// this ensures we always return at most N partitions, including on the first
+	// run when there is no existing processed data.
+	if r.props.Last > 0 && len(rows) > r.props.Last {
+		rows = rows[len(rows)-r.props.Last:]
 	}
 
 	if r.props.TransformSQL != "" {

--- a/runtime/resolvers/glob.go
+++ b/runtime/resolvers/glob.go
@@ -80,7 +80,7 @@ type globProps struct {
 	// first run when there is no existing data. Additionally, when previously
 	// processed partitions exist, it raises the lower bound to the Nth partition
 	// from the end of those successfully processed partitions, forming a rolling
-	// window that re-lists recent partitions.
+	// window that re-lists only recent partitions (to avoid repeated full listings, which are expensive).
 	Last int `mapstructure:"last"`
 	// Partition defines if and how to group the files that match the glob into partitions.
 	Partition globPartitionType `mapstructure:"partition"`

--- a/runtime/resolvers/glob_test.go
+++ b/runtime/resolvers/glob_test.go
@@ -73,6 +73,72 @@ func TestGlobTrimsWhitespace(t *testing.T) {
 	require.Equal(t, "file1.csv", rows[2]["path"])
 }
 
+func TestGlobLast(t *testing.T) {
+	rt, instanceID := prepareGlobTest(t, "mock", map[string]string{
+		"file1.csv":     ``,
+		"dir/file2.csv": ``,
+		"dir/file3.csv": ``,
+	})
+
+	res, _, err := rt.Resolve(context.Background(), &runtime.ResolveOptions{
+		InstanceID: instanceID,
+		Resolver:   "glob",
+		ResolverProperties: map[string]any{
+			"connector": "mock",
+			"path":      "mock://bucket/**/*.csv",
+			"last":      2,
+		},
+		Args:   nil,
+		Claims: &runtime.SecurityClaims{},
+	})
+	require.NoError(t, err)
+	defer res.Close()
+
+	var rows []map[string]interface{}
+	require.NoError(t, json.Unmarshal(must(res.MarshalJSON()), &rows))
+
+	// With no existing partitions, `last` acts as a hard limit on the last N rows (the N highest paths).
+	require.Len(t, rows, 2)
+	require.Equal(t, "dir/file3.csv", rows[0]["path"])
+	require.Equal(t, "file1.csv", rows[1]["path"])
+}
+
+func TestGlobLastPartitioned(t *testing.T) {
+	rt, instanceID := prepareGlobTest(t, "mock", map[string]string{
+		"dir/file1.csv":        ``,
+		"dir/subdir/file2.csv": ``,
+		"dir/subdir/file3.csv": ``,
+	})
+
+	res, _, err := rt.Resolve(context.Background(), &runtime.ResolveOptions{
+		InstanceID: instanceID,
+		Resolver:   "glob",
+		ResolverProperties: map[string]any{
+			"connector":    "mock",
+			"path":         "mock://bucket/**/*.csv",
+			"partition":    "directory",
+			"rollup_files": true,
+			"last":         1,
+		},
+		Args:   nil,
+		Claims: &runtime.SecurityClaims{},
+	})
+	require.NoError(t, err)
+	defer res.Close()
+
+	var rows []map[string]interface{}
+	require.NoError(t, json.Unmarshal(must(res.MarshalJSON()), &rows))
+
+	for _, row := range rows {
+		delete(row, "updated_on")
+	}
+
+	// The limit applies to partition rows, not files: only the last partition is returned.
+	require.Equal(t, []map[string]interface{}{
+		{"uri": "mock://bucket/dir/subdir", "path": "dir/subdir", "files": []any{"dir/subdir/file2.csv", "dir/subdir/file3.csv"}},
+	}, rows)
+}
+
 func TestGlobDirectoryPartitioned(t *testing.T) {
 	rt, instanceID := prepareGlobTest(t, "mock", map[string]string{
 		"dir/file1.csv":        ``,


### PR DESCRIPTION
- `last: N` now always returns at most the N most-recent partitions, including on the first run when there is no previously-processed data. Previously it only acted as a lookback lower bound and returned all partitions when no prior data existed.
- The existing rolling lookback window (based on successfully processed partitions) is unchanged.