### PR TITLE
fix: pivot rows reactivity issue

### DIFF
--- a/web-common/src/features/canvas/CanvasTabGroupView.svelte
+++ b/web-common/src/features/canvas/CanvasTabGroupView.svelte
@@ -33,7 +33,7 @@
       <CanvasTabStrip {group} {maxWidth} {onSelect} />
 
       {#if activeTab && activeRows}
-        {#each $activeRows as row, rowIndex (rowIndex)}
+        {#each $activeRows as row, rowIndex (`${activeTab.name}-${rowIndex}`)}
           <StaticCanvasRow
             {row}
             {rowIndex}

--- a/web-common/src/features/canvas/EditableCanvasTabGroup.svelte
+++ b/web-common/src/features/canvas/EditableCanvasTabGroup.svelte
@@ -128,7 +128,7 @@
       />
 
       {#if activeTab && grid}
-        {#each $grid as row, rowIndex (rowIndex)}
+        {#each $grid as row, rowIndex (`${activeTab.name}-${rowIndex}`)}
           <EditableCanvasRow
             {row}
             {maxWidth}

--- a/web-common/src/features/dashboards/pivot/PivotTable.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTable.svelte
@@ -88,38 +88,36 @@
   export let rowSelectionState: PivotRowSelectionState | undefined = undefined;
   export let clickSelection: PivotClickSelectionState | undefined = undefined;
 
-  const options: Readable<TableOptions<PivotDataRow>> = derived(
-    [pivotDataStore, pivotState],
-    ([pivotData, state]) => {
-      let tableData = [...pivotData.data];
-      if (pivotData.totalsRowData) {
-        tableData = [pivotData.totalsRowData, ...pivotData.data];
-      }
-      return {
-        data: tableData,
-        columns: pivotData.columnDef,
-        state: {
-          expanded: state.expanded,
-          sorting: state.sorting,
-        },
-        onExpandedChange: (updater) => {
-          const expanded =
-            typeof updater === "function" ? updater(state.expanded) : updater;
-          setPivotExpanded(expanded);
-        },
-        getSubRows: (row) => row.subRows,
-        onSortingChange: (updater) => {
-          const sorting =
-            typeof updater === "function" ? updater(state.sorting) : updater;
-          setPivotSort(sorting);
-        },
-        getExpandedRowModel: getExpandedRowModel(),
-        getCoreRowModel: getCoreRowModel(),
-        enableSortingRemoval: false,
-        enableExpanding: true,
-      };
-    },
-  );
+  let options: Readable<TableOptions<PivotDataRow>>;
+  $: options = derived([pivotDataStore, pivotState], ([pivotData, state]) => {
+    let tableData = [...pivotData.data];
+    if (pivotData.totalsRowData) {
+      tableData = [pivotData.totalsRowData, ...pivotData.data];
+    }
+    return {
+      data: tableData,
+      columns: pivotData.columnDef,
+      state: {
+        expanded: state.expanded,
+        sorting: state.sorting,
+      },
+      onExpandedChange: (updater) => {
+        const expanded =
+          typeof updater === "function" ? updater(state.expanded) : updater;
+        setPivotExpanded(expanded);
+      },
+      getSubRows: (row) => row.subRows,
+      onSortingChange: (updater) => {
+        const sorting =
+          typeof updater === "function" ? updater(state.sorting) : updater;
+        setPivotSort(sorting);
+      },
+      getExpandedRowModel: getExpandedRowModel(),
+      getCoreRowModel: getCoreRowModel(),
+      enableSortingRemoval: false,
+      enableExpanding: true,
+    };
+  });
 
   $: table = createSvelteTable(options);
 

--- a/web-common/src/features/dashboards/pivot/PivotTable.svelte
+++ b/web-common/src/features/dashboards/pivot/PivotTable.svelte
@@ -88,36 +88,38 @@
   export let rowSelectionState: PivotRowSelectionState | undefined = undefined;
   export let clickSelection: PivotClickSelectionState | undefined = undefined;
 
-  let options: Readable<TableOptions<PivotDataRow>>;
-  $: options = derived([pivotDataStore, pivotState], ([pivotData, state]) => {
-    let tableData = [...pivotData.data];
-    if (pivotData.totalsRowData) {
-      tableData = [pivotData.totalsRowData, ...pivotData.data];
-    }
-    return {
-      data: tableData,
-      columns: pivotData.columnDef,
-      state: {
-        expanded: state.expanded,
-        sorting: state.sorting,
-      },
-      onExpandedChange: (updater) => {
-        const expanded =
-          typeof updater === "function" ? updater(state.expanded) : updater;
-        setPivotExpanded(expanded);
-      },
-      getSubRows: (row) => row.subRows,
-      onSortingChange: (updater) => {
-        const sorting =
-          typeof updater === "function" ? updater(state.sorting) : updater;
-        setPivotSort(sorting);
-      },
-      getExpandedRowModel: getExpandedRowModel(),
-      getCoreRowModel: getCoreRowModel(),
-      enableSortingRemoval: false,
-      enableExpanding: true,
-    };
-  });
+  const options: Readable<TableOptions<PivotDataRow>> = derived(
+    [pivotDataStore, pivotState],
+    ([pivotData, state]) => {
+      let tableData = [...pivotData.data];
+      if (pivotData.totalsRowData) {
+        tableData = [pivotData.totalsRowData, ...pivotData.data];
+      }
+      return {
+        data: tableData,
+        columns: pivotData.columnDef,
+        state: {
+          expanded: state.expanded,
+          sorting: state.sorting,
+        },
+        onExpandedChange: (updater) => {
+          const expanded =
+            typeof updater === "function" ? updater(state.expanded) : updater;
+          setPivotExpanded(expanded);
+        },
+        getSubRows: (row) => row.subRows,
+        onSortingChange: (updater) => {
+          const sorting =
+            typeof updater === "function" ? updater(state.sorting) : updater;
+          setPivotSort(sorting);
+        },
+        getExpandedRowModel: getExpandedRowModel(),
+        getCoreRowModel: getCoreRowModel(),
+        enableSortingRemoval: false,
+        enableExpanding: true,
+      };
+    },
+  );
 
   $: table = createSvelteTable(options);
 

--- a/web-common/src/features/dashboards/pivot/pivot-queries.ts
+++ b/web-common/src/features/dashboards/pivot/pivot-queries.ts
@@ -208,6 +208,13 @@ export function getAxisForDimensions(
         };
       }
 
+      // A disabled query reports `isFetching: false` with no data at all: canvas
+      // components gate their queries on `visible`, so a pivot that just mounted
+      // sits in that state until the intersection observer fires. That is not an
+      // empty result (which still carries a `data` object), so keep waiting
+      // rather than reporting zero axis values downstream.
+      if (data.some((d) => d?.data === undefined)) return { isFetching: true };
+
       data.forEach((d, i: number) => {
         const dimensionName = dimensions[i];
 


### PR DESCRIPTION
Table options was a constant and it never recomputed if args change without a remount. This was an issue only in canvas with tabs, each tab with the exact same pivot but with different filters.

Making the options store reactive so that changes in `pivotDataStore` / `pivotState` updates the table correctly.

Closes APP-925

**Checklist:**
- [ ] Covered by tests
- [x] Ran it and it works as intended
- [x] Reviewed the diff before requesting a review
- [x] Checked for unhandled edge cases
- [x] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
