### PR TITLE
Fix leak of `model_partitions` catalog rows when deleting a partitioned model

### DIFF
--- a/runtime/reconcilers/model.go
+++ b/runtime/reconcilers/model.go
@@ -166,7 +166,9 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceNa
 			defer r.execSem.Release(1)
 
 			err = prevManager.Delete(ctx, prevResult)
-			return runtime.ReconcileResult{Err: err}
+			if err != nil {
+				return runtime.ReconcileResult{Err: err}
+			}
 		}
 
 		err := r.clearPartitions(ctx, model)

--- a/runtime/reconcilers/model_test.go
+++ b/runtime/reconcilers/model_test.go
@@ -454,6 +454,54 @@ sql: SELECT {{.partition.v}} AS n
 	}
 }
 
+// TestPartitionsClearedOnDelete verifies that deleting a partitioned model that produced output
+// also removes its partition rows from the catalog (they would otherwise be orphaned forever,
+// since each model gets a fresh partitions model ID).
+func TestPartitionsClearedOnDelete(t *testing.T) {
+	rt, instanceID := testruntime.NewInstance(t)
+	ctx := t.Context()
+
+	testruntime.PutFiles(t, rt, instanceID, map[string]string{
+		"rill.yaml": ``,
+		"models/partitioned.yaml": `
+type: model
+incremental: true
+materialize: true
+partitions:
+  sql: SELECT range AS num FROM range(0, 3)
+sql: SELECT {{ .partition.num }} AS num
+`,
+	})
+	testruntime.ReconcileParserAndWait(t, rt, instanceID)
+	testruntime.RequireReconcileState(t, rt, instanceID, 2, 0, 0)
+
+	// Capture the partitions model ID and verify the partition rows exist in the catalog.
+	model := testruntime.GetResource(t, rt, instanceID, runtime.ResourceKindModel, "partitioned").GetModel()
+	require.NotNil(t, model)
+	require.NotEmpty(t, model.State.PartitionsModelId)
+
+	catalog, release, err := rt.Catalog(ctx, instanceID)
+	require.NoError(t, err)
+	defer release()
+
+	partitions, err := catalog.FindModelPartitions(ctx, &drivers.FindModelPartitionsOptions{
+		ModelID: model.State.PartitionsModelId,
+	})
+	require.NoError(t, err)
+	require.Len(t, partitions, 3)
+
+	// Delete the model file and reconcile. The output table is dropped and the partition rows must be cleared.
+	testruntime.DeleteFiles(t, rt, instanceID, "models/partitioned.yaml")
+	testruntime.ReconcileParserAndWait(t, rt, instanceID)
+	testruntime.RequireReconcileState(t, rt, instanceID, 1, 0, 0)
+
+	partitions, err = catalog.FindModelPartitions(ctx, &drivers.FindModelPartitionsOptions{
+		ModelID: model.State.PartitionsModelId,
+	})
+	require.NoError(t, err)
+	require.Empty(t, partitions)
+}
+
 func TestExplicitPartitionRefreshDoesNotProcessNewPartitions(t *testing.T) {
 	rt, instanceID := testruntime.NewInstance(t)
 	ctx := t.Context()


### PR DESCRIPTION
- Deleting a partitioned model that had produced output dropped the output table and returned immediately, skipping `clearPartitions`. The model's rows in the `model_partitions` catalog table were orphaned forever, since each model gets a fresh `PartitionsModelId` and `clearPartitions` is the only caller of `DeleteModelPartitions`.
- The deletion branch in `ModelReconciler.Reconcile` now falls through after a successful output drop, so `clearPartitions` runs on every delete path.
- Added a regression test (`TestPartitionsClearedOnDelete`) that fails on the old code (all partition rows orphaned) and passes with the fix.

**Steps to reproduce:**

1. In Rill Developer, create a partitioned incremental model and let it build:
   ```yaml
   type: model
   incremental: true
   materialize: true
   partitions:
     sql: SELECT range AS num FROM range(0, 50)
   sql: SELECT {{ .partition.num }} AS num
   ```
2. Verify partition rows exist in the catalog: `sqlite3 <project>/tmp/meta.db "SELECT COUNT(*) FROM model_partitions;"` returns 50.
3. Delete the model file and wait for reconcile (the output table is dropped).
4. Re-run the query from step 2. Before this fix, all 50 rows remain orphaned, and repeated create/delete churn grows the catalog DB unbounded. With the fix, the count returns to 0.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
