### PR TITLE
Expand File explorer directories by default and add file explorer expand/collapse control

### DIFF
--- a/web-common/src/features/file-explorer/FileExplorer.svelte
+++ b/web-common/src/features/file-explorer/FileExplorer.svelte
@@ -23,8 +23,16 @@
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
   import { eventBus } from "../../lib/event-bus/event-bus";
   import { fileArtifacts } from "../entity-management/file-artifacts";
+  import { useProjectTitle } from "@rilldata/web-common/features/project/selectors";
+  import { createLocalServiceGetMetadata } from "@rilldata/web-common/runtime-client/local-service";
+  import { ChevronsDownUp, ChevronsUpDown } from "lucide-svelte";
   import NavDirectory from "./NavDirectory.svelte";
-  import { findDirectory, transformFileList } from "./transform-file-list";
+  import { directoryState } from "./directory-store";
+  import {
+    collectDirectoryPaths,
+    findDirectory,
+    transformFileList,
+  } from "./transform-file-list";
   import QuickView from "@rilldata/web-common/features/resource-graph/quick-view/QuickView.svelte";
   import {
     isPinned,
@@ -71,6 +79,39 @@
   );
 
   $: ({ data: fileTree } = $getFileTree);
+
+  $: projectTitleQuery = useProjectTitle(runtimeClient);
+  $: projectTitle = $projectTitleQuery?.data ?? "Untitled Rill Project";
+
+  // Scope the persisted expand/collapse state per project. In the cloud the
+  // instanceId is unique per project; in Rill Developer it is always "default",
+  // so fall back to the on-disk project path there (GetMetadata is a local-only
+  // endpoint that simply errors in the cloud).
+  $: ({ instanceId } = runtimeClient);
+  $: projectMetadataQuery = createLocalServiceGetMetadata({
+    query: { retry: false },
+  });
+  $: projectScopeId = $projectMetadataQuery.isLoading
+    ? undefined
+    : ($projectMetadataQuery.data?.projectPath ?? instanceId);
+  $: if (projectScopeId) directoryState.setProjectScope(projectScopeId);
+
+  $: directoryPaths = fileTree ? collectDirectoryPaths(fileTree) : [];
+  $: allDirectoriesCollapsed =
+    directoryPaths.length > 0 &&
+    directoryPaths.every((path) => $directoryState[path] === false);
+  $: toggleAllDirectoriesLabel = allDirectoriesCollapsed
+    ? "Expand all folders"
+    : "Collapse all folders";
+
+  function toggleAllDirectories() {
+    if (!fileTree) return;
+    if (allDirectoriesCollapsed) {
+      directoryState.expandAll(directoryPaths);
+    } else {
+      directoryState.collapseAll(directoryPaths);
+    }
+  }
 
   let showRenameModelModal = false;
   let renameFilePath: string;
@@ -178,6 +219,26 @@
   onkeydown={saveAll}
 />
 
+<!-- Project header with a collapse-all control -->
+<div class="project-header">
+  <h3 class="truncate" title={projectTitle}>{projectTitle}</h3>
+  {#if directoryPaths.length}
+    <button
+      type="button"
+      class="collapse-all"
+      aria-label={toggleAllDirectoriesLabel}
+      title={toggleAllDirectoriesLabel}
+      onclick={toggleAllDirectories}
+    >
+      {#if allDirectoriesCollapsed}
+        <ChevronsUpDown size="14px" />
+      {:else}
+        <ChevronsDownUp size="14px" />
+      {/if}
+    </button>
+  {/if}
+</div>
+
 <!-- File tree -->
 <ul class="flex flex-col w-full items-start justify-start overflow-auto">
   {#if fileTree}
@@ -218,3 +279,25 @@
 <ForceDeleteConfirmation bind:open={showForceDelete} onDelete={onForceDelete} />
 
 <QuickView />
+
+<style lang="postcss">
+  .project-header {
+    @apply sticky top-0 z-10 bg-surface-base;
+    @apply flex items-center justify-between gap-x-1;
+    @apply h-7 w-full pl-2 pr-1.5;
+  }
+
+  h3 {
+    @apply truncate font-semibold text-[10px] uppercase text-fg-muted;
+  }
+
+  .collapse-all {
+    @apply flex flex-none items-center justify-center;
+    @apply size-5 rounded text-fg-secondary;
+  }
+
+  .collapse-all:hover,
+  .collapse-all:focus-visible {
+    @apply bg-surface-hover text-fg-primary;
+  }
+</style>

--- a/web-common/src/features/file-explorer/NavDirectory.svelte
+++ b/web-common/src/features/file-explorer/NavDirectory.svelte
@@ -14,7 +14,8 @@
   export let onDelete: (filePath: string, isDir: boolean) => void;
   export let onMouseDown: (e: MouseEvent, dragData: NavDragData) => void;
 
-  $: expanded = $directoryState[directory.path];
+  // Directories are expanded by default; only explicitly collapsed ones are false.
+  $: expanded = $directoryState[directory.path] ?? true;
   const { dragData, dropDirs } = navEntryDragDropStore;
   $: isDragDropHover =
     $dragData && $dropDirs[$dropDirs.length - 1] === directory.path;

--- a/web-common/src/features/file-explorer/NavDirectoryEntry.svelte
+++ b/web-common/src/features/file-explorer/NavDirectoryEntry.svelte
@@ -37,7 +37,8 @@
     createRuntimeServiceCreateDirectoryMutation(runtimeClient);
 
   $: id = `${dir.path}-nav-entry`;
-  $: expanded = $directoryState[dir.path];
+  // Directories are expanded by default; only explicitly collapsed ones are false.
+  $: expanded = $directoryState[dir.path] ?? true;
   $: padding = getPaddingFromPath(dir.path);
   $: ({ instanceId } = runtimeClient);
   $: topLevelFolder = getTopLevelFolder(dir.path);

--- a/web-common/src/features/file-explorer/directory-store.ts
+++ b/web-common/src/features/file-explorer/directory-store.ts
@@ -1,3 +1,5 @@
+import { browser } from "$app/environment";
+import { debounce } from "@rilldata/web-common/lib/create-debouncer";
 import { type Writable, writable } from "svelte/store";
 
 interface DirectoryState {
@@ -5,21 +7,64 @@ interface DirectoryState {
 }
 
 interface CustomWritable<T> extends Writable<T> {
+  setProjectScope: (scopeId: string) => void;
   expand: (directoryPath: string) => void;
   collapse: (directoryPath: string) => void;
+  expandAll: (directoryPaths: string[]) => void;
+  collapseAll: (directoryPaths: string[]) => void;
   toggle: (directoryPath: string) => void;
   reset: () => void;
 }
 
+// Directories are expanded by default. Only paths the user has explicitly
+// collapsed (or expanded) are recorded, so a freshly initialized project starts
+// with every folder open and the user's changes are remembered from there.
+const DEFAULT_STATE: DirectoryState = { "/": true };
+const STORAGE_PREFIX = "file-explorer-directory-state";
+
+// A directory is expanded unless it has been explicitly collapsed.
+const isExpanded = (state: DirectoryState, path: string) => state[path] ?? true;
+
 const createDirectoryStore = (): CustomWritable<DirectoryState> => {
   const { subscribe, set, update } = writable<DirectoryState>({
-    "/": true,
+    ...DEFAULT_STATE,
   });
+
+  // The persisted state is scoped per project via setProjectScope(): the
+  // instanceId is always "default" in Rill Developer, so different projects
+  // opened in the same browser would otherwise share one collapsed/expanded map.
+  // localStorageStore can't be reused here because its key is fixed at creation,
+  // whereas the active project (and thus the key) is only known once the runtime
+  // metadata resolves.
+  let storageKey: string | null = null;
+  const persist = debounce((state: DirectoryState) => {
+    if (!storageKey) return;
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(state));
+    } catch {
+      // ignore: localStorage unavailable or over quota (e.g. embed iframe)
+    }
+  }, 300);
+  subscribe((state) => persist(state));
 
   return {
     subscribe,
     set,
     update,
+    setProjectScope: (scopeId: string) => {
+      const key = `${STORAGE_PREFIX}::${scopeId}`;
+      if (key === storageKey) return;
+      storageKey = key;
+      if (!browser) return;
+      try {
+        // Accessing localStorage can throw (e.g. a storage-partitioned embed
+        // iframe raises a SecurityError), so fall back to the default state.
+        const stored = localStorage.getItem(key);
+        set(stored ? JSON.parse(stored) : { ...DEFAULT_STATE });
+      } catch {
+        set({ ...DEFAULT_STATE });
+      }
+    },
     expand: (directoryPath: string) => {
       update((state) => {
         const newState = { ...state };
@@ -40,11 +85,34 @@ const createDirectoryStore = (): CustomWritable<DirectoryState> => {
     collapse: (directoryPath: string) => {
       update((state) => ({ ...state, [directoryPath]: false }));
     },
+    expandAll: (directoryPaths: string[]) => {
+      update((state) => {
+        const newState = { ...state };
+        for (const path of directoryPaths) {
+          newState[path] = true;
+        }
+        return newState;
+      });
+    },
+    collapseAll: (directoryPaths: string[]) => {
+      update((state) => {
+        const newState = { ...state };
+        for (const path of directoryPaths) {
+          // The root is not collapsible; collapsing it would hide the whole tree.
+          if (path === "/") continue;
+          newState[path] = false;
+        }
+        return newState;
+      });
+    },
     toggle: (directoryPath: string) => {
-      update((state) => ({ ...state, [directoryPath]: !state[directoryPath] }));
+      update((state) => ({
+        ...state,
+        [directoryPath]: !isExpanded(state, directoryPath),
+      }));
     },
     reset: () => {
-      set({ "/": true });
+      set({ ...DEFAULT_STATE });
     },
   };
 };

--- a/web-common/src/features/file-explorer/transform-file-list.ts
+++ b/web-common/src/features/file-explorer/transform-file-list.ts
@@ -66,6 +66,16 @@ export function transformFileList(files: V1DirEntry[]): Directory {
   return rootDirectory;
 }
 
+// Collects the paths of every directory in the tree, excluding the root.
+export function collectDirectoryPaths(dir: Directory): string[] {
+  const paths: string[] = [];
+  for (const subDir of dir.directories) {
+    paths.push(subDir.path);
+    paths.push(...collectDirectoryPaths(subDir));
+  }
+  return paths;
+}
+
 export function findDirectory(root: Directory, filePath: string) {
   const folderTree = removeLeadingSlash(filePath).split("/");
   let dir: Directory | undefined = root;

--- a/web-local/tests/canvas/charts.spec.ts
+++ b/web-local/tests/canvas/charts.spec.ts
@@ -6,7 +6,6 @@ test.describe("canvas charts", () => {
   test.use({ project: "AdBids" });
 
   test("switch between charts", async ({ page }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_canvas.yaml");
 
     await page.locator("#AdBids_metrics_canvas--component-1-0 canvas").click();

--- a/web-local/tests/canvas/default-filters.spec.ts
+++ b/web-local/tests/canvas/default-filters.spec.ts
@@ -6,7 +6,6 @@ test.describe("canvas time filters", () => {
   test.use({ project: "AdBids" });
 
   test("save default filters button works", async ({ page }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_canvas.yaml");
 
     await page.getByRole("button", { name: "Options" }).click();
@@ -50,7 +49,6 @@ test.describe("canvas time filters", () => {
   });
 
   test("default filters load", async ({ page }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_canvas.yaml");
 
     await page.getByRole("button", { name: "Options" }).click();
@@ -91,7 +89,6 @@ test.describe("canvas time filters", () => {
   });
 
   test("legacy filters without prefix still work", async ({ page }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_canvas.yaml");
     const currentUrl = new URL(page.url());
 

--- a/web-local/tests/canvas/filters.spec.ts
+++ b/web-local/tests/canvas/filters.spec.ts
@@ -7,7 +7,6 @@ test.describe("canvas time filters", () => {
   test.use({ project: "AdBids" });
 
   test("can update time filters", async ({ page }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_canvas.yaml");
 
     await page.getByLabel("total_records KPI data").first().click();
@@ -61,7 +60,6 @@ test.describe("canvas time filters", () => {
   });
 
   test("can update domain filters", async ({ page }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_canvas.yaml");
 
     await page.getByLabel("total_records KPI data").first().click();

--- a/web-local/tests/canvas/generate-canvas.spec.ts
+++ b/web-local/tests/canvas/generate-canvas.spec.ts
@@ -9,9 +9,6 @@ test.describe.skip("canvas generation", () => {
   test.setTimeout(120_000);
 
   test("Generate canvas dashboard from metrics view", async ({ page }) => {
-    // Expand the metrics folder first
-    await page.getByLabel("/metrics").click();
-
     // Navigate to the metrics view file
     await gotoNavEntry(page, "/metrics/AdBids_metrics.yaml");
 

--- a/web-local/tests/canvas/global-dimension-filters.spec.ts
+++ b/web-local/tests/canvas/global-dimension-filters.spec.ts
@@ -7,7 +7,6 @@ test.describe("canvas global dimension filters", () => {
 
   // TODO: Fix test with latest filter related changes
   test.skip("global dimension filters run through", async ({ page }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_canvas.yaml");
 
     await page.getByRole("button", { name: "Preview" }).click();

--- a/web-local/tests/canvas/global-time-filters.spec.ts
+++ b/web-local/tests/canvas/global-time-filters.spec.ts
@@ -8,7 +8,6 @@ test.describe("canvas global time filters", () => {
 
   // TODO: Fix test with latest time related changes
   test.skip("global time filters run through", async ({ page }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_canvas.yaml");
 
     await page.getByRole("button", { name: "Preview" }).click();

--- a/web-local/tests/canvas/leaderboard.spec.ts
+++ b/web-local/tests/canvas/leaderboard.spec.ts
@@ -5,7 +5,6 @@ test.describe("canvas leaderboards", () => {
   test.use({ project: "AdBids" });
 
   test("add leaderboard component", async ({ page }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_canvas.yaml");
     await page
       .getByRole("button", { name: "Add widget" })

--- a/web-local/tests/connectors/clickhouse-connector.spec.ts
+++ b/web-local/tests/connectors/clickhouse-connector.spec.ts
@@ -301,9 +301,6 @@ test.describe("ClickHouse connector", () => {
 
       await selectAdImpressionsAndSubmit(page, "clickhouse_1");
 
-      // Open the connectors folder
-      await page.getByLabel("/connectors").click();
-
       // Assert that "connector" is created
       await gotoNavEntry(page, "/connectors/clickhouse.yaml");
       await validateYamlContents(page, [
@@ -351,9 +348,6 @@ test.describe("ClickHouse connector", () => {
 
       await selectAdImpressionsAndSubmit(page, "clickhouse");
 
-      // Open the connectors folder
-      await page.getByLabel("/connectors").click();
-
       // Assert that "connector" is created with the second clickhouse instance
       await gotoNavEntry(page, "/connectors/clickhouse.yaml");
       await validateYamlContents(page, [
@@ -394,9 +388,6 @@ test.describe("ClickHouse connector", () => {
 
       // Go back to the connector form
       await page.getByRole("button", { name: "Back" }).click();
-
-      // Open the connectors folder
-      await page.getByLabel("/connectors").click();
 
       // Assert that "connector" is not created
       await expect

--- a/web-local/tests/connectors/postgres-connector.spec.ts
+++ b/web-local/tests/connectors/postgres-connector.spec.ts
@@ -180,9 +180,6 @@ test.describe.skip("Postgres connector", () => {
       // Reload, there should be a blank project
       await page.reload();
 
-      // Open the connectors folder
-      await page.getByLabel("/connectors").click();
-
       // Assert that "connector" is not created
       await expect
         .poll(() => page.getByLabel("/connectors/postgres.yaml").count(), {
@@ -193,9 +190,6 @@ test.describe.skip("Postgres connector", () => {
       // Go to the `.env` file and verify the POSTGRES_PASSWORD is unset
       await page.getByRole("link", { name: ".env" }).click();
       await validateYamlContents(page, [], [`POSTGRES_PASSWORD`]);
-
-      // Open the models folder
-      await page.getByLabel("/models").click();
 
       // Assert that "connector" is not created
       await expect

--- a/web-local/tests/explores/banner.spec.ts
+++ b/web-local/tests/explores/banner.spec.ts
@@ -7,7 +7,6 @@ test.describe("banner in explore preview", () => {
   test.use({ project: "AdBids" });
 
   test("Banner should not be visible in explore preview", async ({ page }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
 
     await page.getByRole("button", { name: "Preview" }).click();
@@ -17,7 +16,6 @@ test.describe("banner in explore preview", () => {
   });
 
   test("Banner should be visible in explore preview", async ({ page }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
 
     const watcher = new ResourceWatcher(page);

--- a/web-local/tests/explores/custom-time-range.spec.ts
+++ b/web-local/tests/explores/custom-time-range.spec.ts
@@ -7,7 +7,6 @@ test.describe("custom timerange in Explore", () => {
   test.use({ project: "AdBids" });
 
   test("Custom time range should be visible by default", async ({ page }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
 
     await page.getByRole("button", { name: "Preview" }).click();
@@ -20,7 +19,6 @@ test.describe("custom timerange in Explore", () => {
   test("Custom time range should not be visible when toggled off", async ({
     page,
   }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
 
     const watcher = new ResourceWatcher(page);

--- a/web-local/tests/explores/dimension-and-measure-selection.spec.ts
+++ b/web-local/tests/explores/dimension-and-measure-selection.spec.ts
@@ -45,7 +45,6 @@ test.describe("dimension and measure selectors", () => {
   test.use({ project: "AdBids" });
 
   test.beforeEach(async ({ page }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
     await page.getByRole("button", { name: "Preview" }).click();
   });

--- a/web-local/tests/explores/leaderboard-and-dim-table-sort.spec.ts
+++ b/web-local/tests/explores/leaderboard-and-dim-table-sort.spec.ts
@@ -23,7 +23,6 @@ test.describe("leaderboard and dimension table sorting", () => {
   test.use({ project: "AdBids" });
 
   test("leaderboard and dimension table sorting", async ({ page }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
     await clickPreviewButton(page);
     await page.waitForURL(new RegExp("/explore/AdBids_metrics_explore"));

--- a/web-local/tests/explores/leaderboard-context-column.spec.ts
+++ b/web-local/tests/explores/leaderboard-context-column.spec.ts
@@ -10,8 +10,6 @@ test.describe("leaderboard context column", () => {
   test("Leaderboard context column", async ({ page }) => {
     const watcher = new ResourceWatcher(page);
 
-    await page.getByLabel("/metrics").click();
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/metrics/AdBids_metrics.yaml");
 
     // reset metrics, and add a metric with `valid_percent_of_total: true`

--- a/web-local/tests/explores/leaderboard-measure-names.spec.ts
+++ b/web-local/tests/explores/leaderboard-measure-names.spec.ts
@@ -6,7 +6,6 @@ test.describe("leaderboard measure names", () => {
   test.use({ project: "AdBids" });
 
   test.beforeEach(async ({ page }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
     await page.getByRole("button", { name: "Preview" }).click();
   });

--- a/web-local/tests/explores/number-formatting.spec.ts
+++ b/web-local/tests/explores/number-formatting.spec.ts
@@ -10,8 +10,6 @@ test.describe("smoke tests for number formatting", () => {
   test("smoke tests for number formatting", async ({ page }) => {
     const watcher = new ResourceWatcher(page);
 
-    await page.getByLabel("/metrics").click();
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/metrics/AdBids_metrics.yaml");
 
     // This is a metrics spec with all available formatting options

--- a/web-local/tests/explores/pivot.spec.ts
+++ b/web-local/tests/explores/pivot.spec.ts
@@ -576,8 +576,6 @@ test.describe("pivot run through", () => {
 
     const watcher = new ResourceWatcher(page);
 
-    await page.getByLabel("/metrics").click();
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/metrics/AdBids_metrics.yaml");
     await page.getByRole("button", { name: "switch to code editor" }).click();
 

--- a/web-local/tests/explores/scrub.spec.ts
+++ b/web-local/tests/explores/scrub.spec.ts
@@ -4,7 +4,6 @@ import { gotoNavEntry } from "../utils/waitHelpers";
 import { interactWithTimeRangeMenu } from "@rilldata/web-common/tests/utils/explore-interactions";
 
 async function setupDashboard(page: Page) {
-  await page.getByLabel("/dashboards").click();
   await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
 
   const bigNumber = page

--- a/web-local/tests/explores/time-controls-from-config.spec.ts
+++ b/web-local/tests/explores/time-controls-from-config.spec.ts
@@ -12,7 +12,6 @@ test.describe("time controls settings from explore preset", () => {
     test.setTimeout(45_000);
     const watcher = new ResourceWatcher(page);
 
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
     await page.getByRole("button", { name: "switch to code editor" }).click();
 
@@ -88,7 +87,6 @@ test.describe("time controls settings from explore preset", () => {
     test.setTimeout(45_000);
     const watcher = new ResourceWatcher(page);
 
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
     await page.getByRole("button", { name: "switch to code editor" }).click();
 
@@ -137,7 +135,6 @@ test.describe("time controls settings from explore preset", () => {
   test("preset time_ranges", async ({ page }) => {
     const watcher = new ResourceWatcher(page);
 
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
     await page.getByRole("button", { name: "switch to code editor" }).click();
 

--- a/web-local/tests/explores/time-dimension-selection.spec.ts
+++ b/web-local/tests/explores/time-dimension-selection.spec.ts
@@ -56,7 +56,6 @@ test.describe("time dimension selection", () => {
   test("time dimensions appear when configured", async ({ page }) => {
     const watcher = new ResourceWatcher(page);
 
-    await page.getByLabel("/metrics").click();
     await gotoNavEntry(page, "/metrics/AdBids_metrics.yaml");
     await page.getByRole("button", { name: "switch to code editor" }).click();
 
@@ -65,7 +64,6 @@ test.describe("time dimension selection", () => {
       "AdBids_metrics",
     );
 
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
     await page.getByRole("button", { name: "Preview" }).click();
 
@@ -81,7 +79,6 @@ test.describe("time dimension selection", () => {
   });
 
   test("URL parameters are preserved for time range", async ({ page }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
     await page.getByRole("button", { name: "Preview" }).click();
 
@@ -104,7 +101,6 @@ test.describe("time dimension selection", () => {
   test("dashboard displays correctly with time range selection", async ({
     page,
   }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
     await page.getByRole("button", { name: "Preview" }).click();
 
@@ -123,7 +119,6 @@ test.describe("time dimension selection", () => {
   });
 
   test("leaderboard data displays correctly", async ({ page }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
     await page.getByRole("button", { name: "Preview" }).click();
 
@@ -147,7 +142,6 @@ test.describe("time dimension selection", () => {
   }) => {
     const watcher = new ResourceWatcher(page);
 
-    await page.getByLabel("/metrics").click();
     await gotoNavEntry(page, "/metrics/AdBids_metrics.yaml");
     await page.getByRole("button", { name: "switch to code editor" }).click();
 
@@ -156,7 +150,6 @@ test.describe("time dimension selection", () => {
       "AdBids_metrics",
     );
 
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
     await page.getByRole("button", { name: "Preview" }).click();
     await waitForDashboard(page);

--- a/web-local/tests/explores/timeseries.spec.ts
+++ b/web-local/tests/explores/timeseries.spec.ts
@@ -114,7 +114,6 @@ test.describe("timeseries charts (rendering)", () => {
     test(`chart data matches API response (dashboard: ${dashboardTZ})`, async ({
       page,
     }) => {
-      await page.getByLabel("/dashboards").click();
       await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
 
       await expect(
@@ -176,7 +175,6 @@ test.describe("timeseries charts system TZ independence", () => {
   }) => {
     const dashboardTZ = "America/Los_Angeles";
 
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
 
     await expect(

--- a/web-local/tests/explores/visual-explore-editing.spec.ts
+++ b/web-local/tests/explores/visual-explore-editing.spec.ts
@@ -13,7 +13,6 @@ test.describe("visual explore editing", () => {
     // before interacting with the visual editor
     await waitForReconciliation(page);
 
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
     await page.getByRole("button", { name: "switch to code editor" }).click();
 

--- a/web-local/tests/metrics-editor.spec.ts
+++ b/web-local/tests/metrics-editor.spec.ts
@@ -1,14 +1,17 @@
 import { expect } from "@playwright/test";
 import { gotoNavEntry } from "./utils/waitHelpers";
 import { updateCodeEditor, wrapRetryAssertion } from "./utils/commonHelpers";
+import { waitForReconciliation } from "./utils/wait-for-reconciliation";
 import { test } from "./setup/base";
 
 test.describe("Metrics editor", () => {
   test.use({ project: "AdBids" });
 
   test("Can add and remove measures and dimensions", async ({ page }) => {
-    await page.getByLabel("/metrics").click();
-    await page.getByLabel("/dashboards").click();
+    // Both tests need the AdBids model ingested: the measure/dimension dialogs
+    // and the inspector read its columns, which are empty until then.
+    await waitForReconciliation(page);
+
     await gotoNavEntry(page, "/metrics/AdBids_metrics.yaml");
 
     await page.getByRole("button", { name: "Add new measure" }).click();
@@ -59,8 +62,8 @@ test.describe("Metrics editor", () => {
   });
 
   test("Metrics editor", async ({ page }) => {
-    await page.getByLabel("/metrics").click();
-    await page.getByLabel("/dashboards").click();
+    await waitForReconciliation(page);
+
     await gotoNavEntry(page, "/metrics/AdBids_metrics.yaml");
 
     await page.getByRole("button", { name: "switch to code editor" }).click();


### PR DESCRIPTION
## Summary
- Add a file explorer header with project title and a bulk expand/collapse control
- Persist directory expansion state per project
- Keep directories expanded by default and allow expanding all after collapsing all

## Test plan
- npm run check -w web-local
- npx prettier --check web-common/src/features/file-explorer/FileExplorer.svelte web-common/src/features/file-explorer/directory-store.ts