### PR TITLE
Fix full model rebuild on rename: point `prevResult` at the renamed table

### DIFF
--- a/runtime/reconcilers/model.go
+++ b/runtime/reconcilers/model.go
@@ -190,6 +190,8 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceNa
 
 				renameRes, err := prevManager.Rename(ctx, prevResult, self.Meta.Name.Name, modelEnv)
 				if err == nil {
+					// Update prevResult to point to the renamed output, so the existence check later in this function targets the renamed table instead of the old one.
+					prevResult = renameRes
 					err = r.updateStateWithResult(ctx, self, renameRes)
 				}
 				if err != nil {

--- a/runtime/reconcilers/model_test.go
+++ b/runtime/reconcilers/model_test.go
@@ -114,6 +114,42 @@ sql: SELECT * FROM up
 	testruntime.RequireOLAPTableCount(t, rt, instanceID, "down", 1)
 }
 
+// TestRenameDoesNotRebuild verifies that renaming a model file renames the underlying table
+// without re-executing the model or discarding its incremental state.
+func TestRenameDoesNotRebuild(t *testing.T) {
+	rt, instanceID := testruntime.NewInstance(t)
+
+	testruntime.PutFiles(t, rt, instanceID, map[string]string{
+		"rill.yaml": ``,
+		"models/foo.yaml": `
+type: model
+incremental: true
+sql: SELECT 1 AS num
+`,
+	})
+	testruntime.ReconcileParserAndWait(t, rt, instanceID)
+	testruntime.RequireReconcileState(t, rt, instanceID, 2, 0, 0)
+	testruntime.RequireOLAPTableCount(t, rt, instanceID, "foo", 1)
+
+	// Run an incremental refresh so the model accumulates output that a full rebuild would lose.
+	testruntime.RefreshAndWait(t, rt, instanceID, &runtimev1.ResourceName{Kind: runtime.ResourceKindModel, Name: "foo"})
+	testruntime.RequireOLAPTableCount(t, rt, instanceID, "foo", 2)
+
+	refreshedOn := testruntime.GetResource(t, rt, instanceID, runtime.ResourceKindModel, "foo").GetModel().State.RefreshedOn
+
+	// Rename the model file without changing its contents.
+	testruntime.RenameFile(t, rt, instanceID, "models/foo.yaml", "models/foo2.yaml")
+	testruntime.ReconcileParserAndWait(t, rt, instanceID)
+	testruntime.RequireReconcileState(t, rt, instanceID, 2, 0, 0)
+
+	// The output table should have been renamed, not rebuilt: the appended row survives and RefreshedOn is unchanged.
+	testruntime.RequireNoOLAPTable(t, rt, instanceID, "foo")
+	testruntime.RequireOLAPTableCount(t, rt, instanceID, "foo2", 2)
+	model := testruntime.GetResource(t, rt, instanceID, runtime.ResourceKindModel, "foo2").GetModel()
+	require.Equal(t, "foo2", model.State.ResultTable)
+	require.Equal(t, refreshedOn.AsTime(), model.State.RefreshedOn.AsTime())
+}
+
 func TestPartitionedIncrementalPostExecSeesIncrementalFlag(t *testing.T) {
 	rt, instanceID := testruntime.NewInstance(t)
 


### PR DESCRIPTION
- On the rename path, the model reconciler renamed the physical output table and updated `State.ResultTable`, but the local `prevResult` still pointed at the old table name. The subsequent `prevManager.Exists` check then failed, so `resolveTrigger` treated the rename as a first run and forced a full reset rebuild — expensive for large models, and it discarded `IncrementalState` for incremental models.
- Fix: after a successful `Rename`, reassign `prevResult` to the renamed result so the existence check targets the renamed table. When the table name is explicitly pinned (`UsedModelName == false`), `Rename` returns the original result unchanged, so this is a no-op there.
- Adds `TestRenameDoesNotRebuild`, which verifies a rename preserves incremental output and does not re-execute the model (`RefreshedOn` unchanged). The test fails without the fix.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!