### PR TITLE
fix: chat e2e test based on mock_ai connector

### DIFF
--- a/runtime/drivers/mock/ai/ai.go
+++ b/runtime/drivers/mock/ai/ai.go
@@ -2,6 +2,7 @@ package ai
 
 import (
 	"context"
+	"strings"
 
 	aiv1 "github.com/rilldata/rill/proto/gen/rill/ai/v1"
 	rillai "github.com/rilldata/rill/runtime/ai"
@@ -195,12 +196,21 @@ func (c *connection) handleToolCalling() *aiv1.CompletionMessage {
 	}
 }
 
+// userRequestMarker separates the analyst agent's templated user prompt preamble from the raw user request.
+// It must stay in sync with the template in runtime/ai/analyst_agent.go.
+const userRequestMarker = "The user's request:\n"
+
 // echoUserMessage finds the last user message and echoes it back
 func (c *connection) echoUserMessage(msgs []*aiv1.CompletionMessage) *aiv1.CompletionMessage {
 	text := c.findLastUserText(msgs)
 	if text == "" {
 		text = "No user message found"
 	} else {
+		// The analyst agent wraps the raw user request in a templated prompt with a leading preamble.
+		// Echo only the raw request when the marker is present; otherwise echo the full message.
+		if idx := strings.LastIndex(text, userRequestMarker); idx != -1 {
+			text = strings.TrimSpace(text[idx+len(userRequestMarker):])
+		}
 		text = "Echo: " + text
 	}
 


### PR DESCRIPTION
https://github.com/rilldata/rill/pull/9645 changed how messages are arranged. This broke how we verify using mock_ai. Updating mock_ai connector to match 9645.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
