### PR TITLE
docs: release notes for 0.89

### DIFF
--- a/docs/blog/0.89.md
+++ b/docs/blog/0.89.md
@@ -12,6 +12,8 @@ description: Rill is the world's first AI-native business intelligence tool. Tru
 👉 [Get Started](https://ui.rilldata.com) • [Join our Discord](https://discord.gg/2ubRfjC7Rh)
 :::
 
+![release-0.89](https://cdn.rilldata.com/docs/release-notes/release-0.89.gif)
+
 ## Conditional Formatting for Pivot Tables
 
 Pivot tables in Explore and Canvas dashboards now support conditional formatting. Define value-based rules to color cells by measure, including a "lower is better" option for measures where the scale should be reversed. Formatting rules are part of the dashboard state: they persist when you switch table types and reset when you change the underlying metrics view.

--- a/docs/blog/0.89.md
+++ b/docs/blog/0.89.md
@@ -1,0 +1,123 @@
+---
+date: 2026-08-19
+image: https://github.com/rilldata/rill/assets/5587788/b30486f6-002a-445d-8a1b-955b6ec0066d
+description: Rill is the world's first AI-native business intelligence tool. Trusted by thousands of developers and analysts around the globe, Rill accelerates the creation of dashboards and data applications using BI-as-code.
+---
+
+# Rill 0.89 - Inline Explore Dashboards, Dashboard Favourites, Conditional Formatting, Scheduled Canvas Reports and Spanish Localization
+
+:::note
+⚡ Rill's BI-as-code powers fast dashboards, embedded analytics, and an agent-ready semantic layer — all running on top of the warehouses you already use.
+
+👉 [Get Started](https://ui.rilldata.com) • [Join our Discord](https://discord.gg/2ubRfjC7Rh)
+:::
+
+## Conditional Formatting for Pivot Tables
+
+Pivot tables in Explore and Canvas dashboards now support conditional formatting. Define value-based rules to color cells by measure, including a "lower is better" option for measures where the scale should be reversed. Formatting rules are part of the dashboard state: they persist when you switch table types and reset when you change the underlying metrics view.
+
+## Scheduled Canvas PDF Reports
+
+Last release introduced one-off PDF downloads for canvas dashboards; this release makes them schedulable. Set up a recurring PDF export of a canvas dashboard, delivered by email — for example, a weekly snapshot for stakeholders. Tab groups are also now supported in the exported PDF.
+
+## Dashboard Favourites and Sorting
+
+You can now mark dashboards as favourites on the project home page in Rill Cloud, keeping the ones you like on at the top of the list. The dashboard list also gains a sort selector that remembers your frequently visited dashboards. Favourites are personal, so each member of a project curates their own list.
+
+## Spanish Localization
+
+Rill's interface is now available in Spanish. More than 1,700 user-facing strings across both Rill Cloud and Rill Developer have been translated, and a new language switcher lets you choose your locale. The underlying implementation architecture also pave the way for additional languages in future releases.
+
+## Invite Users with Custom Attributes
+
+[Custom user attributes](/developers/manage/security) can now be assigned when inviting a user, from both the UI and the CLI, for organization and project invites. Attributes are stored on the invite and applied to the membership once it is accepted. If your dashboard security policies depend on user attributes, external users now get the correct access from their very first login.
+
+## Define Explore Dashboards Inline in Metrics Views
+
+A metrics view can now define its explore dashboard directly with a new `explore:` block, so the semantic model and its dashboard live together in a single file. Until now, every dashboard required a separate explore file, even when it was a thin wrapper around one metrics view — the most common case. The inline block accepts the same field selectors as standalone explores (wildcards, explicit lists, regex, and exclusions), and existing explore files continue to work unchanged. Thsi makes every metrics view explorable by default. See the [metrics view reference](/reference/project-files/metrics-views) for details.
+
+## Bug Fixes and Improvements
+
+### Explore / Dashboards
+
+- Applied theme colors to the explore time picker
+- Fixed chart resizing and dynamic y-axis behavior for non-line chart types
+- Kept one decimal place on line chart y-axis tick labels
+- Fixed leaderboard columns going stale when context columns are shown for all measures
+- Fixed delta column widths in leaderboards and the dimension table
+- Honored an explicit `format_d3` in tooltips and big numbers
+- Fixed toggling off a pivot filter clearing existing filters
+- Capped the pivot drop zone height so a long list of chips no longer hides the table
+- Fixed the filter resource dropdown not scrolling
+- Fixed the collapsed row resizer on wide dashboard rows
+- Fixed the table sort dropdown rendering with a white background
+- Fixed a lock leak in dashboard state sync that could freeze URL and state updates
+- Fixed "View as" behavior, including while editing a project
+
+### Canvas
+
+- Added a row limit setting to canvas pivot tables
+- Returned a clear error instead of panicking on an invalid component variable `value`
+
+### Metrics Views and Metrics SQL
+
+- Applied security row and query filters in the metrics view `Summary` API
+- Enforced the metrics view access policy in the annotations resolver
+- Fixed annotation validation checking the parent's model or table instead of the annotation's
+- Rejected joins and other unsupported top-level clauses in metrics SQL, and allowed `DISTINCT`
+- Fixed `NOT BETWEEN` compiling to the same filter as `BETWEEN` in metrics SQL
+- Fixed `IS FALSE` being parsed identically to `IS TRUE` in metrics SQL
+- Fixed decimal comparisons in metrics SQL filters
+- Fixed panics in Parquet exports of timeseries and in aggregation exports without a time range
+- Fixed `ListResources` failing for projects with a large number of resources
+- Added a refresh trigger for all resources in the resource listing
+
+### Models
+
+- Preserved model output when changing connectors in manual or patch change mode
+- Prevented transient table lookup errors from marking all partitions pending
+- Fixed a full model rebuild on rename by pointing the incremental state at the renamed table
+- Cleared partition catalog rows when deleting a partitioned model
+- Added validation against empty `pre_exec` and `post_exec` statements
+
+### Connectors
+
+- Added support for multiple databases and schemas in the MotherDuck connector
+- Upgraded the embedded DuckDB to 1.5.4
+- Fixed STS configurations not working for DuckDB
+- Used a lightweight system sync replica for replicated ClickHouse engines
+- Supported passing query attributes to the Druid query context
+- Fixed a BigQuery client leak by closing the client in the file iterator
+
+### AI / LLM
+
+- Reworked the analyst agent into a generic skill with a richer user prompt
+- Increased the AI conversation message limit to 100 and made the maximum message size configurable
+- Included exact metrics view field names in the `develop_file` sub-agent prompt
+- Instructed AI agents not to inspect Rill internal state with external tools
+- Fixed a nil-pointer panic in the AI resolver when time ranges are omitted
+
+### Rill Developer
+
+- Expanded file explorer directories by default and added an expand/collapse control
+- Skipped interactive prompts in `rill service create` when flags are passed
+- Fixed `.env` variables not being pushed to the newly created project on deploy
+- Added a gentle prompt to star Rill on GitHub
+
+### Cloud
+
+- Fixed user lists not refreshing after adding, removing, or changing a member's role
+- Fixed a broken infinite query in the user group table
+- Made redeploying a project clean up old stopped deployments
+- Exposed the disk size override in the `rill project get` CLI output
+- Fixed a nil pointer dereference for non-email alert notifiers
+
+### Embedding
+
+- Added a `hide_navigation_bar` embed param that hides the navigation bar while keeping in-dashboard navigation, such as the Canvas to Explore drill-through, enabled; see the [embedding docs](/developers/embed/iframe)
+
+### Security and Infrastructure
+
+- Fixed a path traversal bypass in the local path sandbox and rejected paths outside the repo root in repo drivers and AI file tools
+- Required the `ReadInstance` permission in connector service handlers
+- Upgraded Go to 1.26.5 and patched dependency vulnerabilities (`sigstore-go`, `excelize`, `kin-openapi`, gRPC, and others)

--- a/docs/blog/0.89.md
+++ b/docs/blog/0.89.md
@@ -32,11 +32,11 @@ Rill's interface is now available in Spanish. More than 1,700 user-facing string
 
 ## Invite Users with Custom Attributes
 
-[Custom user attributes](/developers/manage/security) can now be assigned when inviting a user, from both the UI and the CLI, for organization and project invites. Attributes are stored on the invite and applied to the membership once it is accepted. If your dashboard security policies depend on user attributes, external users now get the correct access from their very first login.
+[Custom user attributes](/developers/build/metrics-view/security) can now be assigned when inviting a user, from both the UI and the CLI, for organization and project invites. Attributes are stored on the invite and applied to the membership once it is accepted. If your dashboard security policies depend on user attributes, external users now get the correct access from their very first login.
 
 ## Define Explore Dashboards Inline in Metrics Views
 
-A metrics view can now define its explore dashboard directly with a new `explore:` block, so the semantic model and its dashboard live together in a single file. Until now, every dashboard required a separate explore file, even when it was a thin wrapper around one metrics view — the most common case. The inline block accepts the same field selectors as standalone explores (wildcards, explicit lists, regex, and exclusions), and existing explore files continue to work unchanged. Thsi makes every metrics view explorable by default. See the [metrics view reference](/reference/project-files/metrics-views) for details.
+A metrics view can now define its explore dashboard directly with a new `explore:` block, so the semantic model and its dashboard live together in a single file. Until now, every dashboard required a separate explore file, even when it was a thin wrapper around one metrics view — the most common case. The inline block accepts the same field selectors as standalone explores (wildcards, explicit lists, regex, and exclusions), and existing explore files continue to work unchanged. This makes every metrics view explorable by default. See the [metrics view reference](/reference/project-files/metrics-views) for details.
 
 ## Bug Fixes and Improvements
 

--- a/docs/blog/0.89.md
+++ b/docs/blog/0.89.md
@@ -4,7 +4,7 @@ image: https://github.com/rilldata/rill/assets/5587788/b30486f6-002a-445d-8a1b-9
 description: Rill is the world's first AI-native business intelligence tool. Trusted by thousands of developers and analysts around the globe, Rill accelerates the creation of dashboards and data applications using BI-as-code.
 ---
 
-# Rill 0.89 - Inline Explore Dashboards, Dashboard Favourites, Conditional Formatting, Scheduled Canvas Reports and Spanish Localization
+# Rill 0.89 - Inline Explore Dashboards, Dashboard Favorites, Conditional Formatting, Scheduled Canvas Reports and Spanish Localization
 
 :::note
 ⚡ Rill's BI-as-code powers fast dashboards, embedded analytics, and an agent-ready semantic layer — all running on top of the warehouses you already use.
@@ -16,27 +16,27 @@ description: Rill is the world's first AI-native business intelligence tool. Tru
 
 ## 🎨 Introducing Conditional Formatting for Pivot Tables
 
-Pivot tables in Explore and Canvas dashboards now support conditional formatting. Define value-based rules to color cells by measure, including a "lower is better" option for measures where the scale should be reversed. Formatting rules are part of the dashboard state: they persist when you switch table types and reset when you change the underlying metrics view.
+Pivot tables in Explore and Canvas dashboards now support conditional formatting: define value-based rules to color cells by measure, including a "lower is better" option for reversed scales. Rules are saved as part of the dashboard state: they persist when you switch table types and reset when you change the underlying metrics view.
 
 ## 📬 Schedule Delivery of Canvas Dashboards PDFs
 
-Last release introduced one-off PDF downloads for canvas dashboards; this release makes them schedulable. Set up a recurring PDF export of a canvas dashboard, delivered by email — for example, a weekly snapshot for stakeholders. Tab groups are also now supported in the exported PDF.
+Canvas PDF exports can now be scheduled and delivered by email — a great way to send a weekly snapshot to stakeholders. Tab groups are included in the export.
 
 ## ⭐ Favorite and Sort Dashboards on the Home Page
 
-You can now mark dashboards as favourites on the project home page in Rill Cloud, keeping the ones you like on at the top of the list. The dashboard list also gains a sort selector that remembers your frequently visited dashboards. Favourites are personal, so each member of a project curates their own list.
+Mark dashboards as favorites on the project home page to keep the ones you use most at the top, alongside a new sort selector for the dashboard list. Favorites are user-based, so each member of a project curates their own list.
 
 ## 🇪🇸 Rill Habla Español - Announcing Spanish Localization (with More Languages on the Way)
 
-Rill's interface is now available in Spanish. More than 1,700 user-facing strings across both Rill Cloud and Rill Developer have been translated, and a new language switcher lets you choose your locale. The underlying implementation architecture also pave the way for additional languages in future releases.
+Rill is now available in Spanish, our first of dozens of languages we will be rolling out support for in the coming months. More than 1,700 user-facing strings across both Rill Cloud and Rill Developer have been translated, and a new language switcher lets you choose your locale.
 
 ## 🔐 Securely Invite Users with Custom Attributes
 
-[Custom user attributes](/developers/build/metrics-view/security) can now be assigned when inviting a user, from both the UI and the CLI, for organization and project invites. Attributes are stored on the invite and applied to the membership once it is accepted. If your dashboard security policies depend on user attributes, external users now get the correct access from their very first login.
+[Custom user attributes](/developers/build/metrics-view/security) can now be passed in and assigned at invite time, from either the UI or the CLI, for organization and project invites. Attributes are stored on the invite and applied to the membership once it is accepted, so users whose dashboard access depends on these attributes are correctly handled from their very first login. No additional steps required.
 
 ## 📊 Metrics Views now Include Explore Dashboards
 
-A metrics view can now define its explore dashboard directly with a new `explore:` block, so the semantic model and its dashboard live together in a single file. Until now, every dashboard required a separate explore file, even when it was a thin wrapper around one metrics view — the most common case. The inline block accepts the same field selectors as standalone explores (wildcards, explicit lists, regex, and exclusions), and existing explore files continue to work unchanged. This makes every metrics view explorable by default. See the [metrics view reference](/reference/project-files/metrics-views) for details.
+A metrics view YAML can now define its Explore dashboard configuration inline, using a new `explore` key. Now a single metrics view file contains both the semantic model and its dashboard configuration, making every metrics view explorable by default. The inline block accepts the same field selectors as standalone explores (wildcards, explicit lists, regex, and exclusions), and existing explore files continue to work unchanged. See the [metrics view reference](/reference/project-files/metrics-views) for details.
 
 ## Bug Fixes and Improvements
 

--- a/docs/blog/0.89.md
+++ b/docs/blog/0.89.md
@@ -14,27 +14,27 @@ description: Rill is the world's first AI-native business intelligence tool. Tru
 
 ![release-0.89](https://cdn.rilldata.com/docs/release-notes/release-0.89.gif)
 
-## Conditional Formatting for Pivot Tables
+## 🎨 Introducing Conditional Formatting for Pivot Tables
 
 Pivot tables in Explore and Canvas dashboards now support conditional formatting. Define value-based rules to color cells by measure, including a "lower is better" option for measures where the scale should be reversed. Formatting rules are part of the dashboard state: they persist when you switch table types and reset when you change the underlying metrics view.
 
-## Scheduled Canvas PDF Reports
+## 📬 Schedule Delivery of Canvas Dashboards PDFs
 
 Last release introduced one-off PDF downloads for canvas dashboards; this release makes them schedulable. Set up a recurring PDF export of a canvas dashboard, delivered by email — for example, a weekly snapshot for stakeholders. Tab groups are also now supported in the exported PDF.
 
-## Dashboard Favourites and Sorting
+## ⭐ Favorite and Sort Dashboards on the Home Page
 
 You can now mark dashboards as favourites on the project home page in Rill Cloud, keeping the ones you like on at the top of the list. The dashboard list also gains a sort selector that remembers your frequently visited dashboards. Favourites are personal, so each member of a project curates their own list.
 
-## Spanish Localization
+## 🇪🇸 Rill Habla Español - Announcing Spanish Localization (with More Languages on the Way)
 
 Rill's interface is now available in Spanish. More than 1,700 user-facing strings across both Rill Cloud and Rill Developer have been translated, and a new language switcher lets you choose your locale. The underlying implementation architecture also pave the way for additional languages in future releases.
 
-## Invite Users with Custom Attributes
+## 🔐 Securely Invite Users with Custom Attributes
 
 [Custom user attributes](/developers/build/metrics-view/security) can now be assigned when inviting a user, from both the UI and the CLI, for organization and project invites. Attributes are stored on the invite and applied to the membership once it is accepted. If your dashboard security policies depend on user attributes, external users now get the correct access from their very first login.
 
-## Define Explore Dashboards Inline in Metrics Views
+## 📊 Metrics Views now Include Explore Dashboards
 
 A metrics view can now define its explore dashboard directly with a new `explore:` block, so the semantic model and its dashboard live together in a single file. Until now, every dashboard required a separate explore file, even when it was a thin wrapper around one metrics view — the most common case. The inline block accepts the same field selectors as standalone explores (wildcards, explicit lists, regex, and exclusions), and existing explore files continue to work unchanged. This makes every metrics view explorable by default. See the [metrics view reference](/reference/project-files/metrics-views) for details.
 


### PR DESCRIPTION
Release notes for 0.89, covering everything shipped since the 0.88 announcement:

- Highlights: conditional formatting for pivot tables, scheduled canvas PDF reports, dashboard favourites, Spanish localization, invite-time custom attributes, and inline explore dashboards via the `explore:` block
- Also folds in features that shipped in the 0.88 cycle but were never announced (e.g. model partition skipping, 0.88.x patch fixes)

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
