### PR TITLE
fix: keep one decimal on line chart Y-axis tick labels

### DIFF
--- a/web-common/src/lib/number-formatting/format-measure-value-locale.spec.ts
+++ b/web-common/src/lib/number-formatting/format-measure-value-locale.spec.ts
@@ -159,7 +159,17 @@ describe("format-measure-value with an explicit formatD3", () => {
   it("keeps humanized values in the axis context so tick labels stay compact", () => {
     const formatter = createMeasureValueFormatter(subCentMeasure, "axis");
     expect(formatter(0.0002)).toBe("$2e-4");
-    expect(formatter(1234567.8901)).toBe("$1M");
+    expect(formatter(1234567.8901)).toBe("$1.2M");
+  });
+
+  it("keeps one decimal on axis ticks so half-unit values are not rounded away", () => {
+    const formatter = createMeasureValueFormatter(subCentMeasure, "axis");
+    // 1,500,000 previously rounded up to "$2M", making a tick sitting on 1.5M
+    // read as 2M on the axis.
+    expect(formatter(1_500_000)).toBe("$1.5M");
+    expect(formatter(1_000_000)).toBe("$1M");
+    expect(formatter(500_000)).toBe("$500k");
+    expect(formatter(1_500_000_000)).toBe("$1.5B");
   });
 
   it("still humanizes preset-formatted measures in the big-number context", () => {

--- a/web-common/src/lib/number-formatting/strategies/per-range-axis-options.ts
+++ b/web-common/src/lib/number-formatting/strategies/per-range-axis-options.ts
@@ -21,11 +21,35 @@ const axisRangeSpec: RangeFormatSpec[] = [
     useTrailingDot: false,
     padWithInsignificantZeros: false,
   },
+  // Scale each magnitude band to its own SI unit (k/M/B) and keep one
+  // decimal, so tick labels stay compact without rounding away a meaningful
+  // digit. A single [3, 11) band with baseMagnitude 0 could not do this: it
+  // produced a 4+ digit integer that failed validation, fell through to the
+  // 0-decimal default path, and rounded e.g. 1,500,000 up to "2M".
   {
     minMag: 3,
-    supMag: 11,
-    maxDigitsRight: 2,
-    baseMagnitude: 0,
+    supMag: 6,
+    maxDigitsRight: 1,
+    baseMagnitude: 3,
+    maxDigitsLeft: 3,
+    useTrailingDot: false,
+    padWithInsignificantZeros: false,
+  },
+  {
+    minMag: 6,
+    supMag: 9,
+    maxDigitsRight: 1,
+    baseMagnitude: 6,
+    maxDigitsLeft: 3,
+    useTrailingDot: false,
+    padWithInsignificantZeros: false,
+  },
+  {
+    minMag: 9,
+    supMag: 12,
+    maxDigitsRight: 1,
+    baseMagnitude: 9,
+    maxDigitsLeft: 3,
     useTrailingDot: false,
     padWithInsignificantZeros: false,
   },


### PR DESCRIPTION
- Line chart Y-axis tick labels rounded to whole SI units, so a gridline at `1,500,000` rendered as `$2M`. With the scale's padding often landing a tick on the data's max, the line sat on that gridline and read as ~2M when it was 1.5M.
- Root cause: the `axis` number spec used a single `[3, 11)` band with `baseMagnitude: 0`. In `PerRangeFormatter`, any value ≥ 1000 became a 4+ digit integer that failed validation and fell through to the `defaultMaxDigitsRight: 0` path, rounding the SI mantissa (`1.5M → 2M`). Whole-mantissa values (`500k`, `1M`) were unaffected, which is why it went unnoticed.
- Fix: split the band into per-magnitude `k`/`M`/`B` bands with their own `baseMagnitude` and one decimal, so `1.5M → $1.5M` while `1M` and `500k` stay clean.
- Only the custom time-series renderer (`MeasureChartBody`) uses the `axis` flavor, so tooltip/table/big-number formatting are untouched. The bar chart type (Vega engine) was already correct.

Closes [#9805](https://github.com/rilldata/rill/issues/9805)

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*
