### PR TITLE
Fix path traversal bypass in `ResolveLocalPath` sandbox

### DIFF
--- a/runtime/drivers/duckdb/model_executor_self_sqlite_test.go
+++ b/runtime/drivers/duckdb/model_executor_self_sqlite_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/rilldata/rill/runtime/drivers"
@@ -18,7 +19,7 @@ import (
 func Test_sqliteToDuckDB_Transfer(t *testing.T) {
 	tempDir := t.TempDir()
 
-	dbPath := fmt.Sprintf("%s.db", tempDir)
+	dbPath := filepath.Join(tempDir, "source.db")
 	db, err := sql.Open("sqlite", dbPath)
 	require.NoError(t, err)
 
@@ -41,6 +42,7 @@ func Test_sqliteToDuckDB_Transfer(t *testing.T) {
 		OutputConnector: "duckdb",
 		Env: &drivers.ModelEnv{
 			AllowHostAccess: false,
+			RepoRoot:        tempDir,
 			StageChanges:    true,
 		},
 		PreliminaryInputProperties: map[string]any{

--- a/runtime/drivers/duckdb/model_executor_self_test.go
+++ b/runtime/drivers/duckdb/model_executor_self_test.go
@@ -43,6 +43,7 @@ func TestDuckDBToDuckDBTransfer(t *testing.T) {
 		OutputConnector: "duckdb",
 		Env: &drivers.ModelEnv{
 			AllowHostAccess: false,
+			RepoRoot:        tempDir,
 			StageChanges:    true,
 		},
 		PreliminaryInputProperties: map[string]any{

--- a/runtime/pkg/fileutil/fileutil.go
+++ b/runtime/pkg/fileutil/fileutil.go
@@ -324,10 +324,18 @@ func ResolveLocalPath(path, root string, allowHostAccess bool) (string, error) {
 	if !filepath.IsAbs(path) {
 		finalPath = filepath.Join(root, path)
 	}
+	// Clean here so that ".." segments are resolved before the sandbox check below;
+	// filepath.Join already cleans the relative branch, but an absolute path does not pass through it.
+	finalPath = filepath.Clean(finalPath)
 
-	if !allowHostAccess && !strings.HasPrefix(finalPath, root) {
-		// path is outside the repo root
-		return "", fmt.Errorf("path is outside repo root")
+	if !allowHostAccess {
+		// Ensure the resolved path stays within the repo root.
+		// The trailing separator prevents a sibling directory whose name shares the root's prefix
+		// (e.g. root "/data/proj" matching "/data/proj-x") from passing the check.
+		root = filepath.Clean(root)
+		if finalPath != root && !strings.HasPrefix(finalPath, root+string(filepath.Separator)) {
+			return "", fmt.Errorf("path is outside repo root")
+		}
 	}
 	return finalPath, nil
 }

--- a/runtime/pkg/fileutil/fileutil_test.go
+++ b/runtime/pkg/fileutil/fileutil_test.go
@@ -2,6 +2,7 @@ package fileutil
 
 import (
 	"os/user"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -70,6 +71,52 @@ func TestExpandHome(t *testing.T) {
 			home, err := ExpandHome(tt.Path)
 			require.NoError(t, err)
 			require.Equal(t, tt.ExpectedPath, home)
+		})
+	}
+}
+
+func TestResolveLocalPath(t *testing.T) {
+	sep := string(filepath.Separator)
+	root := filepath.Clean("/data/proj123")
+
+	variations := []struct {
+		Name            string
+		Path            string
+		Root            string
+		AllowHostAccess bool
+		Expected        string
+		ExpectErr       bool
+	}{
+		// Relative paths within the root are joined and cleaned.
+		{"relative within root", "sub/file.csv", root, false, filepath.Join(root, "sub", "file.csv"), false},
+		{"relative to root itself", ".", root, false, root, false},
+
+		// Absolute paths within the root are allowed.
+		{"absolute within root", filepath.Join(root, "file.csv"), root, false, filepath.Join(root, "file.csv"), false},
+
+		// Absolute path traversal must be rejected once cleaned.
+		{"absolute traversal", root + sep + ".." + sep + ".." + sep + "etc" + sep + "passwd", root, false, "", true},
+
+		// Relative traversal escaping the root must be rejected.
+		{"relative traversal", ".." + sep + ".." + sep + "etc" + sep + "passwd", root, false, "", true},
+
+		// Sibling directory sharing the root's prefix must not pass the check.
+		{"sibling prefix collision", "/data/proj123-x/secret", root, false, "", true},
+		{"relative sibling prefix collision", ".." + sep + "proj123-x" + sep + "secret", root, false, "", true},
+
+		// With host access enabled, any path is allowed (but still cleaned).
+		{"host access bypasses sandbox", root + sep + ".." + sep + "etc" + sep + "passwd", root, true, filepath.Clean("/data/etc/passwd"), false},
+	}
+
+	for _, tt := range variations {
+		t.Run(tt.Name, func(t *testing.T) {
+			got, err := ResolveLocalPath(tt.Path, tt.Root, tt.AllowHostAccess)
+			if tt.ExpectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.Expected, got)
 		})
 	}
 }


### PR DESCRIPTION
`ResolveLocalPath` is used as the file/DuckDB sandbox in hosted deployments (via `AllowHostAccess=false`). Two defects let a project-supplied `path` escape the repo root:

- Absolute inputs were returned without `filepath.Clean`, so `..` segments survived (`filepath.Join`, which cleans, only ran for relative paths). `path: /repo/../../etc/passwd` passed `HasPrefix("/repo/../../etc/passwd", "/repo")` and resolved to `/etc/passwd`.
- The prefix check had no trailing separator, so a sibling directory sharing the root's prefix passed. With root `/data/proj123`, `path: ../proj123-x/secret` cleaned to `/data/proj123-x/secret` and slipped through — a potential cross-tenant read.

Fix:
- `filepath.Clean` the resolved path for both the absolute and relative branches before the sandbox check.
- Replace `strings.HasPrefix(finalPath, root)` with `finalPath == root || strings.HasPrefix(finalPath, root+separator)`, cleaning `root` first.
- Added `TestResolveLocalPath` covering absolute/relative traversal, both sibling-prefix variants, in-root paths, and the `allowHostAccess=true` passthrough.

**Reproducing steps:**

1. Configure a `duckdb` or local `file` connector with `allow_host_access: false` (the state hosted Rill Cloud runs the sandbox in).
2. Create a source/model whose `path` is an absolute path containing `..`, e.g. `path: /<project_root>/../../etc/hosts`.
3. Reconcile/ingest the source. Before this change the file resolves outside the project root and is read; after it, the request is rejected with "path is outside repo root".
4. Alternatively, with project root `/data/proj123`, point `path` at `../proj123-x/<file>` and observe it previously resolved to a sibling tenant directory that still passed the prefix check.

In code, the regression is captured by:
- `ResolveLocalPath("/root/../etc/x", "/root", false)` — now returns an error.
- `ResolveLocalPath("../root-x/secret", "/root", false)` — now returns an error.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
