### PR TITLE
fix(dashboards): disable timeseries `explain` when AI is disabled

### DIFF
--- a/web-common/src/features/dashboards/time-series/ChartInteractions.svelte
+++ b/web-common/src/features/dashboards/time-series/ChartInteractions.svelte
@@ -21,6 +21,8 @@
   let priorRange: DashboardTimeControls | null = null;
   let button: HTMLButtonElement;
 
+  const explainEnabled = measureSelection.getEnabledStore();
+
   const StateManagers = getStateManagers();
   const {
     dashboardStore,
@@ -58,7 +60,8 @@
     }
 
     const isMac = window.navigator.userAgent.includes("Macintosh");
-    const isExplainKey = e.key === "e" && !e.metaKey && !e.ctrlKey;
+    const isExplainKey =
+      $explainEnabled && e.key === "e" && !e.metaKey && !e.ctrlKey;
 
     if (e.key === "ArrowLeft" && !e.metaKey && !e.altKey) {
       if ($canPanLeft) {

--- a/web-common/src/features/dashboards/time-series/measure-chart/MeasureChartBody.svelte
+++ b/web-common/src/features/dashboards/time-series/measure-chart/MeasureChartBody.svelte
@@ -95,6 +95,7 @@
 
   const annotationPopover = new AnnotationPopoverController();
   const hoveredAnnotationGroup = annotationPopover.hoveredGroup;
+  const explainEnabled = measureSelection.getEnabledStore();
   const selMeasure = measureSelection.measure;
   const selStart = measureSelection.start;
   const selEnd = measureSelection.end;
@@ -627,7 +628,7 @@
   {/if}
 
   <!-- Explain CTA -->
-  {#if !isScrubbing && explainX !== null}
+  {#if $explainEnabled && !isScrubbing && explainX !== null}
     <ExplainButton
       x={explainX}
       plotBounds={pb}

--- a/web-common/src/features/dashboards/time-series/measure-selection/measure-selection.ts
+++ b/web-common/src/features/dashboards/time-series/measure-selection/measure-selection.ts
@@ -101,9 +101,9 @@ export class MeasureSelection {
 
   public getEnabledStore() {
     return derived(
-      [featureFlags.dashboardChat, getExploreNameStore()],
-      ([dashboardChat, exploreName]) => {
-        return Boolean(dashboardChat && exploreName);
+      [featureFlags.ai, featureFlags.dashboardChat, getExploreNameStore()],
+      ([ai, dashboardChat, exploreName]) => {
+        return Boolean(ai && dashboardChat && exploreName);
       },
     );
   }


### PR DESCRIPTION
- Gates the explore timeseries **Explain** feature on the `ai` feature flag: when AI is disabled, both the on-chart "Explain (E)" button and the `E` keyboard shortcut are hidden.
- Adds `ai` to `measureSelection.getEnabledStore()` and wires that store into `ExplainButton` (`MeasureChartBody.svelte`) and the key handler (`ChartInteractions.svelte`). The store was purpose-built to gate explain but had become unused after an earlier `MeasureChart` refactor, so explain was rendering ungated.
- Restoring the store's existing `dashboardChat && exploreName` conditions only hides explain where it is already non-functional (embeds and the explore editor); normal cloud dashboards are unaffected since `dashboard_chat` defaults to true there.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*
