### PR TITLE
fix: collapsed resiser when dashboard row is wide

### DIFF
--- a/web-admin/src/features/dashboards/listing/DashboardsTable.svelte
+++ b/web-admin/src/features/dashboards/listing/DashboardsTable.svelte
@@ -227,7 +227,7 @@
         </ResizableSidebar>
       {/if}
 
-      <div class="flex flex-col flex-grow">
+      <div class="flex flex-col flex-grow min-w-0">
         <ResourceList
           kind="dashboard"
           data={displayData}

--- a/web-common/src/features/add-data/form/ImportTableForm.svelte
+++ b/web-common/src/features/add-data/form/ImportTableForm.svelte
@@ -200,7 +200,7 @@
   {#if $form["mode"] === "table"}
     {#if analyzedConnector}
       <div class="flex flex-row flex-1 min-h-0 w-full overflow-hidden border-t">
-        <div class="flex flex-col flex-grow min-h-0 border-r pr-6 py-2">
+        <div class="flex flex-col flex-grow min-w-0 min-h-0 border-r pr-6 py-2">
           <DatabaseExplorer
             connector={analyzedConnector}
             store={connectorExplorerStore}

--- a/web-common/src/layout/ResizableSidebar.svelte
+++ b/web-common/src/layout/ResizableSidebar.svelte
@@ -25,7 +25,12 @@
   const store = getWidthStore(id, defaultWidth);
 </script>
 
-<div class="h-full relative {additionalClass}" style="width: {$store}px">
+<!-- `shrink-0` keeps flexbox from squeezing the sidebar below its resized width;
+     siblings that should absorb the remaining space need `min-w-0` to be shrinkable. -->
+<div
+  class="h-full relative shrink-0 {additionalClass}"
+  style="width: {$store}px"
+>
   <Resizer
     min={minWidth}
     max={maxWidth}


### PR DESCRIPTION
In dashboards page, when dashboard row (when there is a description to dashboards) is wide the resizer would get collapsed giving space to the row.

Closes APP-924

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
