### PR TITLE
Add resizable leaderboard dimension column

### DIFF
--- a/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
+++ b/web-common/src/features/dashboards/leaderboard/Leaderboard.svelte
@@ -89,6 +89,9 @@
   export let toggleComparisonDimension: (
     dimensionName: string | undefined,
   ) => void = () => {};
+  // When set, the dimension column becomes resizable and the new width is
+  // reported through this callback.
+  export let onDimensionColumnResize: ((width: number) => void) | null = null;
 
   onMount(() => {
     if (!parentElement) return;
@@ -112,6 +115,8 @@
   let container: HTMLElement;
 
   let hovered: boolean;
+
+  let tableHeight = 0;
 
   $: queryLimit = slice + 1;
   $: maxValuesToShow = slice * 2;
@@ -324,7 +329,10 @@
   onmouseenter={() => (hovered = true)}
   onmouseleave={() => (hovered = false)}
 >
-  <table style:width="{tableWidth + gutterWidth}px">
+  <table
+    style:width="{tableWidth + gutterWidth}px"
+    bind:clientHeight={tableHeight}
+  >
     <colgroup>
       <col data-gutter-column style:width="{gutterWidth}px" />
       <col data-dimension-column style:width="{dimensionColumnWidth}px" />
@@ -369,6 +377,9 @@
       {toggleComparisonDimension}
       {leaderboardSortByMeasureName}
       {measureLabel}
+      {dimensionColumnWidth}
+      {onDimensionColumnResize}
+      {tableHeight}
     />
 
     <tbody>

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardDisplay.svelte
@@ -7,9 +7,16 @@
   } from "@rilldata/web-common/runtime-client";
   import { useRuntimeClient } from "@rilldata/web-common/runtime-client/v2";
   import type { DimensionThresholdFilter } from "web-common/src/features/dashboards/stores/explore-state";
+  import { clamp } from "@rilldata/web-common/lib/clamp";
   import Leaderboard from "./Leaderboard.svelte";
   import LeaderboardControls from "./LeaderboardControls.svelte";
-  import { COMPARISON_COLUMN_WIDTH, valueColumn } from "./leaderboard-widths";
+  import {
+    COMPARISON_COLUMN_WIDTH,
+    dimensionColumn,
+    MAX_DIMENSION_COLUMN_WIDTH,
+    MIN_DIMENSION_COLUMN_WIDTH,
+    valueColumn,
+  } from "./leaderboard-widths";
 
   export let metricsViewName: string;
   export let whereFilter: V1Expression;
@@ -57,7 +64,11 @@
     valueColumn.reset();
   }
 
-  $: dimensionColumnWidth = 164;
+  $: dimensionColumnWidth = clamp(
+    MIN_DIMENSION_COLUMN_WIDTH,
+    $dimensionColumn,
+    MAX_DIMENSION_COLUMN_WIDTH,
+  );
 
   $: showPercentOfTotal = $isMeasureValidPercentOfTotal(
     $leaderboardSortByMeasureName,
@@ -124,6 +135,7 @@
               {toggleDimensionValueSelection}
               {toggleComparisonDimension}
               measureLabel={$measureLabel}
+              onDimensionColumnResize={dimensionColumn.set}
             />
           {/if}
         {/each}

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
@@ -4,12 +4,18 @@
   import Tooltip from "@rilldata/web-common/components/tooltip/Tooltip.svelte";
   import TooltipContent from "@rilldata/web-common/components/tooltip/TooltipContent.svelte";
   import DelayedSpinner from "@rilldata/web-common/features/entity-management/DelayedSpinner.svelte";
+  import Resizer from "@rilldata/web-common/layout/Resizer.svelte";
   import { fly } from "svelte/transition";
   import DeltaChange from "../dimension-table/DeltaChange.svelte";
   import DeltaChangePercentage from "../dimension-table/DeltaChangePercentage.svelte";
   import PercentOfTotal from "../dimension-table/PercentOfTotal.svelte";
   import { SortType } from "../proto-state/derived-types";
   import DimensionCompareMenu from "./DimensionCompareMenu.svelte";
+  import {
+    DEFAULT_DIMENSION_COLUMN_WIDTH,
+    MAX_DIMENSION_COLUMN_WIDTH,
+    MIN_DIMENSION_COLUMN_WIDTH,
+  } from "./leaderboard-widths";
 
   export let dimensionName: string;
   export let isFetching: boolean;
@@ -32,6 +38,11 @@
     dimensionName: string | undefined,
   ) => void;
   export let measureLabel: (measureName: string) => string;
+  export let dimensionColumnWidth: number;
+  export let onDimensionColumnResize: ((width: number) => void) | null = null;
+  // Height of the whole leaderboard table, so the resize handle can span all
+  // rows instead of just the header cell.
+  export let tableHeight = 0;
 
   function shouldShowContextColumns(measureName: string): boolean {
     return (
@@ -57,7 +68,7 @@
       {/if}
     </th>
 
-    <th data-dimension-header>
+    <th data-dimension-header class:resizable={!!onDimensionColumnResize}>
       <Tooltip location="top">
         <button
           disabled={!allowExpandTable}
@@ -93,6 +104,22 @@
           {/if}
         </TooltipContent>
       </Tooltip>
+
+      {#if onDimensionColumnResize}
+        <div class="resizer-container" style:height="{tableHeight}px">
+          <Resizer
+            side="right"
+            direction="EW"
+            min={MIN_DIMENSION_COLUMN_WIDTH}
+            max={MAX_DIMENSION_COLUMN_WIDTH}
+            basis={DEFAULT_DIMENSION_COLUMN_WIDTH}
+            dimension={dimensionColumnWidth}
+            onUpdate={onDimensionColumnResize}
+          >
+            <div class="resize-bar"></div>
+          </Resizer>
+        </div>
+      {/if}
     </th>
 
     {#each leaderboardMeasureNames as measureName, index (index)}
@@ -234,6 +261,20 @@
 
   th[data-dimension-header] {
     @apply sticky left-0 z-30 bg-surface-background text-left;
+  }
+
+  /* Visible separator at the column boundary, marking where to pick up the
+     resize handle (same as the expanded dimension table). */
+  th[data-dimension-header].resizable {
+    @apply border-r;
+  }
+
+  .resizer-container {
+    @apply absolute top-0 right-0 w-0 z-50;
+  }
+
+  .resize-bar {
+    @apply bg-primary-500 w-1 h-full;
   }
 
   th:not(:first-of-type) {

--- a/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
+++ b/web-common/src/features/dashboards/leaderboard/LeaderboardHeader.svelte
@@ -260,7 +260,9 @@
   }
 
   th[data-dimension-header] {
-    @apply sticky left-0 z-30 bg-surface-background text-left;
+    /* z-40 keeps the resize handle (which hangs below the header, down the
+       whole column) above the rows' sticky dimension cells (z-30). */
+    @apply sticky left-0 z-40 bg-surface-background text-left;
   }
 
   /* Visible separator at the column boundary, marking where to pick up the

--- a/web-common/src/features/dashboards/leaderboard/leaderboard-widths.ts
+++ b/web-common/src/features/dashboards/leaderboard/leaderboard-widths.ts
@@ -1,4 +1,5 @@
 import { clamp } from "@rilldata/web-common/lib/clamp";
+import { localStorageStore } from "@rilldata/web-common/lib/store-utils";
 import { get, writable, type Writable } from "svelte/store";
 
 export const DEFAULT_COLUMN_WIDTH = 110;
@@ -7,6 +8,10 @@ export const MEASURES_PADDING = 16;
 
 const MIN_COL_WIDTH = 56;
 const MAX_COL_WIDTH = 164;
+
+export const DEFAULT_DIMENSION_COLUMN_WIDTH = 164;
+export const MIN_DIMENSION_COLUMN_WIDTH = 120;
+export const MAX_DIMENSION_COLUMN_WIDTH = 480;
 
 class ColumnStore {
   private value: Writable<number>;
@@ -40,3 +45,11 @@ class ColumnStore {
 
 export const valueColumn = new ColumnStore(DEFAULT_COLUMN_WIDTH);
 export const deltaColumn = new ColumnStore(COMPARISON_COLUMN_WIDTH);
+
+// Width of the dimension column in explore leaderboards. Shared by all
+// leaderboards so resizing one keeps them symmetric; persisted so the
+// width is remembered across sessions.
+export const dimensionColumn = localStorageStore<number>(
+  "leaderboard-dimension-column-width",
+  DEFAULT_DIMENSION_COLUMN_WIDTH,
+);

--- a/web-local/tests/explores/leaderboard-dimension-resize.spec.ts
+++ b/web-local/tests/explores/leaderboard-dimension-resize.spec.ts
@@ -1,0 +1,60 @@
+import { expect } from "@playwright/test";
+import { gotoNavEntry } from "../utils/waitHelpers";
+import { test } from "../setup/base";
+
+test.describe("leaderboard dimension column resize", () => {
+  test.use({ project: "AdBids" });
+
+  test.beforeEach(async ({ page }) => {
+    await page.getByLabel("/dashboards").click();
+    await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
+    await page.getByRole("button", { name: "Preview" }).click();
+  });
+
+  test("resizing one leaderboard resizes all and persists", async ({
+    page,
+  }) => {
+    const publisherCol = page
+      .getByLabel("publisher leaderboard")
+      .locator("col[data-dimension-column]");
+    const domainCol = page
+      .getByLabel("domain leaderboard")
+      .locator("col[data-dimension-column]");
+
+    // Both leaderboards start at the default width
+    await expect(publisherCol).toHaveAttribute("style", /width: 164px/);
+    await expect(domainCol).toHaveAttribute("style", /width: 164px/);
+
+    // Drag the resize handle on the publisher leaderboard 76px to the right
+    const resizer = page
+      .getByLabel("publisher leaderboard")
+      .locator("th[data-dimension-header] button.EW");
+    const box = await resizer.boundingBox();
+    if (!box) throw new Error("Resizer not found");
+    const startX = box.x + box.width / 2;
+    const startY = box.y + box.height / 2;
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX + 40, startY, { steps: 4 });
+    await page.mouse.move(startX + 76, startY, { steps: 4 });
+    await page.mouse.up();
+
+    // Both leaderboards follow the new width
+    await expect(publisherCol).toHaveAttribute("style", /width: 240px/);
+    await expect(domainCol).toHaveAttribute("style", /width: 240px/);
+
+    // The width is persisted to local storage (debounced)
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          localStorage.getItem("leaderboard-dimension-column-width"),
+        ),
+      )
+      .toBe("240");
+
+    // The width is restored after a reload
+    await page.reload();
+    await expect(publisherCol).toHaveAttribute("style", /width: 240px/);
+    await expect(domainCol).toHaveAttribute("style", /width: 240px/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared persisted dimension-column width for explore leaderboards
- wire a full-height resize handle into leaderboard headers
- cover resizing, cross-leaderboard sync, and persistence with Playwright

