### PR TITLE
fix(explore): make timezone selector list scrollable without search

### DIFF
--- a/web-common/src/features/dashboards/time-controls/super-pill/components/Zone.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/Zone.svelte
@@ -78,108 +78,112 @@
       <Search bind:value={searchValue} autofocus={false} />
     </div>
 
-    {#if !pinnedTimeZones.has(activeTimeZone) && !recentIANAs.includes(activeTimeZone)}
-      <DropdownMenu.Group>
-        {@const formatted = ianaMap.get(activeTimeZone)}
-        {#if formatted}
-          <DropdownMenu.Item>
-            <ZoneDisplay
-              abbreviation={formatted.abbreviation}
-              offset={formatted.offset}
-              iana={activeTimeZone}
-            />
-          </DropdownMenu.Item>
-        {/if}
-      </DropdownMenu.Group>
-      <DropdownMenu.Separator />
-    {/if}
-
-    <DropdownMenu.Group>
-      {#each filteredPinnedTimeZones as [iana, { offset, abbreviation }] (iana)}
-        <DropdownMenu.CheckboxItem
-          checkRight
-          closeOnSelect
-          checked={activeTimeZone === iana}
-          onSelect={() => {
-            onSelectTimeZone(iana);
-          }}
-        >
-          <ZoneDisplay
-            {abbreviation}
-            {offset}
-            isBrowserTime={iana === browserIANA}
-            {iana}
-          />
-        </DropdownMenu.CheckboxItem>
-      {/each}
-    </DropdownMenu.Group>
-
-    {#if !searchValue && recentIANAs.length}
-      <DropdownMenu.Separator />
-
-      <DropdownMenu.Group>
-        <div class="flex justify-between pr-2">
-          <DropdownMenu.Label>Recent</DropdownMenu.Label>
-          {#if recentIANAs.length}
-            <button
-              onclick={() => {
-                recents.set([]);
-              }}
-              class="text-[10px] text-fg-secondary">Clear recents</button
-            >
-          {/if}
-        </div>
-
-        {#each recentIANAs as iana, i (i)}
-          {@const formatted = ianaMap.get(iana)}
-          {#if formatted && !availableTimeZones.includes(iana) && iana !== browserIANA}
-            <DropdownMenu.CheckboxItem
-              checkRight
-              checked={activeTimeZone === iana}
-              onclick={() => {
-                onSelectTimeZone(iana);
-              }}
-            >
+    <div class="max-h-72 overflow-y-auto">
+      {#if !pinnedTimeZones.has(activeTimeZone) && !recentIANAs.includes(activeTimeZone)}
+        <DropdownMenu.Group>
+          {@const formatted = ianaMap.get(activeTimeZone)}
+          {#if formatted}
+            <DropdownMenu.Item>
               <ZoneDisplay
                 abbreviation={formatted.abbreviation}
                 offset={formatted.offset}
-                {iana}
+                iana={activeTimeZone}
               />
-            </DropdownMenu.CheckboxItem>
+            </DropdownMenu.Item>
           {/if}
-        {/each}
-      </DropdownMenu.Group>
-    {/if}
+        </DropdownMenu.Group>
+        <DropdownMenu.Separator />
+      {/if}
 
-    {#if searchValue}
-      <DropdownMenu.Separator />
-
-      <DropdownMenu.Group class="max-h-72 overflow-y-auto">
-        <DropdownMenu.Label
-          class="sticky top-0 bg-gradient-to-b z-10 from-surface from-75% to-transparent"
-        >
-          Search Results
-        </DropdownMenu.Label>
-
-        {#each filteredTimeZones as [iana, { abbreviation, offset }], i (i)}
+      <DropdownMenu.Group>
+        {#each filteredPinnedTimeZones as [iana, { offset, abbreviation }] (iana)}
           <DropdownMenu.CheckboxItem
             checkRight
             closeOnSelect
+            checked={activeTimeZone === iana}
             onSelect={() => {
               onSelectTimeZone(iana);
-              recents.set(Array.from(new Set([iana, ...$recents])).slice(0, 5));
             }}
           >
-            <ZoneDisplay {iana} {offset} {abbreviation} />
+            <ZoneDisplay
+              {abbreviation}
+              {offset}
+              isBrowserTime={iana === browserIANA}
+              {iana}
+            />
           </DropdownMenu.CheckboxItem>
-        {:else}
-          <DropdownMenu.Group>
-            <p class="pt-0 pb-2 text-fg-secondary text-center">
-              No options found
-            </p>
-          </DropdownMenu.Group>
         {/each}
       </DropdownMenu.Group>
-    {/if}
+
+      {#if !searchValue && recentIANAs.length}
+        <DropdownMenu.Separator />
+
+        <DropdownMenu.Group>
+          <div class="flex justify-between pr-2">
+            <DropdownMenu.Label>Recent</DropdownMenu.Label>
+            {#if recentIANAs.length}
+              <button
+                onclick={() => {
+                  recents.set([]);
+                }}
+                class="text-[10px] text-fg-secondary">Clear recents</button
+              >
+            {/if}
+          </div>
+
+          {#each recentIANAs as iana, i (i)}
+            {@const formatted = ianaMap.get(iana)}
+            {#if formatted && !availableTimeZones.includes(iana) && iana !== browserIANA}
+              <DropdownMenu.CheckboxItem
+                checkRight
+                checked={activeTimeZone === iana}
+                onclick={() => {
+                  onSelectTimeZone(iana);
+                }}
+              >
+                <ZoneDisplay
+                  abbreviation={formatted.abbreviation}
+                  offset={formatted.offset}
+                  {iana}
+                />
+              </DropdownMenu.CheckboxItem>
+            {/if}
+          {/each}
+        </DropdownMenu.Group>
+      {/if}
+
+      {#if searchValue}
+        <DropdownMenu.Separator />
+
+        <DropdownMenu.Group>
+          <DropdownMenu.Label
+            class="sticky top-0 bg-gradient-to-b z-10 from-surface from-75% to-transparent"
+          >
+            Search Results
+          </DropdownMenu.Label>
+
+          {#each filteredTimeZones as [iana, { abbreviation, offset }], i (i)}
+            <DropdownMenu.CheckboxItem
+              checkRight
+              closeOnSelect
+              onSelect={() => {
+                onSelectTimeZone(iana);
+                recents.set(
+                  Array.from(new Set([iana, ...$recents])).slice(0, 5),
+                );
+              }}
+            >
+              <ZoneDisplay {iana} {offset} {abbreviation} />
+            </DropdownMenu.CheckboxItem>
+          {:else}
+            <DropdownMenu.Group>
+              <p class="pt-0 pb-2 text-fg-secondary text-center">
+                No options found
+              </p>
+            </DropdownMenu.Group>
+          {/each}
+        </DropdownMenu.Group>
+      {/if}
+    </div>
   </DropdownMenu.Content>
 </DropdownMenu.Root>

--- a/web-common/src/features/dashboards/time-controls/super-pill/components/ZoneContent.svelte
+++ b/web-common/src/features/dashboards/time-controls/super-pill/components/ZoneContent.svelte
@@ -55,126 +55,132 @@
   <Search bind:value={searchValue} autofocus={false} />
 </div>
 
-{#if !pinnedTimeZones.has(activeTimeZone) && !recentIANAs.includes(activeTimeZone)}
-  <div class="group">
-    {#if formatted}
-      <button
-        class="item"
-        onclick={() => {
-          onSelectTimeZone(activeTimeZone);
-        }}
-      >
-        <ZoneDisplay
-          abbreviation={formatted.abbreviation}
-          offset={formatted.offset}
-          iana={activeTimeZone}
-        />
-        <!-- {#if activeTimeZone === iana} -->
-        <Check class="size-4" color="var(--foreground)" />
-        <!-- {/if} -->
-      </button>
-    {/if}
-  </div>
-
-  <div class="separator"></div>
-{/if}
-
-<div class="group">
-  {#each filteredPinnedTimeZones as [iana, { offset, abbreviation }] (iana)}
-    <button
-      class="item"
-      onclick={() => {
-        onSelectTimeZone(iana);
-      }}
-    >
-      <ZoneDisplay
-        {abbreviation}
-        {offset}
-        isBrowserTime={iana === browserIANA}
-        {iana}
-      />
-      <span class="flex flex-none h-3.5 w-3.5 items-center justify-center">
-        {#if activeTimeZone === iana}
-          <Check class="size-4" color="var(--foreground)" />
-        {/if}
-      </span>
-    </button>
-  {/each}
-</div>
-
-{#if !searchValue && recentIANAs.length}
-  <div class="separator"></div>
-  <div class="group">
-    <div class="flex justify-between pr-2 items-center">
-      <h3>Recent</h3>
-      {#if recentIANAs.length}
-        <button
-          class="text-[11px] text-fg-secondary hover:bg-surface-hover p-1 rounded-sm h-fit"
-          onclick={() => {
-            recents.set([]);
-          }}
-        >
-          Clear recents
-        </button>
-      {/if}
-    </div>
-
-    {#each recentIANAs as iana, i (i)}
-      {@const formatted = ianaMap.get(iana)}
-      {#if formatted && !availableTimeZones.includes(iana)}
+<div class="max-h-72 overflow-y-auto">
+  {#if !pinnedTimeZones.has(activeTimeZone) && !recentIANAs.includes(activeTimeZone)}
+    <div class="group">
+      {#if formatted}
         <button
           class="item"
           onclick={() => {
-            onSelectTimeZone(iana);
+            onSelectTimeZone(activeTimeZone);
           }}
         >
           <ZoneDisplay
             abbreviation={formatted.abbreviation}
             offset={formatted.offset}
-            {iana}
+            iana={activeTimeZone}
           />
-          <span class="flex flex-none h-3.5 w-3.5 items-center justify-center">
-            {#if activeTimeZone === iana}
-              <Check class="size-4" color="var(--foreground)" />
-            {/if}
-          </span>
+          <!-- {#if activeTimeZone === iana} -->
+          <Check class="size-4" color="var(--foreground)" />
+          <!-- {/if} -->
         </button>
       {/if}
-    {/each}
-  </div>
-{/if}
+    </div>
 
-{#if searchValue}
-  <div class="separator"></div>
-  <div class="group max-h-72 overflow-y-auto">
-    <h3
-      class="sticky top-0 bg-gradient-to-b z-10 from-surface from-75% to-transparent"
-    >
-      Search Results
-    </h3>
+    <div class="separator"></div>
+  {/if}
 
-    {#each filteredTimeZones as [iana, { abbreviation, offset }], i (i)}
+  <div class="group">
+    {#each filteredPinnedTimeZones as [iana, { offset, abbreviation }] (iana)}
       <button
         class="item"
         onclick={() => {
           onSelectTimeZone(iana);
-          recents.set(Array.from(new Set([iana, ...$recents])).slice(0, 5));
         }}
       >
-        <ZoneDisplay {iana} {offset} {abbreviation} />
+        <ZoneDisplay
+          {abbreviation}
+          {offset}
+          isBrowserTime={iana === browserIANA}
+          {iana}
+        />
         <span class="flex flex-none h-3.5 w-3.5 items-center justify-center">
           {#if activeTimeZone === iana}
             <Check class="size-4" color="var(--foreground)" />
           {/if}
         </span>
       </button>
-    {:else}
-      <div>
-        <p class="pt-0 pb-2 text-fg-secondary text-center">No options found</p>
-      </div>
     {/each}
   </div>
-{/if}
+
+  {#if !searchValue && recentIANAs.length}
+    <div class="separator"></div>
+    <div class="group">
+      <div class="flex justify-between pr-2 items-center">
+        <h3>Recent</h3>
+        {#if recentIANAs.length}
+          <button
+            class="text-[11px] text-fg-secondary hover:bg-surface-hover p-1 rounded-sm h-fit"
+            onclick={() => {
+              recents.set([]);
+            }}
+          >
+            Clear recents
+          </button>
+        {/if}
+      </div>
+
+      {#each recentIANAs as iana, i (i)}
+        {@const formatted = ianaMap.get(iana)}
+        {#if formatted && !availableTimeZones.includes(iana)}
+          <button
+            class="item"
+            onclick={() => {
+              onSelectTimeZone(iana);
+            }}
+          >
+            <ZoneDisplay
+              abbreviation={formatted.abbreviation}
+              offset={formatted.offset}
+              {iana}
+            />
+            <span
+              class="flex flex-none h-3.5 w-3.5 items-center justify-center"
+            >
+              {#if activeTimeZone === iana}
+                <Check class="size-4" color="var(--foreground)" />
+              {/if}
+            </span>
+          </button>
+        {/if}
+      {/each}
+    </div>
+  {/if}
+
+  {#if searchValue}
+    <div class="separator"></div>
+    <div class="group">
+      <h3
+        class="sticky top-0 bg-gradient-to-b z-10 from-surface from-75% to-transparent"
+      >
+        Search Results
+      </h3>
+
+      {#each filteredTimeZones as [iana, { abbreviation, offset }], i (i)}
+        <button
+          class="item"
+          onclick={() => {
+            onSelectTimeZone(iana);
+            recents.set(Array.from(new Set([iana, ...$recents])).slice(0, 5));
+          }}
+        >
+          <ZoneDisplay {iana} {offset} {abbreviation} />
+          <span class="flex flex-none h-3.5 w-3.5 items-center justify-center">
+            {#if activeTimeZone === iana}
+              <Check class="size-4" color="var(--foreground)" />
+            {/if}
+          </span>
+        </button>
+      {:else}
+        <div>
+          <p class="pt-0 pb-2 text-fg-secondary text-center">
+            No options found
+          </p>
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>
 
 <style lang="postcss">
   .item {


### PR DESCRIPTION
- Fixes the timezone selector dropdown (explore dashboards and pivot tables) rendering the full timezone list at unbounded height when no search term is present, causing it to run off-screen with no way to scroll.
- The `max-h-72 overflow-y-auto` scroll constraint was applied only to the "Search Results" group. Moved it to wrap all list content (pinned override, pinned zones, recents, and search results) in a single scroll container below the pinned search input, so scrolling is consistent whether or not a search term is present.
- Applied the same fix to `ZoneContent.svelte`, which had the identical issue.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*
