### PR TITLE
Wrap long values in Pivot's cell hover tooltip

### DIFF
--- a/web-common/src/components/tooltip/TooltipTitle.svelte
+++ b/web-common/src/components/tooltip/TooltipTitle.svelte
@@ -12,10 +12,17 @@
   style="grid-template-columns: auto max-content"
   style:min-width="200px"
 >
+  <!--
+    `min-w-0` is required alongside `break-words`: without it the grid item is sized
+    to its min-content width, and `overflow-wrap: break-word` does not contribute
+    break opportunities to min-content, so a single unbroken value (a URL, a UUID)
+    would overflow the tooltip instead of wrapping.
+  -->
   <div
     class="font-bold text-fg-inverse"
     class:truncate={!wrap}
     class:break-words={wrap}
+    class:min-w-0={wrap}
     aria-label="tooltip-name"
   >
     <slot name="name" />

--- a/web-common/src/components/tooltip/TooltipTitle.svelte
+++ b/web-common/src/components/tooltip/TooltipTitle.svelte
@@ -1,9 +1,23 @@
+<script lang="ts">
+  /**
+   * By default the name is kept on a single line and ellipsized. Set this to
+   * let long values wrap across multiple lines instead, so the full text is
+   * readable on hover.
+   */
+  export let wrap = false;
+</script>
+
 <div
   class="grid gap-x-2 pointer-events-none pt-1 pb-1 items-baseline"
   style="grid-template-columns: auto max-content"
   style:min-width="200px"
 >
-  <div class="font-bold truncate text-fg-inverse" aria-label="tooltip-name">
+  <div
+    class="font-bold text-fg-inverse"
+    class:truncate={!wrap}
+    class:break-words={wrap}
+    aria-label="tooltip-name"
+  >
     <slot name="name" />
   </div>
   <div

--- a/web-common/src/components/virtualized-table/VirtualTooltip.svelte
+++ b/web-common/src/components/virtualized-table/VirtualTooltip.svelte
@@ -34,7 +34,7 @@
     {#if hovering.isPin}
       {pinned ? "Unpin" : "Pin"} this column to left side of the table
     {:else}
-      <TooltipTitle>
+      <TooltipTitle wrap>
         <svelte:fragment slot="name">
           {#if hovering.isHeader}
             {hovering.value}

--- a/web-common/src/components/virtualized-table/VirtualTooltip.svelte
+++ b/web-common/src/components/virtualized-table/VirtualTooltip.svelte
@@ -34,7 +34,7 @@
     {#if hovering.isPin}
       {pinned ? "Unpin" : "Pin"} this column to left side of the table
     {:else}
-      <TooltipTitle wrap>
+      <TooltipTitle wrap={!hovering.isHeader}>
         <svelte:fragment slot="name">
           {#if hovering.isHeader}
             {hovering.value}


### PR DESCRIPTION
Long cell values in the Pivot's hover tooltip were getting cut off to a single ellipsized line, even though the tooltip has room to grow. Full long-text wrapping on hover already worked on the Explore dashboard.

- `TooltipTitle`'s value now supports wrapping across multiple lines via a new `wrap` prop, opt-in and off by default so existing usages (~30 call sites) are unaffected.
- `VirtualTooltip` (used by the Pivot and dimension table) opts in.

**Checklist:**
- [ ] Covered by tests
- [ ] Ran it and it works as intended
- [ ] Reviewed the diff before requesting a review
- [ ] Checked for unhandled edge cases
- [ ] Linked the issues it closes
- [ ] Checked if the docs need to be updated. If so, create a separate Linear DOCS issue
- [ ] Intend to cherry-pick into the release branch
- [ ] I'm proud of this work!