### PR TITLE
Fix panic in Parquet export of `MetricsViewTimeSeries`

### DIFF
--- a/runtime/queries/metricsview.go
+++ b/runtime/queries/metricsview.go
@@ -346,6 +346,9 @@ func WriteParquet(meta []*runtimev1.MetricsViewColumn, data []*structpb.Struct, 
 			arrowField.Type = arrow.FixedWidthTypes.Timestamp_us
 		case runtimev1.Type_CODE_BYTES:
 			arrowField.Type = arrow.BinaryTypes.Binary
+		default:
+			// A nil arrow.DataType panics in array.NewRecordBuilder below, so reject unmapped type codes explicitly.
+			return fmt.Errorf("parquet export: unsupported type %q for column %q", f.Type, f.Name)
 		}
 		fields = append(fields, arrowField)
 	}

--- a/runtime/queries/metricsview_test.go
+++ b/runtime/queries/metricsview_test.go
@@ -2,9 +2,16 @@ package queries
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/stretchr/testify/require"
 	"github.com/xuri/excelize/v2"
@@ -453,4 +460,65 @@ func Test_writeXLSX_quotes(t *testing.T) {
 	v, err := file.GetCellValue("Sheet1", "A2")
 	require.NoError(t, err)
 	require.Equal(t, "a\"", v)
+}
+
+func Test_writeParquet_timestamp(t *testing.T) {
+	// Mirrors the meta produced by MetricsViewTimeSeries.Export:
+	// a timestamp column with an RFC3339 string value, followed by a measure.
+	meta := []*runtimev1.MetricsViewColumn{
+		{
+			Name: "ts",
+			Type: runtimev1.Type_CODE_TIMESTAMP.String(),
+		},
+		{
+			Name: "measure",
+			Type: runtimev1.Type_CODE_FLOAT64.String(),
+		},
+	}
+	ts := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	data := []*structpb.Struct{
+		{
+			Fields: map[string]*structpb.Value{
+				"ts":      structpb.NewStringValue(ts.Format(time.RFC3339Nano)),
+				"measure": structpb.NewNumberValue(2.5),
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+
+	err := WriteParquet(meta, data, &buf)
+	require.NoError(t, err)
+
+	tbl, err := pqarrow.ReadTable(context.Background(), bytes.NewReader(buf.Bytes()), parquet.NewReaderProperties(memory.DefaultAllocator), pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
+	require.NoError(t, err)
+	defer tbl.Release()
+
+	require.EqualValues(t, 1, tbl.NumRows())
+	tsCol, ok := tbl.Column(0).Data().Chunk(0).(*array.Timestamp)
+	require.True(t, ok)
+	require.Equal(t, ts, tsCol.Value(0).ToTime(arrow.Microsecond))
+	measureCol, ok := tbl.Column(1).Data().Chunk(0).(*array.Float64)
+	require.True(t, ok)
+	require.Equal(t, 2.5, measureCol.Value(0))
+}
+
+func Test_writeParquet_untypedColumn(t *testing.T) {
+	meta := []*runtimev1.MetricsViewColumn{
+		{
+			Name: "col",
+		},
+	}
+	data := []*structpb.Struct{
+		{
+			Fields: map[string]*structpb.Value{
+				"col": structpb.NewStringValue("a"),
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+
+	err := WriteParquet(meta, data, &buf)
+	require.ErrorContains(t, err, "unsupported type")
 }

--- a/runtime/queries/metricsview_timeseries.go
+++ b/runtime/queries/metricsview_timeseries.go
@@ -177,9 +177,12 @@ func (q *MetricsViewTimeSeries) Export(ctx context.Context, rt *runtime.Runtime,
 	tmp := make([]*structpb.Struct, 0, len(q.Result.Data))
 	meta := append([]*runtimev1.MetricsViewColumn{{
 		Name: spec.TimeDimension,
+		Type: runtimev1.Type_CODE_TIMESTAMP.String(),
 	}}, q.Result.Meta...)
 	for _, dt := range q.Result.Data {
-		dt.Records.Fields[spec.TimeDimension] = structpb.NewStringValue(dt.Ts.AsTime().Format(time.RFC3339Nano))
+		// Truncate to microseconds since the Parquet writer stores timestamps with microsecond precision
+		// and rejects strings with sub-microsecond components.
+		dt.Records.Fields[spec.TimeDimension] = structpb.NewStringValue(dt.Ts.AsTime().Truncate(time.Microsecond).Format(time.RFC3339Nano))
 		tmp = append(tmp, dt.Records)
 	}
 


### PR DESCRIPTION
- `MetricsViewTimeSeries.Export` prepended the time column to the export meta without a type, so `WriteParquet` built an arrow field with a nil `arrow.DataType` and panicked in `array.NewRecordBuilder`. The column now carries `CODE_TIMESTAMP`, and the timestamp value is truncated to microseconds since arrow rejects sub-microsecond strings for `timestamp[us]` columns. CSV and XLSX output is unchanged.
- `WriteParquet` now returns an error for type codes it does not map to an arrow type (previously a panic for `INT256`, `UINT128`, `UINT256`, `JSON`, `POINT`, `POLYGON`, and untyped columns).
- Added unit tests covering the timestamp round-trip and the untyped-column error.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
