### PR TITLE
fix: blank expanded dimension table while data loads — show a spinner in `DimensionTable`

### DIFF
--- a/web-common/src/features/dashboards/dimension-table/DimensionTable.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionTable.svelte
@@ -9,6 +9,7 @@ TableCells – the cell contents.
   import TableCells from "@rilldata/web-common/components/virtualized-table/sections/TableCells.svelte";
   import type { VirtualizedTableColumns } from "@rilldata/web-common/components/virtualized-table/types";
   import { selectedDimensionValues } from "@rilldata/web-common/features/dashboards/state-managers/selectors/dimension-filters";
+  import DelayedSpinner from "@rilldata/web-common/features/entity-management/DelayedSpinner.svelte";
   import { createVirtualizer } from "@tanstack/svelte-virtual";
   import { setContext } from "svelte";
   import { getStateManagers } from "../state-managers/state-managers";
@@ -191,6 +192,7 @@ TableCells – the cell contents.
   bind:clientWidth={containerWidth}
   style="height: 100%;"
   role="table"
+  class="relative"
   aria-label={m.dashboard_dimension_table_aria()}
 >
   <div
@@ -272,16 +274,22 @@ TableCells – the cell contents.
             onInspect={setActiveIndex}
             cellLabel={m.dashboard_filter_dimension_value()}
           />
-        {:else if isFetching || $selectedValues.isFetching}
-          <div class="flex text-fg-secondary justify-center mt-[30vh]">
-            Loading...
-          </div>
-        {:else}
-          <div class="flex text-fg-secondary justify-center mt-[30vh]">
-            No results to show
-          </div>
         {/if}
       </div>
     {/if}
   </div>
+  {#if !rows.length}
+    <!-- The virtualized grid above is sized to its rows and uses paint containment,
+      so empty states must render outside it to be visible. -->
+    <div
+      class="absolute inset-0 flex items-center justify-center pointer-events-none"
+      style:padding-top="{config.columnHeaderHeight}px"
+    >
+      {#if isFetching || $selectedValues.isFetching}
+        <DelayedSpinner isLoading size="24px" />
+      {:else}
+        <span class="text-fg-secondary">No results to show</span>
+      {/if}
+    </div>
+  {/if}
 </div>


### PR DESCRIPTION
- Since #8320 added `contain: content` to the virtualizer grid in `DimensionTable.svelte`, the `Loading...` and `No results to show` states have been clipped and invisible: with no rows, the grid is only header-height, and the text sat below it at `mt-[30vh]`. Expanding a dimension on a large dataset therefore showed a completely blank table until the query returned.
- Moved the empty/loading state out of the clipped virtualizer div into a centered overlay on the table container.
- While fetching, show a `DelayedSpinner` (same pattern as leaderboard headers; 300ms delay so fast loads don't flicker). The `No results to show` empty state is visible again as well.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!