### PR TITLE
google-cloud-cli-gke-gcloud-auth-plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y ca-certificates git curl gnupg && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         google-cloud-cli \
-        google-cloud-sdk-gke-gcloud-auth-plugin && \
+        google-cloud-cli-gke-gcloud-auth-plugin && \
     rm -rf /var/lib/apt/lists/*
 
 COPY rill /usr/local/bin


### PR DESCRIPTION
 Google renamed the package from google-cloud-sdk-gke-gcloud-auth-plugin to google-cloud-cli-gke-gcloud-auth-plugin (the old name is deprecated for versions ≥ 467.0.0)

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!
