### PR TITLE
fix: `.env` variables pushed to the wrong project when deploy hits a name collision

### DIFF
--- a/cli/pkg/local/server.go
+++ b/cli/pkg/local/server.go
@@ -452,8 +452,8 @@ func (s *Server) DeployProject(ctx context.Context, r *connect.Request[localv1.D
 	}
 	if len(dotenv) > 0 {
 		_, err = c.UpdateProjectVariables(ctx, &adminv1.UpdateProjectVariablesRequest{
-			Org:       r.Msg.Org,
-			Project:   r.Msg.ProjectName,
+			Org:       projResp.Project.OrgName,
+			Project:   projResp.Project.Name,
 			Variables: dotenv,
 		})
 		if err != nil {


### PR DESCRIPTION
- When the requested project name already exists in the org, `DeployProject` retries `CreateProject` with a numeric suffix (e.g. `my-project` → `my-project-1`), but the follow-up `UpdateProjectVariables` call still targeted the originally requested name.
- As a result, the local `.env` (typically connector credentials) overwrote the variables of the unrelated pre-existing project, while the newly created project received no variables at all — so its deployment can't connect to its sources.
- Fix: push the variables to the org/name returned by `CreateProject` (the project actually created), matching what `RedeployProject` already does.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!