### PR TITLE
fix: `ComponentVariableYAML.Proto` panics on unconvertible `value`, aborting the whole project parse

### DIFF
--- a/runtime/parser/parse_component.go
+++ b/runtime/parser/parse_component.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
+	"github.com/rilldata/rill/runtime/pkg/pbutil"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -29,9 +30,9 @@ func (y *ComponentVariableYAML) Proto() (*runtimev1.ComponentVariable, error) {
 	if y == nil {
 		return nil, fmt.Errorf("is empty")
 	}
-	val, err := structpb.NewValue(y.Value)
+	val, err := pbutil.ToValue(y.Value, nil)
 	if err != nil {
-		panic(fmt.Errorf("invalid default value: %w", err))
+		return nil, fmt.Errorf("invalid default value: %w", err)
 	}
 	return &runtimev1.ComponentVariable{
 		Name:         y.Name,

--- a/runtime/parser/parser_test.go
+++ b/runtime/parser/parser_test.go
@@ -1885,6 +1885,43 @@ rows:
 	requireResourcesAndErrors(t, p, resources, nil)
 }
 
+func TestComponentInputDateValue(t *testing.T) {
+	// Regression test: yaml.v3 decodes a bare date like 2024-01-01 into a time.Time,
+	// which structpb.NewValue rejects and previously caused a panic that aborted the entire parse.
+	ctx := context.Background()
+	repo := makeRepo(t, map[string]string{
+		`rill.yaml`: ``,
+		`components/c1.yaml`: `
+type: component
+markdown:
+  content: "Hello"
+input:
+  - name: start
+    type: string
+    value: 2024-01-01
+`,
+	})
+
+	resources := []*Resource{
+		{
+			Name:  ResourceName{Kind: ResourceKindComponent, Name: "c1"},
+			Paths: []string{"/components/c1.yaml"},
+			ComponentSpec: &runtimev1.ComponentSpec{
+				DisplayName:        "C1",
+				Renderer:           "markdown",
+				RendererProperties: must(structpb.NewStruct(map[string]any{"content": "Hello"})),
+				Input: []*runtimev1.ComponentVariable{
+					{Name: "start", Type: "string", DefaultValue: structpb.NewStringValue("2024-01-01T00:00:00Z")},
+				},
+			},
+		},
+	}
+
+	p, err := Parse(ctx, repo, "", "", "duckdb", true)
+	require.NoError(t, err)
+	requireResourcesAndErrors(t, p, resources, nil)
+}
+
 func TestCanvasTabGroups(t *testing.T) {
 	ctx := context.Background()
 	repo := makeRepo(t, map[string]string{


### PR DESCRIPTION
- `ComponentVariableYAML.Proto()` panicked when a component or canvas input variable had a `value:` that `structpb.NewValue` cannot convert. Since there is no `recover()` in the parser, a single bad `value:` in one file aborted the entire project parse.
- The most likely trigger is a bare date default like `value: 2024-01-01`, which yaml.v3 decodes into a `time.Time`.
- The value is now converted with `pbutil.ToValue`, which handles `time.Time` (and other YAML-decoded types), so date defaults now work. Any remaining conversion error is returned as a normal parse error scoped to the file.
- Added a regression test (`TestComponentInputDateValue`) covering the panic trigger.

**Manual testing steps:**

1. Start Rill Developer (`rill start`) on any working project.
2. Create `components/panic-test.yaml` with:
   ```yaml
   type: component
   markdown:
     content: "hello"
   input:
     - name: start
       value: 2024-01-01
   ```
3. Before this fix: the whole project parse fails; every dashboard and model becomes unavailable, and the runtime logs show a recovered panic with `invalid type: time.Time` from the ProjectParser reconcile.
4. After this fix: the component parses successfully, with the date default normalized to the string `2024-01-01T00:00:00Z`; all other resources keep working.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
