### PR TITLE
Fix nil pointer dereference in `popCurrentExecution` for non-email alert notifiers

### DIFF
--- a/runtime/reconcilers/alert.go
+++ b/runtime/reconcilers/alert.go
@@ -924,16 +924,21 @@ func (r *AlertReconciler) popCurrentExecution(ctx context.Context, self *runtime
 					if err != nil {
 						return err
 					}
-					urls, ok := adminMeta.RecipientURLs[""]
-					if !ok {
-						return fmt.Errorf("failed to get recipient URLs for anon user")
+					// Note: adminMeta may not always be available (if outside of cloud). In that case, we leave the links blank (no clickthrough available).
+					msg.OpenLink = ""
+					msg.EditLink = ""
+					if adminMeta != nil && adminMeta.RecipientURLs != nil {
+						urls, ok := adminMeta.RecipientURLs[""]
+						if !ok {
+							return fmt.Errorf("failed to get recipient URLs for anon user")
+						}
+						openLink, err := addExecutionTime(urls.OpenURL, executionTime)
+						if err != nil {
+							return fmt.Errorf("failed to build recipient open url: %w", err)
+						}
+						msg.OpenLink = openLink
+						msg.EditLink = urls.EditURL
 					}
-					openLink, err := addExecutionTime(urls.OpenURL, executionTime)
-					if err != nil {
-						return fmt.Errorf("failed to build recipient open url: %w", err)
-					}
-					msg.OpenLink = openLink
-					msg.EditLink = urls.EditURL
 					start := time.Now()
 					defer func() {
 						totalLatency := time.Since(start).Milliseconds()

--- a/runtime/reconcilers/alert.go
+++ b/runtime/reconcilers/alert.go
@@ -927,6 +927,7 @@ func (r *AlertReconciler) popCurrentExecution(ctx context.Context, self *runtime
 					// Note: adminMeta may not always be available (if outside of cloud). In that case, we leave the links blank (no clickthrough available).
 					msg.OpenLink = ""
 					msg.EditLink = ""
+					msg.UnsubscribeLink = ""
 					if adminMeta != nil && adminMeta.RecipientURLs != nil {
 						urls, ok := adminMeta.RecipientURLs[""]
 						if !ok {


### PR DESCRIPTION
- In Rill Developer, `admin.GetAlertMetadata` returns `ErrNotImplemented`, which `executeAll` tolerates by leaving `adminMeta` nil. The email notifier branch guards against this, but the non-email branch dereferenced `adminMeta.RecipientURLs` unconditionally, so an alert with a Slack (or any non-email) notifier panicked instead of sending.
- Guard the non-email branch the same way as the email branch: when admin metadata is unavailable, leave `OpenLink`/`EditLink` blank and still send the notification.
- Cloud behavior is unchanged, including the error when metadata is present but has no anon-user entry.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!