### PR TITLE
fix: use branch-aware URL for `Project Graphs` link in DAG overlay

### DIFF
--- a/web-common/src/features/resource-graph/embedding/ResourceGraphOverlay.svelte
+++ b/web-common/src/features/resource-graph/embedding/ResourceGraphOverlay.svelte
@@ -5,6 +5,7 @@
   import type { V1Resource } from "@rilldata/web-common/runtime-client";
   import { ALLOWED_FOR_GRAPH } from "../navigation/seed-parser";
   import { ResourceKind } from "@rilldata/web-common/features/entity-management/resource-selectors";
+  import { withEditorPrefix } from "@rilldata/web-common/layout/navigation/editor-routing";
   import { tick } from "svelte";
 
   export let open = false;
@@ -52,9 +53,11 @@
       : null;
 
   $: overlaySeeds = anchorSeed ? [anchorSeed] : undefined;
-  $: graphHref = graphableKind
-    ? `/graph?kind=${encodeURIComponent(KIND_TOKEN_BY_KIND[graphableKind])}`
-    : "/graph";
+  $: graphHref = withEditorPrefix(
+    graphableKind
+      ? `/graph?kind=${encodeURIComponent(KIND_TOKEN_BY_KIND[graphableKind])}`
+      : "/graph",
+  );
 
   $: emptyReason = !anchorSeed ? "unsupported" : null;
 


### PR DESCRIPTION
- The "Project Graphs" link in the resource graph quick-view overlay (`ResourceGraphOverlay.svelte`) used a hardcoded absolute `/graph` path.
- In Rill Cloud editing, the graph route is prefixed with `/{org}/{project}/@{branch}/-/edit`, so the absolute path 404s and ignores the branch context.
- Routed the href through `withEditorPrefix()` — the same helper the graph's own summary-node navigation already uses (`SummaryNode.svelte`). It resolves correctly in web-admin and is a no-op (`""`) in web-local.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*
