### PR TITLE
fix: setValidState embed API fails with tr=inf and no grain

### DIFF
--- a/web-common/src/features/dashboards/url-state/convertURLSearchParamsToExploreState.spec.ts
+++ b/web-common/src/features/dashboards/url-state/convertURLSearchParamsToExploreState.spec.ts
@@ -76,6 +76,28 @@ Unexpected " ".`,
   },
 
   {
+    title: "Time range only with default grain",
+    url: "http://localhost/explore/AdBids_explore?tr=7D",
+    errors: [],
+    entity: {
+      selectedTimeRange: {
+        interval: "TIME_GRAIN_DAY",
+        name: "7D",
+      } as DashboardTimeControls,
+    },
+  },
+  {
+    title: "Time range only with no default grain",
+    url: "http://localhost/explore/AdBids_explore?tr=inf",
+    errors: [],
+    entity: {
+      selectedTimeRange: {
+        interval: "TIME_GRAIN_HOUR",
+        name: "inf",
+      } as DashboardTimeControls,
+    },
+  },
+  {
     title: "Invalid time ranges",
     url: "http://localhost/explore/AdBids_explore?tr=abc&grain=xyz",
     errors: [
@@ -131,7 +153,12 @@ Unexpected " ".`,
   },
 ];
 
-describe("Invalid Human readable URL State", () => {
+/**
+ * Has tests that call convertURLSearchParamsToExploreState directly.
+ * Unlike url-state-variations that tests actions on explore state.
+ * TODO: find a good unification of test cases so that a single set of cases run all variations.
+ */
+describe("direct convertURLSearchParamsToExploreState variations", () => {
   beforeEach(() => {
     metricsExplorerStore.remove(AD_BIDS_EXPLORE_NAME);
   });

--- a/web-common/src/features/dashboards/url-state/convertURLToExplorePreset.ts
+++ b/web-common/src/features/dashboards/url-state/convertURLToExplorePreset.ts
@@ -390,8 +390,9 @@ export function fromTimeRangesParams(
 
       if (grain && grain in V1TimeGrainToDateTimeUnit) {
         preset.timeGrain = V1TimeGrainToDateTimeUnit[grain];
-      } else {
-        errors.push(getSingleFieldError("time grain", grain ?? "undefined"));
+      } else if (grain) {
+        // Only throw error if grain is defined
+        errors.push(getSingleFieldError("time grain", grain));
       }
     } catch {
       // ignore


### PR DESCRIPTION
Calling `setValidState` with `tr=inf` in the url param and no grain would return an error, `Selected time grain: "undefined" is not valid.` This is because we do not have a valid derived grain for inf time range, but an error here doesnt make sense.

Updating to only throw when the derived grain is valid. Absense of grain will be backfilled in other parts of the code. A unification of time controls calc is pending, this should be fixed there and the backfilled grain should be derived upfront.

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
