### PR TITLE
Update AI resource skills

### DIFF
--- a/runtime/ai/instructions/data/development.md
+++ b/runtime/ai/instructions/data/development.md
@@ -44,6 +44,7 @@ The other YAML and SQL files define individual resources in the project. They fo
 - Resources can reference other resources, which forms a dependency graph (DAG) that informs the sequence they are executed.
 - Resource names are unique within a resource type. For example, only one model can be named `events` (regardless of directory), but it is possible for both a model and a metrics view to be called `events`.
 - Clear resource names are important as they are widely used as unique identifiers throughout the platform (e.g. in CLI commands, URL slugs, API calls). They are usually lowercase and snake case, but that is not enforced.
+- Any resource can carry a top-level `tags:` list (free-form labels) for organizing and filtering resources across a project. Distinct from dimension/measure tags inside a metrics view.
 
 ## Project execution
 
@@ -83,11 +84,12 @@ They are usually lightweight as their reconcile logic usually only validates the
 They are normally found at the root of the DAG, powering other downstream resource types.
 
 There are a variety of built-in connector _drivers_, which each implements one or more capabilities:
-- **OLAP database:** can power dashboards (e.g. `duckdb`, `clickhouse`)
+- **OLAP database:** can power dashboards (e.g. `duckdb`, `clickhouse`, `druid`, `pinot`, `starrocks`, and `snowflake`, `bigquery`, `databricks` as live connectors)
 - **SQL database:** can run SQL queries and models (e.g. `postgres`, `bigquery`, `snowflake`)
 - **Information schema:** can list tables and their schemas (e.g. `duckdb`, `bigquery`, `postgres`)
 - **Object store:** can list, read and write flat files (e.g. `s3`)
 - **Notifier:** can send notifications (e.g. `slack`)
+- **AI:** can generate embeddings or responses (e.g. `openai`, `claude`, `gemini`)
 
 Here are some useful things to know when developing connectors:
 - Actual secrets like database passwords should go in `.env` and be referenced from the connector's YAML file

--- a/runtime/ai/instructions/data/resources/canvas.md
+++ b/runtime/ai/instructions/data/resources/canvas.md
@@ -168,6 +168,26 @@ rows:
 - `width: 4` - Third width; use for three equal charts
 - `width: 3` - Quarter width; use for four small components (minimum practical width)
 
+### Tab groups
+
+A row entry can be a tab group instead of a plain row. A tab group has a `name` (URL key) and a list of `tabs`, each with a `label`, optional `name`, and its own `rows`. Only the active tab loads data. Allowed only at the top level, not nested inside a tab.
+
+```yaml
+rows:
+  - name: by_region
+    tabs:
+      - label: North America
+        rows:
+          - items:
+              - width: 6
+                bar_chart: # ...
+      - label: EMEA
+        rows:
+          - items:
+              - width: 6
+                bar_chart: # ...
+```
+
 ## Dashboard Composition Best Practices
 
 When building a new canvas dashboard, follow this recommended structure:

--- a/runtime/ai/instructions/data/resources/connector.md
+++ b/runtime/ai/instructions/data/resources/connector.md
@@ -14,7 +14,7 @@ Connectors are usually lightweight resources. When reconciled, they validate the
 
 Each connector uses a **driver** that implements one or more capabilities:
 
-- **OLAP database**: Can power metrics views and dashboards (e.g., `duckdb`, `clickhouse`, `druid`, `pinot`, `starrocks`; `snowflake`, `bigquery`, `databricks` as live connectors)
+- **OLAP database**: Can power metrics views and dashboards (e.g., `duckdb`, `clickhouse`, `druid`, `pinot`, `starrocks`, `snowflake`, `bigquery`, `databricks` as live connectors)
 - **SQL database**: Can run SQL queries as model inputs (e.g., `postgres`, `bigquery`, `snowflake`)
 - **Information schema**: Can list tables and their schemas (e.g., `duckdb`, `bigquery`)
 - **Object store**: Can list, read, and write flat files (e.g., `s3`, `gcs`)

--- a/runtime/ai/instructions/data/resources/connector.md
+++ b/runtime/ai/instructions/data/resources/connector.md
@@ -14,7 +14,7 @@ Connectors are usually lightweight resources. When reconciled, they validate the
 
 Each connector uses a **driver** that implements one or more capabilities:
 
-- **OLAP database**: Can power metrics views and dashboards (e.g., `duckdb`, `clickhouse`, `druid`, `pinot`, `starrocks`; also `snowflake`, `bigquery`, `databricks` as live connectors)
+- **OLAP database**: Can power metrics views and dashboards (e.g., `duckdb`, `clickhouse`, `druid`, `pinot`, `starrocks`; `snowflake`, `bigquery`, `databricks` as live connectors)
 - **SQL database**: Can run SQL queries as model inputs (e.g., `postgres`, `bigquery`, `snowflake`)
 - **Information schema**: Can list tables and their schemas (e.g., `duckdb`, `bigquery`)
 - **Object store**: Can list, read, and write flat files (e.g., `s3`, `gcs`)

--- a/runtime/ai/instructions/data/resources/connector.md
+++ b/runtime/ai/instructions/data/resources/connector.md
@@ -14,12 +14,12 @@ Connectors are usually lightweight resources. When reconciled, they validate the
 
 Each connector uses a **driver** that implements one or more capabilities:
 
-- **OLAP database**: Can power metrics views and dashboards (e.g., `duckdb`, `clickhouse`)
+- **OLAP database**: Can power metrics views and dashboards (e.g., `duckdb`, `clickhouse`, `druid`, `pinot`, `starrocks`; also `snowflake`, `bigquery`, `databricks` as live connectors)
 - **SQL database**: Can run SQL queries as model inputs (e.g., `postgres`, `bigquery`, `snowflake`)
 - **Information schema**: Can list tables and their schemas (e.g., `duckdb`, `bigquery`)
 - **Object store**: Can list, read, and write flat files (e.g., `s3`, `gcs`)
 - **Notifier**: Can send notifications and alerts (e.g., `slack`)
-- **AI**: Can generate embeddings or responses (e.g., `openai`)
+- **AI**: Can generate embeddings or responses (e.g., `openai`, `claude`, `gemini`)
 
 ## Core Concepts
 
@@ -181,10 +181,26 @@ Amazon Athena. Key properties:
 - `region`: AWS region
 - `output_location`: S3 path in format `s3://bucket/path` to store temporary query results in (Athena only)
 
+### StarRocks
+
+StarRocks live OLAP connector (query in place, no ingestion). Key properties:
+
+- `host`, `port`, `username`, `password`, `database`, `catalog`: Connection parameters
+- `ssl: true`: Enable a secure connection
+- `dsn`: Connection string in place of separate parameters
+
+### Databricks
+
+Databricks, as a live OLAP connector or a data source for ingestion. Key properties:
+
+- `host`, `http_path`, `token`: SQL warehouse hostname, HTTP path, and access token
+- `catalog`, `schema`: Unity Catalog name and schema (optional; default to workspace defaults)
+- `dsn`: Connection string in place of separate parameters
+
 ### Other drivers
 
 - **Slack**: Use `bot_token` for alert notifications
-- **OpenAI** or **Claude**: Use `api_key` for AI-powered features
+- **OpenAI**, **Claude**, or **Gemini**: Use `api_key` for AI-powered features; optionally set `model` to override the default
 - **HTTPS**: Simple connector for public HTTP sources
 - **Pinot**: Use `broker_host`, `controller_host`, `username`, `password`
 
@@ -402,6 +418,43 @@ region: us-east-1
 database: "analytics"
 ```
 
+### StarRocks
+
+```yaml
+# connectors/starrocks.yaml
+type: connector
+driver: starrocks
+host: "{{ .env.starrocks_host }}"
+port: 9030
+username: "{{ .env.starrocks_user }}"
+password: "{{ .env.starrocks_password }}"
+database: "analytics"
+```
+
+### Databricks
+
+```yaml
+# connectors/databricks.yaml
+type: connector
+driver: databricks
+host: "dbc-xxxxxxxx-xxxx.cloud.databricks.com"
+http_path: "/sql/1.0/warehouses/xxxxxxxxxxxxxxxx"
+token: "{{ .env.databricks_token }}"
+catalog: "main"
+schema: "default"
+```
+
+### DuckLake
+
+DuckLake lakehouse. Uses the DuckDB driver with an `attach:` clause pointing at the catalog and data path; queried live (no ingestion):
+
+```yaml
+# connectors/ducklake.yaml
+type: connector
+driver: duckdb
+attach: "'ducklake:metadata.ducklake' (DATA_PATH 's3://my-bucket/ducklake/')"
+```
+
 ### OpenAI
 
 ```yaml
@@ -418,6 +471,15 @@ api_key: "{{ .env.openai_api_key }}"
 type: connector
 driver: claude
 api_key: "{{ .env.claude_api_key }}"
+```
+
+### Gemini
+
+```yaml
+# connectors/gemini.yaml
+type: connector
+driver: gemini
+api_key: "{{ .env.gemini_api_key }}"
 ```
 
 ### Slack

--- a/runtime/ai/instructions/data/resources/metrics_view.md
+++ b/runtime/ai/instructions/data/resources/metrics_view.md
@@ -369,6 +369,34 @@ cache:
 
 You should not add a `cache:` config when the metrics view references a model inside the project since Rill does automatic cache management in that case.
 
+### Tags on dimensions and measures
+
+Add `tags:` (free-form labels) to a dimension or measure to group and filter the dropdowns and pivot tables:
+
+```yaml
+dimensions:
+  - name: campaign_name
+    column: campaign_name
+    tags: [marketing]
+measures:
+  - name: total_spend
+    expression: SUM(spend)
+    tags: [marketing, finance]
+```
+
+### Rollups
+
+Rollups back a metrics view with pre-aggregated tables. When a query's grain, dimensions, measures, time range, and filters match a rollup, Rill reads the smaller table instead of the base table for faster results. Requires a `timeseries:`.
+
+```yaml
+rollups:
+  - model: events_daily       # Pre-aggregated model
+    time_grain: day           # Required
+    dimensions: [country]     # Optional; defaults to all
+    measures: [total_events]  # Optional; defaults to all
+    data_time_range: P90D     # Optional; only route queries in this range
+```
+
 ## Dialect-Specific Notes
 
 SQL expressions in dimensions and measures use the underlying OLAP database's dialect.

--- a/runtime/ai/instructions/data/resources/metrics_view.md
+++ b/runtime/ai/instructions/data/resources/metrics_view.md
@@ -390,11 +390,11 @@ Rollups back a metrics view with pre-aggregated tables. When a query's grain, di
 
 ```yaml
 rollups:
-  - model: events_daily       # Pre-aggregated model
-    time_grain: day           # Required
-    dimensions: [country]     # Optional; defaults to all
-    measures: [total_events]  # Optional; defaults to all
-    data_time_range: P90D     # Optional; only route queries in this range
+  - model: events_daily           # Pre-aggregated model
+    time_grain: day               # Required
+    dimensions: [country]         # Optional; defaults to all
+    measures: [total_events]      # Optional; defaults to all
+    data_time_range: -90D to now  # Optional; indicates rollup data time range if set otherwise min/max queries are done on the timeseries column to figure out rollup's data time range
 ```
 
 ## Dialect-Specific Notes

--- a/runtime/ai/instructions/data/resources/model.md
+++ b/runtime/ai/instructions/data/resources/model.md
@@ -138,6 +138,15 @@ Available template variables:
 
 By default, `glob:` matches files only, but you can pass `partition: directory` to have it emit leaf directory names instead. When you use `partition: directory`, the partition's URI will not include an asterisk, so you have to append that in the SQL query, e.g. `{{ .partition.uri }}/*.parquet`.
 
+Narrow which partitions are matched with `start`/`end` (inclusive/exclusive path bounds) or `last` (keep only the N highest paths; not allowed with `transform_sql`):
+
+```yaml
+partitions:
+  glob:
+    path: s3://bucket/year=*/month=*/day=*
+    last: 180   # Most recent 180 partitions
+```
+
 ### SQL-based partitions
 
 Generate partitions using a SQL query:
@@ -459,6 +468,22 @@ type: model
 
 connector: https
 uri: https://example.com/public/dataset.parquet
+```
+
+### Iceberg / Delta Lake table via DuckDB
+
+Read Iceberg or Delta tables with DuckDB's `iceberg_scan()` / `delta_scan()`. `create_secrets_from_connectors` reuses an object store connector's credentials (GCS requires `key_id`/`secret` HMAC keys):
+
+```yaml
+# models/iceberg_data.yaml
+type: model
+connector: duckdb
+create_secrets_from_connectors: s3
+materialize: true
+
+sql: |
+  SELECT * FROM iceberg_scan('s3://my-bucket/path/to/iceberg_table')
+  -- or: FROM delta_scan('s3://my-bucket/path/to/delta_table')
 ```
 
 ### Partition-based incremental S3 to DuckDB

--- a/runtime/ai/instructions/data/resources/rillyaml.md
+++ b/runtime/ai/instructions/data/resources/rillyaml.md
@@ -55,10 +55,6 @@ Project-wide defaults can be set for resource types using plural keys:
 
 Individual resources can override these defaults.
 
-### Resource tags
-
-Any resource can carry a top-level `tags:` list (free-form labels) for organizing and filtering resources across a project. Set per resource file, not in `rill.yaml`. Distinct from dimension/measure tags inside a metrics view.
-
 ### Path management
 
 - `ignore_paths`: List of paths to exclude from parsing (use leading `/`)

--- a/runtime/ai/instructions/data/resources/rillyaml.md
+++ b/runtime/ai/instructions/data/resources/rillyaml.md
@@ -24,6 +24,10 @@ The `olap_connector` property sets the default OLAP database for the project. Mo
 
 Common values are `duckdb` or `clickhouse`. If not specified, Rill initializes a managed DuckDB database and uses it as the default OLAP connector. 
 
+### Default AI connector
+
+The `ai_connector` property selects the connector powering AI features (developer agent, AI charts, chat). Point it at a project AI connector such as `openai`, `claude`, or `gemini`. Defaults to Rill's built-in AI service.
+
 ### Mock users for security testing
 
 The `mock_users` property defines test users for validating security policies during local development. Each mock user can have:
@@ -51,6 +55,10 @@ Project-wide defaults can be set for resource types using plural keys:
 
 Individual resources can override these defaults.
 
+### Resource tags
+
+Any resource can carry a top-level `tags:` list (free-form labels) for organizing and filtering resources across a project. Set per resource file, not in `rill.yaml`. Distinct from dimension/measure tags inside a metrics view.
+
 ### Path management
 
 - `ignore_paths`: List of paths to exclude from parsing (use leading `/`)
@@ -77,6 +85,9 @@ display_name: Sales Analytics
 description: Sales performance dashboards with partner access controls
 
 olap_connector: duckdb
+
+# Use a project-defined Claude connector to power AI features
+ai_connector: claude
 
 # Non-sensitive environment variables
 env:

--- a/runtime/ai/instructions/data/resources/rillyaml.md
+++ b/runtime/ai/instructions/data/resources/rillyaml.md
@@ -26,7 +26,7 @@ Common values are `duckdb` or `clickhouse`. If not specified, Rill initializes a
 
 ### Default AI connector
 
-The `ai_connector` property selects the connector powering AI features (developer agent, AI charts, chat). Point it at a project AI connector such as `openai`, `claude`, or `gemini`. Defaults to Rill's built-in AI service.
+The `ai_connector` property selects the connector powering AI features (developer agent, AI charts, chat). Point it to an AI connector defined in the project, such as `openai`, `claude`, or `gemini`. Defaults to Rill's built-in AI service.
 
 ### Mock users for security testing
 


### PR DESCRIPTION
Adds resource-authoring guidance to the AI development skills (`runtime/ai/instructions/data/resources/`). 

- `connector`: StarRocks, Databricks, and DuckLake connectors; Gemini AI provider; live-OLAP capability list
- `metrics_view`: `tags` on dimensions/measures; `rollups`
- `model`: glob `start`/`end`/`last` partition window; Iceberg/Delta reads via DuckDB
- `canvas`: tab groups
- `rill.yaml`: `ai_connector`; resource-level `tags`

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!