### PR TITLE
Metrics SQL: reject unsupported top-level clauses, allow `DISTINCT` and matching `GROUP BY`

### DIFF
--- a/runtime/metricsview/metricssql/filter_parser.go
+++ b/runtime/metricsview/metricssql/filter_parser.go
@@ -216,37 +216,14 @@ func parseInSubquery(ctx context.Context, n ast.ExprNode, q *query) (*metricsvie
 	}
 
 	// You can do a lot of stuff in a SELECT statement. Check it doesn't do anything we don't support.
-	switch {
-	case sel.Kind != ast.SelectStmtKindSelect:
-		return nil, fmt.Errorf("metrics sql: subquery of kind %s is not supported", sel.Kind.String())
-	case sel.SelectStmtOpts != nil && sel.SelectStmtOpts.Distinct:
-		return nil, fmt.Errorf("metrics sql: subquery with DISTINCT is not supported")
-	case len(sel.WindowSpecs) > 0:
-		return nil, fmt.Errorf("metrics sql: subquery with window specifications is not supported")
-	case sel.OrderBy != nil:
+	if err := validateSelectStmt(sel); err != nil {
+		return nil, err
+	}
+	if sel.OrderBy != nil {
 		return nil, fmt.Errorf("metrics sql: subquery with ORDER BY is not supported")
-	case sel.Limit != nil:
+	}
+	if sel.Limit != nil {
 		return nil, fmt.Errorf("metrics sql: subquery with LIMIT is not supported")
-	case sel.LockInfo != nil:
-		return nil, fmt.Errorf("metrics sql: subquery with lock info is not supported")
-	case len(sel.TableHints) > 0:
-		return nil, fmt.Errorf("metrics sql: subquery with table hints is not supported")
-	case sel.IsInBraces:
-		return nil, fmt.Errorf("metrics sql: subquery with braces is not supported")
-	case sel.WithBeforeBraces:
-		return nil, fmt.Errorf("metrics sql: subquery with WITH before braces is not supported")
-	case sel.QueryBlockOffset != 0:
-		return nil, fmt.Errorf("metrics sql: subquery with query block offset is not supported")
-	case sel.SelectIntoOpt != nil:
-		return nil, fmt.Errorf("metrics sql: subquery with SELECT INTO is not supported")
-	case sel.AfterSetOperator != nil:
-		return nil, fmt.Errorf("metrics sql: subquery with set operations is not supported")
-	case len(sel.Lists) > 0:
-		return nil, fmt.Errorf("metrics sql: subquery with row expressions is not supported")
-	case sel.With != nil:
-		return nil, fmt.Errorf("metrics sql: subquery with WITH clause is not supported")
-	case sel.AsViewSchema:
-		return nil, fmt.Errorf("metrics sql: subquery as view schema is not supported")
 	}
 
 	// Validate the FROM clause is a plain `FROM metrics_view`
@@ -290,7 +267,7 @@ func parseInSubquery(ctx context.Context, n ast.ExprNode, q *query) (*metricsvie
 		if len(sel.GroupBy.Items) != 1 {
 			return nil, fmt.Errorf("metrics sql: subquery must group by exactly one dimension")
 		}
-		groupByName, err := parseColumnNameExpr(sel.GroupBy.Items[0])
+		groupByName, err := parseColumnNameExpr(sel.GroupBy.Items[0].Expr)
 		if err != nil {
 			return nil, fmt.Errorf("metrics sql: failed to parse GROUP BY expression in subquery: %w", err)
 		}

--- a/runtime/metricsview/metricssql/filter_parser_test.go
+++ b/runtime/metricsview/metricssql/filter_parser_test.go
@@ -191,6 +191,46 @@ func TestParseFilter(t *testing.T) {
 			false,
 		},
 		{
+			"subquery expression with distinct",
+			"dim IN (SELECT DISTINCT dim FROM mv)",
+			&metricsview.Expression{
+				Condition: &metricsview.Condition{
+					Operator: metricsview.OperatorIn,
+					Expressions: []*metricsview.Expression{
+						{
+							Name: "dim",
+						},
+						{
+							Subquery: &metricsview.Subquery{
+								Dimension: metricsview.Dimension{Name: "dim"},
+							},
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"subquery expression with matching group by",
+			"dim IN (SELECT dim FROM mv GROUP BY dim)",
+			&metricsview.Expression{
+				Condition: &metricsview.Condition{
+					Operator: metricsview.OperatorIn,
+					Expressions: []*metricsview.Expression{
+						{
+							Name: "dim",
+						},
+						{
+							Subquery: &metricsview.Subquery{
+								Dimension: metricsview.Dimension{Name: "dim"},
+							},
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
 			"date_add expression",
 			"time >= '2021-01-01' + INTERVAL 1 DAY",
 			&metricsview.Expression{

--- a/runtime/metricsview/metricssql/parser.go
+++ b/runtime/metricsview/metricssql/parser.go
@@ -73,6 +73,11 @@ func (c *Compiler) Parse(ctx context.Context, sql string) (*metricsview.Query, e
 		return nil, errors.New("metrics sql: expected a SELECT statement")
 	}
 
+	// check the statement doesn't use SELECT features that metrics SQL doesn't support
+	if err := validateSelectStmt(stmt); err != nil {
+		return nil, err
+	}
+
 	q := &query{
 		q:    &metricsview.Query{},
 		opts: c.opts,
@@ -86,6 +91,13 @@ func (c *Compiler) Parse(ctx context.Context, sql string) (*metricsview.Query, e
 	// parse select fields
 	if err := q.parseSelect(stmt.Fields); err != nil {
 		return nil, err
+	}
+
+	// check the GROUP BY clause matches the selected dimensions if provided
+	if stmt.GroupBy != nil {
+		if err := q.validateGroupBy(stmt.GroupBy); err != nil {
+			return nil, err
+		}
 	}
 
 	// parse where clause
@@ -120,6 +132,41 @@ func (c *Compiler) Parse(ctx context.Context, sql string) (*metricsview.Query, e
 	return q.q, nil
 }
 
+// validateSelectStmt checks that the SELECT statement doesn't use SQL features that metrics SQL doesn't support.
+// It contains the checks that apply to both top-level queries and subqueries;
+// clauses that are only supported in one of the two contexts (such as ORDER BY, LIMIT and GROUP BY) are validated by the callers.
+// Note that DISTINCT is deliberately allowed as a no-op:
+// metrics SQL queries always group by the selected dimensions, so the results are already distinct.
+func validateSelectStmt(sel *ast.SelectStmt) error {
+	switch {
+	case sel.Kind != ast.SelectStmtKindSelect:
+		return fmt.Errorf("metrics sql: SELECT of kind %s is not supported", sel.Kind.String())
+	case len(sel.WindowSpecs) > 0:
+		return errors.New("metrics sql: window specifications are not supported")
+	case sel.LockInfo != nil:
+		return errors.New("metrics sql: lock info is not supported")
+	case len(sel.TableHints) > 0:
+		return errors.New("metrics sql: table hints are not supported")
+	case sel.IsInBraces:
+		return errors.New("metrics sql: SELECT in braces is not supported")
+	case sel.WithBeforeBraces:
+		return errors.New("metrics sql: WITH before braces is not supported")
+	case sel.QueryBlockOffset != 0:
+		return errors.New("metrics sql: query block offset is not supported")
+	case sel.SelectIntoOpt != nil:
+		return errors.New("metrics sql: SELECT INTO is not supported")
+	case sel.AfterSetOperator != nil:
+		return errors.New("metrics sql: set operations are not supported")
+	case len(sel.Lists) > 0:
+		return errors.New("metrics sql: row expressions are not supported")
+	case sel.With != nil:
+		return errors.New("metrics sql: WITH clause is not supported")
+	case sel.AsViewSchema:
+		return errors.New("metrics sql: view schema is not supported")
+	}
+	return nil
+}
+
 type query struct {
 	q    *metricsview.Query
 	opts *CompilerOptions
@@ -129,6 +176,15 @@ type query struct {
 	metricsViewSpec *runtimev1.MetricsViewSpec
 	dims            map[string]any
 	measures        map[string]any
+
+	// selectFields tracks the select list in order; used to resolve positional references in the GROUP BY clause
+	selectFields []selectField
+}
+
+// selectField describes one output column of the query's select list.
+type selectField struct {
+	name  string
+	isDim bool
 }
 
 func (q *query) parseFrom(ctx context.Context, node *ast.TableRefsClause) error {
@@ -183,16 +239,20 @@ func (q *query) parseSelect(node *ast.FieldList) error {
 	for _, field := range node.Fields {
 		switch v := field.Expr.(type) {
 		case *ast.ColumnNameExpr:
-			// TODO no alias handling for column names
 			col, typ, err := q.parseColumnNameExpr(v)
 			if err != nil {
 				return err
+			}
+			// The result columns must keep the metrics view's dimension/measure names, so an alias that renames the column cannot be honored.
+			if alias := field.AsName.String(); alias != "" && alias != col {
+				return fmt.Errorf("metrics sql: aliasing a dimension or measure is not supported (found `%s AS %s`)", col, alias)
 			}
 			if typ == "DIMENSION" {
 				q.q.Dimensions = append(q.q.Dimensions, metricsview.Dimension{Name: col})
 			} else {
 				q.q.Measures = append(q.q.Measures, metricsview.Measure{Name: col})
 			}
+			q.selectFields = append(q.selectFields, selectField{name: col, isDim: typ == "DIMENSION"})
 		case *ast.FuncCallExpr:
 			alias := field.AsName.String()
 			res, err := q.parseFuncCallExpr(v)
@@ -206,8 +266,59 @@ func (q *query) parseSelect(node *ast.FieldList) error {
 				Name:    alias,
 				Compute: res,
 			})
+			q.selectFields = append(q.selectFields, selectField{name: alias, isDim: true})
 		default:
 			return fmt.Errorf("metrics sql: unsupported expression in select field")
+		}
+	}
+	return nil
+}
+
+// validateGroupBy checks that an explicit GROUP BY clause matches the selected dimensions.
+// Metrics SQL implicitly groups results by all selected dimensions,
+// so an explicit GROUP BY is redundant but allowed when it matches the selected dimensions;
+// a mismatch is rejected because the results would silently differ from what the SQL asks for.
+func (q *query) validateGroupBy(node *ast.GroupByClause) error {
+	if node.Rollup {
+		return errors.New("metrics sql: ROLLUP in GROUP BY is not supported")
+	}
+
+	seen := make(map[string]bool, len(node.Items))
+	for _, item := range node.Items {
+		var name string
+		switch expr := item.Expr.(type) {
+		case *ast.ColumnNameExpr:
+			col, err := parseColumnNameExpr(expr)
+			if err != nil {
+				return err
+			}
+			name = col
+		case *ast.PositionExpr:
+			// positional reference like GROUP BY 1
+			if expr.N < 1 || expr.N > len(q.selectFields) {
+				return fmt.Errorf("metrics sql: GROUP BY position %d is not in the select list", expr.N)
+			}
+			name = q.selectFields[expr.N-1].name
+		default:
+			return fmt.Errorf("metrics sql: unsupported expression %q in GROUP BY", restore(item.Expr))
+		}
+
+		found := false
+		for _, f := range q.selectFields {
+			if f.isDim && f.name == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("metrics sql: GROUP BY column %q must be a selected dimension", name)
+		}
+		seen[name] = true
+	}
+
+	for _, f := range q.selectFields {
+		if f.isDim && !seen[f.name] {
+			return fmt.Errorf("metrics sql: GROUP BY must include all selected dimensions (missing %q)", f.name)
 		}
 	}
 	return nil

--- a/runtime/metricsview/metricssql/parser_test.go
+++ b/runtime/metricsview/metricssql/parser_test.go
@@ -145,7 +145,7 @@ func TestCompile(t *testing.T) {
 			nil,
 		},
 		{
-			"select pub, dom, measure_0 as \"click rate\" from ad_bids_metrics where (pub is not null and dom is null) or (pub = '__default__')",
+			"select pub, dom, measure_0 from ad_bids_metrics where (pub is not null and dom is null) or (pub = '__default__')",
 			"SELECT (\"publisher\") AS \"pub\", (\"domain\") AS \"dom\", (count(*)) AS \"measure_0\" FROM \"ad_bids\" WHERE ((((\"publisher\") IS NOT NULL) AND ((\"domain\") IS NULL)) OR ((\"publisher\") = ?)) GROUP BY 1, 2",
 			mv,
 			[]any{"__default__"},
@@ -180,6 +180,65 @@ func TestCompile(t *testing.T) {
 			advancedMV,
 			[]any{parseTestTime(t, "2022-03-24T00:00:00Z"), parseTestTime(t, "2022-03-31T00:00:00Z")},
 		},
+		{
+			// DISTINCT is a no-op since results are always grouped by the selected dimensions
+			"select distinct pub, dom from ad_bids_metrics",
+			"SELECT (\"publisher\") AS \"pub\", (\"domain\") AS \"dom\" FROM \"ad_bids\" GROUP BY 1, 2",
+			mv,
+			nil,
+		},
+		{
+			// an explicit GROUP BY is allowed when it matches the selected dimensions
+			"select pub, dom, measure_0 from ad_bids_metrics group by pub, dom",
+			"SELECT (\"publisher\") AS \"pub\", (\"domain\") AS \"dom\", (count(*)) AS \"measure_0\" FROM \"ad_bids\" GROUP BY 1, 2",
+			mv,
+			nil,
+		},
+		{
+			// positional GROUP BY references are also allowed
+			"select pub, dom, measure_0 from ad_bids_metrics group by 1, 2",
+			"SELECT (\"publisher\") AS \"pub\", (\"domain\") AS \"dom\", (count(*)) AS \"measure_0\" FROM \"ad_bids\" GROUP BY 1, 2",
+			mv,
+			nil,
+		},
+	}
+
+	errTests := []struct {
+		inSQL   string
+		wantErr string
+	}{
+		{
+			"with x as (select pub from ad_bids_metrics) select pub from x",
+			"WITH clause is not supported",
+		},
+		{
+			"select pub as publisher from ad_bids_metrics",
+			"aliasing a dimension or measure is not supported (found `pub AS publisher`)",
+		},
+		{
+			"select pub, measure_0 as total from ad_bids_metrics",
+			"aliasing a dimension or measure is not supported (found `measure_0 AS total`)",
+		},
+		{
+			"select pub, measure_0 from ad_bids_metrics group by dom",
+			"GROUP BY column \"dom\" must be a selected dimension",
+		},
+		{
+			"select pub, dom, measure_0 from ad_bids_metrics group by pub",
+			"GROUP BY must include all selected dimensions (missing \"dom\")",
+		},
+		{
+			"select pub, measure_0 from ad_bids_metrics group by 2",
+			"GROUP BY column \"measure_0\" must be a selected dimension",
+		},
+		{
+			"select pub, measure_0 from ad_bids_metrics group by 3",
+			"GROUP BY position 3 is not in the select list",
+		},
+		{
+			"select pub from ad_bids_metrics union select dom from ad_bids_metrics",
+			"expected a SELECT statement",
+		},
 	}
 
 	clm, err := rt.ResolveSecurity(t.Context(), instanceID, claims, mv)
@@ -199,6 +258,11 @@ func TestCompile(t *testing.T) {
 		res, err := olap.Query(t.Context(), &drivers.Statement{Query: sql, Args: args})
 		require.NoError(t, err)
 		require.NoError(t, res.Close())
+	}
+
+	for _, test := range errTests {
+		_, err := compiler.Parse(t.Context(), test.inSQL)
+		require.ErrorContains(t, err, test.wantErr, "input = %v", test.inSQL)
 	}
 }
 


### PR DESCRIPTION
Fixes silent clause drops in the metrics SQL top-level SELECT parser: `DISTINCT`, `GROUP BY`, CTEs and column aliases were parsed but silently discarded, so queries could return different results than the SQL asked for.

- Extracted the subquery guard list into a shared `validateSelectStmt`, now applied to top-level queries too: CTEs (`WITH`), window specs, set operations, `SELECT INTO`, table hints, etc. return explicit errors instead of being ignored.
- `DISTINCT` is now explicitly allowed in both top-level queries and `IN (...)` subqueries: metrics SQL always groups results by the selected dimensions, so the output is already distinct and the clause is a semantic no-op.
- An explicit top-level `GROUP BY` is allowed when it exactly matches the selected dimensions (by name or position, e.g. `GROUP BY 1, 2`) and rejected otherwise.
- Aliases on plain dimension/measure columns (`measure_0 AS total`) now error instead of being silently dropped, since the query IR cannot represent renamed output columns.
- Fixed a latent bug where the subquery `GROUP BY` check passed the `*ast.ByItem` instead of its `Expr` to `parseColumnNameExpr`, so any subquery with a `GROUP BY` always errored.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
