### PR TITLE
Fix nil-pointer panic in `ai` resolver when `time_range`/`comparison_time_range` are omitted

### DIFF
--- a/runtime/resolvers/ai.go
+++ b/runtime/resolvers/ai.go
@@ -75,11 +75,19 @@ func newAI(ctx context.Context, opts *runtime.ResolverOptions) (runtime.Resolver
 		return nil, errors.New("prompt is required for non-report AI sessions")
 	}
 
-	if props.TimeRange != nil && (props.TimeRange.IsoDuration != "" || props.TimeRange.IsoOffset != "") {
+	// Default omitted time ranges to empty values, which resolveTimeRange treats as a no-op.
+	if props.TimeRange == nil {
+		props.TimeRange = &metricsview.TimeRange{}
+	}
+	if props.ComparisonTimeRange == nil {
+		props.ComparisonTimeRange = &metricsview.TimeRange{}
+	}
+
+	if props.TimeRange.IsoDuration != "" || props.TimeRange.IsoOffset != "" {
 		return nil, errors.New("iso_duration and iso_offset are deprecated in favor of rilltime expressions")
 	}
 
-	if props.ComparisonTimeRange != nil && (props.ComparisonTimeRange.IsoDuration != "" || props.ComparisonTimeRange.IsoOffset != "") {
+	if props.ComparisonTimeRange.IsoDuration != "" || props.ComparisonTimeRange.IsoOffset != "" {
 		return nil, errors.New("iso_duration and iso_offset are deprecated in favor of rilltime expressions")
 	}
 


### PR DESCRIPTION
Fixes a guaranteed nil-pointer panic in the `ai` resolver when `time_range` or `comparison_time_range` is omitted from the resolver properties.

- `ResolveInteractive` unconditionally dereferences `r.props.TimeRange` and `r.props.ComparisonTimeRange` when building `AnalystAgentArgs`, but both are optional `*metricsview.TimeRange` fields left `nil` when absent. Since `comparison_time_range` is almost never set, essentially every AI report without it panicked; the panic was recovered by the controller, so the report perpetually failed with a reconcile error instead of crashing the process.
- Fix: default both pointers to `&metricsview.TimeRange{}` in `newAI`. An empty time range is already a no-op in `resolveTimeRange` (its `IsZero()` guard), so the agent args now receive zero `time.Time` values, meaning "no time bounds".

**Steps to reproduce (before this fix):**

1. In a Rill project with AI enabled, create a report whose data section uses the AI resolver with only a prompt, e.g. `data: { ai: { agent: analyst_agent, prompt: "Summarize sales", is_report: true } }` — do not set `time_range` or `comparison_time_range`.
2. Trigger the report (via its schedule or "Run now").
3. The report fails every time: the resource shows a reconcile error and the runtime logs contain a recovered nil-pointer panic in `aiResolver.ResolveInteractive`. Setting only `time_range` still fails on the `comparison_time_range` dereference.

**To test:** repeat the steps above on this branch; the report executes and produces an AI summary. Also verify that a report with an explicit `time_range` expression (e.g. `expression: P7D`) still resolves the range correctly.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
