### PR TITLE
docs: fix spelling and grammar

### DIFF
--- a/docs/docs/developers/build/connectors/olap/motherduck.md
+++ b/docs/docs/developers/build/connectors/olap/motherduck.md
@@ -20,7 +20,7 @@ Rill supports connecting to MotherDuck using the latest DuckDB-compatible driver
 
 ## Getting Your MotherDuck Access Token
 
-To connect to MotherDuck, you'll need a access token from your MotherDuck account:
+To connect to MotherDuck, you'll need an access token from your MotherDuck account:
 
 1. Log in to your [MotherDuck account](https://motherduck.com/)
 2. Navigate to the **Settings** section

--- a/docs/docs/developers/build/connectors/services/slack.md
+++ b/docs/docs/developers/build/connectors/services/slack.md
@@ -38,7 +38,7 @@ The last two scopes are required to find the user's ID by email.
 
 ## Enabling the Slack integration in your project
 
-Once the Slack integration has been set up, the Slack destination will need to be enabled on a per project basis (note - alerts can only be configured on projects deployed to Rill Cloud). This requires the `SLACK_BOT_TOKEN` connector variable to be set, which can be configured in Rill in a manner very similar to [setting credentials](/developers/deploy/deploy-credentials) for other connectors. Please use one of the available options below.
+Once the Slack integration has been set up, the Slack destination will need to be enabled on a per-project basis (note - alerts can only be configured on projects deployed to Rill Cloud). This requires the `SLACK_BOT_TOKEN` connector variable to be set, which can be configured in Rill in a manner very similar to [setting credentials](/developers/deploy/deploy-credentials) for other connectors. Please use one of the available options below.
 
 ### Creating a Slack.yaml connector
 
@@ -53,7 +53,7 @@ SLACK_BOT_TOKEN=<BOT_USER_OAUTH_TOKEN>
 ```
 
 
-Afterwards, if the project has already been deployed to Rill Cloud, you can `rill env push` to update your cloud deployment accordingly.
+Afterward, if the project has already been deployed to Rill Cloud, you can `rill env push` to update your cloud deployment accordingly.
 
 ### Using the `rill env set` command
 
@@ -63,7 +63,7 @@ Another option to set this connector variable within your project is to use the 
 rill env set SLACK_BOT_TOKEN <BOT_USER_OAUTH_TOKEN>
 ```
 
-Afterwards, if the project has already been deployed to Rill Cloud, you can `rill env push` to update your cloud deployment accordingly.
+Afterward, if the project has already been deployed to Rill Cloud, you can `rill env push` to update your cloud deployment accordingly.
 
 ### Enabling the Slack connector through `rill.yaml`
 
@@ -84,4 +84,3 @@ If you subsequently add sources that require new credentials (or if you simply e
 ```
 rill env push
 ```
-

--- a/docs/docs/developers/build/metrics-view/rollups.md
+++ b/docs/docs/developers/build/metrics-view/rollups.md
@@ -72,7 +72,7 @@ rollups:
 
 ### Declaring Coverage with `data_time_range`
 
-By default Rill discovers a rollup's time coverage at query time by running `SELECT min(time), max(time)` against the rollup table. If you'd rather declare coverage statically — to skip the probe, or to scope a rollup to a specific window — set `data_time_range` on the rollup. The value is a [rilltime expression](/reference/time-syntax):
+By default, Rill discovers a rollup's time coverage at query time by running `SELECT min(time), max(time)` against the rollup table. If you'd rather declare coverage statically — to skip the probe, or to scope a rollup to a specific window — set `data_time_range` on the rollup. The value is a [rilltime expression](/reference/time-syntax):
 
 ```yaml
 rollups:
@@ -161,13 +161,13 @@ For each eligible rollup, Rill checks that the rollup actually contains data for
 
 - **With a time range.** The query range is first clamped to the base table's `[min, max]` (so a query that extends past the base data isn't penalized for the rollup also stopping there). The rollup must then cover the clamped start and end.
 - **Without a time range** ("all data"). The rollup must cover the base table's full `[min, max]`.
-- **End alignment.** If the base table has data beyond the query's end time, the end must also be aligned to the rollup grain. Otherwise the last rollup bucket would pull in data from outside the requested range. Queries whose end falls past the latest base data don't need to be end-aligned, because there is no extra data to pull in.
+- **End alignment.** If the base table has data beyond the query's end time, the end must also be aligned to the rollup grain. Otherwise, the last rollup bucket would pull in data from outside the requested range. Queries whose end falls past the latest base data don't need to be end-aligned, because there is no extra data to pull in.
 
 ### 4. Selection
 
 Among rollups that pass eligibility and coverage:
 
-1. Prefer the **coarsest grain** — fewer rows to scan.
+1. Prefer the **coarsest grain** — it has fewer rows to scan.
 2. On a tie, prefer the rollup **declared earlier** in the `rollups` list — this is the lever for explicit priority among same-grain rollups.
 
 The base table is used if no rollup is eligible.

--- a/docs/docs/developers/build/models/performance.md
+++ b/docs/docs/developers/build/models/performance.md
@@ -101,7 +101,7 @@ Sorting, especially in DuckDB, _can also be computationally intensive_ and most 
 
 ### Use joins efficiently
 
-Plan your joins carefully, especially when working with large datasets. Most [OLAP engines](/developers/build/connectors/olap), DuckDB included, will optimize join operations, but ensuring the join keys are well chosen and considering the size of the datasets being joined can reduce processing time. For example, if you're looking to perform a cross or cartesian join across a very wide table, be sure it's necessary as it can otherwise explode the size of your result set.
+Plan your joins carefully, especially when working with large datasets. Most [OLAP engines](/developers/build/connectors/olap), DuckDB included, will optimize join operations, but ensuring the join keys are well-chosen and considering the size of the datasets being joined can reduce processing time. For example, if you're looking to perform a cross or cartesian join across a very wide table, be sure it's necessary as it can otherwise explode the size of your result set.
 
 ### Apply filters early and use WHERE clauses wisely
 

--- a/docs/docs/developers/build/project-configuration.md
+++ b/docs/docs/developers/build/project-configuration.md
@@ -240,7 +240,7 @@ security:
     row_filter: "region = '{{ .user.region }}'"
 ```
 
-In order to test both access to the dashboard, as well as the row filter, you can create the following in the project YAML.
+To test both access to the dashboard and the row filter, you can create the following in the project YAML.
 
 ```yaml
 mock_users:

--- a/docs/docs/developers/deploy/deploy-dashboard/deploy-dashboard.md
+++ b/docs/docs/developers/deploy/deploy-dashboard/deploy-dashboard.md
@@ -70,7 +70,7 @@ The required permissions are:
 
 At this point, you have the option to connect your Rill project to a GitHub Repository.
 
-Navigating to the Settings page and selecting `Connect to GitHub` will prompt you to login and create a repository for your project. If you've already created a repository, check the box 'I've created a GitHub Repo' and add the permissions for Rill to access the repository.
+Navigating to the Settings page and selecting `Connect to GitHub` will prompt you to log in and create a repository for your project. If you've already created a repository, check the box 'I've created a GitHub Repo' and add the permissions for Rill to access the repository.
 
 :::info Check with your GitHub organization admin
 
@@ -123,7 +123,7 @@ If you have not already [configured your connections' credentials](https://docs.
 
 **First deployment**
 
-If this is your first deployment to Rill Cloud, you will get prompted to either sign up or log in (if you have an existing account on [Rill Cloud](https://ui.rilldata.com/)). Proceed with the sign up and email verification process for new users or authorization process for existing users. As a new user, you can expect to see the following page:
+If this is your first deployment to Rill Cloud, you will get prompted to either sign up or log in (if you have an existing account on [Rill Cloud](https://ui.rilldata.com/)). Proceed with the sign-up and email verification process for new users or authorization process for existing users. As a new user, you can expect to see the following page:
 
 ![Rill Cloud Sign In](/img/deploy/existing-project/rill-cloud-sign-in.png)
 
@@ -141,7 +141,7 @@ Once the project has been uploaded to Rill Cloud, you should be able to see the 
 
 
 ### Deploy Project with Repository
-Follow the instructions in the Terminal to login to GitHub (if not already done so), and select your repository.
+Follow the instructions in the Terminal to log in to GitHub (if not already done so), and select your repository.
 If you do not set any parameters, Rill will infer the project name based on the folder path and use this as both the repository and project name. If there are any overlaps, we will request for a new name.
 ```bash
 rill project connect-github
@@ -208,7 +208,7 @@ rill connect-github --prod-branch [PROD-BRANCH]
 
 ## Deploy from a monorepo
 
-If your Rill project is in a sub-directory of a Git repository, use the `--subpath` option when creating your project:
+If your Rill project is in a subdirectory of a Git repository, use the `--subpath` option when creating your project:
 ```
 rill connect-github --subpath path/to/rill/project
 ```
@@ -231,7 +231,7 @@ rill deploy
 
 ### Enable Automatic deploys
 
-Like running `rill project connect-github`, you will be [prompted to create a github repository](#deploy-project-with-repository). Once created, Rill will deploy the project. You can confirm that the project has the correct repository linked from the UI on the settings page.
+Like running `rill project connect-github`, you will be [prompted to create a GitHub repository](#deploy-project-with-repository). Once created, Rill will deploy the project. You can confirm that the project has the correct repository linked from the UI on the settings page.
 
 
 ### Disable Automatic deploys

--- a/docs/docs/developers/deploy/deploy-dashboard/github-101.md
+++ b/docs/docs/developers/deploy/deploy-dashboard/github-101.md
@@ -8,7 +8,7 @@ sidebar_position: 20
 ## Overview
 
 :::info New to Git?
-This page makes the deploy process easier for those who are less familiar with GitHub by walking you through the steps to use the UI rather than the GitHub command line interface. Much simpler for those who prefer a graphic interface!
+This page makes the deployment process easier for those who are less familiar with GitHub by walking you through the steps to use the UI rather than the GitHub command line interface. It is much simpler for those who prefer a graphical interface!
 :::
 
 To share dashboards with other users, Rill utilizes GitHub as a means of version control - effectively creating BI-as-code. There are several advantages to Git as the backend for dashboards: develop locally, integrate into existing development workflows, and manage versions + change control. While many users are familiar with Git and basic commands, there are other Rill users who are relatively new to Git. 
@@ -25,7 +25,7 @@ In this section, we will outline:
 
 ## Installing Git
 
--To download the GitHub app for a UI driven workflow, visit the [install site here](https://docs.github.com/en/desktop/installing-and-authenticating-to-github-desktop/installing-github-desktop).
+- To download the GitHub app for a UI-driven workflow, visit the [GitHub Desktop installation page](https://docs.github.com/en/desktop/installing-and-authenticating-to-github-desktop/installing-github-desktop).
 - In your computer's Downloads folder, double-click the GitHub Desktop zip file.
 - After the file has been unzipped, double-click the GitHub Desktop application file.
 - GitHub Desktop will launch after installation is complete.

--- a/docs/docs/developers/embed/iframe.md
+++ b/docs/docs/developers/embed/iframe.md
@@ -16,7 +16,7 @@ Rill Cloud provides the ability to embed dashboards as components in your own ap
 - Embedding individual dashboards with the ability to navigate to other dashboards (that exist in the _same_ project)
 - Embedding the dashboard list page present in a Rill project (with the ability to select and navigate between dashboards)
 
-When embedding Rill, you need to generate a service token for your backend to request an authenticated iframe URL via the Rill API. Afterwards, the iframe URL can be passed to your frontend application for rendering. Here's a high-level diagram of what this flow looks like:
+When embedding Rill, you need to generate a service token for your backend to request an authenticated iframe URL via the Rill API. Afterward, the iframe URL can be passed to your frontend application for rendering. Here's a high-level diagram of what this flow looks like:
 
 ```mermaid
 sequenceDiagram

--- a/docs/docs/developers/other/granting/gcs-bucket.md
+++ b/docs/docs/developers/other/granting/gcs-bucket.md
@@ -24,7 +24,7 @@ Follow the instructions below to grant Rill access to your Google Cloud Storage 
 5. Click Add to open the modal to add members to your bucket.
 ![](https://images.contentful.com/ve6smfzbifwz/2Ki9BiKaHYMivZ5DPTiwbd/762b2a071d3d6fb58a1b08fd13973dc2/8fa34b8-permissions_add.png)
 
-6. In the New members field, enter your google service account. You can find your google service account in the Settings page for your workspace in RCC. This will typically have the form  `{workspace}`-`{organization}`@rilldata.iam.gserviceaccount.com.
+6. In the New members field, enter your Google service account. You can find your Google service account in the Settings page for your workspace in RCC. This will typically have the form  `{workspace}`-`{organization}`@rilldata.iam.gserviceaccount.com.
 ![](https://images.contentful.com/ve6smfzbifwz/50nIholwjMFJkaMTw8bMjy/c3334709d2eb6c8516e056f72f424957/42d2803-new_members_modal.png)
 
 7. Select the role Cloud Storage -> Storage Object Viewer. 

--- a/docs/docs/developers/other/granting/google-bigquery.md
+++ b/docs/docs/developers/other/granting/google-bigquery.md
@@ -22,7 +22,7 @@ Follow the instructions below to grant Rill access to your Google BigQuery datas
 
 4. In the IAM menu click the ADD button. This will display a form where you can input the service accounts that can access your project and the permissions with which they can access it.
 
-5. In the New members field, enter your google service account, found in step 1.  
+5. In the New members field, enter your Google service account, found in step 1.
 
 6. Select the role `BigQuery Data Viewer`, `BigQuery Read Session User`, and `BigQuery Job User`. This will permit Rill to fetch your projects tables into BigQuery. 
   

--- a/docs/docs/developers/tutorials/cost-monitoring-analytics.md
+++ b/docs/docs/developers/tutorials/cost-monitoring-analytics.md
@@ -23,7 +23,7 @@ This dataset is modeled after a similar dashboard we use internally at Rill to b
 The Cost Monitoring Analytics demo analyzes operational costs and revenue data, providing insights into:
 - **Margin trends** – Daily, weekly, and monthly profitability patterns
 - **Customer profitability** – Which customers are driving the highest margins
-- **Cost efficiency** – Understanding operational cost effectiveness across services
+- **Cost efficiency** – Understanding operational cost-effectiveness across services
 - **Revenue optimization** – Monitoring revenue performance against operational costs
 - **Business intelligence** – Identifying opportunities for improved profitability
 
@@ -206,4 +206,3 @@ measures:
 - **Region filter** – Analyze specific regions
 - **Component filter** – Focus on specific system components
 - **Margin threshold filter** – Focus on high/low margin segments
-

--- a/docs/docs/developers/tutorials/performance.md
+++ b/docs/docs/developers/tutorials/performance.md
@@ -24,7 +24,7 @@ Depending on the complexity of your underlying models and the size of the data m
 
 ### Consider which models to materialize
 
-By default, models will be materialized as views (in DuckDB). This allows for a dynamic and highly interactive experience when modeling, such as keystroke-by-keystroke profiling. However, since views are logical in nature, as the complexity and size of your data models continue grow (especially if the underlying data is very large), this can start to significantly impact performance as these complex queries will need to be continuously re-executed along with a number of profiling queries that the Rill runtime will send in the backend. 
+By default, models will be materialized as views (in DuckDB). This allows for a dynamic and highly interactive experience when modeling, such as keystroke-by-keystroke profiling. However, since views are logical in nature, as the complexity and size of your data models continue to grow (especially if the underlying data is very large), this can start to significantly impact performance as these complex queries will need to be continuously re-executed along with a number of profiling queries that the Rill runtime will send in the backend.
 
 In such scenarios, we recommend [materializing these models as tables.](/developers/build/models/performance#model-performance) However, there are some tradeoffs to consider.
 - **Pros:** Materializing a model will generally ensure significantly improved performance for downstream dependent models and dashboards. 
@@ -196,7 +196,7 @@ Sorting, especially in DuckDB, _can also be computationally intensive_ and most 
 
 ### Use joins efficiently
 
-Plan your joins carefully, especially when working with large datasets. Most [OLAP engines](/developers/build/connectors/olap), DuckDB included, will optimize join operations, but ensuring the join keys are well chosen and considering the size of the datasets being joined can reduce processing time. For example, if you're looking to perform a cross or cartesian join across a very wide table, be sure it's necessary as it can otherwise explode the size of your result set. 
+Plan your joins carefully, especially when working with large datasets. Most [OLAP engines](/developers/build/connectors/olap), DuckDB included, will optimize join operations, but ensuring the join keys are well-chosen and considering the size of the datasets being joined can reduce processing time. For example, if you're looking to perform a cross or cartesian join across a very wide table, be sure it's necessary as it can otherwise explode the size of your result set.
 
 ### Apply filters early and use WHERE clauses wisely
 
@@ -236,9 +236,9 @@ Dimension stripping is another tool to reduce data size by removing high cardina
 
 ### Sampling & Datasketches
 
-There are times where you may look at sampling data feeds to trade data accuracy for lower costs and faster query speeds. Sampling involves sending only a percentage of your data, then extrapolating the values to get an estimate. Rill does not recommend sampling your primary KPIs, any records that require a join or are tied to revenue. This filtered data should be decided in random fashion to not skew or bias the results. Please note, tracking uniques is not recommended if you choose to sample. 
+There are times when you may look at sampling data feeds to trade data accuracy for lower costs and faster query speeds. Sampling involves sending only a percentage of your data, then extrapolating the values to get an estimate. Rill does not recommend sampling your primary KPIs, any records that require a join or are tied to revenue. This filtered data should be decided in random fashion to not skew or bias the results. Please note, tracking uniques is not recommended if you choose to sample.
 
-If looking to track uniques, but with smaller datasets and significantly improved performance, you can load unique values (ip addresses, user ids, URLs, etc) with [datasketches](https://datasketches.apache.org). There are multiple types of datasketches supported depending on your engine. At a high level, datasketches use algorithms to approximate unique values. Common use cases for datasketches include count distincts (campaign reach, unique visitors) and quantiles (time spent, frequency). Check out the [Apache Datasketches](https://datasketches.apache.org/docs/Architecture/MajorSketchFamilies.html) site for more details on methodology and use cases.
+If looking to track uniques, but with smaller datasets and significantly improved performance, you can load unique values (IP addresses, user IDs, URLs, etc.) with [datasketches](https://datasketches.apache.org). There are multiple types of datasketches supported depending on your engine. At a high level, datasketches use algorithms to approximate unique values. Common use cases for datasketches include count distincts (campaign reach, unique visitors) and quantiles (time spent, frequency). Check out the [Apache Datasketches](https://datasketches.apache.org/docs/Architecture/MajorSketchFamilies.html) site for more details on methodology and use cases.
 
 ### Lookups
 

--- a/docs/docs/developers/tutorials/rill-clickhouse/2-r_ch_connect.md
+++ b/docs/docs/developers/tutorials/rill-clickhouse/2-r_ch_connect.md
@@ -13,7 +13,7 @@ import TabItem from '@theme/TabItem';
 
 ## Default OLAP connection and Connect to ClickHouse
 
-Within Rill you can set the default OLAP connection on the [project level](https://docs.rilldata.com/reference/project-files/rill-yaml) or the [dashboard level](https://docs.rilldata.com/reference/project-files/explore-dashboards). 
+Within Rill, you can set the default OLAP connection on the [project level](https://docs.rilldata.com/reference/project-files/rill-yaml) or the [dashboard level](https://docs.rilldata.com/reference/project-files/explore-dashboards).
 For this course, we will set it up on the project level so all of our dashboards will be based on our ClickHouse table.
 
 :::tip
@@ -21,7 +21,7 @@ You have two options for your ClickHouse server:
 1. Use a [local running ClickHouse server](https://clickhouse.com/docs/en/install)
 2. Use [ClickHouse Cloud](https://clickhouse.com/docs/en/cloud/overview)
 
-Depending what you choose, the contents of your connection will change and I recommend looking through [our ClickHouse documentation](https://docs.rilldata.com/developers/build/connectors/olap/clickhouse) for further information.
+Depending on what you choose, the contents of your connection will change, and we recommend looking through [our ClickHouse documentation](https://docs.rilldata.com/developers/build/connectors/olap/clickhouse) for further information.
 
 :::
 
@@ -64,7 +64,7 @@ dsn: "clickhouse://localhost:9000"
 Please see our documentation to find the DSN for [your ClickHouse Cloud instance](https://docs.rilldata.com/developers/build/connectors/olap/clickhouse#connecting-to-clickhouse-cloud). 
 
 ### How to pass the credentials to Rill
-There are a few way to define the credentials within Rill.
+There are a few ways to define credentials within Rill.
 
 <Tabs>
 <TabItem value="yaml" label="via yaml" default>
@@ -94,7 +94,7 @@ Navigate back to the Terminal and stop the Rill process. You can run the followi
 rill start --env host='localhost' --env  port='9000'
 ```
 
-Afterwards, create a file called clickhouse.yaml and add the following contents:
+Afterward, create a file called clickhouse.yaml and add the following contents:
 
 ```yaml
 type: connector
@@ -110,7 +110,7 @@ port: "{{ .env.port }}"
 
 
   <TabItem value="env" label="via .env">
-There's a few way to generate the .env file. Making a source that requires credentials will automatically generate it. Else, you can create it using `touch .env` in the rill directory.
+There are a few ways to generate the .env file. Creating a source that requires credentials will automatically generate it. Otherwise, you can create it using `touch .env` in the Rill directory.
 
 ```
 CLICKHOUSE_HOST="localhost"

--- a/docs/docs/developers/tutorials/rill-clickhouse/3-r_ch_metrics-view.md
+++ b/docs/docs/developers/tutorials/rill-clickhouse/3-r_ch_metrics-view.md
@@ -13,7 +13,7 @@ tags:
 If you noticed in the previous screenshot, we had a table called `uk_price_paid`. This is a dataset that is used in ClickHouse's Learning portal, so we thought it was fitting to continue with this dataset.
 
 :::note
-In the case that you have not already added this table to your local or Cloud database, please follow the steps on [ClickHouse's site](https://clickhouse.com/docs/en/getting-started/example-datasets/uk-price-paid) for the steps to do so!
+If you have not already added this table to your local or cloud database, please follow the steps on [ClickHouse's site](https://clickhouse.com/docs/en/getting-started/example-datasets/uk-price-paid) to do so!
 :::
 
 ### Create metrics view

--- a/docs/docs/developers/tutorials/rill-clickhouse/r_ch_ingest.md
+++ b/docs/docs/developers/tutorials/rill-clickhouse/r_ch_ingest.md
@@ -24,7 +24,7 @@ features:
 Once this is enabled, you'll be able to create model files and add sources in the UI and use these for SQL transformations, as you would with DuckDB. 
 
 :::note
-Currently not all the functionality is supported but our team is working on this to add more features! Please reach out to us on our community or via GitHub for any specific missing functionality that you looking for.
+Currently, not all functionality is supported, but our team is working to add more features. Please reach out to us through our community or via GitHub if there is specific missing functionality you're looking for.
 :::
 
 ## Ingestion directly from Snowflake to ClickHouse

--- a/docs/docs/guide/administration/users-and-access/user-management.md
+++ b/docs/docs/guide/administration/users-and-access/user-management.md
@@ -221,7 +221,7 @@ If you are unsure which option to select, select `Continue with Email` and set u
 
 :::
 
-Afterwards, you should receive an email verification to complete the sign-up process.
+Afterward, you should receive an email verification to complete the sign-up process.
 
 ![Verification Email](/img/manage/user-management/verification-email.png)
 

--- a/docs/docs/guide/alerts/index.md
+++ b/docs/docs/guide/alerts/index.md
@@ -34,7 +34,7 @@ Prefer video? Check out our [YouTube playlist](https://www.youtube.com/watch?v=w
 
 ## Overview
 
-Alerting is a key element for any BI or analytics workflow. Because Rill's dashboards are typically built off of raw or near-raw data, we expose alerting on a wide range of filters and depth, including high cardinality fields. Alerts are accessible from any dashboard via the upper-right alarm bell icon and can be used to create context-based triggers or alerts to bring you back to an analysis if an alert is triggered. This allows the analyst or end user to then dive deeper and use Rill dashboards to interactively explore their data as needed.
+Alerting is a key element for any BI or analytics workflow. Because Rill's dashboards are typically built off of raw or near-raw data, we expose alerting on a wide range of filters and depth, including high cardinality fields. Alerts are accessible from any dashboard via the upper-right alarm bell icon and can be used to create context-based triggers or alerts to bring you back to an analysis when an alert is triggered. This allows the analyst or end user to then dive deeper and use Rill dashboards to interactively explore their data as needed.
 
 
 ![Alerts](/img/explore/alerts/alerts.gif)
@@ -75,7 +75,7 @@ On the final tab, you will choose how and where your alert is delivered. By defa
 1. To limit the number of alerts, you can set an optional **Snooze** period after an alert is triggered.
 2. Depending on the available notification targets (see next section), choose which targets and/or users to subscribe to the alert.
 
-Afterwards, click **Create** to finish creating the alert.
+Afterward, click **Create** to finish creating the alert.
 
 ## Available alert notification targets
 
@@ -119,7 +119,7 @@ To view or make changes to existing alerts, navigate to the project home page an
 ## Common use cases
 
 ### Troubleshooting
-Alerts for troubleshooting purposes are useful for making sure that applications are running as expected, campaigns are set up correctly, or any use case where the outcome is binary. For these alerts, the criteria is often: is the amount > 0 or is the amount below a threshold. These alerts are best mixed with dimension filters to be alerted on any instance or split (e.g. Impressions > 0 for all Campaign_ID).
+Alerts for troubleshooting purposes are useful for making sure that applications are running as expected, campaigns are set up correctly, or any use case where the outcome is binary. For these alerts, the criterion is often whether the amount is greater than 0 or below a threshold. These alerts are best mixed with dimension filters to be alerted on any instance or split (e.g. Impressions > 0 for all Campaign_ID).
 
 ### Pacing
 Alerts for pacing purposes are good for budgeting and threshold use cases - where a pre-defined range can be applied to evaluate progress towards a goal. These alerts tend to be more specific (setting up filters and criteria for specific values) and mark progress towards that goal. Consider setting up multiple threshold alerts like 50%, 75% attainment.

--- a/docs/docs/guide/dashboards/bookmarks.md
+++ b/docs/docs/guide/dashboards/bookmarks.md
@@ -10,7 +10,7 @@ Bookmarks are useful to return to regular analyses and filter sets commonly used
 
 Common use cases for Bookmarks include:
 - Weekly/Monthly reporting
-- Setting filters for specific users/use cases (eg. teams or executives with a narrower view, an account manager's book of clients)
+- Setting filters for specific users/use cases (e.g., teams or executives with a narrower view, an account manager's book of clients)
 - Answering common troubleshooting questions by starting with a subset of problem dimensions
 
 <div style={{ 
@@ -49,12 +49,10 @@ On the bookmark screen, you'll then be able to set the options related to the sa
 - **Name:** Set a name and description (_optional_)
 - **Filters:** All filters from your previous analysis will be carried into the bookmark. Add/remove any additional filters as necessary
 - **Shared or Local:** Select a category (_for admins who wish to make a public bookmark_)
-- **Save Filters Only:** this option will save only the filter combination to be re-used later without restricting the measures and dimensions
-- **Absolute Dates:** use this option if you have a saved time period and return exactly to that period versus using the time period filter  
+- **Save Filters Only:** This option will save only the filter combination to be reused later without restricting the measures and dimensions
+- **Absolute Dates:** Use this option if you have a saved time period and return exactly to that period versus using the time period filter
 
 ![Setbookmark](/img/explore/bookmarks/setbookmark.png)
-
-
 
 
 

--- a/docs/docs/guide/dashboards/filters.md
+++ b/docs/docs/guide/dashboards/filters.md
@@ -56,7 +56,7 @@ Or, an administrator can set the default view of a dashboard by [bookmarking the
 
 ### Filter by Dimensions
 
-The primary/easiest way to filter data is by selecting values in the dimension tables. Leaderboards within Rill are fully interactive. Selecting any dimension in the table will automatically filter the remaining leaderboards and metrics by that selection. 
+The primary and easiest way to filter data is by selecting values in the dimension tables. Leaderboards within Rill are fully interactive. Selecting any dimension in the table will automatically filter the remaining leaderboards and metrics by that selection.
 
 To add or remove dimensions on the page - select the All Dimensions picker above the Leaderboards. Next to the All Dimensions picker, you can also change which Metric is being highlighted to be able to update the entire page and cycle through each dimension table sorted by each metric.
 
@@ -103,4 +103,3 @@ Metric filters are a good way to "sort" by two different metrics. First, apply y
 
 As an example - to see the most active enterprise customers - filter all customers with revenue greater than $1000, then sort by number of users in descending order.
 :::
-

--- a/docs/docs/guide/dashboards/time-series.md
+++ b/docs/docs/guide/dashboards/time-series.md
@@ -206,7 +206,7 @@ Along with setting time ranges, you have the ability to set a comparison period 
 
 ### Understanding Comparison Results
 
-Once comparison is enabled, you'll see slightly different information in your dashboard. Along with the current value, you'll see both change in value as well as % change over periods. This gives you a quick glance at how your metrics are performing compared to the previous period.
+Once comparison is enabled, you'll see slightly different information in your dashboard. Along with the current value, you'll see both change in value and percentage change over periods. This gives you a quick glance at how your metrics are performing compared to the previous period.
 
 ![Comparison](/img/explore/filters/comparison.png)
 
@@ -237,7 +237,7 @@ Time dimensions appear in the filter panel alongside your other dimensions. When
 3. **Combine with other filters** to create complex queries
 
 :::tip
-Time dimension filters work independently from the main time series selector. This means you can view your time series chart by order date while filtering to only show records with a ship date in the last 7 days.
+Time dimension filters work independently of the main time series selector. This means you can view your time series chart by order date while filtering to only show records with a ship date in the last 7 days.
 :::
 
 ### Example: Analyzing Fulfillment Delays
@@ -251,4 +251,3 @@ To find orders placed last month that haven't shipped yet:
 This combination lets you identify orders that are still pending fulfillment.
 
 For more details on configuring time dimensions, see the [Time Dimensions](/developers/build/metrics-view/dimensions/time-dimensions) developer documentation.
-


### PR DESCRIPTION
## Summary
- correct verified spelling, capitalization, hyphenation, and grammar issues across hand-authored documentation
- improve sentence structure and punctuation in deployment, dashboard, connector, and ClickHouse tutorial guides
- exclude generated CLI reference pages from the prose edits

## Review
- audited 173 hand-authored Markdown/MDX documentation pages
- applied only source-level corrections verified in context

## Validation
- `codespell --quiet-level=3 --skip="docs/docs/reference/*" docs/docs`
- `npm run build` (from `docs/`)