### PR TITLE
fix: inherit explore default timezone in chat charts without `time_zone`

### DIFF
--- a/web-common/src/features/chat/core/messages/chart/ChartBlock.svelte
+++ b/web-common/src/features/chat/core/messages/chart/ChartBlock.svelte
@@ -5,10 +5,12 @@
 <script lang="ts">
   import { page } from "$app/stores";
   import { ChartContainer } from "@rilldata/web-common/features/components/charts";
+  import { useGetExploresForMetricsView } from "@rilldata/web-common/features/dashboards/selectors";
   import {
     ResourceKind,
     useResource,
   } from "@rilldata/web-common/features/entity-management/resource-selectors";
+  import { selectBestDashboard } from "@rilldata/web-common/features/explore-mappers/explore-validation";
   import { mapResolverExpressionToV1Expression } from "@rilldata/web-common/features/explore-mappers/map-metrics-resolver-query-to-dashboard";
   import { Theme } from "@rilldata/web-common/features/themes/theme";
   import { queryClient } from "@rilldata/web-common/lib/svelte-query/globalQueryClient";
@@ -17,7 +19,7 @@
   import { readable } from "svelte/store";
   import type { V1Tool } from "../../../../../runtime-client";
   import ToolCall from "../tools/ToolCall.svelte";
-  import type { ChartBlock } from "./chart-block";
+  import { resolveChartTimeZone, type ChartBlock } from "./chart-block";
 
   export let block: ChartBlock;
   export let tools: V1Tool[] | undefined = undefined;
@@ -33,17 +35,34 @@
 
   $: spec = readable(chartSpec);
 
+  $: explicitTimeZone =
+    typeof chartSpec.time_range?.time_zone === "string" &&
+    chartSpec.time_range.time_zone
+      ? chartSpec.time_range.time_zone
+      : undefined;
+
+  $: exploresQuery = useGetExploresForMetricsView(
+    runtimeClient,
+    chartSpec.metrics_view ?? "",
+  );
+  $: exploreSpec = selectBestDashboard($exploresQuery.data ?? [])?.explore
+    ?.state?.validSpec;
+  $: timeZone = resolveChartTimeZone(explicitTimeZone, exploreSpec);
+  // Wait for explore lookup when the spec omits time_zone so we don't
+  // briefly query UTC and then refetch after inheritance resolves.
+  $: timezoneReady = !!explicitTimeZone || !$exploresQuery.isLoading;
+
   // Extract time range from the chart spec or use defaults
   $: timeRange = chartSpec.time_range
     ? {
         start: chartSpec.time_range.start,
         end: chartSpec.time_range.end,
-        timeZone: chartSpec.time_range.time_zone || "UTC",
+        timeZone,
       }
     : {
         start: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
         end: new Date().toISOString(),
-        timeZone: "UTC",
+        timeZone,
       };
 
   $: comparisonTimeRange = chartSpec.comparison_time_range
@@ -113,16 +132,18 @@
   />
 
   <div class="chart-container">
-    <ChartContainer
-      chartType={block.chartType}
-      {spec}
-      {timeAndFilterStore}
-      {project}
-      theme={$themeQuery?.data}
-      showExploreLink
-      {organization}
-      themeMode="light"
-    />
+    {#if timezoneReady}
+      <ChartContainer
+        chartType={block.chartType}
+        {spec}
+        {timeAndFilterStore}
+        {project}
+        theme={$themeQuery?.data}
+        showExploreLink
+        {organization}
+        themeMode="light"
+      />
+    {/if}
   </div>
 </div>
 

--- a/web-common/src/features/chat/core/messages/chart/chart-block.spec.ts
+++ b/web-common/src/features/chat/core/messages/chart/chart-block.spec.ts
@@ -1,0 +1,41 @@
+import { resolveChartTimeZone } from "@rilldata/web-common/features/chat/core/messages/chart/chart-block";
+import type { V1ExploreSpec } from "@rilldata/web-common/runtime-client";
+import { describe, expect, it } from "vitest";
+
+describe("resolveChartTimeZone", () => {
+  const shanghaiExplore: V1ExploreSpec = {
+    timeZones: ["Asia/Shanghai", "UTC"],
+  };
+
+  it("keeps an explicit spec time_zone authoritative", () => {
+    expect(resolveChartTimeZone("America/New_York", shanghaiExplore)).toBe(
+      "America/New_York",
+    );
+  });
+
+  it("inherits the explore default when the spec omits time_zone", () => {
+    expect(resolveChartTimeZone(undefined, shanghaiExplore)).toBe(
+      "Asia/Shanghai",
+    );
+  });
+
+  it("inherits defaultPreset.timezone when that is the explore default", () => {
+    const explore: V1ExploreSpec = {
+      defaultPreset: { timezone: "Europe/Paris" },
+      timeZones: ["UTC"],
+    };
+    expect(resolveChartTimeZone(undefined, explore)).toBe("Europe/Paris");
+  });
+
+  it("falls back to UTC when the explore lists no time zones", () => {
+    expect(resolveChartTimeZone(undefined, {})).toBe("UTC");
+  });
+
+  it("falls back to UTC when explore context is absent", () => {
+    expect(resolveChartTimeZone(undefined, undefined)).toBe("UTC");
+  });
+
+  it("does not treat an empty spec time_zone as explicit", () => {
+    expect(resolveChartTimeZone("", shanghaiExplore)).toBe("Asia/Shanghai");
+  });
+});

--- a/web-common/src/features/chat/core/messages/chart/chart-block.ts
+++ b/web-common/src/features/chat/core/messages/chart/chart-block.ts
@@ -1,5 +1,10 @@
 import type { ChartType } from "@rilldata/web-common/features/components/charts";
-import type { V1Message } from "@rilldata/web-common/runtime-client";
+import { getDefaultTimeZone } from "@rilldata/web-common/features/dashboards/stores/get-rill-default-explore-state";
+import { getUTCIANA } from "@rilldata/web-common/lib/time/timezone";
+import type {
+  V1ExploreSpec,
+  V1Message,
+} from "@rilldata/web-common/runtime-client";
 import { MessageContentType } from "../../types";
 
 // =============================================================================
@@ -51,6 +56,23 @@ export function createChartBlock(
     chartType: callData.chart_type,
     chartSpec: callData.spec,
   };
+}
+
+/**
+ * Resolves the timezone used to bin and label a chat chart.
+ *
+ * Explicit `time_range.time_zone` in the spec is authoritative.
+ * Otherwise inherit the explore default (`defaultPreset.timezone`, else
+ * `timeZones[0]`, else UTC). Missing explore context (embed, still loading,
+ * no dashboard for the metrics view) degrades to UTC.
+ */
+export function resolveChartTimeZone(
+  explicitTimeZone: string | undefined,
+  explore: V1ExploreSpec | undefined,
+): string {
+  if (explicitTimeZone) return explicitTimeZone;
+  if (!explore) return getUTCIANA();
+  return getDefaultTimeZone(explore);
 }
 
 // =============================================================================

--- a/web-common/src/features/dashboards/stores/get-rill-default-explore-state.spec.ts
+++ b/web-common/src/features/dashboards/stores/get-rill-default-explore-state.spec.ts
@@ -1,0 +1,37 @@
+import { getDefaultTimeZone } from "@rilldata/web-common/features/dashboards/stores/get-rill-default-explore-state";
+import { DEFAULT_TIMEZONES } from "@rilldata/web-common/lib/time/config";
+import { getLocalIANA } from "@rilldata/web-common/lib/time/timezone";
+import type { V1ExploreSpec } from "@rilldata/web-common/runtime-client";
+import { describe, expect, it } from "vitest";
+
+describe("getDefaultTimeZone", () => {
+  it("uses defaultPreset.timezone over timeZones[0]", () => {
+    const explore: V1ExploreSpec = {
+      defaultPreset: { timezone: "Asia/Shanghai" },
+      timeZones: ["UTC", "Asia/Shanghai"],
+    };
+    expect(getDefaultTimeZone(explore)).toBe("Asia/Shanghai");
+  });
+
+  it("uses the first explore time zone when no preset timezone is set", () => {
+    const explore: V1ExploreSpec = {
+      timeZones: ["America/Los_Angeles", "UTC"],
+    };
+    expect(getDefaultTimeZone(explore)).toBe("America/Los_Angeles");
+  });
+
+  it("falls back to DEFAULT_TIMEZONES[0] when the explore lists none", () => {
+    expect(getDefaultTimeZone({})).toBe(DEFAULT_TIMEZONES[0]);
+    expect(DEFAULT_TIMEZONES[0]).toBe("UTC");
+  });
+
+  it("resolves Local to the browser IANA zone", () => {
+    const explore: V1ExploreSpec = { timeZones: ["Local"] };
+    expect(getDefaultTimeZone(explore)).toBe(getLocalIANA());
+  });
+
+  it("falls back to UTC for an invalid IANA zone", () => {
+    const explore: V1ExploreSpec = { timeZones: ["Not/A_Timezone"] };
+    expect(getDefaultTimeZone(explore)).toBe("UTC");
+  });
+});

--- a/web-common/src/features/dashboards/stores/get-rill-default-explore-state.ts
+++ b/web-common/src/features/dashboards/stores/get-rill-default-explore-state.ts
@@ -246,7 +246,10 @@ export function getGrainForRange(
 }
 
 export function getDefaultTimeZone(explore: V1ExploreSpec) {
-  const preference = explore.timeZones?.[0] ?? DEFAULT_TIMEZONES[0];
+  const preference =
+    explore.defaultPreset?.timezone ||
+    explore.timeZones?.[0] ||
+    DEFAULT_TIMEZONES[0];
 
   if (preference === "Local") {
     return getLocalIANA();


### PR DESCRIPTION
- Chat charts whose spec omits `time_zone` were always binned in UTC, so day grains did not match the explore default timezone.
- `ChartBlock` now resolves timezone the same way dashboards do: explicit spec `time_zone`, else the explore `defaultPreset.timezone` / first `timeZones` entry, else UTC.
- `getDefaultTimeZone` honors `defaultPreset.timezone` first. An explicit spec zone stays authoritative.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!

---
*Developed in collaboration with Claude Code*
