### PR TITLE
Fix guide docs typos and grammar

### DIFF
--- a/docs/docs/guide/administration/organization-settings.md
+++ b/docs/docs/guide/administration/organization-settings.md
@@ -1,18 +1,18 @@
 ---
 title: "Managing Organizations in Rill Cloud"
-description: Basic managment from projects 
+description: Basic management for organizations
 sidebar_label: "Organization Settings"
 sidebar_position: 00
 ---
 
-Before a project can be deployed onto Rill Cloud, an organization must be created. If you are deploying via the UI Deploy, this will automatically be done for you. As an administrator, you can also create, edit, and delete organizations from the CLI. From the organization page, you will be able to view your projects, users, and overall settings. 
+Before a project can be deployed onto Rill Cloud, an organization must be created. If you are deploying via the UI, this will automatically be done for you. As an administrator, you can also create, edit, and delete organizations from the CLI. From the organization page, you will be able to view your projects, users, and overall settings.
 
 ## Organization
 
 ![Rill Org](/img/manage/project-management/rill-org.png)
 
 
-An Organization in Rill is the parent management object and encompasses how your team  interfaces with Rill Cloud. Organizations are designed to hold the different components of your Rill project. Organizations consists of projects that each consist of their own source, models, metrics view, dashboards, user management, and general settings.
+An organization in Rill is the parent management object and encompasses how your team interfaces with Rill Cloud. Organizations are designed to hold the different components of your Rill project. Organizations consist of projects that each have their own sources, models, metrics views, dashboards, user management, and general settings.
 
 ### Organization Hierarchy
 
@@ -37,12 +37,12 @@ Organization
 
 ### User Management
 
-From the User page, you can view and manage your users with organizational. Note that users with specific project access will not appear on this page and can be managed via each individual project. For more information, please review our [User Management documentation](/guide/administration/users-and-access/user-management).
+From the Users page, you can view and manage users within your organization. Note that users with specific project access will not appear on this page and can be managed via each individual project. For more information, please review our [User Management documentation](/guide/administration/users-and-access/user-management).
 
 
 ### Org Settings via Rill Cloud
 
-In the organization setting page, depending on your plan type, you can view the general information, billing and current usage. The Billing tab is only available for those on a `Team Plan`. You can use this page to add, or modify your current payment type. For more information, please review our [Billing Information documentation](/developers/other/plans).
+On the organization settings page, depending on your plan type, you can view the general information, billing, and current usage. The Billing tab is only available for those on a `Team Plan`. You can use this page to add or modify your current payment type. For more information, please review our [Billing Information documentation](/developers/other/plans).
 
 ![Rill Org Settings](/img/manage/project-management/rill-org-settings.png)
 
@@ -76,7 +76,6 @@ Global Flags:
 
 :::tip
 
-Access to Rill can be granted on the [organization level](/guide/administration/users-and-access/user-management#how-to-add-an-organization-user), [project level](/guide/administration/users-and-access/user-management#how-to-add-a-project-user), and [user group level](/guide/administration/users-and-access/user-management#how-to-add-a-user-to-a-usergroup).
+Access to Rill can be granted on the [organization level](/guide/administration/users-and-access/user-management#how-to-add-an-organization-user), [project level](/guide/administration/users-and-access/user-management#how-to-add-a-project-user), and [user group level](/guide/administration/users-and-access/user-management#how-to-add-a-user-to-a-user-group).
 
 :::
-

--- a/docs/docs/guide/administration/project-settings/github-integration.md
+++ b/docs/docs/guide/administration/project-settings/github-integration.md
@@ -27,9 +27,9 @@ In some cases, you will need to change the repository that your project is synce
 2. Select the dropdown next to the repository name
 3. Choose **Disconnect** to remove the current connection
 
-![Disconnect Github](/img/manage/project-management/disconnect-github.png)
+![Disconnect GitHub](/img/manage/project-management/disconnect-github.png)
 
-This action has no effect on your current deployment and will not require a source re-ingest. After disconnecting, you can follow the same steps as [connecting to a GitHub repository](#connecting-to-a-github-repository) to re-connect your project to a new repository.
+This action has no effect on your current deployment and will not require a source re-ingest. After disconnecting, you can follow the same steps as [connecting to a GitHub repository](#connecting-to-a-github-repository) to reconnect your project to a new repository.
 
 ## Deploying from a Branch Other Than `main`
 
@@ -37,7 +37,7 @@ By default, Rill Cloud deploys from the `main` branch of your connected reposito
 
 ### Via Rill Cloud UI
 
-If you have already [setup your connection to GitHub](/developers/deploy/deploy-dashboard/#syncing-your-github-repository), you can edit the branch from the project settings:
+If you have already [set up your connection to GitHub](/developers/deploy/deploy-dashboard/#syncing-your-github-repository), you can edit the branch from the project settings:
 
 ![Main Branch](/img/manage/project-management/main-branch.png)
 
@@ -61,4 +61,3 @@ To manually refresh data sources without pushing code changes (or redeploying yo
 rill project refresh [--source/model] (source_name or model_name)
 ```
 :::
-

--- a/docs/docs/guide/administration/project-settings/project-settings.md
+++ b/docs/docs/guide/administration/project-settings/project-settings.md
@@ -1,6 +1,6 @@
 ---
 title: "Managing Projects in Rill Cloud"
-description: Basic managment from projects 
+description: Basic management for projects
 sidebar_position: 20
 ---
 
@@ -25,7 +25,7 @@ After deploying to Rill Cloud, you can navigate to the status page to monitor yo
 
 ### Resources
 
-The Resources tab lists all project resources (sources, models, metrics views, explores, etc.) with their current reconciliation status. You can search, filter by resource type or status (OK, Error, Warn), and trigger a full refresh of all sources and models. Parse errors are also surfaced here. You can filter the type of resource and it's status to get quick information about the status of your project.
+The Resources tab lists all project resources (sources, models, metrics views, explores, etc.) with their current reconciliation status. You can search, filter by resource type or status (OK, Error, Warn), and trigger a full refresh of all sources and models. Parse errors are also surfaced here. You can filter by resource type and status to get quick information about the status of your project.
 
 ![Resources](<https://cdn.rilldata.com/docs/screenshots/guide/administration/project-status-error-filter.png>)
 
@@ -51,11 +51,11 @@ The Logs tab streams live runtime logs from your deployment via a real-time conn
 
 
 ### Managing Project settings
-You can also manage project objects in the settings page including public URLs (created in an explore dashboard) and environmental variables. For more information on managing variables, see [variables and credentials]( /guide/administration/project-settings/variables-and-credentials).
+You can also manage project objects on the settings page, including public URLs (created in an Explore dashboard) and environment variables. For more information on managing variables, see [variables and credentials](/guide/administration/project-settings/variables-and-credentials).
 
 ![Project Settings](<https://cdn.rilldata.com/docs/screenshots/guide/administration/project-settings-general.png>)
 
-## Managing Rill project from CLI
+## Managing a Rill project from the CLI
 Managing a project includes the project itself and all components or resources that belong to the project. Via the CLI, you can make changes to the project's properties such as description, public access, etc. Run `rill project -h` for an overview of available commands.
 
 ### Refreshing the deployment
@@ -89,4 +89,3 @@ rill project edit --public=true
 **Warning**: If you make a project public, make sure it does not expose any confidential data.
 
 :::
-

--- a/docs/docs/guide/administration/project-settings/variables-and-credentials.md
+++ b/docs/docs/guide/administration/project-settings/variables-and-credentials.md
@@ -1,23 +1,23 @@
 ---
-title: Environmental Variables and Credentials in Rill Cloud
+title: Environment Variables and Credentials in Rill Cloud
 sidebar_label: "Variables and Credentials"
 sidebar_position: 50
 ---
 <!-- WARNING: There are links to this page in source code. If you move it, find and replace the links and consider adding a redirect in docusaurus.config.js. -->
 
-The credentials in a deployed Rill Cloud projects can be managed on the Settings page or via the CLI. If you have yet to deploy your credentials, please follow the steps in our [deploy credentials page](/developers/deploy/deploy-credentials). 
+The credentials in deployed Rill Cloud projects can be managed on the Settings page or via the CLI. If you have yet to deploy your credentials, please follow the steps in our [deploy credentials page](/developers/deploy/deploy-credentials).
 
 ## Modifying Variables and Credentials via the Settings Page
-Upon deployment via Rill Developer, if you have populated your .env file, the contents will be visible as seen below. If there are no environmental variables defined, please run `rill env push` from your local CLI and Rill will automatically push the credentials in your project's `.env` file to Rill Cloud. If you'd like to manually add the credentials, please see [our naming convention](#credentials-naming-schema) to get started. 
+Upon deployment via Rill Developer, if you have populated your .env file, the contents will be visible as seen below. If there are no environment variables defined, please run `rill env push` from your local CLI and Rill will automatically push the credentials in your project's `.env` file to Rill Cloud. If you'd like to manually add the credentials, please see [our naming convention](#credentials-naming-schema) to get started.
 
 ![Environment Variable UI](/img/tutorials/admin/env-var-ui.png)
 
 
-### Adding and Editing Environmental Variables / Importing a `.env` file
-Once your environmental variables are added to Rill Cloud, they can be modified as needed.
+### Adding and Editing Environment Variables / Importing a `.env` file
+Once your environment variables are added to Rill Cloud, they can be modified as needed.
 
 
-![Add Variableiable](/img/manage/var-and-creds/add-variable.png)
+![Add Variable](/img/manage/var-and-creds/add-variable.png)
 
 :::tip Can't find the .env file?
 By default, the hidden files will not be visible in the finder window. In order to view hidden files, you will need to enable "show hidden files".  
@@ -26,7 +26,7 @@ Keyboard shortcut: Command + Shift + .
 
 ## Pushing and pulling credentials to / from Rill Cloud via the CLI
 
-If you'd prefer to use the CLI to managed your credentials, this can be done by running the `rill env pull` to pull your deployed Rill Cloud project's variables locally, or `rill env push` to updated Rill Cloud project's variables.
+If you'd prefer to use the CLI to manage your credentials, this can be done by running `rill env pull` to pull your deployed Rill Cloud project's variables locally, or `rill env push` to update your Rill Cloud project's variables.
 
 :::tip Avoid committing sensitive information to Git
 
@@ -36,7 +36,7 @@ It's never a good idea to commit sensitive information to Git and goes against s
 
 ### `rill env push`
 
-As a project admin, you can run `rill env push` from your local CLI that will update your Rill project with the contexts of your *`<RILL_PROJECT_HOME>/.env`* file.
+As a project admin, you can run `rill env push` from your local CLI, which will update your Rill project with the contents of your *`<RILL_PROJECT_HOME>/.env`* file.
 - Rill Cloud will use the specified credentials and variables in this `.env` file for the deployed project.
 - Other users will also be able to use `rill env pull` to retrieve these defined credentials for local use (with Rill Developer).
 

--- a/docs/docs/guide/administration/users-and-access/user-management.md
+++ b/docs/docs/guide/administration/users-and-access/user-management.md
@@ -28,7 +28,7 @@ At the organization-level, users can have one of the following roles:
 - **Admins** can deploy and manage projects and manage billing.
 - **Editors** can manage non-admin members of the organization by granting and revoking access.
 - **Viewers** can browse the projects they have been given direct access to or indirect access to through user group memberships.
-- **Guests** are similar to viewers, but not part of the "all members" usergroup which is added to projects by default.
+- **Guests** are similar to viewers, but not part of the "all members" user group, which is added to projects by default.
 
 For a detailed list of permissions, please refer to the [Roles and Permissions](roles-permissions).
 
@@ -66,12 +66,12 @@ User "<email here>" added to the user group "<group name>"
 
 ### Automatically add members by email domain
 
-You can automatically add users to your organization by their email domain. During the deployment process and in the Organization settings page. This is limited to the same domain of your user email. If you want to whitelist other domains, contact us! 
+You can automatically add users to your organization by their email domain during the deployment process and in the Organization settings page. This is limited to the same domain as your user email. If you want to whitelist other domains, contact us!
 
 ![Rill Org Settings](/img/manage/user-management/rill-org-settings.png)
 
 
- For example, if you whitelist `yourdomain.com`, new and existing users with an email address ending on `@yourdomain.com` will automatically be added to your organization.
+For example, if you whitelist `yourdomain.com`, new and existing users with an email address ending in `@yourdomain.com` will automatically be added to your organization.
 
 :::info Interested in whitelisting a different domain?
 
@@ -82,7 +82,7 @@ The feature currently requires manual action by a support representative at Rill
 
 ## Project Users
 
-Access to projects are managed at the individual project level subject to some notable rules:
+Access to projects is managed at the individual project level, subject to some notable rules:
 
 1. By default, all organization members (but not guests) are added to new projects through a user group membership with the **viewer** role. You can manually remove this relationship in the project's member settings.
 2. If you grant a project level role to someone who is not a member of the parent organization, they will automatically be added to the organization with the **guest** role.
@@ -102,12 +102,12 @@ For a detailed list of permissions, please refer to the [Roles and Permissions](
 ### How to add a Project User
 There are a few ways to add a project user to Rill Cloud.
 1. Admin invites user to the project using `Share`.
-2. User requests access via the project URL.`https://ui.rilldata.com/<project_name>`
+2. User requests access via the project URL: `https://ui.rilldata.com/<project_name>`
 3. Administrator invites user via the CLI with `--project <project_name>` flag.
 
 ### Admin invites user from Rill Cloud
 
-From the project's splash screen, please select share and type the email[s] along with the type of permissions.
+From the project's splash screen, select Share and type the email address(es) along with the type of permissions.
 
 ![Share Project](/img/manage/user-management/share-project.png)
 
@@ -122,7 +122,7 @@ Alternatively, if you provide the project URL to your users, they can request ac
 ![Request Access](/img/manage/user-management/request-access.png)
 
 
-The admin would receive an email to allow access, and can set the permission after accepting the request via the UI.
+The admin will receive an email to allow access, and can set the permission after accepting the request via the UI.
 
 ![Admin Reply](/img/manage/user-management/admin-reply.png)
 
@@ -146,36 +146,36 @@ Run `rill user --help` to show commands for listing members or changing access.
 
 Another way to manage access is via user groups. You use the Rill CLI to create user groups and add members to them. Once you have created a user group, you can assign roles to it at the organization or project level, similar to how you assign roles to individual users.
 
-User groups are scoped to an organization. They cannot be created only for a single project. Only organization members can be added to user groups, and user groups can only be added to projects within the organization they were created.
+User groups are scoped to an organization. They cannot be created only for a single project. Only organization members can be added to user groups, and user groups can only be added to projects within the organization where they were created.
 
 For more information on setting up user groups, see [user group permissions](usergroup-management).
 
-### How to add a user to a Usergroup
+### How to add a user to a user group
 There are two ways to add a user to a user group.
 1. Admin adds them via Rill Cloud (Coming soon!)
 2. Admin adds them via the CLI
 
-#### Adds a user to a user group in Rill Cloud
+#### Add a user to a user group in Rill Cloud
 
 ### Managing Users via Rill Cloud
 There are two ways that a user can get access to Rill Cloud. 
 
 **Organization invites from Admin**
-From the Users page on the Organization page, you can inivte a user to the organization. Please note that organization viewers have access to view all projects. 
+From the Users page on the Organization page, you can invite a user to the organization. Please note that organization viewers have access to view all projects.
 
 ![Org User Management](/img/tutorials/admin/org-user-management.png)
 **Project level access requests**
 
-  Please refer to the <a href='https://docs.rilldata.com/guide/administration/users-and-access/user-management' target = "blank">documentation how a user can request access to project, or how an admin can invite a user to the project. </a>
+Please refer to the <a href='https://docs.rilldata.com/guide/administration/users-and-access/user-management' target="_blank">documentation on how a user can request access to a project, or how an admin can invite a user to the project.</a>
 
 
 
-#### Adds a user to a user group with the Rill CLI
+#### Add a user to a user group with the Rill CLI
 
 ```
 rill user add --group <group-name>
 ```
-You will then be prompted for details on the user. 
+You will then be prompted for details about the user.
 
 :::note
 If the user you are trying to add is not part of the organization yet, the CLI will prompt you to add them to the organization first then proceed to adding them to a group.
@@ -195,11 +195,11 @@ rill usergroup list [--project my_project_name]
 
 ## Which privilege wins?
 
-Rill uses a logical **OR** operand to define the winning privilege. In other words, if any direct role or indirect role through a usergroup allows a user to take an action, the action will succeed.
+Rill uses a logical **OR** operand to define the winning privilege. In other words, if any direct role or indirect role through a user group allows a user to take an action, the action will succeed.
 
 ## Logging into Rill Cloud
 
-In order to access a deployed project and/or view a shared dashboard, users will need to first login to [Rill Cloud](https://ui.rilldata.com/). When you first navigate to https://ui.rilldata.com/, you will see a few different options to login, including:
+In order to access a deployed project and/or view a shared dashboard, users will need to first log in to [Rill Cloud](https://ui.rilldata.com/). When you first navigate to https://ui.rilldata.com/, you will see a few different options to log in, including:
 - Google SSO
 - Microsoft SSO
 - Email _(basic auth)_
@@ -221,9 +221,8 @@ If you are unsure which option to select, select `Continue with Email` and set u
 
 :::
 
-Afterwards, you should receive an email verification to complete the sign up process. 
+Afterwards, you should receive an email verification to complete the sign-up process.
 
 ![Verification Email](/img/manage/user-management/verification-email.png)
 
-You should now be authenticated with Rill Cloud and be able to sign-in directly going forward!
-
+You should now be authenticated with Rill Cloud and be able to sign in directly going forward!

--- a/docs/docs/guide/administration/users-and-access/usergroup-management.md
+++ b/docs/docs/guide/administration/users-and-access/usergroup-management.md
@@ -1,21 +1,21 @@
 ---
-title: User group Permissions
-sidebar_label: User Groups 
+title: User Group Permissions
+sidebar_label: User Groups
 sidebar_position: 24
 ---
 
-Creating user groups in Rill allows administrators to easily grant permission to multiple projects at different access levels. It is possible to mix and match viewer and administrator permission in a single group and users can be part of multiple groups. However, please keep in mind that the higher permission will be applied.
+Creating user groups in Rill allows administrators to easily grant permissions to multiple projects at different access levels. It is possible to mix and match viewer and administrator permissions in a single group, and users can be part of multiple groups. However, please keep in mind that the higher permission will be applied.
 
-## Managing User groups Permissions
+## Managing User Group Permissions
 There are two ways to set up user groups in Rill.
 
-1. Administrator via Rill Cloud
-2. Administrator via CLI 
+1. Administer them via Rill Cloud
+2. Administer them via CLI
 
 ### How to Manage User Groups in Rill Cloud
 From the organization page, you can manage user groups under the Users tab. Adding user groups from this page will add the user group to the organization. You can then add users to a user group to inherit the group [permissions](/guide/administration/users-and-access/roles-permissions).
 
-![Usergroup Management](/img/manage/user-management/usergroup-management.png)
+![User Group Management](/img/manage/user-management/usergroup-management.png)
 
 ### How to Manage User Groups via the CLI
 ```
@@ -37,7 +37,7 @@ Available Commands:
   remove      Remove a group's role on a project or organization
 ```
 
-## Creating the User group
+## Creating the User Group
 
 You can create a new user group by running the following and following the CLI instructions:
 
@@ -57,7 +57,7 @@ rill usergroup add --project <project_name>
       --project string   Project
       --role string      Role of the user group (options: admin, editor, viewer)
 ```
-You will be prompted for the role and the name of the group you are editing. If you want to specify a specific project, please use the --project flag. If no project flag is defined, you will be setting permission on the organization level.
+You will be prompted for the role and the name of the group you are editing. If you want to specify a specific project, please use the --project flag. If no project flag is defined, you will be setting permissions at the organization level.
 
 If you have any questions on permission levels, please review the [Roles and Permissions page](roles-permissions).
 

--- a/docs/docs/guide/ai/mcp.md
+++ b/docs/docs/guide/ai/mcp.md
@@ -91,7 +91,7 @@ Custom connectors are only available in the paid plan of Claude Desktop. [Learn 
 
 ### Claude Code (Paid Plan)
 
-1. On terminal, run the following command to add mcp server with Claude Code:
+1. In your terminal, run the following command to add an MCP server with Claude Code:
     ```bash
     claude mcp add --transport http <rill-mcp-server-name> https://api.rilldata.com/v1/orgs/{org_name}/projects/{project_name}/runtime/mcp 
     ```
@@ -124,7 +124,7 @@ Custom apps with Developer mode are only available in the paid plans of ChatGPT.
 
 ### Connecting to a specific branch
 
-The normal MCP URL target your project's production deployment. To connect to the deployment for a specific branch (e.g. a dev/preview deployment), insert `/branch/{branch_name}` after the project name:
+The normal MCP URL targets your project's production deployment. To connect to the deployment for a specific branch (e.g. a dev/preview deployment), insert `/branch/{branch_name}` after the project name:
 ```
 https://api.rilldata.com/v1/orgs/{org_name}/projects/{project_name}/branch/{branch_name}/runtime/mcp
 ```
@@ -133,7 +133,7 @@ https://api.rilldata.com/v1/orgs/{org_name}/projects/{project_name}/branch/{bran
 ## Manual Configuration (Alternative Method)
 
 If you prefer to manually configure the connection or need to connect to a local Rill instance, you can edit configuration files directly and provide your own access token.
-Note: If you select this option, you must have Node.js installed on your system which can be downloaded from [nodejs.org](https://nodejs.org/en)
+Note: If you select this option, you must have Node.js installed on your system. It can be downloaded from [nodejs.org](https://nodejs.org/en).
 
 ### Create a Rill Personal Access Token (if your project is on Rill Cloud)
 
@@ -154,7 +154,7 @@ rill token issue
 ```
 
 :::tip Learn more about user tokens
-For comprehensive documentation on creating, managing, and using personal access tokens, see [User Tokens](/guide/administration/access-tokens/user-tokens.
+For comprehensive documentation on creating, managing, and using personal access tokens, see [User Tokens](/guide/administration/access-tokens/user-tokens).
 :::
 
 ### Configure Claude Desktop

--- a/docs/docs/guide/alerts/index.md
+++ b/docs/docs/guide/alerts/index.md
@@ -53,7 +53,7 @@ When creating an alert, it is important to note that any existing filters will _
 1. Add a name for the alert **(required)**
 2. Set what measure to alert on **(required)**, including any dimension splits for the metric _(optional)_ and time grains for analysis _(optional)_
 
-Before selecting **Next**, you will have the optional to preview the data for which you alert will be created on.
+Before selecting **Next**, you will have the option to preview the data for which your alert will be created.
 
 :::tip Maximize Your Alert Filters
 To avoid getting over alerted, consider adding a metric filter to avoid long tail changes on small values. Some examples include:
@@ -122,7 +122,7 @@ To view or make changes to existing alerts, navigate to the project home page an
 Alerts for troubleshooting purposes are useful for making sure that applications are running as expected, campaigns are set up correctly, or any use case where the outcome is binary. For these alerts, the criteria is often: is the amount > 0 or is the amount below a threshold. These alerts are best mixed with dimension filters to be alerted on any instance or split (e.g. Impressions > 0 for all Campaign_ID).
 
 ### Pacing
-Alerts for pacing purposes are good for budgeting and threshold use cases - where a pre-defined range can be applied to evaluate progress towards a goal. There alerts tend to be more specific (setting up filters and criteria for specific values) and marking progress towards that goal. Consider setting up multiple threshold alerts like 50%, 75% attainment.
+Alerts for pacing purposes are good for budgeting and threshold use cases - where a pre-defined range can be applied to evaluate progress towards a goal. These alerts tend to be more specific (setting up filters and criteria for specific values) and mark progress towards that goal. Consider setting up multiple threshold alerts like 50%, 75% attainment.
 
 ### Monitoring & Comparison
 Alerts for monitoring purposes are probably the most common alerting use case, i.e. wanting to be alerted based on relative values to prior periods. For these alerts, rather than absolutes, create criteria for % change of values.

--- a/docs/docs/guide/dashboards/canvas.md
+++ b/docs/docs/guide/dashboards/canvas.md
@@ -5,7 +5,7 @@ sidebar_position: 20
 ---
 
 
-After logging into [Rill Cloud](https://ui.rilldata.com), you should see all projects within your [organization](/guide/administration/organization-settings#organization) that is available and/or has been granted permissions to your user profile. Within each project, you'll then be able to access the corresponding individual dashboards that belong to a particular Rill project. 
+After logging into [Rill Cloud](https://ui.rilldata.com), you should see all projects within your [organization](/guide/administration/organization-settings#organization) that are available and/or have been granted permissions to your user profile. Within each project, you'll then be able to access the corresponding individual dashboards that belong to a particular Rill project.
 
 
 <div style={{ 
@@ -45,7 +45,7 @@ Similar to our [Explore dashboards](/guide/dashboards/explore), Canvas Dashboard
 
 ### Navigation Bar
 
-- _**Time Selector and Time Selector Comparison:**_ You can change the period of analysis to different ranges of time (see `red` box), either by selecting from a pre-defined period (such as last week) or choosing a custom date range. Along with this, you can enable a comparison filter to compare range of dates with 1 click.
+- _**Time Selector and Time Selector Comparison:**_ You can change the period of analysis to different ranges of time (see `red` box), either by selecting from a pre-defined period (such as last week) or choosing a custom date range. Along with this, you can enable a comparison filter to compare a range of dates with one click.
 
 - _**Filtering:**_ Underneath the time selector, you'll also be able to find your filter bar (see `orange` box) where you can [add filters](/guide/dashboards/filters) for metrics (e.g. `campaigns>1000`) or for dimensions (e.g. `campaign_name = Instacart`).
 
@@ -57,7 +57,7 @@ Similar to our [Explore dashboards](/guide/dashboards/explore), Canvas Dashboard
 <!-- - _**Alerts, Bookmarks and Sharing:**_ You can create an [alert](/guide/alerts) by selecting the bell, customizing the default view of the dashboard (see `purple` box) to a predefined set of metrics, dimensions, and filters by selecting the [bookmark](/guide/dashboards/bookmarks.md), or share the dashboard ([internally by clicking the `Share` button](/guide/administration/users-and-access/user-management#admin-invites-user-from-rill-cloud) or [externally via Public URLs](/guide/dashboards/public-urls.md)) . -->
 
 ## Component Navigation
-![Canvas Navigaton](/img/explore/canvas/canvas-navigaton.png)
+![Canvas Navigation](/img/explore/canvas/canvas-navigaton.png)
 
 
 If you want to further drill into a component's data, select the top right button to take you to the equivalent Explore dashboard.

--- a/docs/docs/guide/dashboards/explore/explore.md
+++ b/docs/docs/guide/dashboards/explore/explore.md
@@ -36,7 +36,7 @@ Prefer video? Check out our [YouTube playlist](https://www.youtube.com/watch?v=w
 
 
 **Explore** 
-The main screen of any Rill dashboard is called the _Explore_ page. As seen above, this is divided into three section. 
+The main screen of any Rill dashboard is called the _Explore_ page. As seen above, this is divided into three sections.
 
 - Navigation Bar
 - Measures panel (Left)
@@ -44,13 +44,13 @@ The main screen of any Rill dashboard is called the _Explore_ page. As seen abov
 
 ### Navigation Bar
 
-- _**Time Selector and Time Selector Comparison:**_ You can change the period of analysis to different ranges of time (see `red` box), either by selecting from a pre-defined period (such as last week) or choosing a custom date range. Along with this, you can enable a comparison filter to compare range of dates with 1 click.
+- _**Time Selector and Time Selector Comparison:**_ You can change the period of analysis to different ranges of time (see `red` box), either by selecting from a pre-defined period (such as last week) or choosing a custom date range. Along with this, you can enable a comparison filter to compare a range of dates with one click.
 
 - _**Filtering:**_ Underneath the time selector, you'll also be able to find your filter bar (see `orange` box) where you can [add filters](/guide/dashboards/filters) for metrics (e.g. `campaigns>1000`) or for dimensions (e.g. `campaign_name = Instacart`).
 
-- _**Explore or Pivot:**_ You can switch the view from _explore_ to [_pivot_](/guide/dashboards/explore/pivot) by selecting either from the UI (see `pink` box)
+- _**Explore or Pivot:**_ You can switch the view from _explore_ to [_pivot_](/guide/dashboards/explore/pivot) by selecting either option from the UI (see `pink` box).
 
-- _**Alerts, Bookmarks and Sharing:**_ You can create an [alert](/guide/alerts) by selecting the bell, customizing the default view of the dashboard (see `purple` box) to a predefined set of metrics, dimensions, and filters by selecting the [bookmark](/guide/dashboards/bookmarks), or share the dashboard ([internally by clicking the `Share` button](/guide/administration/users-and-access/user-management#admin-invites-user-from-rill-cloud) or [externally via Public URLs](/guide/dashboards/public-urls)) .
+- _**Alerts, Bookmarks and Sharing:**_ You can create an [alert](/guide/alerts) by selecting the bell, customize the default view of the dashboard (see `purple` box) to a predefined set of metrics, dimensions, and filters by selecting the [bookmark](/guide/dashboards/bookmarks), or share the dashboard ([internally by clicking the `Share` button](/guide/administration/users-and-access/user-management#admin-invites-user-from-rill-cloud) or [externally via Public URLs](/guide/dashboards/public-urls)).
 
 
 ### KPI Widget (Measures) Panel
@@ -80,7 +80,7 @@ The main screen of any Rill dashboard is called the _Explore_ page. As seen abov
 
 
 
-- _**Measures:**_  All _**metrics**_ that are available in the underlying model \ are viewable on the left-hand side, broken out with summary numbers (e.g. eCPM) and timeseries visualizations (based on your configured `timeseries` column in your [dashboard YAML](/reference/project-files/explore-dashboards)). You can add, remove or reorder your metrics from the page by simply selecting them from the dropdown above the charts (see `yellow` box). If you select any specific measure, you will be navigating to the [Time Dimension Detail](/guide/dashboards/explore/tdd).
+- _**Measures:**_  All _**metrics**_ that are available in the underlying model are viewable on the left-hand side, broken out with summary numbers (e.g. eCPM) and timeseries visualizations (based on your configured `timeseries` column in your [dashboard YAML](/reference/project-files/explore-dashboards)). You can add, remove, or reorder your metrics from the page by simply selecting them from the dropdown above the charts (see `yellow` box). If you select any specific measure, you will navigate to the [Time Dimension Detail](/guide/dashboards/explore/tdd).
 
 - _**Time Dimension Detail:**_ A detailed view of a single specific measure that can be further drilled down to understand minute details in your data. As with the Explore page, you can add comparison dimensions to visualize the value for several specific dimension values. For more information see: [Time Dimension Detail](/guide/dashboards/explore/tdd).
 
@@ -146,7 +146,7 @@ Whether you need to see the full value of a long JSON, or copy a value, there ar
 List of commands:
 - __*Copy values*__ ( ``shift + click`` ) - Copy the value of the row value. 
 - __*Value previewer*__ ( ``space`` ) - See the full text value of the row value.
-- __*Lock Insepector*__ ( ``L`` ) - Lock the inspector (allows scrolling through long values)
+- __*Lock Inspector*__ ( ``L`` ) - Lock the inspector (allows scrolling through long values)
 
 ![Preview Value](/img/explore/dashboard101/preview-value.png)
 
@@ -161,7 +161,7 @@ Toggle between light and dark themes by clicking your profile icon in the top ri
 ## Banners!
 Another additional feature that you can add to an Explore dashboard are banners. Whether it is to inform your end-users about specific guidelines on how to use Rill, or an informational post about the datasets being used, you can design the banner to whatever text you'd like.
 
-Simple add the following to your explore-dashboard.yaml 
+Simply add the following to your explore-dashboard.yaml
 
 ```yaml
 banner: Your custom message here!

--- a/docs/docs/guide/dashboards/explore/tdd.md
+++ b/docs/docs/guide/dashboards/explore/tdd.md
@@ -36,11 +36,11 @@ Prefer video? Check out our [YouTube playlist](https://www.youtube.com/watch?v=w
 
 ## Time Dimension Detail (TDD)
 
-Within the TTD screen, you can apply all of the same filters and comparisons as Explore. Any filters applied will be carried into the TDD or will be carried out to Explore if you return to the main page on the top left. 
+Within the TDD screen, you can apply all of the same filters and comparisons as Explore. Any filters applied will be carried into the TDD or will be carried out to Explore if you return to the main page on the top left.
 
 Underneath the expanded time series chart, you will see two sets of dropdowns - one for Rows to change the comparison (this defaults to Time but can be changed to any dimension) and one for Columns (which can be used to cycle through all of your metrics). On the top right, you can also export the TDD pivot view for quick time series reporting. 
 
-Similar to the filters, the Search and Exclude options from the expanded Leadersboards are available on the top right of the TDD table. Lastly, you can also take the TDD table directly to the Pivot view for multi-dimensional analysis - more details on [Pivot here](/guide/dashboards/explore/pivot).
+Similar to the filters, the Search and Exclude options from the expanded Leaderboards are available on the top right of the TDD table. Lastly, you can also take the TDD table directly to the Pivot view for multi-dimensional analysis - more details on [Pivot here](/guide/dashboards/explore/pivot).
 
     
 ![TDD](/img/explore/tdd/tdd.gif)

--- a/docs/docs/guide/dashboards/filters.md
+++ b/docs/docs/guide/dashboards/filters.md
@@ -42,7 +42,7 @@ With the release of v0.52, we have introduced an easy way to craft specific view
 
 ## Add / Hide Dimensions and Metrics
 
-Users can add or hide dimensions and metrics to a subset of fields they wish to see at any given time. At the top left, above the time series and above the top left leaderboard, you'll find the Measures & Dimensions selectors to add or hide from the page. In the example below, `network` and `country` are deselected so would be hidden from view.
+Users can add or hide dimensions and metrics to create a subset of fields they wish to see at any given time. At the top left, above the time series and above the top left leaderboard, you'll find the Measures & Dimensions selectors to add or hide fields from the page. In the example below, `network` and `country` are deselected, so they would be hidden from view.
 
 ![Hide](/img/explore/filters/hide.png)
 
@@ -62,7 +62,7 @@ To add or remove dimensions on the page - select the All Dimensions picker above
 
 You can also expand each dimension table to see all metrics and full list of those dimensions. In the expanded Leaderboard, you can search for dimension values, select all values returned, or exclude values from the result. 
 
-Any filter applied in the Leaderboard will also show up in the filter bar at next to the time picker. You can apply the same search capabilities and select features in the filter bar as well.
+Any filter applied in the Leaderboard will also show up in the filter bar next to the time picker. You can apply the same search capabilities and select features in the filter bar as well.
 
 ![Filter](/img/explore/filters/filter.gif)
 
@@ -91,7 +91,7 @@ These metric filters can be applied from the filter bar. To apply a metric filte
 
 - Select the metric you wish to filter by (e.g. Total Cost)
 - Select which dimension to sort/key the metric by (e.g. Cost by Region)
-- Select your Threshold Type (e.g. Great Than)
+- Select your Threshold Type (e.g. Greater Than)
 - Input your Threshold amount and Click Enter
 
 
@@ -101,7 +101,6 @@ These metric filters can be applied from the filter bar. To apply a metric filte
 :::tip
 Metric filters are a good way to "sort" by two different metrics. First, apply your metric threshold. Then, sort by your metrics within the Leaderboard to do multi-metric sorting. 
 
-As an example - to see most active enterprise customers - filter all customers with revenue greater than $1000 then sorted by number of users increased descending.
+As an example - to see the most active enterprise customers - filter all customers with revenue greater than $1000, then sort by number of users in descending order.
 :::
-
 

--- a/docs/docs/guide/dashboards/public-urls.md
+++ b/docs/docs/guide/dashboards/public-urls.md
@@ -1,6 +1,6 @@
 ---
-title: "Sharing Dashboards with a public URL"
-description: Sharing Dashboard with a few clicks using the public link
+title: "Sharing Dashboards with a Public URL"
+description: Share dashboards with a few clicks using a public link
 sidebar_label: "Public Shareable URLs"
 sidebar_position: 36
 ---
@@ -22,7 +22,7 @@ If you want to set an expiration, please select the toggle and set the expiratio
 
 ### What the recipient sees
 
-As expected, when opening the public URL, the user can view the dashboard. Like a logged-in user, they are able to navigate within the dashboard and drill or slice-and-dice as needed. Unlike a logged in user, they are not able to make any changes to the filter that you've set.
+As expected, when opening the public URL, the user can view the dashboard. Like a logged-in user, they are able to navigate within the dashboard and drill or slice-and-dice as needed. Unlike a logged-in user, they are not able to make any changes to the filters that you've set.
 
 :::info Did you know?
 
@@ -32,13 +32,13 @@ In fact, users who click on a public shareable URL cannot see the parent filters
 
 ## How to manage public URLs
 
-### via the UI
+### Via the UI
 You can now manage public URLs via the UI. You will find a new "settings" tab in the Rill Cloud UI as an administrator.
 
 ![Public URL Settings](/img/explore/publicurl/public-url-settings.png)
 
 
-### via the CLI
+### Via the CLI
 ```
 rill public-url
 Manage public URLs
@@ -63,11 +63,11 @@ Global Flags:
 Use "rill public-url [command] --help" for more information about a command.
 
 ```
-Using the Rill CLI, you can list, create or delete public URLs.
+Using the Rill CLI, you can list, create, or delete public URLs.
 
 #### Deleting a public URL
 
-To delete a public URL, you will need an `id` parameter. In order to retrieve the appropriate `id`, you will need to first list out the public URLs. You can do so using the below with any flags to help you. 
+To delete a public URL, you will need an `id` parameter. In order to retrieve the appropriate `id`, you will need to first list out the public URLs. You can do so using the command below with any flags that help you.
 
 ```
 rill public-url list 
@@ -80,6 +80,4 @@ rill public-url delete <id>
 ```
 
 If you are interested in creating a public URL directly from the CLI, you can do so by passing the required parameters. (You can use the --help flag to see what additional flags are required.)
-
-
 

--- a/docs/docs/guide/reports/exports.md
+++ b/docs/docs/guide/reports/exports.md
@@ -40,7 +40,7 @@ Prefer video? Check out our [YouTube playlist](https://www.youtube.com/watch?v=w
 
 ## Exporting from Rill
 
-There are several places to export your data from Rill. In each case, you will see options for exporting to csv, xlsx or parquet formats. 
+There are several places to export your data from Rill. In each case, you will see options for exporting to CSV, XLSX, or Parquet formats.
 
 Exports are available from:
 
@@ -78,7 +78,7 @@ Follow these simple steps to schedule an email report:
 
 1. **Navigate to Content:** Expand a dimension table by clicking on the dimension name.
 2. **Export Options:** Click on the Export button and select "Create scheduled report..." Filters, comparisons, and sort orders will be preserved for your report.
-3. **Configure Report Settings:** Choose a frequency and set a time to receive the output. Choose a report format (csv/excel/parquet) and specify a list of recipients.
+3. **Configure Report Settings:** Choose a frequency and set a time to receive the output. Choose a report format (CSV/Excel/Parquet) and specify a list of recipients.
 4. **Complete and Enjoy:** Click "Done." User-created reports will be delivered directly to your inbox 🎉.
 
 
@@ -93,5 +93,3 @@ Reports are managed from your home screen. To navigate to the report admin page,
 - **Report Details:** Click into a report to view schedule details, next run information, recipients, and execution history.
 - **Deletion:** To delete a report, click the three-dot menu next to the report name and select "Delete Report."
 - **Unsubscribe Option:** Recipients have the option to unsubscribe by clicking the provided link within the report delivery email.
-
-


### PR DESCRIPTION
## Summary
- Fix spelling and minor grammar issues across guide docs
- Clean up a malformed guide link and a few awkward phrases
- Keep changes scoped to docs/docs/guide

## Testing
- npm run build --prefix docs
- git diff --check -- docs/docs/guide

Note: The docs build still reports existing broken-anchor warnings outside docs/docs/guide.