### PR TITLE
Enforce metrics view access policy in the `metrics_annotations` resolver

### DIFF
--- a/runtime/resolvers/annotations.go
+++ b/runtime/resolvers/annotations.go
@@ -53,6 +53,10 @@ func newAnnotationsResolver(ctx context.Context, opts *runtime.ResolverOptions) 
 		return nil, err
 	}
 
+	if !security.CanAccess() {
+		return nil, runtime.ErrForbidden
+	}
+
 	var userAttrs map[string]any
 	if opts.Claims != nil {
 		userAttrs = opts.Claims.UserAttributes


### PR DESCRIPTION
- The `metrics_annotations` resolver resolved the metrics view's security policy but never checked `CanAccess()`, unlike the other metrics-view-backed resolvers (`metrics`, `metricsview_summary`, `metricsview_time_range`, `metricsview_cache_key`).
- Since `Executor.Annotations` does not apply the access check either, a user with instance-level `ReadMetrics` permission could fetch annotation rows (times, labels, descriptions) for a metrics view whose `security.access` policy denies them.
- This adds the missing `if !security.CanAccess() { return nil, runtime.ErrForbidden }` guard in `newAnnotationsResolver`, matching the sibling resolvers, so the annotations endpoint now returns a permission error like the other query paths.

**Steps to reproduce (before this fix):**

1. Create a metrics view with an `annotations:` section and a security policy that denies the test user, e.g. `security: { access: "{{ .user.admin }}" }`.
2. Deploy and log in as a non-admin user with viewer (`ReadMetrics`) access to the project.
3. Control: query the metrics view normally (open its dashboard or POST to `/v1/instances/{id}/queries/metrics-views/{name}/aggregation`) — returns 403 as expected.
4. POST to `/v1/instances/{id}/queries/metrics-views/{name}/annotations` with the annotation measures and a time range.
5. Before the fix: HTTP 200 with the metrics view's annotation rows despite the denied access policy. After the fix: 403, consistent with the aggregation query.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
