### PR TITLE
fix: broken user group table infinite query

### DIFF
--- a/web-admin/orval.config.ts
+++ b/web-admin/orval.config.ts
@@ -56,6 +56,13 @@ export default defineConfig({
               useInfiniteQueryParam: "pageToken",
             },
           },
+          AdminService_ListOrganizationMemberUsergroups: {
+            query: {
+              useQuery: true,
+              useInfinite: true,
+              useInfiniteQueryParam: "pageToken",
+            },
+          },
         },
       },
     },

--- a/web-admin/src/client/gen/default/default.ts
+++ b/web-admin/src/client/gen/default/default.ts
@@ -10955,12 +10955,144 @@ export const adminServiceListOrganizationMemberUsergroups = (
   });
 };
 
+export const getAdminServiceListOrganizationMemberUsergroupsInfiniteQueryKey = (
+  org?: string,
+  params?: AdminServiceListOrganizationMemberUsergroupsParams,
+) => {
+  return [
+    "infinite",
+    `/v1/orgs/${org}/usergroups`,
+    ...(params ? [params] : []),
+  ] as const;
+};
+
 export const getAdminServiceListOrganizationMemberUsergroupsQueryKey = (
   org?: string,
   params?: AdminServiceListOrganizationMemberUsergroupsParams,
 ) => {
   return [`/v1/orgs/${org}/usergroups`, ...(params ? [params] : [])] as const;
 };
+
+export const getAdminServiceListOrganizationMemberUsergroupsInfiniteQueryOptions =
+  <
+    TData = InfiniteData<
+      Awaited<ReturnType<typeof adminServiceListOrganizationMemberUsergroups>>,
+      AdminServiceListOrganizationMemberUsergroupsParams["pageToken"]
+    >,
+    TError = RpcStatus,
+  >(
+    org: string,
+    params?: AdminServiceListOrganizationMemberUsergroupsParams,
+    options?: {
+      query?: Partial<
+        CreateInfiniteQueryOptions<
+          Awaited<
+            ReturnType<typeof adminServiceListOrganizationMemberUsergroups>
+          >,
+          TError,
+          TData,
+          Awaited<
+            ReturnType<typeof adminServiceListOrganizationMemberUsergroups>
+          >,
+          QueryKey,
+          AdminServiceListOrganizationMemberUsergroupsParams["pageToken"]
+        >
+      >;
+    },
+  ) => {
+    const { query: queryOptions } = options ?? {};
+
+    const queryKey =
+      queryOptions?.queryKey ??
+      getAdminServiceListOrganizationMemberUsergroupsInfiniteQueryKey(
+        org,
+        params,
+      );
+
+    const queryFn: QueryFunction<
+      Awaited<ReturnType<typeof adminServiceListOrganizationMemberUsergroups>>,
+      QueryKey,
+      AdminServiceListOrganizationMemberUsergroupsParams["pageToken"]
+    > = ({ signal, pageParam }) =>
+      adminServiceListOrganizationMemberUsergroups(
+        org,
+        { ...params, pageToken: pageParam || params?.["pageToken"] },
+        signal,
+      );
+
+    return {
+      queryKey,
+      queryFn,
+      enabled: !!org,
+      ...queryOptions,
+    } as CreateInfiniteQueryOptions<
+      Awaited<ReturnType<typeof adminServiceListOrganizationMemberUsergroups>>,
+      TError,
+      TData,
+      Awaited<ReturnType<typeof adminServiceListOrganizationMemberUsergroups>>,
+      QueryKey,
+      AdminServiceListOrganizationMemberUsergroupsParams["pageToken"]
+    > & { queryKey: DataTag<QueryKey, TData, TError> };
+  };
+
+export type AdminServiceListOrganizationMemberUsergroupsInfiniteQueryResult =
+  NonNullable<
+    Awaited<ReturnType<typeof adminServiceListOrganizationMemberUsergroups>>
+  >;
+export type AdminServiceListOrganizationMemberUsergroupsInfiniteQueryError =
+  RpcStatus;
+
+/**
+ * @summary ListOrganizationMemberUsergroups lists the organization's user groups
+ */
+
+export function createAdminServiceListOrganizationMemberUsergroupsInfinite<
+  TData = InfiniteData<
+    Awaited<ReturnType<typeof adminServiceListOrganizationMemberUsergroups>>,
+    AdminServiceListOrganizationMemberUsergroupsParams["pageToken"]
+  >,
+  TError = RpcStatus,
+>(
+  org: string,
+  params?: AdminServiceListOrganizationMemberUsergroupsParams,
+  options?: {
+    query?: Partial<
+      CreateInfiniteQueryOptions<
+        Awaited<
+          ReturnType<typeof adminServiceListOrganizationMemberUsergroups>
+        >,
+        TError,
+        TData,
+        Awaited<
+          ReturnType<typeof adminServiceListOrganizationMemberUsergroups>
+        >,
+        QueryKey,
+        AdminServiceListOrganizationMemberUsergroupsParams["pageToken"]
+      >
+    >;
+  },
+  queryClient?: QueryClient,
+): CreateInfiniteQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions =
+    getAdminServiceListOrganizationMemberUsergroupsInfiniteQueryOptions(
+      org,
+      params,
+      options,
+    );
+
+  const query = createInfiniteQuery(
+    queryOptions,
+    queryClient,
+  ) as CreateInfiniteQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  query.queryKey = queryOptions.queryKey;
+
+  return query;
+}
 
 export const getAdminServiceListOrganizationMemberUsergroupsQueryOptions = <
   TData = Awaited<

--- a/web-admin/src/features/organizations/user-management/selectors.ts
+++ b/web-admin/src/features/organizations/user-management/selectors.ts
@@ -174,7 +174,7 @@ export function getOrgUsergroupsInfinite(organization: string) {
   return createAdminServiceListOrganizationMemberUsergroupsInfinite(
     organization,
     {
-      pageSize: PAGE_SIZE,
+      pageSize: INFINITE_PAGE_SIZE,
       includeCounts: true,
     },
     {

--- a/web-admin/src/features/organizations/user-management/selectors.ts
+++ b/web-admin/src/features/organizations/user-management/selectors.ts
@@ -4,6 +4,7 @@ import {
   createAdminServiceListOrganizationMemberUsergroups,
   getAdminServiceListOrganizationMemberUsergroupsQueryOptions,
   getAdminServiceListUsergroupsForOrganizationAndUserQueryOptions,
+  createAdminServiceListOrganizationMemberUsergroupsInfinite,
 } from "@rilldata/web-admin/client";
 import { OrgUserRoles } from "@rilldata/web-common/features/users/roles.ts";
 import { createQuery } from "@tanstack/svelte-query";
@@ -165,6 +166,26 @@ export function getUserCounts(organization: string) {
         guestsCount: guestUsersCounts,
         groupsCount,
       };
+    },
+  );
+}
+
+export function getOrgUsergroupsInfinite(organization: string) {
+  return createAdminServiceListOrganizationMemberUsergroupsInfinite(
+    organization,
+    {
+      pageSize: PAGE_SIZE,
+      includeCounts: true,
+    },
+    {
+      query: {
+        getNextPageParam: (lastPage) => {
+          if (lastPage.nextPageToken !== "") {
+            return lastPage.nextPageToken;
+          }
+          return undefined;
+        },
+      },
     },
   );
 }

--- a/web-admin/src/routes/[organization]/-/users/groups/+page.svelte
+++ b/web-admin/src/routes/[organization]/-/users/groups/+page.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
   import { m } from "@rilldata/web-common/lib/i18n/gen/messages";
   import { page } from "$app/stores";
-  import {
-    createAdminServiceGetCurrentUser,
-    createAdminServiceListOrganizationMemberUsergroups,
-  } from "@rilldata/web-admin/client";
+  import { createAdminServiceGetCurrentUser } from "@rilldata/web-admin/client";
   import CreateUserGroupDialog from "@rilldata/web-admin/features/organizations/user-management/dialogs/CreateUserGroupDialog.svelte";
   import EditUserGroupDialog from "@rilldata/web-admin/features/organizations/user-management/dialogs/EditUserGroupDialog.svelte";
   import OrgGroupsTable from "@rilldata/web-admin/features/organizations/user-management/table/groups/OrgGroupsTable.svelte";
@@ -12,40 +9,34 @@
   import { Search } from "@rilldata/web-common/components/search";
   import DelayedSpinner from "@rilldata/web-common/features/entity-management/DelayedSpinner.svelte";
   import { Plus } from "lucide-svelte";
-
-  const PAGE_SIZE = 50;
+  import { getOrgUsergroupsInfinite } from "@rilldata/web-admin/features/organizations/user-management/selectors.ts";
 
   let userGroupName = "";
   let isCreateUserGroupDialogOpen = false;
   let isEditUserGroupDialogOpen = false;
   let searchText = "";
-  let pageToken = "";
 
   $: organization = $page.params.organization;
-  $: listOrganizationMemberUsergroups =
-    createAdminServiceListOrganizationMemberUsergroups(organization, {
-      pageSize: PAGE_SIZE,
-      pageToken,
-      includeCounts: true,
-    });
+  $: listOrganizationMemberUsergroups = getOrgUsergroupsInfinite(organization);
   const currentUser = createAdminServiceGetCurrentUser();
 
+  $: allGroups = $listOrganizationMemberUsergroups.data?.pages.flatMap(
+    (page) => page.members ?? [],
+  );
   $: filteredGroups =
-    $listOrganizationMemberUsergroups.data?.members.filter(
+    allGroups?.filter(
       (group) =>
         !group.groupManaged &&
         group.groupName.toLowerCase().includes(searchText.toLowerCase()),
     ) ?? [];
 
-  $: hasNextPage = Boolean(
-    $listOrganizationMemberUsergroups.data?.nextPageToken,
-  );
+  $: hasNextPage = Boolean($listOrganizationMemberUsergroups.hasNextPage);
 
   $: isFetchingNextPage = $listOrganizationMemberUsergroups.isFetching;
 
   function handleLoadMore() {
-    if (hasNextPage) {
-      pageToken = $listOrganizationMemberUsergroups.data?.nextPageToken ?? "";
+    if ($listOrganizationMemberUsergroups.hasNextPage) {
+      $listOrganizationMemberUsergroups.fetchNextPage();
     }
   }
 

--- a/web-admin/src/routes/[organization]/-/users/groups/+page.svelte
+++ b/web-admin/src/routes/[organization]/-/users/groups/+page.svelte
@@ -32,7 +32,7 @@
 
   $: hasNextPage = Boolean($listOrganizationMemberUsergroups.hasNextPage);
 
-  $: isFetchingNextPage = $listOrganizationMemberUsergroups.isFetching;
+  $: isFetchingNextPage = $listOrganizationMemberUsergroups.isFetchingNextPage;
 
   function handleLoadMore() {
     if ($listOrganizationMemberUsergroups.hasNextPage) {


### PR DESCRIPTION
User group table queried a new page each time replacing the old one. Updated to use infinite queries so that all pages are retained.

Closes APP-923

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
