### PR TITLE
fix: canvas dashboards fail to load with non-UTC timezones

### DIFF
--- a/web-common/src/features/canvas/components/BaseCanvasComponent.ts
+++ b/web-common/src/features/canvas/components/BaseCanvasComponent.ts
@@ -230,9 +230,12 @@ export abstract class BaseCanvasComponent<T = ComponentSpec> {
 
         let timeGrain = globalGrainStore;
 
+        // Timestamps sent to the runtime must be UTC:
+        // the protobuf JSON codec rejects ISO strings with both milliseconds and a timezone offset,
+        // which is what Luxon produces for zoned datetimes (e.g. 2026-08-13T00:00:00.000+09:00).
         let timeRange: V1TimeRange = {
-          start: globalInterval?.start.toISO(),
-          end: globalInterval?.end.toISO(),
+          start: globalInterval?.start.toUTC().toISO(),
+          end: globalInterval?.end.toUTC().toISO(),
           timeZone,
         };
 
@@ -245,13 +248,13 @@ export abstract class BaseCanvasComponent<T = ComponentSpec> {
                 interval: globalGrainStore,
               }
             : undefined,
-          timeStart: globalInterval?.start.toISO(),
-          timeEnd: globalInterval?.end.toISO(),
+          timeStart: globalInterval?.start.toUTC().toISO(),
+          timeEnd: globalInterval?.end.toUTC().toISO(),
         };
 
         let comparisonTimeRange: V1TimeRange | undefined = {
-          start: globalComparisonInterval?.start.toISO(),
-          end: globalComparisonInterval?.end.toISO(),
+          start: globalComparisonInterval?.start.toUTC().toISO(),
+          end: globalComparisonInterval?.end.toUTC().toISO(),
           timeZone,
         };
 
@@ -259,8 +262,8 @@ export abstract class BaseCanvasComponent<T = ComponentSpec> {
 
         let comparisonTimeRangeState: ComparisonTimeRangeState | undefined =
           globalComparisonInterval && {
-            comparisonTimeStart: globalComparisonInterval.start.toISO(),
-            comparisonTimeEnd: globalComparisonInterval.end.toISO(),
+            comparisonTimeStart: globalComparisonInterval.start.toUTC().toISO(),
+            comparisonTimeEnd: globalComparisonInterval.end.toUTC().toISO(),
             selectedComparisonTimeRange: {
               start: globalComparisonInterval.start.toJSDate(),
               end: globalComparisonInterval.end.toJSDate(),
@@ -290,14 +293,14 @@ export abstract class BaseCanvasComponent<T = ComponentSpec> {
 
           if (componentSpec?.["time_filters"]) {
             timeRange = {
-              start: localInterval?.start.toISO(),
-              end: localInterval?.end.toISO(),
+              start: localInterval?.start.toUTC().toISO(),
+              end: localInterval?.end.toUTC().toISO(),
               timeZone,
             };
 
             comparisonTimeRange = {
-              start: localComparisonInterval?.start.toISO(),
-              end: localComparisonInterval?.end.toISO(),
+              start: localComparisonInterval?.start.toUTC().toISO(),
+              end: localComparisonInterval?.end.toUTC().toISO(),
               timeZone,
             };
 
@@ -314,14 +317,16 @@ export abstract class BaseCanvasComponent<T = ComponentSpec> {
                     interval: localGrainStore ?? globalGrainStore,
                   }
                 : undefined,
-              timeStart: localInterval?.start.toISO(),
-              timeEnd: localInterval?.end.toISO(),
+              timeStart: localInterval?.start.toUTC().toISO(),
+              timeEnd: localInterval?.end.toUTC().toISO(),
             };
             const localComparisonRangeState:
               | ComparisonTimeRangeState
               | undefined = localComparisonInterval && {
-              comparisonTimeStart: localComparisonInterval.start.toISO(),
-              comparisonTimeEnd: localComparisonInterval.end.toISO(),
+              comparisonTimeStart: localComparisonInterval.start
+                .toUTC()
+                .toISO(),
+              comparisonTimeEnd: localComparisonInterval.end.toUTC().toISO(),
               selectedComparisonTimeRange: {
                 start: localComparisonInterval.start.toJSDate(),
                 end: localComparisonInterval.end.toJSDate(),

--- a/web-common/src/features/canvas/filters/CanvasFilters.svelte
+++ b/web-common/src/features/canvas/filters/CanvasFilters.svelte
@@ -79,8 +79,8 @@
   $: interval = $intervalStore;
   $: minTimeGrain = $largestMinTimeGrain;
 
-  $: timeStart = interval?.start.toISO();
-  $: timeEnd = interval?.end.toISO();
+  $: timeStart = interval?.start.toUTC().toISO();
+  $: timeEnd = interval?.end.toUTC().toISO();
 
   $: minMax = $minMaxTimeStamps;
 

--- a/web-common/src/features/canvas/inspector/DefaultFilterDisplay.svelte
+++ b/web-common/src/features/canvas/inspector/DefaultFilterDisplay.svelte
@@ -41,8 +41,8 @@
       uiFilters={$defaultUIFiltersStore}
       timeRangeString={defaultTimeRange}
       comparisonRange={defaultComparisonRange}
-      timeStart={interval?.start?.toISO()}
-      timeEnd={interval?.end?.toISO()}
+      timeStart={interval?.start?.toUTC().toISO()}
+      timeEnd={interval?.end?.toUTC().toISO()}
     />
   </div>
 

--- a/web-common/src/features/canvas/inspector/filters/TimeFiltersInput.svelte
+++ b/web-common/src/features/canvas/inspector/filters/TimeFiltersInput.svelte
@@ -66,8 +66,8 @@
 
   $: interval = $intervalStore;
 
-  $: timeStart = interval?.start.toISO();
-  $: timeEnd = interval?.end.toISO();
+  $: timeStart = interval?.start.toUTC().toISO();
+  $: timeEnd = interval?.end.toUTC().toISO();
 
   $: comparisonInterval = $comparisonIntervalStore;
   $: comparisonRange = $comparisonRangeStore;


### PR DESCRIPTION
Canvas dashboards showed error icons on every component when a non-UTC timezone was selected (e.g. `tz=Asia/Tokyo`), while UTC worked fine.

- Canvas built query timestamps with Luxon's `toISO()` on zone-set datetimes, producing strings like `2026-08-13T00:00:00.000+09:00`.
- The protobuf JSON codec (`@bufbuild/protobuf` 1.x) used by the v2 runtime client rejects RFC 3339 strings that combine fractional seconds with a timezone offset, so `Timestamp.fromJson` threw and every canvas query failed client-side before reaching the network. With `refetchOnMount: false`, the errored queries never retried.
- Fix: serialize query-bound timestamps as UTC (`.toUTC().toISO()`) in `BaseCanvasComponent`, `CanvasFilters`, `TimeFiltersInput`, and `DefaultFilterDisplay`, matching the existing pattern in explore (`MeasureChart`, `TDDChart`, `lib/time/ranges`).

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
