### PR TITLE
Fix reference docs typos and grammar

### DIFF
--- a/cli/cmd/billing/subscription/list.go
+++ b/cli/cmd/billing/subscription/list.go
@@ -11,7 +11,7 @@ func ListCmd(ch *cmdutil.Helper) *cobra.Command {
 
 	listCmd := &cobra.Command{
 		Use:   "list",
-		Short: "List subscription for an organization",
+		Short: "List subscriptions for an organization",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := ch.Client()

--- a/cli/cmd/billing/subscription/subscription.go
+++ b/cli/cmd/billing/subscription/subscription.go
@@ -8,7 +8,7 @@ import (
 func SubscriptionCmd(ch *cmdutil.Helper) *cobra.Command {
 	subsCmd := &cobra.Command{
 		Use:               "subscription",
-		Short:             "Manage organisation subscription",
+		Short:             "Manage organization subscriptions",
 		PersistentPreRunE: cmdutil.CheckAuth(ch),
 	}
 

--- a/cli/cmd/org/org.go
+++ b/cli/cmd/org/org.go
@@ -12,7 +12,7 @@ import (
 func OrgCmd(ch *cmdutil.Helper) *cobra.Command {
 	orgCmd := &cobra.Command{
 		Use:               "org",
-		Short:             "Manage organisations",
+		Short:             "Manage organizations",
 		PersistentPreRunE: cmdutil.CheckAuth(ch),
 	}
 

--- a/docs/docs/reference/cli/billing/billing.md
+++ b/docs/docs/reference/cli/billing/billing.md
@@ -20,5 +20,5 @@ Billing related commands for org
 * [rill](../cli.md)	 - A CLI for Rill
 * [rill billing list-issues](list-issues.md)	 - List billing issues for an organization
 * [rill billing plan](plan/plan.md)	 - Get billing plans
-* [rill billing subscription](subscription/subscription.md)	 - Manage organisation subscription
+* [rill billing subscription](subscription/subscription.md)	 - Manage organization subscriptions
 

--- a/docs/docs/reference/cli/billing/subscription/cancel.md
+++ b/docs/docs/reference/cli/billing/subscription/cancel.md
@@ -22,5 +22,5 @@ rill billing subscription cancel [flags]
 
 ### SEE ALSO
 
-* [rill billing subscription](subscription.md)	 - Manage organisation subscription
+* [rill billing subscription](subscription.md)	 - Manage organization subscriptions
 

--- a/docs/docs/reference/cli/billing/subscription/edit.md
+++ b/docs/docs/reference/cli/billing/subscription/edit.md
@@ -28,5 +28,5 @@ rill billing subscription edit [flags]
 
 ### SEE ALSO
 
-* [rill billing subscription](subscription.md)	 - Manage organisation subscription
+* [rill billing subscription](subscription.md)	 - Manage organization subscriptions
 

--- a/docs/docs/reference/cli/billing/subscription/list.md
+++ b/docs/docs/reference/cli/billing/subscription/list.md
@@ -4,7 +4,7 @@ title: rill billing subscription list
 ---
 ## rill billing subscription list
 
-List subscription for an organization
+List subscriptions for an organization
 
 ```
 rill billing subscription list [flags]
@@ -22,5 +22,5 @@ rill billing subscription list [flags]
 
 ### SEE ALSO
 
-* [rill billing subscription](subscription.md)	 - Manage organisation subscription
+* [rill billing subscription](subscription.md)	 - Manage organization subscriptions
 

--- a/docs/docs/reference/cli/billing/subscription/renew.md
+++ b/docs/docs/reference/cli/billing/subscription/renew.md
@@ -28,5 +28,5 @@ rill billing subscription renew [flags]
 
 ### SEE ALSO
 
-* [rill billing subscription](subscription.md)	 - Manage organisation subscription
+* [rill billing subscription](subscription.md)	 - Manage organization subscriptions
 

--- a/docs/docs/reference/cli/billing/subscription/subscription.md
+++ b/docs/docs/reference/cli/billing/subscription/subscription.md
@@ -4,7 +4,7 @@ title: rill billing subscription
 ---
 ## rill billing subscription
 
-Manage organisation subscription
+Manage organization subscriptions
 
 ### Flags
 
@@ -26,6 +26,6 @@ Manage organisation subscription
 * [rill billing](../billing.md)	 - Billing related commands for org
 * [rill billing subscription cancel](cancel.md)	 - Cancel subscription for an organization
 * [rill billing subscription edit](edit.md)	 - Edit organization subscription
-* [rill billing subscription list](list.md)	 - List subscription for an organization
+* [rill billing subscription list](list.md)	 - List subscriptions for an organization
 * [rill billing subscription renew](renew.md)	 - Renew cancelled organization subscription
 

--- a/docs/docs/reference/cli/cli.md
+++ b/docs/docs/reference/cli/cli.md
@@ -31,7 +31,7 @@ Work with Rill projects from the command line.
 * [rill init](init.md)	 - Initialize a new Rill project
 * [rill login](login.md)	 - Authenticate with the Rill API
 * [rill logout](logout.md)	 - Logout of the Rill API
-* [rill org](org/org.md)	 - Manage organisations
+* [rill org](org/org.md)	 - Manage organizations
 * [rill project](project/project.md)	 - Manage projects
 * [rill public-url](public-url/public-url.md)	 - Manage public URLs
 * [rill query](query.md)	 - Query data in a project

--- a/docs/docs/reference/cli/org/create.md
+++ b/docs/docs/reference/cli/org/create.md
@@ -28,5 +28,5 @@ rill org create <org-name> [flags]
 
 ### SEE ALSO
 
-* [rill org](org.md)	 - Manage organisations
+* [rill org](org.md)	 - Manage organizations
 

--- a/docs/docs/reference/cli/org/delete.md
+++ b/docs/docs/reference/cli/org/delete.md
@@ -33,5 +33,5 @@ rill org delete [<org-name>] [flags]
 
 ### SEE ALSO
 
-* [rill org](org.md)	 - Manage organisations
+* [rill org](org.md)	 - Manage organizations
 

--- a/docs/docs/reference/cli/org/edit.md
+++ b/docs/docs/reference/cli/org/edit.md
@@ -31,5 +31,5 @@ rill org edit [<org-name>] [flags]
 
 ### SEE ALSO
 
-* [rill org](org.md)	 - Manage organisations
+* [rill org](org.md)	 - Manage organizations
 

--- a/docs/docs/reference/cli/org/list.md
+++ b/docs/docs/reference/cli/org/list.md
@@ -28,5 +28,5 @@ rill org list [flags]
 
 ### SEE ALSO
 
-* [rill org](org.md)	 - Manage organisations
+* [rill org](org.md)	 - Manage organizations
 

--- a/docs/docs/reference/cli/org/org.md
+++ b/docs/docs/reference/cli/org/org.md
@@ -4,7 +4,7 @@ title: rill org
 ---
 ## rill org
 
-Manage organisations
+Manage organizations
 
 ### Global flags
 

--- a/docs/docs/reference/cli/org/rename.md
+++ b/docs/docs/reference/cli/org/rename.md
@@ -29,5 +29,5 @@ rill org rename [flags]
 
 ### SEE ALSO
 
-* [rill org](org.md)	 - Manage organisations
+* [rill org](org.md)	 - Manage organizations
 

--- a/docs/docs/reference/cli/org/show.md
+++ b/docs/docs/reference/cli/org/show.md
@@ -27,5 +27,5 @@ rill org show [<org-name>] [flags]
 
 ### SEE ALSO
 
-* [rill org](org.md)	 - Manage organisations
+* [rill org](org.md)	 - Manage organizations
 

--- a/docs/docs/reference/cli/org/switch.md
+++ b/docs/docs/reference/cli/org/switch.md
@@ -21,5 +21,5 @@ rill org switch [<org-name>] [flags]
 
 ### SEE ALSO
 
-* [rill org](org.md)	 - Manage organisations
+* [rill org](org.md)	 - Manage organizations
 

--- a/docs/docs/reference/cli/org/upload-favicon.md
+++ b/docs/docs/reference/cli/org/upload-favicon.md
@@ -29,5 +29,5 @@ rill org upload-favicon [<org-name> [<path-to-image>]] [flags]
 
 ### SEE ALSO
 
-* [rill org](org.md)	 - Manage organisations
+* [rill org](org.md)	 - Manage organizations
 

--- a/docs/docs/reference/cli/org/upload-logo.md
+++ b/docs/docs/reference/cli/org/upload-logo.md
@@ -30,5 +30,5 @@ rill org upload-logo [<org-name> [<path-to-image>]] [flags]
 
 ### SEE ALSO
 
-* [rill org](org.md)	 - Manage organisations
+* [rill org](org.md)	 - Manage organizations
 

--- a/docs/docs/reference/project-files/alerts.md
+++ b/docs/docs/reference/project-files/alerts.md
@@ -4,7 +4,7 @@ title: Alert YAML
 sidebar_position: 37
 ---
 
-Along with alertings at the dashboard level and can be created via the UI, there might be more extensive alerting that you might want to develop and can be done so the an alert.yaml. When creating an alert via a YAML file, you'll see this denoted in the UI as `Created through code`.
+Along with dashboard-level alerts that can be created via the UI, you can develop more extensive alerting in an alert YAML file. When creating an alert via a YAML file, you'll see this denoted in the UI as `Created through code`.
 
 ## Properties
 
@@ -42,13 +42,13 @@ _[string]_ - Description for the alert
 
 ### `intervals`
 
-_[object]_ - define the interval of the alert to check
+_[object]_ - Defines the alert interval to check.
 
-  - **`duration`** - _[string]_ - a valid ISO8601 duration to define the interval duration
+  - **`duration`** - _[string]_ - An ISO 8601 duration to define the interval duration.
 
-  - **`limit`** - _[integer]_ - maximum number of intervals to check for on invocation
+  - **`limit`** - _[integer]_ - Maximum number of intervals to check on invocation.
 
-  - **`check_unclosed`** - _[boolean]_ - boolean, whether unclosed intervals should be checked
+  - **`check_unclosed`** - _[boolean]_ - Whether unclosed intervals should be checked.
 
 ### `watermark`
 
@@ -56,7 +56,7 @@ _[string]_ - Specifies how the watermark is determined for incremental processin
 
 ### `timeout`
 
-_[string]_ - define the timeout of the alert in seconds (optional).
+_[string]_ - Defines the timeout of the alert in seconds. (optional)
 
 ### `data`
 
@@ -66,7 +66,7 @@ _[oneOf]_ - Data source for the alert _(required)_
 
     - **`sql`** - _[string]_ - Raw SQL query to run against existing models in the project. _(required)_
 
-    - **`connector`** - _[string]_ - specifies the connector to use when running SQL or glob queries.
+    - **`connector`** - _[string]_ - Specifies the connector to use when running SQL or glob queries.
 
   - **option 2** - _[object]_ - Executes a SQL query that targets a defined metrics view.
 
@@ -80,7 +80,7 @@ _[oneOf]_ - Data source for the alert _(required)_
 
   - **option 4** - _[object]_ - Uses a file-matching pattern (glob) to query data from a connector.
 
-    - **`glob`** - _[oneOf]_ - Simple path/glob pattern or path/glob patternwith advanced options . _(required)_
+    - **`glob`** - _[oneOf]_ - Simple path/glob pattern or path/glob pattern with advanced options. _(required)_
 
       - **option 1** - _[string]_ - Glob pattern used to match files or directories in the object store.
 
@@ -205,7 +205,7 @@ _[object]_ - Notification configuration for email and Slack delivery _(required)
 
 ### `annotations`
 
-_[object]_ - Key value pair used for annotations
+_[object]_ - Key-value pairs used for annotations.
 
 ## Common Properties
 

--- a/docs/docs/reference/project-files/apis.md
+++ b/docs/docs/reference/project-files/apis.md
@@ -92,7 +92,7 @@ _[string]_ - Raw SQL query to run against existing models in the project. _(requ
 
 ### `connector`
 
-_[string]_ - specifies the connector to use when running SQL or glob queries.
+_[string]_ - Specifies the connector to use when running SQL or glob queries.
 
 ```yaml
 type: api
@@ -138,7 +138,7 @@ Uses a file-matching pattern (glob) to query data from a connector.
 
 ### `glob`
 
-_[oneOf]_ - Simple path/glob pattern or path/glob patternwith advanced options . _(required)_
+_[oneOf]_ - Simple path/glob pattern or path/glob pattern with advanced options. _(required)_
 
   - **option 1** - _[string]_ - Glob pattern used to match files or directories in the object store.
 
@@ -191,7 +191,7 @@ Invokes multiple resolvers and returns the union of their results. Each entry in
 _[array of object]_ - List of resolver definitions whose results are combined into a single result set. _(required)_
 
 ```yaml
-# Exampe for union resolvers
+# Example for union resolvers
 type: api
 union:
     - connector: duckdb

--- a/docs/docs/reference/project-files/canvas-dashboards.md
+++ b/docs/docs/reference/project-files/canvas-dashboards.md
@@ -26,7 +26,7 @@ _[string]_ - Description for the canvas dashboard
 
 ### `banner`
 
-_[string]_ - Refers to the custom banner displayed at the header of an Canvas dashboard
+_[string]_ - Refers to the custom banner displayed in the header of a Canvas dashboard.
 
 ### `rows`
 
@@ -46,7 +46,7 @@ _[array of object]_ - Refers to all of the rows displayed on the Canvas. Each en
         - **bar_chart** - Normal Bar chart
         - **stacked_bar** - Stacked Bar chart
         - **area_chart** - Line chart with area
-        - **image** - Provide a URL to embed into canvas dashboard
+        - **image** - Provide a URL to embed into the canvas dashboard
         - **table** - Similar to Pivot table, add dimensions and measures to visualize your data
         - **heatmap** - Heat Map chart to visualize distribution of data
         - **donut_chart** - Donut or Pie chart to display sums of total
@@ -88,7 +88,7 @@ _[object]_ - Indicates if filters should be enabled for the canvas.
 
 ### `allow_custom_time_range`
 
-_[boolean]_ - Defaults to true, when set to false it will hide the ability to set a custom time range for the user.
+_[boolean]_ - Defaults to true. When set to false, hides the ability to set a custom time range for the user.
 
 ### `allow_filter_add`
 
@@ -96,7 +96,7 @@ _[boolean]_ - Whether users can add new filters to the canvas dashboard.
 
 ### `time_ranges`
 
-_[array of oneOf]_ - Overrides the list of default time range selections available in the dropdown. It can be string or an object with a 'range' and optional 'comparison_offsets'
+_[array of oneOf]_ - Overrides the list of default time range selections available in the dropdown. It can be a string or an object with a 'range' and optional 'comparison_offsets'.
   ```yaml
   time_ranges:
     - PT15M // Simplified syntax to specify only the range
@@ -110,13 +110,13 @@ _[array of oneOf]_ - Overrides the list of default time range selections availab
   ```
 
 
-  - **option 1** - _[string]_ - a valid [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) duration or one of the [Rill ISO 8601 extensions](/reference/time-syntax/rill-iso-extensions#extensions) extensions for the selection
+  - **option 1** - _[string]_ - An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) duration or one of the [Rill ISO 8601 extensions](/reference/time-syntax/rill-iso-extensions#extensions) extensions for the selection.
 
   - **option 2** - _[object]_ - Object containing time range and comparison configuration
 
-    - **`range`** - _[string]_ - a valid [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) duration or one of the [Rill ISO 8601 extensions](/reference/time-syntax/rill-iso-extensions#extensions) extensions for the selection _(required)_
+    - **`range`** - _[string]_ - An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) duration or one of the [Rill ISO 8601 extensions](/reference/time-syntax/rill-iso-extensions#extensions) extensions for the selection. _(required)_
 
-    - **`comparison_offsets`** - _[array of oneOf]_ - list of time comparison options for this time range selection (optional). Must be one of the [Rill ISO 8601 extensions](https://docs.rilldata.com/reference/rill-iso-extensions#extensions)
+    - **`comparison_offsets`** - _[array of oneOf]_ - List of time comparison options for this time range selection (optional). Must be one of the [Rill ISO 8601 extensions](https://docs.rilldata.com/reference/rill-iso-extensions#extensions).
 
       - **option 1** - _[string]_ - Offset string only (range is inferred)
 
@@ -132,7 +132,7 @@ _[array of string]_ - Refers to the time zones that should be pinned to the top 
 
 ### `defaults`
 
-_[object]_ - defines the defaults YAML struct
+_[object]_ - Defines the defaults YAML struct.
   ```yaml
   defaults:
     time_range: P1M
@@ -143,11 +143,11 @@ _[object]_ - defines the defaults YAML struct
   ```
 
 
-  - **`time_range`** - _[string]_ - Refers to the default time range shown when a user initially loads the dashboard. The value must be either a valid [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) (for example, PT12H for 12 hours, P1M for 1 month, or P26W for 26 weeks) or one of the [Rill ISO 8601 extensions](https://docs.rilldata.com/reference/rill-iso-extensions#extensions)
+  - **`time_range`** - _[string]_ - Refers to the default time range shown when a user initially loads the dashboard. The value must be either an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) (for example, PT12H for 12 hours, P1M for 1 month, or P26W for 26 weeks) or one of the [Rill ISO 8601 extensions](https://docs.rilldata.com/reference/rill-iso-extensions#extensions).
 
   - **`comparison_mode`** - _[string]_ - Controls how to compare current data with historical or categorical baselines. Options: `none` (no comparison), `time` (compares with past based on default_time_range), `dimension` (compares based on comparison_dimension values)
 
-  - **`comparison_dimension`** - _[string]_ - for dimension mode, specify the comparison dimension by name
+  - **`comparison_dimension`** - _[string]_ - For dimension mode, specify the comparison dimension by name.
 
   - **`filters`** - _[object]_ - Default filter expressions keyed by metrics view name. Each value is a Metrics SQL WHERE expression.
 

--- a/docs/docs/reference/project-files/explore-dashboards.md
+++ b/docs/docs/reference/project-files/explore-dashboards.md
@@ -138,7 +138,7 @@ _[oneOf]_ - Name of the theme to use. Only one of theme and embedded_theme can b
 
 ### `time_ranges`
 
-_[array of oneOf]_ - Overrides the list of default time range selections available in the dropdown. It can be string or an object with a 'range' and optional 'comparison_offsets'
+_[array of oneOf]_ - Overrides the list of default time range selections available in the dropdown. It can be a string or an object with a 'range' and optional 'comparison_offsets'.
   ```yaml
   time_ranges:
     - PT15M // Simplified syntax to specify only the range
@@ -152,13 +152,13 @@ _[array of oneOf]_ - Overrides the list of default time range selections availab
   ```
 
 
-  - **option 1** - _[string]_ - a valid [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) duration or one of the [Rill ISO 8601 extensions](/reference/time-syntax/rill-iso-extensions#extensions) extensions for the selection
+  - **option 1** - _[string]_ - An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) duration or one of the [Rill ISO 8601 extensions](/reference/time-syntax/rill-iso-extensions#extensions) extensions for the selection.
 
   - **option 2** - _[object]_ - Object containing time range and comparison configuration
 
-    - **`range`** - _[string]_ - a valid [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) duration or one of the [Rill ISO 8601 extensions](/reference/time-syntax/rill-iso-extensions#extensions) extensions for the selection _(required)_
+    - **`range`** - _[string]_ - An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) duration or one of the [Rill ISO 8601 extensions](/reference/time-syntax/rill-iso-extensions#extensions) extensions for the selection. _(required)_
 
-    - **`comparison_offsets`** - _[array of oneOf]_ - list of time comparison options for this time range selection (optional). Must be one of the [Rill ISO 8601 extensions](https://docs.rilldata.com/reference/rill-iso-extensions#extensions)
+    - **`comparison_offsets`** - _[array of oneOf]_ - List of time comparison options for this time range selection (optional). Must be one of the [Rill ISO 8601 extensions](https://docs.rilldata.com/reference/rill-iso-extensions#extensions).
 
       - **option 1** - _[string]_ - Offset string only (range is inferred)
 
@@ -182,7 +182,7 @@ _[boolean]_ - Defaults to true, when set to false it will hide the ability to se
 
 ### `defaults`
 
-_[object]_ - defines the defaults YAML struct
+_[object]_ - Defines the defaults YAML struct.
   ```yaml
   defaults: #define all the defaults within here
     dimensions:
@@ -225,11 +225,11 @@ _[object]_ - defines the defaults YAML struct
 
       - **`exclude`** - _[object]_ - Select all fields except those listed here
 
-  - **`time_range`** - _[string]_ - Refers to the default time range shown when a user initially loads the dashboard. The value must be either a valid [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) (for example, PT12H for 12 hours, P1M for 1 month, or P26W for 26 weeks) or one of the [Rill ISO 8601 extensions](https://docs.rilldata.com/reference/rill-iso-extensions#extensions)
+  - **`time_range`** - _[string]_ - Refers to the default time range shown when a user initially loads the dashboard. The value must be either an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) (for example, PT12H for 12 hours, P1M for 1 month, or P26W for 26 weeks) or one of the [Rill ISO 8601 extensions](https://docs.rilldata.com/reference/rill-iso-extensions#extensions).
 
   - **`comparison_mode`** - _[string]_ - Controls how to compare current data with historical or categorical baselines. Options: `none` (no comparison), `time` (compares with past based on default_time_range), `dimension` (compares based on comparison_dimension values)
 
-  - **`comparison_dimension`** - _[string]_ - for dimension mode, specify the comparison dimension by name
+  - **`comparison_dimension`** - _[string]_ - For dimension mode, specify the comparison dimension by name.
 
 ### `embeds`
 

--- a/docs/docs/reference/project-files/index.md
+++ b/docs/docs/reference/project-files/index.md
@@ -10,13 +10,13 @@ When you create models and dashboards, these objects are represented as object f
 
 :::info Working with resources outside their native folders
 
-It is possible to define resources (such as [models](models.md), [metrics-views](metrics-views.md), [dashboards](explore-dashboards.md), [custom APIs](apis.md), or [themes](themes.md)) within <u>any</u> nested folder within your Rill project directory. However, for any YAML configuration file, it is then imperative that the `type` property is then appropriately defined within the underlying resource configuration or Rill will not able to resolve the resource type correctly!
+It is possible to define resources (such as [models](models.md), [metrics-views](metrics-views.md), [dashboards](explore-dashboards.md), [custom APIs](apis.md), or [themes](themes.md)) within <u>any</u> nested folder within your Rill project directory. However, for any YAML configuration file, it is imperative that the `type` property is appropriately defined within the underlying resource configuration, or Rill will not be able to resolve the resource type correctly!
 
 :::
 
 Projects can simply be rehydrated from Rill project files into an explorable data application as long as there is sufficient access and credentials to the source data - figuring out the dependencies, pulling down data, & validating your model queries and metrics view configurations. The result is a set of functioning exploratory dashboards.
 
-You can see a few different example projects by visiting our [example github repository](https://github.com/rilldata/rill-examples).
+You can see a few different example projects by visiting our [example GitHub repository](https://github.com/rilldata/rill-examples).
 
 :::tip
 

--- a/docs/docs/reference/project-files/metrics-views.md
+++ b/docs/docs/reference/project-files/metrics-views.md
@@ -92,17 +92,17 @@ _[array of object]_ - Relates to exploring segments or dimensions of your data a
 
   - **`tags`** - _[array of string]_ - optional list of tags for categorizing the dimension (defaults to empty)
 
-  - **`type`** - _[string]_ - Dimension type: "geo" for geospatial dimensions, "time" for time dimensions or "categorical" for categorial dimensions. Default is undefined and the type will be inferred instead
+  - **`type`** - _[string]_ - Dimension type: "geo" for geospatial dimensions, "time" for time dimensions, or "categorical" for categorical dimensions. Default is undefined and the type will be inferred instead.
 
-  - **`column`** - _[string]_ - a categorical column
+  - **`column`** - _[string]_ - A categorical column.
 
-  - **`expression`** - _[string]_ - a non-aggregate expression such as string_split(domain, '.'). One of column and expression is required but cannot have both at the same time
+  - **`expression`** - _[string]_ - A non-aggregate expression such as string_split(domain, '.'). One of column and expression is required, but cannot have both at the same time.
 
-  - **`unnest`** - _[boolean]_ - if true, allows multi-valued dimension to be unnested (such as lists) and filters will automatically switch to "contains" instead of exact match
+  - **`unnest`** - _[boolean]_ - If true, allows multi-valued dimensions to be unnested (such as lists), and filters will automatically switch to "contains" instead of exact match.
 
-  - **`uri`** - _[string, boolean]_ - enable if your dimension is a clickable URL to enable single click navigation (boolean or valid SQL expression)
+  - **`uri`** - _[string, boolean]_ - Enable if your dimension is a clickable URL to enable single-click navigation (boolean or valid SQL expression).
 
-  - **`lookup_table`** - _[string]_ - the name of a ClickHouse dictionary to use for query-time lookups. Use `database.dictionary_name` for dictionaries in a non-default database. All three `lookup_*` fields (`lookup_table`, `lookup_key_column`, `lookup_value_column`) must be specified together. See [Query-Time Joins](/developers/build/metrics-view/dimensions/lookup) for details
+  - **`lookup_table`** - _[string]_ - The name of a ClickHouse dictionary to use for query-time lookups. Use `database.dictionary_name` for dictionaries in a non-default database. All three `lookup_*` fields (`lookup_table`, `lookup_key_column`, `lookup_value_column`) must be specified together. See [Query-Time Joins](/developers/build/metrics-view/dimensions/lookup) for details.
 
   - **`lookup_key_column`** - _[string]_ - the primary key column in the lookup dictionary that corresponds to the dimension's `column` in the fact table
 
@@ -152,7 +152,7 @@ _[array of object]_ - Used to define the numeric aggregates of columns from your
 
       - **`frame`** - _[string]_ - Defines the window frame boundaries for calculations, specifying which rows are included in the window relative to the current row.
 
-  - **`per`** - _[oneOf]_ - for per dimensions
+  - **`per`** - _[oneOf]_ - Dimensions to partition the measure by.
 
     - **option 1** - _[string]_ - Simple field name as a string.
 
@@ -166,7 +166,7 @@ _[array of object]_ - Used to define the numeric aggregates of columns from your
 
         - **`time_grain`** - _[string]_ - Time grain for time-based dimensions.
 
-  - **`requires`** - _[oneOf]_ - using an available measure or dimension in your metrics view to set a required parameter, cannot be used with simple measures. See [referencing measures](/developers/build/metrics-view/measures/referencing) for more information.
+  - **`requires`** - _[oneOf]_ - Uses an available measure or dimension in your metrics view to set a required parameter. Cannot be used with simple measures. See [referencing measures](/developers/build/metrics-view/measures/referencing) for more information.
 
     - **option 1** - _[string]_ - Simple field name as a string.
 
@@ -180,7 +180,7 @@ _[array of object]_ - Used to define the numeric aggregates of columns from your
 
         - **`time_grain`** - _[string]_ - Time grain for time-based dimensions.
 
-  - **`valid_percent_of_total`** - _[boolean]_ - a boolean indicating whether percent-of-total values should be rendered for this measure
+  - **`valid_percent_of_total`** - _[boolean]_ - Indicates whether percent-of-total values should be rendered for this measure.
 
   - **`format_preset`** - _[string]_ - Controls the formatting of this measure using a predefined preset. Measures cannot have both `format_preset` and `format_d3`. If neither is supplied, the measure will be formatted using the `humanize` preset by default.
   
@@ -195,7 +195,7 @@ _[array of object]_ - Used to define the numeric aggregates of columns from your
 
   - **`format_d3`** - _[string]_ - Controls the formatting of this measure using a [d3-format](https://d3js.org/d3-format) string. If an invalid format string is supplied, the measure will fall back to `format_preset: humanize`. A measure cannot have both `format_preset` and `format_d3`. If neither is provided, the humanize preset is used by default. Example: `format_d3: ".2f"` formats using fixed-point notation with two decimal places. Example: `format_d3: ",.2r"` formats using grouped thousands with two significant digits. (optional)
 
-  - **`format_d3_locale`** - _[object]_ - locale configuration passed through to D3, enabling changing the currency symbol among other things. For details, see the docs for D3's formatLocale.
+  - **`format_d3_locale`** - _[object]_ - Locale configuration passed through to D3, enabling changes to the currency symbol and other formatting options. For details, see the docs for D3's formatLocale.
     ```yaml
     format_d3: "$,"
     format_d3_locale:
@@ -204,11 +204,11 @@ _[array of object]_ - Used to define the numeric aggregates of columns from your
     ```
 
 
-    - **`grouping`** - _[array]_ - the grouping of the currency symbol
+    - **`grouping`** - _[array]_ - Grouping for the currency symbol.
 
     - **`currency`** - _[array]_ - the currency symbol
 
-  - **`treat_nulls_as`** - _[string]_ - used to configure what value to fill in for missing time buckets. This also works generally as COALESCING over non empty time buckets.
+  - **`treat_nulls_as`** - _[string]_ - Configures the value to fill in for missing time buckets. This also works generally as COALESCE over non-empty time buckets.
 
   - **`lower_is_better`** - _[boolean]_ - When true, decreases in this measure are favorable (e.g. bounce rate, latency, error count). UI surfaces that render comparison deltas (KPIs, big numbers, leaderboards, pivot tables, time-series tooltips) swap their positive/negative coloring accordingly.
 
@@ -429,15 +429,15 @@ _[object]_ - Defines an optional inline explore view for the metrics view. If no
 
         - **`variables`** - _[object]_ - Custom CSS variables for dark theme
 
-  - **`time_ranges`** - _[array of oneOf]_ - Overrides the list of default time range selections available in the dropdown. It can be string or an object with a 'range' and optional 'comparison_offsets'.
+  - **`time_ranges`** - _[array of oneOf]_ - Overrides the list of default time range selections available in the dropdown. It can be a string or an object with a 'range' and optional 'comparison_offsets'.
 
-    - **option 1** - _[string]_ - a valid [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) duration or one of the [Rill ISO 8601 extensions](/reference/time-syntax/rill-iso-extensions#extensions) extensions for the selection
+    - **option 1** - _[string]_ - An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) duration or one of the [Rill ISO 8601 extensions](/reference/time-syntax/rill-iso-extensions#extensions) extensions for the selection.
 
     - **option 2** - _[object]_ - Object containing time range and comparison configuration
 
-      - **`range`** - _[string]_ - a valid [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) duration or one of the [Rill ISO 8601 extensions](/reference/time-syntax/rill-iso-extensions#extensions) extensions for the selection _(required)_
+      - **`range`** - _[string]_ - An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) duration or one of the [Rill ISO 8601 extensions](/reference/time-syntax/rill-iso-extensions#extensions) extensions for the selection. _(required)_
 
-      - **`comparison_offsets`** - _[array of oneOf]_ - list of time comparison options for this time range selection (optional). Must be one of the [Rill ISO 8601 extensions](https://docs.rilldata.com/reference/rill-iso-extensions#extensions)
+      - **`comparison_offsets`** - _[array of oneOf]_ - List of time comparison options for this time range selection (optional). Must be one of the [Rill ISO 8601 extensions](https://docs.rilldata.com/reference/rill-iso-extensions#extensions).
 
         - **option 1** - _[string]_ - Offset string only (range is inferred)
 

--- a/docs/docs/reference/project-files/models.md
+++ b/docs/docs/reference/project-files/models.md
@@ -49,7 +49,7 @@ refresh:
 
 ### `connector`
 
-_[string]_ - Refers to the resource type and is needed if setting an explicit OLAP engine. IE `clickhouse`
+_[string]_ - Refers to the resource type and is needed when setting an explicit OLAP engine, e.g. `clickhouse`
 
 ### `sql`
 
@@ -129,7 +129,7 @@ _[oneOf]_ - Refers to the explicitly defined state of your model, cannot be used
 
     - **`sql`** - _[string]_ - Raw SQL query to run against existing models in the project. _(required)_
 
-    - **`connector`** - _[string]_ - specifies the connector to use when running SQL or glob queries.
+    - **`connector`** - _[string]_ - Specifies the connector to use when running SQL or glob queries.
 
   - **option 2** - _[object]_ - Executes a SQL query that targets a defined metrics view.
 
@@ -143,7 +143,7 @@ _[oneOf]_ - Refers to the explicitly defined state of your model, cannot be used
 
   - **option 4** - _[object]_ - Uses a file-matching pattern (glob) to query data from a connector.
 
-    - **`glob`** - _[oneOf]_ - Simple path/glob pattern or path/glob patternwith advanced options . _(required)_
+    - **`glob`** - _[oneOf]_ - Simple path/glob pattern or path/glob pattern with advanced options. _(required)_
 
       - **option 1** - _[string]_ - Glob pattern used to match files or directories in the object store.
 
@@ -221,13 +221,13 @@ state:
 
 ### `partitions`
 
-_[oneOf]_ - Refers to the how your data is partitioned, cannot be used with state. (optional)
+_[oneOf]_ - Refers to how your data is partitioned; cannot be used with state. (optional)
 
   - **option 1** - _[object]_ - Executes a raw SQL query against the project's data models.
 
     - **`sql`** - _[string]_ - Raw SQL query to run against existing models in the project. _(required)_
 
-    - **`connector`** - _[string]_ - specifies the connector to use when running SQL or glob queries.
+    - **`connector`** - _[string]_ - Specifies the connector to use when running SQL or glob queries.
 
   - **option 2** - _[object]_ - Executes a SQL query that targets a defined metrics view.
 
@@ -241,7 +241,7 @@ _[oneOf]_ - Refers to the how your data is partitioned, cannot be used with stat
 
   - **option 4** - _[object]_ - Uses a file-matching pattern (glob) to query data from a connector.
 
-    - **`glob`** - _[oneOf]_ - Simple path/glob pattern or path/glob patternwith advanced options . _(required)_
+    - **`glob`** - _[oneOf]_ - Simple path/glob pattern or path/glob pattern with advanced options. _(required)_
 
       - **option 1** - _[string]_ - Glob pattern used to match files or directories in the object store.
 
@@ -377,13 +377,13 @@ stage:
 
 ### `output`
 
-_[object]_ - to define the properties of output
+_[object]_ - Defines the output properties.
 
   - **`table`** - _[string]_ - Name of the output table. If not specified, the model name is used.
 
-  - **`materialize`** - _[boolean]_ - Whether to materialize the model as a table or view
+  - **`materialize`** - _[boolean]_ - Whether to materialize the model as a table or view.
 
-  - **`connector`** - _[string]_ - Refers to the connector type for the output table. Can be `clickhouse` or `duckdb` and their named connector
+  - **`connector`** - _[string]_ - Refers to the connector type for the output table. Can be `clickhouse` or `duckdb` and their named connectors.
 
   - **`incremental_strategy`** - _[string]_ - Strategy to use for incremental updates. Can be 'append', 'merge' or 'partition_overwrite'
 

--- a/docs/docs/reference/project-files/reports.md
+++ b/docs/docs/reference/project-files/reports.md
@@ -46,11 +46,11 @@ _[string]_ - Specifies how the watermark is determined for incremental processin
 
 ### `intervals`
 
-_[object]_ - Define the interval of the report to check
+_[object]_ - Defines the report interval to check.
 
-  - **`duration`** - _[string]_ - A valid ISO8601 duration to define the interval duration
+  - **`duration`** - _[string]_ - An ISO 8601 duration to define the interval duration.
 
-  - **`limit`** - _[integer]_ - Maximum number of intervals to check for on invocation
+  - **`limit`** - _[integer]_ - Maximum number of intervals to check on invocation.
 
   - **`check_unclosed`** - _[boolean]_ - Whether unclosed intervals should be checked
 
@@ -68,7 +68,7 @@ Supports ai resolvers only as of now.
 
     - **`sql`** - _[string]_ - Raw SQL query to run against existing models in the project. _(required)_
 
-    - **`connector`** - _[string]_ - specifies the connector to use when running SQL or glob queries.
+    - **`connector`** - _[string]_ - Specifies the connector to use when running SQL or glob queries.
 
   - **option 2** - _[object]_ - Executes a SQL query that targets a defined metrics view.
 
@@ -82,7 +82,7 @@ Supports ai resolvers only as of now.
 
   - **option 4** - _[object]_ - Uses a file-matching pattern (glob) to query data from a connector.
 
-    - **`glob`** - _[oneOf]_ - Simple path/glob pattern or path/glob patternwith advanced options . _(required)_
+    - **`glob`** - _[oneOf]_ - Simple path/glob pattern or path/glob pattern with advanced options. _(required)_
 
       - **option 1** - _[string]_ - Glob pattern used to match files or directories in the object store.
 

--- a/docs/docs/reference/project-files/rill-yaml.md
+++ b/docs/docs/reference/project-files/rill-yaml.md
@@ -53,13 +53,13 @@ olap_connector: clickhouse
 In `rill.yaml`, project-wide defaults can be specified for a resource type within a project. Unless otherwise specified, _individual resources will inherit any defaults_ that have been specified in `rill.yaml`. For available properties that can be configured, please refer to the YAML specification for each individual resource type - [model](models.md), [metrics_view](metrics-views.md), and [explore](explore-dashboards.md)
 
 :::note Use plurals when specifying project-wide defaults
-In your `rill.yaml`, the top level property for the resource type needs to be **plural**, such as `models`, `metrics_views` and `explores`.
+In your `rill.yaml`, the top-level property for the resource type needs to be **plural**, such as `models`, `metrics_views`, and `explores`.
 :::
 
 :::info Hierarchy of inheritance and property overrides
-As a general rule of thumb, properties that have been specified at a more _granular_ level will supercede or override higher level properties that have been inherited. Therefore, in order of inheritance, Rill will prioritize properties in the following order:
-1. Individual [models](models.md)/[metrics_views](metrics-views.md)/[explore](explore-dashboards.md) object level properties (e.g. `models.yaml` or `explore-dashboards.yaml`)
-2. [Environment](/developers/build/models/templating) level properties (e.g. a specific property that have been set for `dev`)
+As a general rule of thumb, properties that have been specified at a more _granular_ level will supersede or override higher-level properties that have been inherited. Therefore, in order of inheritance, Rill will prioritize properties in the following order:
+1. Individual [models](models.md)/[metrics_views](metrics-views.md)/[explore](explore-dashboards.md) object-level properties (e.g. `models.yaml` or `explore-dashboards.yaml`)
+2. [Environment](/developers/build/models/templating) level properties (e.g. a specific property that has been set for `dev`)
 3. [Project-wide defaults](#project-wide-defaults) for a specific property and resource type
 :::
 
@@ -81,7 +81,7 @@ _[object]_ - Defines project-wide default settings for explores. Unless overridd
 _[object]_ - Defines project-wide default settings for canvases. Unless overridden, individual canvases will inherit these defaults.
 
 ```yaml
-# For complete examples, see: 
+# For complete examples, see:
 # https://docs.rilldata.com/developers/build/rill-project-file#dashboard-defaults
 models:
     refresh:
@@ -109,7 +109,7 @@ canvases:
 
 ## Setting variables
 
-Primarily useful for [templating](/developers/build/connectors/templating), variables can be set in the `rill.yaml` file directly. This allows variables to be set for your projects deployed to Rill Cloud while still being able to use different variable values locally if you prefer. 
+Primarily useful for [templating](/developers/build/connectors/templating), variables can be set in the `rill.yaml` file directly. This allows variables to be set for your projects deployed to Rill Cloud while still being able to use different variable values locally if you prefer.
 :::info Overriding variables locally
 Variables also follow an order of precedence and can be overridden locally. By default, any variables defined will be inherited from `rill.yaml`. However, if you manually pass in a variable when starting Rill Developer locally via the CLI, this value will be used instead for the current instance of your running project:
 ```bash
@@ -190,7 +190,7 @@ env:
 
 The public_paths and ignore_paths properties in the rill.yaml file provide control over which files and directories are processed or exposed by Rill. The public_paths property defines a list of file or directory paths to expose over HTTP. By default, it includes ['./public']. The ignore_paths property specifies a list of files or directories that Rill excludes during ingestion and parsing. This prevents unnecessary or incompatible content from affecting the project.
 :::tip
-Don't forget the leading `/` when specifying the path for `ignore_paths` and this path is also assuming the relative path from your project root.
+Don't forget the leading `/` when specifying the path for `ignore_paths`. This path is relative to your project root.
 :::
 
 
@@ -210,9 +210,9 @@ ignore_paths:
 
 ## Testing access policies
 
-During development, it is always a good idea to check if your [access policies](/developers/build/metrics-view/security) are behaving the way you designed them to before pushing these changes into production. You can set mock users which enables a drop down in the dashboard preview to view as a specific user. 
+During development, it is always a good idea to check if your [access policies](/developers/build/metrics-view/security) are behaving the way you designed them to before pushing these changes into production. You can set mock users, which enables a drop-down in the dashboard preview to view as a specific user.
 :::info The View as selector is not visible in my dashboard, why?
-This feature is _only_ enabled when you have set a security policy on the dashboard. By default, the dashboard and it's contents is viewable by every user.
+This feature is _only_ enabled when you have set a security policy on the dashboard. By default, the dashboard and its contents are viewable by every user.
 :::
 
 

--- a/runtime/parser/schema/project.schema.yaml
+++ b/runtime/parser/schema/project.schema.yaml
@@ -7,13 +7,13 @@ description: |
 
   :::info Working with resources outside their native folders
 
-  It is possible to define resources (such as [models](models.md), [metrics-views](metrics-views.md), [dashboards](explore-dashboards.md), [custom APIs](apis.md), or [themes](themes.md)) within <u>any</u> nested folder within your Rill project directory. However, for any YAML configuration file, it is then imperative that the `type` property is then appropriately defined within the underlying resource configuration or Rill will not able to resolve the resource type correctly!
+  It is possible to define resources (such as [models](models.md), [metrics-views](metrics-views.md), [dashboards](explore-dashboards.md), [custom APIs](apis.md), or [themes](themes.md)) within <u>any</u> nested folder within your Rill project directory. However, for any YAML configuration file, it is imperative that the `type` property is appropriately defined within the underlying resource configuration, or Rill will not be able to resolve the resource type correctly!
 
   :::
 
   Projects can simply be rehydrated from Rill project files into an explorable data application as long as there is sufficient access and credentials to the source data - figuring out the dependencies, pulling down data, & validating your model queries and metrics view configurations. The result is a set of functioning exploratory dashboards.
 
-  You can see a few different example projects by visiting our [example github repository](https://github.com/rilldata/rill-examples).
+  You can see a few different example projects by visiting our [example GitHub repository](https://github.com/rilldata/rill-examples).
 
   :::tip
 
@@ -1395,7 +1395,7 @@ definitions:
           connector:
             type: string
             const: connector
-            description: Refers to the resource type and is needed if setting an explicit OLAP engine. IE `clickhouse`
+            description: Refers to the resource type and is needed when setting an explicit OLAP engine, e.g. `clickhouse`
           sql:
             type: string
             description: Raw SQL query to run against source
@@ -1470,7 +1470,7 @@ definitions:
                   sql: SELECT MAX(date) as max_date
           partitions:
             $ref: '#/definitions/data_properties'
-            description: Refers to the how your data is partitioned, cannot be used with state. (optional)
+            description: Refers to how your data is partitioned; cannot be used with state. (optional)
             examples: 
               - partitions:
                   glob: gcs://my_bucket/y=*/m=*/d=*/*.parquet
@@ -1536,17 +1536,17 @@ definitions:
             additionalProperties: true
           output:
             type: object
-            description: to define the properties of output
+            description: Defines the output properties.
             properties:
               table:
                 type: string
                 description: Name of the output table. If not specified, the model name is used.
               materialize:
                 type: boolean
-                description: Whether to materialize the model as a table or view
+                description: Whether to materialize the model as a table or view.
               connector:
                 type: string
-                description: Refers to the connector type for the output table. Can be `clickhouse` or `duckdb` and their named connector 
+                description: Refers to the connector type for the output table. Can be `clickhouse` or `duckdb` and their named connectors.
               incremental_strategy:
                 type: string
                 enum:
@@ -2116,24 +2116,24 @@ definitions:
                     type: string
                 type:
                     type: string
-                    description: 'Dimension type: "geo" for geospatial dimensions, "time" for time dimensions or "categorical" for categorial dimensions. Default is undefined and the type will be inferred instead'
+                    description: 'Dimension type: "geo" for geospatial dimensions, "time" for time dimensions, or "categorical" for categorical dimensions. Default is undefined and the type will be inferred instead.'
                 column:
                   type: string
-                  description: a categorical column
+                  description: A categorical column.
                 expression:
                   type: string
-                  description: a non-aggregate expression such as string_split(domain, '.'). One of column and expression is required but cannot have both at the same time
+                  description: A non-aggregate expression such as string_split(domain, '.'). One of column and expression is required, but cannot have both at the same time.
                 unnest:
                   type: boolean
-                  description: if true, allows multi-valued dimension to be unnested (such as lists) and filters will automatically switch to "contains" instead of exact match 
+                  description: If true, allows multi-valued dimensions to be unnested (such as lists), and filters will automatically switch to "contains" instead of exact match.
                 uri:
                   type:
                     - string
                     - boolean
-                  description: enable if your dimension is a clickable URL to enable single click navigation (boolean or valid SQL expression)
+                  description: Enable if your dimension is a clickable URL to enable single-click navigation (boolean or valid SQL expression).
                 lookup_table:
                   type: string
-                  description: the name of a ClickHouse dictionary to use for query-time lookups. Use `database.dictionary_name` for dictionaries in a non-default database. All three `lookup_*` fields (`lookup_table`, `lookup_key_column`, `lookup_value_column`) must be specified together. See [Query-Time Joins](/developers/build/metrics-view/dimensions/lookup) for details
+                  description: The name of a ClickHouse dictionary to use for query-time lookups. Use `database.dictionary_name` for dictionaries in a non-default database. All three `lookup_*` fields (`lookup_table`, `lookup_key_column`, `lookup_value_column`) must be specified together. See [Query-Time Joins](/developers/build/metrics-view/dimensions/lookup) for details.
                 lookup_key_column:
                   type: string
                   description: the primary key column in the lookup dictionary that corresponds to the dimension's `column` in the fact table
@@ -2202,13 +2202,13 @@ definitions:
                       additionalProperties: false
                 per:
                   $ref: '#/definitions/field_selectors_properties'
-                  description: for per dimensions
+                  description: Dimensions to partition the measure by.
                 requires:
                   $ref: '#/definitions/field_selectors_properties'
-                  description: using an available measure or dimension in your metrics view to set a required parameter, cannot be used with simple measures. See [referencing measures](/developers/build/metrics-view/measures/referencing) for more information.
+                  description: Uses an available measure or dimension in your metrics view to set a required parameter. Cannot be used with simple measures. See [referencing measures](/developers/build/metrics-view/measures/referencing) for more information.
                 valid_percent_of_total:
                   type: boolean
-                  description: a boolean indicating whether percent-of-total values should be rendered for this measure
+                  description: Indicates whether percent-of-total values should be rendered for this measure.
                 format_preset:
                   type: string
                   description: |
@@ -2227,7 +2227,7 @@ definitions:
                 format_d3_locale:
                   type: object
                   description: |
-                      locale configuration passed through to D3, enabling changing the currency symbol among other things. For details, see the docs for D3's formatLocale.
+                      Locale configuration passed through to D3, enabling changes to the currency symbol and other formatting options. For details, see the docs for D3's formatLocale.
                         ```yaml
                         format_d3: "$,"
                         format_d3_locale:
@@ -2237,14 +2237,14 @@ definitions:
                   properties:
                     grouping:
                       type: array
-                      description: the grouping of the currency symbol
+                      description: Grouping for the currency symbol.
                     currency:
                       type: array
                       description: the currency symbol
 
                 treat_nulls_as:
                   type: string
-                  description: used to configure what value to fill in for missing time buckets. This also works generally as COALESCING over non empty time buckets.
+                  description: Configures the value to fill in for missing time buckets. This also works generally as COALESCE over non-empty time buckets.
                 lower_is_better:
                   type: boolean
                   description: When true, decreases in this measure are favorable (e.g. bounce rate, latency, error count). UI surfaces that render comparison deltas (KPIs, big numbers, leaderboards, pivot tables, time-series tooltips) swap their positive/negative coloring accordingly.
@@ -2373,7 +2373,7 @@ definitions:
             description: Description for the canvas dashboard
           banner:
             type: string
-            description: Refers to the custom banner displayed at the header of an Canvas dashboard
+            description: Refers to the custom banner displayed in the header of a Canvas dashboard.
           rows:
             type: array
             description: Refers to all of the rows displayed on the Canvas. Each entry is either a plain row (with `items`) or a tab group (with `tabs`), but not both.
@@ -2402,7 +2402,7 @@ definitions:
                               - **bar_chart** - Normal Bar chart
                               - **stacked_bar** - Stacked Bar chart
                               - **area_chart** - Line chart with area
-                              - **image** - Provide a URL to embed into canvas dashboard
+                              - **image** - Provide a URL to embed into the canvas dashboard
                               - **table** - Similar to Pivot table, add dimensions and measures to visualize your data
                               - **heatmap** - Heat Map chart to visualize distribution of data
                               - **donut_chart** - Donut or Pie chart to display sums of total
@@ -2464,14 +2464,14 @@ definitions:
                 description: Toggles filtering functionality for the canvas dashboard.
           allow_custom_time_range:
             type: boolean
-            description: Defaults to true, when set to false it will hide the ability to set a custom time range for the user.
+            description: Defaults to true. When set to false, hides the ability to set a custom time range for the user.
           allow_filter_add:
             type: boolean
             description: Whether users can add new filters to the canvas dashboard.
           time_ranges:
             type: array
             description: |
-              Overrides the list of default time range selections available in the dropdown. It can be string or an object with a 'range' and optional 'comparison_offsets'
+              Overrides the list of default time range selections available in the dropdown. It can be a string or an object with a 'range' and optional 'comparison_offsets'.
                 ```yaml
                 time_ranges:
                   - PT15M // Simplified syntax to specify only the range
@@ -2493,7 +2493,7 @@ definitions:
           defaults:
             type: object
             description: |
-              defines the defaults YAML struct
+              Defines the defaults YAML struct.
                 ```yaml
                 defaults:
                   time_range: P1M
@@ -2504,7 +2504,7 @@ definitions:
                 ```
             properties:
               time_range:
-                description: Refers to the default time range shown when a user initially loads the dashboard. The value must be either a valid [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) (for example, PT12H for 12 hours, P1M for 1 month, or P26W for 26 weeks) or one of the [Rill ISO 8601 extensions](https://docs.rilldata.com/reference/rill-iso-extensions#extensions)
+                description: Refers to the default time range shown when a user initially loads the dashboard. The value must be either an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) (for example, PT12H for 12 hours, P1M for 1 month, or P26W for 26 weeks) or one of the [Rill ISO 8601 extensions](https://docs.rilldata.com/reference/rill-iso-extensions#extensions).
                 type: string
               comparison_mode:
                 description: 'Controls how to compare current data with historical or categorical baselines. Options: `none` (no comparison), `time` (compares with past based on default_time_range), `dimension` (compares based on comparison_dimension values)'
@@ -2514,7 +2514,7 @@ definitions:
                   - time
                   - dimension
               comparison_dimension:
-                description: 'for dimension mode, specify the comparison dimension by name'
+                description: 'For dimension mode, specify the comparison dimension by name.'
                 type: string
               filters:
                 type: object
@@ -2610,7 +2610,7 @@ definitions:
           time_ranges:
             type: array
             description: |
-              Overrides the list of default time range selections available in the dropdown. It can be string or an object with a 'range' and optional 'comparison_offsets'
+              Overrides the list of default time range selections available in the dropdown. It can be a string or an object with a 'range' and optional 'comparison_offsets'.
                 ```yaml
                 time_ranges:
                   - PT15M // Simplified syntax to specify only the range
@@ -2638,7 +2638,7 @@ definitions:
           defaults:
             type: object
             description: |
-              defines the defaults YAML struct
+              Defines the defaults YAML struct.
                 ```yaml
                 defaults: #define all the defaults within here
                   dimensions:
@@ -2659,7 +2659,7 @@ definitions:
                 description: Provides the default measures to load on viewing the dashboard
                 $ref: '#/definitions/field_selector_properties'
               time_range:
-                description: Refers to the default time range shown when a user initially loads the dashboard. The value must be either a valid [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) (for example, PT12H for 12 hours, P1M for 1 month, or P26W for 26 weeks) or one of the [Rill ISO 8601 extensions](https://docs.rilldata.com/reference/rill-iso-extensions#extensions)
+                description: Refers to the default time range shown when a user initially loads the dashboard. The value must be either an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) (for example, PT12H for 12 hours, P1M for 1 month, or P26W for 26 weeks) or one of the [Rill ISO 8601 extensions](https://docs.rilldata.com/reference/rill-iso-extensions#extensions).
                 type: string
               comparison_mode:
                 description: 'Controls how to compare current data with historical or categorical baselines. Options: `none` (no comparison), `time` (compares with past based on default_time_range), `dimension` (compares based on comparison_dimension values)'
@@ -2669,7 +2669,7 @@ definitions:
                   - time
                   - dimension
               comparison_dimension:
-                description: 'for dimension mode, specify the comparison dimension by name'
+                description: 'For dimension mode, specify the comparison dimension by name.'
                 type: string
             additionalProperties: false
           embeds:
@@ -2694,7 +2694,7 @@ definitions:
     title: Alert YAML
     id: alerts
     type: object
-    description: Along with alertings at the dashboard level and can be created via the UI, there might be more extensive alerting that you might want to develop and can be done so the an alert.yaml. When creating an alert via a YAML file, you'll see this denoted in the UI as `Created through code`.
+    description: Along with dashboard-level alerts that can be created via the UI, you can develop more extensive alerting in an alert YAML file. When creating an alert via a YAML file, you'll see this denoted in the UI as `Created through code`.
     examples:
       - # Example: To send alert when data lags by more than 1 day to slack channel #rill-cloud-alerts
         type: alert
@@ -2742,18 +2742,18 @@ definitions:
             description: Description for the alert
           intervals:
             type: object
-            description: define the interval of the alert to check
+            description: Defines the alert interval to check.
             properties:
               duration:
                 type: string
-                description: a valid ISO8601 duration to define the interval duration
+                description: An ISO 8601 duration to define the interval duration.
               limit:
                 type: integer
-                description: maximum number of intervals to check for on invocation
+                description: Maximum number of intervals to check on invocation.
                 minimum: 0
               check_unclosed:
                 type: boolean
-                description: 'boolean, whether unclosed intervals should be checked'
+                description: 'Whether unclosed intervals should be checked.'
           watermark:
             type: string
             enum:
@@ -2762,7 +2762,7 @@ definitions:
             description: Specifies how the watermark is determined for incremental processing. Use 'trigger_time' to set it at runtime or 'inherit' to use the upstream model's watermark.
           timeout:
             type: string
-            description: define the timeout of the alert in seconds (optional).
+            description: Defines the timeout of the alert in seconds. (optional)
           data:
             $ref: '#/definitions/data_properties'
             description: Data source for the alert
@@ -2818,7 +2818,7 @@ definitions:
             description: Notification configuration
           annotations:
             type: object
-            description: Key value pair used for annotations
+            description: Key-value pairs used for annotations.
             additionalProperties:
               type: string
 
@@ -2911,14 +2911,14 @@ definitions:
             description: Specifies how the watermark is determined for incremental processing. Use 'trigger_time' to set it at runtime or 'inherit' to use the upstream model's watermark.
           intervals:
             type: object
-            description: Define the interval of the report to check
+            description: Defines the report interval to check.
             properties:
               duration:
                 type: string
-                description: A valid ISO8601 duration to define the interval duration
+                description: An ISO 8601 duration to define the interval duration.
               limit:
                 type: integer
-                description: Maximum number of intervals to check for on invocation
+                description: Maximum number of intervals to check on invocation.
                 minimum: 0
               check_unclosed:
                 type: boolean
@@ -3481,7 +3481,7 @@ definitions:
             description: Raw SQL query to run against existing models in the project.
           connector:
             type: string
-            description: specifies the connector to use when running SQL or glob queries.
+            description: Specifies the connector to use when running SQL or glob queries.
         required:
           - sql
         examples: 
@@ -3527,7 +3527,7 @@ definitions:
         description: Uses a file-matching pattern (glob) to query data from a connector.
         properties:
           glob:
-            description: Simple path/glob pattern or path/glob patternwith advanced options .
+            description: Simple path/glob pattern or path/glob pattern with advanced options.
             oneOf:
               - type: string
                 description: Glob pattern used to match files or directories in the object store.
@@ -3606,7 +3606,7 @@ definitions:
         required:
           - union
         examples:
-          - # Exampe for union resolvers
+          - # Example for union resolvers
             type: api
             union:
               - connector: duckdb
@@ -3624,7 +3624,7 @@ definitions:
             description: Raw SQL query to run against existing models in the project.
           connector:
             type: string
-            description: specifies the connector to use when running SQL or glob queries.
+            description: Specifies the connector to use when running SQL or glob queries.
         required:
           - sql
       - title: Metrics View Query
@@ -3654,7 +3654,7 @@ definitions:
         description: Uses a file-matching pattern (glob) to query data from a connector.
         properties:
           glob:
-            description: Simple path/glob pattern or path/glob patternwith advanced options .
+            description: Simple path/glob pattern or path/glob pattern with advanced options.
             oneOf:
               - type: string
                 description: Glob pattern used to match files or directories in the object store.
@@ -3816,16 +3816,16 @@ definitions:
   explore_time_range_properties:
     oneOf:
       - type: string
-        description: a valid [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) duration or one of the [Rill ISO 8601 extensions](/reference/time-syntax/rill-iso-extensions#extensions) extensions for the selection
+        description: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) duration or one of the [Rill ISO 8601 extensions](/reference/time-syntax/rill-iso-extensions#extensions) extensions for the selection.
       - type: object
         description: Object containing time range and comparison configuration
         properties:
           range:
             type: string
-            description: a valid [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) duration or one of the [Rill ISO 8601 extensions](/reference/time-syntax/rill-iso-extensions#extensions) extensions for the selection
+            description: An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Durations) duration or one of the [Rill ISO 8601 extensions](/reference/time-syntax/rill-iso-extensions#extensions) extensions for the selection.
           comparison_offsets:
             type: array
-            description: list of time comparison options for this time range selection (optional). Must be one of the [Rill ISO 8601 extensions](https://docs.rilldata.com/reference/rill-iso-extensions#extensions)
+            description: List of time comparison options for this time range selection (optional). Must be one of the [Rill ISO 8601 extensions](https://docs.rilldata.com/reference/rill-iso-extensions#extensions).
             items:
               oneOf:
                 - type: string
@@ -4118,7 +4118,7 @@ definitions:
             description: Name of the theme to use or define a theme inline. Either theme name or inline theme can be set.
           time_ranges:
             type: array
-            description: Overrides the list of default time range selections available in the dropdown. It can be string or an object with a 'range' and optional 'comparison_offsets'.
+            description: Overrides the list of default time range selections available in the dropdown. It can be a string or an object with a 'range' and optional 'comparison_offsets'.
             items:
               $ref: '#/definitions/explore_time_range_properties'
           time_zones:

--- a/runtime/parser/schema/rillyaml.schema.yaml
+++ b/runtime/parser/schema/rillyaml.schema.yaml
@@ -15,7 +15,7 @@ allOf:
         description: The display name of the project, shown in the upper-left corner of the UI
       description:
         type: string
-        description: A brief description of the project 
+        description: A brief description of the project
       features:
         type: object
         description: Optional feature flags. Can be specified as a map of feature names to booleans.
@@ -25,7 +25,7 @@ allOf:
       ai_instructions:
         type: string
         description: Extra instructions for LLM/AI features. Used to guide natural language question answering and routing.
-  - title: Configuring the default OLAP Engine  
+  - title: Configuring the default OLAP Engine
     description: |
       Rill allows you to specify the default OLAP engine to use in your project via `rill.yaml`.
       :::info Curious about OLAP Engines?
@@ -36,7 +36,7 @@ allOf:
       olap_connector:
         type: string
         description: Specifies the default OLAP engine for the project. Defaults to duckdb if not set.
-        examples: 
+        examples:
         - olap_connector: clickhouse
   - title: Project-wide defaults
     type: object
@@ -44,13 +44,13 @@ allOf:
       In `rill.yaml`, project-wide defaults can be specified for a resource type within a project. Unless otherwise specified, _individual resources will inherit any defaults_ that have been specified in `rill.yaml`. For available properties that can be configured, please refer to the YAML specification for each individual resource type - [model](models.md), [metrics_view](metrics-views.md), and [explore](explore-dashboards.md)
 
       :::note Use plurals when specifying project-wide defaults
-      In your `rill.yaml`, the top level property for the resource type needs to be **plural**, such as `models`, `metrics_views` and `explores`.
+      In your `rill.yaml`, the top-level property for the resource type needs to be **plural**, such as `models`, `metrics_views`, and `explores`.
       :::
 
       :::info Hierarchy of inheritance and property overrides
-      As a general rule of thumb, properties that have been specified at a more _granular_ level will supercede or override higher level properties that have been inherited. Therefore, in order of inheritance, Rill will prioritize properties in the following order:
-      1. Individual [models](models.md)/[metrics_views](metrics-views.md)/[explore](explore-dashboards.md) object level properties (e.g. `models.yaml` or `explore-dashboards.yaml`)
-      2. [Environment](/developers/build/models/templating) level properties (e.g. a specific property that have been set for `dev`)
+      As a general rule of thumb, properties that have been specified at a more _granular_ level will supersede or override higher-level properties that have been inherited. Therefore, in order of inheritance, Rill will prioritize properties in the following order:
+      1. Individual [models](models.md)/[metrics_views](metrics-views.md)/[explore](explore-dashboards.md) object-level properties (e.g. `models.yaml` or `explore-dashboards.yaml`)
+      2. [Environment](/developers/build/models/templating) level properties (e.g. a specific property that has been set for `dev`)
       3. [Project-wide defaults](#project-wide-defaults) for a specific property and resource type
       :::
     properties:
@@ -62,12 +62,12 @@ allOf:
         description: Defines project-wide default settings for metrics_views. Unless overridden, individual metrics_views will inherit these defaults.
       explores:
         type: object
-        description: Defines project-wide default settings for explores. Unless overridden, individual explores will inherit these defaults. 
+        description: Defines project-wide default settings for explores. Unless overridden, individual explores will inherit these defaults.
       canvases:
         type: object
-        description: Defines project-wide default settings for canvases. Unless overridden, individual canvases will inherit these defaults. 
+        description: Defines project-wide default settings for canvases. Unless overridden, individual canvases will inherit these defaults.
         examples:
-        - # For complete examples, see: 
+        - # For complete examples, see:
           # https://docs.rilldata.com/developers/build/rill-project-file#dashboard-defaults
           models:
             refresh:
@@ -90,10 +90,10 @@ allOf:
               - UTC
             time_ranges:
               - PT24H
-              - P7D        
+              - P7D
   - title: Setting variables
     description: |
-      Primarily useful for [templating](/developers/build/connectors/templating), variables can be set in the `rill.yaml` file directly. This allows variables to be set for your projects deployed to Rill Cloud while still being able to use different variable values locally if you prefer. 
+      Primarily useful for [templating](/developers/build/connectors/templating), variables can be set in the `rill.yaml` file directly. This allows variables to be set for your projects deployed to Rill Cloud while still being able to use different variable values locally if you prefer.
       :::info Overriding variables locally
       Variables also follow an order of precedence and can be overridden locally. By default, any variables defined will be inherited from `rill.yaml`. However, if you manually pass in a variable when starting Rill Developer locally via the CLI, this value will be used instead for the current instance of your running project:
       ```bash
@@ -194,10 +194,10 @@ allOf:
             type: boolean
             description: "Return an error when a model contains unmapped properties. Default: false."
   - title: Managing Paths in Rill
-    description: | 
+    description: |
       The public_paths and ignore_paths properties in the rill.yaml file provide control over which files and directories are processed or exposed by Rill. The public_paths property defines a list of file or directory paths to expose over HTTP. By default, it includes ['./public']. The ignore_paths property specifies a list of files or directories that Rill excludes during ingestion and parsing. This prevents unnecessary or incompatible content from affecting the project.
       :::tip
-      Don't forget the leading `/` when specifying the path for `ignore_paths` and this path is also assuming the relative path from your project root.
+      Don't forget the leading `/` when specifying the path for `ignore_paths`. This path is relative to your project root.
       :::
     type: object
     properties:
@@ -217,16 +217,16 @@ allOf:
           type: string
   - title: Testing access policies
     description: |
-      During development, it is always a good idea to check if your [access policies](/developers/build/metrics-view/security) are behaving the way you designed them to before pushing these changes into production. You can set mock users which enables a drop down in the dashboard preview to view as a specific user. 
+      During development, it is always a good idea to check if your [access policies](/developers/build/metrics-view/security) are behaving the way you designed them to before pushing these changes into production. You can set mock users, which enables a drop-down in the dashboard preview to view as a specific user.
       :::info The View as selector is not visible in my dashboard, why?
-      This feature is _only_ enabled when you have set a security policy on the dashboard. By default, the dashboard and it's contents is viewable by every user.
+      This feature is _only_ enabled when you have set a security policy on the dashboard. By default, the dashboard and its contents are viewable by every user.
       :::
     type: object
     properties:
       mock_users:
         type: array
         description: A list of mock users used to test dashboard security policies within the project
-        examples: 
+        examples:
         - mock_users:
           - email: john@yourcompany.com
             name: John Doe


### PR DESCRIPTION
## Summary
- Fix typos and minor grammar issues in generated reference docs by updating schema and CLI command sources
- Regenerate CLI and project-file reference markdown with TMP_CLONE_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t rill-examples); \
	trap 'rm -rf "$TMP_CLONE_DIR"' EXIT; \
	git clone --quiet --depth=1 https://github.com/rilldata/rill-examples.git "$TMP_CLONE_DIR"; \
	for d in rill-openrtb-prog-ads rill-github-analytics rill-cost-monitoring; do \
		cp -R "$TMP_CLONE_DIR/$d" runtime/pkg/examples/embed/dist/; \
	done
