### PR TITLE
Include exact metrics view field names in the `develop_file` sub-agent prompt

### DIFF
--- a/runtime/ai/develop_file.go
+++ b/runtime/ai/develop_file.go
@@ -3,10 +3,12 @@ package ai
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	aiv1 "github.com/rilldata/rill/proto/gen/rill/ai/v1"
+	runtimev1 "github.com/rilldata/rill/proto/gen/rill/runtime/v1"
 	"github.com/rilldata/rill/runtime"
 	"github.com/rilldata/rill/runtime/ai/instructions"
 )
@@ -122,6 +124,7 @@ func (t *DevelopFile) Handler(ctx context.Context, args *DevelopFileArgs) (*Deve
 			SearchFilesName,
 			ReadFileName,
 			WriteFileName,
+			GetMetricsViewName,
 			ListBucketsName,
 			ListBucketObjectsName,
 			ListTablesName,
@@ -147,14 +150,25 @@ func (t *DevelopFile) userPrompt(ctx context.Context, args *DevelopFileArgs) (st
 		return "", err
 	}
 
+	// For file types that may reference a metrics view, include the exact field names of the project's metrics views.
+	var metricsViewsInfo string
+	switch args.Type {
+	case "", "explore", "canvas", "api", "alert", "report":
+		metricsViewsInfo, err = t.metricsViewsInfo(ctx)
+		if err != nil {
+			return "", err
+		}
+	}
+
 	// Prepare template data.
 	session := GetSession(ctx)
 	data := map[string]any{
-		"path":              args.Path,
-		"type":              args.Type,
-		"prompt":            args.Prompt,
-		"ai_instructions":   session.ProjectInstructions(),
-		"default_olap_info": olapInfo,
+		"path":               args.Path,
+		"type":               args.Type,
+		"prompt":             args.Prompt,
+		"ai_instructions":    session.ProjectInstructions(),
+		"default_olap_info":  olapInfo,
+		"metrics_views_info": metricsViewsInfo,
 	}
 
 	// Generate the user prompt
@@ -166,10 +180,62 @@ You should develop a Rill project file based on the following task description:
 
 Here is some important context:
 - You are running as a sub-agent of a larger developer agent. Stay aligned on your specific task and avoid extra discovery.
+- If the file references a metrics view (as explore and canvas dashboards do), only use the exact measure and dimension names of that metrics view. Use the field names listed below if present; if the metrics view is not listed, call 'get_metrics_view' (or read the metrics view's YAML file) BEFORE writing the file. Never guess field names based on display names or the task description.
 - When you call 'write_file', if it returns a parse or reconcile error, do your best to fix the issue and try again. If you think the error is unrelated to the current path, let the parent agent know to handle it.
 
 Here is some additional context that may or may not be relevant to your task:
 - Info about the project's default OLAP connector: {{ .default_olap_info }}.
+{{ if .metrics_views_info }}- The project's metrics views and their exact field names:
+{{ .metrics_views_info }}{{ end }}
 {{ if .ai_instructions }}- The user has configured global additional instructions for you. They may not relate to the current request, and may not even relate to your work as a data engineer agent. Only use them if you find them relevant. They are: {{ .ai_instructions }}{{ end }}
 `, data)
+}
+
+// metricsViewsInfo returns a summary of the project's valid metrics views with their exact dimension and measure names.
+// It is included in the user prompt for file types that reference metrics views, so the developer doesn't guess field names.
+func (t *DevelopFile) metricsViewsInfo(ctx context.Context) (string, error) {
+	session := GetSession(ctx)
+
+	ctrl, err := t.Runtime.Controller(ctx, session.InstanceID())
+	if err != nil {
+		return "", err
+	}
+
+	rs, err := ctrl.List(ctx, runtime.ResourceKindMetricsView, "", false)
+	if err != nil {
+		return "", err
+	}
+
+	slices.SortFunc(rs, func(a, b *runtimev1.Resource) int {
+		return strings.Compare(a.Meta.Name.Name, b.Meta.Name.Name)
+	})
+
+	var sb strings.Builder
+	for _, r := range rs {
+		r, access, err := t.Runtime.ApplySecurityPolicy(ctx, session.InstanceID(), session.Claims(), r)
+		if err != nil {
+			return "", err
+		}
+		if !access {
+			continue
+		}
+
+		spec := r.GetMetricsView().State.ValidSpec
+		if spec == nil {
+			continue
+		}
+
+		dimensions := make([]string, len(spec.Dimensions))
+		for i, d := range spec.Dimensions {
+			dimensions[i] = d.Name
+		}
+		measures := make([]string, len(spec.Measures))
+		for i, m := range spec.Measures {
+			measures[i] = fmt.Sprintf("%s (display name %q)", m.Name, m.DisplayName)
+		}
+
+		fmt.Fprintf(&sb, "  - %s: dimensions: [%s]; measures: [%s]\n", r.Meta.Name.Name, strings.Join(dimensions, ", "), strings.Join(measures, ", "))
+	}
+
+	return sb.String(), nil
 }

--- a/runtime/ai/develop_file_test.go
+++ b/runtime/ai/develop_file_test.go
@@ -1,0 +1,98 @@
+package ai_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/rilldata/rill/runtime/ai"
+	"github.com/rilldata/rill/runtime/drivers"
+	"github.com/rilldata/rill/runtime/testruntime"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDevelopFileMetricsViewFieldNamesInPrompt verifies that the develop_file prompt includes the
+// exact dimension and measure names of the project's metrics views.
+// It reproduces AI canvas generation for a model with a hyphen in its name (e.g. `bids-data`), where
+// the metrics view's measure names differ from their display names: without the field names in the
+// prompt, the sub-agent guessed measure names from display names and produced a broken dashboard.
+func TestDevelopFileMetricsViewFieldNamesInPrompt(t *testing.T) {
+	rt, instanceID := testruntime.NewInstanceWithOptions(t, testruntime.InstanceOptions{
+		Files: map[string]string{
+			"models/bids-data.yaml": `
+type: model
+sql: |
+  SELECT TIMESTAMP '2024-01-01 00:00:00' AS __time, 'Above the Fold' AS ad_position, 1 AS bid_cnt, 2.5 AS media_spend_usd
+`,
+			"metrics/bids-data_metrics.yaml": `
+type: metrics_view
+model: bids-data
+timeseries: __time
+dimensions:
+  - column: ad_position
+measures:
+  - name: total_bids_measure
+    display_name: Total Bids
+    expression: SUM(bid_cnt)
+  - name: total_media_spend_usd_measure
+    display_name: Total Media Spend (USD)
+    expression: SUM(media_spend_usd)
+`,
+		},
+	})
+	testruntime.RequireReconcileState(t, rt, instanceID, 4, 0, 0)
+
+	// Initialize a test session with a mocked LLM that captures the prompts passed to it.
+	s := newSession(t, rt, instanceID)
+	llm := &capturingAIService{}
+	s.SetLLM(func(ctx context.Context) (drivers.AIService, func(), error) {
+		return llm, func() {}, nil
+	})
+
+	// Ask the developer to create a canvas dashboard using display names only (as the parent agent does).
+	var res *ai.DevelopFileResult
+	_, err := s.CallTool(t.Context(), ai.RoleUser, ai.DevelopFileName, &res, &ai.DevelopFileArgs{
+		Path:   "/dashboards/bids-data_metrics_canvas.yaml",
+		Type:   "canvas",
+		Prompt: `Create a canvas dashboard based on the "bids-data_metrics" metrics view with KPIs for Total Bids and Total Media Spend (USD).`,
+	})
+	require.NoError(t, err)
+
+	// The prompt should contain the exact field names of the metrics view, including the mapping
+	// from display names to measure names.
+	prompt := llm.promptText()
+	require.Contains(t, prompt, "The project's metrics views and their exact field names")
+	require.Contains(t, prompt, "bids-data_metrics")
+	require.Contains(t, prompt, "ad_position")
+	require.Contains(t, prompt, `total_bids_measure (display name "Total Bids")`)
+	require.Contains(t, prompt, `total_media_spend_usd_measure (display name "Total Media Spend (USD)")`)
+}
+
+// capturingAIService is a drivers.AIService that captures the messages passed to it and always
+// returns a plain text response (ending completion loops after one iteration).
+type capturingAIService struct {
+	calls []*drivers.CompleteOptions
+}
+
+func (a *capturingAIService) Complete(ctx context.Context, opts *drivers.CompleteOptions) (*drivers.CompleteResult, error) {
+	a.calls = append(a.calls, opts)
+	return &drivers.CompleteResult{
+		Message: ai.NewTextCompletionMessage(ai.RoleAssistant, "Done."),
+	}, nil
+}
+
+// promptText returns the text content of all messages passed to the service.
+func (a *capturingAIService) promptText() string {
+	var sb strings.Builder
+	for _, call := range a.calls {
+		for _, msg := range call.Messages {
+			for _, block := range msg.Content {
+				if text := block.GetText(); text != "" {
+					sb.WriteString(text)
+					sb.WriteString("\n")
+				}
+			}
+		}
+	}
+	return sb.String()
+}


### PR DESCRIPTION
When the developer agent delegates dashboard creation to the `develop_file` sub-agent, the sub-agent only received display names (e.g. "Total Bids") and guessed the underlying measure names, producing canvases that reference non-existent measures (reproduced with a model named `bids-data`, whose AI-generated metrics view has measures like `total_bids_measure`).

- The `develop_file` prompt now pre-sends the exact dimension and measure names (with display name mappings) of the project's metrics views for file types that reference them (`explore`, `canvas`, `api`, `alert`, `report`, or unspecified).
- Adds the `get_metrics_view` tool to the sub-agent as a fallback for metrics views not yet reconciled.
- Adds a reproducing test that fails without the prompt change.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
