### PR TITLE
fix: close BigQuery client in `fileIterator.Close` to prevent connection leak

### DIFF
--- a/runtime/drivers/bigquery/warehouse.go
+++ b/runtime/drivers/bigquery/warehouse.go
@@ -211,6 +211,7 @@ var _ drivers.FileIterator = &fileIterator{}
 
 // Close implements drivers.FileIterator.
 func (f *fileIterator) Close() error {
+	f.client.Close()
 	return os.RemoveAll(f.tempDir)
 }
 


### PR DESCRIPTION
- `QueryAsFiles` opens a `*bigquery.Client` (with a Storage Read gRPC client) and hands it to the returned `fileIterator`, but the iterator's `Close()` only removed the temp dir; the client was closed only on error paths, so every successful ingest leaked the client and its gRPC connections/goroutines.
- Close the client in `fileIterator.Close()`, matching how the Snowflake and Databricks iterators release their connections.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
