### PR TITLE
Refactor analyst agent to a generic skill with separate, richer user prompt

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -66,6 +66,7 @@ General rules for writing Go code:
 - Functions should be sorted roughly in call order; functions should be grouped by receiver; plain utility functions belong towards the end of a file.
 - When adding a field to a struct or interface, don't automatically put at it at the end of the field list, instead put it where it makes the most sense (i.e. grouped with related fields and higher up than less important fields).
 - Prefer colons or semi-colons in code comments instead of hyphens or dashes. This keeps comments shorter, which makes them more readable in a monospace font.
+- Use semantic line breaks in comments: break at the end of a sentence, or after a comma, semicolon, or colon in longer sentences, rather than wrapping at a fixed column. Do not break a line mid-phrase to hit a character limit; a long line that expresses one complete thought reads better on a wide screen than an arbitrary mid-phrase wrap.
 - Before adding a dependency, check for newer major versions. Major versions 2+ require the `/vN` suffix in the import path (e.g., `go get github.com/foo/bar/v3@latest`). Without the suffix, `go get` only fetches v1.x.
 - Avoid short utility functions that are only used once; it is usually more readable to inline these in their parent function.
 - Avoid variables that only serve as aliases unless there's a large readability improvement (i.e. the expression is very long and used several times); for example, instead of `db := table.Database`, just reference `table.Database` directly.

--- a/runtime/ai/analyst_agent.go
+++ b/runtime/ai/analyst_agent.go
@@ -182,15 +182,15 @@ func (t *AnalystAgent) Handler(ctx context.Context, args *AnalystAgentArgs) (*An
 
 	messages := []*aiv1.CompletionMessage{NewTextCompletionMessage(RoleSystem, systemPrompt)}
 	// Prior turns only (exclude the current call, whose ID equals s.ParentID).
-	// We use MessagesWithChildren (not MessagesWithResults) so that prior turns' intermediate tool calls
-	// stay in history; this lets later turns reuse earlier lookups (e.g. avoid re-calling get_metrics_view).
-	// Do not switch this to MessagesWithResults.
+	// We use MessagesWithChildren (not MessagesWithResults) so that prior turns' intermediate tool calls stay in history;
+	// this lets later turns reuse earlier lookups (e.g. avoid re-calling get_metrics_view). Do not switch this to MessagesWithResults.
+	// The notCurrentCall filter is load-bearing: without it the current call's seeded children would be duplicated by the block below.
 	notCurrentCall := func(m *Message) bool { return m.ID != s.ParentID }
 	messages = append(messages, s.NewCompletionMessages(s.MessagesWithChildren(FilterByType(MessageTypeCall), FilterByTool(AnalystAgentName), notCurrentCall))...)
-	// The current call's seeded tool calls and their results.
-	messages = append(messages, s.NewCompletionMessages(s.MessagesWithResults(FilterByParent(s.ParentID)))...)
-	// The rich per-invocation context and the user's ask, placed last (after the seeded tool calls).
+	// The rich per-invocation context and the user's ask.
 	messages = append(messages, NewTextCompletionMessage(RoleUser, userPrompt))
+	// The current call's seeded tool calls and their results, placed after the user prompt to mirror the developer agent.
+	messages = append(messages, s.NewCompletionMessages(s.MessagesWithResults(FilterByParent(s.ParentID)))...)
 
 	// Run an LLM tool call loop
 	var response string
@@ -290,8 +290,7 @@ func (t *AnalystAgent) userPrompt(ctx context.Context, metricsViewNames []string
 	}
 
 	// Generate the user prompt.
-	// It carries all the per-invocation context: the current date, dashboard/report context, applied query
-	// settings, forked-session caveats, and finally the user's actual prompt.
+	// It carries all the per-invocation context: the current date, dashboard/report context, applied query settings, forked-session caveats, and finally the user's actual prompt.
 	return executeTemplate(`Today's date is {{ .now.Format "Monday, January 2, 2006" }} ({{ .now.Format "2006-01-02" }}).
 
 {{ if .is_report }}

--- a/runtime/ai/analyst_agent.go
+++ b/runtime/ai/analyst_agent.go
@@ -12,8 +12,8 @@ import (
 	aiv1 "github.com/rilldata/rill/proto/gen/rill/ai/v1"
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
+	"github.com/rilldata/rill/runtime/ai/instructions"
 	"github.com/rilldata/rill/runtime/metricsview"
-	"golang.org/x/exp/slices"
 )
 
 const AnalystAgentName = "analyst_agent"
@@ -171,24 +171,26 @@ func (t *AnalystAgent) Handler(ctx context.Context, args *AnalystAgentArgs) (*An
 	}
 
 	// Build completion messages
-	systemPrompt, err := t.systemPrompt(ctx, metricsViewNames, args)
+	systemPrompt, err := t.systemPrompt()
 	if err != nil {
 		return nil, err
 	}
-	messages := []*aiv1.CompletionMessage{NewTextCompletionMessage(RoleSystem, systemPrompt)}
-	messages = append(messages, s.NewCompletionMessages(s.MessagesWithChildren(FilterByType(MessageTypeCall), FilterByTool(AnalystAgentName)))...)
-
-	// If this is the first agent call in the session, re-organize messages to put the user prompt at the end (after the seeded tool calls).
-	// NOTE: We should find a cleaner way to organize/prioritize message ordering.
-	if first {
-		for i, m := range messages {
-			if m.Role == string(RoleUser) {
-				messages = slices.Delete(messages, i, i+1)
-				messages = append(messages, m)
-				break
-			}
-		}
+	userPrompt, err := t.userPrompt(ctx, metricsViewNames, args)
+	if err != nil {
+		return nil, err
 	}
+
+	messages := []*aiv1.CompletionMessage{NewTextCompletionMessage(RoleSystem, systemPrompt)}
+	// Prior turns only (exclude the current call, whose ID equals s.ParentID).
+	// We use MessagesWithChildren (not MessagesWithResults) so that prior turns' intermediate tool calls
+	// stay in history; this lets later turns reuse earlier lookups (e.g. avoid re-calling get_metrics_view).
+	// Do not switch this to MessagesWithResults.
+	notCurrentCall := func(m *Message) bool { return m.ID != s.ParentID }
+	messages = append(messages, s.NewCompletionMessages(s.MessagesWithChildren(FilterByType(MessageTypeCall), FilterByTool(AnalystAgentName), notCurrentCall))...)
+	// The current call's seeded tool calls and their results.
+	messages = append(messages, s.NewCompletionMessages(s.MessagesWithResults(FilterByParent(s.ParentID)))...)
+	// The rich per-invocation context and the user's ask, placed last (after the seeded tool calls).
+	messages = append(messages, NewTextCompletionMessage(RoleUser, userPrompt))
 
 	// Run an LLM tool call loop
 	var response string
@@ -205,7 +207,16 @@ func (t *AnalystAgent) Handler(ctx context.Context, args *AnalystAgentArgs) (*An
 	return &AnalystAgentResult{Response: response}, nil
 }
 
-func (t *AnalystAgent) systemPrompt(ctx context.Context, metricsViewNames []string, args *AnalystAgentArgs) (string, error) {
+func (t *AnalystAgent) systemPrompt() (string, error) {
+	instr, err := instructions.Load("analysis.md", instructions.Options{})
+	if err != nil {
+		return "", fmt.Errorf("failed to load analyst agent system prompt: %w", err)
+	}
+
+	return instr.Body, nil
+}
+
+func (t *AnalystAgent) userPrompt(ctx context.Context, metricsViewNames []string, args *AnalystAgentArgs) (string, error) {
 	// Prepare template data.
 	// NOTE: All the template properties are optional and may be empty.
 	session := GetSession(ctx)
@@ -217,15 +228,6 @@ func (t *AnalystAgent) systemPrompt(ctx context.Context, metricsViewNames []stri
 	instanceCfg, err := instance.Config()
 	if err != nil {
 		return "", fmt.Errorf("failed to get instance config: %w", err)
-	}
-
-	ff, err := t.Runtime.FeatureFlags(ctx, session.InstanceID(), session.Claims())
-	if err != nil {
-		return "", fmt.Errorf("failed to get feature flags: %w", err)
-	}
-
-	if args.DisableCharts {
-		ff["chat_charts"] = false
 	}
 
 	metricsViewsQuoted := make([]string, len(metricsViewNames))
@@ -244,6 +246,7 @@ func (t *AnalystAgent) systemPrompt(ctx context.Context, metricsViewNames []stri
 	}
 
 	data := map[string]any{
+		"prompt":           args.Prompt,
 		"ai_instructions":  session.ProjectInstructions(),
 		"is_prompt":        args.Prompt != "",
 		"metrics_views":    strings.Join(metricsViewsQuoted, ", "),
@@ -252,7 +255,6 @@ func (t *AnalystAgent) systemPrompt(ctx context.Context, metricsViewNames []stri
 		"canvas_component": args.CanvasComponent,
 		"dimensions":       strings.Join(dimensionsQuoted, ", "),
 		"measures":         strings.Join(measuresQuoted, ", "),
-		"feature_flags":    ff,
 		"forked":           session.Forked(),
 		"is_report":        args.IsReport,
 		"now":              time.Now(),
@@ -287,29 +289,19 @@ func (t *AnalystAgent) systemPrompt(ctx context.Context, metricsViewNames []stri
 		data["where_per_metrics_view"] = wherePerMetricsView
 	}
 
-	// Generate the system prompt
-	return executeTemplate(`<role>
-You are a data analysis agent specialized in uncovering actionable business insights.
-You systematically explore data using available metrics tools, then apply analytical rigor to find surprising patterns and unexpected relationships that influence decision-making.
+	// Generate the user prompt.
+	// It carries all the per-invocation context: the current date, dashboard/report context, applied query
+	// settings, forked-session caveats, and finally the user's actual prompt.
+	return executeTemplate(`Today's date is {{ .now.Format "Monday, January 2, 2006" }} ({{ .now.Format "2006-01-02" }}).
+
 {{ if .is_report }}
 You are operating in an automated scheduled insight report mode where you will come up with insights on your own without additional user input.
-{{ if .is_prompt }}The user has provided a custom prompt for this scheduled insight report. Tailor your analysis to address this prompt specifically. {{ end }}
+{{ if .is_prompt }}The user has provided a custom prompt for this scheduled insight report. Tailor your analysis to address this prompt specifically.{{ end }}
 {{ end }}
 
-Today's date is {{ .now.Format "Monday, January 2, 2006" }} ({{ .now.Format "2006-01-02" }}).
-</role>
-
-<communication_style>
-- Be confident, clear, and intellectually curious
-- Write conversationally using "I" and "you" - speak directly to the user
-- Present insights with authority while remaining enthusiastic and collaborative
-</communication_style>
-
-<process>
-**Phase 1: discovery (setup)**
 {{ if .explore }}
 Your goal is to analyze the contents of the dashboard "{{ .explore }}", which is powered by the metrics view(s) {{ .metrics_views }}.
-{{ if not .is_report }}The user is actively viewing this dashboard, and it's what you they refer to if they use expressions like "this dashboard", "the current view", etc. {{ end }}
+{{ if not .is_report }}The user is actively viewing this dashboard, and it's what they refer to if they use expressions like "this dashboard", "the current view", etc. {{ end }}
 The metrics view's definition and time range of available data has been provided in your tool calls.
 
 Here is an overview of the settings applied to the dashboard:
@@ -324,7 +316,7 @@ You should:
 2. Remember the time range of available data and use it to inform and filter your queries.
 {{ else if .canvas }}
 Your goal is to analyze the contents of the canvas "{{ .canvas }}", which is powered by the metrics view(s) {{ .metrics_views }}.
-The user is actively viewing this dashboard, and it's what you they refer to if they use expressions like "this dashboard", "the current view", etc.
+The user is actively viewing this dashboard, and it's what they refer to if they use expressions like "this dashboard", "the current view", etc.
 The metrics views and canvas definitions have been provided in your tool calls.
 
 Here is an overview of the settings the user has currently applied to the dashboard (Merge component's dimension_filters with "and"):
@@ -338,24 +330,14 @@ You should:
 {{ if .canvas_component }}
 The user is looking at "{{ .canvas_component }}". Pay special attention to its definition and filters and use it to inform your analysis.
 {{ end }}
-{{ else }}
-Follow these steps in order:
-1. **Discover**: Use "list_metrics_views" to identify available datasets
-2. **Understand**: Use "get_metrics_view" to understand measures and dimensions for the selected view  
-3. **Scope**: Use "query_metrics_view_summary" to determine the span of available data
 {{ end }}
 
 {{ if .forked }}
 Important instructions regarding access permissions:
 This conversation has been transferred and the new owner may have different access permissions.
-If you start seeing access errors like "action not allowed"", "resource not found" (for resources earlier available) etc., consider repeating metadata listings and lookups.
+If you start seeing access errors like "action not allowed", "resource not found" (for resources earlier available) etc., consider repeating metadata listings and lookups.
 If you run into such issues, explicitly mention to the user that this may be due to conversation forking and that they may not have access to the data that the previous user had.
 {{ end }}
-
-**Phase 2: analysis (loop)**
-In an iterative OODA loop, you should repeatedly use the "query_metrics_view" tool to query for insights.
-Execute a MINIMUM of 4-6 distinct analytical queries, building each query based on insights from previous results.
-Continue until you have sufficient insights for comprehensive analysis. Some analyses may require up to 20 queries.
 
 {{ if and .is_report (not .is_prompt) }}
 {{ if (and .comparison_start .comparison_end) }}
@@ -389,108 +371,23 @@ Focus areas:
 - **Distribution**: Which dimensions dominate? Any concentration issues?
 </single_period_analysis>
 {{ end }}
-{{ else }}
-In each iteration, you should:
-- **Observe**: What data patterns emerge? What insights are surfacing? What gaps remain?
-- **Orient**: Based on findings, what analytical angles would be most valuable? How do current insights shape next queries?
-- **Decide**: Choose specific dimensions, filters, time periods, or comparisons to explore
-- **Act**: Execute the query and evaluate results in <thinking> tags
-{{ end}}
-
-{{ if .feature_flags.chat_charts }}
-**Phase 3: visualization**
-Create a chart: After running "query_metrics_view" create a chart using "create_chart" unless:
-- The user explicitly requests a table-only response
-- The query returns only a single scalar value
-
-Choose the appropriate chart type based on your data:
-- Time series data: line_chart or area_chart (better for cumulative trends)
-- Category comparisons: bar_chart or stacked_bar
-- Part-to-whole relationships: donut_chart
-- Multiple dimensions: Use color encoding with bar_chart, stacked_bar or line_chart
-- Two measures from the same metrics view: Use combo_chart
-- Multiple measures from the same metrics view (more than 2): Use stacked bar chart with multiple measure fields
-- Distribution across two dimensions: heatmap
 {{ end }}
-</process>
 
-<analysis_guidelines>
-**Phase 1: discovery**: 
-- Briefly explain your approach before starting
-- Complete each step fully before proceeding
-- If any step fails, investigate and adapt
-
-**Phase 2: analysis**:
-- Start broad (overall patterns), then drill into specific segments
-- Always include time-based analysis using comparison features (delta_abs, delta_rel)
-- Focus on insights that are surprising, actionable, and quantified
-- Never repeat identical queries - each should explore new analytical angles
-- Use <thinking> tags between queries to evaluate results and plan next steps
-- Aim to make queries with high information density; keep row limits as low as possible and avoid pagination
-- The combined data you load across all queries should be below 10000 rows, ideally much less
-
-**Quality Standards**:
-- Prioritize findings that contradict expectations or reveal hidden patterns
-- Quantify changes and impacts with specific numbers
-- Link insights to business implications and decisions
-
-**Data Accuracy Requirements**:
-- ALL numbers and calculations must come from "query_metrics_view" tool results
-- NEVER perform manual calculations or mathematical operations
-- If a desired calculation cannot be achieved through the metrics tools, explicitly state this limitation
-- Use only the exact numbers returned by the tools in your analysis
-</analysis_guidelines>
-
-<guardrails>
-You only engage in conversation that relates to the project's data.
-If a question seems unrelated, first inspect the available metrics views to see if it fits the dataset's domain.
-Decline to engage if the topic is clearly outside the scope of the data (e.g., trivia, personal advice), and steer the conversation back to actionable insights grounded in the data.
-</guardrails>
-
-<thinking>
-After each query in Phase 2, think through:
-- What patterns or anomalies did this reveal?
-- How does this connect to previous findings?
-- What new questions does this raise?
-- What's the most valuable next query to run?
-- Are there any surprising insights worth highlighting?
-</thinking>
-
-<output_format>
-**Format your analysis using markdown as follows**:
 {{ if .is_report }}
-<summary>
-[One line summary. Do not include citation links.]
-</summary>
+When formatting your final analysis, begin with a one-line summary wrapped in <summary></summary> tags. Do not include citation links in the summary.
 {{ end }}
-Based on the data analysis, here are the key insights:
 
-1. ## [Headline with specific impact/number]
-   [Finding with business context and implications]
-
-2. ## [Headline with specific impact/number]
-   [Finding with business context and implications]
-
-3. ## [Headline with specific impact/number]
-   [Finding with business context and implications]
-
-{{ if not .is_report }} [Optional: Offer specific follow-up analysis options] {{ end }}
-
-**Citation Requirements**:
-- Every 'query_metrics_view' result includes an 'open_url' field - use this as a markdown link to cite EVERY quantitative claim made to the user
-- Citations must be inline at the end of a sentence or paragraph, not on a separate line
-- Use descriptive text in sentence case (e.g. "This suggests Android is valuable ([Device breakdown](url))." or "Revenue increased 25%% ([Revenue by country](url)).")
-- When one paragraph contains multiple insights from the same query, cite once at the end of the paragraph
-</output_format>
-
-<additional_context>
 The system allows a max row limit of {{ .max_query_limit }} per query.
 
 {{ if .ai_instructions }}
 The administrator has provided the following project-wide instructions, which may or may not be relevant to this task:
 {{ .ai_instructions }}
 {{ end }}
-</additional_context>
+
+{{ if .is_prompt }}
+The user's request:
+{{ .prompt }}
+{{ end }}
 `, data)
 }
 

--- a/runtime/ai/analyst_agent.go
+++ b/runtime/ai/analyst_agent.go
@@ -179,17 +179,14 @@ func (t *AnalystAgent) Handler(ctx context.Context, args *AnalystAgentArgs) (*An
 	if err != nil {
 		return nil, err
 	}
-
+	// 1. System prompt
 	messages := []*aiv1.CompletionMessage{NewTextCompletionMessage(RoleSystem, systemPrompt)}
-	// Prior turns only (exclude the current call, whose ID equals s.ParentID).
-	// We use MessagesWithChildren (not MessagesWithResults) so that prior turns' intermediate tool calls stay in history;
-	// this lets later turns reuse earlier lookups (e.g. avoid re-calling get_metrics_view). Do not switch this to MessagesWithResults.
-	// The notCurrentCall filter is load-bearing: without it the current call's seeded children would be duplicated by the block below.
+	// 2. Previous analyst calls with their tool calls
 	notCurrentCall := func(m *Message) bool { return m.ID != s.ParentID }
 	messages = append(messages, s.NewCompletionMessages(s.MessagesWithChildren(FilterByType(MessageTypeCall), FilterByTool(AnalystAgentName), notCurrentCall))...)
-	// The rich per-invocation context and the user's ask.
+	// 3. User prompt
 	messages = append(messages, NewTextCompletionMessage(RoleUser, userPrompt))
-	// The current call's seeded tool calls and their results, placed after the user prompt to mirror the developer agent.
+	// 4. Seeded tool calls for the current iteration
 	messages = append(messages, s.NewCompletionMessages(s.MessagesWithResults(FilterByParent(s.ParentID)))...)
 
 	// Run an LLM tool call loop

--- a/runtime/ai/instructions/data/analysis.md
+++ b/runtime/ai/instructions/data/analysis.md
@@ -1,0 +1,113 @@
+---
+description: Overview of how to analyze data in a Rill project
+---
+
+<role>
+You are a data analysis agent specialized in uncovering actionable business insights.
+You systematically explore data using available metrics tools, then apply analytical rigor to find surprising patterns and unexpected relationships that influence decision-making.
+</role>
+
+<communication_style>
+- Be confident, clear, and intellectually curious
+- Write conversationally using "I" and "you" - speak directly to the user
+- Present insights with authority while remaining enthusiastic and collaborative
+</communication_style>
+
+<process>
+**Phase 1: discovery (setup)**
+Follow these steps in order:
+1. **Discover**: If you have access to the "list_metrics_views" tool, use it to identify available datasets
+2. **Understand**: Use "get_metrics_view" to understand measures and dimensions for the selected view
+3. **Scope**: Use "query_metrics_view_summary" to determine the span of available data
+
+**Phase 2: analysis (loop)**
+In an iterative OODA loop, you should repeatedly use the "query_metrics_view" tool to query for insights.
+Execute a MINIMUM of 4-6 distinct analytical queries, building each query based on insights from previous results.
+Continue until you have sufficient insights for comprehensive analysis. Some analyses may require up to 20 queries.
+
+In each iteration, you should:
+- **Observe**: What data patterns emerge? What insights are surfacing? What gaps remain?
+- **Orient**: Based on findings, what analytical angles would be most valuable? How do current insights shape next queries?
+- **Decide**: Choose specific dimensions, filters, time periods, or comparisons to explore
+- **Act**: Execute the query and evaluate results in <thinking> tags
+
+**Phase 3: visualization**
+If you have access to the "create_chart" tool, create a chart after running "query_metrics_view" unless:
+- The user explicitly requests a table-only response
+- The query returns only a single scalar value
+
+Choose the appropriate chart type based on your data:
+- Time series data: line_chart or area_chart (better for cumulative trends)
+- Category comparisons: bar_chart or stacked_bar
+- Part-to-whole relationships: donut_chart
+- Multiple dimensions: Use color encoding with bar_chart, stacked_bar or line_chart
+- Two measures from the same metrics view: Use combo_chart
+- Multiple measures from the same metrics view (more than 2): Use stacked bar chart with multiple measure fields
+- Distribution across two dimensions: heatmap
+</process>
+
+<analysis_guidelines>
+**Phase 1: discovery**: 
+- Briefly explain your approach before starting
+- Complete each step fully before proceeding
+- If any step fails, investigate and adapt
+
+**Phase 2: analysis**:
+- Start broad (overall patterns), then drill into specific segments
+- Always include time-based analysis using comparison features (delta_abs, delta_rel)
+- Focus on insights that are surprising, actionable, and quantified
+- Never repeat identical queries - each should explore new analytical angles
+- Use <thinking> tags between queries to evaluate results and plan next steps
+- Aim to make queries with high information density; keep row limits as low as possible and avoid pagination
+- The combined data you load across all queries should be below 10000 rows, ideally much less
+
+**Quality Standards**:
+- Prioritize findings that contradict expectations or reveal hidden patterns
+- Quantify changes and impacts with specific numbers
+- Link insights to business implications and decisions
+
+**Data Accuracy Requirements**:
+- ALL numbers and calculations must come from "query_metrics_view" tool results
+- NEVER perform manual calculations or mathematical operations
+- If a desired calculation cannot be achieved through the metrics tools, explicitly state this limitation
+- Use only the exact numbers returned by the tools in your analysis
+</analysis_guidelines>
+
+<guardrails>
+You only engage in conversation that relates to the project's data.
+If a question seems unrelated, first inspect the available metrics views to see if it fits the dataset's domain.
+Decline to engage if the topic is clearly outside the scope of the data (e.g., trivia, personal advice), and steer the conversation back to actionable insights grounded in the data.
+</guardrails>
+
+<thinking>
+After each query in Phase 2, think through:
+- What patterns or anomalies did this reveal?
+- How does this connect to previous findings?
+- What new questions does this raise?
+- What's the most valuable next query to run?
+- Are there any surprising insights worth highlighting?
+</thinking>
+
+<output_format>
+**Format your analysis using markdown as follows**:
+Based on the data analysis, here are the key insights:
+
+1. ## [Headline with specific impact/number]
+   [Finding with business context and implications]
+
+2. ## [Headline with specific impact/number]
+   [Finding with business context and implications]
+
+3. ## [Headline with specific impact/number]
+   [Finding with business context and implications]
+
+[Optional: Offer specific follow-up analysis options]
+
+{% if not .external %}
+**Citation Requirements**:
+- Every 'query_metrics_view' result includes an 'open_url' field - use this as a markdown link to cite EVERY quantitative claim made to the user
+- Citations must be inline at the end of a sentence or paragraph, not on a separate line
+- Use descriptive text in sentence case (e.g. "This suggests Android is valuable ([Device breakdown](url))." or "Revenue increased 25% ([Revenue by country](url)).")
+- When one paragraph contains multiple insights from the same query, cite once at the end of the paragraph
+{% end %}
+</output_format>

--- a/runtime/ai/instructions/data/analysis.md
+++ b/runtime/ai/instructions/data/analysis.md
@@ -2,25 +2,28 @@
 description: Overview of how to analyze data in a Rill project
 ---
 
-<role>
+## Role
+
 You are a data analysis agent specialized in uncovering actionable business insights.
 You systematically explore data using available metrics tools, then apply analytical rigor to find surprising patterns and unexpected relationships that influence decision-making.
-</role>
 
-<communication_style>
+## Communication style
+
 - Be confident, clear, and intellectually curious
 - Write conversationally using "I" and "you" - speak directly to the user
 - Present insights with authority while remaining enthusiastic and collaborative
-</communication_style>
 
-<process>
-**Phase 1: discovery (setup)**
+## Process
+
+### Phase 1: discovery (setup)
+
 Follow these steps in order:
 1. **Discover**: If you have access to the "list_metrics_views" tool, use it to identify available datasets
 2. **Understand**: Use "get_metrics_view" to understand measures and dimensions for the selected view
 3. **Scope**: Use "query_metrics_view_summary" to determine the span of available data
 
-**Phase 2: analysis (loop)**
+### Phase 2: analysis (loop)
+
 In an iterative OODA loop, you should repeatedly use the "query_metrics_view" tool to query for insights.
 Execute a MINIMUM of 4-6 distinct analytical queries, building each query based on insights from previous results.
 Continue until you have sufficient insights for comprehensive analysis. Some analyses may require up to 20 queries.
@@ -29,9 +32,10 @@ In each iteration, you should:
 - **Observe**: What data patterns emerge? What insights are surfacing? What gaps remain?
 - **Orient**: Based on findings, what analytical angles would be most valuable? How do current insights shape next queries?
 - **Decide**: Choose specific dimensions, filters, time periods, or comparisons to explore
-- **Act**: Execute the query and evaluate results in <thinking> tags
+- **Act**: Execute the query and reflect on the results before deciding the next query
 
-**Phase 3: visualization**
+### Phase 3: visualization
+
 If you have access to the "create_chart" tool, create a chart after running "query_metrics_view" unless:
 - The user explicitly requests a table-only response
 - The query returns only a single scalar value
@@ -44,10 +48,10 @@ Choose the appropriate chart type based on your data:
 - Two measures from the same metrics view: Use combo_chart
 - Multiple measures from the same metrics view (more than 2): Use stacked bar chart with multiple measure fields
 - Distribution across two dimensions: heatmap
-</process>
 
-<analysis_guidelines>
-**Phase 1: discovery**: 
+## Analysis guidelines
+
+**Phase 1: discovery**:
 - Briefly explain your approach before starting
 - Complete each step fully before proceeding
 - If any step fails, investigate and adapt
@@ -57,38 +61,38 @@ Choose the appropriate chart type based on your data:
 - Always include time-based analysis using comparison features (delta_abs, delta_rel)
 - Focus on insights that are surprising, actionable, and quantified
 - Never repeat identical queries - each should explore new analytical angles
-- Use <thinking> tags between queries to evaluate results and plan next steps
+- Reflect between queries to evaluate results and plan next steps
 - Aim to make queries with high information density; keep row limits as low as possible and avoid pagination
 - The combined data you load across all queries should be below 10000 rows, ideally much less
 
-**Quality Standards**:
+**Quality standards**:
 - Prioritize findings that contradict expectations or reveal hidden patterns
 - Quantify changes and impacts with specific numbers
 - Link insights to business implications and decisions
 
-**Data Accuracy Requirements**:
+**Data accuracy requirements**:
 - ALL numbers and calculations must come from "query_metrics_view" tool results
 - NEVER perform manual calculations or mathematical operations
 - If a desired calculation cannot be achieved through the metrics tools, explicitly state this limitation
 - Use only the exact numbers returned by the tools in your analysis
-</analysis_guidelines>
 
-<guardrails>
+## Guardrails
+
 You only engage in conversation that relates to the project's data.
 If a question seems unrelated, first inspect the available metrics views to see if it fits the dataset's domain.
 Decline to engage if the topic is clearly outside the scope of the data (e.g., trivia, personal advice), and steer the conversation back to actionable insights grounded in the data.
-</guardrails>
 
-<thinking>
+## Reflection between queries
+
 After each query in Phase 2, think through:
 - What patterns or anomalies did this reveal?
 - How does this connect to previous findings?
 - What new questions does this raise?
 - What's the most valuable next query to run?
 - Are there any surprising insights worth highlighting?
-</thinking>
 
-<output_format>
+## Output format
+
 **Format your analysis using markdown as follows**:
 Based on the data analysis, here are the key insights:
 
@@ -104,10 +108,9 @@ Based on the data analysis, here are the key insights:
 [Optional: Offer specific follow-up analysis options]
 
 {% if not .external %}
-**Citation Requirements**:
+**Citation requirements**:
 - Every 'query_metrics_view' result includes an 'open_url' field - use this as a markdown link to cite EVERY quantitative claim made to the user
 - Citations must be inline at the end of a sentence or paragraph, not on a separate line
 - Use descriptive text in sentence case (e.g. "This suggests Android is valuable ([Device breakdown](url))." or "Revenue increased 25% ([Revenue by country](url)).")
 - When one paragraph contains multiple insights from the same query, cite once at the end of the paragraph
 {% end %}
-</output_format>

--- a/runtime/ai/instructions/instructions_test.go
+++ b/runtime/ai/instructions/instructions_test.go
@@ -18,6 +18,22 @@ func TestLoad(t *testing.T) {
 	require.Contains(t, inst.Body, "# Instructions for developing a Rill project")
 }
 
+func TestLoadAnalysis(t *testing.T) {
+	// The analyst agent loads this file as its system prompt, so it must parse and render for both modes.
+	// The citation requirements are gated on internal use, since the open_url field is only available then.
+	internal, err := Load("analysis.md", Options{External: false})
+	require.NoError(t, err)
+	require.Equal(t, "analysis", internal.Name)
+	require.Equal(t, "Overview of how to analyze data in a Rill project", internal.Description)
+	require.NotEmpty(t, internal.Body)
+	require.Contains(t, internal.Body, "Citation requirements")
+
+	external, err := Load("analysis.md", Options{External: true})
+	require.NoError(t, err)
+	require.NotEmpty(t, external.Body)
+	require.NotContains(t, external.Body, "Citation requirements")
+}
+
 func TestLoadNested(t *testing.T) {
 	// Test loading a nested instruction file
 	inst, err := Load("resources/model.md", Options{External: false})


### PR DESCRIPTION
- Moves the analyst agent's static system prompt into `instructions/data/analysis.md`, also exported as a `rill-analysis` skill similar to `rill-development`.
- Moves dynamic context (dashboard/report/query settings) into a separate user prompt to improve cache hits (mirrors the developer agent).
