### PR TITLE
Preserve model output on connector change in manual/patch change mode

### DIFF
--- a/runtime/reconcilers/model.go
+++ b/runtime/reconcilers/model.go
@@ -212,7 +212,10 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceNa
 	// Check refs - stop if any of them are invalid
 	err = checkRefs(ctx, r.C, self.Meta.Refs)
 	if err != nil {
-		// If not staging changes, we need to drop the previous output (if any) before returning
+		// If not staging changes, we need to drop the previous output (if any) before returning.
+		// Note: ChangeMode is intentionally not checked here.
+		// When StageChanges is off, the manual/patch data-preservation guarantee does not apply,
+		// so dropping the previous output on invalid refs is acceptable.
 		if !modelEnv.StageChanges && prevManager != nil {
 			err := r.execSem.Acquire(ctx, 1)
 			if err != nil {
@@ -337,7 +340,12 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceNa
 
 	// If the output connector has changed, drop data in the old output connector (if any).
 	// If only the output properties have changed, the executor will handle dropping existing data (to comply with StageChanges).
-	if prevManager != nil && model.State.ResultConnector != model.Spec.OutputConnector {
+	// This drop is not gated by StageChanges, so in manual/patch mode we never do it automatically:
+	// the old connector's data is left in place for the user to remove manually.
+	// Only reset mode drops the old output when the connector changes.
+	if prevManager != nil && model.State.ResultConnector != model.Spec.OutputConnector &&
+		model.Spec.ChangeMode != runtimev1.ModelChangeMode_MODEL_CHANGE_MODE_MANUAL &&
+		model.Spec.ChangeMode != runtimev1.ModelChangeMode_MODEL_CHANGE_MODE_PATCH {
 		err = prevManager.Delete(ctx, prevResult)
 		if err != nil {
 			r.C.Logger.Warn("failed to delete model output", zap.String("model", n.Name), zap.Error(err), observability.ZapCtx(ctx))
@@ -419,7 +427,10 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceNa
 		}
 	}
 
-	// If the build failed, clear the state only if we're not staging changes
+	// If the build failed, clear the state only if we're not staging changes.
+	// Note: ChangeMode is intentionally not checked here.
+	// When StageChanges is off, the manual/patch data-preservation guarantee does not apply,
+	// so clearing the state after a failed build is acceptable.
 	if execErr != nil {
 		if !modelEnv.StageChanges {
 			err := r.clearPartitions(ctx, model)

--- a/runtime/reconcilers/model_test.go
+++ b/runtime/reconcilers/model_test.go
@@ -52,6 +52,68 @@ sql: SELECT '{{.partition.now}}::TIMESTAMP' AS now
 	})
 }
 
+// TestPatchModeOutputConnectorChangePreservesData verifies that in change_mode=patch,
+// changing the model's output connector never drops the existing data in the old connector.
+// The reconciler leaves the old output in place (for the user to remove manually),
+// on both automatic runs and explicit triggers.
+func TestPatchModeOutputConnectorChangePreservesData(t *testing.T) {
+	rt, instanceID := testruntime.NewInstance(t)
+
+	// Declare a second output connector to migrate to.
+	testruntime.PutFiles(t, rt, instanceID, map[string]string{
+		"rill.yaml": ``,
+		"connectors/alt.yaml": `
+type: connector
+driver: duckdb
+`,
+		// An upstream model whose refreshes drive an automatic (ref_update) reconcile of the downstream model.
+		"models/up.yaml": `
+type: model
+sql: SELECT 1 AS id
+`,
+		// The downstream incremental patch-mode model, initially writing to the default connector.
+		"models/down.yaml": `
+type: model
+incremental: true
+change_mode: patch
+refresh:
+  ref_update: true
+sql: SELECT * FROM up
+`,
+	})
+	testruntime.ReconcileParserAndWait(t, rt, instanceID)
+
+	// Explicitly build the downstream model so it has prior state on the default connector.
+	testruntime.RefreshModelAndWait(t, rt, instanceID, &runtimev1.RefreshModelTrigger{Model: "down", Full: true})
+	testruntime.RequireOLAPTableCount(t, rt, instanceID, "down", 1)
+
+	// Change the output connector.
+	// In patch mode this is absorbed (spec hash patched) without triggering execution, so nothing is dropped yet.
+	testruntime.PutFiles(t, rt, instanceID, map[string]string{
+		"models/down.yaml": `
+type: model
+incremental: true
+change_mode: patch
+refresh:
+  ref_update: true
+output:
+  connector: alt
+sql: SELECT * FROM up
+`,
+	})
+	testruntime.ReconcileParserAndWait(t, rt, instanceID)
+	testruntime.RequireOLAPTableCount(t, rt, instanceID, "down", 1)
+
+	// Drive an automatic reconcile of the downstream model by refreshing the upstream model (ref_update).
+	// This is not an explicit trigger of "down", so the old connector's data must not be dropped.
+	testruntime.RefreshModelAndWait(t, rt, instanceID, &runtimev1.RefreshModelTrigger{Model: "up", Full: true})
+	testruntime.RequireOLAPTableCount(t, rt, instanceID, "down", 1)
+
+	// An explicit full trigger of the downstream model must also leave the old connector's data in place.
+	testruntime.RefreshModelAndWait(t, rt, instanceID, &runtimev1.RefreshModelTrigger{Model: "down", Full: true})
+	testruntime.RequireOLAPTableCount(t, rt, instanceID, "down", 1)
+}
+
 func TestPartitionedIncrementalPostExecSeesIncrementalFlag(t *testing.T) {
 	rt, instanceID := testruntime.NewInstance(t)
 


### PR DESCRIPTION
- In `manual`/`patch` change mode, the reconciler no longer automatically drops the old output when a model's output connector changes; the data is left in place for the user to remove manually.
- Only `reset` mode continues to drop the old output on a connector change. Documents the two `StageChanges`-guarded drop paths where `ChangeMode` is intentionally not consulted.
