### PR TITLE
telemetry follow ups

### DIFF
--- a/web-admin/src/features/navigation/nav-utils.ts
+++ b/web-admin/src/features/navigation/nav-utils.ts
@@ -159,22 +159,24 @@ export function isOnboardingPage(page: Page): boolean {
   );
 }
 
+// `isProjectPage` matches every `/{org}/{project}/-/*` route bar a few exceptions, so it subsumes
+// reports and alerts. It has to be tested last, or the specific screens below it are never reached.
 export function getScreenNameFromPage(page: Page): MetricsEventScreenName {
   switch (true) {
     case isOrganizationPage(page):
       return MetricsEventScreenName.Organization;
-    case isProjectPage(page):
-      return MetricsEventScreenName.Project;
     case isMetricsExplorerPage(page):
       return MetricsEventScreenName.Dashboard;
     case isCanvasDashboardPage(page):
       return MetricsEventScreenName.Canvas;
+    case isReportExportPage(page):
+      return MetricsEventScreenName.ReportExport;
     case isReportPage(page):
       return MetricsEventScreenName.Report;
     case isAlertPage(page):
       return MetricsEventScreenName.Alert;
-    case isReportExportPage(page):
-      return MetricsEventScreenName.ReportExport;
+    case isProjectPage(page):
+      return MetricsEventScreenName.Project;
   }
   return MetricsEventScreenName.Unknown;
 }

--- a/web-admin/src/routes/[organization]/[project]/+layout.svelte
+++ b/web-admin/src/routes/[organization]/[project]/+layout.svelte
@@ -12,7 +12,7 @@
 <script lang="ts">
   import { beforeNavigate, goto } from "$app/navigation";
   import { page } from "$app/state";
-  import { untrack } from "svelte";
+  import { onDestroy, untrack } from "svelte";
   import type { Snippet } from "svelte";
   import { m } from "@rilldata/web-common/lib/i18n/gen/messages";
   import {
@@ -289,6 +289,11 @@
       ),
     );
   });
+
+  // Navigating out of the project within the throttle window destroys this layout with a callback
+  // still pending. Left alone it would fire from the page the user has already left, and the event's
+  // `page_url` is read when it fires, so it would pair this page's resource with the next page's URL.
+  onDestroy(() => pageViewThrottler.cancel());
 </script>
 
 {#if error}

--- a/web-common/src/metrics/service/ErrorEventFactory.ts
+++ b/web-common/src/metrics/service/ErrorEventFactory.ts
@@ -12,6 +12,7 @@ import type {
   SourceFileType,
 } from "./SourceEventTypes";
 import type { AddDataBehaviourEventFields } from "@rilldata/web-common/metrics/service/BehaviourEventTypes.ts";
+import { sanitizePageUrl } from "./sanitizePageUrl";
 
 export enum ErrorEventAction {
   SourceError = "source-error",
@@ -124,7 +125,7 @@ export class ErrorEventFactory extends MetricsEventFactory {
     event.api = api;
     event.status = status;
     event.message = message;
-    event.page_url = pageUrl;
+    event.page_url = sanitizePageUrl(pageUrl);
     return event;
   }
 
@@ -146,7 +147,7 @@ export class ErrorEventFactory extends MetricsEventFactory {
     event.screen_name = screen_name;
     event.stack = stack;
     event.message = message;
-    event.page_url = pageUrl;
+    event.page_url = sanitizePageUrl(pageUrl);
     return event;
   }
 }

--- a/web-common/src/metrics/service/MetricsEventFactory.ts
+++ b/web-common/src/metrics/service/MetricsEventFactory.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import type { CommonUserFields, MetricsEvent } from "./MetricsTypes";
 import type { CommonFields } from "./MetricsTypes";
+import { sanitizePageUrl } from "./sanitizePageUrl";
 
 export class MetricsEventFactory {
   protected getBaseMetricsEvent(
@@ -19,7 +20,7 @@ export class MetricsEventFactory {
       event_time: new Date().toISOString(),
       event_type: eventType,
       event_name: eventName,
-      page_url: window.location.href,
+      page_url: sanitizePageUrl(window.location.href),
     };
   }
 }

--- a/web-common/src/metrics/service/sanitizePageUrl.spec.ts
+++ b/web-common/src/metrics/service/sanitizePageUrl.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { sanitizePageUrl } from "./sanitizePageUrl";
+
+describe("sanitizePageUrl", () => {
+  it("redacts the magic token in a public URL path", () => {
+    expect(
+      sanitizePageUrl(
+        "https://ui.rilldata.com/myorg/myproject/-/share/rill_mgc_1yvUkhRrPE0VjwD8EbIluP0OOPz7gLm5/explore/revenue",
+      ),
+    ).toBe(
+      "https://ui.rilldata.com/myorg/myproject/-/share/redacted/explore/revenue",
+    );
+  });
+
+  it("redacts credential query params", () => {
+    expect(
+      sanitizePageUrl(
+        "https://ui.rilldata.com/myorg/myproject/-/reports/weekly?token=rill_mgc_abc123",
+      ),
+    ).toBe(
+      "https://ui.rilldata.com/myorg/myproject/-/reports/weekly?token=redacted",
+    );
+
+    expect(
+      sanitizePageUrl("https://ui.rilldata.com/-/embed?access_token=eyJhbGc"),
+    ).toBe("https://ui.rilldata.com/-/embed?access_token=redacted");
+  });
+
+  it("keeps dashboard state intact", () => {
+    const url =
+      "https://ui.rilldata.com/myorg/myproject/explore/revenue?view=pivot&tr=P7D&f=country+IN+%28%27US%27%29";
+    expect(sanitizePageUrl(url)).toBe(url);
+  });
+
+  it("returns an empty string rather than passing through unparseable input", () => {
+    expect(sanitizePageUrl("not a url")).toBe("");
+  });
+});

--- a/web-common/src/metrics/service/sanitizePageUrl.ts
+++ b/web-common/src/metrics/service/sanitizePageUrl.ts
@@ -1,0 +1,42 @@
+// Deliberately free of characters that a URL would percent-encode, so the marker reads the same
+// whether it lands in the path or the query string.
+const Redacted = "redacted";
+
+// Query params that carry a credential rather than dashboard state.
+// `token` is used by public report and alert links, `access_token` by embeds.
+const CredentialParams = ["token", "access_token"];
+
+// Public URLs put the magic token in the path, e.g. /{org}/{project}/-/share/{token}/explore/{name}.
+const ShareTokenPattern = /\/-\/share\/[^/]+/;
+
+/**
+ * Strips credentials out of a URL before it is recorded as telemetry.
+ *
+ * Public URL and embed tokens grant access to a dashboard and stay valid after use, so they must not
+ * be sent to the telemetry pipeline: the events are queryable, and are exposed to customers through
+ * the monitoring dashboards built on them.
+ *
+ * Returns an empty string for input that isn't a parseable URL, so that a malformed location can
+ * never pass a raw token through untouched.
+ */
+export function sanitizePageUrl(href: string): string {
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return "";
+  }
+
+  url.pathname = url.pathname.replace(
+    ShareTokenPattern,
+    `/-/share/${Redacted}`,
+  );
+
+  for (const param of CredentialParams) {
+    if (url.searchParams.has(param)) {
+      url.searchParams.set(param, Redacted);
+    }
+  }
+
+  return url.toString();
+}


### PR DESCRIPTION
Addressing feedback 

```

  - [P1] Redact access tokens from telemetry page URLs — /Users/paragjain/work/rill-developer/web-common/src/metrics/service/MetricsEventFactory.ts:22-22
    When an authenticated user opens a public URL, dashboard links contain the bearer token in /-/share/[token] and report/alert links can contain it in ?token=...; copying the full window.location.href into every event sends that reusable credential to the telemetry pipeline.
    Construct a sanitized URL that removes or replaces these token values before assigning page_url.

  - [P2] Classify reports and alerts before generic project pages — /Users/paragjain/work/rill-developer/web-admin/src/routes/[organization]/[project]/+layout.svelte:282-282
    On /.../-/reports/[report] and /.../-/alerts/[alert], this new call yields Project because getScreenNameFromPage checks isProjectPage first, and that predicate accepts these /-/ routes. Page-view telemetry therefore never uses the existing Report or Alert screen values for
    these pages; reorder the specific checks or narrow the generic project match.

  - [P2] Cancel the page-view timer when leaving the project layout — /Users/paragjain/work/rill-developer/web-admin/src/routes/[organization]/[project]/+layout.svelte:284-284
    When a client-side navigation leaves the project layout within 250 ms, the component is destroyed without cancelling this timer, so its retained callback still emits the page that the user only passed through. Because page_url is read when the callback eventually fires, the
    event can also combine the old captured screen/resource with the destination URL; cancel the throttler during layout teardown.

```
**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
