### PR TITLE
fix: metrics SQL compiles `IS FALSE` / `IS NOT FALSE` identically to `IS TRUE`

### DIFF
--- a/runtime/metricsview/metricssql/filter_parser.go
+++ b/runtime/metricsview/metricssql/filter_parser.go
@@ -139,18 +139,46 @@ func parseIsTruthOperation(ctx context.Context, node *ast.IsTruthExpr, q *query)
 		return nil, err
 	}
 
-	var op metricsview.Operator
-	if node.Not {
-		op = metricsview.OperatorNeq
-	} else {
-		op = metricsview.OperatorEq
+	// node.True distinguishes IS [NOT] TRUE (1) from IS [NOT] FALSE (0)
+	target := node.True != 0
+
+	if !node.Not {
+		// `expr IS TRUE` and `expr IS FALSE` exclude NULL rows, matching the semantics of `=`.
+		return &metricsview.Expression{
+			Condition: &metricsview.Condition{
+				Operator: metricsview.OperatorEq,
+				Expressions: []*metricsview.Expression{
+					expr,
+					{Value: target},
+				},
+			},
+		}, nil
 	}
+
+	// `expr IS NOT TRUE` and `expr IS NOT FALSE` include NULL rows,
+	// so `!=` alone is not sufficient: add an explicit IS NULL check.
 	return &metricsview.Expression{
 		Condition: &metricsview.Condition{
-			Operator: op,
+			Operator: metricsview.OperatorOr,
 			Expressions: []*metricsview.Expression{
-				expr,
-				{Value: "TRUE"},
+				{
+					Condition: &metricsview.Condition{
+						Operator: metricsview.OperatorNeq,
+						Expressions: []*metricsview.Expression{
+							expr,
+							{Value: target},
+						},
+					},
+				},
+				{
+					Condition: &metricsview.Condition{
+						Operator: metricsview.OperatorEq,
+						Expressions: []*metricsview.Expression{
+							expr,
+							{Value: nil},
+						},
+					},
+				},
 			},
 		},
 	}, nil

--- a/runtime/metricsview/metricssql/filter_parser_test.go
+++ b/runtime/metricsview/metricssql/filter_parser_test.go
@@ -191,6 +191,118 @@ func TestParseFilter(t *testing.T) {
 			false,
 		},
 		{
+			"is true expression",
+			"dim IS TRUE",
+			&metricsview.Expression{
+				Condition: &metricsview.Condition{
+					Operator: metricsview.OperatorEq,
+					Expressions: []*metricsview.Expression{
+						{
+							Name: "dim",
+						},
+						{
+							Value: true,
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"is false expression",
+			"dim IS FALSE",
+			&metricsview.Expression{
+				Condition: &metricsview.Condition{
+					Operator: metricsview.OperatorEq,
+					Expressions: []*metricsview.Expression{
+						{
+							Name: "dim",
+						},
+						{
+							Value: false,
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"is not true expression",
+			"dim IS NOT TRUE",
+			&metricsview.Expression{
+				Condition: &metricsview.Condition{
+					Operator: metricsview.OperatorOr,
+					Expressions: []*metricsview.Expression{
+						{
+							Condition: &metricsview.Condition{
+								Operator: metricsview.OperatorNeq,
+								Expressions: []*metricsview.Expression{
+									{
+										Name: "dim",
+									},
+									{
+										Value: true,
+									},
+								},
+							},
+						},
+						{
+							Condition: &metricsview.Condition{
+								Operator: metricsview.OperatorEq,
+								Expressions: []*metricsview.Expression{
+									{
+										Name: "dim",
+									},
+									{
+										Value: nil,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"is not false expression",
+			"dim IS NOT FALSE",
+			&metricsview.Expression{
+				Condition: &metricsview.Condition{
+					Operator: metricsview.OperatorOr,
+					Expressions: []*metricsview.Expression{
+						{
+							Condition: &metricsview.Condition{
+								Operator: metricsview.OperatorNeq,
+								Expressions: []*metricsview.Expression{
+									{
+										Name: "dim",
+									},
+									{
+										Value: false,
+									},
+								},
+							},
+						},
+						{
+							Condition: &metricsview.Condition{
+								Operator: metricsview.OperatorEq,
+								Expressions: []*metricsview.Expression{
+									{
+										Name: "dim",
+									},
+									{
+										Value: nil,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
 			"date_add expression",
 			"time >= '2021-01-01' + INTERVAL 1 DAY",
 			&metricsview.Expression{


### PR DESCRIPTION
`parseIsTruthOperation` in the metrics SQL filter parser never inspected `ast.IsTruthExpr.True`, which distinguishes `IS TRUE` from `IS FALSE`. As a result, `flag IS FALSE` compiled to the exact same expression as `flag IS TRUE` (and `IS NOT FALSE` the same as `IS NOT TRUE`), silently inverting boolean filters in metrics SQL queries, canvas `dimension_filters`, and SQL-based where expressions.

- Branch on `node.True` so `IS FALSE` compiles to `eq(expr, false)` instead of `eq(expr, true)`.
- Compare against a typed boolean value instead of the string `'TRUE'`, which relied on implicit string-to-boolean casts that are not reliable across ClickHouse/Druid.
- `IS NOT TRUE` / `IS NOT FALSE` now compile to `expr != <bool> OR expr IS NULL`, matching SQL semantics where the negated forms include NULL rows (a plain `!=` excludes them).
- Added parser tests for all four combinations; all four fail against the previous implementation.

**Steps to reproduce manually:**

1. In a Rill project with a metrics view `mv` that has a boolean dimension `flag`, run a metrics SQL query (e.g. via a `metrics_sql` resolver in a custom API, or a canvas widget's `dimension_filters`):
   ```sql
   SELECT flag, count FROM mv WHERE flag IS FALSE
   ```
2. Before this fix, the result contains only rows where `flag` is **true**; the same query with `IS TRUE` returns identical results. After the fix, `IS FALSE` returns the false rows.
3. The inversion is also visible at the parser level:
   ```go
   expr, _ := metricssql.ParseFilter("flag IS FALSE")
   b, _ := json.Marshal(expr)
   fmt.Println(string(b))
   // before: {"cond":{"op":"eq","exprs":[{"name":"flag"},{"val":"TRUE"}]}}  (identical to IS TRUE)
   // after:  {"cond":{"op":"eq","exprs":[{"name":"flag"},{"val":false}]}}
   ```

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
