### PR TITLE
fix(dashboards): make timezone list scrollable when not searching

### DIFF
--- a/web-common/src/features/dashboards/time-controls/super-pill/components/Zone.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/Zone.svelte
@@ -94,7 +94,7 @@
       <DropdownMenu.Separator />
     {/if}
 
-    <DropdownMenu.Group>
+    <DropdownMenu.Group class="max-h-72 overflow-y-auto">
       {#each filteredPinnedTimeZones as [iana, { offset, abbreviation }] (iana)}
         <DropdownMenu.CheckboxItem
           checkRight

--- a/web-common/src/features/dashboards/time-controls/super-pill/components/ZoneContent.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/ZoneContent.svelte
@@ -79,7 +79,7 @@
   <div class="separator"></div>
 {/if}
 
-<div class="group">
+<div class="group max-h-72 overflow-y-auto">
   {#each filteredPinnedTimeZones as [iana, { offset, abbreviation }] (iana)}
     <button
       class="item"


### PR DESCRIPTION
- The timezone selector only capped and scrolled the **search-results** group (`max-h-72 overflow-y-auto`); the pinned/available-zones group rendered on open was uncapped, so projects with many configured timezones overflowed off-screen.
- Applied the same `max-h-72 overflow-y-auto` constraint to the pinned group in both `Zone.svelte` and `ZoneContent.svelte` (the latter used by `RangePickerV2`), so the default list scrolls just like the search results.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*
