### PR TITLE
Expose developer file tools over MCP for callers with edit access

### DIFF
--- a/runtime/ai/file_list.go
+++ b/runtime/ai/file_list.go
@@ -41,7 +41,7 @@ func (t *ListFiles) Spec() *mcp.Tool {
 }
 
 func (t *ListFiles) CheckAccess(ctx context.Context) (bool, error) {
-	return checkDeveloperAccess(ctx, t.Runtime, true)
+	return checkDeveloperAccess(ctx, t.Runtime, false)
 }
 
 func (t *ListFiles) Handler(ctx context.Context, args *ListFilesArgs) (*ListFilesResult, error) {

--- a/runtime/ai/file_read.go
+++ b/runtime/ai/file_read.go
@@ -43,7 +43,7 @@ func (t *ReadFile) Spec() *mcp.Tool {
 }
 
 func (t *ReadFile) CheckAccess(ctx context.Context) (bool, error) {
-	return checkDeveloperAccess(ctx, t.Runtime, true)
+	return checkDeveloperAccess(ctx, t.Runtime, false)
 }
 
 func (t *ReadFile) Handler(ctx context.Context, args *ReadFileArgs) (*ReadFileResult, error) {

--- a/runtime/ai/file_search.go
+++ b/runtime/ai/file_search.go
@@ -54,7 +54,7 @@ func (t *SearchFiles) Spec() *mcp.Tool {
 }
 
 func (t *SearchFiles) CheckAccess(ctx context.Context) (bool, error) {
-	return checkDeveloperAccess(ctx, t.Runtime, true)
+	return checkDeveloperAccess(ctx, t.Runtime, false)
 }
 
 func (t *SearchFiles) Handler(ctx context.Context, args *SearchFilesArgs) (*SearchFilesResult, error) {

--- a/runtime/ai/file_write.go
+++ b/runtime/ai/file_write.go
@@ -52,7 +52,7 @@ func (t *WriteFile) Spec() *mcp.Tool {
 }
 
 func (t *WriteFile) CheckAccess(ctx context.Context) (bool, error) {
-	return checkDeveloperAccess(ctx, t.Runtime, true)
+	return checkDeveloperAccess(ctx, t.Runtime, false)
 }
 
 func (t *WriteFile) Handler(ctx context.Context, args *WriteFileArgs) (*WriteFileResult, error) {

--- a/runtime/ai/mcp.go
+++ b/runtime/ai/mcp.go
@@ -22,6 +22,13 @@ This server exposes APIs for querying **metrics views**, which represent Rill's 
 
 In the workflow, do not proceed with the next step until the previous step has been completed. If the information from the previous step is already known (let's say for subsequent queries), you can skip it.
 If a response contains an "ai_instructions" field, you should interpret it as additional instructions for how to behave in subsequent responses that relate to that tool call.
+
+## Project Development
+If you have edit access, the server also exposes tools for inspecting and editing the project's source code, which consists of YAML and SQL files:
+- **List files:** Use "list_files" to browse the files in the project.
+- **Search files:** Use "search_files" to find files by name or content.
+- **Read a file:** Use "read_file" to read the contents of a file.
+- **Write a file:** Use "write_file" to create, update or delete a file. If the file declares a Rill resource, it returns the resource's status and any errors encountered after reconciliation.
 `
 
 // MCPServer returns a new MCP server scoped to the current session.

--- a/runtime/ai/mcp_test.go
+++ b/runtime/ai/mcp_test.go
@@ -1,0 +1,67 @@
+package ai_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rilldata/rill/runtime"
+	"github.com/rilldata/rill/runtime/ai"
+	"github.com/rilldata/rill/runtime/pkg/activity"
+	"github.com/rilldata/rill/runtime/testruntime"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeveloperToolsMCPAccess verifies that the leaf developer tools are exposed to external
+// MCP clients (non-rill user agents) for callers with EditRepo, while the developer agents remain
+// restricted to first-party Rill clients.
+func TestDeveloperToolsMCPAccess(t *testing.T) {
+	rt, instanceID := testruntime.NewInstanceWithOptions(t, testruntime.InstanceOptions{})
+
+	newMCPSession := func(t *testing.T, permissions ...runtime.Permission) *ai.Session {
+		claims := &runtime.SecurityClaims{
+			UserID:      uuid.NewString(),
+			SkipChecks:  false,
+			Permissions: permissions,
+		}
+		r := ai.NewRunner(rt, activity.NewNoopClient())
+		s, err := r.Session(t.Context(), &ai.SessionOptions{
+			InstanceID: instanceID,
+			Claims:     claims,
+			UserAgent:  "mcp-client", // Non-rill user agent, i.e. an external MCP client
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, s.Flush(t.Context()))
+		})
+		return s
+	}
+
+	assertAccess := func(t *testing.T, s *ai.Session, name string, want bool) {
+		t.Helper()
+		tool, ok := s.Tool(name)
+		require.True(t, ok, "tool %q should be registered", name)
+		allowed, err := tool.CheckAccess(ai.WithSession(t.Context(), s))
+		require.NoError(t, err)
+		require.Equal(t, want, allowed, "tool %q access", name)
+	}
+
+	leafTools := []string{ai.WriteFileName, ai.ReadFileName, ai.ListFilesName, ai.SearchFilesName}
+	agentTools := []string{ai.DevelopFileName, ai.DeveloperAgentName}
+
+	t.Run("with EditRepo", func(t *testing.T) {
+		s := newMCPSession(t, runtime.UseAI, runtime.EditRepo)
+		for _, name := range leafTools {
+			assertAccess(t, s, name, true)
+		}
+		for _, name := range agentTools {
+			assertAccess(t, s, name, false)
+		}
+	})
+
+	t.Run("without EditRepo", func(t *testing.T) {
+		s := newMCPSession(t, runtime.UseAI)
+		for _, name := range leafTools {
+			assertAccess(t, s, name, false)
+		}
+	})
+}

--- a/runtime/server/mcp_test.go
+++ b/runtime/server/mcp_test.go
@@ -79,6 +79,10 @@ explore:
 		ai.ShowTableName,
 		ai.ListBucketsName,
 		ai.ListBucketObjectsName,
+		ai.ListFilesName,
+		ai.ReadFileName,
+		ai.SearchFilesName,
+		ai.WriteFileName,
 	}
 	require.Len(t, tools.Tools, len(expectedTools))
 	for _, tool := range tools.Tools {


### PR DESCRIPTION
- Exposes `list_files`, `read_file`, `search_files`, and `write_file` to external MCP clients with the `EditRepo` permission; the developer agents (`developer_agent`, `develop_file`) stay first-party only.

