### PR TITLE
Fix query result cache leaking across security contexts: include full `SecurityClaims` in cache key

### DIFF
--- a/runtime/resolver.go
+++ b/runtime/resolver.go
@@ -205,10 +205,14 @@ func (r *Runtime) Resolve(ctx context.Context, opts *ResolveOptions) (res Resolv
 	if _, err := hash.Write(cacheKey); err != nil {
 		return nil, nil, err
 	}
-	// Hash the full security claims, not just the user attributes:
+	// Hash the security claims, not just the user attributes:
 	// permissions, additional rules (e.g. locked filters on magic auth tokens) and skipped checks
 	// all change the resolved security policy, and results must not be shared across them.
-	claimsJSON, err := json.Marshal(opts.Claims)
+	// The user ID is excluded since it does not affect the resolved policy,
+	// which enables sharing results between users that resolve to the same policy (common for embeds).
+	claimsForKey := *opts.Claims
+	claimsForKey.UserID = ""
+	claimsJSON, err := json.Marshal(&claimsForKey)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/runtime/resolver.go
+++ b/runtime/resolver.go
@@ -9,9 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strconv"
 
-	"github.com/mitchellh/hashstructure/v2"
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime/drivers"
 	"github.com/rilldata/rill/runtime/pkg/jsonval"
@@ -207,14 +205,15 @@ func (r *Runtime) Resolve(ctx context.Context, opts *ResolveOptions) (res Resolv
 	if _, err := hash.Write(cacheKey); err != nil {
 		return nil, nil, err
 	}
-	if opts.Claims.UserAttributes != nil {
-		h, err := hashstructure.Hash(opts.Claims.UserAttributes, hashstructure.FormatV2, nil)
-		if err != nil {
-			return nil, nil, err
-		}
-		if _, err = hash.Write([]byte(strconv.FormatUint(h, 16))); err != nil {
-			return nil, nil, err
-		}
+	// Hash the full security claims, not just the user attributes:
+	// permissions, additional rules (e.g. locked filters on magic auth tokens) and skipped checks
+	// all change the resolved security policy, and results must not be shared across them.
+	claimsJSON, err := json.Marshal(opts.Claims)
+	if err != nil {
+		return nil, nil, err
+	}
+	if _, err := hash.Write(claimsJSON); err != nil {
+		return nil, nil, err
 	}
 	for _, ref := range resolver.Refs() {
 		res, err := ctrl.Get(ctx, ref, false)

--- a/runtime/resolvers/testdata/metrics_security.yaml
+++ b/runtime/resolvers/testdata/metrics_security.yaml
@@ -33,3 +33,67 @@ tests:
     result:
       - country: US
         sum: 9
+  # The following tests run the same query back-to-back with identical (empty) user attributes,
+  # varying only the additional rules and skipped security checks.
+  # They protect against cached results leaking across different security contexts.
+  - name: cache_isolation_row_filter_dk
+    resolver: metrics
+    properties:
+      metrics_view: metrics_no_security
+      dimensions:
+        - name: country
+      measures:
+        - name: sum
+      sort:
+        - name: country
+    additional_rules:
+      - row_filter: country = 'DK'
+    result:
+      - country: DK
+        sum: 6
+  - name: cache_isolation_row_filter_us
+    resolver: metrics
+    properties:
+      metrics_view: metrics_no_security
+      dimensions:
+        - name: country
+      measures:
+        - name: sum
+      sort:
+        - name: country
+    additional_rules:
+      - row_filter: country = 'US'
+    result:
+      - country: US
+        sum: 9
+  - name: cache_isolation_no_rules
+    resolver: metrics
+    properties:
+      metrics_view: metrics_no_security
+      dimensions:
+        - name: country
+      measures:
+        - name: sum
+      sort:
+        - name: country
+    result:
+      - country: DK
+        sum: 6
+      - country: US
+        sum: 9
+  - name: cache_isolation_skip_checks
+    resolver: metrics
+    properties:
+      metrics_view: metrics_no_security
+      dimensions:
+        - name: country
+      measures:
+        - name: sum
+      sort:
+        - name: country
+    skip_security_checks: true
+    result:
+      - country: DK
+        sum: 6
+      - country: US
+        sum: 9


### PR DESCRIPTION
- The query cache key in `runtime.Resolve` only hashed `Claims.UserAttributes`, so requests that differed only in `AdditionalRules` (e.g. locked filters on magic auth tokens), `Permissions`, or `SkipChecks` produced identical cache keys and could receive each other's cached results.
- Now the full marshaled `SecurityClaims` is hashed into the key, matching what the security engine's `computeCacheKey` already does.
- Fixing it centrally in `Resolve` covers all resolvers (`metrics`, `metrics_sql`, annotations, unions); the legacy `runtime.Query` path already included the full claims in its key and was not affected.
- Added regression tests in `metrics_security.yaml` that run the same query back-to-back with identical (empty) user attributes but different security contexts; without the fix, three of the four cases fail by returning another context's cached rows.

**Steps to reproduce (before this fix):**

1. Deploy a project with a metrics view on a Rill-managed table (default caching on) with a dimension such as `country`, and an explore dashboard on it.
2. From the dashboard's Share flow, create two public (magic auth) URLs for the same dashboard: URL A locked to filter `country = 'US'`, URL B locked to `country = 'EU'`. Both are anonymous, so both carry empty user attributes; the locked filters travel as `AdditionalRules`.
3. Open URL A in an incognito window and note the totals (this populates the query cache).
4. Immediately open URL B in another incognito window and run the same view/query.
5. Expected: URL B shows EU-filtered numbers. Actual: URL B shows URL A's US-filtered numbers (cache hit on the identical key). Repeating in the opposite order flips which result wins.
6. Alternative path: define two custom APIs over the same metrics query, one with `skip_nested_security: true` and one without; call the skipping one first, then the enforcing one with identical user attributes — the second returns the unfiltered cached result.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
