### PR TITLE
fix(runtime): skip config reload when no `admin_connector` is configured

### DIFF
--- a/runtime/config_reloader.go
+++ b/runtime/config_reloader.go
@@ -57,6 +57,14 @@ func (r *configReloader) reloadConfig(ctx context.Context, instanceID string) (v
 		return 0, false, err
 	}
 
+	// Nothing to reload without an admin connector (not configured for tests
+	// and standalone runtimes). Acquiring the admin service anyway fails with
+	// `unknown connector ""`, which made CreateInstance return a 500 on
+	// standalone runtimes even though the instance was created successfully.
+	if inst.AdminConnector == "" {
+		return 0, false, nil
+	}
+
 	admin, release, err := r.rt.Admin(ctx, instanceID)
 	if err != nil {
 		return 0, false, err

--- a/runtime/config_reloader.go
+++ b/runtime/config_reloader.go
@@ -57,10 +57,7 @@ func (r *configReloader) reloadConfig(ctx context.Context, instanceID string) (v
 		return 0, false, err
 	}
 
-	// Nothing to reload without an admin connector (not configured for tests
-	// and standalone runtimes). Acquiring the admin service anyway fails with
-	// `unknown connector ""`, which made CreateInstance return a 500 on
-	// standalone runtimes even though the instance was created successfully.
+	// Nothing to reload without an admin connector (just a defensive check, usually always configured if configReloader is enabled)
 	if inst.AdminConnector == "" {
 		return 0, false, nil
 	}

--- a/runtime/registry_test.go
+++ b/runtime/registry_test.go
@@ -537,39 +537,3 @@ func must[T any](v T, err error) T {
 	}
 	return v
 }
-
-func TestRuntime_ReloadConfigWithoutAdminConnector(t *testing.T) {
-	// Standalone runtimes (`rill runtime start`) run with the config reloader
-	// enabled but often without an admin connector. CreateInstance calls
-	// ReloadConfig, so an unguarded admin acquisition here failed instance
-	// creation with `unknown connector ""` even though the instance was fine.
-	repodsn := t.TempDir()
-	rt := newTestRuntime(t)
-	rt.configReloader = newConfigReloader(rt)
-	defer rt.Close()
-	ctx := context.Background()
-
-	inst := &drivers.Instance{
-		Environment:   "test",
-		OLAPConnector: "duckdb",
-		RepoConnector: "repo",
-		Connectors: []*runtimev1.Connector{
-			{
-				Type:   "file",
-				Name:   "repo",
-				Config: must(structpb.NewStruct(map[string]any{"dsn": repodsn})),
-			},
-			{
-				Type:   "duckdb",
-				Name:   "duckdb",
-				Config: must(structpb.NewStruct(map[string]any{"dsn": ":memory:"})),
-			},
-		},
-	}
-	require.NoError(t, rt.CreateInstance(ctx, inst))
-
-	summary, err := rt.ReloadConfig(ctx, inst.ID)
-	require.NoError(t, err)
-	require.Zero(t, summary.VarsCount)
-	require.False(t, summary.VarsModified)
-}

--- a/runtime/registry_test.go
+++ b/runtime/registry_test.go
@@ -537,3 +537,39 @@ func must[T any](v T, err error) T {
 	}
 	return v
 }
+
+func TestRuntime_ReloadConfigWithoutAdminConnector(t *testing.T) {
+	// Standalone runtimes (`rill runtime start`) run with the config reloader
+	// enabled but often without an admin connector. CreateInstance calls
+	// ReloadConfig, so an unguarded admin acquisition here failed instance
+	// creation with `unknown connector ""` even though the instance was fine.
+	repodsn := t.TempDir()
+	rt := newTestRuntime(t)
+	rt.configReloader = newConfigReloader(rt)
+	defer rt.Close()
+	ctx := context.Background()
+
+	inst := &drivers.Instance{
+		Environment:   "test",
+		OLAPConnector: "duckdb",
+		RepoConnector: "repo",
+		Connectors: []*runtimev1.Connector{
+			{
+				Type:   "file",
+				Name:   "repo",
+				Config: must(structpb.NewStruct(map[string]any{"dsn": repodsn})),
+			},
+			{
+				Type:   "duckdb",
+				Name:   "duckdb",
+				Config: must(structpb.NewStruct(map[string]any{"dsn": ":memory:"})),
+			},
+		},
+	}
+	require.NoError(t, rt.CreateInstance(ctx, inst))
+
+	summary, err := rt.ReloadConfig(ctx, inst.ID)
+	require.NoError(t, err)
+	require.Zero(t, summary.VarsCount)
+	require.False(t, summary.VarsModified)
+}


### PR DESCRIPTION
Defensively skip config reloads if `admin_connector` is always configured (Just a defensive check, usually always configured if configReloader is enabled).

Closes #9832

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*