### PR TITLE
Reject joins in metrics SQL

### DIFF
--- a/runtime/metricsview/metricssql/parser.go
+++ b/runtime/metricsview/metricssql/parser.go
@@ -192,6 +192,9 @@ func (q *query) parseFrom(ctx context.Context, node *ast.TableRefsClause) error 
 	if n == nil || n.Left == nil {
 		return fmt.Errorf("metrics sql: need `FROM metrics_view` clause")
 	}
+	if n.Right != nil {
+		return fmt.Errorf("metrics sql: join is not supported")
+	}
 
 	tblSrc, ok := n.Left.(*ast.TableSource)
 	if !ok {

--- a/runtime/metricsview/metricssql/parser_test.go
+++ b/runtime/metricsview/metricssql/parser_test.go
@@ -239,6 +239,18 @@ func TestCompile(t *testing.T) {
 			"select pub from ad_bids_metrics union select dom from ad_bids_metrics",
 			"expected a SELECT statement",
 		},
+		{
+			"select pub from ad_bids_metrics join ad_bids_metrics_advanced on ad_bids_metrics.pub = ad_bids_metrics_advanced.pub",
+			"metrics sql: join is not supported",
+		},
+		{
+			"select pub from ad_bids_metrics cross join ad_bids_metrics_advanced",
+			"metrics sql: join is not supported",
+		},
+		{
+			"select pub from ad_bids_metrics, ad_bids_metrics_advanced",
+			"metrics sql: join is not supported",
+		},
 	}
 
 	clm, err := rt.ResolveSecurity(t.Context(), instanceID, claims, mv)


### PR DESCRIPTION
Metrics SQL only supports querying a single metrics view, but JOIN syntax was accepted while the right-hand table was ignored. Reject joined table references explicitly instead.

This covers regular JOINs, CROSS JOINs, and comma-separated table references.

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [x] Checked if the docs need to be updated. No docs change is needed
- [ ] Intend to cherry-pick into the release branch
- [x] Proud of this work!