### PR TITLE
fix: table sort component having white background

### DIFF
--- a/web-common/src/components/table-toolbar/TableToolbarSort.svelte
+++ b/web-common/src/components/table-toolbar/TableToolbarSort.svelte
@@ -36,7 +36,7 @@
   let sizeClass = $derived(ClassForSize[size]);
 
   let outlineClass = $derived(
-    noOutline ? "" : "border rounded-[2px] shadow-xs bg-white",
+    noOutline ? "" : "border rounded-[2px] shadow-xs",
   );
 </script>
 


### PR DESCRIPTION
Table sort component had a rogue white background. This doesnt work well with dark theme.

We should do something like this ASAP to avoid this: https://github.com/rilldata/rill/pull/8709

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
