### PR TITLE
Fix stale expectations in Pinot information schema and chat conversation tests

### DIFF
--- a/runtime/drivers/pinot/information_schema_test.go
+++ b/runtime/drivers/pinot/information_schema_test.go
@@ -14,6 +14,22 @@ import (
 	"go.uber.org/zap"
 )
 
+// expectedTables are tables bootstrapped by the Pinot batch quickstart.
+// The tests only assert that these are present, not that they are the only ones,
+// since newer Pinot versions bootstrap additional tables.
+var expectedTables = []string{
+	"airlineStats",
+	"baseballStats",
+	"billing",
+	"clickstreamFunnel",
+	"dimBaseballTeams",
+	"fineFoodReviews",
+	"githubComplexTypeEvents",
+	"githubEvents",
+	"starbucksStores",
+	"testUnnest",
+}
+
 func TestInformationSchema(t *testing.T) {
 	testmode.Expensive(t)
 	cfg := testruntime.AcquireConnector(t, "pinot")
@@ -40,18 +56,13 @@ func TestInformationSchema(t *testing.T) {
 func testInformationSchemaAll(t *testing.T, olap drivers.OLAPStore) {
 	tables, _, err := olap.InformationSchema().All(context.Background(), "", 0, "")
 	require.NoError(t, err)
-	require.Equal(t, 10, len(tables))
 
-	require.Equal(t, "airlineStats", tables[0].Name)
-	require.Equal(t, "baseballStats", tables[1].Name)
-	require.Equal(t, "billing", tables[2].Name)
-	require.Equal(t, "clickstreamFunnel", tables[3].Name)
-	require.Equal(t, "dimBaseballTeams", tables[4].Name)
-	require.Equal(t, "fineFoodReviews", tables[5].Name)
-	require.Equal(t, "githubComplexTypeEvents", tables[6].Name)
-	require.Equal(t, "githubEvents", tables[7].Name)
-	require.Equal(t, "starbucksStores", tables[8].Name)
-	require.Equal(t, "testUnnest", tables[9].Name)
+	names := make([]string, len(tables))
+	for i, table := range tables {
+		names[i] = table.Name
+	}
+	require.Subset(t, names, expectedTables)
+	require.IsNonDecreasing(t, names)
 }
 
 func testInformationSchemaAllLike(t *testing.T, olap drivers.OLAPStore) {
@@ -72,36 +83,39 @@ func testInformationSchemaAllLike(t *testing.T, olap drivers.OLAPStore) {
 
 func testInformationSchemaAllPagination(t *testing.T, olap drivers.OLAPStore) {
 	ctx := context.Background()
-	pageSize := 4
+	const pageSize = 4
 
-	// Test first page
-	tables1, nextToken1, err := olap.InformationSchema().All(ctx, "", uint32(pageSize), "")
-	require.NoError(t, err)
-	require.Equal(t, pageSize, len(tables1))
-	require.NotEmpty(t, nextToken1)
-
-	// Test second page
-	tables2, nextToken2, err := olap.InformationSchema().All(ctx, "", uint32(pageSize), nextToken1)
-	require.NoError(t, err)
-	require.Equal(t, pageSize, len(tables2))
-	require.NotEmpty(t, nextToken2)
-
-	// Test third page
-	tables3, nextToken3, err := olap.InformationSchema().All(ctx, "", uint32(pageSize), nextToken2)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(tables3))
-	require.Empty(t, nextToken3)
-
-	// Test with page size 0
+	// Test with page size 0, which returns all tables in one page
 	tables, nextToken, err := olap.InformationSchema().All(ctx, "", 0, "")
 	require.NoError(t, err)
-	require.Equal(t, 10, len(tables))
 	require.Empty(t, nextToken)
+	all := make([]string, len(tables))
+	for i, table := range tables {
+		all[i] = table.Name
+	}
+	require.Subset(t, all, expectedTables)
+
+	// Test that paging through the results yields the same tables in the same order
+	var paged []string
+	for token := ""; ; {
+		page, next, err := olap.InformationSchema().All(ctx, "", pageSize, token)
+		require.NoError(t, err)
+		for _, table := range page {
+			paged = append(paged, table.Name)
+		}
+		if next == "" {
+			require.LessOrEqual(t, len(page), pageSize)
+			break
+		}
+		require.Equal(t, pageSize, len(page))
+		token = next
+	}
+	require.Equal(t, all, paged)
 
 	// Test with page size larger than total results
 	tables, nextToken, err = olap.InformationSchema().All(ctx, "", 1000, "")
 	require.NoError(t, err)
-	require.Equal(t, 10, len(tables))
+	require.Equal(t, len(all), len(tables))
 	require.Empty(t, nextToken)
 }
 
@@ -145,52 +159,50 @@ func testInformationSchemaListDatabaseSchemas(t *testing.T, infoSchema drivers.I
 func testInformationSchemaListTables(t *testing.T, infoSchema drivers.InformationSchema) {
 	tables, _, err := infoSchema.ListTables(context.Background(), "", "default", 0, "")
 	require.NoError(t, err)
-	require.Equal(t, 10, len(tables))
 
-	require.Equal(t, "airlineStats", tables[0].Name)
-	require.Equal(t, "baseballStats", tables[1].Name)
-	require.Equal(t, "billing", tables[2].Name)
-	require.Equal(t, "clickstreamFunnel", tables[3].Name)
-	require.Equal(t, "dimBaseballTeams", tables[4].Name)
-	require.Equal(t, "fineFoodReviews", tables[5].Name)
-	require.Equal(t, "githubComplexTypeEvents", tables[6].Name)
-	require.Equal(t, "githubEvents", tables[7].Name)
-	require.Equal(t, "starbucksStores", tables[8].Name)
-	require.Equal(t, "testUnnest", tables[9].Name)
+	names := make([]string, len(tables))
+	for i, table := range tables {
+		names[i] = table.Name
+	}
+	require.Subset(t, names, expectedTables)
+	require.IsNonDecreasing(t, names)
 }
 
 func testInformationSchemaListTablesPagination(t *testing.T, infoSchema drivers.InformationSchema) {
 	ctx := context.Background()
-	pageSize := 4
+	const pageSize = 4
 
-	// Test first page
-	tables1, nextToken1, err := infoSchema.ListTables(ctx, "", "default", uint32(pageSize), "")
-	require.NoError(t, err)
-	require.Equal(t, pageSize, len(tables1))
-	require.NotEmpty(t, nextToken1)
-
-	// Test second page
-	tables2, nextToken2, err := infoSchema.ListTables(ctx, "", "default", uint32(pageSize), nextToken1)
-	require.NoError(t, err)
-	require.Equal(t, pageSize, len(tables2))
-	require.NotEmpty(t, nextToken2)
-
-	// Test third page
-	tables3, nextToken3, err := infoSchema.ListTables(ctx, "", "default", uint32(pageSize), nextToken2)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(tables3))
-	require.Empty(t, nextToken3)
-
-	// Test with page size 0
+	// Test with page size 0, which returns all tables in one page
 	tables, nextToken, err := infoSchema.ListTables(ctx, "", "default", 0, "")
 	require.NoError(t, err)
-	require.Equal(t, 10, len(tables))
 	require.Empty(t, nextToken)
+	all := make([]string, len(tables))
+	for i, table := range tables {
+		all[i] = table.Name
+	}
+	require.Subset(t, all, expectedTables)
+
+	// Test that paging through the results yields the same tables in the same order
+	var paged []string
+	for token := ""; ; {
+		page, next, err := infoSchema.ListTables(ctx, "", "default", pageSize, token)
+		require.NoError(t, err)
+		for _, table := range page {
+			paged = append(paged, table.Name)
+		}
+		if next == "" {
+			require.LessOrEqual(t, len(page), pageSize)
+			break
+		}
+		require.Equal(t, pageSize, len(page))
+		token = next
+	}
+	require.Equal(t, all, paged)
 
 	// Test with page size larger than total results
 	tables, nextToken, err = infoSchema.ListTables(ctx, "", "default", 1000, "")
 	require.NoError(t, err)
-	require.Equal(t, 10, len(tables))
+	require.Equal(t, len(all), len(tables))
 	require.Empty(t, nextToken)
 }
 

--- a/runtime/server/chat_test.go
+++ b/runtime/server/chat_test.go
@@ -150,7 +150,7 @@ measures:
 		ConversationId: res1.ConversationId,
 		MessageId:      "doesntexist",
 	})
-	require.ErrorContains(t, err, "failed to find the call")
+	require.ErrorContains(t, err, "not found in conversation")
 	// Happy path for getting a message.
 	msgRes, err := srv.GetAIMessage(fooCtx, &runtimev1.GetAIMessageRequest{
 		InstanceId:     instanceID,


### PR DESCRIPTION
- `TestConversations` asserted on a `GetAIMessage` error message that was reworded in #9277.
- The Pinot tests assumed the batch quickstart bootstraps exactly 10 tables, but `apachepinot/pinot:latest` is a nightly master snapshot that now bootstraps 15; they now assert the known tables are present and page through the full result set instead of hardcoding counts.
