### PR TITLE
fix: render previous-period comparison lines in the TDD line chart

### DIFF
--- a/web-common/src/features/components/charts/comparison-builder.ts
+++ b/web-common/src/features/components/charts/comparison-builder.ts
@@ -11,6 +11,13 @@ export const ColorWithComparisonField = "color_with_comparison";
 export const SortOrderField = "sortOrder";
 
 /**
+ * Opacity for previous-period marks in comparison mode.
+ * Shared with the custom time series chart so both renderers
+ * fade comparison data the same way.
+ */
+export const ComparisonMarkOpacity = 0.4;
+
+/**
  * Creates Vega-Lite transforms for period-over-period comparison.
  * This function generates the fold and calculate transforms needed to
  * display current and comparison data side-by-side.
@@ -84,7 +91,7 @@ export function createComparisonOpacityEncoding(
     condition: [
       {
         test: `datum['${MeasureKeyField}'] === '${previousLiteral}'`,
-        value: 0.4,
+        value: ComparisonMarkOpacity,
       },
     ],
     value: 1,

--- a/web-common/src/features/dashboards/time-series/measure-chart/MeasureChartBody.svelte
+++ b/web-common/src/features/dashboards/time-series/measure-chart/MeasureChartBody.svelte
@@ -177,12 +177,17 @@
   $: maxSnapDistance = Math.max(MIN_SNAP_INDICES, data.length * SNAP_FRACTION);
   $: isLocallyHovered =
     hoverState.isHovered && hoverState.index !== null && data.length > 0;
-  // All series the cursor can snap to: the primary measure, its time
-  // comparison, and any dimension comparison series.
+  // All series the cursor can snap to: the primary measure, any dimension
+  // comparison series, and their time comparisons.
   $: snapSeries = [
     data.map((d) => d.value),
     ...(showComparison ? [data.map((d) => d.comparisonValue ?? null)] : []),
     ...dimensionData.map((dim) => dim.data.map((d) => d.value)),
+    ...(showComparison
+      ? dimensionData.map((dim) =>
+          dim.data.map((d) => d.comparisonValue ?? null),
+        )
+      : []),
   ];
   // Snap to the nearest non-null point so sparse data is easy to hover; null
   // when the cursor is in a gap wider than maxSnapDistance.

--- a/web-common/src/features/dashboards/time-series/measure-chart/chart-series.ts
+++ b/web-common/src/features/dashboards/time-series/measure-chart/chart-series.ts
@@ -1,4 +1,5 @@
 import { COMPARISON_COLORS } from "@rilldata/web-common/features/dashboards/config";
+import { ComparisonMarkOpacity } from "@rilldata/web-common/features/components/charts/comparison-builder";
 import {
   isAdaptiveChartType,
   TDDChart,
@@ -25,13 +26,30 @@ export function buildChartSeries(
   showComparison: boolean,
 ): ChartSeries[] {
   if (dimData.length > 0) {
-    return dimData.map((dim, i) => ({
+    const currentSeries: ChartSeries[] = dimData.map((dim, i) => ({
       id: `dim-${dim.dimensionValue ?? i}`,
       values: dim.data.map((pt) => pt.value),
       color: dim.color || COMPARISON_COLORS[i % COMPARISON_COLORS.length],
       opacity: dim.isFetching ? 0.5 : 1,
       strokeWidth: 1.5,
     }));
+
+    if (!showComparison) return currentSeries;
+
+    // Previous-period lines: same hue as the current-period series,
+    // faded to the same opacity as comparison marks in the Vega charts.
+    const comparisonSeries: ChartSeries[] = dimData.map((dim, i) => ({
+      id: `dim-${dim.dimensionValue ?? i}-comparison`,
+      values: dim.data.map((pt) => pt.comparisonValue ?? null),
+      color: dim.color || COMPARISON_COLORS[i % COMPARISON_COLORS.length],
+      opacity: dim.isFetching ? 0.2 : ComparisonMarkOpacity,
+      strokeWidth: 1.5,
+    }));
+
+    // TimeSeriesChart paints series[0] last (on top) and the rest in array
+    // order, so this keeps every faded previous-period line beneath every
+    // current-period line.
+    return [currentSeries[0], ...comparisonSeries, ...currentSeries.slice(1)];
   }
 
   const result: ChartSeries[] = [];

--- a/web-common/src/features/dashboards/time-series/measure-chart/scales.ts
+++ b/web-common/src/features/dashboards/time-series/measure-chart/scales.ts
@@ -123,6 +123,14 @@ export function computeYExtent(
       if (d.value !== null && Number.isFinite(d.value)) {
         values.push(d.value);
       }
+      if (
+        showComparison &&
+        d.comparisonValue !== null &&
+        d.comparisonValue !== undefined &&
+        Number.isFinite(d.comparisonValue)
+      ) {
+        values.push(d.comparisonValue);
+      }
     }
   }
 


### PR DESCRIPTION
In the Time Dimension Detail view with time comparison on, the Vega chart types (grouped bar, stacked bar, stacked area) render a faded mark per dimension value for the previous period, but the line chart rendered nothing: `buildChartSeries` only emitted current-period series, even though the per-dimension comparison values were already fetched and merged into `DimensionSeriesData`.

- **Previous-period lines.** `buildChartSeries` now emits a comparison series per dimension value in the same color, faded to the same opacity the Vega comparison marks use — extracted as `ComparisonMarkOpacity` in `comparison-builder.ts` so both renderers stay in sync. The series order keeps every faded line beneath every current-period line, since `TimeSeriesChart` paints `series[0]` last.
- **Y extent.** `computeYExtent` now includes dimension comparison values when comparison is shown, so a previous period that peaks above the current one is not clipped.
- **Hover snapping.** `snapSeries` in `MeasureChartBody` includes the dimension comparison points, so trailing buckets where only previous-period data exists yet (e.g. an incomplete current day) are hoverable.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

https://claude.ai/code/session_01HZg85dzz4bkcY53V1AEa7z