### PR TITLE
Require `ReadInstance` permission in `ConnectorService` handlers

### DIFF
--- a/runtime/server/connector_service.go
+++ b/runtime/server/connector_service.go
@@ -5,11 +5,17 @@ import (
 	"fmt"
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
+	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/drivers"
+	"github.com/rilldata/rill/runtime/server/auth"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func (s *Server) ListBuckets(ctx context.Context, req *runtimev1.ListBucketsRequest) (*runtimev1.ListBucketsResponse, error) {
+	if !auth.GetClaims(ctx, req.InstanceId).Can(runtime.ReadInstance) {
+		return nil, ErrForbidden
+	}
+
 	handle, release, err := s.runtime.AcquireHandle(ctx, req.InstanceId, req.Connector)
 	if err != nil {
 		return nil, err
@@ -33,6 +39,10 @@ func (s *Server) ListBuckets(ctx context.Context, req *runtimev1.ListBucketsRequ
 }
 
 func (s *Server) ListObjects(ctx context.Context, req *runtimev1.ListObjectsRequest) (*runtimev1.ListObjectsResponse, error) {
+	if !auth.GetClaims(ctx, req.InstanceId).Can(runtime.ReadInstance) {
+		return nil, ErrForbidden
+	}
+
 	handle, release, err := s.runtime.AcquireHandle(ctx, req.InstanceId, req.Connector)
 	if err != nil {
 		return nil, err
@@ -72,6 +82,10 @@ func (s *Server) ListObjects(ctx context.Context, req *runtimev1.ListObjectsRequ
 }
 
 func (s *Server) OLAPListTables(ctx context.Context, req *runtimev1.OLAPListTablesRequest) (*runtimev1.OLAPListTablesResponse, error) {
+	if !auth.GetClaims(ctx, req.InstanceId).Can(runtime.ReadInstance) {
+		return nil, ErrForbidden
+	}
+
 	olap, release, err := s.runtime.OLAP(ctx, req.InstanceId, req.Connector)
 	if err != nil {
 		return nil, err
@@ -104,6 +118,10 @@ func (s *Server) OLAPListTables(ctx context.Context, req *runtimev1.OLAPListTabl
 }
 
 func (s *Server) OLAPGetTable(ctx context.Context, req *runtimev1.OLAPGetTableRequest) (*runtimev1.OLAPGetTableResponse, error) {
+	if !auth.GetClaims(ctx, req.InstanceId).Can(runtime.ReadInstance) {
+		return nil, ErrForbidden
+	}
+
 	olap, release, err := s.runtime.OLAP(ctx, req.InstanceId, req.Connector)
 	if err != nil {
 		return nil, err
@@ -125,6 +143,10 @@ func (s *Server) OLAPGetTable(ctx context.Context, req *runtimev1.OLAPGetTableRe
 }
 
 func (s *Server) ListDatabaseSchemas(ctx context.Context, req *runtimev1.ListDatabaseSchemasRequest) (*runtimev1.ListDatabaseSchemasResponse, error) {
+	if !auth.GetClaims(ctx, req.InstanceId).Can(runtime.ReadInstance) {
+		return nil, ErrForbidden
+	}
+
 	handle, release, err := s.runtime.AcquireHandle(ctx, req.InstanceId, req.Connector)
 	if err != nil {
 		return nil, err
@@ -154,6 +176,10 @@ func (s *Server) ListDatabaseSchemas(ctx context.Context, req *runtimev1.ListDat
 }
 
 func (s *Server) ListTables(ctx context.Context, req *runtimev1.ListTablesRequest) (*runtimev1.ListTablesResponse, error) {
+	if !auth.GetClaims(ctx, req.InstanceId).Can(runtime.ReadInstance) {
+		return nil, ErrForbidden
+	}
+
 	handle, release, err := s.runtime.AcquireHandle(ctx, req.InstanceId, req.Connector)
 	if err != nil {
 		return nil, err
@@ -183,6 +209,10 @@ func (s *Server) ListTables(ctx context.Context, req *runtimev1.ListTablesReques
 }
 
 func (s *Server) GetTable(ctx context.Context, req *runtimev1.GetTableRequest) (*runtimev1.GetTableResponse, error) {
+	if !auth.GetClaims(ctx, req.InstanceId).Can(runtime.ReadInstance) {
+		return nil, ErrForbidden
+	}
+
 	handle, release, err := s.runtime.AcquireHandle(ctx, req.InstanceId, req.Connector)
 	if err != nil {
 		return nil, err

--- a/runtime/server/connector_service_test.go
+++ b/runtime/server/connector_service_test.go
@@ -1,0 +1,81 @@
+package server_test
+
+import (
+	"context"
+	"testing"
+
+	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
+	"github.com/rilldata/rill/runtime"
+	"github.com/rilldata/rill/runtime/pkg/activity"
+	"github.com/rilldata/rill/runtime/pkg/ratelimit"
+	"github.com/rilldata/rill/runtime/server"
+	"github.com/rilldata/rill/runtime/server/auth"
+	"github.com/rilldata/rill/runtime/testruntime"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestConnectorServiceAuth(t *testing.T) {
+	rt, instanceID := testruntime.NewInstanceWithModel(t, "foo", "SELECT 1 AS a")
+
+	srv, err := server.NewServer(context.Background(), &server.Options{}, rt, zap.NewNop(), ratelimit.NewNoop(), activity.NewNoopClient())
+	require.NoError(t, err)
+
+	// Claims matching a Rill Cloud project viewer; must not grant access to connector introspection.
+	viewerCtx := auth.WithClaims(context.Background(), &runtime.SecurityClaims{
+		Permissions: []runtime.Permission{runtime.ReadAPI, runtime.ReadMetrics, runtime.ReadObjects, runtime.UseAI},
+	})
+
+	// Claims with ReadInstance, as granted to users with status/manage access.
+	adminCtx := auth.WithClaims(context.Background(), &runtime.SecurityClaims{
+		Permissions: []runtime.Permission{runtime.ReadInstance},
+	})
+
+	t.Run("ListBuckets", func(t *testing.T) {
+		_, err := srv.ListBuckets(viewerCtx, &runtimev1.ListBucketsRequest{InstanceId: instanceID, Connector: "duckdb"})
+		require.ErrorIs(t, err, server.ErrForbidden)
+	})
+
+	t.Run("ListObjects", func(t *testing.T) {
+		_, err := srv.ListObjects(viewerCtx, &runtimev1.ListObjectsRequest{InstanceId: instanceID, Connector: "duckdb"})
+		require.ErrorIs(t, err, server.ErrForbidden)
+	})
+
+	t.Run("OLAPListTables", func(t *testing.T) {
+		_, err := srv.OLAPListTables(viewerCtx, &runtimev1.OLAPListTablesRequest{InstanceId: instanceID})
+		require.ErrorIs(t, err, server.ErrForbidden)
+
+		res, err := srv.OLAPListTables(adminCtx, &runtimev1.OLAPListTablesRequest{InstanceId: instanceID})
+		require.NoError(t, err)
+		require.Len(t, res.Tables, 1)
+		require.Equal(t, "foo", res.Tables[0].Name)
+	})
+
+	t.Run("OLAPGetTable", func(t *testing.T) {
+		_, err := srv.OLAPGetTable(viewerCtx, &runtimev1.OLAPGetTableRequest{InstanceId: instanceID, Table: "foo"})
+		require.ErrorIs(t, err, server.ErrForbidden)
+
+		res, err := srv.OLAPGetTable(adminCtx, &runtimev1.OLAPGetTableRequest{InstanceId: instanceID, Table: "foo"})
+		require.NoError(t, err)
+		require.Len(t, res.Schema.Fields, 1)
+	})
+
+	t.Run("ListDatabaseSchemas", func(t *testing.T) {
+		_, err := srv.ListDatabaseSchemas(viewerCtx, &runtimev1.ListDatabaseSchemasRequest{InstanceId: instanceID, Connector: "duckdb"})
+		require.ErrorIs(t, err, server.ErrForbidden)
+
+		res, err := srv.ListDatabaseSchemas(adminCtx, &runtimev1.ListDatabaseSchemasRequest{InstanceId: instanceID, Connector: "duckdb"})
+		require.NoError(t, err)
+		require.NotEmpty(t, res.DatabaseSchemas)
+	})
+
+	t.Run("ListTables", func(t *testing.T) {
+		_, err := srv.ListTables(viewerCtx, &runtimev1.ListTablesRequest{InstanceId: instanceID, Connector: "duckdb"})
+		require.ErrorIs(t, err, server.ErrForbidden)
+	})
+
+	t.Run("GetTable", func(t *testing.T) {
+		_, err := srv.GetTable(viewerCtx, &runtimev1.GetTableRequest{InstanceId: instanceID, Connector: "duckdb", Table: "foo"})
+		require.ErrorIs(t, err, server.ErrForbidden)
+	})
+}


### PR DESCRIPTION
The `ConnectorService` handlers (`ListBuckets`, `ListObjects`, `OLAPListTables`, `OLAPGetTable`, `ListDatabaseSchemas`, `ListTables`, `GetTable`) performed no permission checks, so any caller with a valid JWT for the runtime (or none at all) could enumerate OLAP tables, connector schemas, and object storage contents. All seven now require `ReadInstance` on the requested instance.

- `ReadInstance` matches `AnalyzeConnectors`, the sibling endpoint powering the same connector explorer UI, and is held by every legitimate caller: Rill Developer (auth disabled), the Cloud status page (gated on `manageProject`), cloud editing, and the admin service account.
- `ReadOLAP` was not used for the OLAP endpoints because it is only granted on editable deployments, which would break the status page's tables tab on prod. `ReadObjects` was not used for the object store endpoints because it is part of every viewer's base grant and would not restrict access.
- Because permissions are resolved for the requested `instance_id`, the check also prevents using a JWT issued for one instance against another instance on the same runtime.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!