### PR TITLE
Make AI max message size configurable via instance config

### DIFF
--- a/runtime/ai/ai.go
+++ b/runtime/ai/ai.go
@@ -32,10 +32,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// maxMessageSizeBytes is the maximum allowed size of a message's contents.
-// Exceeding it will result in an error.
-const maxMessageSizeBytes = 100 * 1024 // 100 KB
-
 // Tracer for instrumenting requests.
 var tracer = otel.Tracer("github.com/rilldata/rill/runtime/ai")
 
@@ -948,12 +944,19 @@ func (s *Session) Call(ctx context.Context, opts *CallOptions) (*CallResult, err
 		return nil, ctx.Err()
 	}
 
+	// Resolve the configured maximum message size.
+	cfg, err := s.runner.Runtime.InstanceConfig(ctx, s.instanceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get instance config: %w", err)
+	}
+	maxMessageSizeBytes := cfg.AIMaxMessageSizeBytes
+
 	var argsJSON json.RawMessage
-	argsJSON, err := json.Marshal(opts.Args)
+	argsJSON, err = json.Marshal(opts.Args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal args: %w", err)
 	}
-	if len(argsJSON) > maxMessageSizeBytes {
+	if len(argsJSON) > int(maxMessageSizeBytes) {
 		return nil, fmt.Errorf("call args size %d exceeds maximum of %d bytes", len(argsJSON), maxMessageSizeBytes)
 	}
 
@@ -1014,7 +1017,7 @@ func (s *Session) Call(ctx context.Context, opts *CallOptions) (*CallResult, err
 		outJSON, err = json.Marshal(handlerOut)
 		if err != nil {
 			handlerErr = fmt.Errorf("failed to marshal result: %w (out: %v)", err, handlerOut)
-		} else if len(outJSON) > maxMessageSizeBytes {
+		} else if len(outJSON) > int(maxMessageSizeBytes) {
 			handlerErr = fmt.Errorf("marshaled result size %d exceeds maximum of %d bytes", len(outJSON), maxMessageSizeBytes)
 			outJSON = nil
 		}

--- a/runtime/drivers/registry.go
+++ b/runtime/drivers/registry.go
@@ -135,6 +135,8 @@ type InstanceConfig struct {
 	AIRequireTimeRange bool `mapstructure:"rill.ai.require_time_range"`
 	// AIMaxTimeRangeDays is the maximum time range allowed for AI tool queries, in days. If set to 0, there is no limit.
 	AIMaxTimeRangeDays int64 `mapstructure:"rill.ai.max_time_range_days"`
+	// AIMaxMessageSizeBytes is the maximum allowed size of an AI message's contents (tool call args or results). Exceeding it results in an error.
+	AIMaxMessageSizeBytes int64 `mapstructure:"rill.ai.max_message_size_bytes"`
 	// StrictResolverProps indicates whether to return an error when a resolver contains properties that are not recognized by the resolver implementation.
 	StrictResolverProps bool `mapstructure:"rill.strict_resolver_properties"`
 	// StrictModelProps indicates whether to return an error when a model contains unmapped properties.
@@ -220,6 +222,7 @@ func (i *Instance) Config() (InstanceConfig, error) {
 		AIDefaultQueryLimit:                  25,
 		AIMaxQueryLimit:                      250,
 		AIRequireTimeRange:                   true,
+		AIMaxMessageSizeBytes:                200 * 1024, // 200 KB
 		ModelPartitionsWarnOnFailure:         i.Environment == "prod",
 		ModelTestsWarnOnFailure:              i.Environment == "prod",
 	}


### PR DESCRIPTION
Replaces the hard-coded 100 KB limit with a `rill.ai.max_message_size_bytes` instance config setting.

Also changed the default to 200 KB.