### PR TITLE
Notify Slack when `validate-sequential` fails

### DIFF
--- a/.github/workflows/go-migrate.yml
+++ b/.github/workflows/go-migrate.yml
@@ -28,8 +28,8 @@ jobs:
       if: always()
       with:
         status: ${{ job.status }}
-        notification_title: "{workflow} has {status_message}"
-        message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+        notification_title: "{workflow} / {job} has {status_message}"
+        message_format: "{emoji} *{workflow} / {job}* {status_message} in <{repo_url}|{repo}>"
         footer: "Linked Repo <{repo_url}|{repo}>"
         notify_when: "failure"
       env:
@@ -75,8 +75,8 @@ jobs:
       if: always()
       with:
         status: ${{ job.status }}
-        notification_title: "{workflow} has {status_message}"
-        message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+        notification_title: "{workflow} / {job} has {status_message}"
+        message_format: "{emoji} *{workflow} / {job}* {status_message} in <{repo_url}|{repo}>"
         footer: "Linked Repo <{repo_url}|{repo}>"
         notify_when: "failure"
       env:

--- a/.github/workflows/go-migrate.yml
+++ b/.github/workflows/go-migrate.yml
@@ -23,6 +23,18 @@ jobs:
       run: |
         ./scripts/check_migrations.sh runtime/drivers/sqlite/migrations
 
+    - name: Notify Slack
+      uses: ravsamhq/notify-slack-action@v2
+      if: always()
+      with:
+        status: ${{ job.status }}
+        notification_title: "{workflow} has {status_message}"
+        message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+        footer: "Linked Repo <{repo_url}|{repo}>"
+        notify_when: "failure"
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ANNOUNCE_DD }}
+
   validate-apply:
     runs-on: ubuntu-22.04
     needs: validate-sequential

--- a/.github/workflows/rill-cloud.yml
+++ b/.github/workflows/rill-cloud.yml
@@ -34,6 +34,18 @@ jobs:
       run: |
         ./scripts/check_migrations.sh runtime/drivers/sqlite/migrations
 
+    - name: Notify Slack
+      uses: ravsamhq/notify-slack-action@v2
+      if: always()
+      with:
+        status: ${{ job.status }}
+        notification_title: "{workflow} has {status_message}"
+        message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+        footer: "Linked Repo <{repo_url}|{repo}>"
+        notify_when: "failure"
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ANNOUNCE_DD }}
+
   build:
     # https://github.com/orgs/community/discussions/54860
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'push' || ( github.event_name == 'create' && startsWith(github.ref_name, 'release') )

--- a/.github/workflows/rill-cloud.yml
+++ b/.github/workflows/rill-cloud.yml
@@ -39,8 +39,8 @@ jobs:
       if: always()
       with:
         status: ${{ job.status }}
-        notification_title: "{workflow} has {status_message}"
-        message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+        notification_title: "{workflow} / {job} has {status_message}"
+        message_format: "{emoji} *{workflow} / {job}* {status_message} in <{repo_url}|{repo}>"
         footer: "Linked Repo <{repo_url}|{repo}>"
         notify_when: "failure"
       env:
@@ -140,8 +140,8 @@ jobs:
         if: always()
         with:
           status: ${{ job.status }}
-          notification_title: "{workflow} has {status_message}"
-          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          notification_title: "{workflow} / {job} has {status_message}"
+          message_format: "{emoji} *{workflow} / {job}* {status_message} in <{repo_url}|{repo}>"
           footer: "Linked Repo <{repo_url}|{repo}>"
           notify_when: "failure"
         env:

--- a/.github/workflows/rill-ui.yml
+++ b/.github/workflows/rill-ui.yml
@@ -51,6 +51,18 @@ jobs:
         run: |
           ./scripts/check_migrations.sh runtime/drivers/sqlite/migrations
 
+      - name: Notify Slack
+        uses: ravsamhq/notify-slack-action@v2
+        if: always()
+        with:
+          status: ${{ job.status }}
+          notification_title: "{workflow} has {status_message}"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          footer: "Linked Repo <{repo_url}|{repo}>"
+          notify_when: "failure"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ANNOUNCE_DD }}
+
   build:
     # https://github.com/orgs/community/discussions/54860
     if: |

--- a/.github/workflows/rill-ui.yml
+++ b/.github/workflows/rill-ui.yml
@@ -56,8 +56,8 @@ jobs:
         if: always()
         with:
           status: ${{ job.status }}
-          notification_title: "{workflow} has {status_message}"
-          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          notification_title: "{workflow} / {job} has {status_message}"
+          message_format: "{emoji} *{workflow} / {job}* {status_message} in <{repo_url}|{repo}>"
           footer: "Linked Repo <{repo_url}|{repo}>"
           notify_when: "failure"
         env:
@@ -131,8 +131,8 @@ jobs:
         if: always()
         with:
           status: ${{ job.status }}
-          notification_title: "{workflow} has {status_message}"
-          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>"
+          notification_title: "{workflow} / {job} has {status_message}"
+          message_format: "{emoji} *{workflow} / {job}* {status_message} in <{repo_url}|{repo}>"
           footer: "Linked Repo <{repo_url}|{repo}>"
           notify_when: "failure"
         env:


### PR DESCRIPTION
- Adds failure-only Slack notifications directly to `validate-sequential` in the Cloud UI, Rill Cloud, and migration workflows.
- Prevents validation failures from going unreported when dependent jobs—and their existing notification steps—are skipped.
- Keeps the existing downstream failure notifications unchanged.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
