### PR TITLE
fix: user lists not refreshing after add, remove or role change

### DIFF
--- a/web-admin/src/features/organizations/user-management/dialogs/AddGuestsDialog.svelte
+++ b/web-admin/src/features/organizations/user-management/dialogs/AddGuestsDialog.svelte
@@ -3,12 +3,14 @@
   import { page } from "$app/stores";
   import {
     createAdminServiceAddProjectMemberUser,
-    getAdminServiceListOrganizationInvitesQueryKey,
-    getAdminServiceListOrganizationMemberUsersQueryKey,
     type V1Project,
   } from "@rilldata/web-admin/client";
   import { getRpcErrorMessage } from "@rilldata/web-admin/components/errors/error-utils";
   import { getOrgRolesOptions } from "@rilldata/web-admin/features/organizations/constants";
+  import {
+    invalidateOrgInvites,
+    invalidateOrgMemberUsers,
+  } from "@rilldata/web-admin/features/organizations/user-management/utils";
   import { listProjectsForOrgQueryOptions } from "@rilldata/web-admin/features/projects/list-projects-query-options";
   import { Button } from "@rilldata/web-common/components/button";
   import {
@@ -166,14 +168,8 @@
         if (failed.length > 0) failedInvites = failed;
 
         // Invalidate lists
-        await queryClient.invalidateQueries({
-          queryKey:
-            getAdminServiceListOrganizationMemberUsersQueryKey(organization),
-        });
-        await queryClient.invalidateQueries({
-          queryKey:
-            getAdminServiceListOrganizationInvitesQueryKey(organization),
-        });
+        await invalidateOrgMemberUsers(queryClient, organization);
+        await invalidateOrgInvites(queryClient, organization);
 
         if (failedInvites.length === 0) {
           open = false;

--- a/web-admin/src/features/organizations/user-management/dialogs/AddUsersDialog.svelte
+++ b/web-admin/src/features/organizations/user-management/dialogs/AddUsersDialog.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { m } from "@rilldata/web-common/lib/i18n/gen/messages";
   import { page } from "$app/stores";
+  import { createAdminServiceAddOrganizationMemberUser } from "@rilldata/web-admin/client";
   import {
-    createAdminServiceAddOrganizationMemberUser,
-    getAdminServiceListOrganizationInvitesQueryKey,
-    getAdminServiceListOrganizationMemberUsersQueryKey,
-  } from "@rilldata/web-admin/client";
+    invalidateOrgInvites,
+    invalidateOrgMemberUsers,
+  } from "@rilldata/web-admin/features/organizations/user-management/utils";
   import {
     DropdownMenu,
     DropdownMenuContent,
@@ -59,14 +59,9 @@
       },
     });
 
-    await queryClient.invalidateQueries({
-      queryKey:
-        getAdminServiceListOrganizationMemberUsersQueryKey(organization),
-    });
+    await invalidateOrgMemberUsers(queryClient, organization);
 
-    await queryClient.invalidateQueries({
-      queryKey: getAdminServiceListOrganizationInvitesQueryKey(organization),
-    });
+    await invalidateOrgInvites(queryClient, organization);
 
     email = "";
     role = "";

--- a/web-admin/src/features/organizations/user-management/dialogs/ConvertGuestToMemberDialog.svelte
+++ b/web-admin/src/features/organizations/user-management/dialogs/ConvertGuestToMemberDialog.svelte
@@ -3,10 +3,12 @@
   import { page } from "$app/stores";
   import {
     createAdminServiceSetOrganizationMemberUserRole,
-    getAdminServiceListOrganizationInvitesQueryKey,
-    getAdminServiceListOrganizationMemberUsersQueryKey,
     type V1OrganizationMemberUser,
   } from "@rilldata/web-admin/client";
+  import {
+    invalidateOrgInvites,
+    invalidateOrgMemberUsers,
+  } from "@rilldata/web-admin/features/organizations/user-management/utils.ts";
   import {
     getProjectRolesDescriptionMap,
     getProjectRolesOptions,
@@ -45,14 +47,9 @@
         },
       });
 
-      await queryClient.invalidateQueries({
-        queryKey:
-          getAdminServiceListOrganizationMemberUsersQueryKey(organization),
-      });
+      await invalidateOrgMemberUsers(queryClient, organization);
 
-      await queryClient.invalidateQueries({
-        queryKey: getAdminServiceListOrganizationInvitesQueryKey(organization),
-      });
+      await invalidateOrgInvites(queryClient, organization);
 
       eventBus.emit("notification", {
         message: m.users_guest_upgraded({ role }),

--- a/web-admin/src/features/organizations/user-management/dialogs/CreateUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/user-management/dialogs/CreateUserGroupDialog.svelte
@@ -6,10 +6,12 @@
     createAdminServiceAddUsergroupMemberUser,
     createAdminServiceCreateUsergroup,
     createAdminServiceListOrganizationMemberUsersInfinite,
-    getAdminServiceListOrganizationMemberUsergroupsQueryKey,
-    getAdminServiceListOrganizationMemberUsersQueryKey,
     getAdminServiceListUsergroupMemberUsersQueryKey,
   } from "@rilldata/web-admin/client";
+  import {
+    invalidateOrgMemberUsers,
+    invalidateOrgUsergroups,
+  } from "@rilldata/web-admin/features/organizations/user-management/utils.ts";
   import AvatarListItem from "@rilldata/web-common/components/avatar/AvatarListItem.svelte";
   import { Button } from "@rilldata/web-common/components/button";
   import Combobox from "@rilldata/web-common/components/combobox/Combobox.svelte";
@@ -114,14 +116,7 @@
       // Apply pending user changes after group creation
       await applyPendingChanges(newName);
 
-      await queryClient.invalidateQueries({
-        queryKey: getAdminServiceListOrganizationMemberUsergroupsQueryKey(
-          organization,
-          {
-            includeCounts: true,
-          },
-        ),
-      });
+      await invalidateOrgUsergroups(queryClient, organization);
 
       groupName = "";
       selectedUsers = [];
@@ -152,10 +147,7 @@
         });
       }
 
-      await queryClient.invalidateQueries({
-        queryKey:
-          getAdminServiceListOrganizationMemberUsersQueryKey(organization),
-      });
+      await invalidateOrgMemberUsers(queryClient, organization);
 
       await queryClient.invalidateQueries({
         queryKey: getAdminServiceListUsergroupMemberUsersQueryKey(

--- a/web-admin/src/features/organizations/user-management/dialogs/DeleteUserGroupConfirmDialog.svelte
+++ b/web-admin/src/features/organizations/user-management/dialogs/DeleteUserGroupConfirmDialog.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
   import { m } from "@rilldata/web-common/lib/i18n/gen/messages";
   import { page } from "$app/stores";
-  import {
-    createAdminServiceDeleteUsergroup,
-    getAdminServiceListOrganizationMemberUsergroupsQueryKey,
-  } from "@rilldata/web-admin/client";
+  import { createAdminServiceDeleteUsergroup } from "@rilldata/web-admin/client";
+  import { invalidateOrgUsergroups } from "@rilldata/web-admin/features/organizations/user-management/utils.ts";
   import {
     AlertDialog,
     AlertDialogContent,
@@ -33,14 +31,7 @@
         usergroup: deletedUserGroupName,
       });
 
-      await queryClient.invalidateQueries({
-        queryKey: getAdminServiceListOrganizationMemberUsergroupsQueryKey(
-          organization,
-          {
-            includeCounts: true,
-          },
-        ),
-      });
+      await invalidateOrgUsergroups(queryClient, organization);
 
       eventBus.emit("notification", { message: m.groups_deleted() });
     } catch (error) {

--- a/web-admin/src/features/organizations/user-management/dialogs/EditUserGroupDialog.svelte
+++ b/web-admin/src/features/organizations/user-management/dialogs/EditUserGroupDialog.svelte
@@ -8,9 +8,9 @@
     createAdminServiceListUsergroupMemberUsers,
     createAdminServiceRemoveUsergroupMemberUser,
     createAdminServiceUpdateUsergroup,
-    getAdminServiceListOrganizationMemberUsergroupsQueryKey,
     getAdminServiceListUsergroupMemberUsersQueryKey,
   } from "@rilldata/web-admin/client";
+  import { invalidateOrgUsergroups } from "@rilldata/web-admin/features/organizations/user-management/utils.ts";
   import AvatarListItem from "@rilldata/web-common/components/avatar/AvatarListItem.svelte";
   import { Button } from "@rilldata/web-common/components/button";
   import Combobox from "@rilldata/web-common/components/combobox/Combobox.svelte";
@@ -114,14 +114,7 @@
         },
       });
 
-      await queryClient.invalidateQueries({
-        queryKey: getAdminServiceListOrganizationMemberUsergroupsQueryKey(
-          organization,
-          {
-            includeCounts: true,
-          },
-        ),
-      });
+      await invalidateOrgUsergroups(queryClient, organization);
 
       eventBus.emit("notification", { message: m.groups_renamed() });
     } catch (error) {
@@ -175,14 +168,7 @@
         ),
       });
 
-      await queryClient.invalidateQueries({
-        queryKey: getAdminServiceListOrganizationMemberUsergroupsQueryKey(
-          organization,
-          {
-            includeCounts: true,
-          },
-        ),
-      });
+      await invalidateOrgUsergroups(queryClient, organization);
 
       pendingAdditions = [];
       pendingRemovals = [];

--- a/web-admin/src/features/organizations/user-management/table/groups/GroupRoleCell.svelte
+++ b/web-admin/src/features/organizations/user-management/table/groups/GroupRoleCell.svelte
@@ -9,8 +9,8 @@
     createAdminServiceAddOrganizationMemberUsergroup,
     createAdminServiceRemoveOrganizationMemberUsergroup,
     createAdminServiceSetOrganizationMemberUsergroupRole,
-    getAdminServiceListOrganizationMemberUsergroupsQueryKey,
   } from "@rilldata/web-admin/client";
+  import { invalidateOrgUsergroups } from "@rilldata/web-admin/features/organizations/user-management/utils.ts";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus.ts";
   import { capitalize } from "@rilldata/web-common/components/table/utils.ts";
   import { m } from "@rilldata/web-common/lib/i18n/gen/messages";
@@ -48,10 +48,7 @@
         },
       });
 
-      await queryClient.invalidateQueries({
-        queryKey:
-          getAdminServiceListOrganizationMemberUsergroupsQueryKey(organization),
-      });
+      await invalidateOrgUsergroups(queryClient, organization);
 
       eventBus.emit("notification", { message: m.groups_role_added() });
     } catch (error) {
@@ -73,10 +70,7 @@
         },
       });
 
-      await queryClient.invalidateQueries({
-        queryKey:
-          getAdminServiceListOrganizationMemberUsergroupsQueryKey(organization),
-      });
+      await invalidateOrgUsergroups(queryClient, organization);
 
       eventBus.emit("notification", { message: m.groups_role_updated() });
     } catch {
@@ -94,10 +88,7 @@
         usergroup: name,
       });
 
-      await queryClient.invalidateQueries({
-        queryKey:
-          getAdminServiceListOrganizationMemberUsergroupsQueryKey(organization),
-      });
+      await invalidateOrgUsergroups(queryClient, organization);
 
       eventBus.emit("notification", { message: m.groups_role_revoked() });
     } catch {

--- a/web-admin/src/features/organizations/user-management/table/users/UserRoleCell.svelte
+++ b/web-admin/src/features/organizations/user-management/table/users/UserRoleCell.svelte
@@ -3,6 +3,8 @@
   import {
     canManageOrgUser,
     invalidateAfterUserDelete,
+    invalidateOrgInvites,
+    invalidateOrgMemberUsers,
   } from "@rilldata/web-admin/features/organizations/user-management/utils.ts";
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
   import CaretUpIcon from "@rilldata/web-common/components/icons/CaretUpIcon.svelte";
@@ -10,8 +12,6 @@
   import {
     createAdminServiceRemoveOrganizationMemberUser,
     createAdminServiceSetOrganizationMemberUserRole,
-    getAdminServiceListOrganizationInvitesQueryKey,
-    getAdminServiceListOrganizationMemberUsersQueryKey,
     type V1OrganizationPermissions,
   } from "@rilldata/web-admin/client";
   import { page } from "$app/stores";
@@ -68,14 +68,9 @@
         },
       });
 
-      await queryClient.invalidateQueries({
-        queryKey:
-          getAdminServiceListOrganizationMemberUsersQueryKey(organization),
-      });
+      await invalidateOrgMemberUsers(queryClient, organization);
 
-      await queryClient.invalidateQueries({
-        queryKey: getAdminServiceListOrganizationInvitesQueryKey(organization),
-      });
+      await invalidateOrgInvites(queryClient, organization);
 
       eventBus.emit("notification", {
         message: m.users_role_updated(),
@@ -99,14 +94,9 @@
         },
       });
 
-      await queryClient.invalidateQueries({
-        queryKey:
-          getAdminServiceListOrganizationMemberUsersQueryKey(organization),
-      });
+      await invalidateOrgMemberUsers(queryClient, organization);
 
-      await queryClient.invalidateQueries({
-        queryKey: getAdminServiceListOrganizationInvitesQueryKey(organization),
-      });
+      await invalidateOrgInvites(queryClient, organization);
 
       eventBus.emit("notification", {
         message: m.users_guest_upgraded_to({ role }),

--- a/web-admin/src/features/organizations/user-management/utils.spec.ts
+++ b/web-admin/src/features/organizations/user-management/utils.spec.ts
@@ -1,0 +1,94 @@
+import {
+  getAdminServiceListOrganizationInvitesInfiniteQueryKey,
+  getAdminServiceListOrganizationInvitesQueryKey,
+  getAdminServiceListOrganizationMemberUsergroupsInfiniteQueryKey,
+  getAdminServiceListOrganizationMemberUsergroupsQueryKey,
+  getAdminServiceListOrganizationMemberUsersInfiniteQueryKey,
+  getAdminServiceListOrganizationMemberUsersQueryKey,
+} from "@rilldata/web-admin/client";
+import { QueryClient, type QueryKey } from "@tanstack/query-core";
+import { describe, expect, it } from "vitest";
+import {
+  invalidateOrgInvites,
+  invalidateOrgMemberUsers,
+  invalidateOrgUsergroups,
+} from "./utils";
+
+const ORG = "acme";
+
+// The params mirror what the user management pages query with.
+// Infinite query keys are prefixed with "infinite",
+// so a plain key does not match them and the paginated tables would go stale.
+const cases: {
+  name: string;
+  invalidate: (
+    queryClient: QueryClient,
+    organization: string,
+  ) => Promise<void[]>;
+  plainKey: QueryKey;
+  infiniteKey: QueryKey;
+}[] = [
+  {
+    name: "org member users",
+    invalidate: invalidateOrgMemberUsers,
+    plainKey: getAdminServiceListOrganizationMemberUsersQueryKey(ORG, {
+      pageSize: 50,
+      includeCounts: true,
+    }),
+    infiniteKey: getAdminServiceListOrganizationMemberUsersInfiniteQueryKey(
+      ORG,
+      { pageSize: 50, includeCounts: true },
+    ),
+  },
+  {
+    name: "org invites",
+    invalidate: invalidateOrgInvites,
+    plainKey: getAdminServiceListOrganizationInvitesQueryKey(ORG, {
+      pageSize: 50,
+    }),
+    infiniteKey: getAdminServiceListOrganizationInvitesInfiniteQueryKey(ORG, {
+      pageSize: 50,
+    }),
+  },
+  {
+    name: "org usergroups",
+    invalidate: invalidateOrgUsergroups,
+    plainKey: getAdminServiceListOrganizationMemberUsergroupsQueryKey(ORG, {
+      pageSize: 50,
+      includeCounts: true,
+    }),
+    infiniteKey:
+      getAdminServiceListOrganizationMemberUsergroupsInfiniteQueryKey(ORG, {
+        pageSize: 50,
+        includeCounts: true,
+      }),
+  },
+];
+
+describe.each(cases)(
+  "$name invalidation",
+  ({ invalidate, plainKey, infiniteKey }) => {
+    it("invalidates both the plain and the infinite query", async () => {
+      const queryClient = new QueryClient();
+      queryClient.setQueryData(plainKey, {});
+      queryClient.setQueryData(infiniteKey, { pages: [], pageParams: [] });
+
+      await invalidate(queryClient, ORG);
+
+      expect(queryClient.getQueryState(plainKey)?.isInvalidated).toBe(true);
+      expect(queryClient.getQueryState(infiniteKey)?.isInvalidated).toBe(true);
+    });
+
+    it("does not invalidate queries for another organization", async () => {
+      const queryClient = new QueryClient();
+      const otherOrgKey = infiniteKey.map((part) =>
+        typeof part === "string" ? part.replace(ORG, "other-org") : part,
+      );
+      queryClient.setQueryData(otherOrgKey, { pages: [], pageParams: [] });
+
+      await invalidate(queryClient, ORG);
+
+      expect(queryClient.getQueryState(otherOrgKey)?.isInvalidated).toBe(false);
+    });
+  },
+);

--- a/web-admin/src/features/organizations/user-management/utils.ts
+++ b/web-admin/src/features/organizations/user-management/utils.ts
@@ -1,5 +1,9 @@
 import {
+  getAdminServiceListOrganizationInvitesInfiniteQueryKey,
   getAdminServiceListOrganizationInvitesQueryKey,
+  getAdminServiceListOrganizationMemberUsergroupsInfiniteQueryKey,
+  getAdminServiceListOrganizationMemberUsergroupsQueryKey,
+  getAdminServiceListOrganizationMemberUsersInfiniteQueryKey,
   getAdminServiceListOrganizationMemberUsersQueryKey,
   getAdminServiceListUsergroupMemberUsersQueryKey,
   type V1OrganizationPermissions,
@@ -17,17 +21,69 @@ export function canManageOrgUser(
   );
 }
 
+// The org user, invite and group lists are read through both plain and infinite queries.
+// Orval caches the infinite variants under an "infinite"-prefixed query key,
+// so invalidating the plain key alone leaves the paginated tables showing stale data.
+// Always invalidate through these helpers rather than a single key.
+
+export function invalidateOrgMemberUsers(
+  queryClient: QueryClient,
+  organization: string,
+) {
+  return Promise.all([
+    queryClient.invalidateQueries({
+      queryKey:
+        getAdminServiceListOrganizationMemberUsersQueryKey(organization),
+    }),
+    queryClient.invalidateQueries({
+      queryKey:
+        getAdminServiceListOrganizationMemberUsersInfiniteQueryKey(
+          organization,
+        ),
+    }),
+  ]);
+}
+
+export function invalidateOrgInvites(
+  queryClient: QueryClient,
+  organization: string,
+) {
+  return Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: getAdminServiceListOrganizationInvitesQueryKey(organization),
+    }),
+    queryClient.invalidateQueries({
+      queryKey:
+        getAdminServiceListOrganizationInvitesInfiniteQueryKey(organization),
+    }),
+  ]);
+}
+
+export function invalidateOrgUsergroups(
+  queryClient: QueryClient,
+  organization: string,
+) {
+  return Promise.all([
+    queryClient.invalidateQueries({
+      queryKey:
+        getAdminServiceListOrganizationMemberUsergroupsQueryKey(organization),
+    }),
+    queryClient.invalidateQueries({
+      queryKey:
+        getAdminServiceListOrganizationMemberUsergroupsInfiniteQueryKey(
+          organization,
+        ),
+    }),
+  ]);
+}
+
 export async function invalidateAfterUserDelete(
   queryClient: QueryClient,
   organization: string,
 ) {
-  await queryClient.invalidateQueries({
-    queryKey: getAdminServiceListOrganizationMemberUsersQueryKey(organization),
-  });
+  await invalidateOrgMemberUsers(queryClient, organization);
 
-  await queryClient.invalidateQueries({
-    queryKey: getAdminServiceListOrganizationInvitesQueryKey(organization),
-  });
+  await invalidateOrgInvites(queryClient, organization);
 
   await queryClient.invalidateQueries({
     queryKey: getAdminServiceListUsergroupMemberUsersQueryKey(

--- a/web-admin/src/features/projects/user-management/OrgUserGroupSetRole.svelte
+++ b/web-admin/src/features/projects/user-management/OrgUserGroupSetRole.svelte
@@ -3,9 +3,9 @@
     createAdminServiceRemoveOrganizationMemberUsergroup,
     createAdminServiceSetOrganizationMemberUsergroupRole,
     createAdminServiceAddOrganizationMemberUsergroup,
-    getAdminServiceListOrganizationMemberUsergroupsQueryKey,
   } from "@rilldata/web-admin/client";
   import type { V1MemberUsergroup } from "@rilldata/web-admin/client";
+  import { invalidateOrgUsergroups } from "@rilldata/web-admin/features/organizations/user-management/utils";
   import * as DropdownMenu from "@rilldata/web-common/components/dropdown-menu";
   import { capitalize } from "@rilldata/web-common/components/table/utils";
   import { OrgUserRoles } from "@rilldata/web-common/features/users/roles.ts";
@@ -46,10 +46,7 @@
         },
       });
 
-      await queryClient.invalidateQueries({
-        queryKey:
-          getAdminServiceListOrganizationMemberUsergroupsQueryKey(organization),
-      });
+      await invalidateOrgUsergroups(queryClient, organization);
 
       eventBus.emit("notification", {
         message: m.groups_role_added(),
@@ -74,10 +71,7 @@
         },
       });
 
-      await queryClient.invalidateQueries({
-        queryKey:
-          getAdminServiceListOrganizationMemberUsergroupsQueryKey(organization),
-      });
+      await invalidateOrgUsergroups(queryClient, organization);
 
       eventBus.emit("notification", {
         message: m.groups_role_updated(),
@@ -99,10 +93,7 @@
         usergroup: group.groupName,
       });
 
-      await queryClient.invalidateQueries({
-        queryKey:
-          getAdminServiceListOrganizationMemberUsergroupsQueryKey(organization),
-      });
+      await invalidateOrgUsergroups(queryClient, organization);
 
       eventBus.emit("notification", {
         message: m.groups_removed(),

--- a/web-admin/src/features/projects/user-management/UserAndGroupInviteForm.svelte
+++ b/web-admin/src/features/projects/user-management/UserAndGroupInviteForm.svelte
@@ -4,12 +4,12 @@
     createAdminServiceAddProjectMemberUser,
     createAdminServiceAddProjectMemberUsergroup,
     getAdminServiceListOrganizationMemberUsersQueryOptions,
-    getAdminServiceListOrganizationMemberUsersQueryKey,
     getAdminServiceListProjectInvitesQueryKey,
     getAdminServiceListProjectMemberUsersQueryKey,
     getAdminServiceListProjectMemberUsergroupsQueryKey,
     createAdminServiceGetCurrentUser,
   } from "@rilldata/web-admin/client";
+  import { invalidateOrgMemberUsers } from "@rilldata/web-admin/features/organizations/user-management/utils";
   import { RFC5322EmailRegex } from "@rilldata/web-common/components/forms/validation";
   import { ProjectUserRoles } from "@rilldata/web-common/features/users/roles.ts";
   import { eventBus } from "@rilldata/web-common/lib/event-bus/event-bus";
@@ -89,11 +89,7 @@
           project,
         ),
       }),
-      queryClient.invalidateQueries({
-        queryKey:
-          getAdminServiceListOrganizationMemberUsersQueryKey(organization),
-        type: "all", // Clear regular and inactive queries
-      }),
+      invalidateOrgMemberUsers(queryClient, organization),
     ]);
 
     // Generate success notification message

--- a/web-admin/src/features/projects/user-management/UserInviteForm.svelte
+++ b/web-admin/src/features/projects/user-management/UserInviteForm.svelte
@@ -2,10 +2,10 @@
   import { m } from "@rilldata/web-common/lib/i18n/gen/messages";
   import {
     createAdminServiceAddProjectMemberUser,
-    getAdminServiceListOrganizationMemberUsersQueryKey,
     getAdminServiceListProjectInvitesQueryKey,
     getAdminServiceListProjectMemberUsersQueryKey,
   } from "@rilldata/web-admin/client";
+  import { invalidateOrgMemberUsers } from "@rilldata/web-admin/features/organizations/user-management/utils";
   import UserRoleSelect from "@rilldata/web-admin/features/projects/user-management/UserRoleSelect.svelte";
   import { Button } from "@rilldata/web-common/components/button";
   import MultiInput from "@rilldata/web-common/components/forms/MultiInput.svelte";
@@ -88,11 +88,7 @@
           ),
         });
 
-        await queryClient.invalidateQueries({
-          queryKey:
-            getAdminServiceListOrganizationMemberUsersQueryKey(organization),
-          type: "all", // Clear regular and inactive queries
-        });
+        await invalidateOrgMemberUsers(queryClient, organization);
 
         eventBus.emit("notification", {
           type: "success",


### PR DESCRIPTION
The org users, invites and groups tables read through Orval's *infinite* queries, which are cached under an `"infinite"`-prefixed key (`["infinite", "/v1/orgs/{org}/members", …]`). Every mutation invalidated only the plain key (`["/v1/orgs/{org}/members", …]`). TanStack matches keys by prefix, so the leading `"infinite"` element made the match fail and nothing refetched — the tables only updated on a page reload.

- Added `invalidateOrgMemberUsers`, `invalidateOrgInvites` and `invalidateOrgUsergroups` to `user-management/utils.ts`, each invalidating both key variants, and routed all 12 call sites through them: the add/remove/role-change dialogs, the groups tab, and the project-side invite forms.
- The groups tab had the same defect: `#9793` moved that table to an infinite query but left the invalidations on the plain key.
- Dropped `type: "all"` from two project-side call sites. It is TanStack's default filter value, so it was a no-op.
- `utils.spec.ts` covers all three helpers: both key variants get invalidated, and another organization's cache does not.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
