### PR TITLE
docs: release notes for 0.88

### DIFF
--- a/docs/blog/0.88.md
+++ b/docs/blog/0.88.md
@@ -1,0 +1,114 @@
+---
+date: 2026-07-15
+image: https://github.com/rilldata/rill/assets/5587788/b30486f6-002a-445d-8a1b-955b6ec0066d
+description: Rill is the world's first AI-native business intelligence tool. Trusted by thousands of developers and analysts around the globe, Rill accelerates the creation of dashboards and data applications using BI-as-code.
+---
+
+# Rill 0.88 - Canvas Tab Groups, PDF Export, Resource Tags and Cloud Editing Improvements
+
+:::note
+⚡ Rill's BI-as-code powers fast dashboards, embedded analytics, and an agent-ready semantic layer — all running on top of the warehouses you already use.
+
+👉 [Get Started](https://ui.rilldata.com) • [Join our Discord](https://discord.gg/2ubRfjC7Rh)
+:::
+
+## Canvas Tab Groups
+
+Canvas dashboards now support **tab groups**, so you can organize a large dashboard into tabs instead of one long scroll. Mix regular rows with one or more tab groups on the same canvas — for example, an overview up top with tabs for each region or product line below. Only the active tab loads its data, dashboards stay fast even as number of tabs grow. In the visual canvas editor you can add, rename, reorder, and delete tabs, turn existing rows into a tab group, and drag components between tabs.
+
+## Canvas PDF Export
+
+Canvas dashboards can now be downloaded as a **PDF** straight from the Share menu — perfect for sending a snapshot to stakeholders who aren't in Rill.
+
+## Tags for All Resources
+
+Building on last release's tags for dimensions and measures, **tags can now be added to any resource** — dashboards, models, metrics views, and more. Each dashboard shows its tags in the project dashboard list, and a new tag filter on the project home page makes it easy to find the right dashboard in a large project — filter to "Marketing", "Finance", or whatever grouping fits your team. Tags can be managed from the visual editor, and a feature flag lets you browse tags as folders in the sidebar.
+
+## URI Dimensions as Links Everywhere
+
+Dimensions that link to a URL — like a campaign, ad, or page dimension — were previously only clickable in the leaderboard. Now they're clickable everywhere values appear: the **dimension table, pivot tables, and Time Dimension Detail**. Hover over a value and jump straight to the underlying page in a new tab, without leaving your analysis. See [`uri` in the metrics view reference](/reference/project-files/metrics-views) to set this up.
+
+## Cloud Editing Improvements
+
+Cloud Editing (beta) got a significant round of polish this release:
+
+- **Preview changes before publishing:** the Merge/Publish flow now lists every changed file with a full side-by-side diff, so you can see exactly what you're about to publish.
+- **Undo changes from the UI:** made an edit you don't want to keep? You can now revert a single file, revert a selected set of files, or discard all changes — each behind a confirmation so nothing is lost by accident.
+- Fixed an issue with edit session getting stuck at "Starting" when resumed, along with several smaller issues in the editing experience.
+
+## Personal Canvas Dashboards (Beta)
+
+You can now build your own **personal canvas dashboards** directly from the project home page in Rill Cloud. Personal dashboards are private to you and stay out of the project's shared dashboard list — a great way to experiment with your own views of the data. When one is ready for a wider audience, share it with the project in one click. Available in beta behind the `personal_canvases` feature flag.
+
+## Starter and Growth Plans
+
+Rill Cloud now offers **Starter** and **Growth** self-serve plans with higher quotas as part of our new [pricing](https://www.rilldata.com/pricing). Every new trials come with free credits, and org admins get a **usage page** to see where their spend is going.
+
+## Bug Fixes and Improvements
+
+### Explore / Dashboards
+
+- Added a resizable leaderboard dimension column, synced across leaderboards and persisted
+- Added a resizable divider between the chart and detail table in Time Dimension Detail, and persisted the explore timeseries/leaderboard split
+- Surfaced defined time dimensions in the visual metrics editor's time column picker and in time picker tooltips
+- Persisted exclude mode for Select filters so the URL serializes correctly
+- Fixed the Select dimension filter auto-switching to In List when typing commas
+- Fixed dimension filter chip exclude state not re-rendering
+- Showed a loading spinner in the expanded dimension table instead of a blank panel
+- Showed the full value in the cell inspector for expanded dimension tables
+- Added measure and dimension name tooltips to the pivot view
+- Wrapped long tooltip text so tooltips don't clip at iframe edges
+- Made the timezone list scrollable when not searching
+- Disabled timeseries "Explain" when AI is disabled
+
+### Charts
+
+- Improved sparse data handling in time series charts: null gaps are bridged consistently and the hover cursor snaps to the nearest data point
+
+### Canvas
+
+- Made pivot tables fill their container in canvas
+- Fixed a transient "Metrics view not found" error flash in canvas table and pivot components while metrics views load
+- Fixed canvas component subscribe/unsubscribe race conditions and leaked spec subscriptions
+- Fixed canvas dashboard filenames containing dots
+- Hid the Discord link in embedded canvas pivot tables
+
+### Models
+
+- Allowed glob `start` and `end` to compose with `transform_sql`
+- Made the glob resolver's `last` parameter a hard limit on returned partitions, including on first runs
+- Added the ability to fully disable models in a project
+- Fixed `post_exec` not running for the first partition in a full reset
+- Fixed incremental logic not applying to the second partition in a full refresh
+- Added validation for bounded time ranges in rollup data ranges
+- Logged the executing model partition at info level
+
+### Connectors
+
+- Used `arrayJoin` for ClickHouse unnests
+- Prevented ClickHouse tenant database name collisions by keeping the resource ID from being truncated
+- Ran system sync replica before replace partition on replicated ClickHouse engines, gated behind a config
+
+### AI / LLM
+
+- Improved the developer agent's context
+
+### Rill Developer
+
+- Rendered `.parquet` files as a data preview in the file browser instead of erroring
+- Added a `--force-push` flag to `rill deploy` for Rill-managed repos
+- Overhauled env variable management with a centralized store and edit sessions
+- Fixed the env of unpublished projects not being editable
+
+### Cloud
+
+- Moved deployment resource checks into the deployment reconciliation logic to prevent race conditions
+- Fixed exports failing intermittently due to tmp directory errors
+- Fixed the download handler checking the wrong claims
+- Fixed the project creation flow setting its own slots
+- Used a branch-aware URL for the Project Graphs link in the DAG overlay
+- Redirected to the project home when a user with access lands on the request-access page
+
+### Embedding
+
+- Added `setValidState` to the embed API: validates state params against the dashboard's specs upfront, reports invalid parameters, and returns the applied state

--- a/docs/blog/0.88.md
+++ b/docs/blog/0.88.md
@@ -42,7 +42,7 @@ You can now build your own **personal canvas dashboards** directly from the proj
 
 ## Starter and Growth Plans
 
-Rill Cloud now offers **Starter** and **Growth** self-serve plans with higher quotas as part of our new [pricing](https://www.rilldata.com/pricing). Every new trials come with free credits, and org admins get a **usage page** to see where their spend is going.
+Rill Cloud now offers **Starter** and **Growth** self-serve plans with higher quotas as part of our new [pricing](https://www.rilldata.com/pricing). Every new trial comes with $250 in free credits, and org admins get a **usage page** to see where their spend is going.
 
 ## Bug Fixes and Improvements
 

--- a/docs/blog/0.88.md
+++ b/docs/blog/0.88.md
@@ -1,20 +1,18 @@
 ---
-date: 2026-07-15
-image: https://github.com/rilldata/rill/assets/5587788/b30486f6-002a-445d-8a1b-955b6ec0066d
-description: Rill is the world's first AI-native business intelligence tool. Trusted by thousands of developers and analysts around the globe, Rill accelerates the creation of dashboards and data applications using BI-as-code.
----
+
+## date: 2026-07-15 image: https://github.com/rilldata/rill/assets/5587788/b30486f6-002a-445d-8a1b-955b6ec0066d description: Rill is the world's first AI-native business intelligence tool. Trusted by thousands of developers and analysts around the globe, Rill accelerates the creation of dashboards and data applications using BI-as-code.
 
 # Rill 0.88 - Canvas Tab Groups, PDF Export, Resource Tags and Cloud Editing Improvements
 
-:::note
-⚡ Rill's BI-as-code powers fast dashboards, embedded analytics, and an agent-ready semantic layer — all running on top of the warehouses you already use.
+:::note ⚡ Rill's BI-as-code powers fast dashboards, embedded analytics, and an agent-ready semantic layer — all running on top of the warehouses you already use.
 
-👉 [Get Started](https://ui.rilldata.com) • [Join our Discord](https://discord.gg/2ubRfjC7Rh)
-:::
+👉 [Get Started](https://ui.rilldata.com) • [Join our Discord](https://discord.gg/2ubRfjC7Rh):::
+
+![release-0.88](https://cdn.rilldata.com/docs/release-notes/release-0.88.gif)
 
 ## Canvas Tab Groups
 
-Canvas dashboards now support **tab groups**, so you can organize a large dashboard into tabs instead of one long scroll. Mix regular rows with one or more tab groups on the same canvas — for example, an overview up top with tabs for each region or product line below. Only the active tab loads its data, dashboards stay fast even as number of tabs grow. In the visual canvas editor you can add, rename, reorder, and delete tabs, turn existing rows into a tab group, and drag components between tabs.
+Canvas dashboards now support **tab groups**, so you can organize a large dashboard into tabs instead of one long scroll. Mix regular rows with one or more tab groups on the same canvas — for example, an overview up top with tabs for each region or product line below. Only the active tab loads its data, so dashboards stay fast even as the number of tabs grows. In the visual canvas editor you can add, rename, reorder, and delete tabs, turn existing rows into a tab group, and drag components between tabs.
 
 ## Canvas PDF Export
 
@@ -26,7 +24,7 @@ Building on last release's tags for dimensions and measures, **tags can now be a
 
 ## URI Dimensions as Links Everywhere
 
-Dimensions that link to a URL — like a campaign, ad, or page dimension — were previously only clickable in the leaderboard. Now they're clickable everywhere values appear: the **dimension table, pivot tables, and Time Dimension Detail**. Hover over a value and jump straight to the underlying page in a new tab, without leaving your analysis. See [`uri` in the metrics view reference](/reference/project-files/metrics-views) to set this up.
+Dimensions that link to a URL — like a campaign, ad, or page dimension — were previously only clickable in the leaderboard. Now they're clickable everywhere values appear: the **dimension table, pivot tables, and Time Dimension Detail**. Hover over a value and jump straight to the underlying page in a new tab, without leaving your analysis. See `uri`[ in the metrics view reference](/reference/project-files/metrics-views) to set this up.
 
 ## Cloud Editing Improvements
 

--- a/docs/blog/0.88.md
+++ b/docs/blog/0.88.md
@@ -1,12 +1,16 @@
 ---
-
-## date: 2026-07-15 image: https://github.com/rilldata/rill/assets/5587788/b30486f6-002a-445d-8a1b-955b6ec0066d description: Rill is the world's first AI-native business intelligence tool. Trusted by thousands of developers and analysts around the globe, Rill accelerates the creation of dashboards and data applications using BI-as-code.
+date: 2026-07-15
+image: https://github.com/rilldata/rill/assets/5587788/b30486f6-002a-445d-8a1b-955b6ec0066d
+description: Rill is the world's first AI-native business intelligence tool. Trusted by thousands of developers and analysts around the globe, Rill accelerates the creation of dashboards and data applications using BI-as-code.
+---
 
 # Rill 0.88 - Canvas Tab Groups, PDF Export, Resource Tags and Cloud Editing Improvements
 
-:::note ⚡ Rill's BI-as-code powers fast dashboards, embedded analytics, and an agent-ready semantic layer — all running on top of the warehouses you already use.
+:::note
+⚡ Rill's BI-as-code powers fast dashboards, embedded analytics, and an agent-ready semantic layer — all running on top of the warehouses you already use.
 
-👉 [Get Started](https://ui.rilldata.com) • [Join our Discord](https://discord.gg/2ubRfjC7Rh):::
+👉 [Get Started](https://ui.rilldata.com) • [Join our Discord](https://discord.gg/2ubRfjC7Rh)
+:::
 
 ![release-0.88](https://cdn.rilldata.com/docs/release-notes/release-0.88.gif)
 
@@ -24,7 +28,7 @@ Building on last release's tags for dimensions and measures, **tags can now be a
 
 ## URI Dimensions as Links Everywhere
 
-Dimensions that link to a URL — like a campaign, ad, or page dimension — were previously only clickable in the leaderboard. Now they're clickable everywhere values appear: the **dimension table, pivot tables, and Time Dimension Detail**. Hover over a value and jump straight to the underlying page in a new tab, without leaving your analysis. See `uri`[ in the metrics view reference](/reference/project-files/metrics-views) to set this up.
+Dimensions that link to a URL — like a campaign, ad, or page dimension — were previously only clickable in the leaderboard. Now they're clickable everywhere values appear: the **dimension table, pivot tables, and Time Dimension Detail**. Hover over a value and jump straight to the underlying page in a new tab, without leaving your analysis. See [`uri` in the metrics view reference](/reference/project-files/metrics-views) to set this up.
 
 ## Cloud Editing Improvements
 


### PR DESCRIPTION
Adds release notes for Rill 0.88, covering changes between `release-0.87` and `release-0.88`.

- Headline sections: canvas tab groups, canvas PDF export, tags for all resources, URI dimensions as links, cloud editing improvements, personal canvas dashboards (beta), and Starter/Growth plans
- Categorized bug fixes and improvements, excluding items already announced in the 0.87 notes and including a few fixes from the 0.87 cycle that were never announced

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!