### PR TITLE
fix: no scroll in filter resource drop down

### DIFF
--- a/web-common/src/components/table-toolbar/TableToolbarFilterDropdown.svelte
+++ b/web-common/src/components/table-toolbar/TableToolbarFilterDropdown.svelte
@@ -40,7 +40,7 @@
       <FilterOutlined size="16" />
       <span>Filter</span>
     </DropdownMenu.Trigger>
-    <DropdownMenu.Content align="start">
+    <DropdownMenu.Content align="start" class="max-h-72 overflow-y-auto">
       {#each filterGroups as group, i (group.key)}
         <DropdownMenu.Group>
           <DropdownMenu.Label class="uppercase">


### PR DESCRIPTION
Before:
<img width="137" height="434" alt="image" src="https://github.com/user-attachments/assets/60745776-8420-4717-a340-1c06d9115b53" />

After:
<img width="152" height="354" alt="image" src="https://github.com/user-attachments/assets/f2e75bd2-f3fd-42bc-9190-357491fce300" />


**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [x] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
