### PR TITLE
fix: derive semantic theme tokens on the dashboard theme boundary

### DIFF
--- a/runtime/parser/parse_theme.go
+++ b/runtime/parser/parse_theme.go
@@ -83,6 +83,16 @@ var allowedCSSVariables = map[string]bool{
 	"ring-focus":  true,
 	"ring-offset": true,
 
+	// Dimension styling
+	"dimension":            true,
+	"dimension-foreground": true,
+	"dimension-border":     true,
+
+	// Measure styling
+	"measure":            true,
+	"measure-foreground": true,
+	"measure-border":     true,
+
 	// Tooltip
 	"tooltip": true,
 

--- a/runtime/parser/parser_test.go
+++ b/runtime/parser/parser_test.go
@@ -3068,6 +3068,34 @@ light:
 				},
 			},
 		},
+		{
+			name: "dimension and measure variables are accepted",
+			yaml: `
+type: theme
+light:
+  primary: red
+  dimension: "#f1f5f9"
+  dimension-foreground: "#0f172a"
+  dimension-border: "#cbd5e1"
+  measure: "#f1f5f9"
+  measure-foreground: "#0f172a"
+  measure-border: "#cbd5e1"
+`,
+			expectError: false,
+			expectedSpec: &runtimev1.ThemeSpec{
+				Light: &runtimev1.ThemeColors{
+					Primary: "red",
+					Variables: map[string]string{
+						"dimension":            "#f1f5f9",
+						"dimension-foreground": "#0f172a",
+						"dimension-border":     "#cbd5e1",
+						"measure":              "#f1f5f9",
+						"measure-foreground":   "#0f172a",
+						"measure-border":       "#cbd5e1",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/web-common/src/app.css
+++ b/web-common/src/app.css
@@ -65,6 +65,12 @@
     --radius: 0.5rem;
 
     /* SEMANTIC VARIABLES */
+    /*
+     * Tokens below that read from --color-primary-* or --color-secondary-* are
+     * re-derived per dashboard theme by PALETTE_DERIVED_TOKENS in
+     * web-common/src/features/themes/theme.ts. Keep the shade there in sync when
+     * changing one of these (same for the :root.dark block further down).
+     */
     --surface-base: var(--white);
     --surface-subtle: var(--color-gray-50);
     --surface-background: var(--white);
@@ -284,6 +290,10 @@
     color-scheme: dark;
     color: var(--fg-primary);
 
+    /*
+     * Palette-derived tokens here mirror the `dark` shade in PALETTE_DERIVED_TOKENS in
+     * web-common/src/features/themes/theme.ts. Keep them in sync.
+     */
     --surface-background: var(--color-rill-gray-dark-300);
     --surface-base: var(--color-rill-gray-dark-50);
     --surface-subtle: var(--color-rill-gray-dark-200);

--- a/web-common/src/components/alert-dialog/alert-dialog-content.svelte
+++ b/web-common/src/components/alert-dialog/alert-dialog-content.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { getThemeBoundaryClass } from "@rilldata/web-common/features/themes/theme-boundary";
   import { cn } from "@rilldata/web-common/lib/shadcn";
   import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
   import { X } from "lucide-svelte";
@@ -11,12 +12,15 @@
   let className: $$Props["class"] = undefined;
   export let noCancel = false;
   export { className as class };
+
+  const themeBoundaryClass = getThemeBoundaryClass();
 </script>
 
 <AlertDialog.Portal>
   <AlertDialog.Overlay />
   <AlertDialogPrimitive.Content
     class={cn(
+      themeBoundaryClass,
       "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-gray-300 bg-surface-subtle p-6 shadow-lg sm:rounded-lg md:w-full",
       className,
     )}

--- a/web-common/src/components/dialog/dialog-content.svelte
+++ b/web-common/src/components/dialog/dialog-content.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { getThemeBoundaryClass } from "@rilldata/web-common/features/themes/theme-boundary";
   import { cn } from "@rilldata/web-common/lib/shadcn";
   import { Dialog as DialogPrimitive } from "bits-ui";
   import { X } from "lucide-svelte";
@@ -9,12 +10,15 @@
   let className: $$Props["class"] = undefined;
   export let noClose = false;
   export { className as class };
+
+  const themeBoundaryClass = getThemeBoundaryClass();
 </script>
 
 <Dialog.Portal>
   <Dialog.Overlay />
   <DialogPrimitive.Content
     class={cn(
+      themeBoundaryClass,
       "fixed left-[50%] top-[50%] z-50 grid w-full max-w-xl translate-x-[-50%] translate-y-[-50%] gap-4 border bg-surface-overlay p-6 shadow-lg sm:rounded-lg md:w-full",
       className,
     )}

--- a/web-common/src/features/themes/theme-manager.ts
+++ b/web-common/src/features/themes/theme-manager.ts
@@ -81,11 +81,16 @@ class ThemeManager {
 
       const themeBoundary = document.querySelector(".dashboard-theme-boundary");
       if (themeBoundary) {
-        const scopedValue = getComputedStyle(
-          themeBoundary as HTMLElement,
-        ).getPropertyValue(modeVariant);
-        if (scopedValue && scopedValue.trim()) {
-          return scopedValue.trim();
+        const boundaryStyle = getComputedStyle(themeBoundary as HTMLElement);
+        // Theme.generateCSS declares the plain `--color-primary-500` form on the boundary
+        // rather than the -light-/-dark- pair, and already picks the shade for the active
+        // mode. Check the mode variant first (themeManager.applyTheme sets those), then the
+        // plain name, so both ways of theming a dashboard resolve here.
+        for (const name of [modeVariant, varName]) {
+          const scopedValue = boundaryStyle.getPropertyValue(name);
+          if (scopedValue && scopedValue.trim()) {
+            return scopedValue.trim();
+          }
         }
       }
 

--- a/web-common/src/features/themes/theme.spec.ts
+++ b/web-common/src/features/themes/theme.spec.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import type { V1ThemeSpec } from "@rilldata/web-common/runtime-client";
+import { Theme } from "./theme";
+
+const PRIMARY = "#49A9DE";
+const SECONDARY = "#17407D";
+
+/**
+ * Splits the generated CSS into its light and dark rules, each as a
+ * variable name (without the leading `--`) to value map.
+ */
+function parseCSS(css: string): {
+  light: Record<string, string>;
+  dark: Record<string, string>;
+} {
+  const blocks = [...css.matchAll(/([^{}]+)\{([^{}]*)\}/g)];
+
+  const parseBlock = (body: string) =>
+    Object.fromEntries(
+      [...body.matchAll(/--([\w-]+):\s*([^;]+);/g)].map(([, name, value]) => [
+        name,
+        value.trim(),
+      ]),
+    );
+
+  const find = (dark: boolean) =>
+    parseBlock(
+      blocks.find(
+        ([, selector]) => selector.includes(".dark ") === dark,
+      )?.[2] ?? "",
+    );
+
+  return { light: find(false), dark: find(true) };
+}
+
+describe("Theme", () => {
+  describe("palette-derived semantic tokens", () => {
+    // app.css declares these on :root against Rill's own palette. Custom properties are
+    // substituted where they are declared, so a theme scoped to .dashboard-theme-boundary
+    // cannot reach them; the theme has to re-declare them on the boundary itself.
+    const colors = { primary: PRIMARY, secondary: SECONDARY };
+    const { light, dark } = parseCSS(
+      new Theme({ light: colors, dark: colors }).css,
+    );
+
+    it("derives the hover and active surfaces from the theme palette", () => {
+      expect(light["surface-hover"]).toBe(light["color-theme-50"]);
+      expect(light["surface-active"]).toBe(light["color-theme-100"]);
+    });
+
+    it("points popover-accent at surface-hover, as app.css does", () => {
+      expect(light["popover-accent"]).toBe(light["color-theme-50"]);
+      expect(light["popover-accent"]).toBe(light["surface-hover"]);
+    });
+
+    it("derives accents, focus rings, and dimension and measure chips", () => {
+      expect(light["accent-primary"]).toBe(light["color-theme-500"]);
+      expect(light["icon-accent"]).toBe(light["color-theme-500"]);
+      expect(light["ring-focus"]).toBe(light["color-theme-300"]);
+      expect(light["fg-accent"]).toBe(light["color-theme-900"]);
+      expect(light["dimension"]).toBe(light["color-theme-100"]);
+      expect(light["dimension-foreground"]).toBe(light["color-theme-800"]);
+      expect(light["measure"]).toBe(light["color-theme-secondary-100"]);
+      expect(light["measure-foreground"]).toBe(
+        light["color-theme-secondary-800"],
+      );
+    });
+
+    it("keeps the neutral gray surfaces in dark mode", () => {
+      // Emitted as `unset` so the boundary inherits :root.dark rather than tinting.
+      expect(dark["surface-hover"]).toBe("unset");
+      expect(dark["surface-active"]).toBe("unset");
+      expect(dark["popover-accent"]).toBe("unset");
+    });
+
+    it("uses light-palette shades for dark-mode accents, matching :root.dark", () => {
+      // :root.dark reaches for --color-primary-light-* rather than the dark palette,
+      // because those shades stay legible against dark surfaces. The light block's
+      // color-theme-* are those same shades.
+      expect(dark["accent-primary"]).toBe(light["color-theme-600"]);
+      expect(dark["icon-accent"]).toBe(light["color-theme-400"]);
+      expect(dark["dimension"]).toBe(light["color-theme-950"]);
+    });
+
+    it("falls back to Rill's defaults in dark mode when the theme is light-only", () => {
+      const { dark } = parseCSS(new Theme({ light: colors }).css);
+
+      expect(dark["accent-primary"]).toBe("unset");
+      expect(dark["dimension"]).toBe("unset");
+    });
+
+    it("leaves secondary-derived tokens alone when the theme has no secondary", () => {
+      const { light } = parseCSS(
+        new Theme({ light: { primary: PRIMARY } }).css,
+      );
+
+      expect(light["dimension"]).toBe(light["color-theme-100"]);
+      expect(light).not.toHaveProperty("measure");
+      expect(light).not.toHaveProperty("accent-secondary-action");
+    });
+  });
+
+  describe("explicit theme variables", () => {
+    it("win over the derived values", () => {
+      const { light } = parseCSS(
+        new Theme({
+          light: {
+            primary: PRIMARY,
+            variables: { "surface-hover": "#ff0000" },
+          },
+        }).css,
+      );
+
+      expect(light["surface-hover"]).toBe("hsl(0deg 100% 50%)");
+      expect(light["popover-accent"]).toBe(light["surface-hover"]);
+    });
+
+    it("let fg-primary keep ownership of fg-accent", () => {
+      const { light } = parseCSS(
+        new Theme({
+          light: {
+            primary: PRIMARY,
+            variables: { "fg-primary": "#111111" },
+          },
+        }).css,
+      );
+
+      expect(light["fg-accent"]).toBe(light["fg-primary"]);
+    });
+  });
+
+  describe("palette aliasing", () => {
+    it("shadows Rill's primary and secondary palettes inside the boundary", () => {
+      // So that the `bg-primary-500`-style utilities used throughout dashboard
+      // components follow the theme without each one having to be migrated.
+      const { light } = parseCSS(
+        new Theme({ light: { primary: PRIMARY, secondary: SECONDARY } }).css,
+      );
+
+      expect(light["color-primary-500"]).toBe(light["color-theme-500"]);
+      expect(light["color-secondary-500"]).toBe(
+        light["color-theme-secondary-500"],
+      );
+    });
+  });
+
+  describe("legacy colors format", () => {
+    it("derives the same tokens from primaryColorRaw and secondaryColorRaw", () => {
+      const legacy: V1ThemeSpec = {
+        primaryColorRaw: PRIMARY,
+        secondaryColorRaw: SECONDARY,
+      };
+      const { light } = parseCSS(new Theme(legacy).css);
+
+      expect(light["surface-hover"]).toBe(light["color-theme-50"]);
+      expect(light["popover-accent"]).toBe(light["color-theme-50"]);
+      expect(light["measure"]).toBe(light["color-theme-secondary-100"]);
+    });
+  });
+});

--- a/web-common/src/features/themes/theme.spec.ts
+++ b/web-common/src/features/themes/theme.spec.ts
@@ -127,6 +127,22 @@ describe("Theme", () => {
 
       expect(light["fg-accent"]).toBe(light["fg-primary"]);
     });
+
+    it("let fg-primary keep ownership of fg-accent in dark mode too", () => {
+      // The light block derives fg-accent from the palette. Resetting it to `unset` in the
+      // dark block would both discard dark's own fg-primary and fall back to Rill's indigo.
+      const { dark } = parseCSS(
+        new Theme({
+          light: { primary: PRIMARY },
+          dark: {
+            primary: PRIMARY,
+            variables: { "fg-primary": "#eeeeee" },
+          },
+        }).css,
+      );
+
+      expect(dark["fg-accent"]).toBe(dark["fg-primary"]);
+    });
   });
 
   describe("palette aliasing", () => {

--- a/web-common/src/features/themes/theme.ts
+++ b/web-common/src/features/themes/theme.ts
@@ -9,6 +9,8 @@ import { primary } from "./colors";
 import { getChroma, resolveThemeObject } from "./theme-utils";
 import { createDarkVariation } from "./color-generation";
 
+type Shade = (typeof TailwindColorSpacing)[number];
+
 export class Theme {
   colors: { light: Colors; dark: Colors };
   spec: V1ThemeSpec;
@@ -43,6 +45,58 @@ export class Theme {
       light: resolveThemeObject(spec, false) ?? {},
     };
   }
+
+  /**
+   * Semantic tokens that app.css derives from Rill's own primary/secondary palettes.
+   *
+   * Those declarations live on :root, and a custom property's var() references are
+   * substituted at the element that declares it. So they always resolve against the
+   * default Rill palette, and a dashboard theme -- which is scoped to the
+   * .dashboard-theme-boundary element further down the tree -- can never influence them.
+   * The result is Rill's indigo leaking into hover, selection, focus rings, and dimension
+   * and measure chips on a rethemed dashboard.
+   *
+   * Re-declaring them on the boundary from the theme's own palettes fixes that. The shades
+   * below mirror app.css exactly, so only the hue source changes, not the design.
+   *
+   * `light` is the shade :root uses, `dark` the shade :root.dark uses. Both read from the
+   * theme's light palette, because :root.dark also picks light-palette shades
+   * (--color-primary-light-*) -- they stay legible against dark surfaces. A token with no
+   * `dark` shade is not palette-derived in dark mode (dark surfaces are neutral grays) and
+   * is left to app.css.
+   */
+  private static PALETTE_DERIVED_TOKENS: {
+    token: keyof Colors;
+    source: "primary" | "secondary";
+    light: Shade;
+    dark?: Shade;
+  }[] = [
+    { token: "surface-hover", source: "primary", light: 50 },
+    { token: "surface-active", source: "primary", light: 100 },
+    { token: "fg-accent", source: "primary", light: 900, dark: 100 },
+    { token: "accent-primary", source: "primary", light: 500, dark: 600 },
+    {
+      token: "accent-primary-action",
+      source: "primary",
+      light: 500,
+      dark: 400,
+    },
+    { token: "accent-secondary", source: "primary", light: 500, dark: 700 },
+    {
+      token: "accent-secondary-action",
+      source: "secondary",
+      light: 500,
+      dark: 400,
+    },
+    { token: "icon-accent", source: "primary", light: 500, dark: 400 },
+    { token: "ring-focus", source: "primary", light: 300, dark: 500 },
+    { token: "dimension", source: "primary", light: 100, dark: 950 },
+    { token: "dimension-foreground", source: "primary", light: 800, dark: 100 },
+    { token: "dimension-border", source: "primary", light: 800, dark: 800 },
+    { token: "measure", source: "secondary", light: 100, dark: 950 },
+    { token: "measure-foreground", source: "secondary", light: 800, dark: 100 },
+    { token: "measure-border", source: "secondary", light: 800, dark: 800 },
+  ];
 
   // Opacity percentages for fg-* hierarchy when auto-generating from fg-primary
   private static FG_OPACITY_HIERARCHY: Record<string, number> = {
@@ -134,26 +188,35 @@ export class Theme {
     const finalColors: Colors = {};
     const { primary, secondary, variables } = colors;
 
+    let primaryPalette: Color[] | undefined;
+    let secondaryPalette: Color[] | undefined;
+
     if (primary) {
       const primaryReference = getChroma(primary);
-      const primaryPalette = generateColorPalette(primaryReference);
+      primaryPalette = generateColorPalette(primaryReference);
       const finalColorPalette = dark
         ? createDarkVariation(primaryPalette)
         : primaryPalette;
       for (const [i, color] of finalColorPalette.entries()) {
         finalColors[`color-theme-${TailwindColorSpacing[i]}`] = color;
+        // Alias Rill's own palette to the theme's inside the boundary, so the ~300
+        // `bg-primary-500`-style utilities scattered through dashboard components follow
+        // the theme too. Only shadowed within the boundary: the rest of the app -- nav,
+        // file explorer, admin chrome -- keeps Rill's brand colors.
+        finalColors[`color-primary-${TailwindColorSpacing[i]}`] = color;
       }
       finalColors.primary = primaryReference;
     }
 
     if (secondary) {
       const secondaryReference = getChroma(secondary);
-      const secondaryPalette = generateColorPalette(secondaryReference);
+      secondaryPalette = generateColorPalette(secondaryReference);
       const finalColorPalette = dark
         ? createDarkVariation(secondaryPalette)
         : secondaryPalette;
       for (const [i, color] of finalColorPalette.entries()) {
         finalColors[`color-theme-secondary-${TailwindColorSpacing[i]}`] = color;
+        finalColors[`color-secondary-${TailwindColorSpacing[i]}`] = color;
       }
       finalColors.secondary = secondaryReference;
     }
@@ -163,7 +226,49 @@ export class Theme {
       finalColors[k] = getChroma(v);
     }
 
+    this.applyPaletteDerivedTokens(
+      finalColors,
+      { primary: primaryPalette, secondary: secondaryPalette },
+      dark,
+    );
+
     return finalColors;
+  }
+
+  /**
+   * Fills in the semantic tokens listed in PALETTE_DERIVED_TOKENS from the theme's
+   * palettes. Tokens the theme sets explicitly are left untouched, as are tokens whose
+   * source palette the theme doesn't define: a theme with only a primary color keeps
+   * Rill's defaults for the secondary-derived tokens.
+   */
+  private applyPaletteDerivedTokens(
+    finalColors: Colors,
+    palettes: { primary?: Color[]; secondary?: Color[] },
+    dark: boolean,
+  ): void {
+    for (const {
+      token,
+      source,
+      light,
+      dark: darkShade,
+    } of Theme.PALETTE_DERIVED_TOKENS) {
+      if (token in finalColors) continue;
+
+      // fg-accent is part of the fg-* hierarchy generated from fg-primary in stringifyVars.
+      // A theme that sets its own fg-primary owns fg-accent too, so leave it alone.
+      if (token === "fg-accent" && "fg-primary" in finalColors) continue;
+
+      const shade = dark ? darkShade : light;
+      if (shade === undefined) continue;
+
+      const color = palettes[source]?.[TailwindColorSpacing.indexOf(shade)];
+      if (color) finalColors[token] = color;
+    }
+
+    // popover-accent follows surface-hover, mirroring app.css.
+    if (!("popover-accent" in finalColors) && finalColors["surface-hover"]) {
+      finalColors["popover-accent"] = finalColors["surface-hover"];
+    }
   }
 }
 

--- a/web-common/src/features/themes/theme.ts
+++ b/web-common/src/features/themes/theme.ts
@@ -60,10 +60,10 @@ export class Theme {
    * below mirror app.css exactly, so only the hue source changes, not the design.
    *
    * `light` is the shade :root uses, `dark` the shade :root.dark uses. Both read from the
-   * theme's light palette, because :root.dark also picks light-palette shades
-   * (--color-primary-light-*) -- they stay legible against dark surfaces. A token with no
-   * `dark` shade is not palette-derived in dark mode (dark surfaces are neutral grays) and
-   * is left to app.css.
+   * un-darkened palette of the mode's own primary, because :root.dark also picks
+   * light-palette shades (--color-primary-light-*) -- they stay legible against dark
+   * surfaces. A token with no `dark` shade is not palette-derived in dark mode (dark
+   * surfaces are neutral grays) and is left to app.css.
    */
   private static PALETTE_DERIVED_TOKENS: {
     token: keyof Colors;
@@ -143,9 +143,15 @@ export class Theme {
     const lightColors = this.colors.light;
 
     for (const [k] of Object.entries(lightColors)) {
-      if (!(k in darkColors)) {
-        darkColors[k] = undefined;
-      }
+      if (k in darkColors) continue;
+
+      // A light-only token is reset to `unset` in dark mode, so the boundary inherits
+      // :root.dark instead of keeping the light value. The fg-* hierarchy is the exception:
+      // stringifyVars only fills a slot that isn't already a key, so an `unset` placeholder
+      // would suppress the value dark's own fg-primary should produce.
+      if (darkColors["fg-primary"] && k in Theme.FG_OPACITY_HIERARCHY) continue;
+
+      darkColors[k] = undefined;
     }
 
     const css = `


### PR DESCRIPTION
`app.css` declares the hover, accent, focus-ring, dimension and measure tokens on `:root`, against Rill's own primary/secondary palettes:

```css
:root {
  --surface-hover: var(--color-primary-50);
  --popover-accent: var(--surface-hover);
  --ring-focus: var(--color-theme-300);
  /* ...accent-*, icon-accent, fg-accent, dimension-*, measure-* */
}
```

A custom property's `var()` references are substituted at the element that declares it, so these always resolve against the default palette. A dashboard theme is scoped to `.dashboard-theme-boundary` further down the tree, so it can never reach them — Rill's indigo leaks into hover, selection, focus rings and dimension/measure chips on a rethemed dashboard, even though `--color-theme-*` itself is correct.

- Re-declare the affected tokens on the boundary from the theme's own palettes. The shades mirror `app.css` exactly (`PALETTE_DERIVED_TOKENS`), so only the hue source changes, not the design.
- Dark mode keeps its neutral gray surfaces: `surface-hover`/`surface-active`/`popover-accent` are emitted as `unset` so the boundary inherits `:root.dark`. Dark accents read the light-palette shades, matching what `:root.dark` does.
- Alias `--color-primary-*` and `--color-secondary-*` to the theme's palettes inside the boundary, so the ~300 `bg-primary-500`-style utilities in dashboard components follow the theme without each one being migrated. Outside the boundary — nav, file explorer, admin chrome — Rill's brand colors are untouched.
- Explicit `variables:` in the theme YAML still win, and a theme that sets `fg-primary` keeps ownership of `fg-accent`.

Worth a look during review: this now themes the dimension and measure chips as well. That is the intended behaviour for brand adherence, but it is the most visible change beyond hover and selection.

Reported for explore leaderboards, where hover (`bg-popover-accent`) and excluded bars (`var(--surface-active)`) stayed purple under a custom theme. The fix is at the token level, so it clears the same leak in dropdowns, pivot rows, the TDD table and filter chips at the same time.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!