### PR TITLE
Minor follow up: Visual editor support to allow adding tags

### DIFF
--- a/web-common/src/components/forms/TagInput.svelte
+++ b/web-common/src/components/forms/TagInput.svelte
@@ -6,6 +6,7 @@
     suggestions?: string[];
     label?: string;
     placeholder?: string;
+    size?: "sm" | "md";
     onChange: (tags: string[]) => void;
   };
 
@@ -14,6 +15,7 @@
     suggestions = [],
     label = "Tags",
     placeholder = "Add a tag and press Enter",
+    size = "md",
     onChange,
   }: Props = $props();
 
@@ -41,6 +43,7 @@
   const DROPDOWN_MAX_HEIGHT = 240;
   const VIEWPORT_PADDING = 8;
 
+  let isSmall = $derived(size === "sm");
   let trimmedInput = $derived(inputValue.trim());
 
   let filteredSuggestions = $derived.by(() => {
@@ -206,9 +209,19 @@
 </script>
 
 <div class="flex flex-col gap-y-1" bind:this={wrapperRef}>
-  <span class="text-fg-secondary text-sm font-medium">{label}</span>
+  <span
+    class="text-fg-secondary font-medium"
+    class:text-xs={isSmall}
+    class:text-sm={!isSmall}
+  >
+    {label}
+  </span>
   <div
-    class="input-wrapper flex flex-wrap items-center gap-1 px-1.5 py-1 min-h-8 cursor-text"
+    class="input-wrapper flex flex-wrap items-center gap-1 px-1.5 cursor-text"
+    class:min-h-6={isSmall}
+    class:min-h-8={!isSmall}
+    class:py-0.5={isSmall}
+    class:py-1={!isSmall}
     role="presentation"
     onclick={() => inputRef?.focus()}
   >
@@ -236,7 +249,9 @@
       onkeydown={handleKeyDown}
       onfocus={handleFocusIn}
       onblur={handleInputBlur}
-      class="flex-1 min-w-[100px] bg-transparent outline-none text-sm py-0.5"
+      class="flex-1 min-w-[100px] bg-transparent outline-none py-0.5"
+      class:text-xs={isSmall}
+      class:text-sm={!isSmall}
       {placeholder}
       autocomplete="off"
       aria-label={label}
@@ -265,7 +280,9 @@
         type="button"
         role="option"
         aria-selected={highlightedIndex === i}
-        class="w-full text-left px-2.5 py-1 text-sm text-fg-primary hover:bg-popover-accent flex items-center"
+        class="w-full text-left px-2.5 py-1 text-fg-primary hover:bg-popover-accent flex items-center"
+        class:text-xs={isSmall}
+        class:text-sm={!isSmall}
         class:bg-popover-accent={highlightedIndex === i}
         onmousedown={(e) => e.preventDefault()}
         onclick={() => pickSuggestion(s)}

--- a/web-common/src/features/canvas/inspector/PageEditor.svelte
+++ b/web-common/src/features/canvas/inspector/PageEditor.svelte
@@ -191,6 +191,7 @@
     </div>
     <div class="page-param">
       <TagInput
+        size="sm"
         tags={resourceTags}
         suggestions={tagSuggestions}
         onChange={updateResourceTags}

--- a/web-common/src/features/canvas/inspector/PageEditor.svelte
+++ b/web-common/src/features/canvas/inspector/PageEditor.svelte
@@ -2,6 +2,7 @@
   import { m } from "@rilldata/web-common/lib/i18n/gen/messages";
   import Input from "@rilldata/web-common/components/forms/Input.svelte";
   import InputLabel from "@rilldata/web-common/components/forms/InputLabel.svelte";
+  import TagInput from "@rilldata/web-common/components/forms/TagInput.svelte";
   import Switch from "@rilldata/web-common/components/forms/Switch.svelte";
   import { getParsedDocument } from "@rilldata/web-common/features/canvas/inspector/selectors";
   import { getCanvasStore } from "@rilldata/web-common/features/canvas/state-managers/state-managers";
@@ -13,6 +14,11 @@
   } from "@rilldata/web-common/features/entity-management/resource-selectors";
   import MultiSelectInput from "@rilldata/web-common/features/visual-editing/MultiSelectInput.svelte";
   import SidebarWrapper from "@rilldata/web-common/features/visual-editing/SidebarWrapper.svelte";
+  import {
+    getResourceTagSuggestions,
+    normalizeTags,
+    readRootYamlTags,
+  } from "@rilldata/web-common/features/visual-editing/tag-utils";
   import ThemeInput from "@rilldata/web-common/features/visual-editing/ThemeInput.svelte";
   import {
     DEFAULT_RANGES,
@@ -26,7 +32,10 @@
   } from "@rilldata/web-common/lib/time/config";
   import { allTimeZones } from "@rilldata/web-common/lib/time/timezone";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
-  import { createRuntimeServiceGetInstance } from "@rilldata/web-common/runtime-client";
+  import {
+    createRuntimeServiceGetInstance,
+    createRuntimeServiceListResources,
+  } from "@rilldata/web-common/runtime-client";
   import { YAMLMap, YAMLSeq } from "yaml";
   import { DEFAULT_DASHBOARD_WIDTH } from "../layout-util";
 
@@ -56,6 +65,22 @@
   $: rawTimeRanges = $parsedDocument.get("time_ranges");
   $: rawTimeZones = $parsedDocument.get("time_zones");
   $: rawMaxWidth = $parsedDocument.get("max_width");
+
+  $: resourcesQuery = createRuntimeServiceListResources(
+    client,
+    {},
+    {
+      query: {
+        select: (data) => data.resources ?? [],
+      },
+    },
+  );
+
+  $: resourceTags = readRootYamlTags($parsedDocument);
+  $: tagSuggestions = getResourceTagSuggestions(
+    $resourcesQuery?.data,
+    resourceTags,
+  );
 
   $: timeZones = new Set(
     rawTimeZones instanceof YAMLSeq
@@ -128,6 +153,16 @@
     }
   }
 
+  async function updateResourceTags(tags: string[]) {
+    const normalizedTags = normalizeTags(tags);
+
+    if (normalizedTags.length) {
+      await updateProperties({ tags: normalizedTags });
+    } else {
+      await updateProperties({}, ["tags"]);
+    }
+  }
+
   let currentTab: string = "options";
 </script>
 
@@ -152,6 +187,13 @@
         onEnter={async () => {
           await updateProperties({ display_name: title });
         }}
+      />
+    </div>
+    <div class="page-param">
+      <TagInput
+        tags={resourceTags}
+        suggestions={tagSuggestions}
+        onChange={updateResourceTags}
       />
     </div>
     <div class="page-param">

--- a/web-common/src/features/visual-editing/tag-utils.spec.ts
+++ b/web-common/src/features/visual-editing/tag-utils.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { parseDocument } from "yaml";
+import {
+  getResourceTagSuggestions,
+  readRootYamlTags,
+  setRootYamlTags,
+} from "./tag-utils";
+
+describe("visual editing tag utils", () => {
+  it("reads top-level YAML tags from scalar nodes", () => {
+    const document = parseDocument(`
+type: metrics_view
+tags:
+  - finance
+  - "growth"
+  - ""
+  - finance
+`);
+
+    expect(readRootYamlTags(document)).toEqual(["finance", "growth"]);
+  });
+
+  it("writes and removes top-level YAML tags", () => {
+    const document = parseDocument("type: explore\n");
+
+    setRootYamlTags(document, [" analytics ", "growth", "analytics"]);
+    expect(readRootYamlTags(document)).toEqual(["analytics", "growth"]);
+
+    setRootYamlTags(document, []);
+    expect(document.has("tags")).toBe(false);
+  });
+
+  it("builds suggestions from resource metadata and extra tags", () => {
+    expect(
+      getResourceTagSuggestions(
+        [
+          { meta: { tags: ["finance", "growth"] } },
+          { meta: { tags: ["growth", "sales"] } },
+        ] as never,
+        ["executive"],
+      ),
+    ).toEqual(["executive", "finance", "growth", "sales"]);
+  });
+});

--- a/web-common/src/features/visual-editing/tag-utils.ts
+++ b/web-common/src/features/visual-editing/tag-utils.ts
@@ -1,0 +1,79 @@
+import type { V1Resource } from "@rilldata/web-common/runtime-client";
+import { Scalar, YAMLSeq } from "yaml";
+
+type YamlDocumentWithTags = {
+  get(key: string): unknown;
+  set(key: string, value: unknown): void;
+  delete(key: string): unknown;
+  createNode(value: unknown): unknown;
+};
+
+function readYamlString(node: unknown): string {
+  if (typeof node === "string") return node.trim();
+
+  if (node instanceof Scalar) {
+    return typeof node.value === "string" ? node.value.trim() : "";
+  }
+
+  if (node && typeof node === "object" && "value" in node) {
+    const value = (node as { value: unknown }).value;
+    return typeof value === "string" ? value.trim() : "";
+  }
+
+  return "";
+}
+
+export function normalizeTags(tags: string[] | undefined): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const tag of tags ?? []) {
+    const value = tag.trim();
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+    normalized.push(value);
+  }
+
+  return normalized;
+}
+
+export function readYamlTags(node: unknown): string[] {
+  if (!(node instanceof YAMLSeq)) return [];
+
+  return normalizeTags(node.items.map(readYamlString));
+}
+
+export function readRootYamlTags(document: { get(key: string): unknown }) {
+  return readYamlTags(document.get("tags"));
+}
+
+export function setRootYamlTags(
+  document: YamlDocumentWithTags,
+  tags: string[],
+) {
+  const normalizedTags = normalizeTags(tags);
+
+  if (normalizedTags.length) {
+    document.set("tags", document.createNode(normalizedTags));
+  } else {
+    document.delete("tags");
+  }
+}
+
+export function getResourceTagSuggestions(
+  resources: V1Resource[] | undefined,
+  ...extraTags: Array<string[] | undefined>
+) {
+  return buildTagSuggestions(
+    resources?.flatMap((resource) => resource.meta?.tags ?? []),
+    ...extraTags,
+  );
+}
+
+export function buildTagSuggestions(
+  ...sources: Array<string[] | undefined>
+): string[] {
+  return normalizeTags(sources.flatMap((source) => source ?? [])).sort((a, b) =>
+    a.localeCompare(b),
+  );
+}

--- a/web-common/src/features/workspaces/VisualExploreEditing.svelte
+++ b/web-common/src/features/workspaces/VisualExploreEditing.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { replaceState } from "$app/navigation";
   import Button from "@rilldata/web-common/components/button/Button.svelte";
+  import TagInput from "@rilldata/web-common/components/forms/TagInput.svelte";
   import Input from "@rilldata/web-common/components/forms/Input.svelte";
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
@@ -21,6 +22,7 @@
   } from "@rilldata/web-common/lib/time/types";
   import {
     createRuntimeServiceGetInstance,
+    createRuntimeServiceListResources,
     type V1Explore,
   } from "@rilldata/web-common/runtime-client";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
@@ -38,6 +40,11 @@
   import MeasureDimensionSelector from "../visual-editing/MeasureDimensionSelector.svelte";
   import MultiSelectInput from "../visual-editing/MultiSelectInput.svelte";
   import SidebarWrapper from "../visual-editing/SidebarWrapper.svelte";
+  import {
+    getResourceTagSuggestions,
+    readRootYamlTags,
+    setRootYamlTags,
+  } from "../visual-editing/tag-utils";
   import ThemeInput from "../visual-editing/ThemeInput.svelte";
 
   const itemTypes = ["measures", "dimensions"] as const;
@@ -72,6 +79,16 @@
 
   $: parsedDocument = parseDocument($editorContent ?? "");
 
+  $: resourcesQuery = createRuntimeServiceListResources(
+    runtimeClient,
+    {},
+    {
+      query: {
+        select: (data) => data.resources ?? [],
+      },
+    },
+  );
+
   $: metricsViewsQuery = useFilteredResources(
     runtimeClient,
     ResourceKind.MetricsView,
@@ -101,6 +118,12 @@
   $: rawTheme = parsedDocument.get("theme");
   $: rawTimeRanges = parsedDocument.get("time_ranges");
   $: rawDefaults = parsedDocument.get("defaults");
+
+  $: resourceTags = readRootYamlTags(parsedDocument);
+  $: tagSuggestions = getResourceTagSuggestions(
+    $resourcesQuery?.data,
+    resourceTags,
+  );
 
   $: timeZones = new Set(
     rawTimeZones instanceof YAMLSeq
@@ -262,6 +285,12 @@
     updateEditorContent(parsedDocument.toString(), false, autoSave);
   }
 
+  function updateResourceTags(tags: string[]) {
+    setRootYamlTags(parsedDocument, tags);
+    killState();
+    updateEditorContent(parsedDocument.toString(), false, autoSave);
+  }
+
   function killState() {
     localStorage.removeItem(`${exploreName}-persistentDashboardStore`);
 
@@ -373,6 +402,12 @@
       onEnter={() => {
         updateProperties({ display_name: title });
       }}
+    />
+
+    <TagInput
+      tags={resourceTags}
+      suggestions={tagSuggestions}
+      onChange={updateResourceTags}
     />
 
     <Input


### PR DESCRIPTION
## Summary
- Add resource-level tag editing to explore dashboard visual editor
- Add resource-level tag editing to canvas dashboard visual editor
- Add shared YAML tag helpers and focused tests

## Tests
- npm run test -w web-common -- src/features/visual-editing/tag-utils.spec.ts