### PR TITLE
fix: file list in revert confirmation dialog overlaps instead of scrolling

### DIFF
--- a/web-common/src/features/project/changes/RevertConfirmDialog.svelte
+++ b/web-common/src/features/project/changes/RevertConfirmDialog.svelte
@@ -65,6 +65,8 @@
   }
 
   .file-list li {
-    @apply truncate;
+    /* shrink-0 keeps items at full height when the list overflows max-h; without it,
+       truncate's overflow:hidden lets flex shrink the items so they overlap instead of scrolling */
+    @apply truncate shrink-0;
   }
 </style>


### PR DESCRIPTION
- With many changed files, the file list in the revert confirmation dialog rendered as overlapping text instead of scrolling.
- The list is a `flex flex-col` container with `max-h-40 overflow-y-auto`, but each `li` uses `truncate` (`overflow: hidden`), which drops the flex items' automatic minimum size to zero — so flexbox compressed the rows vertically rather than overflowing into the scrollbar.
- Added `shrink-0` to the list items so they keep their natural height and the list scrolls as intended.

Before this overlapping text - 
<img width="525" height="356" alt="Screenshot 2026-07-15 at 9 35 59 PM" src="https://github.com/user-attachments/assets/701fb68c-ea4e-4922-8f02-f22c07bbf6bb" />


After this, clear listing and scrollable list - 
<img width="511" height="340" alt="Screenshot 2026-07-15 at 9 34 36 PM" src="https://github.com/user-attachments/assets/0e002787-4183-40fd-8171-7b377ac10027" />


**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!