### PR TITLE
fix: delta column width for dimension table

### DIFF
--- a/web-common/src/features/alerts/AlertPreviewTable.svelte
+++ b/web-common/src/features/alerts/AlertPreviewTable.svelte
@@ -58,6 +58,7 @@
     estimateColumnSize = estimateColumnSizes(
       columns,
       columnWidths,
+      rows,
       containerWidth,
       config,
     );

--- a/web-common/src/features/dashboards/dimension-table/DimensionTable.svelte
+++ b/web-common/src/features/dashboards/dimension-table/DimensionTable.svelte
@@ -119,6 +119,7 @@ TableCells – the cell contents.
     estimateColumnSize = estimateColumnSizes(
       columns,
       columnWidths,
+      rows,
       containerWidth,
       config,
     );

--- a/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
+++ b/web-common/src/features/dashboards/dimension-table/dimension-table-utils.ts
@@ -16,7 +16,10 @@ import {
 import { type V1MetricsViewAggregationResponseDataItem } from "../../../runtime-client";
 import PercentOfTotal from "./PercentOfTotal.svelte";
 
-import { PERC_DIFF } from "../../../components/data-types/type-utils";
+import {
+  isPercDiff,
+  PERC_DIFF,
+} from "../../../components/data-types/type-utils";
 import type {
   MetricsViewSpecDimension,
   MetricsViewSpecMeasure,
@@ -26,6 +29,7 @@ import type {
 
 import type { VirtualizedTableColumns } from "@rilldata/web-common/components/virtualized-table/types";
 
+import { clamp } from "@rilldata/web-common/lib/clamp";
 import { createMeasureValueFormatter } from "@rilldata/web-common/lib/number-formatting/format-measure-value";
 import { FormatPreset } from "@rilldata/web-common/lib/number-formatting/humanizer-types";
 import { formatMeasurePercentageDifference } from "@rilldata/web-common/lib/number-formatting/percentage-formatter";
@@ -175,19 +179,27 @@ const HEADER_ICON_WIDTHS = 16;
 const HEADER_X_PAD = CHARACTER_X_PAD;
 const HEADER_FLEX_SPACING = 14;
 // const CHARACTER_LIMIT_FOR_WRAPPING = 9;
+/** A context column cell loses 18px to chrome: a 10px gutter on the cell and
+ * an 8px inset on the label. The rest is breathing room, so the value doesn't
+ * butt up against the previous column. */
+const COMPARISON_X_PAD = 24;
 
 export function estimateColumnSizes(
   columns: VirtualizedTableColumns[],
   columnWidths: {
     [key: string]: number;
   },
+  rows: DimensionTableRow[],
   containerWidth: number,
   config: DimensionTableConfig,
 ): number[] {
   const estimatedColumnSizes = columns.map((column, i) => {
-    if (column.name.includes("delta")) return config.comparisonColumnWidth;
-    if (column.name.includes("percent_of_total"))
-      return config.comparisonColumnWidth;
+    if (
+      column.name.includes("delta") ||
+      column.name.includes("percent_of_total")
+    ) {
+      return estimateComparisonColumnSize(column.name, rows, config);
+    }
     if (i != 0) return config.defaultColumnWidth;
 
     const largestStringLength =
@@ -225,6 +237,40 @@ export function estimateColumnSizes(
   });
 
   return estimatedColumnSizes;
+}
+
+/** Context columns (delta, delta percent and percent of total) hold formatted
+ * measure values, which can be far wider than the minimum comparison width,
+ * e.g. a currency delta like "-$1,234,567.89". Size them to their content,
+ * the same way the pivot table sizes its measure columns.
+ */
+function estimateComparisonColumnSize(
+  columnName: string,
+  rows: DimensionTableRow[],
+  config: DimensionTableConfig,
+): number {
+  const largestValueLength = rows.reduce((largest, row) => {
+    const value = row["__formatted_" + columnName] ?? row[columnName];
+    return Math.max(largest, renderedValueLength(value));
+  }, 0);
+
+  return clamp(
+    config.comparisonColumnWidth,
+    largestValueLength * CHARACTER_WIDTH + COMPARISON_X_PAD,
+    config.maxColumnWidth,
+  );
+}
+
+/** Formatted context column values are not always strings: percentages are
+ * NumberParts objects, and missing data is a PERC_DIFF token rendered as "-".
+ */
+function renderedValueLength(
+  value: DimensionTableRow[keyof DimensionTableRow],
+): number {
+  if (value === null || value === undefined) return 0;
+  if (isPercDiff(value)) return 1;
+  if (typeof value === "object") return numberPartsToString(value).length;
+  return `${value}`.length;
 }
 
 export function prepareVirtualizedDimTableColumns(


### PR DESCRIPTION
Fixes delta column width when the value is large so that the values are all rendered in full.

<img width="859" height="347" alt="image" src="https://github.com/user-attachments/assets/cc0ae3bf-1d35-4fbf-8771-d65b520b2033" />

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
