### PR TITLE
fix: nil `TimeRange` panic in `MetricsViewAggregation.Export`

### DIFF
--- a/runtime/queries/metricsview_aggregation.go
+++ b/runtime/queries/metricsview_aggregation.go
@@ -162,8 +162,12 @@ func (q *MetricsViewAggregation) Export(ctx context.Context, rt *runtime.Runtime
 	}
 	defer e.Close()
 
+	qryTimeDim := ""
+	if q.TimeRange != nil {
+		qryTimeDim = q.TimeRange.TimeDimension
+	}
 	if mv.ValidSpec.TimeDimension != "" {
-		tsRes, err := ResolveTimestampResult(ctx, rt, instanceID, q.MetricsViewName, q.TimeRange.TimeDimension, q.SecurityClaims, opts.Priority)
+		tsRes, err := ResolveTimestampResult(ctx, rt, instanceID, q.MetricsViewName, qryTimeDim, q.SecurityClaims, opts.Priority)
 		if err != nil {
 			return err
 		}
@@ -520,7 +524,7 @@ func (q *MetricsViewAggregation) generateExportHeaders(ctx context.Context, rt *
 	headers = append(headers, title)
 
 	// Build date range
-	if !qry.TimeRange.Start.IsZero() || !qry.TimeRange.End.IsZero() {
+	if qry.TimeRange != nil && (!qry.TimeRange.Start.IsZero() || !qry.TimeRange.End.IsZero()) {
 		timeRange := fmt.Sprintf("Date range: %s to %s", qry.TimeRange.Start.Format(time.RFC3339), qry.TimeRange.End.Format(time.RFC3339))
 		headers = append(headers, timeRange)
 	}


### PR DESCRIPTION
- `Export` dereferenced `q.TimeRange.TimeDimension` guarded only by `mv.ValidSpec.TimeDimension != ""`, so an export request with no `TimeRange`/`TimeStart`/`TimeEnd` panicked on any time-dimensioned metrics view. Now mirrors the nil-safe `qryTimeDim` pattern already used in `Resolve`.
- `generateExportHeaders` read `qry.TimeRange.Start`/`.End` without a nil check; `RewriteQueryTimeRanges` leaves `qry.TimeRange` unallocated for metrics views without a time dimension, so header-including exports panicked there. The date-range header is now skipped when `TimeRange` is nil.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
