### PR TITLE
fix: toggling off pivot filter clearing existing filters

### DIFF
--- a/web-common/src/features/canvas/components/pivot/pivot-click-to-filter.spec.ts
+++ b/web-common/src/features/canvas/components/pivot/pivot-click-to-filter.spec.ts
@@ -3,7 +3,10 @@ import type {
   PivotDataStore,
   PivotDataStoreConfig,
 } from "@rilldata/web-common/features/dashboards/pivot/types";
-import { createAndExpression } from "@rilldata/web-common/features/dashboards/stores/filter-utils";
+import {
+  createAndExpression,
+  createInExpression,
+} from "@rilldata/web-common/features/dashboards/stores/filter-utils";
 import type { V1Expression } from "@rilldata/web-common/runtime-client";
 import { get, writable, type Readable } from "svelte/store";
 import { describe, expect, it, vi } from "vitest";
@@ -109,6 +112,7 @@ function setup(
   config: PivotDataStoreConfig,
   data: PivotDataRow[],
   columnDimensionAxes: Record<string, string[]> = {},
+  whereFilter?: V1Expression,
 ) {
   const selfFilteredDimensions = writable<Set<string>>(new Set());
   const { fm, filterClass } = stubFilterManagerWithClass("mv1");
@@ -120,6 +124,7 @@ function setup(
       filterManager: fm,
       activeComponent: writable<string | null>("pivot-1"),
       selfFilteredDimensions,
+      whereFilterStore: writable<V1Expression | undefined>(whereFilter),
     }),
   );
 
@@ -630,6 +635,229 @@ describe("deselect retains shared column filters", () => {
     );
     expectNoToggle(filterClass, "status");
     expectNoToggle(filterClass, "type");
+
+    result.destroy();
+  });
+});
+
+// A dashboard can already carry filters the pivot knows nothing about. The
+// filter expressions produced for a clicked cell/header must describe only that
+// element, otherwise toggling the pivot selection off also toggles off those
+// unrelated filters.
+describe("unrelated global filters are left alone", () => {
+  const globalFilter = createAndExpression([
+    createInExpression("domain", ["google.com"]),
+    createInExpression("device", ["mobile"]),
+  ]);
+
+  /** Assert a dimension was neither added to nor removed from the filter set. */
+  function expectUntouched(
+    filterClass: ReturnType<typeof stubFilterManagerWithClass>["filterClass"],
+    dimensionName: string,
+  ) {
+    expectNoToggle(filterClass, dimensionName);
+    const addCalls = filterClass.addDimensionValueSelections.mock.calls.filter(
+      (call: unknown[]) => call[0] === dimensionName,
+    );
+    expect(addCalls).toHaveLength(0);
+  }
+
+  const flatConfig = makeConfig({
+    rowDimensionNames: ["country"],
+    measureNames: ["revenue"],
+    isFlat: true,
+    whereFilter: globalFilter,
+  });
+  const flatData: PivotDataRow[] = [{ country: "US", revenue: 100 }];
+
+  it("does not re-add global filter values when selecting a cell", () => {
+    const { result, filterClass } = setup(
+      flatConfig,
+      flatData,
+      {},
+      globalFilter,
+    );
+
+    result.handleCellClickToFilter("0", "revenue", false, flatData[0]);
+
+    expect(filterClass.addDimensionValueSelections).toHaveBeenCalledWith(
+      "country",
+      ["US"],
+    );
+    expectUntouched(filterClass, "domain");
+    expectUntouched(filterClass, "device");
+
+    result.destroy();
+  });
+
+  it("marks only the pivot's own dimension as self-filtered", () => {
+    const { result, selfFilteredDimensions } = setup(
+      flatConfig,
+      flatData,
+      {},
+      globalFilter,
+    );
+
+    result.handleCellClickToFilter("0", "revenue", false, flatData[0]);
+
+    expect([...get(selfFilteredDimensions)]).toEqual(["country"]);
+
+    result.destroy();
+  });
+
+  it("keeps global filters when deselecting a cell", () => {
+    const { result, filterClass } = setup(
+      flatConfig,
+      flatData,
+      {},
+      globalFilter,
+    );
+
+    result.handleCellClickToFilter("0", "revenue", false, flatData[0]);
+    filterClass.toggleDimensionValueSelections.mockClear();
+    filterClass.addDimensionValueSelections.mockClear();
+    result.handleCellClickToFilter("0", "revenue", false, flatData[0]);
+
+    expect(sel(result).cellSelections.size).toBe(0);
+    expect(filterClass.toggleDimensionValueSelections).toHaveBeenCalledWith(
+      "country",
+      ["US"],
+      false,
+      false,
+    );
+    expectUntouched(filterClass, "domain");
+    expectUntouched(filterClass, "device");
+
+    result.destroy();
+  });
+
+  it("keeps global filters when deselecting a row header", () => {
+    const nestedConfig = makeConfig({
+      rowDimensionNames: ["country"],
+      measureNames: ["revenue"],
+      whereFilter: globalFilter,
+    });
+    const nestedData: PivotDataRow[] = [{ country: "US", revenue: 100 }];
+
+    const { result, filterClass } = setup(
+      nestedConfig,
+      nestedData,
+      {},
+      globalFilter,
+    );
+
+    result.handleCellClickToFilter("1", "country", true, nestedData[0]);
+    expect(sel(result).rowHeaderSelections.size).toBe(1);
+
+    filterClass.toggleDimensionValueSelections.mockClear();
+    filterClass.addDimensionValueSelections.mockClear();
+    result.handleCellClickToFilter("1", "country", true, nestedData[0]);
+
+    expect(sel(result).rowHeaderSelections.size).toBe(0);
+    expect(filterClass.toggleDimensionValueSelections).toHaveBeenCalledWith(
+      "country",
+      ["US"],
+      false,
+      false,
+    );
+    expectUntouched(filterClass, "domain");
+    expectUntouched(filterClass, "device");
+
+    result.destroy();
+  });
+
+  it("keeps global filters when deselecting a column header", () => {
+    const colConfig = makeConfig({
+      rowDimensionNames: ["country"],
+      colDimensionNames: ["region"],
+      measureNames: ["revenue"],
+      whereFilter: globalFilter,
+    });
+
+    const { result, filterClass } = setup(colConfig, [], {}, globalFilter);
+
+    result.handleColumnHeaderClick({ region: "NA" });
+    filterClass.toggleDimensionValueSelections.mockClear();
+    filterClass.addDimensionValueSelections.mockClear();
+    result.handleColumnHeaderClick({ region: "NA" });
+
+    expect(sel(result).columnHeaderSelections.size).toBe(0);
+    expect(filterClass.toggleDimensionValueSelections).toHaveBeenCalledWith(
+      "region",
+      ["NA"],
+      false,
+      false,
+    );
+    expectUntouched(filterClass, "domain");
+    expectUntouched(filterClass, "device");
+
+    result.destroy();
+  });
+
+  it("keeps global filters when a column header level switch replaces selections", () => {
+    const colConfig = makeConfig({
+      rowDimensionNames: ["country"],
+      colDimensionNames: ["region", "category"],
+      measureNames: ["revenue"],
+      whereFilter: globalFilter,
+    });
+
+    const { result, filterClass } = setup(colConfig, [], {}, globalFilter);
+
+    result.handleColumnHeaderClick({ region: "NA" });
+    filterClass.toggleDimensionValueSelections.mockClear();
+    filterClass.addDimensionValueSelections.mockClear();
+    result.handleColumnHeaderClick({ region: "NA", category: "Electronics" });
+
+    expect(filterClass.addDimensionValueSelections).toHaveBeenCalledWith(
+      "category",
+      ["Electronics"],
+    );
+    expectUntouched(filterClass, "domain");
+    expectUntouched(filterClass, "device");
+
+    result.destroy();
+  });
+
+  it("keeps global filters when a row-header click evicts a child cell", () => {
+    const nestedConfig = makeConfig({
+      rowDimensionNames: ["outer", "inner"],
+      measureNames: ["revenue"],
+      whereFilter: globalFilter,
+    });
+    const nestedData: PivotDataRow[] = [
+      {
+        outer: "Zoom",
+        revenue: 100,
+        subRows: [{ outer: "US-East", inner: "US-East", revenue: 50 }],
+      },
+    ];
+
+    const { result, filterClass } = setup(
+      nestedConfig,
+      nestedData,
+      {},
+      globalFilter,
+    );
+
+    result.handleCellClickToFilter(
+      "1.0",
+      "revenue",
+      false,
+      nestedData[0].subRows![0],
+    );
+    filterClass.toggleDimensionValueSelections.mockClear();
+    filterClass.addDimensionValueSelections.mockClear();
+    result.handleCellClickToFilter("1", "outer", true, nestedData[0]);
+
+    expect(filterClass.toggleDimensionValueSelections).toHaveBeenCalledWith(
+      "inner",
+      ["US-East"],
+      false,
+      false,
+    );
+    expectUntouched(filterClass, "domain");
+    expectUntouched(filterClass, "device");
 
     result.destroy();
   });

--- a/web-common/src/features/dashboards/pivot/pivot-data-assembly.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-data-assembly.ts
@@ -7,6 +7,7 @@ import {
   getFiltersForCell,
   getPivotConfigKey,
 } from "@rilldata/web-common/features/dashboards/pivot/pivot-utils";
+import { mergeFilters } from "./pivot-merge-filters";
 import { reduceTableCellDataIntoRows } from "./pivot-table-transformations";
 import type { PivotDataRow, PivotDataStoreConfig, PivotFilter } from "./types";
 
@@ -211,17 +212,25 @@ function getActiveCellFilters(
   config: PivotDataStoreConfig,
   columnDimensionAxes: Record<string, string[]> | undefined,
   tableData: PivotDataRow[],
-) {
+): PivotFilter | undefined {
   const activeCell = config.pivot.activeCell;
   if (!activeCell) return undefined;
 
-  return getFiltersForCell(
+  const cellFilter = getFiltersForCell(
     config,
     activeCell.rowId,
     activeCell.columnId,
     columnDimensionAxes,
     tableData,
   );
+
+  // getFiltersForCell only describes the cell itself. The rows viewer queries
+  // actual rows with this expression, so it must also honour the dashboard's
+  // global filters.
+  return {
+    ...cellFilter,
+    filters: mergeFilters(cellFilter.filters, config.whereFilter),
+  };
 }
 
 function getReachedEndForRowData(

--- a/web-common/src/features/dashboards/pivot/pivot-filter-scope.spec.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-filter-scope.spec.ts
@@ -1,0 +1,184 @@
+/**
+ * The pivot filter builders serve two callers with opposite needs:
+ *
+ * - Click-to-filter reads the returned expression back to decide which
+ *   dimension values to toggle on the dashboard, so the expression must
+ *   describe only the clicked element. Including the global where filter here
+ *   made deselecting a pivot cell also toggle off unrelated global filters.
+ * - The rows viewer queries actual rows with the expression, so it must honour
+ *   the global where filter on top of the cell's own filters.
+ *
+ * These tests pin both halves of that contract.
+ */
+import {
+  createAndExpression,
+  createInExpression,
+} from "@rilldata/web-common/features/dashboards/stores/filter-utils";
+import type { V1Expression } from "@rilldata/web-common/runtime-client";
+import { describe, expect, it } from "vitest";
+import { buildFinalPivotStateDetails } from "./pivot-data-assembly";
+import {
+  getFiltersForColumnHeader,
+  getFiltersForRowData,
+  getFiltersForRowHeader,
+} from "./pivot-row-selection";
+import { getFiltersForCell, getFiltersFromRow } from "./pivot-utils";
+import type { PivotDataRow, PivotDataStoreConfig } from "./types";
+
+/** An unrelated global filter, as if the user had picked it from the filter bar. */
+const GLOBAL_FILTER = createAndExpression([
+  createInExpression("domain", ["google.com"]),
+]);
+
+function makeConfig(
+  overrides: Partial<PivotDataStoreConfig> = {},
+): PivotDataStoreConfig {
+  return {
+    rowDimensionNames: ["country"],
+    colDimensionNames: [],
+    measureNames: ["revenue"],
+    isFlat: true,
+    whereFilter: GLOBAL_FILTER,
+    time: { timeDimension: "", timeStart: undefined, timeEnd: undefined },
+    pivot: {
+      activeCell: null,
+      rowPage: 1,
+      showTotalsRow: false,
+      sorting: [],
+    },
+    ...overrides,
+  } as unknown as PivotDataStoreConfig;
+}
+
+/** Dimension names referenced by the top-level AND expression, in order. */
+function identsIn(expr: V1Expression | undefined): string[] {
+  return (expr?.cond?.exprs ?? [])
+    .map((e) => e.cond?.exprs?.[0]?.ident)
+    .filter((ident): ident is string => ident !== undefined);
+}
+
+const FLAT_DATA: PivotDataRow[] = [
+  { country: "US", revenue: 100 },
+  { country: "UK", revenue: 200 },
+];
+
+describe("pivot filter builders exclude the global where filter", () => {
+  it("getFiltersForRowData", () => {
+    const result = getFiltersForRowData(makeConfig(), FLAT_DATA[0]);
+
+    expect(identsIn(result.filters)).toEqual(["country"]);
+  });
+
+  it("getFiltersFromRow", () => {
+    const result = getFiltersFromRow(makeConfig(), FLAT_DATA[0], "revenue");
+
+    expect(identsIn(result.filters)).toEqual(["country"]);
+  });
+
+  it("getFiltersForRowHeader", () => {
+    const result = getFiltersForRowHeader(makeConfig(), "0", FLAT_DATA);
+
+    expect(identsIn(result.filters)).toEqual(["country"]);
+  });
+
+  it("getFiltersForColumnHeader", () => {
+    const config = makeConfig({ colDimensionNames: ["region"] });
+
+    const result = getFiltersForColumnHeader(config, { region: "NA" });
+
+    expect(identsIn(result.filters)).toEqual(["region"]);
+  });
+
+  it("getFiltersForCell on a flat table", () => {
+    const result = getFiltersForCell(
+      makeConfig(),
+      "0",
+      "revenue",
+      {},
+      FLAT_DATA,
+    );
+
+    expect(identsIn(result.filters)).toEqual(["country"]);
+  });
+
+  it("getFiltersForCell on a nested table with column dimensions", () => {
+    const config = makeConfig({
+      isFlat: false,
+      rowDimensionNames: ["country"],
+      colDimensionNames: ["region"],
+    });
+
+    const result = getFiltersForCell(
+      config,
+      "0",
+      "c0v0m0",
+      { region: ["NA", "EU"] },
+      FLAT_DATA,
+    );
+
+    expect(identsIn(result.filters)).toEqual(["country", "region"]);
+  });
+
+  it("does not merge a global filter on a dimension the pivot also filters", () => {
+    // The global filter already narrows `country`; the cell's own filter must
+    // not be intersected with it, otherwise click-to-filter would toggle
+    // values the user selected elsewhere.
+    const config = makeConfig({
+      whereFilter: createAndExpression([
+        createInExpression("country", ["US", "UK"]),
+      ]),
+    });
+
+    const result = getFiltersFromRow(config, FLAT_DATA[0], "revenue");
+
+    expect(identsIn(result.filters)).toEqual(["country"]);
+    const countryExpr = result.filters?.cond?.exprs?.[0];
+    expect(countryExpr?.cond?.exprs?.slice(1).map((e) => e.val)).toEqual([
+      "US",
+    ]);
+  });
+});
+
+describe("rows viewer cell filters include the global where filter", () => {
+  it("merges config.whereFilter into activeCellFilters", () => {
+    const config = makeConfig({
+      pivot: {
+        activeCell: { rowId: "0", columnId: "revenue" },
+        rowPage: 1,
+        showTotalsRow: false,
+        sorting: [],
+      } as unknown as PivotDataStoreConfig["pivot"],
+    });
+
+    const { activeCellFilters } = buildFinalPivotStateDetails({
+      anchorDimension: "country",
+      columnDimensionAxes: {},
+      config,
+      data: FLAT_DATA,
+      hasMoreRows: false,
+      isCellDataEmpty: false,
+      rowDimensionValues: ["US", "UK"],
+      rowOffset: 0,
+    });
+
+    expect(identsIn(activeCellFilters?.filters).sort()).toEqual([
+      "country",
+      "domain",
+    ]);
+  });
+
+  it("is undefined when no cell is active", () => {
+    const { activeCellFilters } = buildFinalPivotStateDetails({
+      anchorDimension: "country",
+      columnDimensionAxes: {},
+      config: makeConfig(),
+      data: FLAT_DATA,
+      hasMoreRows: false,
+      isCellDataEmpty: false,
+      rowDimensionValues: ["US", "UK"],
+      rowOffset: 0,
+    });
+
+    expect(activeCellFilters).toBeUndefined();
+  });
+});

--- a/web-common/src/features/dashboards/pivot/pivot-utils.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-utils.ts
@@ -10,7 +10,6 @@ import {
 import { TIME_GRAIN } from "@rilldata/web-common/lib/time/config";
 import { getOffset } from "@rilldata/web-common/lib/time/transforms";
 import {
-  Period,
   TimeOffsetType,
   type AvailableTimeGrain,
   type TimeRangeString,
@@ -125,7 +124,7 @@ export function getTimeForQuery(
       startTimeOfLastInterval = startTimeDt;
     }
 
-    const duration = TIME_GRAIN[filter.interval]?.duration as Period;
+    const duration = TIME_GRAIN[filter.interval]?.duration;
     const endTimeDt = getOffset(
       startTimeOfLastInterval,
       duration,
@@ -607,7 +606,14 @@ export function getValuesForFlatTable(
 /**
  * Shared core for all pivot filter builders. Takes dimension name/value pairs,
  * separates time dimensions into TimeFilters, creates IN expressions for the rest,
- * computes the narrowed time range, and merges everything with optional extra filters.
+ * and computes the narrowed time range.
+ *
+ * The returned expression describes only the clicked element; the dashboard's
+ * global where filter is deliberately left out. Click-to-filter reads these
+ * expressions back to decide which dimension values to toggle, so folding the
+ * global filter in here would make deselecting a pivot cell also drop unrelated
+ * global filters. Callers that query data with the result (the rows viewer)
+ * merge config.whereFilter themselves.
  *
  * Every public getFiltersFor* function delegates here after extracting its
  * dimension entries from whichever data source it uses (positional rowId,
@@ -616,7 +622,6 @@ export function getValuesForFlatTable(
 export function buildPivotFilter(
   config: PivotDataStoreConfig,
   dimEntries: Array<{ name: string; value: string | null }>,
-  extraFilters?: V1Expression,
 ): PivotFilter {
   const timeFilters: TimeFilters[] = [];
   const dimExprs: V1Expression[] = [];
@@ -637,15 +642,7 @@ export function buildPivotFilter(
     dimExprs.length > 0 ? createAndExpression(dimExprs) : undefined;
   const timeRange = getTimeForQuery(config.time, timeFilters);
 
-  let filters: V1Expression | undefined;
-  if (extraFilters) {
-    const combined = mergeFilters(dimFilter, extraFilters);
-    filters = mergeFilters(combined, config.whereFilter);
-  } else {
-    filters = mergeFilters(dimFilter, config.whereFilter);
-  }
-
-  return { filters, timeRange };
+  return { filters: dimFilter, timeRange };
 }
 
 export function getFiltersForCell(


### PR DESCRIPTION
We merge global filters to cell filters and use this to unset them when toggled off. This will lead to unrelated filters being cleared.

Updated to only merge global filters while querying.

Closes APP-922

**Checklist:**
- [x] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
