### PR TITLE
fix: transient `Metrics view not found` error flash in canvas table/pivot components

### DIFF
--- a/web-common/src/features/canvas/components/pivot/CanvasPivotDisplay.svelte
+++ b/web-common/src/features/canvas/components/pivot/CanvasPivotDisplay.svelte
@@ -37,10 +37,10 @@
   $: _metricViewSpec = getMetricsViewFromName(tableSpec.metrics_view);
   $: metricsViewSpec = $_metricViewSpec.metricsView;
 
-  $: schema = validateTableSchema(metricsViewSpec, tableSpec);
+  $: schema = validateTableSchema($_metricViewSpec, tableSpec);
   $: widthScopeKey = `canvas:${component.parent.name}:${component.id}`;
 
-  $: if ("columns" in tableSpec && schema.isValid) {
+  $: if ("columns" in tableSpec && schema.isValid && !schema.isLoading) {
     const columns = tableSpec?.columns || [];
     pivotState.update((state) => ({
       ...state,
@@ -53,7 +53,7 @@
       showTotalsColumn: tableSpec.hide_totals_col !== true,
       showTotalsRow: tableSpec.hide_totals_row !== true,
     }));
-  } else if (!("columns" in tableSpec) && schema.isValid) {
+  } else if (!("columns" in tableSpec) && schema.isValid && !schema.isLoading) {
     const measures = tableSpec.measures || [];
     const colDimensions = tableSpec.col_dimensions || [];
     const rowDimensions = tableSpec.row_dimensions || [];

--- a/web-common/src/features/canvas/components/pivot/selector.ts
+++ b/web-common/src/features/canvas/components/pivot/selector.ts
@@ -7,12 +7,24 @@ import type { PivotSpec, TableSpec } from "./";
 import type { V1MetricsViewSpec } from "@rilldata/web-common/runtime-client";
 
 export function validateTableSchema(
-  metricsView: V1MetricsViewSpec | undefined,
+  metricsViewQuery: {
+    metricsView: V1MetricsViewSpec | undefined;
+    isLoading: boolean;
+  },
   tableSpec: PivotSpec | TableSpec,
 ): {
   isValid: boolean;
   error?: string;
+  isLoading?: boolean;
 } {
+  if (metricsViewQuery.isLoading) {
+    return {
+      isValid: true,
+      error: undefined,
+      isLoading: true,
+    };
+  }
+  const metricsView = metricsViewQuery.metricsView;
   if (!metricsView) {
     return {
       isValid: false,


### PR DESCRIPTION
- On canvas page load, the table/pivot component briefly flashed a red `Metrics view not found` error before rendering: while the `ListResources` query was still in flight, `validateTableSchema` treated the momentarily-undefined metrics view spec as a hard error.
- `validateTableSchema` now takes the `{ metricsView, isLoading }` query result and reports a loading state instead of an error while the fetch is in flight, matching the existing guards in the KPI, chart, and leaderboard components.
- `CanvasPivotDisplay` skips populating pivot state until loading completes, so column/time-dimension mapping is not computed from an undefined spec. While loading, the component falls through to the pivot's existing loading spinner; a genuine missing metrics view still shows the error.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

