### PR TITLE
Fix flaky and racy tests in the daily Go test run

### DIFF
--- a/runtime/ai/mcp.go
+++ b/runtime/ai/mcp.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
@@ -79,8 +78,7 @@ func (s *Session) MCPServer(ctx context.Context) *mcp.Server {
 					}
 				}
 			},
-			KeepAlive: 30 * time.Second,
-			HasTools:  true,
+			HasTools: true,
 			GetSessionID: func() string {
 				return s.id
 			},

--- a/runtime/drivers/clickhouse/testclickhouse/testdata/ch_cluster_2S_2R/docker-compose.yaml
+++ b/runtime/drivers/clickhouse/testclickhouse/testdata/ch_cluster_2S_2R/docker-compose.yaml
@@ -3,7 +3,6 @@ services:
   clickhouse-01:
     image: "clickhouse/clickhouse-server:26.3.1.896"
     user: "101:101"
-    container_name: clickhouse-01
     hostname: clickhouse-01
     volumes:
       - ./fs/volumes/clickhouse-01/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
@@ -17,7 +16,6 @@ services:
   clickhouse-02:
     image: "clickhouse/clickhouse-server:26.3.1.896"
     user: "101:101"
-    container_name: clickhouse-02
     hostname: clickhouse-02
     volumes:
       - ./fs/volumes/clickhouse-02/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
@@ -31,7 +29,6 @@ services:
   clickhouse-03:
     image: "clickhouse/clickhouse-server:26.3.1.896"
     user: "101:101"
-    container_name: clickhouse-03
     hostname: clickhouse-03
     volumes:
       - ./fs/volumes/clickhouse-03/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
@@ -45,7 +42,6 @@ services:
   clickhouse-04:
     image: "clickhouse/clickhouse-server:26.3.1.896"
     user: "101:101"
-    container_name: clickhouse-04
     hostname: clickhouse-04
     volumes:
       - ./fs/volumes/clickhouse-04/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
@@ -59,7 +55,6 @@ services:
   clickhouse-keeper-01:
     image: "clickhouse/clickhouse-keeper:26.3.1.896-alpine"
     user: "101:101"
-    container_name: clickhouse-keeper-01
     hostname: clickhouse-keeper-01
     volumes:
      - ./fs/volumes/clickhouse-keeper-01/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml

--- a/runtime/drivers/duckdb/model_executor_sqlstore_self_mysql_test.go
+++ b/runtime/drivers/duckdb/model_executor_sqlstore_self_mysql_test.go
@@ -70,7 +70,7 @@ func TestMySQLToDuckDBTransfer(t *testing.T) {
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		Started: true,
 		ContainerRequest: testcontainers.ContainerRequest{
-			WaitingFor:   wait.ForLog("mysqld: ready for connections").WithOccurrence(2).WithStartupTimeout(15 * time.Second),
+			WaitingFor:   wait.ForLog("mysqld: ready for connections").WithOccurrence(2).WithStartupTimeout(time.Minute),
 			Image:        "mysql:8.3.0",
 			ExposedPorts: []string{"3306/tcp"},
 			Env: map[string]string{

--- a/runtime/testruntime/connectors.go
+++ b/runtime/testruntime/connectors.go
@@ -283,7 +283,7 @@ var Connectors = map[string]ConnectorAcquireFunc{
 				Image:        "apachepinot/pinot:latest",
 				ExposedPorts: []string{"9000/tcp", "8000/tcp"},
 				Cmd:          []string{"QuickStart", "-type", "batch"},
-				WaitingFor:   wait.ForLog("You can always go to http://localhost:9000").WithStartupTimeout(4 * time.Minute),
+				WaitingFor:   wait.ForLog("You can always go to http://localhost:9000").WithStartupTimeout(5 * time.Minute),
 			},
 			Started: true,
 		})


### PR DESCRIPTION
Fixes issues seen in the daily test run here:  https://github.com/rilldata/rill/actions/runs/34086202592

- Drops `KeepAlive` from the MCP server options: sessions are served over stateless streamable HTTP and live for a single request, so it never fires usefully, but it races with the session close at the end of the request (`TestMCP` failed under `-race` in the last three daily runs; fixed upstream in go-sdk v1.6.0).
- Removes `container_name` from the ClickHouse cluster compose file so parallel packages each get their own containers instead of colliding on `clickhouse-keeper-01`.
- Raises the MySQL and Pinot container startup timeouts, both of which expired mid-startup on a loaded runner.
