### PR TITLE
fix: wrap long tooltip text in `tooltip-v2` so tooltips don't clip at iframe edges

### DIFF
--- a/web-common/src/components/tooltip-v2/tooltip-content.svelte
+++ b/web-common/src/components/tooltip-v2/tooltip-content.svelte
@@ -13,7 +13,7 @@
   <TooltipPrimitive.Content
     {sideOffset}
     class={cn(
-      "bg-tooltip text-fg-inverse border shadow-md z-50 overflow-hidden rounded-md px-3 py-1.5 text-xs",
+      "bg-tooltip text-fg-inverse border shadow-md z-50 overflow-hidden rounded-md px-3 py-1.5 text-xs max-w-[min(24rem,calc(100vw-16px))] break-words",
       className,
     )}
     {...$$restProps}


### PR DESCRIPTION
- Tooltips rendered via `tooltip-v2` (e.g. dimension descriptions in the "All Dimensions" menu) had no width constraint, so long text rendered as a single line wider than the viewport and got clipped at the edge of embedded iframes.
- Adds a default `max-w-[min(24rem,calc(100vw-16px))] break-words` to the shared `tooltip-content.svelte` so long text wraps within a ~384px box (and fits even in narrow embeds); bits-ui's collision handling then keeps the tooltip fully inside the viewport.
- Call sites that set their own `max-w-*` are unaffected since the class goes through tailwind-merge.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!