### PR TITLE
Minor doc spelling fixes

### DIFF
--- a/docs/docs/developers/build/connectors/credentials.md
+++ b/docs/docs/developers/build/connectors/credentials.md
@@ -23,7 +23,7 @@ While Rill **can** infer credentials from your local environment (AWS CLI, Azure
 :::
 
 1. **Credentials referenced in connection strings or DSN within YAML files (RECOMMENDED)** - The UI creates YAML configurations that reference credentials from your `.env` file using templating (see [Connector YAML](/reference/project-files/connectors) for more details)
-2. **Credentials passed in as variables** - When starting Rill Developer via `rill start --env key=value` (see [passing environmental variables](/developers/build/connectors/templating) for more details)
+2. **Credentials passed in as variables** - When starting Rill Developer via `rill start --env key=value` (see [passing environment variables](/developers/build/connectors/templating) for more details)
 3. **Credentials configured via CLI** - For [AWS](/developers/build/connectors/data-source/s3#method-4-local-aws-credentials-local-development-only) / [Azure](/developers/build/connectors/data-source/azure#method-5-azure-cli-authentication-local-development-only) / [Google Cloud](/developers/build/connectors/data-source/gcs#method-4-local-google-cloud-cli-credentials) - **NOT RECOMMENDED for production use**
 
 For more details, please refer to the corresponding [connector](/developers/build/connectors) or [OLAP engine](/developers/build/connectors/olap) page.

--- a/docs/docs/developers/build/connectors/olap/clickhouse.md
+++ b/docs/docs/developers/build/connectors/olap/clickhouse.md
@@ -12,7 +12,7 @@ import LoomVideo from '@site/src/components/LoomVideo'; // Adjust the path as ne
 
 <LoomVideo loomId='b96143c386104576bcfe6cabe1038c38' /> <br />
 
-Rill supports connecting to an existing ClickHouse cluster via a "live connector" and using it as an OLAP engine  built against [external tables](/developers/build/connectors/olap#external-olap-tables) to power Rill dashboards. This is particularly useful when working with extremely large datasets (hundreds of GBs or even TB+ in size).
+Rill supports connecting to an existing ClickHouse cluster via a "live connector" and using it as an OLAP engine built against [external tables](/developers/build/connectors/olap#external-olap-tables) to power Rill dashboards. This is particularly useful when working with extremely large datasets (hundreds of GBs or even TB+ in size).
 
 
 :::note Supported Versions

--- a/docs/docs/developers/build/connectors/olap/druid.md
+++ b/docs/docs/developers/build/connectors/olap/druid.md
@@ -7,7 +7,7 @@ sidebar_position: 05
 
 [Apache Druid](https://druid.apache.org/docs/latest/design/) is an open-source, high-performance OLAP engine designed for real-time analytics on large datasets. It excels in analytical workloads due to its columnar storage format, which enables fast data aggregation, querying, and filtering. Druid is particularly well-suited for use cases that require interactive exploration of large-scale data, real-time data ingestion, and fast query responses, making it a popular choice for applications in business intelligence, user behavior analytics, and financial analysis.
 
-Rill supports connecting to an existing Druid cluster via a "live connector" and using it as an OLAP engine  built against [external tables](/developers/build/connectors/olap#external-olap-tables) to power Rill dashboards. This is particularly useful when working with extremely large datasets (hundreds of GBs or even TB+ in size).
+Rill supports connecting to an existing Druid cluster via a "live connector" and using it as an OLAP engine built against [external tables](/developers/build/connectors/olap#external-olap-tables) to power Rill dashboards. This is particularly useful when working with extremely large datasets (hundreds of GBs or even TB+ in size).
 
 
 ## Configuring Rill Developer with Druid

--- a/docs/docs/developers/build/connectors/olap/olap.md
+++ b/docs/docs/developers/build/connectors/olap/olap.md
@@ -1,5 +1,5 @@
 ---
-title: "Bring Your Own  OLAP Engine (Live Connector)"
+title: "Bring Your Own OLAP Engine (Live Connector)"
 description: Configure the OLAP engine used by Rill
 sidebar_label: "OLAP Engines"
 sidebar_position: 0
@@ -23,8 +23,8 @@ Rill also offers the ability to ingest and create tables directly from a [data s
 
 
 
-In order to connect Rill to your OLAP Engine:
-1. Create the connector via the UI 
+In order to connect Rill to your OLAP engine:
+1. Create the connector via the UI.
 2. [Create the YAML](/reference/project-files/connectors#olap-engines) and set the [default OLAP engine](/reference/project-files/rill-yaml#configuring-the-default-olap-engine) via the rill.yaml file.
 
 :::note `olap_connector` in rill.yaml

--- a/docs/docs/developers/build/connectors/olap/pinot.md
+++ b/docs/docs/developers/build/connectors/olap/pinot.md
@@ -7,7 +7,7 @@ sidebar_position: 20
 
 [Apache Pinot](https://docs.pinot.apache.org/) is a real-time distributed OLAP datastore purpose-built for low-latency, high-throughput analytics, and is perfect for user-facing analytical workloads.
 
-Rill supports connecting to an existing Pinot cluster via a "live connector" and using it as an OLAP engine  built against [external tables](/developers/build/connectors/olap#external-olap-tables) to power Rill dashboards. This is particularly useful when working with extremely large datasets (hundreds of GBs or even TB+ in size).
+Rill supports connecting to an existing Pinot cluster via a "live connector" and using it as an OLAP engine built against [external tables](/developers/build/connectors/olap#external-olap-tables) to power Rill dashboards. This is particularly useful when working with extremely large datasets (hundreds of GBs or even TB+ in size).
 
 
 ## Configuring Rill Developer with Pinot

--- a/docs/docs/developers/build/connectors/templating.md
+++ b/docs/docs/developers/build/connectors/templating.md
@@ -17,9 +17,9 @@ Unless explicitly defined, Rill Developer will use a `dev` environment. If you w
 
 :::
 
-## Setting Up Environmental Variables
+## Setting Up Environment Variables
 
-You can set up environmental variables in several locations in Rill. Please review our [configure local credentials documentation](/developers/build/connectors/credentials#setting-credentials-for-rill-developer) for more information.
+You can set up environment variables in several locations in Rill. Please review our [configure local credentials documentation](/developers/build/connectors/credentials#setting-credentials-for-rill-developer) for more information.
 
 ## Referencing Environment Variables
 

--- a/docs/docs/developers/build/index.md
+++ b/docs/docs/developers/build/index.md
@@ -39,7 +39,7 @@ Rill provides a comprehensive platform for building end-to-end data analytics so
 - [**Slice-and-Dice Dashboards**](/developers/build/dashboards/explore) - Explore and find insights in your data
 - [**Traditional Visualizations**](/developers/build/dashboards/canvas) - Visualize your data with various chart types
 - [**Canvas Components**](/developers/build/dashboards/canvas-widgets) - See all of our supported components!
-- [**Define Dashboard Access**](/developers/build/dashboards/customization#define-dashboard-access) - Set a SQL boolean query that defines access to dashboard
+- [**Define Dashboard Access**](/developers/build/dashboards/customization#define-dashboard-access) - Set a SQL boolean query that defines access to the dashboard
 
 ### Build Integrations with Custom APIs
 - [**Custom APIs Overview**](/developers/build/custom-apis) - Create HTTP API endpoints to expose your Rill data
@@ -52,4 +52,4 @@ Rill provides a comprehensive platform for building end-to-end data analytics so
 - [**Project Configuration**](/developers/build/project-configuration) - Configure your Rill Project and set default behavior
 - [**Structure your Project**](/developers/build/structure) - Structure folder architecture in Rill
 - [**Use your favorite IDE**](/developers/build/ide) - Utilize your favorite IDE to build Rill projects
-- [**Debugging Rill Developer**](/developers/build/debugging/trace-viewer) - Troubleshoot dashboard access, trace your reconciled resources, and understand project logs  
+- [**Debugging Rill Developer**](/developers/build/debugging/trace-viewer) - Troubleshoot dashboard access, trace your reconciled resources, and understand project logs

--- a/docs/docs/developers/build/models/incremental-partitioned-models.md
+++ b/docs/docs/developers/build/models/incremental-partitioned-models.md
@@ -17,7 +17,7 @@ If you're looking for a working example, take a look at [my-rill-tutorial in our
 
 :::
 
-As we already know how to set up these separately, let's see what changes in the UI when we enable both on a single model. In the following example, note that both incremental is enabled and partitions are defined by the Google Cloud Storage directory.
+As we already know how to set these up separately, let's see what changes in the UI when we enable both on a single model. In the following example, note that incremental modeling is enabled and partitions are defined by the Google Cloud Storage directory.
 
 ```yaml
 type: model

--- a/docs/docs/developers/build/models/model-differences.md
+++ b/docs/docs/developers/build/models/model-differences.md
@@ -28,7 +28,7 @@ For most users working with DuckDB-backed Rill projects, SQL models provide ever
 
 ### Creating a SQL Model
 
-When using the UI to create a new model, you'll see something similar to the below screenshot. You can also create a model directly from the connector UI in the bottom left by selecting the "...". This will create a `select * from underlying_table` as SQL model file.
+When using the UI to create a new model, you'll see something similar to the screenshot below. You can also create a model directly from the connector UI in the bottom left by selecting the "...". This will create a `select * from underlying_table` as a SQL model file.
 
 ![Model](/img/build/model/model.png)
 
@@ -69,4 +69,3 @@ output:
 ```
 
 Please refer to [our reference documentation](/reference/project-files/models) linked above for the available parameters to set in your model.
-

--- a/docs/docs/developers/build/models/performance.md
+++ b/docs/docs/developers/build/models/performance.md
@@ -122,7 +122,7 @@ If your time series column is quite granular, this may affect your dashboards as
 
 :::note Query-time vs Model processing
 
-There are benefits to pre-procesing the data in the model layer but for some quick processing this can be done in the metrics view.
+There are benefits to pre-processing the data in the model layer, but for some quick processing, this can be done in the metrics view.
 
 **Query-time processing** (in metrics views):
 - Flexible and dynamic

--- a/docs/docs/developers/build/structure/structure.md
+++ b/docs/docs/developers/build/structure/structure.md
@@ -9,7 +9,7 @@ After creating your initial set of sources, models, and dashboards, you may have
 - [Metrics Views](/reference/project-files/metrics-views)
 - [Dashboards](/reference/project-files/explore-dashboards)
 
-By default, any new sources, models, metrics views, and dashboards will be created in their respective native folders. However, this does not necessarily have to be the case, and Rill Developer allows a flexible project directory structure, including nested folders or even storing objects in non-native folders. This is a powerful feature that allows you, as a developer, to organize your project to meet your team's specific needs.
+By default, any new sources, models, metrics views, and dashboards will be created in their respective native folders. However, this does not necessarily have to be the case, and Rill Developer allows for a flexible project directory structure, including nested folders or even storing objects in non-native folders. This is a powerful feature that allows you, as a developer, to organize your project to meet your team's specific needs.
 
 ## Adding new resources or parent folders
 

--- a/docs/docs/developers/deploy/deploy-credentials.md
+++ b/docs/docs/developers/deploy/deploy-credentials.md
@@ -5,9 +5,9 @@ sidebar_label: Configure Deployment Credentials
 sidebar_position: 10
 ---
 
-:::tip Development and Production setup
+:::tip Development and Production Setup
 
-We recommend reviewing the [Development/Production Setup](/developers/build/connectors/templating) documentation before deploying your project to Rill Cloud to ensure that your local development and production environments have been separated. 
+We recommend reviewing the [Development/Production Setup](/developers/build/connectors/templating) documentation before deploying your project to Rill Cloud to ensure that your local development and production environments have been separated.
 
 This will ensure that your shared dashboard will be decoupled from your local Rill Developer environment, and you can further develop your dashboards locally without worrying about data availability.
 
@@ -15,7 +15,7 @@ This will ensure that your shared dashboard will be decoupled from your local Ri
 
 When deploying a project, credentials that have been defined in your `.env` file will be automatically passed into your Rill Cloud project. However, for [remote sources](/developers/build/connectors) that are dynamically retrieving your credentials via the CLI, such as S3 and GCS, you will need to ensure that these are [defined in the .env file]( /guide/administration/project-settings/variables-and-credentials#credentials-naming-schema). 
 
-[Local credentials](/developers/build/connectors/credentials#setting-credentials-for-rill-developer) are used by Rill Developer to connect to sources from your local machine, while deployment credentials are what is used by Rill Cloud for production workloads. There are a [few ways to set up credentials in Rill Developer](/developers/build/connectors/credentials/#setting-credentials-for-rill-developer), however you will need to ensure that they are set up in your `.env` file for a seamless experience.
+[Local credentials](/developers/build/connectors/credentials#setting-credentials-for-rill-developer) are used by Rill Developer to connect to sources from your local machine, while deployment credentials are used by Rill Cloud for production workloads. There are a [few ways to set up credentials in Rill Developer](/developers/build/connectors/credentials/#setting-credentials-for-rill-developer); however, you will need to ensure that they are set up in your `.env` file for a seamless experience.
 
 If you have defined your connector's credentials in your `.env` file, these will be deployed along with your project. You should see the credentials in [your project's settings page]( /guide/administration/project-settings/variables-and-credentials#modifying-variables-and-credentials-via-the-settings-page).
 

--- a/docs/docs/developers/deploy/deploy-dashboard/deploy-dashboard.md
+++ b/docs/docs/developers/deploy/deploy-dashboard/deploy-dashboard.md
@@ -40,7 +40,7 @@ Starting from **v0.48**, we have introduced the possibility to push dashboards _
 
 ![Deploy UI](/img/deploy/existing-project/deploy-ui.gif)
 
-Now that you project has been deployed to Rill Cloud, you will need to ensure that your users have access! Please refer to the [user management](/guide/administration/users-and-access/user-management) section. 
+Now that your project has been deployed to Rill Cloud, you will need to ensure that your users have access! Please refer to the [user management](/guide/administration/users-and-access/user-management) section.
 
 If you make changes locally on Rill Developer, you will need to push the contents to Rill Cloud by selecting the `Update` button.
 
@@ -171,7 +171,7 @@ Your project can be accessed at: https://ui.rilldata.com/Rill_Learn/my-rill-tuto
 Opening project in browser...
 ```
 
-Once completed, you will see the following in the settings page. Note that the GitHub repository is already setup!
+Once completed, you will see the following in the settings page. Note that the GitHub repository is already set up!
 
 ![Cli Upload](/img/deploy/existing-project/cli-upload.png)
 
@@ -179,7 +179,7 @@ Once completed, you will see the following in the settings page. Note that the G
 
 ## Continuous Deployment 
 
-Whether you decide to manage your Rill projects using GitHub or re-running `rill project deploy`, Rill should automatically detect changes that you have pushed locally and update your deployed project accordingly. Depending on the changes, this may result in a project reconciliation. If you are experiencing some issues with the project after pushing changes to the CLI, please refer to the project's status page for more information or you can run via the CLI:
+Whether you decide to manage your Rill projects using GitHub or by re-running `rill project deploy`, Rill should automatically detect changes that you have pushed locally and update your deployed project accordingly. Depending on the changes, this may result in a project reconciliation. If you are experiencing issues with the project after pushing changes with the CLI, please refer to the project's status page for more information, or run the following command:
 
 ```
 rill project status
@@ -187,9 +187,9 @@ rill project status
 
 Likewise, if using the UI by selecting the `Update` button, Rill will detect the changes in files and update your deployed project accordingly. Along with the above CLI command, you can view the status of the objects in the Status page.
 
-:::tip Interested in using Gitlab?
+:::tip Interested in using GitLab?
 
-Check out our documentation on deploying a [Rill project using Gitlab](/developers/deploy/deploy-dashboard/deploy-from-cli)!
+Check out our documentation on deploying a [Rill project using GitLab](/developers/deploy/deploy-dashboard/deploy-from-cli)!
 
 :::
 

--- a/docs/docs/developers/deploy/deploy-dashboard/deploy-from-cli.md
+++ b/docs/docs/developers/deploy/deploy-dashboard/deploy-from-cli.md
@@ -1,15 +1,15 @@
 ---
-title: Deploy to Rill Cloud from Gitlab
-description: How to setup continuous deploys to Rill Cloud from Gitlab
-sidebar_label: Deploy from Gitlab
+title: Deploy to Rill Cloud from GitLab
+description: How to set up continuous deploys to Rill Cloud from GitLab
+sidebar_label: Deploy from GitLab
 sidebar_position: 10
 ---
 
-While Rill Cloud natively integrates with [GitHub](https://github.com), you can also deploy your Rill project from [Gitlab](https://about.gitlab.com/) using direct uploads from a [Gitlab CI/CD pipeline](https://docs.gitlab.com/ee/ci/quick_start/).
+While Rill Cloud natively integrates with [GitHub](https://github.com), you can also deploy your Rill project from [GitLab](https://about.gitlab.com/) using direct uploads from a [GitLab CI/CD pipeline](https://docs.gitlab.com/ee/ci/quick_start/).
 
-Follow these steps to set up continuous deployment from Gitlab to Rill Cloud:
+Follow these steps to set up continuous deployment from GitLab to Rill Cloud:
 
-1. Create a new Gitlab repository and push your Rill project to it.
+1. Create a new GitLab repository and push your Rill project to it.
 
 2. On your local, [authenticate with Rill Cloud](/guide/administration/users-and-access/user-management#logging-into-rill-cloud) and create an organization (replace `my-org-name` with your desired name):
 ```bash
@@ -34,7 +34,7 @@ rill project edit --project my-project-name --prod-branch my-branch-name
 rill service create gitlab-ci
 ```
 
-5. Set the service token as a CI/CD variable called `RILL_SERVICE_TOKEN` in Gitlab (from the repository page, it's under _Settings > CI/CD > Variables_).
+5. Set the service token as a CI/CD variable called `RILL_SERVICE_TOKEN` in GitLab (from the repository page, it's under _Settings > CI/CD > Variables_).
 
 6. Create a file named `.gitlab-ci.yml` at the root of the repository containing your Rill project. Paste the following contents into it (replace `my-org-name` and `my-project-name` with your desired names):
 ```yaml
@@ -47,7 +47,7 @@ deploy-rill-cloud:
     - $HOME/rill project deploy --org my-org-name --project my-project-name --interactive=false --api-token $RILL_SERVICE_TOKEN
 ```
 
-Your Rill project should now automatically deploy to `ui.rilldata.com/my-org-name/my-project-name` each time changes are pushed to Gitlab!
+Your Rill project should now automatically deploy to `ui.rilldata.com/my-org-name/my-project-name` each time changes are pushed to GitLab!
 
 :::note File size limits
 We enforce a file size limit of 100mb so ensure you do not unpack the rill binary in the repo root or add it to your .gitignore

--- a/docs/docs/developers/embed/iframe.md
+++ b/docs/docs/developers/embed/iframe.md
@@ -84,7 +84,7 @@ curl -X POST --location 'https://api.rilldata.com/v1/orgs/<org-name>/projects/<p
 }'
 ```
   </TabItem>
-  <TabItem value="js" label="Javascript">
+  <TabItem value="js" label="JavaScript">
     JavaScript (Node.js) with Express.js
 
 ```js

--- a/docs/docs/developers/other/granting/aws-s3-bucket.md
+++ b/docs/docs/developers/other/granting/aws-s3-bucket.md
@@ -1,18 +1,18 @@
 ---
 title: "Managed AWS S3 Bucket"
-description: Setting up s3 access
+description: Setting up S3 access
 sidebar_label: "AWS S3 Bucket"
 sidebar_position: 10
 ---
 
 
 :::warning
-Please note that these instructions were made specifically for Rill Managed Pipelines and used by our data engineering team to set up orchestration from object stores/data warehouses into Rill Managed Database Services. While some of the concepts may apply, please refer to your providers documentation on the correct permissions required to connect to your service.
+Please note that these instructions were made specifically for Rill Managed Pipelines and used by our data engineering team to set up orchestration from object stores/data warehouses into Rill Managed Database Services. While some of the concepts may apply, please refer to your provider's documentation on the correct permissions required to connect to your service.
 :::
 
 ## Setup instructions
 
-### Setup S3 bucket
+### Set up S3 bucket
 
 * Create a new bucket, in the US Standard S3 region, named `rill-ORG_NAME-share`, where **"ORG_NAME"** is your organizational name. Make sure the bucket name is a DNS-compliant address. For example, the name should not include any underscores; use hyphens instead, as shown in the example above.
 * Be sure to disable the "Requester Pays" feature. For more information on S3 bucket name guidelines, see [the AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RequesterPaysBuckets.html).

--- a/docs/docs/developers/other/granting/azure-storage-container.md
+++ b/docs/docs/developers/other/granting/azure-storage-container.md
@@ -5,12 +5,12 @@ sidebar_label: "Azure Storage Container"
 sidebar_position: 40
 ---
 :::warning
-Please note that these instructions were made specifically for Rill Managed Pipelines and used by our data engineering team to set up orchestration from object stores/data warehouses into Rill Managed Database Services. While some of the concepts may apply, please refer to your providers documentation on the correct permissions required to connect to your service.
+Please note that these instructions were made specifically for Rill Managed Pipelines and used by our data engineering team to set up orchestration from object stores/data warehouses into Rill Managed Database Services. While some of the concepts may apply, please refer to your provider's documentation on the correct permissions required to connect to your service.
 :::
 
 ## Overview
 
-Rill would need access to the Azure Storage Container to fetch the data. For this Rill needs 
+Rill would need access to the Azure Storage Container to fetch the data. For this, Rill needs:
 * Storage Account
 * Container Name
 * Access Key

--- a/docs/docs/developers/other/granting/gcs-bucket.md
+++ b/docs/docs/developers/other/granting/gcs-bucket.md
@@ -1,12 +1,12 @@
 ---
 title: "Managed GCS Bucket"
-description: Setting up gcs access
+description: Setting up GCS access
 sidebar_label: "GCS Bucket"
 sidebar_position: 20
 ---
 
 :::warning
-Please note that these instructions were made specifically for Rill Managed Pipelines and used by our data engineering team to set up orchestration from object stores/data warehouses into Rill Managed Database Services. While some of the concepts may apply, please refer to your providers documentation on the correct permissions required to connect to your service.
+Please note that these instructions were made specifically for Rill Managed Pipelines and used by our data engineering team to set up orchestration from object stores/data warehouses into Rill Managed Database Services. While some of the concepts may apply, please refer to your provider's documentation on the correct permissions required to connect to your service.
 :::
 
 ## Setup instructions

--- a/docs/docs/developers/other/granting/google-bigquery.md
+++ b/docs/docs/developers/other/granting/google-bigquery.md
@@ -6,13 +6,13 @@ sidebar_position: 30
 ---
 
 :::warning
-Please note that these instructions were made specifically for Rill Managed Pipelines and used by our data engineering team to set up orchestration from object stores/data warehouses into Rill Managed Database Services. While some of the concepts may apply, please refer to your providers documentation on the correct permissions required to connect to your service.
+Please note that these instructions were made specifically for Rill Managed Pipelines and used by our data engineering team to set up orchestration from object stores/data warehouses into Rill Managed Database Services. While some of the concepts may apply, please refer to your provider's documentation on the correct permissions required to connect to your service.
 :::
 
 ## Setup instructions
 Follow the instructions below to grant Rill access to your Google BigQuery datasets.
 
-1. Find your Google Cloud Service Account by logging into Rill and clicking on Integrations. Your Google Cloud Service Account will be displayed. It will be of the form ```organization```-```workspace name```>@rilldata.iam.gserviceaccount.com. 
+1. Find your Google Cloud Service Account by logging into Rill and clicking on Integrations. Your Google Cloud Service Account will be displayed. It will be of the form `organization-workspace-name@rilldata.iam.gserviceaccount.com`.
 
 2. Go to your Google Cloud Console and select the project to which you want to grant access.
 ![](https://images.contentful.com/ve6smfzbifwz/4KskMcw6t4az7qdW5i9YDa/7c8fe66bdd9b02864ffd878a29031ac8/2c3627e-Project_selector.png)

--- a/docs/docs/developers/other/plans.md
+++ b/docs/docs/developers/other/plans.md
@@ -1,20 +1,20 @@
 ---
 title: "Billing Plans Explained"
-description: How Billing works for non-enterprise accounts
+description: How billing works for non-enterprise accounts
 sidebar_label: Billing Plans Explained
 sidebar_position: 00
 ---
 
-Billing cycles begin on the first of the every month (12:00am UTC). If you start your plan mid-month, your first month will be pro-rated accordingly. You can subcribe to a Team Plan at any point via your Rill Cloud billing page. 
+Billing cycles begin on the first of every month (12:00 AM UTC). If you start your plan mid-month, your first month will be prorated accordingly. You can subscribe to a Team Plan at any point via your Rill Cloud billing page.
 
 
-### How does it work? 
-Rill Data does not use a user-based license system. Instead, we calculate your data usage, after ingestion, and calculate the pricing based on this. For more information on pricing, see our [pricing page](https://www.rilldata.com/pricing). 
+### How does it work?
+Rill Data does not use a user-based license system. Instead, we calculate your data usage after ingestion and calculate pricing based on that usage. For more information on pricing, see our [pricing page](https://www.rilldata.com/pricing).
 
 
 ## Trial Plan
 
-Get started with Rill Cloud with our 30 day free trial! Upon deployment of your first project, your trial will automatically start.  On a free trial, you will be allowed 1 project up to 10GB of data storage.  Like all plans in Rill Data, this also comes with unlimited seats. As an admin, you'll notice banners at the top of the UI indicating the remaining time left on your trial. Once your time has run out, your projects in Rill Cloud will hibernate. While your project wont be accessible on Rill Cloud, the files will still be available if your choose to upgrade to a Team plan.
+Get started with Rill Cloud with our 30-day free trial! Upon deployment of your first project, your trial will automatically start. On a free trial, you will be allowed one project with up to 10 GB of data storage. Like all plans in Rill Data, this also comes with unlimited seats. As an admin, you'll notice banners at the top of the UI indicating the remaining time left on your trial. Once your time has run out, your projects in Rill Cloud will hibernate. While your project won't be accessible on Rill Cloud, the files will still be available if you choose to upgrade to a Team Plan.
 
 ![Deploy Project](/img/manage/billing/deploy-project.png)
 
@@ -27,17 +27,17 @@ Once you are ready to upgrade to a Team Plan, you can do so via the organization
 
 ### Managing Payment Information
 
-Please add a payment method and billing information that is accepted by Stripe. For more information please visit Stripe's website, [here.](https://docs.stripe.com/payments/payment-methods/overview)
+Please add a payment method and billing information that is accepted by Stripe. For more information, please visit [Stripe's website](https://docs.stripe.com/payments/payment-methods/overview).
 
 ![Stripe](/img/manage/billing/stripe.png)
 
 
 ## Team Plan
 
-Team Plan unlocks unlimited projects with a 50GB data storage limit per project. Like all plans in Rill Data, this also comes with unlimited seats. As an admin, you will have access to your billing and usage page to monitor your project. If you decide to unsubcribe from your subcription, you will have access to Rill Cloud until the end of the month. Afterwards, your project will hibernate.
-Your project will not be accessible while hibernating. You will need to renew your subscription in order to access your project on Rill Cloud. 
+The Team Plan unlocks unlimited projects with a 50 GB data storage limit per project. Like all plans in Rill Data, this also comes with unlimited seats. As an admin, you will have access to your billing and usage page to monitor your project. If you decide to unsubscribe from your subscription, you will have access to Rill Cloud until the end of the month. Afterward, your project will hibernate.
+Your project will not be accessible while hibernating. You will need to renew your subscription in order to access your project on Rill Cloud.
 
-To calculate your current usage and pricing, see our [pricing page](https://www.rilldata.com/pricing). 
+To calculate your current usage and pricing, see our [pricing page](https://www.rilldata.com/pricing).
 
 ![Team Plan2](/img/manage/billing/team-plan2.png)
 
@@ -45,7 +45,7 @@ To calculate your current usage and pricing, see our [pricing page](https://www.
 
 ## Enterprise Plan
 
-Enterprise plan includes all the features of a Team Plan but also provides further offerings, such as a dedicated Technical Account Manager and less restrictions on data storage. For more information, please visit our price page, [here](https://www.rilldata.com/pricing), or [contact us](/contact).
+The Enterprise Plan includes all the features of a Team Plan but also provides further offerings, such as a dedicated Technical Account Manager and fewer restrictions on data storage. For more information, please visit our [pricing page](https://www.rilldata.com/pricing), or [contact us](/contact).
 
 ### Enterprise usage-based billing
 
@@ -53,7 +53,7 @@ Enterprise plan includes all the features of a Team Plan but also provides furth
 
 Storage is the total compressed data in the cluster. It's available in [two performance tiers](/developers/other/FAQ#what-are-the-compute-requirements-for-each-performance-tier), Hot and Cold, which set minimum [compute requirements](/developers/other/FAQ#what-are-the-compute-requirements-for-data-processing).
 
-Data can be also offloaded to an archival tier where it does not consume any compute
+Data can also be offloaded to an archival tier where it does not consume any compute.
 
 `$0.0005 / GB per hour`
 
@@ -62,6 +62,6 @@ Data can be also offloaded to an archival tier where it does not consume any com
 
 [Rill Compute Units (RCU)](/developers/other/FAQ#what-is-a-rill-compute-unit-rcu) are a combination of CPU, memory, and disk used for ingesting and querying data.
 
-RCU scale up elastically for data ingestion & processing with enterprise discounts on RCUs provisioned for querying.
+RCUs scale up elastically for data ingestion and processing, with enterprise discounts on RCUs provisioned for querying.
 
 `$0.09 RCU per hour`

--- a/docs/docs/developers/tutorials/openrtb-analytics.md
+++ b/docs/docs/developers/tutorials/openrtb-analytics.md
@@ -34,7 +34,7 @@ rill-openrtb-prog-ads/
 ├── rill.yaml                           # Project configuration
 ├── sources/                            # Data source definitions
 │   ├── auction_data_raw.yaml           # Ad impression data
-│   └── bids_data_raw.yaml.yaml         # Bid request/response data
+│   └── bids_data_raw.yaml              # Bid request/response data
 ├── models/                             # SQL transformations
 │   ├── auction_data_model.sql          # Workaround SQL to keep data up to date
 │   └── bids_data_model.sql             # Workaround SQL to keep data up to date

--- a/docs/docs/developers/tutorials/performance.md
+++ b/docs/docs/developers/tutorials/performance.md
@@ -172,11 +172,11 @@ Some organizations might have both a development and production version of sourc
 
 ## Query Optimization
 
-Query optimization is crucial for maintaining high performance and efficiency, especially when working with data-intensive applications. As Rill dashboards are powered by [OLAP engines](/developers/build/connectors/olap), designed for analytical queries, ensuring that our queries are well-optimized can help maximize the responsiveness and speed of our dashboards. There are also additional potential second-order benefits to optimizing queries in Rill, such as improving ingestion times, how long it takes to build models, how resource intensive it is to build models, how fast profiling queries run, and more. 
+Query optimization is crucial for maintaining high performance and efficiency, especially when working with data-intensive applications. As Rill dashboards are powered by [OLAP engines](/developers/build/connectors/olap), designed for analytical queries, ensuring that our queries are well-optimized can help maximize the responsiveness and speed of our dashboards. There are also additional potential second-order benefits to optimizing queries in Rill, such as improving ingestion times, how long it takes to build models, how resource-intensive it is to build models, how fast profiling queries run, and more.
 
 ### Use appropriate data types and avoid casting when possible
 
-Casting can be expensive, especially when the underlying models are views and not [materialized](#consider-which-models-to-materialize) as a table. For example, if a timestamp column is actually incorrectly typed as a string, then for timeseries charts, Rill ends up having to iterate across each row to try to infer the timestamp and a lot of time parsing has to occur. Similarly, for incorrectly typed or casted columns that are used in calculations, the calculations will have to be constantly looped through, which can be both inefficient and expensive over time (and simply make everything slower). 
+Casting can be expensive, especially when the underlying models are views and not [materialized](#consider-which-models-to-materialize) as a table. For example, if a timestamp column is actually incorrectly typed as a string, then for timeseries charts, Rill ends up having to iterate across each row to try to infer the timestamp and a lot of time parsing has to occur. Similarly, for incorrectly typed or cast columns that are used in calculations, the calculations will have to be constantly looped through, which can be both inefficient and expensive over time (and simply make everything slower).
 
 Similarly, choosing the right data type for each column is also important. Smaller data types, when applicable, consume less memory and can improve query performance. For example, use `INT` instead of `BIGINT` if your data range permits.
 
@@ -186,7 +186,7 @@ Because most [OLAP databases](/developers/build/connectors/olap) store data in a
 
 ### Consider sorting your data by an appropriate timestamp column
 
-Generally speaking, if possible, it is recommended to make sure that your upstream data is relatively well organized and/or sorted by timestamp before being ingested into Rill. This helps to ensure that timeseries queries are efficient when they execute against resulting models and can result in an order of magnitude difference in query performance. This can also help improve the effectiveness of filters by reducing IO.
+Generally speaking, if possible, it is recommended to make sure that your upstream data is relatively well organized and/or sorted by timestamp before being ingested into Rill. This helps to ensure that timeseries queries are efficient when they execute against resulting models and can result in an order of magnitude difference in query performance. This can also help improve the effectiveness of filters by reducing I/O.
 
 :::info When to sort vs not to sort?
 

--- a/docs/docs/developers/tutorials/rill-clickhouse/3-r_ch_metrics-view.md
+++ b/docs/docs/developers/tutorials/rill-clickhouse/3-r_ch_metrics-view.md
@@ -10,7 +10,7 @@ tags:
 
 ## Create the Metrics View.
 
-If you noticed in the previous screenshot, we had a table called `uk_price_paid`. This is a dataset that is used in ClickHouse's Learning portal, so we thought it was fitting to go ahead and continue on this dataset.
+If you noticed in the previous screenshot, we had a table called `uk_price_paid`. This is a dataset that is used in ClickHouse's Learning portal, so we thought it was fitting to continue with this dataset.
 
 :::note
 In the case that you have not already added this table to your local or Cloud database, please follow the steps on [ClickHouse's site](https://clickhouse.com/docs/en/getting-started/example-datasets/uk-price-paid) for the steps to do so!
@@ -50,7 +50,7 @@ While we go into more details in our [Rill Basics course](/developers/tutorials/
 
 ---
 
-`timeseries` - This is our time column that is used on as our x-axis for graphs.
+`timeseries` - This is our time column, which is used as our x-axis for graphs.
 
 `connector` - this is our manually defined ClickHouse connector
 

--- a/docs/docs/developers/tutorials/rill-clickhouse/4-r_ch_dashboard.md
+++ b/docs/docs/developers/tutorials/rill-clickhouse/4-r_ch_dashboard.md
@@ -11,24 +11,24 @@ tags:
 
 ### Create the explore dashboard
 
-When you're ready, you can create the visualization on top of the metric layer. Let's select `Create Explore dashboard`. This will create a simple explore-dashboards/uk_price_paid_metrics_explore.yaml file that reads in all the dimensions and measures. For more information on the available key-pairs, please refer to the [reference documentation.](https://docs.rilldata.com/reference/project-files/explore-dashboards)
+When you're ready, you can create the visualization on top of the metrics layer. Select `Create Explore dashboard`. This will create a simple explore-dashboards/uk_price_paid_metrics_explore.yaml file that reads in all the dimensions and measures. For more information on the available key-value pairs, please refer to the [reference documentation](https://docs.rilldata.com/reference/project-files/explore-dashboards).
 
 ---
 
 ### What can we do in Rill?
-In our case, as we have generated this with AI, so we can look through the description of the populated measures for more information. Based on this, we can find some specific information on the UK properties dataset at a glance, such as:
+In our case, since we generated this with AI, we can look through the description of the populated measures for more information. Based on this, we can find some specific information on the UK properties dataset at a glance, such as:
 
-1. In 2023, What was the minimum/maximum detached property sold in London? [46.5K, 65.0M]
-2. In 2023, What was the average price of detached properties sold in London? How many? [2.5M, 981]
+1. In 2023, what was the minimum/maximum detached property sold in London? [46.5K, 65.0M]
+2. In 2023, what was the average price of detached properties sold in London? How many? [2.5M, 981]
 
 
 ![2023 London](/img/tutorials/ch/2023-london.png)
 
-If we wanted to go further into details, we can even compare detached vs flat vs terraced properties using our compare feature. Based on the x-axis, we can drill down futher from the 2023 year into a specific month, week, or even day.
+If we want to go further into the details, we can even compare detached vs flat vs terraced properties using our compare feature. Using the x-axis, we can drill down further from the 2023 year into a specific month, week, or even day.
 
 
 ![2023 London Compare](/img/tutorials/ch/2023-london-compare.png)
 
-Or, if you want to compare time periods 2022 to 2023's total transactions. In the below screenshot, we selected the Total Transactions metric and enable the time-compare feature to see the delta, delta percent of change from two time periods.
+You can also compare total transactions between 2022 and 2023. In the screenshot below, we selected the Total Transactions metric and enabled the time-compare feature to see the delta and delta percent change between the two time periods.
 
 ![Time Compare](/img/tutorials/ch/time-compare.png)

--- a/docs/docs/developers/tutorials/rill-clickhouse/5-r_ch_deploy.md
+++ b/docs/docs/developers/tutorials/rill-clickhouse/5-r_ch_deploy.md
@@ -37,4 +37,4 @@ connection: dial tcp 127.0.0.1:9000: connect: connection refused
 
 This is likely due to using a locally running ClickHouse server. If so, you will not be able to access your locally running server from Rill Cloud. Instead, we suggest using [ClickHouse Cloud](https://clickhouse.com/cloud). 
 
-For steps to setup ClickHouse Cloud, please refer to [our documentation](https://docs.rilldata.com/developers/build/connectors/olap/clickhouse#connecting-to-clickhouse-cloud).
+For steps to set up ClickHouse Cloud, please refer to [our documentation](https://docs.rilldata.com/developers/build/connectors/olap/clickhouse#connecting-to-clickhouse-cloud).

--- a/docs/docs/developers/tutorials/rill-clickhouse/r_ch_ingest.md
+++ b/docs/docs/developers/tutorials/rill-clickhouse/r_ch_ingest.md
@@ -60,7 +60,7 @@ AWS_ACCESS_KEY_ID=""
 AWS_SECRET_ACCESS_KEY=""
 ```
 :::note
-If you already set up ClickHouse via the .env file, you will just need to add your snowflake and s3 credentials.
+If you already set up ClickHouse via the `.env` file, you will just need to add your Snowflake and S3 credentials.
 :::
 
 


### PR DESCRIPTION
## Summary
- Fix minor spelling and grammar issues in developer docs
- Clean up a few casing and punctuation inconsistencies

## Test Plan
- /tmp/rill-docspell/bin/codespell docs/docs/developers --skip='*.png,*.jpg,*.jpeg,*.gif,*.svg'
- git diff --check -- docs/docs/developers
- npm run build -w docs