### PR TITLE
fix: chart resize and dynamic y-axis for non-line chart types in Explore

### DIFF
--- a/web-common/src/components/time-series-chart/BarChart.svelte
+++ b/web-common/src/components/time-series-chart/BarChart.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import type { ChartSeries } from "@rilldata/web-common/features/dashboards/time-series/measure-chart/types";
-  import { computeBarSlotGeometry } from "@rilldata/web-common/features/dashboards/time-series/measure-chart/utils";
+  import {
+    clampToRange,
+    computeBarSlotGeometry,
+  } from "@rilldata/web-common/features/dashboards/time-series/measure-chart/utils";
   import type { ScaleLinear } from "d3-scale";
 
   const BAR_RADIUS = 3;
@@ -21,7 +24,9 @@
 
   $: visibleCount = Math.max(1, visibleEnd - visibleStart + 1);
   $: geo = computeBarSlotGeometry(plotWidth, visibleCount, series.length);
-  $: zeroY = yScale(0);
+  // With a dynamic y-axis the domain can exclude zero, putting yScale(0) outside the plot.
+  // Clamp the baseline to the scale's range so bars stay inside the plot area.
+  $: zeroY = clampToRange(yScale(0), yScale.range());
 
   function isInScrub(ptIdx: number): boolean {
     if (!hasScrub) return true;

--- a/web-common/src/components/time-series-chart/TimeSeriesChart.svelte
+++ b/web-common/src/components/time-series-chart/TimeSeriesChart.svelte
@@ -7,6 +7,7 @@
     ChartScales,
     ChartSeries,
   } from "@rilldata/web-common/features/dashboards/time-series/measure-chart/types";
+  import { clampToRange } from "@rilldata/web-common/features/dashboards/time-series/measure-chart/utils";
   import { bridgeGaps } from "./sparse-data-utils";
 
   const numAccessor = (d: number | null) => d;
@@ -27,9 +28,11 @@
     defined: (d) => d !== null,
   });
 
+  // With a dynamic y-axis the domain can exclude zero, putting scales.y(0) outside the plot.
+  // Clamp the area's baseline to the scale's range so the fill stays inside the plot area.
   $: areaGen = createAreaGenerator<number | null>({
     x: (_d, i) => scales.x(i),
-    y0: scales.y(0),
+    y0: clampToRange(scales.y(0), scales.y.range()),
     y1: (d) => scales.y(d ?? 0),
     defined: (d) => d !== null,
   });

--- a/web-common/src/components/vega/VegaLiteRenderer.svelte
+++ b/web-common/src/components/vega/VegaLiteRenderer.svelte
@@ -11,7 +11,7 @@
   } from "svelte-vega";
   import type { Config } from "vega-lite";
   import type { ExpressionFunction, VLTooltipFormatter } from "./types";
-  import { createEmbedOptions } from "./vega-embed-options";
+  import { createBaseEmbedOptions } from "./vega-embed-options";
   import { VegaLiteTooltipHandler } from "./vega-tooltip";
   import "./vega.css";
 
@@ -59,10 +59,10 @@
     stableHasComparison = hasComparison;
   }
 
-  $: options = createEmbedOptions({
+  // Deliberately excludes width/height so a resize leaves this object's identity untouched
+  // and svelte-vega resizes the existing view rather than re-embedding it.
+  $: baseOptions = createBaseEmbedOptions({
     client: runtimeClient,
-    width,
-    height,
     config,
     renderer,
     themeMode,
@@ -70,6 +70,8 @@
     colorMapping: stableColorMapping,
     hasComparison: stableHasComparison,
   });
+
+  $: options = { ...baseOptions, width, height };
 
   // Create a more efficient key for component remounting
   $: configKey = config ? Object.keys(config).sort().join(",") : "default";

--- a/web-common/src/components/vega/VegaRenderer.svelte
+++ b/web-common/src/components/vega/VegaRenderer.svelte
@@ -11,7 +11,7 @@
   } from "svelte-vega";
   import type { Config } from "vega-lite";
   import type { ExpressionFunction, VLTooltipFormatter } from "./types";
-  import { createEmbedOptions } from "./vega-embed-options";
+  import { createBaseEmbedOptions } from "./vega-embed-options";
   import { VegaLiteTooltipHandler } from "./vega-tooltip";
   import "./vega.css";
 
@@ -84,10 +84,10 @@
     stableHasComparison = hasComparison;
   }
 
-  $: options = createEmbedOptions({
+  // Deliberately excludes width/height so a resize leaves this object's identity untouched
+  // and svelte-vega resizes the existing view rather than re-embedding it.
+  $: baseOptions = createBaseEmbedOptions({
     client: runtimeClient,
-    width,
-    height,
     config,
     renderer,
     themeMode: theme,
@@ -95,6 +95,8 @@
     colorMapping: stableColorMapping,
     hasComparison: stableHasComparison,
   });
+
+  $: options = { ...baseOptions, width, height };
 
   const onError = (e: Error) => {
     error = e.message;

--- a/web-common/src/components/vega/vega-embed-options.ts
+++ b/web-common/src/components/vega/vega-embed-options.ts
@@ -8,10 +8,8 @@ import type { ExpressionFunction } from "./types";
 import { sanitizeTitleForVegaTooltip } from "./util";
 import { getRillTheme } from "./vega-config";
 
-export interface CreateEmbedOptionsParams {
+export interface CreateBaseEmbedOptionsParams {
   client: RuntimeClient;
-  width: number;
-  height: number;
   config?: Config;
   renderer?: "canvas" | "svg";
   themeMode?: "light" | "dark";
@@ -21,10 +19,17 @@ export interface CreateEmbedOptionsParams {
   hasComparison?: boolean;
 }
 
-export function createEmbedOptions({
+/**
+ * Builds the size-independent half of the vega-embed options.
+ *
+ * Callers spread `width` and `height` on top of the result, and must keep this object's
+ * identity stable while only the dimensions change: svelte-vega compares options key by key
+ * with `===` (ignoring width and height), and a single fresh nested object makes it tear
+ * down and re-embed the whole view instead of calling `view.width()`. That loses brush state
+ * and, while a resize divider is being dragged, re-embeds on every frame.
+ */
+export function createBaseEmbedOptions({
   client,
-  width,
-  height,
   config,
   renderer = "canvas",
   themeMode = "light",
@@ -32,7 +37,7 @@ export function createEmbedOptions({
   useExpressionInterpreter = true,
   colorMapping,
   hasComparison,
-}: CreateEmbedOptionsParams): EmbedOptions {
+}: CreateBaseEmbedOptionsParams): EmbedOptions {
   const jwt = client.getJwt();
 
   return {
@@ -46,8 +51,6 @@ export function createEmbedOptions({
     },
     actions: false,
     logLevel: 0, // only show errors
-    width,
-    height,
     ...(useExpressionInterpreter && {
       // Add interpreter so that vega expressions are CSP compliant
       ast: true,

--- a/web-common/src/features/components/charts/builder.ts
+++ b/web-common/src/features/components/charts/builder.ts
@@ -127,6 +127,23 @@ export function createPositionEncoding(
   };
 }
 
+/**
+ * Turns off Vega-Lite's implicit stacking when the axis should not be anchored at zero.
+ *
+ * Vega-Lite stacks bar and area marks by default, and a stacked scale takes its domain from
+ * the stack's start/end fields, which always span zero. `scale.zero: false` is therefore
+ * compiled in but has nothing to act on. Un-stacking is only safe for a single series: with a
+ * color field the marks would overlap instead of stack, so those charts stay zero-based.
+ *
+ * Spread this after `createPositionEncoding` so it wins over any default `stack`.
+ */
+export function createStackOverride(
+  field: FieldConfig | undefined,
+  colorField: string | undefined,
+): { stack?: null } {
+  return field?.zeroBasedOrigin === false && !colorField ? { stack: null } : {};
+}
+
 export function getTemporalAxisLabelExpr(format: string | undefined) {
   if (format !== "%H:%M") return undefined;
 

--- a/web-common/src/features/components/charts/cartesian/area/spec.ts
+++ b/web-common/src/features/components/charts/cartesian/area/spec.ts
@@ -9,6 +9,7 @@ import {
   createDefaultTooltipEncoding,
   createMultiLayerBaseSpec,
   createPositionEncoding,
+  createStackOverride,
 } from "@rilldata/web-common/features/components/charts/builder";
 import type { VisualizationSpec } from "svelte-vega";
 import type { Field } from "vega-lite/types_unstable/channeldef.js";
@@ -50,7 +51,11 @@ export function generateVLAreaChartSpec(
   const layers: Array<LayerSpec<Field> | UnitSpec<Field>> = [
     {
       encoding: {
-        y: { ...createPositionEncoding(config.y, data), stack: "zero" },
+        y: {
+          ...createPositionEncoding(config.y, data),
+          stack: "zero",
+          ...createStackOverride(config.y, colorField),
+        },
         color: createColorEncoding(config.color, data),
       },
       layer: inner,

--- a/web-common/src/features/components/charts/cartesian/bar-chart/spec.ts
+++ b/web-common/src/features/components/charts/cartesian/bar-chart/spec.ts
@@ -8,6 +8,7 @@ import {
   createDefaultTooltipEncoding,
   createMultiLayerBaseSpec,
   createPositionEncoding,
+  createStackOverride,
 } from "@rilldata/web-common/features/components/charts/builder";
 import {
   ColorWithComparisonField,
@@ -73,7 +74,10 @@ export function generateVLBarChartSpec(
   const barLayer: UnitSpec<Field> = {
     mark: { type: "bar", clip: true, width: { band: 0.9 } },
     encoding: {
-      y: createPositionEncoding(config.y, data),
+      y: {
+        ...createPositionEncoding(config.y, data),
+        ...createStackOverride(config.y, colorField),
+      },
       color: createColorEncoding(config.color, data),
       // Only add xOffset for color field when NOT in comparison mode
       // In comparison mode, we'll handle xOffset separately to include comparison grouping

--- a/web-common/src/features/components/charts/cartesian/stacked-bar/default.ts
+++ b/web-common/src/features/components/charts/cartesian/stacked-bar/default.ts
@@ -8,6 +8,7 @@ import {
   createDefaultTooltipEncoding,
   createMultiLayerBaseSpec,
   createPositionEncoding,
+  createStackOverride,
 } from "@rilldata/web-common/features/components/charts/builder";
 import {
   createComparisonOpacityEncoding,
@@ -70,7 +71,10 @@ export function generateVLStackedBarChartSpec(
   const barLayer: UnitSpec<Field> = {
     mark: { type: "bar", clip: true, width: { band: 0.9 } },
     encoding: {
-      y: createPositionEncoding(config.y, data),
+      y: {
+        ...createPositionEncoding(config.y, data),
+        ...createStackOverride(config.y, colorField),
+      },
       color: createColorEncoding(config.color, data),
       tooltip: defaultTooltipChannel,
     },

--- a/web-common/src/features/dashboards/time-dimension-details/charts/TDDChart.svelte
+++ b/web-common/src/features/dashboards/time-dimension-details/charts/TDDChart.svelte
@@ -49,6 +49,7 @@
   export let showComparison: boolean = false;
   export let showTimeDimensionDetail: boolean = true;
   export let chartType: TDDChart;
+  export let dynamicYAxis: boolean = false;
   export let onChartHover: (
     dimension: undefined | string | null,
     ts: Date | undefined,
@@ -78,6 +79,7 @@
     dimensionValues,
     dimensionData,
     showTimeDimensionDetail,
+    dynamicYAxis,
   );
 
   $: componentChartType = TDD_TO_COMPONENT_CHART_TYPE[chartType];

--- a/web-common/src/features/dashboards/time-dimension-details/charts/tdd-chart-config.spec.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/charts/tdd-chart-config.spec.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect } from "vitest";
+import type { ChartDataResult } from "@rilldata/web-common/features/components/charts/types";
+import { generateSpec } from "@rilldata/web-common/features/components/charts/util";
+import chroma from "chroma-js";
+import { compile } from "vega-lite";
+import { describe, expect, it } from "vitest";
 import { createTDDCartesianSpec } from "./tdd-chart-config";
 
 describe("createTDDCartesianSpec", () => {
@@ -55,5 +59,72 @@ describe("createTDDCartesianSpec", () => {
         ],
       }),
     );
+  });
+});
+
+describe("dynamic y-axis", () => {
+  const rows = [
+    { timestamp: "2024-01-01", total_sales: 5, country: "US" },
+    { timestamp: "2024-01-02", total_sales: 9, country: "UK" },
+  ];
+
+  const data = {
+    data: rows,
+    isFetching: false,
+    error: undefined,
+    fields: {
+      total_sales: { displayName: "Total Sales" },
+      timestamp: { displayName: "Time" },
+      country: { displayName: "Country" },
+    },
+    domainValues: { country: ["US", "UK"] },
+    theme: { primary: chroma("#4a5ad0"), secondary: chroma("#a0a7e0") },
+    isDarkMode: false,
+    hasComparison: false,
+  } as unknown as ChartDataResult;
+
+  /**
+   * Compiles all the way down to Vega, because the y scale's `zero` flag alone does not tell
+   * you whether the axis is actually dynamic: Vega-Lite stacks bar and area marks by default,
+   * and a stacked domain is derived from start/end fields that always span zero.
+   */
+  function compiledYScale(dynamicYAxis: boolean, comparisonDimension?: string) {
+    const config = createTDDCartesianSpec(
+      "my_metrics_view",
+      "total_sales",
+      "timestamp",
+      comparisonDimension,
+      comparisonDimension ? ["US", "UK"] : [],
+      [],
+      false,
+      dynamicYAxis,
+    );
+    const vlSpec = generateSpec("bar_chart", config, data);
+    const compiled = compile({ ...vlSpec, data: { values: rows } } as never)
+      .spec as { scales?: { name: string; zero?: boolean; domain?: unknown }[] };
+    return compiled.scales?.find((scale) => scale.name === "y");
+  }
+
+  it("anchors the axis at zero when the toggle is off", () => {
+    const yScale = compiledYScale(false);
+
+    expect(yScale?.zero).toBe(true);
+  });
+
+  it("drops stacking so the domain follows the data when the toggle is on", () => {
+    const yScale = compiledYScale(true);
+
+    expect(yScale?.zero).toBe(false);
+    // A stacked domain would be {fields: [..._start, ..._end]}, which always spans zero.
+    expect(yScale?.domain).toEqual({ data: "data_2", field: "total_sales" });
+  });
+
+  it("keeps multi-series charts stacked, since un-stacking would overlap the marks", () => {
+    const yScale = compiledYScale(true, "country");
+
+    expect(yScale?.domain).toEqual({
+      data: "data_2",
+      fields: ["total_sales_start", "total_sales_end"],
+    });
   });
 });

--- a/web-common/src/features/dashboards/time-dimension-details/charts/tdd-chart-config.spec.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/charts/tdd-chart-config.spec.ts
@@ -101,7 +101,9 @@ describe("dynamic y-axis", () => {
     );
     const vlSpec = generateSpec("bar_chart", config, data);
     const compiled = compile({ ...vlSpec, data: { values: rows } } as never)
-      .spec as { scales?: { name: string; zero?: boolean; domain?: unknown }[] };
+      .spec as {
+      scales?: { name: string; zero?: boolean; domain?: unknown }[];
+    };
     return compiled.scales?.find((scale) => scale.name === "y");
   }
 

--- a/web-common/src/features/dashboards/time-dimension-details/charts/tdd-chart-config.ts
+++ b/web-common/src/features/dashboards/time-dimension-details/charts/tdd-chart-config.ts
@@ -38,6 +38,7 @@ export function createTDDCartesianSpec(
   selectedValues?: (string | null)[],
   dimensionData?: DimensionSeriesData[],
   showTimeDimensionDetail = true,
+  dynamicYAxis = false,
 ): CartesianChartSpec & Pick<ChartSpec, "vl_config"> {
   const spec: CartesianChartSpec & Pick<ChartSpec, "vl_config"> = {
     metrics_view: metricsViewName,
@@ -50,6 +51,8 @@ export function createTDDCartesianSpec(
       field: measureName,
       type: "quantitative",
       axisOrient: "right",
+      // The "Dynamic Y-axis scale" toggle: off means the axis is anchored at zero.
+      zeroBasedOrigin: !dynamicYAxis,
     },
     isInteractive: true,
     // Fix vertical alignment across stacked TDD charts: force a fixed axis

--- a/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
+++ b/web-common/src/features/dashboards/time-series/MetricsTimeSeriesCharts.svelte
@@ -379,7 +379,9 @@
           class="sticky top-0 z-10 bg-surface-background col-span-2 grid grid-cols-subgrid"
         >
           <div></div>
-          <div class="relative">
+          <!-- min-w-0 lets the 1fr track follow the resizable panel width instead of
+               being propped open by the chart's intrinsic size (see the chart cell below) -->
+          <div class="relative min-w-0">
             <MeasureChartXAxis
               interval={chartInterval}
               timeGranularity={activeTimeGrain}
@@ -409,7 +411,10 @@
         />
 
         {#if activeTimeGrain}
-          <div class="relative">
+          <!-- min-w-0 is required for the Vega-rendered chart types: their canvas has an
+               intrinsic pixel width, which would otherwise become the 1fr track's minimum
+               size and stop the column from shrinking when the divider is dragged in. -->
+          <div class="relative min-w-0">
             <MeasureChart
               {measure}
               {scrubController}

--- a/web-common/src/features/dashboards/time-series/measure-chart/MeasureChart.svelte
+++ b/web-common/src/features/dashboards/time-series/measure-chart/MeasureChart.svelte
@@ -343,6 +343,7 @@
         {dimensionData}
         {showComparison}
         {showTimeDimensionDetail}
+        {dynamicYAxis}
         onChartHover={handleTddHover}
         onChartBrushEnd={handleTddBrushEnd}
         onChartBrushClear={handleTddBrushClear}

--- a/web-common/src/features/dashboards/time-series/measure-chart/utils.ts
+++ b/web-common/src/features/dashboards/time-series/measure-chart/utils.ts
@@ -27,6 +27,18 @@ export function dateToIndex(
   return best;
 }
 
+/**
+ * Clamp a pixel position into a d3 scale's range.
+ *
+ * When the y-axis is dynamic, its domain can exclude zero, so yScale(0) falls outside the
+ * plot. Marks anchored at zero (bar baselines, area fills) use this to stay inside the plot.
+ * The range is passed as d3 emits it, so the two bounds may be in either order.
+ */
+export function clampToRange(value: number, range: number[]): number {
+  const [a, b] = range;
+  return Math.min(Math.max(value, Math.min(a, b)), Math.max(a, b));
+}
+
 export interface BarSlotGeometry {
   slotWidth: number;
   gap: number;


### PR DESCRIPTION
Explore's timeseries area has two renderers: a custom SVG one for the default/line types, and Vega-Lite for grouped bar, stacked bar and stacked area (`usesVegaRenderer` in `chart-series.ts`). Neither the resize divider nor the dynamic y-axis toggle was wired into the Vega path.

- **Resize.** Added `min-w-0` to the chart grid cells in `MetricsTimeSeriesCharts.svelte`. A `1fr` track's floor is its item's min-content size, and the Vega `<canvas>` has an intrinsic pixel width, so the column could grow but never shrink past the last width Vega drew at. The container therefore never shrank, `bind:contentRect` never fired, and the chart never re-rendered smaller. The SVG chart is a `w-full` `<svg>` with no intrinsic width, which is why only the line chart resized correctly.
- **Dynamic y-axis.** Threaded `dynamicYAxis` through `MeasureChart` and `TDDChart` into `createTDDCartesianSpec` as `zeroBasedOrigin`. The field was previously never set, and `builder.ts` emits `zero: false` whenever it is not `true`, so every Vega chart was permanently dynamic — bar charts drew from a non-zero baseline even with the toggle off, and toggling it had no effect.
- **Zero baseline in the SVG marks.** Clamped `zeroY` in `BarChart.svelte` and the area generator's `y0` in `TimeSeriesChart.svelte` via a new `clampToRange` helper. With a dynamic axis the domain can exclude zero, putting `yScale(0)` outside the clipped plot, which rendered bars as full-height slabs and flooded the area fill. `MeasureChartBody` and `MeasureChartTooltip` already clamped the same value. Reachable in Explore whenever the default chart type falls under six points.
- **Vega resize path.** Split `createEmbedOptions` into `createBaseEmbedOptions` plus a `width`/`height` spread at the call site. svelte-vega compares options key by key with `===`, ignoring width and height, so the fresh `tooltip`/`loader`/`config` objects made it tear down and re-embed the whole view on every frame of a drag. It now calls `view.width()` on the existing view, which also fixes brush state being lost on resize — something the existing `spec`/`colorMapping` memoization was already trying to achieve. Applied to `VegaRenderer.svelte` too, since canvas dashboards hit the same path.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

https://claude.ai/code/session_01DT291cEZct4NiwpGFbyq7o
