### PR TITLE
Increase the max number of files in a project to 10,000

### DIFF
--- a/runtime/drivers/repo.go
+++ b/runtime/drivers/repo.go
@@ -120,7 +120,7 @@ type WatchEvent struct {
 
 // RepoListLimit is the maximum number of files that can be listed in a call to RepoStore.ListGlob.
 // This limit is effectively a cap on the number of files in a project because `rill start` lists the project directory using a "**" glob.
-const RepoListLimit = 2000
+const RepoListLimit = 10000
 
 // ErrRepoListLimitExceeded should be returned when RepoListLimit is exceeded.
 var ErrRepoListLimitExceeded = fmt.Errorf("glob exceeded limit of %d matched files", RepoListLimit)


### PR DESCRIPTION
Raises `RepoListLimit` from 2,000 to 10,000.
