### PR TITLE
Fix decimal comparisons in metrics SQL filters

### DIFF
--- a/runtime/metricsview/metricssql/filter_parser.go
+++ b/runtime/metricsview/metricssql/filter_parser.go
@@ -3,12 +3,14 @@ package metricssql
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/itlightning/dateparse"
 	"github.com/pingcap/tidb/pkg/parser"
 	"github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/mysql"
+	"github.com/pingcap/tidb/pkg/parser/test_driver"
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime/metricsview"
 )
@@ -434,6 +436,13 @@ func parseValueExpr(in ast.Node) (any, error) {
 		val = int(actual) // Cast to plain int
 	case uint64:
 		val = int(actual) // Cast to plain int
+	case *test_driver.MyDecimal:
+		// Decimal literals arrive as an opaque struct that would serialize to an empty value; convert to float64
+		f, err := strconv.ParseFloat(actual.String(), 64)
+		if err != nil {
+			return nil, fmt.Errorf("metrics sql: failed to parse decimal literal %q: %w", actual.String(), err)
+		}
+		val = f
 	}
 
 	return val, nil

--- a/runtime/metricsview/metricssql/filter_parser_test.go
+++ b/runtime/metricsview/metricssql/filter_parser_test.go
@@ -70,6 +70,42 @@ func TestParseFilter(t *testing.T) {
 			false,
 		},
 		{
+			"greater than decimal expression",
+			"measure > 10.5",
+			&metricsview.Expression{
+				Condition: &metricsview.Condition{
+					Operator: metricsview.OperatorGt,
+					Expressions: []*metricsview.Expression{
+						{
+							Name: "measure",
+						},
+						{
+							Value: 10.5,
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"in decimal expression",
+			"measure IN (1.5, 2.5)",
+			&metricsview.Expression{
+				Condition: &metricsview.Condition{
+					Operator: metricsview.OperatorIn,
+					Expressions: []*metricsview.Expression{
+						{
+							Name: "measure",
+						},
+						{
+							Value: []any{1.5, 2.5},
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
 			"subquery expression with having",
 			"dim IN (SELECT dim FROM mv HAVING count > 10)",
 			&metricsview.Expression{


### PR DESCRIPTION
## Summary

- Convert TiDB decimal literal values to float64 when parsing metrics SQL filters.
- Prevent decimal comparison values from remaining opaque MyDecimal structs that serialize incorrectly.
- Add regression coverage for greater-than and IN expressions with decimal literals.

## Steps to reproduce

1. Add float64 expectations for measure > 10.5 and measure IN (1.5, 2.5) to TestParseFilter.
2. Run: go test ./runtime/metricsview/metricssql -run ^TestParseFilter$ -count=1
3. On main, observe both decimal cases fail because the actual values are test_driver.MyDecimal rather than float64.
4. Apply this fix and rerun the same command; both cases pass.

## Testing

- Verified the targeted test fails without the parser change and passes with it.
- go test ./runtime/metricsview/metricssql -count=1

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. No docs changes are needed
- [ ] Intend to cherry-pick into the release branch
- [x] I am proud of this work!