### PR TITLE
fix: wrap long display names in bignumbers tooltip

### DIFF
--- a/web-common/src/features/dashboards/big-number/BigNumberTooltipContent.svelte
+++ b/web-common/src/features/dashboards/big-number/BigNumberTooltipContent.svelte
@@ -18,7 +18,7 @@
 </script>
 
 <TooltipContent maxWidth="280px">
-  <TooltipTitle>
+  <TooltipTitle wrap>
     <svelte:fragment slot="name">
       {name}
     </svelte:fragment>


### PR DESCRIPTION
Before:
<img width="469" height="116" alt="image" src="https://github.com/user-attachments/assets/706ab7a2-7bb0-4d20-ac68-6a0b79000af4" />

After:
<img width="436" height="139" alt="image" src="https://github.com/user-attachments/assets/4c2fa861-ca5f-49da-8d69-3a8e9c64c963" />

