### PR TITLE
fix: broken E2E after expanding directories by default

### DIFF
--- a/web-local/tests/explores/leaderboard-dimension-resize.spec.ts
+++ b/web-local/tests/explores/leaderboard-dimension-resize.spec.ts
@@ -6,7 +6,6 @@ test.describe("leaderboard dimension column resize", () => {
   test.use({ project: "AdBids" });
 
   test.beforeEach(async ({ page }) => {
-    await page.getByLabel("/dashboards").click();
     await gotoNavEntry(page, "/dashboards/AdBids_metrics_explore.yaml");
     await page.getByRole("button", { name: "Preview" }).click();
   });


### PR DESCRIPTION
- The e2e test added in #9684 clicks `getByLabel("/dashboards")` to expand the directory, but #9682 made file-explorer directories expanded by default, so the label now resolves to 5 elements and the click fails with a strict mode violation. This breaks `e2e (web-local)` on every PR.
- Removes the expand click; `gotoNavEntry` alone is the pattern the other explore specs use.
- Verified locally: the spec passes (`1 passed`).

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!