### PR TITLE
Prevent transient table lookup errors from marking all partitions pending

### DIFF
--- a/runtime/drivers/clickhouse/model_manager.go
+++ b/runtime/drivers/clickhouse/model_manager.go
@@ -2,6 +2,7 @@ package clickhouse
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -282,7 +283,13 @@ func (c *Connection) Exists(ctx context.Context, res *drivers.ModelResult) (bool
 	}
 
 	_, err := olap.InformationSchema().Lookup(ctx, c.config.Database, "", res.Table)
-	return err == nil, nil
+	if err != nil {
+		if errors.Is(err, drivers.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func (c *Connection) Delete(ctx context.Context, res *drivers.ModelResult) error {

--- a/runtime/drivers/duckdb/information_schema.go
+++ b/runtime/drivers/duckdb/information_schema.go
@@ -219,9 +219,11 @@ func scanTables(rows []*rduckdb.Table) ([]*drivers.OlapTable, error) {
 		for idx, colName := range row.ColumnNames {
 			databaseType := row.ColumnTypes[idx].(string)
 			nullable := row.ColumnNullable[idx].(bool)
-			// For views that depend on secrets, we have an inaccessible schema since
-			// the secret is only set at write time.
-			if strings.HasPrefix(colName.(string), "error(") && databaseType == "\"NULL\"" {
+			// Views that wrap an error() call have an inaccessible schema.
+			// This happens for views that depend on secrets (since the secret is only set at write time)
+			// and for views that rduckdb has replaced with an error placeholder because they broke against the underlying data.
+			// Note: depending on the DuckDB version, the generated column name may or may not quote the function name.
+			if (strings.HasPrefix(colName.(string), "error(") || strings.HasPrefix(colName.(string), `"error"(`)) && databaseType == `"NULL"` {
 				continue
 			}
 			colType, err := databaseTypeToPB(databaseType, nullable)
@@ -305,7 +307,8 @@ func databaseTypeToPB(dbt string, nullable bool) (*runtimev1.Type, error) {
 		t.Code = runtimev1.Type_CODE_POINT
 	case "POLYGON_2D":
 		t.Code = runtimev1.Type_CODE_POLYGON
-	case "NULL":
+	// The type of the SQL NULL constant; information_schema reports it quoted as `"NULL"` in recent DuckDB versions.
+	case "NULL", `"NULL"`:
 		t.Code = runtimev1.Type_CODE_UNSPECIFIED
 	default:
 		match = false

--- a/runtime/drivers/duckdb/model_manager.go
+++ b/runtime/drivers/duckdb/model_manager.go
@@ -2,6 +2,7 @@ package duckdb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -137,7 +138,13 @@ func (c *connection) Exists(ctx context.Context, res *drivers.ModelResult) (bool
 	}
 
 	_, err := olap.InformationSchema().Lookup(ctx, "", "", res.Table)
-	return err == nil, nil
+	if err != nil {
+		if errors.Is(err, drivers.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func (c *connection) Delete(ctx context.Context, res *drivers.ModelResult) error {

--- a/runtime/metricsview/executor/executor_validate.go
+++ b/runtime/metricsview/executor/executor_validate.go
@@ -75,7 +75,7 @@ func (e *Executor) ValidateAndNormalizeMetricsView(ctx context.Context) (*Valida
 			res.OtherErrs = append(res.OtherErrs, fmt.Errorf("table %q does not exist", mv.Table))
 			return res, nil
 		}
-		return nil, fmt.Errorf("could not find table %q: %w", mv.Table, err)
+		return nil, fmt.Errorf("failed to look up table %q: %w", mv.Table, err)
 	}
 
 	// Populate empty database/databaseSchema from table metadata for StarRocks only.

--- a/runtime/reconcilers/model.go
+++ b/runtime/reconcilers/model.go
@@ -284,9 +284,15 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceNa
 		// so we let it proceed as the escape hatch for a persistently failing check.
 		if err != nil {
 			if !model.Spec.TriggerFull {
+				// Note: not reusing refreshOn here since it is derived from the last successful refresh and may be in the past,
+				// where it would cause an immediate retrigger loop against a potentially failing connector.
+				retriggerOn, err2 := nextRefreshTime(time.Now(), model.Spec.RefreshSchedule)
+				if err2 != nil {
+					return runtime.ReconcileResult{Err: err2}
+				}
 				return runtime.ReconcileResult{
 					Err:       fmt.Errorf("failed to check if model output exists (trigger a full refresh to rebuild anyway): %w", err),
-					Retrigger: refreshOn,
+					Retrigger: retriggerOn,
 				}
 			}
 			r.C.Logger.Warn("failed to check if model output exists, proceeding because a full refresh was manually triggered", zap.String("model", n.Name), zap.Error(err), observability.ZapCtx(ctx))

--- a/runtime/reconcilers/model.go
+++ b/runtime/reconcilers/model.go
@@ -277,8 +277,19 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceNa
 	var exists bool
 	if prevManager != nil {
 		exists, err = prevManager.Exists(ctx, prevResult)
+		// If the check errored, we can't know if the output is still there.
+		// Treating it as missing could trigger a destructive full reset on a transient failure,
+		// so we return the error instead and let the next reconcile retry.
+		// Exception: a manually triggered full refresh is an explicit instruction to rebuild,
+		// so we let it proceed as the escape hatch for a persistently failing check.
+		if err != nil && !model.Spec.TriggerFull {
+			return runtime.ReconcileResult{
+				Err:       fmt.Errorf("failed to check if model output exists (trigger a full refresh to rebuild anyway): %w", err),
+				Retrigger: refreshOn,
+			}
+		}
 		if err != nil {
-			r.C.Logger.Warn("failed to check if model output exists", zap.String("model", n.Name), zap.Error(err), observability.ZapCtx(ctx))
+			r.C.Logger.Warn("failed to check if model output exists, proceeding because a full refresh was manually triggered", zap.String("model", n.Name), zap.Error(err), observability.ZapCtx(ctx))
 		}
 	}
 

--- a/runtime/reconcilers/model.go
+++ b/runtime/reconcilers/model.go
@@ -282,13 +282,13 @@ func (r *ModelReconciler) Reconcile(ctx context.Context, n *runtimev1.ResourceNa
 		// so we return the error instead and let the next reconcile retry.
 		// Exception: a manually triggered full refresh is an explicit instruction to rebuild,
 		// so we let it proceed as the escape hatch for a persistently failing check.
-		if err != nil && !model.Spec.TriggerFull {
-			return runtime.ReconcileResult{
-				Err:       fmt.Errorf("failed to check if model output exists (trigger a full refresh to rebuild anyway): %w", err),
-				Retrigger: refreshOn,
-			}
-		}
 		if err != nil {
+			if !model.Spec.TriggerFull {
+				return runtime.ReconcileResult{
+					Err:       fmt.Errorf("failed to check if model output exists (trigger a full refresh to rebuild anyway): %w", err),
+					Retrigger: refreshOn,
+				}
+			}
 			r.C.Logger.Warn("failed to check if model output exists, proceeding because a full refresh was manually triggered", zap.String("model", n.Name), zap.Error(err), observability.ZapCtx(ctx))
 		}
 	}


### PR DESCRIPTION
- `Exists()` in the DuckDB and ClickHouse model managers swallowed all lookup errors, so a transient connectivity failure (e.g. an unreachable database ATTACHed via `init_sql`) read as a missing table and escalated a scheduled refresh into a full reset.
- The model reconciler now fails the reconcile on an errored existence check (retrying at the next scheduled refresh) instead of assuming the table is missing; a manually triggered full refresh still proceeds as an escape hatch.
- The metrics view validation error `could not find table` now says `failed to look up table`, since it wraps any lookup error; only genuine absence reports "does not exist".
